### PR TITLE
chore: add project-wide ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,30 @@ export default tseslint.config(
     ignores: ["**/dist/", "**/.next/", "**/.turbo/"],
   },
   {
+    // Rules for all TypeScript files
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      // Max file length — encourages decomposition into focused modules
+      "max-lines": ["warn", { max: 300, skipBlankLines: true, skipComments: true }],
+
+      // Type safety
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+
+      // Code quality
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "prefer-const": "error",
+      "no-var": "error",
+      eqeqeq: ["error", "always"],
+      curly: ["error", "multi-line"],
+      "no-throw-literal": "error",
+    },
+  },
+  {
+    // Next.js plugin for web package
     files: ["packages/web/**/*.{ts,tsx}"],
     plugins: { "@next/next": nextPlugin },
     rules: { ...nextPlugin.configs.recommended.rules },


### PR DESCRIPTION
## Summary

Add consistent lint rules across all packages, aligned with conventions from seatify and bleep repos.

## Rules added

| Rule | Severity | Purpose |
|---|---|---|
| `max-lines` | warn | 300 lines max per file (excluding blanks/comments) |
| `@typescript-eslint/no-explicit-any` | warn | Flag `any` usage |
| `@typescript-eslint/no-unused-vars` | warn | With `_` prefix ignore pattern |
| `no-console` | warn | Only `console.warn`/`console.error` allowed |
| `prefer-const` | error | Use `const` over `let` when not reassigned |
| `no-var` | error | No `var` declarations |
| `eqeqeq` | error | Strict equality only |
| `curly` | error | Braces required for multi-line blocks |
| `no-throw-literal` | error | Only throw Error objects |

## Notes

- One existing warning: CLI placeholder `console.log("issuectl")` — will be replaced in Phase 4
- All existing code passes with zero errors