### PR TITLE
feat: launch modal and launch active view (Phase 11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ issuectl web                    # Start dashboard (localhost:3847)
 
 ### After completing a phase or major feature
 
-4. **`/review-pr`** — Run a comprehensive PR review before considering any phase complete. This is the final gate. It reviews all changes holistically — cross-file issues, missed edge cases, convention violations across the full diff. Use the full review, not a quick scan.
+4. **`/pr-review-toolkit:review-pr`** — Run a comprehensive PR review before considering any phase complete. This is the final gate. It reviews all changes holistically — cross-file issues, missed edge cases, convention violations across the full diff. Use the full review, not a quick scan.
 
 5. **Validate the plugin/project structure** as needed — if you've added new packages, changed the monorepo structure, or modified build config, verify that `pnpm turbo build` still succeeds and all packages resolve correctly.
 

--- a/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.module.css
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.module.css
@@ -1,0 +1,25 @@
+.content {
+  padding: 0 32px 32px;
+  max-width: 640px;
+}
+
+.pageTitle {
+  font-size: 22px;
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 8px;
+}
+
+.error {
+  padding: 40px 32px;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  text-align: center;
+}

--- a/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
@@ -55,8 +55,11 @@ export default async function LaunchActivePage({
     );
     commentCount = detail.comments.length;
     fileCount = detail.referencedFiles.length;
-  } catch {
-    // Non-fatal — we still show the deployment info
+  } catch (err) {
+    console.error(
+      `[issuectl] Failed to load issue detail for #${issueNumber} on launch page:`,
+      err,
+    );
   }
 
   return (

--- a/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+import {
+  getDb,
+  getDeploymentById,
+  getIssueDetail,
+  getOctokit,
+} from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/Button";
+import { LaunchActiveBanner } from "@/components/launch/LaunchActiveBanner";
+import { LaunchProgress } from "@/components/launch/LaunchProgress";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ owner: string; repo: string; number: string }>;
+  searchParams: Promise<{ deploymentId?: string }>;
+};
+
+export default async function LaunchActivePage({
+  params,
+  searchParams,
+}: Props) {
+  const { owner, repo, number: numStr } = await params;
+  const { deploymentId: depIdStr } = await searchParams;
+  const issueNumber = parseInt(numStr, 10);
+  const deploymentId = depIdStr ? parseInt(depIdStr, 10) : null;
+
+  if (Number.isNaN(issueNumber) || issueNumber < 1) {
+    return <div className={styles.error}>Invalid issue number.</div>;
+  }
+
+  const db = getDb();
+
+  const deployment =
+    deploymentId && !Number.isNaN(deploymentId)
+      ? getDeploymentById(db, deploymentId)
+      : undefined;
+
+  if (!deployment) {
+    return <div className={styles.error}>Deployment not found.</div>;
+  }
+
+  let commentCount = 0;
+  let fileCount = 0;
+  try {
+    const octokit = await getOctokit();
+    const detail = await getIssueDetail(
+      db,
+      octokit,
+      owner,
+      repo,
+      issueNumber,
+    );
+    commentCount = detail.comments.length;
+    fileCount = detail.referencedFiles.length;
+  } catch {
+    // Non-fatal — we still show the deployment info
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={
+          <span className={styles.pageTitle}>
+            Launching <span className={styles.accent}>#{issueNumber}</span> to
+            Claude Code
+          </span>
+        }
+        breadcrumb={
+          <>
+            <Link href="/">Dashboard</Link>
+            <span>/</span>
+            <Link href={`/${owner}/${repo}`}>{repo}</Link>
+            <span>/</span>
+            <Link href={`/${owner}/${repo}/issues/${issueNumber}`}>
+              #{issueNumber}
+            </Link>
+            <span>/</span>
+            <span>Launching</span>
+          </>
+        }
+      />
+      <div className={styles.content}>
+        <LaunchActiveBanner branchName={deployment.branchName} />
+
+        <LaunchProgress
+          deployment={deployment}
+          commentCount={commentCount}
+          fileCount={fileCount}
+        />
+
+        <div className={styles.actions}>
+          <Link href={`/${owner}/${repo}/issues/${issueNumber}`}>
+            <Button variant="secondary">Back to issue</Button>
+          </Link>
+          <Link href={`/${owner}/${repo}`}>
+            <Button variant="secondary">Back to {repo}</Button>
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
-import { getDb, getOctokit, getIssueDetail } from "@issuectl/core";
+import { getDb, getOctokit, getIssueDetail, getRepo } from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { Button } from "@/components/ui/Button";
 import { IssueBody } from "@/components/issue/IssueBody";
 import { CommentThread } from "@/components/issue/CommentThread";
 import { IssueSidebar } from "@/components/issue/IssueSidebar";
 import { CloseIssueButton } from "@/components/issue/CloseIssueButton";
+import { LaunchButton } from "@/components/launch/LaunchButton";
 import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
@@ -22,10 +22,10 @@ export default async function IssueDetailPage({ params }: Props) {
     return <div className={styles.error}>Invalid issue number.</div>;
   }
 
+  const db = getDb();
   let data: Awaited<ReturnType<typeof getIssueDetail>> | null = null;
 
   try {
-    const db = getDb();
     const octokit = await getOctokit();
     data = await getIssueDetail(db, octokit, owner, repo, issueNumber);
   } catch (err) {
@@ -40,6 +40,9 @@ export default async function IssueDetailPage({ params }: Props) {
   }
 
   const { issue, comments, deployments, linkedPRs, referencedFiles } = data;
+
+  const repoRecord = getRepo(db, owner, repo);
+  const repoLocalPath = repoRecord?.localPath ?? null;
 
   return (
     <>
@@ -58,18 +61,21 @@ export default async function IssueDetailPage({ params }: Props) {
         }
         actions={
           <>
-            <Button variant="secondary" disabled>
-              Edit
-            </Button>
             <CloseIssueButton
               owner={owner}
               repo={repo}
               number={issueNumber}
               isClosed={issue.state === "closed"}
             />
-            <Button variant="launch">
-              {deployments.length > 0 ? "Re-launch" : "Launch to Claude Code"}
-            </Button>
+            <LaunchButton
+              owner={owner}
+              repo={repo}
+              repoLocalPath={repoLocalPath}
+              issue={issue}
+              comments={comments}
+              deployments={deployments}
+              referencedFiles={referencedFiles}
+            />
           </>
         }
       />
@@ -85,12 +91,13 @@ export default async function IssueDetailPage({ params }: Props) {
         </div>
         <IssueSidebar
           issue={issue}
-          commentCount={comments.length}
+          comments={comments}
           deployments={deployments}
           linkedPRs={linkedPRs}
           referencedFiles={referencedFiles}
           owner={owner}
           repo={repo}
+          repoLocalPath={repoLocalPath}
         />
       </div>
     </>

--- a/packages/web/components/issue/IssueSidebar.tsx
+++ b/packages/web/components/issue/IssueSidebar.tsx
@@ -1,5 +1,6 @@
 import type {
   GitHubIssue,
+  GitHubComment,
   GitHubPull,
   GitHubLabel,
   Deployment,
@@ -13,12 +14,13 @@ import styles from "./IssueSidebar.module.css";
 
 type Props = {
   issue: GitHubIssue;
-  commentCount: number;
+  comments: GitHubComment[];
   deployments: Deployment[];
   linkedPRs: GitHubPull[];
   referencedFiles: string[];
   owner: string;
   repo: string;
+  repoLocalPath: string | null;
 };
 
 function getDisplayLabels(labels: GitHubLabel[]): GitHubLabel[] {
@@ -32,20 +34,24 @@ function getDisplayLabels(labels: GitHubLabel[]): GitHubLabel[] {
 
 export function IssueSidebar({
   issue,
-  commentCount,
+  comments,
   deployments,
   linkedPRs,
   referencedFiles,
   owner,
   repo,
+  repoLocalPath,
 }: Props) {
   const displayLabels = getDisplayLabels(issue.labels);
 
   return (
     <div className={styles.sidebar}>
       <LaunchCard
+        owner={owner}
+        repo={repo}
+        repoLocalPath={repoLocalPath}
         issue={issue}
-        commentCount={commentCount}
+        comments={comments}
         deployments={deployments}
         referencedFiles={referencedFiles}
       />

--- a/packages/web/components/issue/LaunchCard.tsx
+++ b/packages/web/components/issue/LaunchCard.tsx
@@ -1,33 +1,36 @@
-import type { Deployment, GitHubIssue } from "@issuectl/core";
-import { Button } from "@/components/ui/Button";
+import type {
+  Deployment,
+  GitHubIssue,
+  GitHubComment,
+} from "@issuectl/core";
+import { generateBranchName } from "@/lib/branch";
+import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
+import { LaunchButton } from "@/components/launch/LaunchButton";
 import styles from "./LaunchCard.module.css";
 
 type Props = {
+  owner: string;
+  repo: string;
+  repoLocalPath: string | null;
   issue: GitHubIssue;
-  commentCount: number;
+  comments: GitHubComment[];
   deployments: Deployment[];
   referencedFiles: string[];
 };
 
-function slugify(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 40);
-}
-
 export function LaunchCard({
+  owner,
+  repo,
+  repoLocalPath,
   issue,
-  commentCount,
+  comments,
   deployments,
   referencedFiles,
 }: Props) {
   const lastDeployment = deployments[0];
   const branch =
     lastDeployment?.branchName ??
-    `issue-${issue.number}-${slugify(issue.title)}`;
-  const hasLaunched = deployments.length > 0;
+    generateBranchName(DEFAULT_BRANCH_PATTERN, issue.number, issue.title);
 
   return (
     <div className={styles.card}>
@@ -38,13 +41,20 @@ export function LaunchCard({
       <div className={styles.meta}>
         context:{" "}
         <span className={styles.value}>
-          issue + {commentCount} comment{commentCount !== 1 ? "s" : ""} +{" "}
+          issue + {comments.length} comment{comments.length !== 1 ? "s" : ""} +{" "}
           {referencedFiles.length} file{referencedFiles.length !== 1 ? "s" : ""}
         </span>
       </div>
-      <Button variant="launch" className={styles.launchBtn}>
-        {hasLaunched ? "Re-launch" : "Launch"}
-      </Button>
+      <LaunchButton
+        owner={owner}
+        repo={repo}
+        repoLocalPath={repoLocalPath}
+        issue={issue}
+        comments={comments}
+        deployments={deployments}
+        referencedFiles={referencedFiles}
+        className={styles.launchBtn}
+      />
     </div>
   );
 }

--- a/packages/web/components/launch/BranchInput.module.css
+++ b/packages/web/components/launch/BranchInput.module.css
@@ -1,0 +1,35 @@
+.field {
+  margin-bottom: 16px;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-mono), monospace;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}

--- a/packages/web/components/launch/BranchInput.tsx
+++ b/packages/web/components/launch/BranchInput.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import styles from "./BranchInput.module.css";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function BranchInput({ value, onChange }: Props) {
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor="launch-branch">Branch</label>
+      <input
+        id="launch-branch"
+        className={styles.input}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+      />
+      <div className={styles.hint}>
+        Existing branch will be checked out; otherwise a new branch is created
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/launch/ClonePromptModal.module.css
+++ b/packages/web/components/launch/ClonePromptModal.module.css
@@ -1,0 +1,88 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: 500px;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
+}
+
+.header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-family: var(--font-display), sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.close {
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 18px;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.body {
+  padding: 20px 24px;
+}
+
+.footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.warning {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: var(--yellow-surface);
+  border: 1px solid var(--yellow-border);
+  border-radius: var(--radius-md);
+}
+
+.warningIcon {
+  color: var(--yellow);
+  font-size: 18px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.warningText {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}

--- a/packages/web/components/launch/ClonePromptModal.tsx
+++ b/packages/web/components/launch/ClonePromptModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import styles from "./ClonePromptModal.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+export function ClonePromptModal({ owner, repo, onConfirm, onClose }: Props) {
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <span className={styles.title}>Repository not cloned</span>
+          <button className={styles.close} onClick={onClose}>
+            &times;
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          <div className={styles.warning}>
+            <span className={styles.warningIcon}>!</span>
+            <div className={styles.warningText}>
+              <strong>
+                {owner}/{repo}
+              </strong>{" "}
+              has no local path configured. To launch Claude Code, the repo
+              will be cloned automatically.
+            </div>
+          </div>
+
+          <div className={styles.hint}>
+            A shallow clone will be created in your configured worktree
+            directory. You can change the local path later in Settings.
+          </div>
+        </div>
+
+        <div className={styles.footer}>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onConfirm}>
+            Clone &amp; Launch
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/launch/ContextToggles.module.css
+++ b/packages/web/components/launch/ContextToggles.module.css
@@ -1,0 +1,48 @@
+.field {
+  margin-bottom: 16px;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.checkbox {
+  accent-color: var(--accent);
+}
+
+.hint {
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+
+.divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.filePath {
+  font-family: var(--font-mono), monospace;
+  color: var(--cyan);
+  font-size: 11px;
+}

--- a/packages/web/components/launch/ContextToggles.tsx
+++ b/packages/web/components/launch/ContextToggles.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { GitHubComment } from "@issuectl/core";
+import { timeAgo } from "@/lib/format";
+import styles from "./ContextToggles.module.css";
+
+type Props = {
+  comments: GitHubComment[];
+  referencedFiles: string[];
+  selectedComments: number[];
+  selectedFiles: string[];
+  onToggleComment: (index: number) => void;
+  onToggleFile: (path: string) => void;
+};
+
+function commentLabel(comment: GitHubComment): string {
+  const author = comment.user?.login ?? "unknown";
+  const age = timeAgo(comment.createdAt);
+  const snippet = comment.body.slice(0, 40).replace(/\n/g, " ");
+  return `Comment: ${author} (${age}) — ${snippet}${comment.body.length > 40 ? "…" : ""}`;
+}
+
+export function ContextToggles({
+  comments,
+  referencedFiles,
+  selectedComments,
+  selectedFiles,
+  onToggleComment,
+  onToggleFile,
+}: Props) {
+  return (
+    <div className={styles.field}>
+      <div className={styles.label}>Context</div>
+      <div className={styles.list}>
+        <label className={styles.item}>
+          <input
+            type="checkbox"
+            className={styles.checkbox}
+            checked
+            disabled
+          />
+          <span>Issue body</span>
+          <span className={styles.hint}>always included</span>
+        </label>
+
+        {comments.map((comment, i) => (
+          <label key={comment.id} className={styles.item}>
+            <input
+              type="checkbox"
+              className={styles.checkbox}
+              checked={selectedComments.includes(i)}
+              onChange={() => onToggleComment(i)}
+            />
+            <span>{commentLabel(comment)}</span>
+          </label>
+        ))}
+
+        {referencedFiles.length > 0 && (
+          <div className={styles.divider} />
+        )}
+
+        {referencedFiles.map((file) => (
+          <label key={file} className={styles.item}>
+            <input
+              type="checkbox"
+              className={styles.checkbox}
+              checked={selectedFiles.includes(file)}
+              onChange={() => onToggleFile(file)}
+            />
+            <span className={styles.filePath}>{file}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/launch/LaunchActiveBanner.module.css
+++ b/packages/web/components/launch/LaunchActiveBanner.module.css
@@ -1,0 +1,45 @@
+.banner {
+  padding: 16px 20px;
+  background: linear-gradient(
+    135deg,
+    rgba(232, 113, 37, 0.08) 0%,
+    rgba(232, 113, 37, 0.02) 100%
+  );
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--accent-border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.text {
+  flex: 1;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.sub {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}

--- a/packages/web/components/launch/LaunchActiveBanner.tsx
+++ b/packages/web/components/launch/LaunchActiveBanner.tsx
@@ -1,0 +1,19 @@
+import styles from "./LaunchActiveBanner.module.css";
+
+type Props = {
+  branchName: string;
+};
+
+export function LaunchActiveBanner({ branchName }: Props) {
+  return (
+    <div className={styles.banner}>
+      <div className={styles.spinner} />
+      <div className={styles.text}>
+        <div className={styles.title}>Claude Code session active</div>
+        <div className={styles.sub}>
+          Opened in Ghostty &middot; branch: {branchName}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/launch/LaunchButton.tsx
+++ b/packages/web/components/launch/LaunchButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  GitHubIssue,
+  GitHubComment,
+  Deployment,
+} from "@issuectl/core";
+import { Button } from "@/components/ui/Button";
+import { LaunchModal } from "./LaunchModal";
+import { ClonePromptModal } from "./ClonePromptModal";
+
+type Props = {
+  owner: string;
+  repo: string;
+  repoLocalPath: string | null;
+  issue: GitHubIssue;
+  comments: GitHubComment[];
+  deployments: Deployment[];
+  referencedFiles: string[];
+  className?: string;
+};
+
+export function LaunchButton({
+  owner,
+  repo,
+  repoLocalPath,
+  issue,
+  comments,
+  deployments,
+  referencedFiles,
+  className,
+}: Props) {
+  const [showModal, setShowModal] = useState(false);
+  const [showClonePrompt, setShowClonePrompt] = useState(false);
+  const [forceCloneMode, setForceCloneMode] = useState(false);
+
+  const hasLaunched = deployments.length > 0;
+
+  function handleClick() {
+    if (!repoLocalPath) {
+      setShowClonePrompt(true);
+    } else {
+      setForceCloneMode(false);
+      setShowModal(true);
+    }
+  }
+
+  function handleCloneConfirm() {
+    setShowClonePrompt(false);
+    setForceCloneMode(true);
+    setShowModal(true);
+  }
+
+  return (
+    <>
+      <Button variant="launch" className={className} onClick={handleClick}>
+        {hasLaunched ? "Re-launch" : "Launch to Claude Code"}
+      </Button>
+
+      {showClonePrompt && (
+        <ClonePromptModal
+          owner={owner}
+          repo={repo}
+          onConfirm={handleCloneConfirm}
+          onClose={() => setShowClonePrompt(false)}
+        />
+      )}
+
+      {showModal && (
+        <LaunchModal
+          owner={owner}
+          repo={repo}
+          repoLocalPath={repoLocalPath}
+          issue={issue}
+          comments={comments}
+          deployments={deployments}
+          referencedFiles={referencedFiles}
+          initialWorkspaceMode={forceCloneMode ? "clone" : undefined}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/launch/LaunchModal.module.css
+++ b/packages/web/components/launch/LaunchModal.module.css
@@ -1,0 +1,101 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: 620px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
+}
+
+.header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-family: var(--font-display), sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.close {
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 18px;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.body {
+  padding: 20px 24px;
+}
+
+.footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* Issue summary card */
+.issueSummary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.issueDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  flex-shrink: 0;
+}
+
+.issueTitle {
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.issueRepo {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.error {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius-md);
+  color: var(--red);
+  font-size: 12px;
+}

--- a/packages/web/components/launch/LaunchModal.module.css
+++ b/packages/web/components/launch/LaunchModal.module.css
@@ -60,7 +60,6 @@
   gap: 8px;
 }
 
-/* Issue summary card */
 .issueSummary {
   display: flex;
   align-items: center;

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -97,18 +97,24 @@ export function LaunchModal({
         return;
       }
 
+      const deploymentId = result.deploymentId;
+      if (!deploymentId) {
+        setError("Launch succeeded but deployment ID was not returned");
+        return;
+      }
+
       router.push(
-        `/${owner}/${repo}/issues/${issue.number}/launch?deploymentId=${result.launchResult!.deploymentId}`,
+        `/${owner}/${repo}/issues/${issue.number}/launch?deploymentId=${deploymentId}`,
       );
     });
   }
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
+    <div className={styles.overlay} onClick={isPending ? undefined : onClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.header}>
           <span className={styles.title}>Launch to Claude Code</span>
-          <button className={styles.close} onClick={onClose}>
+          <button className={styles.close} onClick={isPending ? undefined : onClose} disabled={isPending}>
             &times;
           </button>
         </div>

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useTransition, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  GitHubIssue,
+  GitHubComment,
+  Deployment,
+  WorkspaceMode,
+} from "@issuectl/core";
+import { generateBranchName } from "@/lib/branch";
+import { launchIssue } from "@/lib/actions/launch";
+import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
+import { Button } from "@/components/ui/Button";
+import { BranchInput } from "./BranchInput";
+import { WorkspaceModeSelector } from "./WorkspaceModeSelector";
+import { ContextToggles } from "./ContextToggles";
+import { PreambleInput } from "./PreambleInput";
+import styles from "./LaunchModal.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  repoLocalPath: string | null;
+  issue: GitHubIssue;
+  comments: GitHubComment[];
+  deployments: Deployment[];
+  referencedFiles: string[];
+  initialWorkspaceMode?: WorkspaceMode;
+  onClose: () => void;
+};
+
+export function LaunchModal({
+  owner,
+  repo,
+  repoLocalPath,
+  issue,
+  comments,
+  deployments,
+  referencedFiles,
+  initialWorkspaceMode,
+  onClose,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const lastDeployment = deployments[0];
+  const defaultBranch =
+    lastDeployment?.branchName ??
+    generateBranchName(DEFAULT_BRANCH_PATTERN, issue.number, issue.title);
+
+  const [branchName, setBranchName] = useState(defaultBranch);
+  const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>(
+    initialWorkspaceMode ?? (repoLocalPath ? "existing" : "clone"),
+  );
+  const [selectedComments, setSelectedComments] = useState<number[]>(
+    comments.map((_, i) => i),
+  );
+  const [selectedFiles, setSelectedFiles] = useState<string[]>(
+    referencedFiles,
+  );
+  const [preamble, setPreamble] = useState("");
+
+  const toggleComment = useCallback((index: number) => {
+    setSelectedComments((prev) =>
+      prev.includes(index)
+        ? prev.filter((i) => i !== index)
+        : [...prev, index],
+    );
+  }, []);
+
+  const toggleFile = useCallback((path: string) => {
+    setSelectedFiles((prev) =>
+      prev.includes(path)
+        ? prev.filter((p) => p !== path)
+        : [...prev, path],
+    );
+  }, []);
+
+  function handleLaunch() {
+    setError(null);
+    startTransition(async () => {
+      const result = await launchIssue({
+        owner,
+        repo,
+        issueNumber: issue.number,
+        branchName: branchName.trim(),
+        workspaceMode,
+        selectedCommentIndices: selectedComments,
+        selectedFilePaths: selectedFiles,
+        preamble: preamble.trim() || undefined,
+      });
+
+      if (!result.success) {
+        setError(result.error ?? "Launch failed");
+        return;
+      }
+
+      router.push(
+        `/${owner}/${repo}/issues/${issue.number}/launch?deploymentId=${result.launchResult!.deploymentId}`,
+      );
+    });
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <span className={styles.title}>Launch to Claude Code</span>
+          <button className={styles.close} onClick={onClose}>
+            &times;
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          <div className={styles.issueSummary}>
+            <span className={styles.issueDot} />
+            <div>
+              <div className={styles.issueTitle}>
+                #{issue.number} &middot; {issue.title}
+              </div>
+              <div className={styles.issueRepo}>
+                {owner}/{repo}
+              </div>
+            </div>
+          </div>
+
+          <BranchInput value={branchName} onChange={setBranchName} />
+
+          <WorkspaceModeSelector
+            value={workspaceMode}
+            onChange={setWorkspaceMode}
+            repoLocalPath={repoLocalPath}
+            repo={repo}
+            issueNumber={issue.number}
+          />
+
+          <ContextToggles
+            comments={comments}
+            referencedFiles={referencedFiles}
+            selectedComments={selectedComments}
+            selectedFiles={selectedFiles}
+            onToggleComment={toggleComment}
+            onToggleFile={toggleFile}
+          />
+
+          <PreambleInput value={preamble} onChange={setPreamble} />
+
+          {error && (
+            <div className={styles.error} role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.footer}>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="launch"
+            onClick={handleLaunch}
+            disabled={isPending || !branchName.trim()}
+          >
+            {isPending ? "Launching…" : "Launch"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/launch/LaunchProgress.module.css
+++ b/packages/web/components/launch/LaunchProgress.module.css
@@ -1,0 +1,75 @@
+.steps {
+  margin-top: 24px;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.step:last-child {
+  border-bottom: none;
+}
+
+.numDone {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono), monospace;
+  background: var(--green-surface);
+  color: var(--green);
+  border: 1px solid var(--green-border);
+}
+
+.numActive {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 2px solid var(--accent-border);
+  border-top-color: var(--accent);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.content {
+  flex: 1;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.labelActive {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+
+.detail {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono), monospace;
+}
+
+.highlight {
+  color: var(--cyan);
+}

--- a/packages/web/components/launch/LaunchProgress.tsx
+++ b/packages/web/components/launch/LaunchProgress.tsx
@@ -1,0 +1,80 @@
+import type { Deployment } from "@issuectl/core";
+import { LIFECYCLE_LABEL } from "@issuectl/core";
+import styles from "./LaunchProgress.module.css";
+
+type Step = {
+  label: string;
+  detail: string;
+  highlightDetail?: boolean;
+  status: "done" | "active";
+};
+
+type Props = {
+  deployment: Deployment;
+  commentCount: number;
+  fileCount: number;
+};
+
+export function LaunchProgress({ deployment, commentCount, fileCount }: Props) {
+  const steps: Step[] = [
+    {
+      label: "Assembled issue context",
+      detail: `issue + ${commentCount} comment${commentCount !== 1 ? "s" : ""} + ${fileCount} referenced file${fileCount !== 1 ? "s" : ""}`,
+      status: "done",
+    },
+    {
+      label: "Checked deployment history",
+      detail: `Deployment #${deployment.id}`,
+      status: "done",
+    },
+    {
+      label: "Checked out branch",
+      detail: deployment.branchName,
+      highlightDetail: true,
+      status: "done",
+    },
+    {
+      label: "Applied lifecycle label",
+      detail: LIFECYCLE_LABEL.deployed,
+      status: "done",
+    },
+    {
+      label: "Claude Code running",
+      detail: deployment.workspacePath,
+      highlightDetail: true,
+      status: "active",
+    },
+  ];
+
+  return (
+    <div className={styles.steps}>
+      {steps.map((step) => (
+        <div key={step.label} className={styles.step}>
+          <div
+            className={
+              step.status === "done" ? styles.numDone : styles.numActive
+            }
+          >
+            {step.status === "done" ? "\u2713" : ""}
+          </div>
+          <div className={styles.content}>
+            <div
+              className={
+                step.status === "active" ? styles.labelActive : styles.label
+              }
+            >
+              {step.label}
+            </div>
+            <div className={styles.detail}>
+              {step.highlightDetail ? (
+                <span className={styles.highlight}>{step.detail}</span>
+              ) : (
+                step.detail
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/launch/PreambleInput.module.css
+++ b/packages/web/components/launch/PreambleInput.module.css
@@ -1,0 +1,36 @@
+.field {
+  /* Last field in modal body — no bottom margin */
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.optional {
+  text-transform: none;
+  font-weight: 400;
+}
+
+.textarea {
+  width: 100%;
+  height: 60px;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+  resize: vertical;
+}
+
+.textarea:focus {
+  border-color: var(--accent-border);
+}

--- a/packages/web/components/launch/PreambleInput.tsx
+++ b/packages/web/components/launch/PreambleInput.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import styles from "./PreambleInput.module.css";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function PreambleInput({ value, onChange }: Props) {
+  return (
+    <div className={styles.field}>
+      <label className={styles.label}>
+        Custom preamble <span className={styles.optional}>(optional)</span>
+      </label>
+      <textarea
+        className={styles.textarea}
+        placeholder="Additional instructions for Claude Code..."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/packages/web/components/launch/WorkspaceModeSelector.module.css
+++ b/packages/web/components/launch/WorkspaceModeSelector.module.css
@@ -1,0 +1,56 @@
+.field {
+  margin-bottom: 16px;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.option.selected {
+  background: var(--accent-surface);
+  border-color: var(--accent-border);
+}
+
+.option.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.radio {
+  margin-top: 2px;
+  accent-color: var(--accent);
+}
+
+.optionLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.optionDetail {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 1px;
+}

--- a/packages/web/components/launch/WorkspaceModeSelector.tsx
+++ b/packages/web/components/launch/WorkspaceModeSelector.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { WorkspaceMode } from "@issuectl/core";
+import { cn } from "@/lib/cn";
+import styles from "./WorkspaceModeSelector.module.css";
+
+type Props = {
+  value: WorkspaceMode;
+  onChange: (value: WorkspaceMode) => void;
+  repoLocalPath: string | null;
+  repo: string;
+  issueNumber: number;
+};
+
+type Option = {
+  mode: WorkspaceMode;
+  label: string;
+  detail: string;
+};
+
+export function WorkspaceModeSelector({
+  value,
+  onChange,
+  repoLocalPath,
+  repo,
+  issueNumber,
+}: Props) {
+  const options: Option[] = [
+    {
+      mode: "existing",
+      label: "Existing repo",
+      detail: repoLocalPath ?? "No local path configured",
+    },
+    {
+      mode: "worktree",
+      label: "Git worktree",
+      detail: `~/.issuectl/worktrees/${repo}-issue-${issueNumber}/ · isolated, fast, shared history`,
+    },
+    {
+      mode: "clone",
+      label: "Fresh clone",
+      detail: `~/.issuectl/worktrees/${repo}-issue-${issueNumber}/ · fully isolated, slower`,
+    },
+  ];
+
+  return (
+    <div className={styles.field}>
+      <div className={styles.label}>Workspace</div>
+      <div className={styles.options}>
+        {options.map((opt) => {
+          const isSelected = value === opt.mode;
+          const isDisabled = opt.mode === "existing" && !repoLocalPath;
+          return (
+            <label
+              key={opt.mode}
+              className={cn(
+                styles.option,
+                isSelected && styles.selected,
+                isDisabled && styles.disabled,
+              )}
+            >
+              <input
+                type="radio"
+                name="workspace"
+                className={styles.radio}
+                checked={isSelected}
+                disabled={isDisabled}
+                onChange={() => onChange(opt.mode)}
+              />
+              <div>
+                <div className={styles.optionLabel}>{opt.label}</div>
+                <div className={styles.optionDetail}>{opt.detail}</div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getDb,
+  getOctokit,
+  executeLaunch,
+  type LaunchResult,
+  type WorkspaceMode,
+} from "@issuectl/core";
+
+type LaunchFormData = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  branchName: string;
+  workspaceMode: WorkspaceMode;
+  selectedCommentIndices: number[];
+  selectedFilePaths: string[];
+  preamble?: string;
+};
+
+type LaunchResponse = {
+  success: boolean;
+  launchResult?: LaunchResult;
+  error?: string;
+};
+
+const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
+  "existing",
+  "worktree",
+  "clone",
+];
+
+export async function launchIssue(
+  formData: LaunchFormData,
+): Promise<LaunchResponse> {
+  const { owner, repo, issueNumber, branchName, workspaceMode } = formData;
+
+  if (!owner || !repo || !Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return { success: false, error: "Invalid issue reference" };
+  }
+  if (!branchName.trim()) {
+    return { success: false, error: "Branch name is required" };
+  }
+  if (!VALID_WORKSPACE_MODES.includes(workspaceMode)) {
+    return { success: false, error: "Invalid workspace mode" };
+  }
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+
+    const result = await executeLaunch(db, octokit, {
+      owner,
+      repo,
+      issueNumber,
+      branchName,
+      workspaceMode,
+      selectedComments: formData.selectedCommentIndices,
+      selectedFiles: formData.selectedFilePaths,
+      preamble: formData.preamble || undefined,
+      terminalMode: "window",
+    });
+
+    revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
+
+    return { success: true, launchResult: result };
+  } catch (err) {
+    console.error("[issuectl] Launch failed:", err);
+    const message =
+      err instanceof Error ? err.message : "Launch failed unexpectedly";
+    return { success: false, error: message };
+  }
+}

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -5,7 +5,6 @@ import {
   getDb,
   getOctokit,
   executeLaunch,
-  type LaunchResult,
   type WorkspaceMode,
 } from "@issuectl/core";
 
@@ -22,7 +21,7 @@ type LaunchFormData = {
 
 type LaunchResponse = {
   success: boolean;
-  launchResult?: LaunchResult;
+  deploymentId?: number;
   error?: string;
 };
 
@@ -32,6 +31,8 @@ const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
   "clone",
 ];
 
+const VALID_BRANCH_RE = /^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/;
+
 export async function launchIssue(
   formData: LaunchFormData,
 ): Promise<LaunchResponse> {
@@ -40,11 +41,18 @@ export async function launchIssue(
   if (!owner || !repo || !Number.isInteger(issueNumber) || issueNumber <= 0) {
     return { success: false, error: "Invalid issue reference" };
   }
-  if (!branchName.trim()) {
+  const trimmedBranch = branchName.trim();
+  if (!trimmedBranch) {
     return { success: false, error: "Branch name is required" };
+  }
+  if (!VALID_BRANCH_RE.test(trimmedBranch)) {
+    return { success: false, error: "Branch name contains invalid characters" };
   }
   if (!VALID_WORKSPACE_MODES.includes(workspaceMode)) {
     return { success: false, error: "Invalid workspace mode" };
+  }
+  if (formData.selectedCommentIndices.some((i) => !Number.isInteger(i) || i < 0)) {
+    return { success: false, error: "Invalid comment selection" };
   }
 
   try {
@@ -55,7 +63,7 @@ export async function launchIssue(
       owner,
       repo,
       issueNumber,
-      branchName,
+      branchName: trimmedBranch,
       workspaceMode,
       selectedComments: formData.selectedCommentIndices,
       selectedFiles: formData.selectedFilePaths,
@@ -63,9 +71,13 @@ export async function launchIssue(
       terminalMode: "window",
     });
 
-    revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
+    try {
+      revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
+    } catch (revalErr) {
+      console.warn("[issuectl] Cache revalidation failed (launch succeeded):", revalErr);
+    }
 
-    return { success: true, launchResult: result };
+    return { success: true, deploymentId: result.deploymentId };
   } catch (err) {
     console.error("[issuectl] Launch failed:", err);
     const message =

--- a/packages/web/lib/branch.ts
+++ b/packages/web/lib/branch.ts
@@ -1,7 +1,7 @@
 /**
- * Generate a branch name from a pattern, issue number, and title.
- * Mirrors the logic in @issuectl/core but lives in the web package
- * so it can be used in client components without pulling in Node.js deps.
+ * Duplicated from @issuectl/core/launch/branch.ts because that module
+ * imports Node.js built-ins (child_process, util) unavailable in client
+ * components. If the core version changes, this must be updated to match.
  */
 export function generateBranchName(
   pattern: string,

--- a/packages/web/lib/branch.ts
+++ b/packages/web/lib/branch.ts
@@ -1,0 +1,22 @@
+/**
+ * Generate a branch name from a pattern, issue number, and title.
+ * Mirrors the logic in @issuectl/core but lives in the web package
+ * so it can be used in client components without pulling in Node.js deps.
+ */
+export function generateBranchName(
+  pattern: string,
+  issueNumber: number,
+  issueTitle: string,
+): string {
+  const slug =
+    issueTitle
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 50)
+      .replace(/-$/, "") || "untitled";
+
+  return pattern
+    .replace("{number}", String(issueNumber))
+    .replace("{slug}", slug);
+}

--- a/packages/web/lib/constants.ts
+++ b/packages/web/lib/constants.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_BRANCH_PATTERN = "issue-{number}-{slug}";
+
 export const REPO_COLORS = [
   "#f85149",
   "#58a6ff",

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -5,6 +5,14 @@ export function daysSince(date: string): string {
   return `${days}d`;
 }
 
+export function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days < 1) return "today";
+  if (days === 1) return "1d ago";
+  return `${days}d ago`;
+}
+
 export function formatDate(dateStr: string): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",


### PR DESCRIPTION
## Summary
- **Launch confirmation modal** with editable branch name, workspace mode selector (existing/worktree/clone), context toggles for comments and referenced files, and optional custom preamble
- **Launch active page** (`/{owner}/{repo}/issues/{number}/launch`) showing step-by-step progress with animated session banner
- **Clone prompt modal** for repos without a configured local path — confirms clone before proceeding
- **Server Action** (`launchIssue`) wrapping core `executeLaunch` with input validation
- **Wired up** the issue detail page and sidebar LaunchCard with functional launch buttons

## Key decisions
- `generateBranchName` duplicated to `packages/web/lib/branch.ts` because client components cannot import from `@issuectl/core` (it bundles `better-sqlite3` / `child_process`)
- ClonePromptModal is informational only (no editable path) since core's `prepareClone` hardcodes the clone destination to the worktree dir
- `DEFAULT_BRANCH_PATTERN` extracted to `packages/web/lib/constants.ts` to avoid duplication

## Test plan
- [ ] Open an issue detail page — Launch button appears in header and sidebar
- [ ] Click Launch — modal opens with pre-filled branch name, correct workspace options, all context checked
- [ ] Edit branch name, toggle comments/files, change workspace mode, add preamble
- [ ] Click Launch — Ghostty opens with Claude Code, redirects to launch active page
- [ ] Launch active page shows all steps as done with spinning "Claude Code running" indicator
- [ ] For a repo without local path: clone prompt modal appears first, then launch modal opens in clone mode
- [ ] Cancel buttons close modals without side effects
- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo build` passes