### PR TITLE
feat: add PR detail page (Phase 8)

### DIFF
--- a/packages/core/src/data/comments.ts
+++ b/packages/core/src/data/comments.ts
@@ -52,5 +52,6 @@ export async function addComment(
   const comment = await postComment(octokit, owner, repo, issueNumber, body);
   clearCacheKey(db, `comments:${owner}/${repo}#${issueNumber}`);
   clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+  clearCacheKey(db, `pull-detail:${owner}/${repo}#${issueNumber}`);
   return comment;
 }

--- a/packages/core/src/data/pulls.ts
+++ b/packages/core/src/data/pulls.ts
@@ -1,7 +1,7 @@
 import type { Octokit } from "@octokit/rest";
 import type Database from "better-sqlite3";
-import type { GitHubPull, GitHubCheck, GitHubIssue } from "../github/types.js";
-import { listPulls, getPull, getPullChecks } from "../github/pulls.js";
+import type { GitHubPull, GitHubCheck, GitHubIssue, GitHubPullFile } from "../github/types.js";
+import { listPulls, getPull, getPullChecks, listPullFiles } from "../github/pulls.js";
 import { getIssue } from "../github/issues.js";
 import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
 
@@ -46,20 +46,16 @@ export async function getPulls(
   return { pulls, fromCache: false, cachedAt: new Date() };
 }
 
-export async function getPullDetail(
-  db: Database.Database,
+async function fetchPullDetail(
   octokit: Octokit,
   owner: string,
   repo: string,
   number: number,
-): Promise<{
-  pull: GitHubPull;
-  checks: GitHubCheck[];
-  linkedIssue: GitHubIssue | null;
-}> {
-  const [pull, checks] = await Promise.all([
+): Promise<CachedPullDetail> {
+  const [pull, checks, files] = await Promise.all([
     getPull(octokit, owner, repo, number),
     getPullChecks(octokit, owner, repo, `pull/${number}/head`),
+    listPullFiles(octokit, owner, repo, number),
   ]);
 
   const issueNumber = extractLinkedIssueNumber(pull.body);
@@ -78,5 +74,42 @@ export async function getPullDetail(
     }
   }
 
-  return { pull, checks, linkedIssue };
+  return { pull, checks, files, linkedIssue };
+}
+
+type CachedPullDetail = {
+  pull: GitHubPull;
+  checks: GitHubCheck[];
+  files: GitHubPullFile[];
+  linkedIssue: GitHubIssue | null;
+};
+
+export async function getPullDetail(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  options?: { forceRefresh?: boolean },
+): Promise<CachedPullDetail & { fromCache: boolean; cachedAt: Date | null }> {
+  const cacheKey = `pull-detail:${owner}/${repo}#${number}`;
+  const ttl = getCacheTtl(db);
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<CachedPullDetail>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        fetchPullDetail(octokit, owner, repo, number).then((data) => {
+          setCached(db, cacheKey, data);
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+      return { ...cached.data, fromCache: true, cachedAt: cached.fetchedAt };
+    }
+  }
+
+  const data = await fetchPullDetail(octokit, owner, repo, number);
+  setCached(db, cacheKey, data);
+  return { ...data, fromCache: false, cachedAt: new Date() };
 }

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -1,5 +1,5 @@
 import type { Octokit } from "@octokit/rest";
-import type { GitHubPull, GitHubCheck, RawGitHubUser } from "./types.js";
+import type { GitHubPull, GitHubCheck, GitHubPullFile, RawGitHubUser } from "./types.js";
 import { mapUser } from "./types.js";
 
 function mapPull(raw: unknown): GitHubPull {
@@ -15,6 +15,7 @@ function mapPull(raw: unknown): GitHubPull {
     base: { ref: string };
     additions: number;
     deletions: number;
+    changed_files: number;
     created_at: string;
     updated_at: string;
     closed_at: string | null;
@@ -31,6 +32,7 @@ function mapPull(raw: unknown): GitHubPull {
     baseRef: r.base.ref,
     additions: r.additions ?? 0,
     deletions: r.deletions ?? 0,
+    changedFiles: r.changed_files ?? 0,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     mergedAt: r.merged_at ?? null,
@@ -82,8 +84,30 @@ export async function getPullChecks(
   return data.check_runs.map((run) => ({
     name: run.name,
     status: run.status as GitHubCheck["status"],
-    conclusion: run.conclusion ?? null,
+    conclusion: (run.conclusion as GitHubCheck["conclusion"]) ?? null,
+    startedAt: run.started_at ?? null,
+    completedAt: run.completed_at ?? null,
     htmlUrl: run.html_url ?? null,
+  }));
+}
+
+export async function listPullFiles(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<GitHubPullFile[]> {
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: number,
+    per_page: 100,
+  });
+  return files.map((f) => ({
+    filename: f.filename,
+    status: f.status as GitHubPullFile["status"],
+    additions: f.additions,
+    deletions: f.deletions,
   }));
 }
 

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -42,6 +42,7 @@ export type GitHubPull = {
   baseRef: string;
   additions: number;
   deletions: number;
+  changedFiles: number;
   createdAt: string;
   updatedAt: string;
   mergedAt: string | null;
@@ -59,6 +60,15 @@ export function mapUser(raw: RawGitHubUser): GitHubUser | null {
 export type GitHubCheck = {
   name: string;
   status: "queued" | "in_progress" | "completed";
-  conclusion: string | null;
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "timed_out" | "action_required" | "skipped" | "stale" | null;
+  startedAt: string | null;
+  completedAt: string | null;
   htmlUrl: string | null;
+};
+
+export type GitHubPullFile = {
+  filename: string;
+  status: "added" | "modified" | "removed" | "renamed" | "copied" | "changed" | "unchanged";
+  additions: number;
+  deletions: number;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   GitHubComment,
   GitHubLabel,
   GitHubCheck,
+  GitHubPullFile,
 } from "./github/types.js";
 export { getGhToken, checkGhAuth } from "./github/auth.js";
 export { getOctokit, resetOctokit } from "./github/client.js";

--- a/packages/web/app/[owner]/[repo]/pulls/[number]/loading.module.css
+++ b/packages/web/app/[owner]/[repo]/pulls/[number]/loading.module.css
@@ -1,0 +1,112 @@
+@keyframes pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.15; }
+}
+
+.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 24px 32px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.breadcrumb {
+  width: 200px;
+  height: 12px;
+  background: var(--bg-elevated);
+  border-radius: 4px;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.title {
+  width: 500px;
+  height: 26px;
+  background: var(--bg-elevated);
+  border-radius: 6px;
+  animation: pulse 1.8s ease-in-out infinite 0.1s;
+}
+
+.badge {
+  width: 70px;
+  height: 32px;
+  background: var(--bg-elevated);
+  border-radius: 999px;
+  animation: pulse 1.8s ease-in-out infinite 0.2s;
+}
+
+.body {
+  padding: 0 32px 32px;
+  display: flex;
+  gap: 24px;
+  flex: 1;
+  margin-top: 20px;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.statRow {
+  height: 44px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  animation: pulse 1.8s ease-in-out infinite 0.1s;
+}
+
+.bodyBlock {
+  height: 200px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  animation: pulse 1.8s ease-in-out infinite 0.2s;
+}
+
+.commentsTitle {
+  width: 80px;
+  height: 16px;
+  background: var(--bg-elevated);
+  border-radius: 4px;
+  margin-top: 8px;
+  animation: pulse 1.8s ease-in-out infinite 0.3s;
+}
+
+.commentCard {
+  height: 80px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  animation: pulse 1.8s ease-in-out infinite 0.4s;
+}
+
+.sidebar {
+  width: 280px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebarCard {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  animation: pulse 1.8s ease-in-out infinite 0.3s;
+}

--- a/packages/web/app/[owner]/[repo]/pulls/[number]/loading.tsx
+++ b/packages/web/app/[owner]/[repo]/pulls/[number]/loading.tsx
@@ -1,0 +1,29 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.breadcrumb} />
+        <div className={styles.titleRow}>
+          <div className={styles.title} />
+          <div className={styles.badge} />
+        </div>
+      </div>
+      <div className={styles.body}>
+        <div className={styles.main}>
+          <div className={styles.statRow} />
+          <div className={styles.bodyBlock} />
+          <div className={styles.commentsTitle} />
+          <div className={styles.commentCard} />
+        </div>
+        <div className={styles.sidebar}>
+          <div className={styles.sidebarCard} style={{ height: 140 }} />
+          <div className={styles.sidebarCard} style={{ height: 70 }} />
+          <div className={styles.sidebarCard} style={{ height: 60 }} />
+          <div className={styles.sidebarCard} style={{ height: 160 }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/[owner]/[repo]/pulls/[number]/page.module.css
+++ b/packages/web/app/[owner]/[repo]/pulls/[number]/page.module.css
@@ -1,0 +1,22 @@
+.detailView {
+  padding: 0 32px 32px;
+  display: flex;
+  gap: 24px;
+  flex: 1;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+
+.pageTitle {
+  font-size: 22px;
+}
+
+.error {
+  padding: 40px 32px;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  text-align: center;
+}

--- a/packages/web/app/[owner]/[repo]/pulls/[number]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/pulls/[number]/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { getDb, getOctokit, getPullDetail, getComments } from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { IssueBody } from "@/components/issue/IssueBody";
+import { PRStatRow } from "@/components/pr/PRStatRow";
+import { PRSidebar } from "@/components/pr/PRSidebar";
+import { PRStatusBadge } from "@/components/pr/PRStatusBadge";
+import { CommentThread } from "@/components/issue/CommentThread";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ owner: string; repo: string; number: string }>;
+};
+
+export default async function PRDetailPage({ params }: Props) {
+  const { owner, repo, number: numStr } = await params;
+  const prNumber = parseInt(numStr, 10);
+
+  if (Number.isNaN(prNumber) || prNumber < 1) {
+    return <div className={styles.error}>Invalid PR number.</div>;
+  }
+
+  let data: Awaited<ReturnType<typeof getPullDetail>> | null = null;
+  let comments: Awaited<ReturnType<typeof getComments>> | null = null;
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    [data, comments] = await Promise.all([
+      getPullDetail(db, octokit, owner, repo, prNumber),
+      getComments(db, octokit, owner, repo, prNumber),
+    ]);
+  } catch (err) {
+    console.error(`[issuectl] Failed to load PR #${prNumber}:`, err);
+  }
+
+  if (!data || !comments) {
+    return <div className={styles.error}>Failed to load pull request.</div>;
+  }
+
+  const { pull, checks, files, linkedIssue } = data;
+
+  return (
+    <>
+      <PageHeader
+        title={
+          <span className={styles.pageTitle}>{pull.title}</span>
+        }
+        breadcrumb={
+          <>
+            <Link href="/">Dashboard</Link>
+            <span>/</span>
+            <Link href={`/${owner}/${repo}`}>{repo}</Link>
+            <span>/</span>
+            <span>PR #{prNumber}</span>
+          </>
+        }
+        actions={
+          <PRStatusBadge pull={pull} />
+        }
+      />
+      <div className={styles.detailView}>
+        <div className={styles.main}>
+          <PRStatRow pull={pull} />
+          <IssueBody body={pull.body} />
+          <CommentThread
+            comments={comments.comments}
+            owner={owner}
+            repo={repo}
+            issueNumber={prNumber}
+            title="Review"
+          />
+        </div>
+        <PRSidebar
+          checks={checks}
+          files={files}
+          linkedIssue={linkedIssue}
+          headRef={pull.headRef}
+          owner={owner}
+          repo={repo}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/web/components/issue/CommentThread.tsx
+++ b/packages/web/components/issue/CommentThread.tsx
@@ -8,13 +8,14 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  title?: string;
 };
 
-export function CommentThread({ comments, owner, repo, issueNumber }: Props) {
+export function CommentThread({ comments, owner, repo, issueNumber, title }: Props) {
   return (
     <div className={styles.container}>
       <span className={styles.title}>
-        {comments.length} Comment{comments.length !== 1 ? "s" : ""}
+        {title ?? `${comments.length} Comment${comments.length !== 1 ? "s" : ""}`}
       </span>
       {comments.map((comment) => (
         <CommentCard key={comment.id} comment={comment} />

--- a/packages/web/components/pr/CIChecks.module.css
+++ b/packages/web/components/pr/CIChecks.module.css
@@ -1,0 +1,62 @@
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotPass {
+  background: var(--green);
+}
+
+.dotFail {
+  background: var(--red);
+}
+
+.dotPending {
+  background: var(--yellow);
+}
+
+.name {
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+}
+
+.time {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+  flex-shrink: 0;
+}

--- a/packages/web/components/pr/CIChecks.tsx
+++ b/packages/web/components/pr/CIChecks.tsx
@@ -1,0 +1,36 @@
+import type { GitHubCheck } from "@issuectl/core";
+import { formatDuration } from "@/lib/format";
+import styles from "./CIChecks.module.css";
+
+type Props = {
+  checks: GitHubCheck[];
+};
+
+function dotClass(check: GitHubCheck): string {
+  if (check.status !== "completed") return styles.dotPending;
+  if (check.conclusion === "success") return styles.dotPass;
+  return styles.dotFail;
+}
+
+export function CIChecks({ checks }: Props) {
+  if (checks.length === 0) return null;
+
+  return (
+    <div className={styles.card}>
+      <span className={styles.title}>CI Checks</span>
+      <div className={styles.list}>
+        {checks.map((check, index) => (
+          <div key={`${check.name}-${index}`} className={styles.check}>
+            <span className={`${styles.dot} ${dotClass(check)}`} />
+            <span className={styles.name}>{check.name}</span>
+            {check.startedAt && check.completedAt && (
+              <span className={styles.time}>
+                {formatDuration(check.startedAt, check.completedAt)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/pr/FilesChanged.module.css
+++ b/packages/web/components/pr/FilesChanged.module.css
@@ -1,0 +1,49 @@
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+}
+
+.list {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--text-secondary);
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.file {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.added {
+  color: var(--green);
+  font-weight: 600;
+}
+
+.removed {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.modified {
+  color: var(--yellow);
+  font-weight: 600;
+}

--- a/packages/web/components/pr/FilesChanged.tsx
+++ b/packages/web/components/pr/FilesChanged.tsx
@@ -1,0 +1,37 @@
+import type { GitHubPullFile } from "@issuectl/core";
+import styles from "./FilesChanged.module.css";
+
+type Props = {
+  files: GitHubPullFile[];
+};
+
+function statusIndicator(status: GitHubPullFile["status"]): { symbol: string; className: string } {
+  switch (status) {
+    case "added":
+      return { symbol: "+", className: styles.added };
+    case "removed":
+      return { symbol: "-", className: styles.removed };
+    default:
+      return { symbol: "~", className: styles.modified };
+  }
+}
+
+export function FilesChanged({ files }: Props) {
+  if (files.length === 0) return null;
+
+  return (
+    <div className={styles.card}>
+      <span className={styles.title}>Files Changed ({files.length})</span>
+      <div className={styles.list}>
+        {files.map((file) => {
+          const { symbol, className } = statusIndicator(file.status);
+          return (
+            <span key={file.filename} className={styles.file}>
+              <span className={className}>{symbol}</span> {file.filename}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/pr/LinkedIssueCard.module.css
+++ b/packages/web/components/pr/LinkedIssueCard.module.css
@@ -1,0 +1,58 @@
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.link:hover {
+  opacity: 0.8;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotOpen {
+  background: var(--green);
+}
+
+.dotClosed {
+  background: var(--red);
+}
+
+.number {
+  font-size: 13px;
+  color: var(--blue);
+  flex-shrink: 0;
+}
+
+.issueTitle {
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/web/components/pr/LinkedIssueCard.tsx
+++ b/packages/web/components/pr/LinkedIssueCard.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import type { GitHubIssue } from "@issuectl/core";
+import styles from "./LinkedIssueCard.module.css";
+
+type Props = {
+  issue: GitHubIssue;
+  owner: string;
+  repo: string;
+};
+
+export function LinkedIssueCard({ issue, owner, repo }: Props) {
+  return (
+    <div className={styles.card}>
+      <span className={styles.title}>Linked Issue</span>
+      <Link
+        href={`/${owner}/${repo}/issues/${issue.number}`}
+        className={styles.link}
+      >
+        <span
+          className={`${styles.dot} ${issue.state === "open" ? styles.dotOpen : styles.dotClosed}`}
+        />
+        <span className={styles.number}>#{issue.number}</span>
+        <span className={styles.issueTitle}>{issue.title}</span>
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/components/pr/PRSidebar.module.css
+++ b/packages/web/components/pr/PRSidebar.module.css
@@ -1,0 +1,32 @@
+.sidebar {
+  width: 280px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 20px;
+}
+
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+}
+
+.branchName {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  color: var(--cyan);
+}

--- a/packages/web/components/pr/PRSidebar.tsx
+++ b/packages/web/components/pr/PRSidebar.tsx
@@ -1,0 +1,30 @@
+import type { GitHubCheck, GitHubIssue, GitHubPullFile } from "@issuectl/core";
+import { CIChecks } from "./CIChecks";
+import { LinkedIssueCard } from "./LinkedIssueCard";
+import { FilesChanged } from "./FilesChanged";
+import styles from "./PRSidebar.module.css";
+
+type Props = {
+  checks: GitHubCheck[];
+  files: GitHubPullFile[];
+  linkedIssue: GitHubIssue | null;
+  headRef: string;
+  owner: string;
+  repo: string;
+};
+
+export function PRSidebar({ checks, files, linkedIssue, headRef, owner, repo }: Props) {
+  return (
+    <div className={styles.sidebar}>
+      <CIChecks checks={checks} />
+      {linkedIssue && (
+        <LinkedIssueCard issue={linkedIssue} owner={owner} repo={repo} />
+      )}
+      <div className={styles.card}>
+        <span className={styles.title}>Branch</span>
+        <div className={styles.branchName}>{headRef}</div>
+      </div>
+      <FilesChanged files={files} />
+    </div>
+  );
+}

--- a/packages/web/components/pr/PRStatRow.module.css
+++ b/packages/web/components/pr/PRStatRow.module.css
@@ -1,0 +1,37 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-top: 20px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+}
+
+.plus {
+  color: var(--green);
+  font-weight: 600;
+  font-family: var(--font-mono), monospace;
+}
+
+.minus {
+  color: var(--red);
+  font-weight: 600;
+  font-family: var(--font-mono), monospace;
+}
+
+.files {
+  color: var(--text-secondary);
+}
+
+.branch {
+  color: var(--text-tertiary);
+}

--- a/packages/web/components/pr/PRStatRow.tsx
+++ b/packages/web/components/pr/PRStatRow.tsx
@@ -1,0 +1,29 @@
+import type { GitHubPull } from "@issuectl/core";
+import styles from "./PRStatRow.module.css";
+
+type Props = {
+  pull: GitHubPull;
+};
+
+export function PRStatRow({ pull }: Props) {
+  return (
+    <div className={styles.row}>
+      <div className={styles.stat}>
+        <span className={styles.plus}>+{pull.additions}</span>
+      </div>
+      <div className={styles.stat}>
+        <span className={styles.minus}>-{pull.deletions}</span>
+      </div>
+      <div className={styles.stat}>
+        <span className={styles.files}>
+          {pull.changedFiles} file{pull.changedFiles !== 1 ? "s" : ""} changed
+        </span>
+      </div>
+      <div className={styles.stat}>
+        <span className={styles.branch}>
+          base: {pull.baseRef} &larr; {pull.headRef}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/pr/PRStatusBadge.module.css
+++ b/packages/web/components/pr/PRStatusBadge.module.css
@@ -1,0 +1,25 @@
+.badge {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  letter-spacing: 0.3px;
+}
+
+.open {
+  background: rgba(63, 185, 80, 0.12);
+  color: var(--green);
+  border: 1px solid rgba(63, 185, 80, 0.25);
+}
+
+.merged {
+  background: rgba(188, 140, 255, 0.12);
+  color: var(--purple);
+  border: 1px solid rgba(188, 140, 255, 0.25);
+}
+
+.closed {
+  background: rgba(248, 81, 73, 0.12);
+  color: var(--red);
+  border: 1px solid rgba(248, 81, 73, 0.25);
+}

--- a/packages/web/components/pr/PRStatusBadge.tsx
+++ b/packages/web/components/pr/PRStatusBadge.tsx
@@ -1,0 +1,17 @@
+import type { GitHubPull } from "@issuectl/core";
+import styles from "./PRStatusBadge.module.css";
+
+type Props = {
+  pull: GitHubPull;
+};
+
+function getStatus(pull: GitHubPull): { label: string; className: string } {
+  if (pull.merged) return { label: "Merged", className: styles.merged };
+  if (pull.state === "closed") return { label: "Closed", className: styles.closed };
+  return { label: "Open", className: styles.open };
+}
+
+export function PRStatusBadge({ pull }: Props) {
+  const { label, className } = getStatus(pull);
+  return <span className={`${styles.badge} ${className}`}>{label}</span>;
+}

--- a/packages/web/lib/actions/comments.ts
+++ b/packages/web/lib/actions/comments.ts
@@ -22,5 +22,6 @@ export async function addComment(
     return { success: false, error: "Failed to post comment" };
   }
   revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
+  revalidatePath(`/${owner}/${repo}/pulls/${issueNumber}`);
   return { success: true };
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -13,3 +13,13 @@ export function formatDate(dateStr: string): string {
     timeZone: "UTC",
   }).format(new Date(dateStr));
 }
+
+export function formatDuration(startedAt: string, completedAt: string): string {
+  const raw = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (Number.isNaN(raw)) return "--";
+  const ms = Math.max(0, raw);
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}


### PR DESCRIPTION
## Summary
- Adds PR detail view at `/[owner]/[repo]/pulls/[number]` with rendered markdown body, diff stat row (+/-/files/branch), review comments section, and loading skeleton
- Sidebar with CI checks (pass/fail dots + durations), linked issue card, branch name, and files changed list with add/modify/remove indicators  
- PR status badge (Open/Merged/Closed) with colored pill styling
- SWR caching on `getPullDetail` with background revalidation, consistent with all other data-layer functions
- Extended core types: `changedFiles` on GitHubPull, `startedAt`/`completedAt` on GitHubCheck, union `conclusion` type, new `GitHubPullFile` type with full API status coverage
- Fixed comment revalidation to bust both `/issues/` and `/pulls/` Next.js page caches
- Added `pull-detail:` cache key clearing on comment add for cache coherence
- Reuses `IssueBody` (via `MarkdownBody`) and `CommentThread` from Phase 7 — no duplication

## Test plan
- [ ] Navigate to a tracked repo's PR detail page — verify markdown body renders with GFM
- [ ] Verify diff stat row shows correct +additions/-deletions, file count, and branch info
- [ ] Verify CI checks sidebar shows pass/fail dots with durations
- [ ] Verify linked issue card appears and links to the issue detail page
- [ ] Verify files changed list shows +/~/- indicators for each file
- [ ] Verify PR status badge shows Open/Merged/Closed correctly
- [ ] Post a review comment — verify it appears without page refresh
- [ ] Verify loading skeleton displays while data loads
- [ ] Verify breadcrumb navigation: Dashboard > repo > PR #N