### PR TITLE
feat: add SQLite database layer with typed CRUD operations (Phase 1)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,12 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "dependencies": {
+    "better-sqlite3": "^11.9.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/db/cache.ts
+++ b/packages/core/src/db/cache.ts
@@ -1,0 +1,61 @@
+import type Database from "better-sqlite3";
+import type { CacheEntry } from "../types.js";
+
+export function getCached<T>(
+  db: Database.Database,
+  key: string,
+): CacheEntry<T> | null {
+  const row = db
+    .prepare("SELECT data, fetched_at FROM cache WHERE key = ?")
+    .get(key) as { data: string; fetched_at: string } | undefined;
+
+  if (!row) return null;
+
+  try {
+    return {
+      data: JSON.parse(row.data) as T,
+      fetchedAt: new Date(row.fetched_at + "Z"),
+    };
+  } catch {
+    // Corrupt cache entry — evict and treat as miss
+    db.prepare("DELETE FROM cache WHERE key = ?").run(key);
+    return null;
+  }
+}
+
+export function setCached(
+  db: Database.Database,
+  key: string,
+  data: unknown,
+): void {
+  db.prepare(
+    "INSERT INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET data = excluded.data, fetched_at = excluded.fetched_at",
+  ).run(key, JSON.stringify(data));
+}
+
+export function isFresh(
+  db: Database.Database,
+  key: string,
+  ttlSeconds: number,
+): boolean {
+  const row = db
+    .prepare("SELECT fetched_at FROM cache WHERE key = ?")
+    .get(key) as { fetched_at: string } | undefined;
+
+  if (!row) return false;
+
+  const fetchedAt = new Date(row.fetched_at + "Z").getTime();
+  const now = Date.now();
+  return now - fetchedAt < ttlSeconds * 1000;
+}
+
+export function clearCache(
+  db: Database.Database,
+  keyPattern?: string,
+): void {
+  if (keyPattern) {
+    db.prepare("DELETE FROM cache WHERE key LIKE ?").run(keyPattern);
+  } else {
+    db.prepare("DELETE FROM cache").run();
+  }
+}

--- a/packages/core/src/db/connection.ts
+++ b/packages/core/src/db/connection.ts
@@ -1,0 +1,38 @@
+import Database from "better-sqlite3";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { initSchema } from "./schema.js";
+import { runMigrations } from "./migrations.js";
+
+const ISSUECTL_DIR = join(homedir(), ".issuectl");
+const DB_FILENAME = "issuectl.db";
+
+export function getDbPath(): string {
+  return join(ISSUECTL_DIR, DB_FILENAME);
+}
+
+export function dbExists(): boolean {
+  return existsSync(getDbPath());
+}
+
+let instance: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (instance) return instance;
+  mkdirSync(ISSUECTL_DIR, { recursive: true });
+  const db = new Database(getDbPath());
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  initSchema(db);
+  runMigrations(db);
+  instance = db;
+  return db;
+}
+
+export function closeDb(): void {
+  if (instance) {
+    instance.close();
+    instance = null;
+  }
+}

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -1,0 +1,104 @@
+import type Database from "better-sqlite3";
+import type { Deployment } from "../types.js";
+
+type DeploymentRow = {
+  id: number;
+  repo_id: number;
+  issue_number: number;
+  branch_name: string;
+  workspace_mode: string;
+  workspace_path: string;
+  linked_pr_number: number | null;
+  launched_at: string;
+};
+
+function rowToDeployment(row: DeploymentRow): Deployment {
+  return {
+    id: row.id,
+    repoId: row.repo_id,
+    issueNumber: row.issue_number,
+    branchName: row.branch_name,
+    workspaceMode: row.workspace_mode as Deployment["workspaceMode"],
+    workspacePath: row.workspace_path,
+    linkedPrNumber: row.linked_pr_number,
+    launchedAt: row.launched_at,
+  };
+}
+
+export function recordDeployment(
+  db: Database.Database,
+  deployment: {
+    repoId: number;
+    issueNumber: number;
+    branchName: string;
+    workspaceMode: Deployment["workspaceMode"];
+    workspacePath: string;
+  },
+): Deployment {
+  const result = db
+    .prepare(
+      `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      deployment.repoId,
+      deployment.issueNumber,
+      deployment.branchName,
+      deployment.workspaceMode,
+      deployment.workspacePath,
+    );
+
+  const inserted = getDeploymentById(db, Number(result.lastInsertRowid));
+  if (!inserted) throw new Error("Failed to read back deployment after insert");
+  return inserted;
+}
+
+export function getDeploymentById(
+  db: Database.Database,
+  id: number,
+): Deployment | undefined {
+  const row = db
+    .prepare("SELECT * FROM deployments WHERE id = ?")
+    .get(id) as DeploymentRow | undefined;
+  return row ? rowToDeployment(row) : undefined;
+}
+
+export function getDeploymentsForIssue(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): Deployment[] {
+  const rows = db
+    .prepare(
+      "SELECT * FROM deployments WHERE repo_id = ? AND issue_number = ? ORDER BY launched_at DESC",
+    )
+    .all(repoId, issueNumber) as DeploymentRow[];
+  return rows.map(rowToDeployment);
+}
+
+export function getDeploymentsByRepo(
+  db: Database.Database,
+  repoId: number,
+): Deployment[] {
+  const rows = db
+    .prepare(
+      "SELECT * FROM deployments WHERE repo_id = ? ORDER BY launched_at DESC",
+    )
+    .all(repoId) as DeploymentRow[];
+  return rows.map(rowToDeployment);
+}
+
+export function updateLinkedPR(
+  db: Database.Database,
+  deploymentId: number,
+  prNumber: number,
+): void {
+  const result = db
+    .prepare("UPDATE deployments SET linked_pr_number = ? WHERE id = ?")
+    .run(prNumber, deploymentId);
+  if (result.changes === 0) {
+    throw new Error(
+      `No deployment found with id ${deploymentId} to link PR`,
+    );
+  }
+}

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -1,0 +1,29 @@
+import type Database from "better-sqlite3";
+import { getSchemaVersion } from "./schema.js";
+
+type Migration = {
+  version: number;
+  up: (db: Database.Database) => void;
+};
+
+// Add migrations here as the schema evolves.
+// Each migration bumps the version and applies DDL changes.
+const migrations: Migration[] = [];
+
+export function runMigrations(db: Database.Database): void {
+  const currentVersion = getSchemaVersion(db);
+
+  const pending = migrations.filter((m) => m.version > currentVersion);
+  if (pending.length === 0) return;
+
+  const applyAll = db.transaction(() => {
+    for (const migration of pending) {
+      migration.up(db);
+      db.prepare("UPDATE schema_version SET version = ?").run(
+        migration.version,
+      );
+    }
+  });
+
+  applyAll();
+}

--- a/packages/core/src/db/repos.ts
+++ b/packages/core/src/db/repos.ts
@@ -1,0 +1,111 @@
+import type Database from "better-sqlite3";
+import type { Repo } from "../types.js";
+
+type RepoRow = {
+  id: number;
+  owner: string;
+  name: string;
+  local_path: string | null;
+  branch_pattern: string | null;
+  created_at: string;
+};
+
+function rowToRepo(row: RepoRow): Repo {
+  return {
+    id: row.id,
+    owner: row.owner,
+    name: row.name,
+    localPath: row.local_path,
+    branchPattern: row.branch_pattern,
+    createdAt: row.created_at,
+  };
+}
+
+export function addRepo(
+  db: Database.Database,
+  repo: {
+    owner: string;
+    name: string;
+    localPath?: string;
+    branchPattern?: string;
+  },
+): Repo {
+  const result = db
+    .prepare(
+      "INSERT INTO repos (owner, name, local_path, branch_pattern) VALUES (?, ?, ?, ?)",
+    )
+    .run(
+      repo.owner,
+      repo.name,
+      repo.localPath ?? null,
+      repo.branchPattern ?? null,
+    );
+
+  const inserted = getRepoById(db, Number(result.lastInsertRowid));
+  if (!inserted) throw new Error("Failed to read back repo after insert");
+  return inserted;
+}
+
+export function removeRepo(db: Database.Database, id: number): void {
+  const result = db.prepare("DELETE FROM repos WHERE id = ?").run(id);
+  if (result.changes === 0) {
+    throw new Error(`No repo found with id ${id} to remove`);
+  }
+}
+
+export function getRepo(
+  db: Database.Database,
+  owner: string,
+  name: string,
+): Repo | undefined {
+  const row = db
+    .prepare("SELECT * FROM repos WHERE owner = ? AND name = ?")
+    .get(owner, name) as RepoRow | undefined;
+  return row ? rowToRepo(row) : undefined;
+}
+
+export function getRepoById(
+  db: Database.Database,
+  id: number,
+): Repo | undefined {
+  const row = db.prepare("SELECT * FROM repos WHERE id = ?").get(id) as
+    | RepoRow
+    | undefined;
+  return row ? rowToRepo(row) : undefined;
+}
+
+export function listRepos(db: Database.Database): Repo[] {
+  const rows = db
+    .prepare("SELECT * FROM repos ORDER BY created_at DESC")
+    .all() as RepoRow[];
+  return rows.map(rowToRepo);
+}
+
+export function updateRepo(
+  db: Database.Database,
+  id: number,
+  updates: Partial<Pick<Repo, "localPath" | "branchPattern">>,
+): Repo {
+  const fields: string[] = [];
+  const values: (string | number | null)[] = [];
+
+  if (updates.localPath !== undefined) {
+    fields.push("local_path = ?");
+    values.push(updates.localPath);
+  }
+  if (updates.branchPattern !== undefined) {
+    fields.push("branch_pattern = ?");
+    values.push(updates.branchPattern);
+  }
+
+  if (fields.length > 0) {
+    values.push(id);
+    db.prepare(`UPDATE repos SET ${fields.join(", ")} WHERE id = ?`).run(
+      ...values,
+    );
+  }
+
+  const updated = getRepoById(db, id);
+  if (!updated) throw new Error(`Repo with id ${id} not found`);
+  return updated;
+}

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,0 +1,62 @@
+import type Database from "better-sqlite3";
+
+const SCHEMA_VERSION = 1;
+
+const CREATE_TABLES = `
+  CREATE TABLE IF NOT EXISTS repos (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner          TEXT NOT NULL,
+    name           TEXT NOT NULL,
+    local_path     TEXT,
+    branch_pattern TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(owner, name)
+  );
+
+  CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS deployments (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id          INTEGER NOT NULL REFERENCES repos(id),
+    issue_number     INTEGER NOT NULL,
+    branch_name      TEXT NOT NULL,
+    workspace_mode   TEXT NOT NULL,
+    workspace_path   TEXT NOT NULL,
+    linked_pr_number INTEGER,
+    launched_at      TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS cache (
+    key        TEXT PRIMARY KEY,
+    data       TEXT NOT NULL,
+    fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+  );
+`;
+
+export function initSchema(db: Database.Database): void {
+  db.exec(CREATE_TABLES);
+
+  const row = db.prepare("SELECT version FROM schema_version").get() as
+    | { version: number }
+    | undefined;
+
+  if (!row) {
+    db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(
+      SCHEMA_VERSION,
+    );
+  }
+}
+
+export function getSchemaVersion(db: Database.Database): number {
+  const row = db.prepare("SELECT version FROM schema_version").get() as
+    | { version: number }
+    | undefined;
+  return row?.version ?? 0;
+}

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -1,0 +1,48 @@
+import type Database from "better-sqlite3";
+import type { Setting, SettingKey } from "../types.js";
+
+const DEFAULT_SETTINGS: Setting[] = [
+  { key: "branch_pattern", value: "issue-{number}-{slug}" },
+  { key: "terminal_app", value: "ghostty" },
+  { key: "terminal_mode", value: "window" },
+  { key: "cache_ttl", value: "300" },
+  { key: "worktree_dir", value: "~/.issuectl/worktrees/" },
+];
+
+export function getSetting(
+  db: Database.Database,
+  key: SettingKey,
+): string | undefined {
+  const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value;
+}
+
+export function setSetting(
+  db: Database.Database,
+  key: SettingKey,
+  value: string,
+): void {
+  db.prepare(
+    "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+  ).run(key, value);
+}
+
+export function getSettings(db: Database.Database): Setting[] {
+  return db.prepare("SELECT key, value FROM settings ORDER BY key").all() as Setting[];
+}
+
+export function seedDefaults(db: Database.Database): void {
+  const insert = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+  );
+
+  const insertAll = db.transaction(() => {
+    for (const setting of DEFAULT_SETTINGS) {
+      insert.run(setting.key, setting.value);
+    }
+  });
+
+  insertAll();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,32 @@
-export {};
+export type { Repo, Setting, SettingKey, Deployment, CacheEntry } from "./types.js";
+
+export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
+export { initSchema, getSchemaVersion } from "./db/schema.js";
+export { runMigrations } from "./db/migrations.js";
+export {
+  addRepo,
+  removeRepo,
+  getRepo,
+  getRepoById,
+  listRepos,
+  updateRepo,
+} from "./db/repos.js";
+export {
+  getSetting,
+  setSetting,
+  getSettings,
+  seedDefaults,
+} from "./db/settings.js";
+export {
+  recordDeployment,
+  getDeploymentById,
+  getDeploymentsForIssue,
+  getDeploymentsByRepo,
+  updateLinkedPR,
+} from "./db/deployments.js";
+export {
+  getCached,
+  setCached,
+  isFresh,
+  clearCache,
+} from "./db/cache.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,36 @@
+export type Repo = {
+  id: number;
+  owner: string;
+  name: string;
+  localPath: string | null;
+  branchPattern: string | null;
+  createdAt: string;
+};
+
+export type SettingKey =
+  | "branch_pattern"
+  | "terminal_app"
+  | "terminal_mode"
+  | "cache_ttl"
+  | "worktree_dir";
+
+export type Setting = {
+  key: SettingKey;
+  value: string;
+};
+
+export type Deployment = {
+  id: number;
+  repoId: number;
+  issueNumber: number;
+  branchName: string;
+  workspaceMode: "existing" | "worktree" | "clone";
+  workspacePath: string;
+  linkedPrNumber: number | null;
+  launchedAt: string;
+};
+
+export type CacheEntry<T = unknown> = {
+  data: T;
+  fetchedAt: Date;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,15 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.9.1
+        version: 11.10.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
 
   packages/web:
     dependencies:
@@ -662,6 +670,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -761,6 +772,18 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -768,6 +791,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -785,6 +811,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -820,12 +849,23 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -878,6 +918,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -907,6 +951,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -925,10 +972,16 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -943,6 +996,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -954,6 +1010,12 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1016,9 +1078,19 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1033,6 +1105,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1058,9 +1133,16 @@ packages:
       sass:
         optional: true
 
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1125,6 +1207,12 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1134,12 +1222,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -1149,6 +1244,10 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1170,6 +1269,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1190,6 +1292,12 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1197,6 +1305,13 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1215,6 +1330,13 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1269,6 +1391,9 @@ packages:
       typescript:
         optional: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   turbo@2.9.4:
     resolution: {integrity: sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ==}
     hasBin: true
@@ -1298,6 +1423,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1306,6 +1434,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1691,6 +1822,10 @@ snapshots:
   '@turbo/windows-arm64@2.9.4':
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -1817,6 +1952,23 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -1824,6 +1976,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -1837,6 +1994,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   client-only@0.0.1: {}
 
@@ -1860,10 +2019,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1960,6 +2128,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  expand-template@2.0.3: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -1986,6 +2156,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -2008,8 +2180,12 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -2021,11 +2197,17 @@ snapshots:
 
   husky@9.1.7: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-extglob@2.1.1: {}
 
@@ -2075,9 +2257,15 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -2095,6 +2283,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -2121,7 +2311,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   object-assign@4.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2172,13 +2370,40 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -2186,6 +2411,12 @@ snapshots:
       scheduler: 0.27.0
 
   react@19.2.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -2227,6 +2458,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   scheduler@0.27.0: {}
 
@@ -2270,9 +2503,23 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
@@ -2288,6 +2535,21 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -2346,6 +2608,10 @@ snapshots:
       - tsx
       - yaml
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   turbo@2.9.4:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.4
@@ -2380,10 +2646,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
## Summary

- Add `better-sqlite3` to `@issuectl/core` with full schema: repos, settings, deployments, cache, schema_version tables
- Implement typed CRUD operations for all tables with explicit `Database` parameter convention
- Add `SettingKey` union type for compile-time safety on settings access
- Add generic `CacheEntry<T>` with corrupt-entry eviction and TTL freshness checking
- Singleton `getDb()` with WAL mode, foreign keys, auto schema init + migrations

## Key design decisions

- **Explicit DB parameter**: every function accepts `db: Database.Database` — no global singleton inside core (per CLAUDE.md)
- **Defensive error handling**: mutations throw on non-existent IDs, `getCached` evicts corrupt entries instead of crashing
- **`SettingKey` union**: prevents typos in `getSetting`/`setSetting` at compile time
- **Singleton `getDb()` + `closeDb()`**: connection reuse with clean teardown for tests

## Files added/modified

| File | Purpose |
|---|---|
| `core/src/types.ts` | Repo, SettingKey, Setting, Deployment, CacheEntry<T> |
| `core/src/db/connection.ts` | getDb (singleton), getDbPath, dbExists, closeDb |
| `core/src/db/schema.ts` | initSchema, getSchemaVersion (5 tables) |
| `core/src/db/migrations.ts` | runMigrations (transactional, sequential) |
| `core/src/db/repos.ts` | addRepo, removeRepo, getRepo, getRepoById, listRepos, updateRepo |
| `core/src/db/settings.ts` | getSetting, setSetting, getSettings, seedDefaults |
| `core/src/db/deployments.ts` | recordDeployment, getDeploymentById, getDeploymentsForIssue, getDeploymentsByRepo, updateLinkedPR |
| `core/src/db/cache.ts` | getCached<T>, setCached, isFresh, clearCache |
| `core/src/index.ts` | Barrel re-exports for all public API |

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] Reviewer can verify schema matches design spec at `docs/specs/2026-04-06-issuectl-design.md`
- [ ] Function signatures match implementation plan Phase 1 section