### PR TITLE
feat: add cached data access layer with SWR pattern (Phase 3)

### DIFF
--- a/packages/core/src/data/comments.ts
+++ b/packages/core/src/data/comments.ts
@@ -1,0 +1,55 @@
+import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
+import type { GitHubComment } from "../github/types.js";
+import {
+  getComments as fetchComments,
+  addComment as postComment,
+} from "../github/issues.js";
+import { getCacheTtl, getCached, setCached, isFresh, clearCacheKey } from "../db/cache.js";
+
+export async function getComments(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  comments: GitHubComment[];
+  fromCache: boolean;
+  cachedAt: Date | null;
+}> {
+  const cacheKey = `comments:${owner}/${repo}#${issueNumber}`;
+  const ttl = getCacheTtl(db);
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<GitHubComment[]>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        fetchComments(octokit, owner, repo, issueNumber).then((data) => {
+          setCached(db, cacheKey, data);
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+      return { comments: cached.data, fromCache: true, cachedAt: cached.fetchedAt };
+    }
+  }
+
+  const comments = await fetchComments(octokit, owner, repo, issueNumber);
+  setCached(db, cacheKey, comments);
+  return { comments, fromCache: false, cachedAt: new Date() };
+}
+
+export async function addComment(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<GitHubComment> {
+  const comment = await postComment(octokit, owner, repo, issueNumber, body);
+  clearCacheKey(db, `comments:${owner}/${repo}#${issueNumber}`);
+  return comment;
+}

--- a/packages/core/src/data/issues.ts
+++ b/packages/core/src/data/issues.ts
@@ -1,0 +1,131 @@
+import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
+import type { GitHubIssue, GitHubComment, GitHubPull } from "../github/types.js";
+import type { Deployment } from "../types.js";
+import { listIssues, getIssue, getComments as fetchComments } from "../github/issues.js";
+import { findLinkedPRs } from "../github/pulls.js";
+import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
+import { getDeploymentsForIssue } from "../db/deployments.js";
+import { getRepo } from "../db/repos.js";
+
+const FILE_PATH_PATTERN = /`([a-zA-Z0-9_./-]+\.[a-zA-Z]{1,10})`/g;
+const GITHUB_BLOB_PATTERN =
+  /https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/([^\s)]+)/g;
+
+function extractReferencedFiles(body: string | null): string[] {
+  if (!body) return [];
+  const files = new Set<string>();
+
+  for (const match of body.matchAll(FILE_PATH_PATTERN)) {
+    files.add(match[1]);
+  }
+  for (const match of body.matchAll(GITHUB_BLOB_PATTERN)) {
+    files.add(decodeURIComponent(match[1]));
+  }
+
+  return [...files];
+}
+
+export async function getIssues(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  issues: GitHubIssue[];
+  fromCache: boolean;
+  cachedAt: Date | null;
+}> {
+  const cacheKey = `issues:${owner}/${repo}`;
+  const ttl = getCacheTtl(db);
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<GitHubIssue[]>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        listIssues(octokit, owner, repo, "all").then((data) => {
+          setCached(db, cacheKey, data);
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+      return { issues: cached.data, fromCache: true, cachedAt: cached.fetchedAt };
+    }
+  }
+
+  const issues = await listIssues(octokit, owner, repo, "all");
+  setCached(db, cacheKey, issues);
+  return { issues, fromCache: false, cachedAt: new Date() };
+}
+
+export async function getIssueDetail(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  issue: GitHubIssue;
+  comments: GitHubComment[];
+  deployments: Deployment[];
+  linkedPRs: GitHubPull[];
+  referencedFiles: string[];
+  fromCache: boolean;
+}> {
+  const cacheKey = `issue-detail:${owner}/${repo}#${number}`;
+  const ttl = getCacheTtl(db);
+  const repoRecord = getRepo(db, owner, repo);
+
+  type CachedDetail = {
+    issue: GitHubIssue;
+    comments: GitHubComment[];
+    linkedPRs: GitHubPull[];
+  };
+
+  const deployments = repoRecord
+    ? getDeploymentsForIssue(db, repoRecord.id, number)
+    : [];
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<CachedDetail>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        Promise.all([
+          getIssue(octokit, owner, repo, number),
+          fetchComments(octokit, owner, repo, number),
+          findLinkedPRs(octokit, owner, repo, number),
+        ]).then(([issue, comments, linkedPRs]) => {
+          setCached(db, cacheKey, { issue, comments, linkedPRs });
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+
+      return {
+        ...cached.data,
+        deployments,
+        referencedFiles: extractReferencedFiles(cached.data.issue.body),
+        fromCache: true,
+      };
+    }
+  }
+
+  const [issue, comments, linkedPRs] = await Promise.all([
+    getIssue(octokit, owner, repo, number),
+    fetchComments(octokit, owner, repo, number),
+    findLinkedPRs(octokit, owner, repo, number),
+  ]);
+
+  setCached(db, cacheKey, { issue, comments, linkedPRs });
+
+  return {
+    issue,
+    comments,
+    deployments,
+    linkedPRs,
+    referencedFiles: extractReferencedFiles(issue.body),
+    fromCache: false,
+  };
+}

--- a/packages/core/src/data/pulls.ts
+++ b/packages/core/src/data/pulls.ts
@@ -1,0 +1,82 @@
+import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
+import type { GitHubPull, GitHubCheck, GitHubIssue } from "../github/types.js";
+import { listPulls, getPull, getPullChecks } from "../github/pulls.js";
+import { getIssue } from "../github/issues.js";
+import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
+
+function extractLinkedIssueNumber(body: string | null): number | null {
+  if (!body) return null;
+  const match = body.match(
+    /(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/i,
+  );
+  return match ? Number(match[1]) : null;
+}
+
+export async function getPulls(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  pulls: GitHubPull[];
+  fromCache: boolean;
+  cachedAt: Date | null;
+}> {
+  const cacheKey = `pulls:${owner}/${repo}`;
+  const ttl = getCacheTtl(db);
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<GitHubPull[]>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        listPulls(octokit, owner, repo, "all").then((data) => {
+          setCached(db, cacheKey, data);
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+      return { pulls: cached.data, fromCache: true, cachedAt: cached.fetchedAt };
+    }
+  }
+
+  const pulls = await listPulls(octokit, owner, repo, "all");
+  setCached(db, cacheKey, pulls);
+  return { pulls, fromCache: false, cachedAt: new Date() };
+}
+
+export async function getPullDetail(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<{
+  pull: GitHubPull;
+  checks: GitHubCheck[];
+  linkedIssue: GitHubIssue | null;
+}> {
+  const [pull, checks] = await Promise.all([
+    getPull(octokit, owner, repo, number),
+    getPullChecks(octokit, owner, repo, `pull/${number}/head`),
+  ]);
+
+  const issueNumber = extractLinkedIssueNumber(pull.body);
+  let linkedIssue: GitHubIssue | null = null;
+  if (issueNumber) {
+    try {
+      linkedIssue = await getIssue(octokit, owner, repo, issueNumber);
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      if (status !== 404) {
+        console.warn(
+          `[issuectl] Failed to fetch linked issue #${issueNumber} for PR #${number}:`,
+          err,
+        );
+      }
+    }
+  }
+
+  return { pull, checks, linkedIssue };
+}

--- a/packages/core/src/data/repos.ts
+++ b/packages/core/src/data/repos.ts
@@ -1,0 +1,89 @@
+import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
+import type { Repo } from "../types.js";
+import type { GitHubLabel } from "../github/types.js";
+import { listRepos } from "../db/repos.js";
+import { getIssues } from "./issues.js";
+import { getPulls } from "./pulls.js";
+import { getDeploymentsByRepo } from "../db/deployments.js";
+
+function countLabelOccurrences(
+  labels: GitHubLabel[][],
+): Array<{ name: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const labelSet of labels) {
+    for (const label of labelSet) {
+      counts.set(label.name, (counts.get(label.name) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function daysSince(isoDate: string): number {
+  return Math.floor(
+    (Date.now() - new Date(isoDate).getTime()) / (1000 * 60 * 60 * 24),
+  );
+}
+
+export async function getDashboardData(
+  db: Database.Database,
+  octokit: Octokit,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  repos: Array<
+    Repo & {
+      issueCount: number;
+      prCount: number;
+      deployedCount: number;
+      labels: Array<{ name: string; count: number }>;
+      oldestIssueAge: number;
+    }
+  >;
+  totalIssues: number;
+  totalPRs: number;
+  cachedAt: Date | null;
+}> {
+  const repos = listRepos(db);
+  let oldestCachedAt: Date | null = null;
+
+  const enrichedRepos = await Promise.all(
+    repos.map(async (repo) => {
+      const [issueResult, pullResult] = await Promise.all([
+        getIssues(db, octokit, repo.owner, repo.name, options),
+        getPulls(db, octokit, repo.owner, repo.name, options),
+      ]);
+
+      const deployments = getDeploymentsByRepo(db, repo.id);
+      const openIssues = issueResult.issues.filter((i) => i.state === "open");
+
+      if (issueResult.cachedAt) {
+        if (!oldestCachedAt || issueResult.cachedAt < oldestCachedAt) {
+          oldestCachedAt = issueResult.cachedAt;
+        }
+      }
+
+      return {
+        ...repo,
+        issueCount: openIssues.length,
+        prCount: pullResult.pulls.filter((p) => p.state === "open").length,
+        deployedCount: deployments.length,
+        labels: countLabelOccurrences(openIssues.map((i) => i.labels)),
+        oldestIssueAge: openIssues.length > 0
+          ? Math.max(...openIssues.map((i) => daysSince(i.createdAt)))
+          : 0,
+      };
+    }),
+  );
+
+  const totalIssues = enrichedRepos.reduce((sum, r) => sum + r.issueCount, 0);
+  const totalPRs = enrichedRepos.reduce((sum, r) => sum + r.prCount, 0);
+
+  return {
+    repos: enrichedRepos,
+    totalIssues,
+    totalPRs,
+    cachedAt: oldestCachedAt,
+  };
+}

--- a/packages/core/src/data/settings.ts
+++ b/packages/core/src/data/settings.ts
@@ -1,0 +1,6 @@
+export {
+  getSetting,
+  setSetting,
+  getSettings,
+  seedDefaults,
+} from "../db/settings.js";

--- a/packages/core/src/db/cache.ts
+++ b/packages/core/src/db/cache.ts
@@ -1,5 +1,11 @@
 import type Database from "better-sqlite3";
 import type { CacheEntry } from "../types.js";
+import { getSetting } from "./settings.js";
+
+export function getCacheTtl(db: Database.Database): number {
+  const ttl = getSetting(db, "cache_ttl");
+  return ttl ? Number(ttl) : 300;
+}
 
 export function getCached<T>(
   db: Database.Database,
@@ -33,20 +39,15 @@ export function setCached(
   ).run(key, JSON.stringify(data));
 }
 
-export function isFresh(
+export function isFresh(fetchedAt: Date, ttlSeconds: number): boolean {
+  return Date.now() - fetchedAt.getTime() < ttlSeconds * 1000;
+}
+
+export function clearCacheKey(
   db: Database.Database,
   key: string,
-  ttlSeconds: number,
-): boolean {
-  const row = db
-    .prepare("SELECT fetched_at FROM cache WHERE key = ?")
-    .get(key) as { fetched_at: string } | undefined;
-
-  if (!row) return false;
-
-  const fetchedAt = new Date(row.fetched_at + "Z").getTime();
-  const now = Date.now();
-  return now - fetchedAt < ttlSeconds * 1000;
+): void {
+  db.prepare("DELETE FROM cache WHERE key = ?").run(key);
 }
 
 export function clearCache(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,9 +25,11 @@ export {
   updateLinkedPR,
 } from "./db/deployments.js";
 export {
+  getCacheTtl,
   getCached,
   setCached,
   isFresh,
+  clearCacheKey,
   clearCache,
 } from "./db/cache.js";
 
@@ -43,20 +45,10 @@ export type {
 export { getGhToken, checkGhAuth } from "./github/auth.js";
 export { getOctokit, resetOctokit } from "./github/client.js";
 export {
-  listIssues,
-  getIssue,
   createIssue,
   updateIssue,
   closeIssue,
-  getComments,
-  addComment,
 } from "./github/issues.js";
-export {
-  listPulls,
-  getPull,
-  getPullChecks,
-  findLinkedPRs,
-} from "./github/pulls.js";
 export {
   LIFECYCLE_LABEL,
   listLabels,
@@ -64,3 +56,18 @@ export {
   addLabel,
   removeLabel,
 } from "./github/labels.js";
+
+// Cached data layer (SWR)
+export {
+  getIssues,
+  getIssueDetail,
+} from "./data/issues.js";
+export {
+  getPulls,
+  getPullDetail,
+} from "./data/pulls.js";
+export { getDashboardData } from "./data/repos.js";
+export {
+  getComments,
+  addComment,
+} from "./data/comments.js";


### PR DESCRIPTION
## Summary

- Implement stale-while-revalidate data layer composing GitHub client (Phase 2) + SQLite cache (Phase 1)
- All functions accept explicit `db` + `octokit` parameters per project convention
- Background revalidation with `console.warn` logging on failures (not silent)
- `isFresh()` simplified to pure function — no DB dependency, just `(fetchedAt, ttl)`

## Modules

| Module | Functions |
|---|---|
| `data/issues.ts` | `getIssues` (SWR), `getIssueDetail` (SWR + deployments + file path extraction) |
| `data/pulls.ts` | `getPulls` (SWR), `getPullDetail` (checks + linked issue, 404-only catch) |
| `data/repos.ts` | `getDashboardData` (label aggregation, oldest issue age, open counts) |
| `data/comments.ts` | `getComments` (SWR), `addComment` (with exact-key cache invalidation) |
| `data/settings.ts` | Passthrough re-exports from db/settings |
| `db/cache.ts` | Added `getCacheTtl`, `clearCacheKey`, simplified `isFresh` |

## Key fixes from review

- Extracted triplicated `getCacheTtl` to shared location
- Added `clearCacheKey` for exact-match deletion (fixes LIKE semantics bug)
- Replaced `.catch(() => {})` with `console.warn` logging on all background revalidation
- `getPullDetail` catches only 404 on linked issue fetch, logs other errors
- Added missing `labels` and `oldestIssueAge` fields to `getDashboardData`

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] SWR behavior matches plan: fresh → cached, stale → cached + background revalidate, miss → fetch
- [ ] File path extraction regex matches plan patterns