### PR TITLE
feat: lifecycle label reconciliation (Phase 12)

### DIFF
--- a/packages/core/src/data/issues.ts
+++ b/packages/core/src/data/issues.ts
@@ -7,6 +7,7 @@ import { findLinkedPRs } from "../github/pulls.js";
 import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
 import { getDeploymentsForIssue } from "../db/deployments.js";
 import { getRepo } from "../db/repos.js";
+import { reconcileIssueLifecycle } from "../lifecycle/reconcile.js";
 
 const FILE_PATH_PATTERN = /`([a-zA-Z0-9_./-]+\.[a-zA-Z]{1,10})`/g;
 const GITHUB_BLOB_PATTERN =
@@ -96,8 +97,13 @@ export async function getIssueDetail(
           getIssue(octokit, owner, repo, number),
           fetchComments(octokit, owner, repo, number),
           findLinkedPRs(octokit, owner, repo, number),
-        ]).then(([issue, comments, linkedPRs]) => {
+        ]).then(async ([issue, comments, linkedPRs]) => {
           setCached(db, cacheKey, { issue, comments, linkedPRs });
+          try {
+            await reconcileIssueLifecycle(db, octokit, owner, repo, issue, linkedPRs);
+          } catch (err) {
+            console.warn(`[issuectl] Lifecycle reconciliation failed for #${number}:`, err);
+          }
         }).catch((err) => {
           console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
         });
@@ -119,6 +125,12 @@ export async function getIssueDetail(
   ]);
 
   setCached(db, cacheKey, { issue, comments, linkedPRs });
+
+  if (!options?.forceRefresh) {
+    reconcileIssueLifecycle(db, octokit, owner, repo, issue, linkedPRs).catch(
+      (err) => console.warn(`[issuectl] Lifecycle reconciliation failed for #${number}:`, err),
+    );
+  }
 
   return {
     issue,

--- a/packages/core/src/data/repos.ts
+++ b/packages/core/src/data/repos.ts
@@ -6,6 +6,7 @@ import { listRepos } from "../db/repos.js";
 import { getIssues } from "./issues.js";
 import { getPulls } from "./pulls.js";
 import { getDeploymentsByRepo } from "../db/deployments.js";
+import { reconcileRepoLifecycle } from "../lifecycle/reconcile.js";
 
 function countLabelOccurrences(
   labels: GitHubLabel[][],
@@ -54,6 +55,25 @@ export async function getDashboardData(
         getIssues(db, octokit, repo.owner, repo.name, options),
         getPulls(db, octokit, repo.owner, repo.name, options),
       ]);
+
+      if (
+        !options?.forceRefresh &&
+        (!issueResult.fromCache || !pullResult.fromCache)
+      ) {
+        reconcileRepoLifecycle(
+          db,
+          octokit,
+          repo.owner,
+          repo.name,
+          issueResult.issues,
+          pullResult.pulls,
+        ).catch((err) =>
+          console.warn(
+            `[issuectl] Repo lifecycle reconciliation failed for ${repo.owner}/${repo.name}:`,
+            err,
+          ),
+        );
+      }
 
       const deployments = getDeploymentsByRepo(db, repo.id);
       const openIssues = issueResult.issues.filter((i) => i.state === "open");

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -1,6 +1,7 @@
 import type { Octokit } from "@octokit/rest";
 import type { GitHubPull, GitHubCheck, GitHubPullFile, RawGitHubUser } from "./types.js";
 import { mapUser } from "./types.js";
+import { matchLinkedPRs } from "../lifecycle/detect.js";
 
 function mapPull(raw: unknown): GitHubPull {
   const r = raw as {
@@ -117,13 +118,6 @@ export async function findLinkedPRs(
   repo: string,
   issueNumber: number,
 ): Promise<GitHubPull[]> {
-  const pattern = /(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
   const pulls = await listPulls(octokit, owner, repo, "all");
-  return pulls.filter((pr) => {
-    if (!pr.body) return false;
-    for (const match of pr.body.matchAll(pattern)) {
-      if (Number(match[1]) === issueNumber) return true;
-    }
-    return false;
-  });
+  return matchLinkedPRs(pulls, issueNumber);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,3 +99,12 @@ export {
   openGhosttyTab,
   verifyGhosttyInstalled,
 } from "./launch/ghostty.js";
+
+// Lifecycle label reconciliation
+export { matchLinkedPRs } from "./lifecycle/detect.js";
+export {
+  reconcileIssueLifecycle,
+  reconcileRepoLifecycle,
+  type ReconcileResult,
+  type LinkedPRState,
+} from "./lifecycle/reconcile.js";

--- a/packages/core/src/lifecycle/detect.ts
+++ b/packages/core/src/lifecycle/detect.ts
@@ -1,0 +1,25 @@
+import type { GitHubPull } from "../github/types.js";
+
+const CLOSING_PATTERN =
+  /(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+
+/**
+ * Filters a pre-fetched PR list for PRs that reference the given issue
+ * via GitHub closing keywords (Closes #N, Fixes #N, Resolves #N).
+ * Only scans PR body text; does not check titles or commit messages.
+ *
+ * `findLinkedPRs` in the GitHub layer wraps this with a full paginated
+ * PR fetch — use this function directly when you already have the list.
+ */
+export function matchLinkedPRs(
+  pulls: GitHubPull[],
+  issueNumber: number,
+): GitHubPull[] {
+  return pulls.filter((pr) => {
+    if (!pr.body) return false;
+    for (const match of pr.body.matchAll(CLOSING_PATTERN)) {
+      if (Number(match[1]) === issueNumber) return true;
+    }
+    return false;
+  });
+}

--- a/packages/core/src/lifecycle/reconcile.ts
+++ b/packages/core/src/lifecycle/reconcile.ts
@@ -1,0 +1,144 @@
+import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
+import type { GitHubIssue, GitHubPull } from "../github/types.js";
+import {
+  LIFECYCLE_LABEL,
+  addLabel,
+  removeLabel,
+  ensureLifecycleLabels,
+} from "../github/labels.js";
+import { getRepo } from "../db/repos.js";
+import {
+  getDeploymentsForIssue,
+  getDeploymentsByRepo,
+  updateLinkedPR,
+} from "../db/deployments.js";
+import { matchLinkedPRs } from "./detect.js";
+
+export type LinkedPRState = "open" | "closed" | "merged";
+
+type LifecycleLabelValue = (typeof LIFECYCLE_LABEL)[keyof typeof LIFECYCLE_LABEL];
+
+export type ReconcileResult = {
+  labelsAdded: LifecycleLabelValue[];
+  labelsRemoved: LifecycleLabelValue[];
+  linkedPR: { number: number; state: LinkedPRState } | null;
+};
+
+/**
+ * Reconcile lifecycle labels for a single deployed issue.
+ *
+ * Accepts pre-fetched issue and linkedPRs so callers can share
+ * data they have already retrieved, avoiding redundant API calls.
+ * No-ops if the issue lacks the `issuectl:deployed` label or has
+ * no linked PRs.
+ */
+export async function reconcileIssueLifecycle(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issue: GitHubIssue,
+  linkedPRs: GitHubPull[],
+): Promise<ReconcileResult> {
+  const currentLabels = issue.labels.map((l) => l.name);
+
+  if (!currentLabels.includes(LIFECYCLE_LABEL.deployed)) {
+    return { labelsAdded: [], labelsRemoved: [], linkedPR: null };
+  }
+
+  const mergedPR = linkedPRs.find((pr) => pr.merged);
+  const openPR = linkedPRs.find((pr) => pr.state === "open");
+  const linkedPR = mergedPR ?? openPR ?? null;
+
+  if (!linkedPR) {
+    return { labelsAdded: [], labelsRemoved: [], linkedPR: null };
+  }
+
+  const repoRecord = getRepo(db, owner, repo);
+  if (repoRecord) {
+    const deployments = getDeploymentsForIssue(
+      db,
+      repoRecord.id,
+      issue.number,
+    );
+    for (const dep of deployments) {
+      if (dep.linkedPrNumber !== linkedPR.number) {
+        updateLinkedPR(db, dep.id, linkedPR.number);
+      }
+    }
+  }
+
+  const hasLabel = (name: string) => currentLabels.includes(name);
+  const toAdd: LifecycleLabelValue[] = [];
+  const toRemove: LifecycleLabelValue[] = [];
+
+  if (linkedPR.merged) {
+    if (hasLabel(LIFECYCLE_LABEL.prOpen)) {
+      toRemove.push(LIFECYCLE_LABEL.prOpen);
+    }
+    if (issue.state === "closed" && !hasLabel(LIFECYCLE_LABEL.done)) {
+      toAdd.push(LIFECYCLE_LABEL.done);
+    }
+  } else if (linkedPR.state === "open") {
+    if (!hasLabel(LIFECYCLE_LABEL.prOpen)) {
+      toAdd.push(LIFECYCLE_LABEL.prOpen);
+    }
+  }
+
+  if (toAdd.length > 0 || toRemove.length > 0) {
+    await ensureLifecycleLabels(octokit, owner, repo);
+    await Promise.all([
+      ...toRemove.map((l) => removeLabel(octokit, owner, repo, issue.number, l)),
+      ...toAdd.map((l) => addLabel(octokit, owner, repo, issue.number, l)),
+    ]);
+  }
+
+  const state: LinkedPRState = linkedPR.merged ? "merged" : linkedPR.state;
+  return { labelsAdded: toAdd, labelsRemoved: toRemove, linkedPR: { number: linkedPR.number, state } };
+}
+
+/**
+ * Reconcile lifecycle labels for all deployed issues in a repo.
+ *
+ * Accepts pre-fetched issues and pulls to avoid redundant API calls.
+ * Ensures lifecycle labels exist on the repo first.
+ */
+export async function reconcileRepoLifecycle(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issues: GitHubIssue[],
+  pulls: GitHubPull[],
+): Promise<void> {
+  const repoRecord = getRepo(db, owner, repo);
+  if (!repoRecord) {
+    console.warn(`[issuectl] Repo ${owner}/${repo} not found in DB during reconciliation — skipping`);
+    return;
+  }
+
+  const deployments = getDeploymentsByRepo(db, repoRecord.id);
+  if (deployments.length === 0) return;
+
+  await ensureLifecycleLabels(octokit, owner, repo);
+
+  const deployedIssueNumbers = new Set(deployments.map((d) => d.issueNumber));
+  const deployedIssues = issues.filter((i) =>
+    deployedIssueNumbers.has(i.number),
+  );
+
+  await Promise.all(
+    deployedIssues.map(async (issue) => {
+      try {
+        const linked = matchLinkedPRs(pulls, issue.number);
+        await reconcileIssueLifecycle(db, octokit, owner, repo, issue, linked);
+      } catch (err) {
+        console.warn(
+          `[issuectl] Failed to reconcile issue #${issue.number}:`,
+          err,
+        );
+      }
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- Add automatic lifecycle label management: detect linked PRs for deployed issues and apply `issuectl:pr-open` (PR open) / `issuectl:done` (PR merged + issue closed) labels
- New `lifecycle/detect.ts` with `matchLinkedPRs` — pure function for batch PR matching, used by both single-issue and repo-wide reconciliation
- New `lifecycle/reconcile.ts` with `reconcileIssueLifecycle` (per-issue) and `reconcileRepoLifecycle` (batch)
- Integrated into data layer: reconciliation runs fire-and-forget on fresh fetches in `getIssueDetail` and `getDashboardData`, skipped on manual refresh and cached reads
- Refactored `findLinkedPRs` to delegate to `matchLinkedPRs`, eliminating regex duplication
- Narrowed `ReconcileResult` types: `LinkedPRState` union, `LifecycleLabelValue` for label arrays
- `ensureLifecycleLabels` called before label mutations to prevent 422 on first use

## Test plan
- [ ] Deploy an issue via launch flow → verify `issuectl:deployed` label appears
- [ ] Open a PR referencing the issue with "Closes #N" → visit issue detail → verify `issuectl:pr-open` label appears
- [ ] Merge the PR → visit issue detail again → verify `issuectl:pr-open` removed and `issuectl:done` added
- [ ] Visit dashboard → verify repo-wide reconciliation runs for deployed issues
- [ ] Manual refresh button → verify labels are NOT reconciled (data-only refresh)
- [ ] Issue without `issuectl:deployed` label → verify reconciliation is a no-op
- [ ] Verify `deployments.linked_pr_number` is updated in DB when PR is detected