### PR TITLE
feat: add web dashboard with sidebar, repo cards, and SWR refresh (Phase 5)

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -43,9 +43,43 @@
 }
 
 body {
-  font-family: "Karla", system-ui, sans-serif;
   background: var(--bg-base);
   color: var(--text-primary);
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
+}
+
+/* Noise texture overlay */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0.015;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 256px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-accent);
 }

--- a/packages/web/app/layout.module.css
+++ b/packages/web/app/layout.module.css
@@ -1,0 +1,11 @@
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,6 +1,24 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Karla, Syne, Source_Code_Pro } from "next/font/google";
+import { Sidebar } from "@/components/sidebar/Sidebar";
 import "./globals.css";
+import styles from "./layout.module.css";
+
+const karla = Karla({
+  subsets: ["latin"],
+  variable: "--font-karla",
+});
+
+const syne = Syne({
+  subsets: ["latin"],
+  variable: "--font-display",
+});
+
+const sourceCodePro = Source_Code_Pro({
+  subsets: ["latin"],
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "issuectl",
@@ -13,8 +31,13 @@ type Props = {
 
 export default function RootLayout({ children }: Props) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
+      <body className={karla.className}>
+        <div className={styles.app}>
+          <Sidebar />
+          <main className={styles.content}>{children}</main>
+        </div>
+      </body>
     </html>
   );
 }

--- a/packages/web/app/loading.module.css
+++ b/packages/web/app/loading.module.css
@@ -1,0 +1,55 @@
+.skeleton {
+  padding: 20px 32px 32px;
+}
+
+.headerSkeleton {
+  padding: 24px 32px 0;
+  margin-bottom: 16px;
+}
+
+.titleBar {
+  height: 32px;
+  width: 220px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.cacheBarSkeleton {
+  height: 32px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+
+.cardSkeleton {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  height: 160px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.cardSkeleton:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.cardSkeleton:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/packages/web/app/loading.tsx
+++ b/packages/web/app/loading.tsx
@@ -1,0 +1,19 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <>
+      <div className={styles.headerSkeleton}>
+        <div className={styles.titleBar} />
+      </div>
+      <div className={styles.cacheBarSkeleton} />
+      <div className={styles.skeleton}>
+        <div className={styles.grid}>
+          <div className={styles.cardSkeleton} />
+          <div className={styles.cardSkeleton} />
+          <div className={styles.cardSkeleton} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,3 +1,39 @@
-export default function Home() {
-  return <h1>issuectl</h1>;
+import { getDb, getOctokit, getDashboardData } from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { RepoGrid } from "@/components/dashboard/RepoGrid";
+import { CacheBar } from "@/components/dashboard/CacheBar";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  let data;
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    data = await getDashboardData(db, octokit);
+  } catch (err) {
+    // DB or auth may not be initialized — show empty state
+    console.error("[issuectl] Dashboard data fetch failed:", err);
+    data = { repos: [], totalIssues: 0, totalPRs: 0, cachedAt: null };
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={
+          <>
+            <span style={{ color: "var(--accent)" }}>{data.repos.length}</span>{" "}
+            {data.repos.length === 1 ? "Repository" : "Repositories"}
+          </>
+        }
+      />
+      <CacheBar
+        cachedAt={data.cachedAt?.toISOString() ?? null}
+        totalIssues={data.totalIssues}
+        totalPRs={data.totalPRs}
+      />
+      <RepoGrid repos={data.repos} />
+    </>
+  );
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,4 +1,4 @@
-import { getDb, getOctokit, getDashboardData } from "@issuectl/core";
+import { getDb, getOctokit, getDashboardData, dbExists } from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { RepoGrid } from "@/components/dashboard/RepoGrid";
 import { CacheBar } from "@/components/dashboard/CacheBar";
@@ -6,14 +6,24 @@ import { CacheBar } from "@/components/dashboard/CacheBar";
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
+  // Not initialized — show genuine empty state
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Getting Started" />
+        <RepoGrid repos={[]} />
+      </>
+    );
+  }
+
+  const db = getDb();
   let data;
 
   try {
-    const db = getDb();
     const octokit = await getOctokit();
     data = await getDashboardData(db, octokit);
   } catch (err) {
-    // DB or auth may not be initialized — show empty state
+    // Auth or API failure — log and show empty state with error context
     console.error("[issuectl] Dashboard data fetch failed:", err);
     data = { repos: [], totalIssues: 0, totalPRs: 0, cachedAt: null };
   }

--- a/packages/web/components/dashboard/CacheBar.module.css
+++ b/packages/web/components/dashboard/CacheBar.module.css
@@ -1,0 +1,38 @@
+.bar {
+  padding: 8px 32px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: var(--font-mono), monospace;
+}
+
+.dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--green);
+}
+
+.refreshLink {
+  color: var(--accent);
+  cursor: pointer;
+  margin-left: auto;
+  font-family: inherit;
+  background: none;
+  border: none;
+  font-size: 11px;
+  padding: 0;
+}
+
+.refreshLink:hover {
+  text-decoration: underline;
+}
+
+.refreshLink:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  text-decoration: none;
+}

--- a/packages/web/components/dashboard/CacheBar.tsx
+++ b/packages/web/components/dashboard/CacheBar.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useTransition } from "react";
+import { refreshDashboard } from "@/lib/actions/refresh";
+import styles from "./CacheBar.module.css";
+
+type Props = {
+  cachedAt: string | null;
+  totalIssues: number;
+  totalPRs: number;
+};
+
+function formatAge(dateStr: string | null): string {
+  if (!dateStr) return "not cached";
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes === 1) return "1 minute ago";
+  return `${minutes} minutes ago`;
+}
+
+export function CacheBar({ cachedAt, totalIssues, totalPRs }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleRefresh() {
+    startTransition(async () => {
+      await refreshDashboard();
+    });
+  }
+
+  return (
+    <div className={styles.bar}>
+      <span className={styles.dot} />
+      <span>
+        cached {formatAge(cachedAt)} &middot; {totalIssues} issues &middot;{" "}
+        {totalPRs} PRs
+      </span>
+      <button
+        className={styles.refreshLink}
+        onClick={handleRefresh}
+        disabled={isPending}
+      >
+        {isPending ? "refreshing..." : "refresh now"}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/components/dashboard/RepoCard.module.css
+++ b/packages/web/components/dashboard/RepoCard.module.css
@@ -1,0 +1,117 @@
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  position: relative;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.card:hover {
+  border-color: var(--border-accent);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.name {
+  font-family: var(--font-display), sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.3px;
+}
+
+.org {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+  font-family: var(--font-mono), monospace;
+}
+
+.stats {
+  display: flex;
+  gap: 16px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statValue {
+  font-family: var(--font-display), sans-serif;
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -1px;
+}
+
+.statLabel {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.bar {
+  display: flex;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.barSegment {
+  height: 100%;
+  border-radius: 2px;
+}
+
+.tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border);
+}

--- a/packages/web/components/dashboard/RepoCard.tsx
+++ b/packages/web/components/dashboard/RepoCard.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import type { RepoWithStats } from "@/lib/types";
+import { REPO_COLORS } from "@/lib/constants";
+import styles from "./RepoCard.module.css";
+
+type Props = {
+  repo: RepoWithStats;
+  index: number;
+};
+
+const LABEL_COLORS: Record<string, string> = {
+  bug: "var(--red)",
+  enhancement: "var(--purple)",
+};
+
+export function RepoCard({ repo, index }: Props) {
+  const color = REPO_COLORS[index % REPO_COLORS.length];
+  const totalLabeled = repo.labels.reduce((sum, l) => sum + l.count, 0);
+  const unlabeled = Math.max(0, repo.issueCount - totalLabeled);
+
+  return (
+    <Link
+      href={`/${repo.owner}/${repo.name}`}
+      className={styles.card}
+    >
+      <div className={styles.header}>
+        <span className={styles.dot} style={{ background: color }} />
+        <span className={styles.name}>{repo.name}</span>
+        <span className={styles.org}>{repo.owner}</span>
+      </div>
+
+      <div className={styles.stats}>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>{repo.issueCount}</span>
+          <span className={styles.statLabel}>Issues</span>
+        </div>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>{repo.prCount}</span>
+          <span className={styles.statLabel}>PRs</span>
+        </div>
+        <div className={styles.stat}>
+          <span
+            className={styles.statValue}
+            style={{
+              color: repo.deployedCount > 0 ? "var(--yellow)" : "var(--text-tertiary)",
+            }}
+          >
+            {repo.deployedCount}
+          </span>
+          <span className={styles.statLabel}>Deployed</span>
+        </div>
+      </div>
+
+      {repo.issueCount > 0 && (
+        <div className={styles.bar}>
+          {repo.labels.map((l) => (
+            <span
+              key={l.name}
+              className={styles.barSegment}
+              style={{
+                flex: l.count,
+                background: LABEL_COLORS[l.name.toLowerCase()] ?? "var(--text-tertiary)",
+              }}
+            />
+          ))}
+          {unlabeled > 0 && (
+            <span
+              className={styles.barSegment}
+              style={{ flex: unlabeled, background: "var(--text-tertiary)" }}
+            />
+          )}
+        </div>
+      )}
+
+      <div className={styles.tags}>
+        {repo.labels.slice(0, 3).map((l) => (
+          <span key={l.name} className={styles.tag}>
+            {l.count} {l.name}
+          </span>
+        ))}
+        {unlabeled > 0 && (
+          <span className={styles.tag}>{unlabeled} unlabeled</span>
+        )}
+        {repo.oldestIssueAge > 0 && (
+          <span className={styles.tag}>oldest: {repo.oldestIssueAge}d</span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/packages/web/components/dashboard/RepoGrid.module.css
+++ b/packages/web/components/dashboard/RepoGrid.module.css
@@ -1,0 +1,30 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+  padding: 20px 32px 32px;
+}
+
+.empty {
+  padding: 60px 32px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}
+
+.emptyTitle {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.emptyLink {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.emptyLink:hover {
+  text-decoration: underline;
+}

--- a/packages/web/components/dashboard/RepoGrid.tsx
+++ b/packages/web/components/dashboard/RepoGrid.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import type { RepoWithStats } from "@/lib/types";
+import { RepoCard } from "./RepoCard";
+import styles from "./RepoGrid.module.css";
+
+type Props = {
+  repos: RepoWithStats[];
+};
+
+export function RepoGrid({ repos }: Props) {
+  if (repos.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyTitle}>No repositories tracked</div>
+        <p>
+          Run <code>issuectl repo add</code> or go to{" "}
+          <Link href="/settings" className={styles.emptyLink}>
+            Settings
+          </Link>{" "}
+          to add your first repository.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.grid}>
+      {repos.map((repo, i) => (
+        <RepoCard key={`${repo.owner}/${repo.name}`} repo={repo} index={i} />
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/sidebar/Sidebar.module.css
+++ b/packages/web/components/sidebar/Sidebar.module.css
@@ -1,0 +1,182 @@
+.sidebar {
+  width: 260px;
+  min-width: 260px;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.logo {
+  padding: 20px 20px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.logoMark {
+  width: 28px;
+  height: 28px;
+  background: var(--accent);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono), monospace;
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--text-inverse);
+  letter-spacing: -1px;
+}
+
+.logoText {
+  font-family: var(--font-display), sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.5px;
+}
+
+.logoVersion {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono), monospace;
+  background: var(--bg-elevated);
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: auto;
+}
+
+.nav {
+  padding: 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: var(--radius-md);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.navItem:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.navItemActive {
+  composes: navItem;
+  background: var(--accent-surface);
+  color: var(--accent);
+}
+
+.navIcon {
+  width: 18px;
+  text-align: center;
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.navItemActive .navIcon {
+  opacity: 1;
+}
+
+.navBadge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-mono), monospace;
+  min-width: 22px;
+  text-align: center;
+}
+
+.divider {
+  height: 1px;
+  background: var(--border);
+  margin: 8px 10px;
+}
+
+.sectionTitle {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--text-tertiary);
+  padding: 12px 14px 6px;
+}
+
+.repos {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.repoItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.repoItem:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.repoDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.repoLabel {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repoCount {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-mono), monospace;
+  color: var(--text-tertiary);
+}
+
+.footer {
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.authDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+}

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -30,17 +30,15 @@ export async function Sidebar() {
         totalPRs += cached.data.filter((p) => p.state === "open").length;
       }
     }
-  } catch {
+  } catch (err) {
     // DB may not exist yet (first run before init)
+    console.warn("[issuectl] Sidebar failed to load repos:", err);
   }
 
-  try {
-    const auth = await checkGhAuth();
-    if (auth.ok && auth.username) {
-      username = auth.username;
-    }
-  } catch {
-    // Auth check may fail
+  // checkGhAuth returns errors as values — no try-catch needed
+  const auth = await checkGhAuth();
+  if (auth.ok && auth.username) {
+    username = auth.username;
   }
 
   return (

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { getDb, listRepos, checkGhAuth, getCached } from "@issuectl/core";
+import type { GitHubIssue, GitHubPull } from "@issuectl/core";
+import { REPO_COLORS } from "@/lib/constants";
+import { SidebarRepoList } from "./SidebarRepoList";
+import styles from "./Sidebar.module.css";
+
+export async function Sidebar() {
+  let repos: Array<{ owner: string; name: string; issueCount: number }> = [];
+  let username = "unknown";
+  let totalIssues = 0;
+  let totalPRs = 0;
+
+  try {
+    const db = getDb();
+    const dbRepos = listRepos(db);
+    repos = dbRepos.map((r) => {
+      const cached = getCached<GitHubIssue[]>(db, `issues:${r.owner}/${r.name}`);
+      const openCount = cached
+        ? cached.data.filter((i) => i.state === "open").length
+        : 0;
+      return { owner: r.owner, name: r.name, issueCount: openCount };
+    });
+    totalIssues = repos.reduce((sum, r) => sum + r.issueCount, 0);
+
+    // Get PR counts from cache
+    for (const r of dbRepos) {
+      const cached = getCached<GitHubPull[]>(db, `pulls:${r.owner}/${r.name}`);
+      if (cached) {
+        totalPRs += cached.data.filter((p) => p.state === "open").length;
+      }
+    }
+  } catch {
+    // DB may not exist yet (first run before init)
+  }
+
+  try {
+    const auth = await checkGhAuth();
+    if (auth.ok && auth.username) {
+      username = auth.username;
+    }
+  } catch {
+    // Auth check may fail
+  }
+
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.logo}>
+        <div className={styles.logoMark}>ic</div>
+        <span className={styles.logoText}>issuectl</span>
+        <span className={styles.logoVersion}>v0.1.0</span>
+      </div>
+
+      <nav className={styles.nav}>
+        <Link href="/" className={styles.navItemActive}>
+          <span className={styles.navIcon}>&bull;</span>
+          Dashboard
+        </Link>
+        <Link href="/" className={styles.navItem}>
+          <span className={styles.navIcon}>&rarr;</span>
+          Issues
+          {totalIssues > 0 && (
+            <span className={styles.navBadge}>{totalIssues}</span>
+          )}
+        </Link>
+        <Link href="/" className={styles.navItem}>
+          <span className={styles.navIcon}>&uarr;</span>
+          Pull Requests
+          {totalPRs > 0 && (
+            <span className={styles.navBadge}>{totalPRs}</span>
+          )}
+        </Link>
+        <Link href="/settings" className={styles.navItem}>
+          <span className={styles.navIcon}>&#9881;</span>
+          Settings
+        </Link>
+      </nav>
+
+      <div className={styles.divider} />
+      <div className={styles.sectionTitle}>Repositories</div>
+
+      <SidebarRepoList repos={repos} colors={REPO_COLORS} />
+
+      <div className={styles.footer}>
+        <span className={styles.authDot} />
+        <span>{username} via gh auth</span>
+      </div>
+    </aside>
+  );
+}

--- a/packages/web/components/sidebar/SidebarRepoList.tsx
+++ b/packages/web/components/sidebar/SidebarRepoList.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import styles from "./Sidebar.module.css";
+
+type Props = {
+  repos: Array<{ owner: string; name: string; issueCount: number }>;
+  colors: string[];
+};
+
+export function SidebarRepoList({ repos, colors }: Props) {
+  if (repos.length === 0) {
+    return (
+      <div className={styles.repos}>
+        <div style={{ padding: "8px 12px", fontSize: "12px", color: "var(--text-tertiary)" }}>
+          No repositories tracked
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.repos}>
+      {repos.map((repo, i) => (
+        <Link
+          key={`${repo.owner}/${repo.name}`}
+          href={`/${repo.owner}/${repo.name}`}
+          className={styles.repoItem}
+        >
+          <span
+            className={styles.repoDot}
+            style={{ background: colors[i % colors.length] }}
+          />
+          <span className={styles.repoLabel}>{repo.name}</span>
+          {repo.issueCount > 0 && (
+            <span className={styles.repoCount}>{repo.issueCount}</span>
+          )}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/ui/Badge.module.css
+++ b/packages/web/components/ui/Badge.module.css
@@ -1,0 +1,9 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}

--- a/packages/web/components/ui/Badge.tsx
+++ b/packages/web/components/ui/Badge.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties } from "react";
+import { cn } from "@/lib/cn";
+import styles from "./Badge.module.css";
+
+type Props = {
+  label: string;
+  color?: string;
+  className?: string;
+};
+
+function labelColor(name: string, hexColor?: string): CSSProperties {
+  const lower = name.toLowerCase();
+  if (lower === "bug") {
+    return { background: "var(--red-surface)", color: "var(--red)" };
+  }
+  if (lower === "enhancement") {
+    return { background: "var(--purple-surface)", color: "var(--purple)" };
+  }
+  if (lower.startsWith("issuectl:deployed")) {
+    return {
+      background: "var(--yellow-surface)",
+      color: "var(--yellow)",
+      border: "1px solid var(--yellow-border)",
+    };
+  }
+  if (lower.startsWith("issuectl:pr-open")) {
+    return {
+      background: "var(--blue-surface)",
+      color: "var(--blue)",
+      border: "1px solid var(--blue-border)",
+    };
+  }
+  if (lower.startsWith("issuectl:done")) {
+    return {
+      background: "var(--green-surface)",
+      color: "var(--green)",
+      border: "1px solid var(--green-border)",
+    };
+  }
+  if (hexColor) {
+    return {
+      background: `#${hexColor}18`,
+      color: `#${hexColor}`,
+    };
+  }
+  return {
+    background: "var(--bg-elevated)",
+    color: "var(--text-tertiary)",
+    border: "1px solid var(--border)",
+  };
+}
+
+export function Badge({ label, color, className }: Props) {
+  const style = labelColor(label, color);
+  return (
+    <span className={cn(styles.badge, className)} style={style}>
+      {label}
+    </span>
+  );
+}

--- a/packages/web/components/ui/Button.module.css
+++ b/packages/web/components/ui/Button.module.css
@@ -1,0 +1,66 @@
+.btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.secondary {
+  composes: btn;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.secondary:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+.primary {
+  composes: btn;
+  background: var(--accent);
+  color: var(--text-inverse);
+  border: none;
+  font-weight: 600;
+}
+
+.primary:hover {
+  background: var(--accent-hover);
+}
+
+.ghost {
+  composes: btn;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.ghost:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.launch {
+  composes: btn;
+  background: linear-gradient(135deg, var(--accent) 0%, #d05e18 100%);
+  color: var(--text-inverse);
+  border: none;
+  font-weight: 600;
+  box-shadow: 0 0 20px rgba(232, 113, 37, 0.15);
+  padding: 8px 18px;
+}
+
+.launch:hover {
+  box-shadow: 0 0 28px rgba(232, 113, 37, 0.25);
+  transform: translateY(-1px);
+}

--- a/packages/web/components/ui/Button.tsx
+++ b/packages/web/components/ui/Button.tsx
@@ -1,0 +1,22 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/cn";
+import styles from "./Button.module.css";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "ghost" | "launch";
+  children: ReactNode;
+};
+
+export function Button({
+  variant = "secondary",
+  children,
+  className,
+  ...rest
+}: Props) {
+  const cls = cn(styles[variant], className);
+  return (
+    <button className={cls} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/packages/web/components/ui/PageHeader.module.css
+++ b/packages/web/components/ui/PageHeader.module.css
@@ -1,0 +1,47 @@
+.header {
+  padding: 24px 32px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.title {
+  font-family: var(--font-display), sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.breadcrumb a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.breadcrumb a:hover {
+  color: var(--text-primary);
+}

--- a/packages/web/components/ui/PageHeader.tsx
+++ b/packages/web/components/ui/PageHeader.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import styles from "./PageHeader.module.css";
+
+type Props = {
+  title: ReactNode;
+  actions?: ReactNode;
+  breadcrumb?: ReactNode;
+};
+
+export function PageHeader({ title, actions, breadcrumb }: Props) {
+  return (
+    <div className={styles.header}>
+      {breadcrumb && <div className={styles.breadcrumb}>{breadcrumb}</div>}
+      <div className={styles.titleRow}>
+        <h1 className={styles.title}>{title}</h1>
+        {actions && <div className={styles.actions}>{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getDb, getOctokit, getDashboardData } from "@issuectl/core";
+
+export async function refreshDashboard(): Promise<void> {
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    await getDashboardData(db, octokit, { forceRefresh: true });
+  } catch (err) {
+    console.error("[issuectl] Dashboard refresh failed:", err);
+  }
+  revalidatePath("/");
+}

--- a/packages/web/lib/cn.ts
+++ b/packages/web/lib/cn.ts
@@ -1,0 +1,5 @@
+export function cn(
+  ...classes: (string | undefined | false | null)[]
+): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/packages/web/lib/constants.ts
+++ b/packages/web/lib/constants.ts
@@ -1,0 +1,9 @@
+export const REPO_COLORS = [
+  "#f85149",
+  "#58a6ff",
+  "#3fb950",
+  "#bc8cff",
+  "#d29922",
+  "#39d0d6",
+  "#e87125",
+];

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -1,0 +1,9 @@
+import type { Repo } from "@issuectl/core";
+
+export type RepoWithStats = Repo & {
+  issueCount: number;
+  prCount: number;
+  deployedCount: number;
+  labels: Array<{ name: string; count: number }>;
+  oldestIssueAge: number;
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint app/",
+    "lint": "eslint app/ components/ lib/",
     "dev": "next dev --port 3847"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

First real web UI — the main dashboard page with full mockup fidelity.

- **Sidebar**: logo, nav items (Dashboard/Issues/PRs/Settings) with aggregate counts from cache, per-repo issue counts, auth footer
- **Dashboard page**: Server Component with repo cards showing stats, proportional label bars, and oldest issue age
- **Repo cards**: hover effects, accent stripe, stat values in Syne display font
- **CacheBar**: shows cache age + totals, "refresh now" button calls forceRefresh server action
- **Loading skeleton**: staggered pulse animations matching page structure
- **Shared utilities**: `cn()`, `REPO_COLORS`, `RepoWithStats` type

## Design fidelity

- Three Google Fonts via `next/font`: Karla (body), Syne (display/headings), Source Code Pro (monospace)
- CSS Modules with full design token set from mockup
- Noise texture overlay, custom scrollbar, hover states
- Empty state with setup instructions when no repos tracked

## Architecture

- Server Components for all data reads (dashboard page, sidebar)
- Single Client Component: `CacheBar` (needs `useTransition` for refresh UX)
- Server Action: `refreshDashboard` calls `getDashboardData` with `forceRefresh: true` then `revalidatePath`
- `dynamic = "force-dynamic"` — appropriate since data is user-specific + time-sensitive

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] Dashboard renders repo cards with stats from getDashboardData
- [ ] Sidebar shows nav items with counts, repo list with colors
- [ ] Loading skeleton displays while data fetches
- [ ] Empty state renders when no repos configured