### PR TITLE
feat: add settings page with repo management, defaults, terminal mode, and worktree cleanup (Phase 9)

### DIFF
--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -1,0 +1,18 @@
+.content {
+  padding: 20px 32px 32px;
+  max-width: 720px;
+}
+
+.section {
+  margin-bottom: 32px;
+}
+
+.sectionTitle {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -1,0 +1,86 @@
+import {
+  getDb,
+  dbExists,
+  listRepos,
+  getSettings,
+  checkGhAuth,
+} from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { TrackedRepos } from "@/components/settings/TrackedRepos";
+import { DefaultsForm } from "@/components/settings/DefaultsForm";
+import { TerminalSettings } from "@/components/settings/TerminalSettings";
+import { AuthStatus } from "@/components/settings/AuthStatus";
+import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
+import { listWorktrees } from "@/lib/actions/worktrees";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Settings" />
+        <div className={styles.content}>
+          <p style={{ color: "var(--text-secondary)" }}>
+            Run <code>issuectl init</code> to get started.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  const db = getDb();
+  const repos = listRepos(db);
+  const settings = getSettings(db);
+
+  const settingMap = Object.fromEntries(settings.map((s) => [s.key, s.value]));
+  const branchPattern = settingMap.branch_pattern ?? "issue-{number}-{slug}";
+  const cacheTTL = settingMap.cache_ttl ?? "300";
+  const terminalApp = settingMap.terminal_app ?? "ghostty";
+  const terminalMode = settingMap.terminal_mode ?? "window";
+
+  const [authResult, worktrees] = await Promise.all([
+    checkGhAuth().catch(() => ({ ok: false, username: undefined })),
+    listWorktrees(),
+  ]);
+  const username = authResult.username ?? null;
+
+  return (
+    <>
+      <PageHeader title="Settings" />
+      <div className={styles.content}>
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>Tracked Repositories</div>
+          <TrackedRepos repos={repos} />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>Defaults</div>
+          <DefaultsForm
+            branchPattern={branchPattern}
+            cacheTTL={cacheTTL}
+          />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>Terminal</div>
+          <TerminalSettings
+            terminalApp={terminalApp}
+            terminalMode={terminalMode}
+          />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>Worktrees</div>
+          <WorktreeCleanup worktrees={worktrees} />
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>Authentication</div>
+          <AuthStatus username={username} />
+        </section>
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -34,6 +34,7 @@ export default async function SettingsPage() {
   const repos = listRepos(db);
   const settings = getSettings(db);
 
+  // Fallback defaults match DEFAULT_SETTINGS in core/db/settings.ts
   const settingMap = Object.fromEntries(settings.map((s) => [s.key, s.value]));
   const branchPattern = settingMap.branch_pattern ?? "issue-{number}-{slug}";
   const cacheTTL = settingMap.cache_ttl ?? "300";
@@ -42,7 +43,10 @@ export default async function SettingsPage() {
 
   const [authResult, worktrees] = await Promise.all([
     checkGhAuth().catch(() => ({ ok: false, username: undefined })),
-    listWorktrees(),
+    listWorktrees().catch((err) => {
+      console.error("[issuectl] Failed to list worktrees:", err);
+      return [] as Awaited<ReturnType<typeof listWorktrees>>;
+    }),
   ]);
   const username = authResult.username ?? null;
 

--- a/packages/web/components/settings/AddRepoForm.module.css
+++ b/packages/web/components/settings/AddRepoForm.module.css
@@ -1,0 +1,61 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.field {
+  flex: 1;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--red);
+}
+
+.pathHint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useRef, useEffect } from "react";
 import { addRepo } from "@/lib/actions/repos";
 import { Button } from "@/components/ui/Button";
 import styles from "./AddRepoForm.module.css";
@@ -15,6 +15,13 @@ export function AddRepoForm({ onClose }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   function handleSubmit() {
     setError(null);
@@ -34,7 +41,7 @@ export function AddRepoForm({ onClose }: Props) {
       if (result.success) {
         if (result.warning) {
           setWarning(result.warning);
-          setTimeout(() => onClose(), 2000);
+          timerRef.current = setTimeout(() => onClose(), 2000);
         } else {
           onClose();
         }

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { addRepo } from "@/lib/actions/repos";
+import { Button } from "@/components/ui/Button";
+import styles from "./AddRepoForm.module.css";
+
+type Props = {
+  onClose: () => void;
+};
+
+export function AddRepoForm({ onClose }: Props) {
+  const [ownerRepo, setOwnerRepo] = useState("");
+  const [localPath, setLocalPath] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit() {
+    setError(null);
+    setWarning(null);
+    const parts = ownerRepo.trim().split("/");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      setError("Format: owner/repo (e.g., mean-weasel/seatify)");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await addRepo(
+        parts[0],
+        parts[1],
+        localPath.trim() || undefined,
+      );
+      if (result.success) {
+        if (result.warning) {
+          setWarning(result.warning);
+          setTimeout(() => onClose(), 2000);
+        } else {
+          onClose();
+        }
+      } else {
+        setError(result.error ?? "Failed to add repo");
+      }
+    });
+  }
+
+  return (
+    <div className={styles.form}>
+      <div className={styles.row}>
+        <div className={styles.field}>
+          <div className={styles.label}>Repository</div>
+          <input
+            className={styles.input}
+            value={ownerRepo}
+            onChange={(e) => setOwnerRepo(e.target.value)}
+            placeholder="owner/repo (e.g., mean-weasel/seatify)"
+            autoFocus
+          />
+        </div>
+        <div className={styles.field}>
+          <div className={styles.label}>Local Path (optional)</div>
+          <input
+            className={styles.input}
+            value={localPath}
+            onChange={(e) => setLocalPath(e.target.value)}
+            placeholder="~/Desktop/seatify"
+          />
+          <div className={styles.pathHint}>Leave blank to prompt on launch</div>
+        </div>
+      </div>
+      {error && (
+        <span className={styles.error} role="alert">{error}</span>
+      )}
+      {warning && (
+        <span className={styles.pathHint} style={{ color: "var(--yellow)" }} role="status">{warning}</span>
+      )}
+      <div className={styles.actions}>
+        <Button variant="ghost" onClick={onClose} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={isPending || !ownerRepo.trim()}
+        >
+          {isPending ? "Adding..." : "Add Repo"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/settings/AuthStatus.module.css
+++ b/packages/web/components/settings/AuthStatus.module.css
@@ -1,0 +1,45 @@
+.card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotOk {
+  composes: dot;
+  background: var(--green);
+}
+
+.dotError {
+  composes: dot;
+  background: var(--red);
+}
+
+.text {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.username {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--cyan);
+  background: var(--bg-elevated);
+  padding: 2px 6px;
+  border-radius: 3px;
+}

--- a/packages/web/components/settings/AuthStatus.tsx
+++ b/packages/web/components/settings/AuthStatus.tsx
@@ -1,0 +1,28 @@
+import styles from "./AuthStatus.module.css";
+
+type Props = {
+  username: string | null;
+};
+
+export function AuthStatus({ username }: Props) {
+  if (!username) {
+    return (
+      <div className={styles.card}>
+        <span className={styles.dotError} />
+        <span className={styles.text}>
+          Not authenticated — run <code className={styles.code}>gh auth login</code>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.card}>
+      <span className={styles.dotOk} />
+      <span className={styles.text}>
+        Authenticated as <strong className={styles.username}>{username}</strong> via{" "}
+        <code className={styles.code}>gh auth</code>
+      </span>
+    </div>
+  );
+}

--- a/packages/web/components/settings/DefaultsForm.module.css
+++ b/packages/web/components/settings/DefaultsForm.module.css
@@ -1,0 +1,46 @@
+.row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.field {
+  flex: 1;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.saved {
+  font-size: 11px;
+  color: var(--green);
+  margin-top: 4px;
+}
+
+.error {
+  font-size: 11px;
+  color: var(--red);
+  margin-top: 4px;
+}

--- a/packages/web/components/settings/DefaultsForm.tsx
+++ b/packages/web/components/settings/DefaultsForm.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useTransition, useRef, useCallback, useEffect } from "react";
+import { updateSetting } from "@/lib/actions/settings";
+import type { SettingKey } from "@issuectl/core";
+import styles from "./DefaultsForm.module.css";
+
+type DefaultKey = Extract<SettingKey, "branch_pattern" | "cache_ttl">;
+
+type Props = {
+  branchPattern: string;
+  cacheTTL: string;
+};
+
+export function DefaultsForm({ branchPattern, cacheTTL }: Props) {
+  const [values, setValues] = useState({
+    branch_pattern: branchPattern,
+    cache_ttl: cacheTTL,
+  });
+  const [savedKey, setSavedKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const save = useCallback(
+    (key: DefaultKey, value: string) => {
+      setError(null);
+      setSavedKey(null);
+      startTransition(async () => {
+        const result = await updateSetting(key, value);
+        if (result.success) {
+          setSavedKey(key);
+          if (timerRef.current) clearTimeout(timerRef.current);
+          timerRef.current = setTimeout(() => setSavedKey(null), 2000);
+        } else {
+          setError(result.error ?? "Failed to save");
+        }
+      });
+    },
+    [startTransition],
+  );
+
+  function handleBlur(key: DefaultKey) {
+    const original = key === "branch_pattern" ? branchPattern : cacheTTL;
+    if (values[key] !== original) {
+      save(key, values[key]);
+    }
+  }
+
+  return (
+    <>
+      <div className={styles.row}>
+        <div className={styles.field}>
+          <div className={styles.label}>Branch Pattern</div>
+          <input
+            className={styles.input}
+            value={values.branch_pattern}
+            onChange={(e) =>
+              setValues((v) => ({ ...v, branch_pattern: e.target.value }))
+            }
+            onBlur={() => handleBlur("branch_pattern")}
+            disabled={isPending}
+          />
+        </div>
+        <div className={styles.field}>
+          <div className={styles.label}>Cache TTL (seconds)</div>
+          <input
+            className={styles.input}
+            value={values.cache_ttl}
+            onChange={(e) =>
+              setValues((v) => ({ ...v, cache_ttl: e.target.value }))
+            }
+            onBlur={() => handleBlur("cache_ttl")}
+            disabled={isPending}
+          />
+        </div>
+      </div>
+      {savedKey && <div className={styles.saved}>Saved</div>}
+      {error && <div className={styles.error} role="alert">{error}</div>}
+    </>
+  );
+}

--- a/packages/web/components/settings/DefaultsForm.tsx
+++ b/packages/web/components/settings/DefaultsForm.tsx
@@ -17,7 +17,7 @@ export function DefaultsForm({ branchPattern, cacheTTL }: Props) {
     branch_pattern: branchPattern,
     cache_ttl: cacheTTL,
   });
-  const [savedKey, setSavedKey] = useState<string | null>(null);
+  const [savedKey, setSavedKey] = useState<DefaultKey | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);

--- a/packages/web/components/settings/RepoRow.module.css
+++ b/packages/web/components/settings/RepoRow.module.css
@@ -1,0 +1,142 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+}
+
+.rowNoPath {
+  composes: row;
+  border-style: dashed;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotNoPath {
+  composes: dot;
+  background: var(--text-tertiary);
+}
+
+.name {
+  font-weight: 500;
+  flex: 1;
+}
+
+.nameNoPath {
+  composes: name;
+  color: var(--text-tertiary);
+}
+
+.path {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  flex: 1;
+}
+
+.noPath {
+  composes: path;
+  color: var(--yellow);
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+}
+
+.actionBtn {
+  font-size: 11px;
+  padding: 4px 8px;
+}
+
+.dangerBtn {
+  composes: actionBtn;
+  color: var(--red);
+}
+
+.editForm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+}
+
+.editRow {
+  display: flex;
+  gap: 12px;
+}
+
+.editField {
+  flex: 1;
+}
+
+.editLabel {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.editInput {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla);
+  outline: none;
+}
+
+.editInput:focus {
+  border-color: var(--accent-border);
+}
+
+.editActions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--red);
+}
+
+.confirmOverlay {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--red-surface);
+  border: 1px solid var(--red);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+}
+
+.confirmText {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.confirmActions {
+  display: flex;
+  gap: 8px;
+}

--- a/packages/web/components/settings/RepoRow.tsx
+++ b/packages/web/components/settings/RepoRow.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { removeRepo, updateRepo } from "@/lib/actions/repos";
+import { Button } from "@/components/ui/Button";
+import type { Repo } from "@issuectl/core";
+import styles from "./RepoRow.module.css";
+
+type Props = {
+  repo: Repo;
+  color: string;
+};
+
+export function RepoRow({ repo, color }: Props) {
+  const [mode, setMode] = useState<"view" | "edit" | "confirm">("view");
+  const [localPath, setLocalPath] = useState(repo.localPath ?? "");
+  const [branchPattern, setBranchPattern] = useState(repo.branchPattern ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSave() {
+    setError(null);
+    startTransition(async () => {
+      const result = await updateRepo(repo.id, {
+        localPath: localPath || undefined,
+        branchPattern: branchPattern || undefined,
+      });
+      if (result.success) {
+        setMode("view");
+      } else {
+        setError(result.error ?? "Failed to save");
+      }
+    });
+  }
+
+  function handleRemove() {
+    setError(null);
+    startTransition(async () => {
+      const result = await removeRepo(repo.id);
+      if (!result.success) {
+        setError(result.error ?? "Failed to remove");
+        setMode("view");
+      }
+    });
+  }
+
+  if (mode === "confirm") {
+    return (
+      <div className={styles.confirmOverlay}>
+        <span className={styles.confirmText}>
+          Remove <strong>{repo.owner}/{repo.name}</strong>? This cannot be undone.
+        </span>
+        <div className={styles.confirmActions}>
+          <Button
+            variant="ghost"
+            onClick={() => setMode("view")}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleRemove}
+            disabled={isPending}
+            className={styles.dangerBtn}
+          >
+            {isPending ? "Removing..." : "Remove"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (mode === "edit") {
+    return (
+      <div className={styles.editForm}>
+        <div className={styles.editRow}>
+          <div className={styles.editField}>
+            <div className={styles.editLabel}>Local Path</div>
+            <input
+              className={styles.editInput}
+              value={localPath}
+              onChange={(e) => setLocalPath(e.target.value)}
+              placeholder="~/Desktop/my-repo"
+            />
+          </div>
+          <div className={styles.editField}>
+            <div className={styles.editLabel}>Branch Pattern</div>
+            <input
+              className={styles.editInput}
+              value={branchPattern}
+              onChange={(e) => setBranchPattern(e.target.value)}
+              placeholder="issue-{number}-{slug}"
+            />
+          </div>
+        </div>
+        {error && (
+          <span className={styles.error} role="alert">{error}</span>
+        )}
+        <div className={styles.editActions}>
+          <Button variant="ghost" onClick={() => setMode("view")} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={isPending}>
+            {isPending ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const hasPath = !!repo.localPath;
+
+  return (
+    <div className={hasPath ? styles.row : styles.rowNoPath}>
+      <span
+        className={hasPath ? styles.dot : styles.dotNoPath}
+        style={hasPath ? { background: color } : undefined}
+      />
+      <span className={hasPath ? styles.name : styles.nameNoPath}>
+        {repo.owner}/{repo.name}
+      </span>
+      <span className={hasPath ? styles.path : styles.noPath}>
+        {repo.localPath ?? "no local path \u2014 will prompt to clone"}
+      </span>
+      <div className={styles.actions}>
+        <Button
+          variant="ghost"
+          className={styles.actionBtn}
+          onClick={() => setMode("edit")}
+        >
+          {hasPath ? "Edit" : "Set path"}
+        </Button>
+        <Button
+          variant="ghost"
+          className={styles.dangerBtn}
+          onClick={() => setMode("confirm")}
+        >
+          Remove
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/settings/TerminalSettings.module.css
+++ b/packages/web/components/settings/TerminalSettings.module.css
@@ -1,0 +1,72 @@
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.field {
+  flex: 1;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.input {
+  width: 100%;
+  max-width: 240px;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+  font-size: 13px;
+  font-family: var(--font-karla);
+  cursor: default;
+}
+
+.toggle {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.toggleBtn {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-family: var(--font-karla);
+  background: var(--bg-elevated);
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toggleBtn:not(:last-child) {
+  border-right: 1px solid var(--border);
+}
+
+.toggleBtnActive {
+  composes: toggleBtn;
+  background: var(--accent-surface);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.saved {
+  font-size: 11px;
+  color: var(--green);
+  margin-top: 8px;
+}
+
+.error {
+  font-size: 11px;
+  color: var(--red);
+  margin-top: 8px;
+}

--- a/packages/web/components/settings/TerminalSettings.tsx
+++ b/packages/web/components/settings/TerminalSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useRef, useEffect } from "react";
 import { updateSetting } from "@/lib/actions/settings";
 import styles from "./TerminalSettings.module.css";
 
@@ -14,6 +14,13 @@ export function TerminalSettings({ terminalApp, terminalMode }: Props) {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   function handleModeChange(newMode: string) {
     if (newMode === mode) return;
@@ -24,7 +31,8 @@ export function TerminalSettings({ terminalApp, terminalMode }: Props) {
       const result = await updateSetting("terminal_mode", newMode);
       if (result.success) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setSaved(false), 2000);
       } else {
         setMode(mode);
         setError(result.error ?? "Failed to save");

--- a/packages/web/components/settings/TerminalSettings.tsx
+++ b/packages/web/components/settings/TerminalSettings.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { updateSetting } from "@/lib/actions/settings";
+import styles from "./TerminalSettings.module.css";
+
+type Props = {
+  terminalApp: string;
+  terminalMode: string;
+};
+
+export function TerminalSettings({ terminalApp, terminalMode }: Props) {
+  const [mode, setMode] = useState(terminalMode);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleModeChange(newMode: string) {
+    if (newMode === mode) return;
+    setMode(newMode);
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const result = await updateSetting("terminal_mode", newMode);
+      if (result.success) {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      } else {
+        setMode(mode);
+        setError(result.error ?? "Failed to save");
+      }
+    });
+  }
+
+  return (
+    <>
+      <div className={styles.row}>
+        <div className={styles.field}>
+          <div className={styles.label}>Application</div>
+          <input
+            className={styles.input}
+            value={terminalApp}
+            readOnly
+          />
+        </div>
+        <div className={styles.field}>
+          <div className={styles.label}>Mode</div>
+          <div className={styles.toggle}>
+            <button
+              type="button"
+              className={mode === "window" ? styles.toggleBtnActive : styles.toggleBtn}
+              onClick={() => handleModeChange("window")}
+              disabled={isPending}
+            >
+              Window
+            </button>
+            <button
+              type="button"
+              className={mode === "tab" ? styles.toggleBtnActive : styles.toggleBtn}
+              onClick={() => handleModeChange("tab")}
+              disabled={isPending}
+            >
+              Tab
+            </button>
+          </div>
+        </div>
+      </div>
+      {saved && <div className={styles.saved}>Saved</div>}
+      {error && <div className={styles.error} role="alert">{error}</div>}
+    </>
+  );
+}

--- a/packages/web/components/settings/TrackedRepos.module.css
+++ b/packages/web/components/settings/TrackedRepos.module.css
@@ -1,0 +1,4 @@
+.addBtn {
+  font-size: 12px;
+  padding: 4px 10px;
+}

--- a/packages/web/components/settings/TrackedRepos.tsx
+++ b/packages/web/components/settings/TrackedRepos.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import type { Repo } from "@issuectl/core";
+import { REPO_COLORS } from "@/lib/constants";
+import { Button } from "@/components/ui/Button";
+import { RepoRow } from "./RepoRow";
+import { AddRepoForm } from "./AddRepoForm";
+import styles from "./TrackedRepos.module.css";
+
+type Props = {
+  repos: Repo[];
+};
+
+export function TrackedRepos({ repos }: Props) {
+  const [showAdd, setShowAdd] = useState(false);
+
+  return (
+    <>
+      {repos.map((repo, i) => (
+        <RepoRow
+          key={repo.id}
+          repo={repo}
+          color={REPO_COLORS[i % REPO_COLORS.length]}
+        />
+      ))}
+      {showAdd ? (
+        <AddRepoForm onClose={() => setShowAdd(false)} />
+      ) : (
+        <Button
+          variant="secondary"
+          className={styles.addBtn}
+          onClick={() => setShowAdd(true)}
+        >
+          + Add Repo
+        </Button>
+      )}
+    </>
+  );
+}

--- a/packages/web/components/settings/WorktreeCleanup.module.css
+++ b/packages/web/components/settings/WorktreeCleanup.module.css
@@ -1,0 +1,90 @@
+.empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+}
+
+.rowStale {
+  composes: row;
+  border-color: var(--yellow);
+  border-style: dashed;
+}
+
+.name {
+  font-weight: 500;
+  flex: 1;
+}
+
+.badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+.badgeStale {
+  composes: badge;
+  color: var(--yellow);
+  background: var(--yellow-surface);
+}
+
+.badgeActive {
+  composes: badge;
+  color: var(--green);
+  background: var(--green-surface);
+}
+
+.issue {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+}
+
+.deleteBtn {
+  font-size: 11px;
+  padding: 4px 8px;
+  color: var(--red);
+}
+
+.bulkBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.staleCount {
+  font-size: 13px;
+  color: var(--yellow);
+}
+
+.cleanAllBtn {
+  font-size: 12px;
+  padding: 4px 12px;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--red);
+  margin-top: 4px;
+}
+
+.success {
+  font-size: 12px;
+  color: var(--green);
+  margin-top: 4px;
+}

--- a/packages/web/components/settings/WorktreeCleanup.tsx
+++ b/packages/web/components/settings/WorktreeCleanup.tsx
@@ -37,11 +37,10 @@ export function WorktreeCleanup({ worktrees }: Props) {
     setSuccess(null);
     startTransition(async () => {
       const result = await cleanupStaleWorktrees();
-      if (result.success) {
-        if (result.removed > 0) {
-          setSuccess(`Removed ${result.removed} stale worktree${result.removed > 1 ? "s" : ""}`);
-        }
-      } else {
+      if (result.removed > 0) {
+        setSuccess(`Removed ${result.removed} stale worktree${result.removed > 1 ? "s" : ""}`);
+      }
+      if (!result.success) {
         setError(result.error ?? "Failed to clean stale worktrees");
       }
     });

--- a/packages/web/components/settings/WorktreeCleanup.tsx
+++ b/packages/web/components/settings/WorktreeCleanup.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { cleanupWorktree, cleanupStaleWorktrees } from "@/lib/actions/worktrees";
+import type { WorktreeInfo } from "@/lib/actions/worktrees";
+import { Button } from "@/components/ui/Button";
+import styles from "./WorktreeCleanup.module.css";
+
+type Props = {
+  worktrees: WorktreeInfo[];
+};
+
+export function WorktreeCleanup({ worktrees }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  if (worktrees.length === 0) {
+    return <div className={styles.empty}>No worktrees found</div>;
+  }
+
+  const staleCount = worktrees.filter((wt) => wt.stale).length;
+
+  function handleDelete(wt: WorktreeInfo) {
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      const result = await cleanupWorktree(wt.path, wt.localPath ?? undefined);
+      if (!result.success) {
+        setError(result.error ?? "Failed to delete worktree");
+      }
+    });
+  }
+
+  function handleCleanAll() {
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      const result = await cleanupStaleWorktrees();
+      if (result.success) {
+        if (result.removed > 0) {
+          setSuccess(`Removed ${result.removed} stale worktree${result.removed > 1 ? "s" : ""}`);
+        }
+      } else {
+        setError(result.error ?? "Failed to clean stale worktrees");
+      }
+    });
+  }
+
+  return (
+    <>
+      {staleCount > 0 && (
+        <div className={styles.bulkBar}>
+          <span className={styles.staleCount}>
+            {staleCount} stale worktree{staleCount > 1 ? "s" : ""}
+          </span>
+          <Button
+            variant="secondary"
+            className={styles.cleanAllBtn}
+            onClick={handleCleanAll}
+            disabled={isPending}
+          >
+            {isPending ? "Cleaning..." : "Clean all stale"}
+          </Button>
+        </div>
+      )}
+      {worktrees.map((wt) => (
+        <div key={wt.path} className={wt.stale ? styles.rowStale : styles.row}>
+          <span className={styles.name}>{wt.name}</span>
+          <span className={wt.stale ? styles.badgeStale : styles.badgeActive}>
+            {wt.stale ? "stale" : "active"}
+          </span>
+          {wt.issueNumber && (
+            <span className={styles.issue}>#{wt.issueNumber}</span>
+          )}
+          <Button
+            variant="ghost"
+            className={styles.deleteBtn}
+            onClick={() => handleDelete(wt)}
+            disabled={isPending}
+          >
+            Delete
+          </Button>
+        </div>
+      ))}
+      {error && <div className={styles.error} role="alert">{error}</div>}
+      {success && <div className={styles.success} role="status">{success}</div>}
+    </>
+  );
+}

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import {
+  getDb,
+  addRepo as coreAddRepo,
+  removeRepo as coreRemoveRepo,
+  updateRepo as coreUpdateRepo,
+} from "@issuectl/core";
+
+function expandHome(p: string): string {
+  return p.startsWith("~") ? p.replace("~", homedir()) : p;
+}
+
+export async function addRepo(
+  owner: string,
+  name: string,
+  localPath?: string,
+): Promise<{ success: boolean; warning?: string; error?: string }> {
+  if (!owner || !name) {
+    return { success: false, error: "Owner and repo name are required" };
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(owner) || !/^[a-zA-Z0-9._-]+$/.test(name)) {
+    return { success: false, error: "Invalid owner/repo format" };
+  }
+
+  try {
+    const db = getDb();
+    coreAddRepo(db, { owner, name, localPath });
+  } catch (err) {
+    console.error("[issuectl] Failed to add repo:", err);
+    const msg =
+      err instanceof Error && err.message.includes("UNIQUE")
+        ? "Repository already tracked"
+        : "Failed to add repository";
+    return { success: false, error: msg };
+  }
+  revalidatePath("/settings");
+  revalidatePath("/");
+
+  if (localPath) {
+    const exists = await stat(expandHome(localPath)).catch(() => null);
+    if (!exists) {
+      return { success: true, warning: "Local path does not exist — will prompt to clone on launch" };
+    }
+  }
+
+  return { success: true };
+}
+
+export async function removeRepo(
+  id: number,
+): Promise<{ success: boolean; error?: string }> {
+  if (!id || id <= 0) {
+    return { success: false, error: "Invalid repo ID" };
+  }
+
+  try {
+    const db = getDb();
+    coreRemoveRepo(db, id);
+  } catch (err) {
+    console.error("[issuectl] Failed to remove repo:", err);
+    return { success: false, error: "Failed to remove repository" };
+  }
+  revalidatePath("/settings");
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function updateRepo(
+  id: number,
+  updates: { localPath?: string; branchPattern?: string },
+): Promise<{ success: boolean; error?: string }> {
+  if (!id || id <= 0) {
+    return { success: false, error: "Invalid repo ID" };
+  }
+
+  try {
+    const db = getDb();
+    coreUpdateRepo(db, id, updates);
+  } catch (err) {
+    console.error("[issuectl] Failed to update repo:", err);
+    return { success: false, error: "Failed to update repository" };
+  }
+  revalidatePath("/settings");
+  return { success: true };
+}

--- a/packages/web/lib/actions/settings.ts
+++ b/packages/web/lib/actions/settings.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getDb, setSetting } from "@issuectl/core";
+import type { SettingKey } from "@issuectl/core";
+
+const VALID_KEYS = [
+  "branch_pattern",
+  "terminal_app",
+  "terminal_mode",
+  "cache_ttl",
+  "worktree_dir",
+] as const satisfies readonly SettingKey[];
+
+export async function updateSetting(
+  key: SettingKey,
+  value: string,
+): Promise<{ success: boolean; error?: string }> {
+  if (!VALID_KEYS.includes(key)) {
+    return { success: false, error: "Invalid setting key" };
+  }
+  if (!value.trim()) {
+    return { success: false, error: "Value cannot be empty" };
+  }
+  if (key === "cache_ttl") {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num < 0) {
+      return { success: false, error: "Cache TTL must be a non-negative number" };
+    }
+  }
+
+  try {
+    const db = getDb();
+    setSetting(db, key, value.trim());
+  } catch (err) {
+    console.error("[issuectl] Failed to update setting:", err);
+    return { success: false, error: "Failed to update setting" };
+  }
+  revalidatePath("/settings");
+  return { success: true };
+}

--- a/packages/web/lib/actions/worktrees.ts
+++ b/packages/web/lib/actions/worktrees.ts
@@ -38,7 +38,11 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
 
   try {
     entries = await readdir(dir);
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    console.error("[issuectl] Failed to read worktree directory:", err);
     return [];
   }
 
@@ -51,11 +55,12 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
       const info = await stat(fullPath).catch(() => null);
       if (!info?.isDirectory()) return null;
 
+      // Worktree dirs follow: {repo-or-owner-repo}-issue-{number}
       const match = name.match(/^(.+)-issue-(\d+)$/);
       const repoName = match ? match[1] : null;
       const issueNumber = match ? Number(match[2]) : null;
 
-      // Try to match against tracked repos by name
+      // Match against tracked repos — worktree dirs may use "repo" or "owner-repo" naming
       const trackedRepo = repoName
         ? repos.find((r) => r.name === repoName || `${r.owner}-${r.name}` === repoName)
         : null;
@@ -79,7 +84,8 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
   let octokit;
   try {
     octokit = await getOctokit();
-  } catch {
+  } catch (err) {
+    console.warn("[issuectl] Could not authenticate with GitHub — staleness checks skipped:", err);
     return worktrees;
   }
 
@@ -87,7 +93,7 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
     worktrees.map(async (wt) => {
       if (!wt.owner || !wt.repo || !wt.issueNumber) return;
 
-      // Resolve the actual repo name (strip owner prefix if present)
+      // Look up the canonical repo name from tracked repos
       const repoName = repos.find(
         (r) => r.name === wt.repo || `${r.owner}-${r.name}` === wt.repo,
       )?.name;
@@ -100,8 +106,15 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
           issue_number: wt.issueNumber,
         });
         wt.stale = data.state === "closed";
-      } catch {
-        // API failure — leave as not stale
+      } catch (err) {
+        if (err && typeof err === "object" && "status" in err) {
+          const status = (err as { status: number }).status;
+          if (status === 404 || status === 410) {
+            wt.stale = true;
+            return;
+          }
+        }
+        console.warn(`[issuectl] Failed to check staleness for ${wt.owner}/${repoName}#${wt.issueNumber}:`, err);
       }
     }),
   );
@@ -114,20 +127,37 @@ export async function cleanupWorktree(
   parentRepoPath?: string,
 ): Promise<{ success: boolean; error?: string }> {
   const worktreeDir = getWorktreeDir();
+  // Prevent path traversal — only allow deletion within the configured worktree directory
   const resolved = resolve(path);
   if (!resolved.startsWith(resolve(worktreeDir))) {
     return { success: false, error: "Invalid worktree path" };
   }
 
+  // Validate parentRepoPath against tracked repos if provided
+  let cwd: string | undefined;
+  if (parentRepoPath) {
+    const db = getDb();
+    const repos = listRepos(db);
+    const matched = repos.find(
+      (r) => r.localPath && resolve(expandHome(r.localPath)) === resolve(expandHome(parentRepoPath)),
+    );
+    if (!matched) {
+      return { success: false, error: "Unknown repository path" };
+    }
+    cwd = expandHome(parentRepoPath);
+  }
+
   try {
-    const cwd = parentRepoPath ? expandHome(parentRepoPath) : undefined;
+    // Two-phase cleanup: best-effort git worktree remove, then always rm the directory
     await execFileAsync("git", ["worktree", "remove", resolved, "--force"], { cwd }).catch(
       (err) => {
-        console.warn("[issuectl] git worktree remove failed, falling back to rm:", err.message);
+        console.warn("[issuectl] git worktree remove failed, will still rm directory:", err.message);
       },
     );
     if (cwd) {
-      await execFileAsync("git", ["worktree", "prune"], { cwd }).catch(() => {});
+      await execFileAsync("git", ["worktree", "prune"], { cwd }).catch((err) => {
+        console.warn("[issuectl] git worktree prune failed:", err.message);
+      });
     }
     await rm(resolved, { recursive: true, force: true });
   } catch (err) {
@@ -148,11 +178,23 @@ export async function cleanupStaleWorktrees(): Promise<{ success: boolean; remov
   }
 
   let removed = 0;
+  const failures: string[] = [];
   for (const wt of stale) {
     const result = await cleanupWorktree(wt.path, wt.localPath ?? undefined);
-    if (result.success) removed++;
+    if (result.success) {
+      removed++;
+    } else {
+      failures.push(`${wt.name}: ${result.error}`);
+    }
   }
 
   revalidatePath("/settings");
+  if (failures.length > 0) {
+    return {
+      success: false,
+      removed,
+      error: `Failed to remove ${failures.length} worktree(s)`,
+    };
+  }
   return { success: true, removed };
 }

--- a/packages/web/lib/actions/worktrees.ts
+++ b/packages/web/lib/actions/worktrees.ts
@@ -1,0 +1,158 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { getDb, getSetting, listRepos, getOctokit } from "@issuectl/core";
+
+const execFileAsync = promisify(execFile);
+
+export type WorktreeInfo = {
+  path: string;
+  name: string;
+  repo: string | null;
+  owner: string | null;
+  localPath: string | null;
+  issueNumber: number | null;
+  stale: boolean;
+};
+
+function expandHome(p: string): string {
+  return p.startsWith("~") ? p.replace("~", homedir()) : p;
+}
+
+const DEFAULT_WORKTREE_DIR = "~/.issuectl/worktrees/";
+
+function getWorktreeDir(): string {
+  const db = getDb();
+  const configured = getSetting(db, "worktree_dir");
+  return expandHome(configured ?? DEFAULT_WORKTREE_DIR);
+}
+
+export async function listWorktrees(): Promise<WorktreeInfo[]> {
+  const dir = getWorktreeDir();
+  let entries: string[];
+
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const db = getDb();
+  const repos = listRepos(db);
+
+  const results = await Promise.all(
+    entries.map(async (name) => {
+      const fullPath = join(dir, name);
+      const info = await stat(fullPath).catch(() => null);
+      if (!info?.isDirectory()) return null;
+
+      const match = name.match(/^(.+)-issue-(\d+)$/);
+      const repoName = match ? match[1] : null;
+      const issueNumber = match ? Number(match[2]) : null;
+
+      // Try to match against tracked repos by name
+      const trackedRepo = repoName
+        ? repos.find((r) => r.name === repoName || `${r.owner}-${r.name}` === repoName)
+        : null;
+
+      const wt: WorktreeInfo = {
+        path: fullPath,
+        name,
+        repo: repoName,
+        owner: trackedRepo?.owner ?? null,
+        localPath: trackedRepo?.localPath ?? null,
+        issueNumber,
+        stale: false,
+      };
+      return wt;
+    }),
+  );
+
+  const worktrees = results.filter((wt): wt is WorktreeInfo => wt !== null);
+
+  // Check staleness via GitHub API — a closed issue means the worktree is stale
+  let octokit;
+  try {
+    octokit = await getOctokit();
+  } catch {
+    return worktrees;
+  }
+
+  await Promise.all(
+    worktrees.map(async (wt) => {
+      if (!wt.owner || !wt.repo || !wt.issueNumber) return;
+
+      // Resolve the actual repo name (strip owner prefix if present)
+      const repoName = repos.find(
+        (r) => r.name === wt.repo || `${r.owner}-${r.name}` === wt.repo,
+      )?.name;
+      if (!repoName) return;
+
+      try {
+        const { data } = await octokit.rest.issues.get({
+          owner: wt.owner,
+          repo: repoName,
+          issue_number: wt.issueNumber,
+        });
+        wt.stale = data.state === "closed";
+      } catch {
+        // API failure — leave as not stale
+      }
+    }),
+  );
+
+  return worktrees;
+}
+
+export async function cleanupWorktree(
+  path: string,
+  parentRepoPath?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const worktreeDir = getWorktreeDir();
+  const resolved = resolve(path);
+  if (!resolved.startsWith(resolve(worktreeDir))) {
+    return { success: false, error: "Invalid worktree path" };
+  }
+
+  try {
+    const cwd = parentRepoPath ? expandHome(parentRepoPath) : undefined;
+    await execFileAsync("git", ["worktree", "remove", resolved, "--force"], { cwd }).catch(
+      (err) => {
+        console.warn("[issuectl] git worktree remove failed, falling back to rm:", err.message);
+      },
+    );
+    if (cwd) {
+      await execFileAsync("git", ["worktree", "prune"], { cwd }).catch(() => {});
+    }
+    await rm(resolved, { recursive: true, force: true });
+  } catch (err) {
+    console.error("[issuectl] Failed to cleanup worktree:", err);
+    return { success: false, error: "Failed to remove worktree" };
+  }
+
+  revalidatePath("/settings");
+  return { success: true };
+}
+
+export async function cleanupStaleWorktrees(): Promise<{ success: boolean; removed: number; error?: string }> {
+  const worktrees = await listWorktrees();
+  const stale = worktrees.filter((wt) => wt.stale);
+
+  if (stale.length === 0) {
+    return { success: true, removed: 0 };
+  }
+
+  let removed = 0;
+  for (const wt of stale) {
+    const result = await cleanupWorktree(wt.path, wt.localPath ?? undefined);
+    if (result.success) removed++;
+  }
+
+  revalidatePath("/settings");
+  return { success: true, removed };
+}


### PR DESCRIPTION
## Summary
- Add `/settings` page with five sections: Tracked Repositories, Defaults, Terminal, Worktrees, and Authentication
- Tracked repos: add/edit/remove with inline forms, confirmation dialogs, and local-path existence warnings
- Defaults: branch pattern + cache TTL with save-on-blur
- Terminal: read-only app display + window/tab mode toggle
- Worktrees: list with stale detection (checks closed issues via GitHub API), individual delete, and "Clean all stale" bulk action with proper `cwd` for `git worktree remove`
- Authentication: green/red status dot with username display

## Implementation details
- Server Actions: `repos.ts`, `settings.ts`, `worktrees.ts` — all follow existing `{ success, error? }` pattern
- 8 new components with CSS Modules matching the mockup design tokens
- Path traversal protection in `cleanupWorktree` via `resolve()` before prefix check
- `Promise.all` for concurrent `checkGhAuth()` + `listWorktrees()` on page load
- `Promise.all` for parallel `stat()` and GitHub API calls in `listWorktrees`
- Worktree dir reads from DB setting (not hardcoded)
- `satisfies` on `VALID_KEYS` for type synchronization with `SettingKey`

## Test plan
- [ ] Navigate to `/settings` — all sections render
- [ ] Add a repo with valid `owner/repo` format — appears in list
- [ ] Add a repo with non-existent local path — warning displays
- [ ] Edit a repo's local path and branch pattern — saves on Save click
- [ ] Remove a repo — confirmation dialog shows, repo disappears after confirm
- [ ] Change branch pattern — saves on blur, "Saved" indicator appears
- [ ] Change cache TTL — saves on blur
- [ ] Toggle terminal mode between Window and Tab — saves immediately
- [ ] Auth status shows green dot with username
- [ ] Worktrees section shows empty state when no worktrees exist
- [ ] Stale worktrees (closed issues) show dashed border + "stale" badge
- [ ] "Clean all stale" button removes only stale worktrees