### PR TITLE
feat: add repo detail page with Issues + PRs tables (Phase 6)

### DIFF
--- a/packages/web/app/[owner]/[repo]/loading.module.css
+++ b/packages/web/app/[owner]/[repo]/loading.module.css
@@ -1,0 +1,74 @@
+.skeleton {
+  padding: 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.breadcrumb {
+  height: 14px;
+  width: 180px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.titleBar {
+  height: 32px;
+  width: 200px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  animation: pulse 1.5s ease-in-out infinite;
+  animation-delay: 0.1s;
+}
+
+.tabsBar {
+  height: 40px;
+  border-bottom: 1px solid var(--border);
+  animation: pulse 1.5s ease-in-out infinite;
+  animation-delay: 0.2s;
+}
+
+.toolbarBar {
+  height: 36px;
+  width: 320px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  animation: pulse 1.5s ease-in-out infinite;
+  animation-delay: 0.3s;
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.row {
+  height: 56px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.row:nth-child(2) {
+  animation-delay: 0.1s;
+}
+
+.row:nth-child(3) {
+  animation-delay: 0.2s;
+}
+
+.row:nth-child(4) {
+  animation-delay: 0.3s;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/packages/web/app/[owner]/[repo]/loading.tsx
+++ b/packages/web/app/[owner]/[repo]/loading.tsx
@@ -1,0 +1,17 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.skeleton}>
+      <div className={styles.breadcrumb} />
+      <div className={styles.titleBar} />
+      <div className={styles.tabsBar} />
+      <div className={styles.toolbarBar} />
+      <div className={styles.rows}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className={styles.row} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/[owner]/[repo]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/page.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from "react";
+import { getDb, getOctokit, getIssues, getPulls } from "@issuectl/core";
+import { RepoHeader } from "@/components/repo/RepoHeader";
+import { TabBar } from "@/components/repo/TabBar";
+import { IssuesTable } from "@/components/repo/IssuesTable";
+import { PullsTable } from "@/components/repo/PullsTable";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ owner: string; repo: string }>;
+  searchParams: Promise<{ tab?: string }>;
+};
+
+export default async function RepoDetailPage({ params, searchParams }: Props) {
+  const { owner, repo } = await params;
+  const { tab } = await searchParams;
+  const activeTab = tab === "prs" ? "prs" : "issues";
+
+  let issues: Awaited<ReturnType<typeof getIssues>>["issues"] = [];
+  let pulls: Awaited<ReturnType<typeof getPulls>>["pulls"] = [];
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    const [issueResult, pullResult] = await Promise.all([
+      getIssues(db, octokit, owner, repo),
+      getPulls(db, octokit, owner, repo),
+    ]);
+    issues = issueResult.issues;
+    pulls = pullResult.pulls;
+  } catch (err) {
+    console.error(`[issuectl] Failed to load data for ${owner}/${repo}:`, err);
+  }
+
+  return (
+    <>
+      <RepoHeader owner={owner} repo={repo} />
+      <Suspense>
+        <TabBar issueCount={issues.length} prCount={pulls.length} />
+      </Suspense>
+      {activeTab === "issues" ? (
+        <IssuesTable issues={issues} owner={owner} repo={repo} />
+      ) : (
+        <PullsTable pulls={pulls} owner={owner} repo={repo} />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/repo/IssuesTable.module.css
+++ b/packages/web/components/repo/IssuesTable.module.css
@@ -1,0 +1,156 @@
+.container {
+  flex: 1;
+  padding: 0 32px 32px;
+  overflow-y: auto;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 0;
+  position: sticky;
+  top: 0;
+  background: var(--bg-base);
+  z-index: 10;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  padding: 10px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.table tbody td {
+  padding: 12px 12px;
+  font-size: 13.5px;
+  vertical-align: middle;
+}
+
+.issueCell {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.stateDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+
+.open {
+  background: var(--green);
+}
+
+.closed {
+  background: var(--red);
+}
+
+.issueInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.issueTitle {
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 480px;
+}
+
+.issueSubtitle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.num {
+  font-family: var(--font-mono), monospace;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.labelsCell {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.ageCell {
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.actionCell {
+  display: flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.table tbody tr:hover .actionCell {
+  opacity: 1;
+}
+
+.launchBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-surface);
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 0 10px;
+  height: 30px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.launchBtn:hover {
+  background: var(--accent);
+  color: var(--text-inverse);
+}
+
+.empty {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}

--- a/packages/web/components/repo/IssuesTable.tsx
+++ b/packages/web/components/repo/IssuesTable.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { GitHubIssue } from "@issuectl/core";
+import { Badge } from "@/components/ui/Badge";
+import { LifecycleIndicator } from "@/components/ui/LifecycleIndicator";
+import { SearchInput } from "@/components/ui/SearchInput";
+import { FilterChips } from "@/components/ui/FilterChips";
+import { daysSince } from "@/lib/format";
+import styles from "./IssuesTable.module.css";
+
+type Props = {
+  issues: GitHubIssue[];
+  owner: string;
+  repo: string;
+};
+
+const FILTERS = ["All", "bug", "enhancement", "deployed"];
+
+function hasLabel(issue: GitHubIssue, name: string): boolean {
+  return issue.labels.some(
+    (l) => l.name.toLowerCase() === name.toLowerCase(),
+  );
+}
+
+export function IssuesTable({ issues, owner, repo }: Props) {
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState("All");
+
+  const filtered = issues
+    .filter((issue) => {
+      if (filter !== "All") {
+        if (filter === "deployed") {
+          return hasLabel(issue, "issuectl:deployed");
+        }
+        return hasLabel(issue, filter);
+      }
+      return true;
+    })
+    .filter((issue) => {
+      if (!search) return true;
+      const q = search.toLowerCase();
+      return (
+        issue.title.toLowerCase().includes(q) ||
+        `#${issue.number}`.includes(q)
+      );
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+
+  const isDeployed = (issue: GitHubIssue) =>
+    hasLabel(issue, "issuectl:deployed");
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter issues..."
+        />
+        <FilterChips options={FILTERS} active={filter} onChange={setFilter} />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className={styles.empty}>No issues match your filters.</div>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Issue</th>
+              <th>Labels</th>
+              <th>Lifecycle</th>
+              <th>Age</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((issue) => (
+              <tr key={issue.number}>
+                <td>
+                  <Link
+                    href={`/${owner}/${repo}/issues/${issue.number}`}
+                    className={styles.issueCell}
+                  >
+                    <span
+                      className={`${styles.stateDot} ${issue.state === "open" ? styles.open : styles.closed}`}
+                    />
+                    <div className={styles.issueInfo}>
+                      <span className={styles.issueTitle}>{issue.title}</span>
+                      <span className={styles.issueSubtitle}>
+                        <span className={styles.num}>#{issue.number}</span>
+                        opened {daysSince(issue.createdAt)} ago
+                      </span>
+                    </div>
+                  </Link>
+                </td>
+                <td>
+                  <div className={styles.labelsCell}>
+                    {issue.labels
+                      .filter((l) => !l.name.startsWith("issuectl:"))
+                      .map((l) => (
+                        <Badge
+                          key={l.name}
+                          label={l.name}
+                          color={l.color}
+                        />
+                      ))}
+                  </div>
+                </td>
+                <td>
+                  <LifecycleIndicator labels={issue.labels} />
+                </td>
+                <td className={styles.ageCell}>
+                  {daysSince(issue.updatedAt)}
+                </td>
+                <td>
+                  <div className={styles.actionCell}>
+                    <button className={styles.launchBtn}>
+                      {isDeployed(issue) ? "Re-launch" : "Launch"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/repo/PullsTable.module.css
+++ b/packages/web/components/repo/PullsTable.module.css
@@ -1,0 +1,175 @@
+.container {
+  flex: 1;
+  padding: 0 32px 32px;
+  overflow-y: auto;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 0;
+  position: sticky;
+  top: 0;
+  background: var(--bg-base);
+  z-index: 10;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  padding: 10px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.table tbody tr {
+  cursor: pointer;
+  transition: background 0.1s;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.table tbody td {
+  padding: 12px 12px;
+  font-size: 13.5px;
+  vertical-align: middle;
+}
+
+.prCell {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.stateDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+
+.open {
+  background: var(--green);
+}
+
+.merged {
+  background: var(--purple);
+}
+
+.closed {
+  background: var(--red);
+}
+
+.prInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.prTitle {
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 480px;
+}
+
+.prSubtitle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.num {
+  font-family: var(--font-mono), monospace;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.statusOpen {
+  composes: statusBadge;
+  background: var(--green-surface);
+  color: var(--green);
+  border: 1px solid var(--green-border);
+}
+
+.statusMerged {
+  composes: statusBadge;
+  background: var(--purple-surface);
+  color: var(--purple);
+  border: 1px solid rgba(188, 140, 255, 0.2);
+}
+
+.statusClosed {
+  composes: statusBadge;
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border);
+}
+
+.linkedIssue {
+  color: var(--blue);
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+}
+
+.changes {
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+  display: flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.plus {
+  color: var(--green);
+  font-weight: 600;
+}
+
+.minus {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.ageCell {
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.empty {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}

--- a/packages/web/components/repo/PullsTable.tsx
+++ b/packages/web/components/repo/PullsTable.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { GitHubPull } from "@issuectl/core";
+import { SearchInput } from "@/components/ui/SearchInput";
+import { FilterChips } from "@/components/ui/FilterChips";
+import { daysSince } from "@/lib/format";
+import styles from "./PullsTable.module.css";
+
+type Props = {
+  pulls: GitHubPull[];
+  owner: string;
+  repo: string;
+};
+
+function getStatus(pr: GitHubPull): "open" | "merged" | "closed" {
+  if (pr.merged) return "merged";
+  return pr.state;
+}
+
+const FILTERS = ["All", "Open", "Merged"];
+
+export function PullsTable({ pulls, owner, repo }: Props) {
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState("All");
+
+  const filtered = pulls
+    .filter((pr) => {
+      if (filter === "Open") return pr.state === "open";
+      if (filter === "Merged") return pr.merged;
+      return true;
+    })
+    .filter((pr) => {
+      if (!search) return true;
+      const q = search.toLowerCase();
+      return (
+        pr.title.toLowerCase().includes(q) || `#${pr.number}`.includes(q)
+      );
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Filter pull requests..."
+        />
+        <FilterChips options={FILTERS} active={filter} onChange={setFilter} />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className={styles.empty}>No pull requests match your filters.</div>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Pull Request</th>
+              <th>Status</th>
+              <th>Linked Issue</th>
+              <th>Changes</th>
+              <th>Age</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((pr) => {
+              const status = getStatus(pr);
+              const linkedMatch = pr.body?.match(
+                /(?:closes|fixes|resolves)\s+#(\d+)/i,
+              );
+              return (
+                <tr key={pr.number}>
+                  <td>
+                    <Link
+                      href={`/${owner}/${repo}/pulls/${pr.number}`}
+                      className={styles.prCell}
+                    >
+                      <span
+                        className={`${styles.stateDot} ${styles[status]}`}
+                      />
+                      <div className={styles.prInfo}>
+                        <span className={styles.prTitle}>{pr.title}</span>
+                        <span className={styles.prSubtitle}>
+                          <span className={styles.num}>#{pr.number}</span>
+                          by {pr.user?.login ?? "unknown"}
+                        </span>
+                      </div>
+                    </Link>
+                  </td>
+                  <td>
+                    <span
+                      className={
+                        status === "merged"
+                          ? styles.statusMerged
+                          : status === "open"
+                            ? styles.statusOpen
+                            : styles.statusClosed
+                      }
+                    >
+                      {status === "merged"
+                        ? "Merged"
+                        : status === "open"
+                          ? "Open"
+                          : "Closed"}
+                    </span>
+                  </td>
+                  <td>
+                    {linkedMatch && (
+                      <span className={styles.linkedIssue}>
+                        Closes #{linkedMatch[1]}
+                      </span>
+                    )}
+                  </td>
+                  <td>
+                    <div className={styles.changes}>
+                      <span className={styles.plus}>+{pr.additions}</span>
+                      <span className={styles.minus}>-{pr.deletions}</span>
+                    </div>
+                  </td>
+                  <td className={styles.ageCell}>
+                    {daysSince(pr.updatedAt)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/repo/RepoHeader.tsx
+++ b/packages/web/components/repo/RepoHeader.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { PageHeader } from "@/components/ui/PageHeader";
+
+type Props = {
+  owner: string;
+  repo: string;
+};
+
+export function RepoHeader({ owner, repo }: Props) {
+  return (
+    <PageHeader
+      title={repo}
+      breadcrumb={
+        <>
+          <Link href="/">Dashboard</Link>
+          <span>/</span>
+          <span>
+            {owner}/{repo}
+          </span>
+        </>
+      }
+    />
+  );
+}

--- a/packages/web/components/repo/TabBar.module.css
+++ b/packages/web/components/repo/TabBar.module.css
@@ -1,0 +1,49 @@
+.bar {
+  display: flex;
+  gap: 0;
+  padding: 0 32px;
+  margin-top: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.tab {
+  padding: 10px 16px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-family: inherit;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+  margin-bottom: -1px;
+}
+
+.tab:hover {
+  color: var(--text-secondary);
+}
+
+.active {
+  composes: tab;
+  color: var(--text-primary);
+  border-bottom-color: var(--accent);
+}
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-mono), monospace;
+  background: var(--bg-elevated);
+  padding: 1px 7px;
+  border-radius: 10px;
+  margin-left: 6px;
+  color: var(--text-tertiary);
+  vertical-align: 1px;
+}
+
+.active .badge {
+  background: var(--accent-surface);
+  color: var(--accent);
+}

--- a/packages/web/components/repo/TabBar.tsx
+++ b/packages/web/components/repo/TabBar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import styles from "./TabBar.module.css";
+
+type Props = {
+  issueCount: number;
+  prCount: number;
+};
+
+export function TabBar({ issueCount, prCount }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const activeTab = params.get("tab") === "prs" ? "prs" : "issues";
+
+  function setTab(tab: string) {
+    const sp = new URLSearchParams(params.toString());
+    if (tab === "issues") {
+      sp.delete("tab");
+    } else {
+      sp.set("tab", tab);
+    }
+    const qs = sp.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
+  }
+
+  return (
+    <div className={styles.bar}>
+      <button
+        className={activeTab === "issues" ? styles.active : styles.tab}
+        onClick={() => setTab("issues")}
+      >
+        Issues <span className={styles.badge}>{issueCount}</span>
+      </button>
+      <button
+        className={activeTab === "prs" ? styles.active : styles.tab}
+        onClick={() => setTab("prs")}
+      >
+        Pull Requests <span className={styles.badge}>{prCount}</span>
+      </button>
+    </div>
+  );
+}

--- a/packages/web/components/ui/FilterChips.module.css
+++ b/packages/web/components/ui/FilterChips.module.css
@@ -1,0 +1,31 @@
+.chips {
+  display: flex;
+  gap: 6px;
+}
+
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.chip:hover {
+  border-color: var(--border-accent);
+  color: var(--text-primary);
+}
+
+.active {
+  composes: chip;
+  border-color: var(--accent-border);
+  background: var(--accent-surface);
+  color: var(--accent);
+}

--- a/packages/web/components/ui/FilterChips.tsx
+++ b/packages/web/components/ui/FilterChips.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import styles from "./FilterChips.module.css";
+
+type Props = {
+  options: string[];
+  active: string;
+  onChange: (value: string) => void;
+};
+
+export function FilterChips({ options, active, onChange }: Props) {
+  return (
+    <div className={styles.chips}>
+      {options.map((opt) => (
+        <button
+          key={opt}
+          className={opt === active ? styles.active : styles.chip}
+          onClick={() => onChange(opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/ui/LifecycleIndicator.module.css
+++ b/packages/web/components/ui/LifecycleIndicator.module.css
@@ -1,0 +1,36 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.idle {
+  background: var(--text-tertiary);
+}
+
+.deployed {
+  background: var(--yellow);
+  box-shadow: 0 0 6px var(--yellow);
+}
+
+.pr {
+  background: var(--blue);
+  box-shadow: 0 0 6px var(--blue);
+}
+
+.done {
+  background: var(--green);
+}
+
+.text {
+  color: var(--text-secondary);
+}

--- a/packages/web/components/ui/LifecycleIndicator.tsx
+++ b/packages/web/components/ui/LifecycleIndicator.tsx
@@ -1,0 +1,37 @@
+import type { GitHubLabel } from "@issuectl/core";
+import styles from "./LifecycleIndicator.module.css";
+
+type LifecycleState = "idle" | "deployed" | "pr" | "done";
+
+function getLifecycleState(labels: GitHubLabel[]): {
+  state: LifecycleState;
+  text: string;
+} {
+  const names = new Set(labels.map((l) => l.name));
+
+  if (names.has("issuectl:done")) {
+    return { state: "done", text: "Done" };
+  }
+  if (names.has("issuectl:pr-open")) {
+    return { state: "pr", text: "PR open" };
+  }
+  if (names.has("issuectl:deployed")) {
+    return { state: "deployed", text: "Deployed" };
+  }
+  return { state: "idle", text: "New" };
+}
+
+type Props = {
+  labels: GitHubLabel[];
+};
+
+export function LifecycleIndicator({ labels }: Props) {
+  const { state, text } = getLifecycleState(labels);
+
+  return (
+    <div className={styles.wrapper}>
+      <span className={`${styles.dot} ${styles[state]}`} />
+      <span className={styles.text}>{text}</span>
+    </div>
+  );
+}

--- a/packages/web/components/ui/SearchInput.module.css
+++ b/packages/web/components/ui/SearchInput.module.css
@@ -1,0 +1,37 @@
+.wrap {
+  position: relative;
+  flex: 1;
+  max-width: 320px;
+}
+
+.wrap::before {
+  content: "\2315";
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 15px;
+  color: var(--text-tertiary);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px 8px 36px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.input::placeholder {
+  color: var(--text-tertiary);
+}

--- a/packages/web/components/ui/SearchInput.tsx
+++ b/packages/web/components/ui/SearchInput.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import styles from "./SearchInput.module.css";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+};
+
+export function SearchInput({ value, onChange, placeholder }: Props) {
+  return (
+    <div className={styles.wrap}>
+      <input
+        type="text"
+        className={styles.input}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder ?? "Filter..."}
+      />
+    </div>
+  );
+}

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -1,0 +1,6 @@
+export function daysSince(date: string): string {
+  const days = Math.floor(
+    (Date.now() - new Date(date).getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return `${days}d`;
+}

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["es2022", "dom", "dom.iterable"],
     "jsx": "preserve",
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Implement the repo detail view at `/[owner]/[repo]` with tabbed Issues + PRs tables, client-side filtering, and search.

- **TabBar**: client component switching between Issues/PRs views via URL search params
- **IssuesTable**: search by title/number, filter by label (All/bug/enhancement/deployed), lifecycle indicators, Launch/Re-launch buttons (no-op until Phase 11)
- **PullsTable**: search by title/number, filter by status (All/Open/Merged), linked issue detection, diff stats
- **LifecycleIndicator**: colored dots for New/Deployed/PR open/Done lifecycle states
- **Loading skeleton**: staggered row animations matching table layout

## Key decisions

- **Client-side filtering**: data is fetched once by the Server Component, then filtered in the browser
- **URL-based tab state**: `?tab=prs` search param, no client state for tab — enables shareable URLs
- **Error handling**: try-catch with console.error, empty table on failure
- **Launch buttons**: rendered with correct Launch/Re-launch text but no onClick until Phase 11

## Test plan

- [ ] CI passes build + typecheck + lint
- [ ] `/[owner]/[repo]` renders issues table by default
- [ ] `?tab=prs` switches to PRs table
- [ ] Search filters by title and issue/PR number
- [ ] Filter chips work for labels/status
- [ ] Breadcrumb links back to dashboard
- [ ] Loading skeleton shows while data fetches