### PR TITLE
feat: add CLI commands — init, web, and repo management (Phase 4)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,9 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.5.0",
     "@issuectl/core": "workspace:*",
+    "chalk": "^5.4.1",
     "commander": "^13.1.0"
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -24,8 +24,16 @@ export async function initCommand(): Promise<void> {
     closeDb();
   }
 
-  const db = getDb();
-  seedDefaults(db);
+  let db;
+  try {
+    db = getDb();
+    seedDefaults(db);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`Failed to initialize database: ${message}`);
+    log.info("Check that ~/.issuectl/ is writable and has sufficient disk space.");
+    process.exit(1);
+  }
   log.success("Database created and defaults seeded.");
 
   const addFirst = await confirm({

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,63 @@
+import { confirm, input } from "@inquirer/prompts";
+import { dbExists, getDb, closeDb, seedDefaults, addRepo } from "@issuectl/core";
+import * as log from "../utils/logger.js";
+import { requireAuth } from "../utils/auth.js";
+import { validateOwnerRepo, parseOwnerRepo } from "../utils/validation.js";
+
+export async function initCommand(): Promise<void> {
+  log.banner();
+  console.error("First-time setup\n");
+
+  const { username } = await requireAuth();
+  log.success(`Authenticated as ${username} via gh`);
+
+  if (dbExists()) {
+    const reinit = await confirm({
+      message: "Database already exists. Re-initialize?",
+      default: false,
+    });
+    if (!reinit) {
+      log.info("Keeping existing database.");
+      return;
+    }
+    // Reset the singleton so getDb() creates a fresh connection
+    closeDb();
+  }
+
+  const db = getDb();
+  seedDefaults(db);
+  log.success("Database created and defaults seeded.");
+
+  const addFirst = await confirm({
+    message: "Add your first repository?",
+    default: true,
+  });
+
+  if (addFirst) {
+    const ownerRepo = await input({
+      message: "Repository (owner/name):",
+      validate: validateOwnerRepo,
+    });
+
+    const { owner, name } = parseOwnerRepo(ownerRepo);
+
+    const localPath = await input({
+      message: "Local path (optional, press Enter to skip):",
+      default: `~/Desktop/${name}`,
+    });
+
+    const repo = addRepo(db, {
+      owner,
+      name,
+      localPath: localPath || undefined,
+    });
+
+    log.success(`Added ${repo.owner}/${repo.name}`);
+    if (repo.localPath) {
+      log.info(`Local path: ${repo.localPath}`);
+    }
+  }
+
+  console.error("");
+  log.success("Setup complete. Run `issuectl web` to start the dashboard.");
+}

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -1,0 +1,115 @@
+import { existsSync } from "node:fs";
+import { confirm, input } from "@inquirer/prompts";
+import { addRepo, removeRepo, listRepos, getRepo, updateRepo } from "@issuectl/core";
+import * as log from "../utils/logger.js";
+import { requireDb } from "../utils/db.js";
+import { isValidOwnerRepo, parseOwnerRepo } from "../utils/validation.js";
+
+function requireValidOwnerRepo(value: string): { owner: string; name: string } {
+  if (!isValidOwnerRepo(value)) {
+    log.error("Invalid format. Use: owner/name (e.g., mean-weasel/seatify)");
+    process.exit(1);
+  }
+  return parseOwnerRepo(value);
+}
+
+export async function repoAddCommand(
+  ownerRepo: string,
+  options: { path?: string },
+): Promise<void> {
+  const { owner, name } = requireValidOwnerRepo(ownerRepo);
+  const db = requireDb();
+
+  const existing = getRepo(db, owner, name);
+  if (existing) {
+    log.warn(`${owner}/${name} is already tracked.`);
+    return;
+  }
+
+  let localPath = options.path;
+  if (!localPath) {
+    localPath = await input({
+      message: "Local path (optional, press Enter to skip):",
+      default: "",
+    });
+  }
+
+  if (localPath && !existsSync(localPath)) {
+    log.warn(`Path "${localPath}" does not exist. Saving anyway.`);
+  }
+
+  const repo = addRepo(db, {
+    owner,
+    name,
+    localPath: localPath || undefined,
+  });
+  log.success(`Added ${repo.owner}/${repo.name}`);
+}
+
+export async function repoRemoveCommand(ownerRepo: string): Promise<void> {
+  const { owner, name } = requireValidOwnerRepo(ownerRepo);
+  const db = requireDb();
+  const repo = getRepo(db, owner, name);
+
+  if (!repo) {
+    log.error(`${owner}/${name} is not tracked.`);
+    process.exit(1);
+  }
+
+  const ok = await confirm({
+    message: `Remove ${owner}/${name}?`,
+    default: false,
+  });
+
+  if (!ok) {
+    log.info("Cancelled.");
+    return;
+  }
+
+  removeRepo(db, repo.id);
+  log.success(`Removed ${owner}/${name}`);
+}
+
+export function repoListCommand(): void {
+  const db = requireDb();
+  const repos = listRepos(db);
+
+  if (repos.length === 0) {
+    log.info("No repositories tracked. Run `issuectl repo add` to add one.");
+    return;
+  }
+
+  console.error("");
+  for (const repo of repos) {
+    const path = repo.localPath ?? "(no local path)";
+    const pattern = repo.branchPattern ?? "(default)";
+    console.error(`  ${repo.owner}/${repo.name}`);
+    console.error(`    Path:    ${path}`);
+    console.error(`    Pattern: ${pattern}`);
+    console.error("");
+  }
+}
+
+export async function repoUpdateCommand(
+  ownerRepo: string,
+  options: { path?: string },
+): Promise<void> {
+  const { owner, name } = requireValidOwnerRepo(ownerRepo);
+  const db = requireDb();
+  const repo = getRepo(db, owner, name);
+
+  if (!repo) {
+    log.error(`${owner}/${name} is not tracked.`);
+    process.exit(1);
+  }
+
+  if (options.path) {
+    if (!existsSync(options.path)) {
+      log.warn(`Path "${options.path}" does not exist. Saving anyway.`);
+    }
+    updateRepo(db, repo.id, { localPath: options.path });
+    log.success(`Updated ${owner}/${name} path to ${options.path}`);
+  } else {
+    log.warn("No updates specified. Use --path to update the local path.");
+  }
+}

--- a/packages/cli/src/commands/web.ts
+++ b/packages/cli/src/commands/web.ts
@@ -1,0 +1,52 @@
+import { execFile, spawn } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as log from "../utils/logger.js";
+import { requireDb } from "../utils/db.js";
+import { requireAuth } from "../utils/auth.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getWebPackagePath(): string {
+  // From cli/dist/ → cli/ → packages/ → packages/web/
+  return resolve(__dirname, "..", "..", "web");
+}
+
+export async function webCommand(options: { port: string }): Promise<void> {
+  const port = options.port;
+
+  requireDb();
+  await requireAuth();
+
+  const webPath = getWebPackagePath();
+  const nextBin = resolve(webPath, "node_modules", ".bin", "next");
+
+  log.info(`Starting dashboard on http://localhost:${port}`);
+
+  const child = spawn(nextBin, ["dev", "--turbopack", "--port", port], {
+    cwd: webPath,
+    stdio: "inherit",
+  });
+
+  // Auto-open browser after a short delay (macOS only for v1)
+  setTimeout(() => {
+    execFile("open", [`http://localhost:${port}`], () => {});
+  }, 2000);
+
+  child.on("error", (err) => {
+    log.error(`Failed to start Next.js: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code) => {
+    process.exit(code ?? 0);
+  });
+
+  process.on("SIGINT", () => {
+    child.kill("SIGINT");
+  });
+
+  process.on("SIGTERM", () => {
+    child.kill("SIGTERM");
+  });
+}

--- a/packages/cli/src/commands/web.ts
+++ b/packages/cli/src/commands/web.ts
@@ -30,7 +30,13 @@ export async function webCommand(options: { port: string }): Promise<void> {
 
   // Auto-open browser after a short delay (macOS only for v1)
   setTimeout(() => {
-    execFile("open", [`http://localhost:${port}`], () => {});
+    execFile("open", [`http://localhost:${port}`], (err) => {
+      if (err) {
+        log.warn(
+          `Could not auto-open browser: ${err.message}. Open http://localhost:${port} manually.`,
+        );
+      }
+    });
   }, 2000);
 
   child.on("error", (err) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,55 @@
-console.log("issuectl");
+import { Command } from "commander";
+import { initCommand } from "./commands/init.js";
+import { webCommand } from "./commands/web.js";
+import {
+  repoAddCommand,
+  repoRemoveCommand,
+  repoListCommand,
+  repoUpdateCommand,
+} from "./commands/repo.js";
+
+const program = new Command();
+
+program
+  .name("issuectl")
+  .description("Cross-repo GitHub issue command center")
+  .version("0.1.0");
+
+program
+  .command("init")
+  .description("First-time setup — create database and configure")
+  .action(initCommand);
+
+program
+  .command("web")
+  .description("Start the web dashboard")
+  .option("-p, --port <port>", "Port number", "3847")
+  .action(webCommand);
+
+const repo = program
+  .command("repo")
+  .description("Manage tracked repositories");
+
+repo
+  .command("add <owner/repo>")
+  .description("Add a repository to track")
+  .option("--path <local-path>", "Local filesystem path to the repo")
+  .action(repoAddCommand);
+
+repo
+  .command("remove <owner/repo>")
+  .description("Remove a tracked repository")
+  .action(repoRemoveCommand);
+
+repo
+  .command("list")
+  .description("List all tracked repositories")
+  .action(repoListCommand);
+
+repo
+  .command("update <owner/repo>")
+  .description("Update a tracked repository")
+  .option("--path <local-path>", "New local filesystem path")
+  .action(repoUpdateCommand);
+
+program.parse();

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -1,0 +1,20 @@
+import { checkGhAuth } from "@issuectl/core";
+import * as log from "./logger.js";
+
+export async function requireAuth(): Promise<{ username: string }> {
+  const auth = await checkGhAuth();
+  if (!auth.ok) {
+    log.error("GitHub CLI is not authenticated.");
+    console.error(
+      "\nTo fix this:\n" +
+        "  1. Install the GitHub CLI: https://cli.github.com/\n" +
+        "  2. Run: gh auth login\n" +
+        "  3. Then re-run your command.\n",
+    );
+    if (auth.error) {
+      console.error(`Details: ${auth.error}\n`);
+    }
+    process.exit(1);
+  }
+  return { username: auth.username ?? "unknown" };
+}

--- a/packages/cli/src/utils/auth.ts
+++ b/packages/cli/src/utils/auth.ts
@@ -16,5 +16,8 @@ export async function requireAuth(): Promise<{ username: string }> {
     }
     process.exit(1);
   }
+  if (!auth.username) {
+    log.warn("Could not determine GitHub username. Some features may not work correctly.");
+  }
   return { username: auth.username ?? "unknown" };
 }

--- a/packages/cli/src/utils/db.ts
+++ b/packages/cli/src/utils/db.ts
@@ -1,0 +1,11 @@
+import type Database from "better-sqlite3";
+import { dbExists, getDb } from "@issuectl/core";
+import * as log from "./logger.js";
+
+export function requireDb(): Database.Database {
+  if (!dbExists()) {
+    log.error("No database found. Run `issuectl init` first.");
+    process.exit(1);
+  }
+  return getDb();
+}

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -1,0 +1,21 @@
+import chalk from "chalk";
+
+export function banner(): void {
+  console.error(chalk.bold("issuectl v0.1.0"));
+}
+
+export function success(message: string): void {
+  console.error(chalk.green("✓") + " " + message);
+}
+
+export function info(message: string): void {
+  console.error(chalk.blue("ℹ") + " " + message);
+}
+
+export function warn(message: string): void {
+  console.error(chalk.yellow("⚠") + " " + message);
+}
+
+export function error(message: string): void {
+  console.error(chalk.red("✗") + " " + message);
+}

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -1,0 +1,14 @@
+const OWNER_REPO_PATTERN = /^[\w.-]+\/[\w.-]+$/;
+
+export function isValidOwnerRepo(value: string): boolean {
+  return OWNER_REPO_PATTERN.test(value);
+}
+
+export function parseOwnerRepo(value: string): { owner: string; name: string } {
+  const [owner, name] = value.split("/");
+  return { owner, name };
+}
+
+export function validateOwnerRepo(value: string): true | string {
+  return isValidOwnerRepo(value) || "Format: owner/name (e.g., mean-weasel/seatify)";
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,15 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^7.5.0
+        version: 7.10.1(@types/node@22.19.17)
       '@issuectl/core':
         specifier: workspace:*
         version: link:../core
+      chalk:
+        specifier: ^5.4.1
+        version: 5.6.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -436,6 +442,140 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -820,6 +960,14 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -866,6 +1014,13 @@ packages:
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -873,8 +1028,19 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -921,6 +1087,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1057,6 +1226,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1081,6 +1254,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1161,6 +1338,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -1336,6 +1517,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1356,6 +1540,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -1370,8 +1558,16 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -1502,12 +1698,20 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -1735,6 +1939,131 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/core@10.3.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/editor@4.2.23(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/number@3.0.23(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/password@4.0.23(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.17)
+      '@inquirer/input': 4.3.1(@types/node@22.19.17)
+      '@inquirer/number': 3.0.23(@types/node@22.19.17)
+      '@inquirer/password': 4.0.23(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.17)
+      '@inquirer/search': 3.2.2(@types/node@22.19.17)
+      '@inquirer/select': 4.4.2(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/search@3.2.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/select@4.4.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@3.0.10(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2078,6 +2407,12 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   any-promise@1.3.0: {}
 
   balanced-match@4.0.4: {}
@@ -2123,13 +2458,25 @@ snapshots:
 
   caniuse-lite@1.0.30001786: {}
 
+  chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   commander@13.1.0: {}
 
@@ -2160,6 +2507,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
+
+  emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2331,6 +2680,10 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -2344,6 +2697,8 @@ snapshots:
   ini@1.3.8: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2411,6 +2766,8 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -2597,6 +2954,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   semver@7.7.4: {}
@@ -2639,6 +2998,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -2651,9 +3012,19 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -2792,6 +3163,14 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}


### PR DESCRIPTION
## Summary

- Implement `issuectl init` — first-time setup with gh auth check, DB creation, default seeding, interactive repo add
- Implement `issuectl web` — start Next.js dashboard with DB/auth checks, auto-open browser
- Implement `issuectl repo add/remove/list/update` — manage tracked repositories
- Add shared utilities: requireAuth, requireDb, owner/repo validation, styled logger

## Key design decisions

- **stderr for status output**: all CLI messages go to stderr via `console.error`, keeping stdout clean for piping
- **Shared helpers**: extracted common patterns (auth check, DB check, validation) to `utils/` after code review
- **Re-init safety**: `issuectl init` calls `closeDb()` before re-creating when user confirms re-initialization
- **macOS only for v1**: browser auto-open uses `open` command per spec

## Files

| File | Purpose |
|---|---|
| `cli/src/index.ts` | Commander program with 3 commands + repo subcommands |
| `cli/src/commands/init.ts` | First-time setup flow |
| `cli/src/commands/web.ts` | Start Next.js dev server |
| `cli/src/commands/repo.ts` | Repository CRUD subcommands |
| `cli/src/utils/auth.ts` | Shared `requireAuth()` |
| `cli/src/utils/db.ts` | Shared `requireDb()` |
| `cli/src/utils/validation.ts` | Owner/repo format validation |
| `cli/src/utils/logger.ts` | Chalk-based styled output |

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] `node packages/cli/dist/index.js --help` shows all commands
- [ ] `node packages/cli/dist/index.js repo --help` shows subcommands