### PR TITLE
feat: add GitHub client with typed Octokit wrapper (Phase 2)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.0",
     "better-sqlite3": "^11.9.1"
   },
   "devDependencies": {

--- a/packages/core/src/github/auth.ts
+++ b/packages/core/src/github/auth.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function getGhToken(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "token"]);
+    const token = stdout.trim();
+    if (!token) {
+      throw new Error("gh auth token returned empty output");
+    }
+    return token;
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Unknown error";
+    throw new Error(
+      `Failed to get GitHub token via 'gh auth token': ${message}. ` +
+        "Ensure the GitHub CLI is installed and you are authenticated (run 'gh auth login').",
+      { cause: err },
+    );
+  }
+}
+
+export async function checkGhAuth(): Promise<{
+  ok: boolean;
+  username?: string;
+  error?: string;
+}> {
+  try {
+    const { stdout, stderr } = await execFileAsync("gh", [
+      "auth",
+      "status",
+    ]);
+    const output = stdout + stderr;
+    // Matches both "Logged in to github.com as user" (old gh) and
+    // "Logged in to github.com account user (keyring)" (new gh)
+    const match = output.match(/Logged in to \S+ (?:as|account) (\S+)/);
+    return {
+      ok: true,
+      username: match?.[1],
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error:
+        err instanceof Error ? err.message : "gh auth status failed",
+    };
+  }
+}

--- a/packages/core/src/github/auth.ts
+++ b/packages/core/src/github/auth.ts
@@ -4,13 +4,9 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export async function getGhToken(): Promise<string> {
+  let stdout: string;
   try {
-    const { stdout } = await execFileAsync("gh", ["auth", "token"]);
-    const token = stdout.trim();
-    if (!token) {
-      throw new Error("gh auth token returned empty output");
-    }
-    return token;
+    ({ stdout } = await execFileAsync("gh", ["auth", "token"]));
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Unknown error";
@@ -20,6 +16,15 @@ export async function getGhToken(): Promise<string> {
       { cause: err },
     );
   }
+
+  const token = stdout.trim();
+  if (!token) {
+    throw new Error(
+      "gh auth token succeeded but returned an empty token. " +
+        "Try running 'gh auth login' to re-authenticate.",
+    );
+  }
+  return token;
 }
 
 export async function checkGhAuth(): Promise<{
@@ -41,6 +46,18 @@ export async function checkGhAuth(): Promise<{
       username: match?.[1],
     };
   } catch (err) {
+    // Distinguish missing gh binary from auth failure
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return {
+        ok: false,
+        error:
+          "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/",
+      };
+    }
     return {
       ok: false,
       error:

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1,0 +1,11 @@
+import { Octokit } from "@octokit/rest";
+import { getGhToken } from "./auth.js";
+
+let instance: Octokit | null = null;
+
+export async function getOctokit(): Promise<Octokit> {
+  if (instance) return instance;
+  const token = await getGhToken();
+  instance = new Octokit({ auth: token });
+  return instance;
+}

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -9,3 +9,7 @@ export async function getOctokit(): Promise<Octokit> {
   instance = new Octokit({ auth: token });
   return instance;
 }
+
+export function resetOctokit(): void {
+  instance = null;
+}

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -1,0 +1,162 @@
+import type { Octokit } from "@octokit/rest";
+import type { GitHubIssue, GitHubComment, RawGitHubUser } from "./types.js";
+import { mapUser } from "./types.js";
+
+function mapIssue(raw: unknown): GitHubIssue {
+  const r = raw as {
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    labels: Array<{ name?: string; color?: string; description?: string | null } | string>;
+    user: RawGitHubUser;
+    created_at: string;
+    updated_at: string;
+    closed_at: string | null;
+    html_url: string;
+  };
+  return {
+    number: r.number,
+    title: r.title,
+    body: r.body,
+    state: r.state as GitHubIssue["state"],
+    labels: r.labels
+      .filter((l): l is { name?: string; color?: string; description?: string | null } => typeof l !== "string")
+      .map((l) => ({
+        name: l.name ?? "",
+        color: l.color ?? "",
+        description: l.description ?? null,
+      })),
+    user: mapUser(r.user),
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    closedAt: r.closed_at,
+    htmlUrl: r.html_url,
+  };
+}
+
+function mapComment(raw: unknown): GitHubComment {
+  const r = raw as {
+    id: number;
+    body: string;
+    user: RawGitHubUser;
+    created_at: string;
+    updated_at: string;
+    html_url: string;
+  };
+  return {
+    id: r.id,
+    body: r.body ?? "",
+    user: mapUser(r.user),
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    htmlUrl: r.html_url,
+  };
+}
+
+export async function listIssues(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  state: "open" | "closed" | "all" = "open",
+): Promise<GitHubIssue[]> {
+  const items = await octokit.paginate(octokit.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state,
+    per_page: 100,
+  });
+  // GitHub API returns PRs in the issues endpoint — filter them out
+  return items
+    .filter((item) => !("pull_request" in item && item.pull_request))
+    .map((item) => mapIssue(item));
+}
+
+export async function getIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<GitHubIssue> {
+  const { data } = await octokit.rest.issues.get({
+    owner,
+    repo,
+    issue_number: number,
+  });
+  return mapIssue(data);
+}
+
+export async function createIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  data: { title: string; body?: string; labels?: string[] },
+): Promise<GitHubIssue> {
+  const { data: created } = await octokit.rest.issues.create({
+    owner,
+    repo,
+    title: data.title,
+    body: data.body,
+    labels: data.labels,
+  });
+  return mapIssue(created);
+}
+
+export async function updateIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  data: { title?: string; body?: string; labels?: string[] },
+): Promise<GitHubIssue> {
+  const { data: updated } = await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: number,
+    ...data,
+  });
+  return mapIssue(updated);
+}
+
+export async function closeIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<void> {
+  await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: number,
+    state: "closed",
+  });
+}
+
+export async function getComments(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<GitHubComment[]> {
+  const items = await octokit.paginate(
+    octokit.rest.issues.listComments,
+    { owner, repo, issue_number: number, per_page: 100 },
+  );
+  return items.map((item) => mapComment(item));
+}
+
+export async function addComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  body: string,
+): Promise<GitHubComment> {
+  const { data } = await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: number,
+    body,
+  });
+  return mapComment(data);
+}

--- a/packages/core/src/github/labels.ts
+++ b/packages/core/src/github/labels.ts
@@ -1,0 +1,104 @@
+import type { Octokit } from "@octokit/rest";
+import type { GitHubLabel } from "./types.js";
+
+export const LIFECYCLE_LABEL = {
+  deployed: "issuectl:deployed",
+  prOpen: "issuectl:pr-open",
+  done: "issuectl:done",
+} as const;
+
+const LIFECYCLE_LABELS = [
+  {
+    name: LIFECYCLE_LABEL.deployed,
+    color: "d29922",
+    description: "Launched to Claude Code via issuectl",
+  },
+  {
+    name: LIFECYCLE_LABEL.prOpen,
+    color: "58a6ff",
+    description: "PR referencing this issue is open",
+  },
+  {
+    name: LIFECYCLE_LABEL.done,
+    color: "3fb950",
+    description: "PR merged and issue closed",
+  },
+];
+
+function isNotFound(err: unknown): boolean {
+  return (err as { status?: number }).status === 404;
+}
+
+export async function ensureLifecycleLabels(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<void> {
+  await Promise.all(
+    LIFECYCLE_LABELS.map(async (label) => {
+      try {
+        await octokit.rest.issues.getLabel({ owner, repo, name: label.name });
+      } catch (err) {
+        if (!isNotFound(err)) throw err;
+        await octokit.rest.issues.createLabel({
+          owner,
+          repo,
+          name: label.name,
+          color: label.color,
+          description: label.description,
+        });
+      }
+    }),
+  );
+}
+
+export async function listLabels(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<GitHubLabel[]> {
+  const items = await octokit.paginate(octokit.rest.issues.listLabelsForRepo, {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  return items.map((item) => ({
+    name: item.name,
+    color: item.color ?? "",
+    description: item.description ?? null,
+  }));
+}
+
+export async function addLabel(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  await octokit.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [label],
+  });
+}
+
+export async function removeLabel(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  try {
+    await octokit.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name: label,
+    });
+  } catch (err) {
+    if (!isNotFound(err)) throw err;
+  }
+}

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -1,0 +1,105 @@
+import type { Octokit } from "@octokit/rest";
+import type { GitHubPull, GitHubCheck, RawGitHubUser } from "./types.js";
+import { mapUser } from "./types.js";
+
+function mapPull(raw: unknown): GitHubPull {
+  const r = raw as {
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    merged: boolean;
+    merged_at: string | null;
+    user: RawGitHubUser;
+    head: { ref: string };
+    base: { ref: string };
+    additions: number;
+    deletions: number;
+    created_at: string;
+    updated_at: string;
+    closed_at: string | null;
+    html_url: string;
+  };
+  return {
+    number: r.number,
+    title: r.title,
+    body: r.body,
+    state: r.state as GitHubPull["state"],
+    merged: r.merged ?? r.merged_at !== null,
+    user: mapUser(r.user),
+    headRef: r.head.ref,
+    baseRef: r.base.ref,
+    additions: r.additions ?? 0,
+    deletions: r.deletions ?? 0,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    mergedAt: r.merged_at ?? null,
+    closedAt: r.closed_at,
+    htmlUrl: r.html_url,
+  };
+}
+
+export async function listPulls(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  state: "open" | "closed" | "all" = "all",
+): Promise<GitHubPull[]> {
+  const items = await octokit.paginate(octokit.rest.pulls.list, {
+    owner,
+    repo,
+    state,
+    per_page: 100,
+  });
+  return items.map((item) => mapPull(item));
+}
+
+export async function getPull(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<GitHubPull> {
+  const { data } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: number,
+  });
+  return mapPull(data);
+}
+
+export async function getPullChecks(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+): Promise<GitHubCheck[]> {
+  const { data } = await octokit.rest.checks.listForRef({
+    owner,
+    repo,
+    ref,
+  });
+  return data.check_runs.map((run) => ({
+    name: run.name,
+    status: run.status as GitHubCheck["status"],
+    conclusion: run.conclusion ?? null,
+    htmlUrl: run.html_url ?? null,
+  }));
+}
+
+export async function findLinkedPRs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<GitHubPull[]> {
+  const pattern = /(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+  const pulls = await listPulls(octokit, owner, repo, "all");
+  return pulls.filter((pr) => {
+    if (!pr.body) return false;
+    for (const match of pr.body.matchAll(pattern)) {
+      if (Number(match[1]) === issueNumber) return true;
+    }
+    return false;
+  });
+}

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -1,0 +1,64 @@
+export type GitHubUser = {
+  login: string;
+  avatarUrl: string;
+};
+
+export type GitHubLabel = {
+  name: string;
+  color: string;
+  description: string | null;
+};
+
+export type GitHubIssue = {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  labels: GitHubLabel[];
+  user: GitHubUser | null;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  htmlUrl: string;
+};
+
+export type GitHubComment = {
+  id: number;
+  body: string;
+  user: GitHubUser | null;
+  createdAt: string;
+  updatedAt: string;
+  htmlUrl: string;
+};
+
+export type GitHubPull = {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  merged: boolean;
+  user: GitHubUser | null;
+  headRef: string;
+  baseRef: string;
+  additions: number;
+  deletions: number;
+  createdAt: string;
+  updatedAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+  htmlUrl: string;
+};
+
+// Raw API user shape for mapper functions
+export type RawGitHubUser = { login: string; avatar_url: string } | null;
+
+export function mapUser(raw: RawGitHubUser): GitHubUser | null {
+  return raw ? { login: raw.login, avatarUrl: raw.avatar_url } : null;
+}
+
+export type GitHubCheck = {
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: string | null;
+  htmlUrl: string | null;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,7 +41,7 @@ export type {
   GitHubCheck,
 } from "./github/types.js";
 export { getGhToken, checkGhAuth } from "./github/auth.js";
-export { getOctokit } from "./github/client.js";
+export { getOctokit, resetOctokit } from "./github/client.js";
 export {
   listIssues,
   getIssue,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,37 @@ export {
   isFresh,
   clearCache,
 } from "./db/cache.js";
+
+// GitHub client
+export type {
+  GitHubUser,
+  GitHubIssue,
+  GitHubPull,
+  GitHubComment,
+  GitHubLabel,
+  GitHubCheck,
+} from "./github/types.js";
+export { getGhToken, checkGhAuth } from "./github/auth.js";
+export { getOctokit } from "./github/client.js";
+export {
+  listIssues,
+  getIssue,
+  createIssue,
+  updateIssue,
+  closeIssue,
+  getComments,
+  addComment,
+} from "./github/issues.js";
+export {
+  listPulls,
+  getPull,
+  getPullChecks,
+  findLinkedPRs,
+} from "./github/pulls.js";
+export {
+  LIFECYCLE_LABEL,
+  listLabels,
+  ensureLifecycleLabels,
+  addLabel,
+  removeLabel,
+} from "./github/labels.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@octokit/rest':
+        specifier: ^22.0.0
+        version: 22.0.1
       better-sqlite3:
         specifier: ^11.9.1
         version: 11.10.0
@@ -512,6 +515,58 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
@@ -775,6 +830,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
@@ -922,6 +980,9 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1044,6 +1105,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1420,6 +1484,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -1725,6 +1792,69 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
@@ -1954,6 +2084,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  before-after-hook@4.0.0: {}
+
   better-sqlite3@11.10.0:
     dependencies:
       bindings: 1.5.0
@@ -2130,6 +2262,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  fast-content-type-parse@3.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -2226,6 +2360,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-with-bigint@3.5.8: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2641,6 +2777,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  universal-user-agent@7.0.3: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@octokit/rest` to `@issuectl/core` with typed GitHub API functions
- Auth via `gh auth token` (execFile, no shell injection) with both old/new `gh` CLI format support
- Slimmed-down mapped types (GitHubUser, GitHubIssue, GitHubPull, GitHubComment, GitHubLabel, GitHubCheck)
- All list functions use `octokit.paginate()` for automatic pagination
- `LIFECYCLE_LABEL` exported constant for compile-time safe label references

## Key design decisions

- **Explicit Octokit parameter**: every function accepts `octokit: Octokit` — no global state
- **404-only error handling**: `ensureLifecycleLabels` and `removeLabel` catch only 404s, re-throw real errors
- **Parallel label creation**: `ensureLifecycleLabels` runs all 3 labels concurrently via `Promise.all`
- **Shared `mapUser` helper**: deduplicates the `avatar_url` → `avatarUrl` mapping across 3 modules
- **`findLinkedPRs` regex**: matches `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive, optional owner/repo prefix)

## Files added/modified

| File | Purpose |
|---|---|
| `github/types.ts` | GitHubUser, GitHubLabel, GitHubIssue, GitHubComment, GitHubPull, GitHubCheck, mapUser |
| `github/auth.ts` | getGhToken, checkGhAuth (both old/new gh CLI) |
| `github/client.ts` | getOctokit singleton factory |
| `github/issues.ts` | listIssues, getIssue, createIssue, updateIssue, closeIssue, getComments, addComment |
| `github/pulls.ts` | listPulls, getPull, getPullChecks, findLinkedPRs |
| `github/labels.ts` | LIFECYCLE_LABEL, listLabels, ensureLifecycleLabels, addLabel, removeLabel |

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] Function signatures match implementation plan Phase 2 section
- [ ] Lifecycle label colors/descriptions match design spec