### PR TITLE
feat: issue mutation flows — create, edit, close, labels (Phase 13)

### DIFF
--- a/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
-import { getDb, getOctokit, getIssueDetail, getRepo } from "@issuectl/core";
+import {
+  getDb,
+  getOctokit,
+  getIssueDetail,
+  getRepo,
+  listLabels,
+  type GitHubLabel,
+} from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { IssueBody } from "@/components/issue/IssueBody";
+import { IssueDetailClient } from "@/components/issue/IssueDetailClient";
 import { CommentThread } from "@/components/issue/CommentThread";
 import { IssueSidebar } from "@/components/issue/IssueSidebar";
 import { CloseIssueButton } from "@/components/issue/CloseIssueButton";
@@ -24,10 +31,16 @@ export default async function IssueDetailPage({ params }: Props) {
 
   const db = getDb();
   let data: Awaited<ReturnType<typeof getIssueDetail>> | null = null;
+  let availableLabels: GitHubLabel[] = [];
 
   try {
     const octokit = await getOctokit();
-    data = await getIssueDetail(db, octokit, owner, repo, issueNumber);
+    const [detail, repoLabels] = await Promise.all([
+      getIssueDetail(db, octokit, owner, repo, issueNumber),
+      listLabels(octokit, owner, repo),
+    ]);
+    data = detail;
+    availableLabels = repoLabels;
   } catch (err) {
     console.error(
       `[issuectl] Failed to load issue #${issueNumber}:`,
@@ -81,7 +94,11 @@ export default async function IssueDetailPage({ params }: Props) {
       />
       <div className={styles.detailView}>
         <div className={styles.main}>
-          <IssueBody body={issue.body} />
+          <IssueDetailClient
+            owner={owner}
+            repo={repo}
+            issue={issue}
+          />
           <CommentThread
             comments={comments}
             owner={owner}
@@ -98,6 +115,7 @@ export default async function IssueDetailPage({ params }: Props) {
           owner={owner}
           repo={repo}
           repoLocalPath={repoLocalPath}
+          availableLabels={availableLabels}
         />
       </div>
     </>

--- a/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/page.tsx
@@ -35,12 +35,14 @@ export default async function IssueDetailPage({ params }: Props) {
 
   try {
     const octokit = await getOctokit();
-    const [detail, repoLabels] = await Promise.all([
-      getIssueDetail(db, octokit, owner, repo, issueNumber),
-      listLabels(octokit, owner, repo),
-    ]);
-    data = detail;
-    availableLabels = repoLabels;
+    data = await getIssueDetail(db, octokit, owner, repo, issueNumber);
+
+    // Labels are supplementary — fetch separately so a failure doesn't break the page
+    try {
+      availableLabels = await listLabels(octokit, owner, repo);
+    } catch (labelErr) {
+      console.warn(`[issuectl] Failed to load labels for ${owner}/${repo}:`, labelErr);
+    }
   } catch (err) {
     console.error(
       `[issuectl] Failed to load issue #${issueNumber}:`,

--- a/packages/web/app/[owner]/[repo]/page.module.css
+++ b/packages/web/app/[owner]/[repo]/page.module.css
@@ -1,0 +1,6 @@
+.error {
+  padding: 40px 32px;
+  color: var(--red);
+  font-size: 14px;
+  text-align: center;
+}

--- a/packages/web/app/[owner]/[repo]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/page.tsx
@@ -1,9 +1,18 @@
 import { Suspense } from "react";
-import { getDb, getOctokit, getIssues, getPulls } from "@issuectl/core";
+import {
+  getDb,
+  getOctokit,
+  getIssues,
+  getPulls,
+  listRepos,
+  listLabels,
+  type GitHubLabel,
+} from "@issuectl/core";
 import { RepoHeader } from "@/components/repo/RepoHeader";
 import { TabBar } from "@/components/repo/TabBar";
 import { IssuesTable } from "@/components/repo/IssuesTable";
 import { PullsTable } from "@/components/repo/PullsTable";
+import { NewIssueButton } from "@/components/issue/NewIssueButton";
 
 export const dynamic = "force-dynamic";
 
@@ -19,23 +28,38 @@ export default async function RepoDetailPage({ params, searchParams }: Props) {
 
   let issues: Awaited<ReturnType<typeof getIssues>>["issues"] = [];
   let pulls: Awaited<ReturnType<typeof getPulls>>["pulls"] = [];
+  let labels: GitHubLabel[] = [];
+
+  const db = getDb();
+  const repos = listRepos(db).map((r) => ({ owner: r.owner, repo: r.name }));
 
   try {
-    const db = getDb();
     const octokit = await getOctokit();
-    const [issueResult, pullResult] = await Promise.all([
+    const [issueResult, pullResult, repoLabels] = await Promise.all([
       getIssues(db, octokit, owner, repo),
       getPulls(db, octokit, owner, repo),
+      listLabels(octokit, owner, repo),
     ]);
     issues = issueResult.issues;
     pulls = pullResult.pulls;
+    labels = repoLabels;
   } catch (err) {
     console.error(`[issuectl] Failed to load data for ${owner}/${repo}:`, err);
   }
 
   return (
     <>
-      <RepoHeader owner={owner} repo={repo} />
+      <RepoHeader
+        owner={owner}
+        repo={repo}
+        actions={
+          <NewIssueButton
+            repos={repos}
+            currentRepo={{ owner, repo }}
+            availableLabels={labels}
+          />
+        }
+      />
       <Suspense>
         <TabBar issueCount={issues.length} prCount={pulls.length} />
       </Suspense>

--- a/packages/web/app/[owner]/[repo]/page.tsx
+++ b/packages/web/app/[owner]/[repo]/page.tsx
@@ -13,6 +13,7 @@ import { TabBar } from "@/components/repo/TabBar";
 import { IssuesTable } from "@/components/repo/IssuesTable";
 import { PullsTable } from "@/components/repo/PullsTable";
 import { NewIssueButton } from "@/components/issue/NewIssueButton";
+import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
 
@@ -29,22 +30,29 @@ export default async function RepoDetailPage({ params, searchParams }: Props) {
   let issues: Awaited<ReturnType<typeof getIssues>>["issues"] = [];
   let pulls: Awaited<ReturnType<typeof getPulls>>["pulls"] = [];
   let labels: GitHubLabel[] = [];
-
-  const db = getDb();
-  const repos = listRepos(db).map((r) => ({ owner: r.owner, repo: r.name }));
+  let repos: { owner: string; repo: string }[] = [];
+  let loadError: string | null = null;
 
   try {
+    const db = getDb();
+    repos = listRepos(db).map((r) => ({ owner: r.owner, repo: r.name }));
     const octokit = await getOctokit();
-    const [issueResult, pullResult, repoLabels] = await Promise.all([
+    const [issueResult, pullResult] = await Promise.all([
       getIssues(db, octokit, owner, repo),
       getPulls(db, octokit, owner, repo),
-      listLabels(octokit, owner, repo),
     ]);
     issues = issueResult.issues;
     pulls = pullResult.pulls;
-    labels = repoLabels;
+
+    // Labels are supplementary — fetch separately so a failure doesn't break the page
+    try {
+      labels = await listLabels(octokit, owner, repo);
+    } catch (labelErr) {
+      console.warn(`[issuectl] Failed to load labels for ${owner}/${repo}:`, labelErr);
+    }
   } catch (err) {
     console.error(`[issuectl] Failed to load data for ${owner}/${repo}:`, err);
+    loadError = "Failed to load repository data. Check that the GitHub CLI is authenticated.";
   }
 
   return (
@@ -53,20 +61,28 @@ export default async function RepoDetailPage({ params, searchParams }: Props) {
         owner={owner}
         repo={repo}
         actions={
-          <NewIssueButton
-            repos={repos}
-            currentRepo={{ owner, repo }}
-            availableLabels={labels}
-          />
+          !loadError && (
+            <NewIssueButton
+              repos={repos}
+              currentRepo={{ owner, repo }}
+              availableLabels={labels}
+            />
+          )
         }
       />
-      <Suspense>
-        <TabBar issueCount={issues.length} prCount={pulls.length} />
-      </Suspense>
-      {activeTab === "issues" ? (
-        <IssuesTable issues={issues} owner={owner} repo={repo} />
+      {loadError ? (
+        <div className={styles.error}>{loadError}</div>
       ) : (
-        <PullsTable pulls={pulls} owner={owner} repo={repo} />
+        <>
+          <Suspense>
+            <TabBar issueCount={issues.length} prCount={pulls.length} />
+          </Suspense>
+          {activeTab === "issues" ? (
+            <IssuesTable issues={issues} owner={owner} repo={repo} />
+          ) : (
+            <PullsTable pulls={pulls} owner={owner} repo={repo} />
+          )}
+        </>
       )}
     </>
   );

--- a/packages/web/components/issue/CloseIssueButton.module.css
+++ b/packages/web/components/issue/CloseIssueButton.module.css
@@ -1,8 +1,0 @@
-.danger {
-  color: var(--red);
-}
-
-.error {
-  font-size: 12px;
-  color: var(--red);
-}

--- a/packages/web/components/issue/CloseIssueButton.tsx
+++ b/packages/web/components/issue/CloseIssueButton.tsx
@@ -44,7 +44,7 @@ export function CloseIssueButton({ owner, repo, number, isClosed }: Props) {
           onConfirm={handleClose}
           onCancel={() => setShowConfirm(false)}
           isPending={isPending}
-          error={error}
+          error={error ?? undefined}
         />
       )}
     </>

--- a/packages/web/components/issue/CloseIssueButton.tsx
+++ b/packages/web/components/issue/CloseIssueButton.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { closeIssue } from "@/lib/actions/issues";
 import { Button } from "@/components/ui/Button";
-import styles from "./CloseIssueButton.module.css";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 type Props = {
   owner: string;
@@ -20,43 +20,33 @@ export function CloseIssueButton({ owner, repo, number, isClosed }: Props) {
   if (isClosed) return null;
 
   function handleClose() {
-    setShowConfirm(false);
     setError(null);
     startTransition(async () => {
       const result = await closeIssue(owner, repo, number);
       if (!result.success) {
         setError(result.error ?? "Failed to close issue. Please try again.");
-        setShowConfirm(true);
+        return;
       }
+      setShowConfirm(false);
     });
   }
 
-  if (showConfirm) {
-    return (
-      <>
-        {error && (
-          <span className={styles.error} role="alert">
-            {error}
-          </span>
-        )}
-        <Button variant="ghost" onClick={() => setShowConfirm(false)}>
-          Cancel
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={handleClose}
-          disabled={isPending}
-          className={styles.danger}
-        >
-          {isPending ? "Closing..." : "Confirm Close"}
-        </Button>
-      </>
-    );
-  }
-
   return (
-    <Button variant="secondary" onClick={() => setShowConfirm(true)}>
-      Close
-    </Button>
+    <>
+      <Button variant="secondary" onClick={() => setShowConfirm(true)}>
+        Close
+      </Button>
+      {showConfirm && (
+        <ConfirmDialog
+          title="Close Issue"
+          message={`Close issue #${number}? This can be reopened later from GitHub.`}
+          confirmLabel="Close Issue"
+          onConfirm={handleClose}
+          onCancel={() => setShowConfirm(false)}
+          isPending={isPending}
+          error={error}
+        />
+      )}
+    </>
   );
 }

--- a/packages/web/components/issue/CreateIssueModal.module.css
+++ b/packages/web/components/issue/CreateIssueModal.module.css
@@ -1,0 +1,132 @@
+.field {
+  margin-bottom: 16px;
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+
+.hint {
+  text-transform: none;
+  font-weight: 400;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.textarea {
+  width: 100%;
+  height: 120px;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+  resize: vertical;
+}
+
+.textarea:focus {
+  border-color: var(--accent-border);
+}
+
+.repoDisplay {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.repoDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  flex-shrink: 0;
+}
+
+.repoName {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.changeLink {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.changeLink:hover {
+  color: var(--text-secondary);
+}
+
+.repoList {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.repoOption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.repoOption:last-child {
+  border-bottom: none;
+}
+
+.repoOption:hover {
+  background: var(--bg-hover);
+}
+
+.error {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius-md);
+  color: var(--red);
+  font-size: 12px;
+}

--- a/packages/web/components/issue/CreateIssueModal.tsx
+++ b/packages/web/components/issue/CreateIssueModal.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { GitHubLabel } from "@issuectl/core";
+import { createIssue } from "@/lib/actions/issues";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import type { RepoOption } from "./NewIssueButton";
+import { LabelSelector } from "./LabelSelector";
+import styles from "./CreateIssueModal.module.css";
+
+type Props = {
+  repos: RepoOption[];
+  defaultRepo: RepoOption;
+  availableLabels: GitHubLabel[];
+  onClose: () => void;
+};
+
+export function CreateIssueModal({
+  repos,
+  defaultRepo,
+  availableLabels,
+  onClose,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedRepo, setSelectedRepo] = useState(defaultRepo);
+  const [showRepoSelect, setShowRepoSelect] = useState(false);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+
+  function handleToggleLabel(label: string) {
+    setSelectedLabels((prev) =>
+      prev.includes(label)
+        ? prev.filter((l) => l !== label)
+        : [...prev, label],
+    );
+  }
+
+  function handleSubmit() {
+    setError(null);
+    startTransition(async () => {
+      const result = await createIssue({
+        owner: selectedRepo.owner,
+        repo: selectedRepo.repo,
+        title,
+        body: body || undefined,
+        labels: selectedLabels.length > 0 ? selectedLabels : undefined,
+      });
+
+      if (!result.success) {
+        setError(result.error ?? "Failed to create issue");
+        return;
+      }
+
+      router.push(
+        `/${selectedRepo.owner}/${selectedRepo.repo}/issues/${result.issueNumber}`,
+      );
+      onClose();
+    });
+  }
+
+  return (
+    <Modal
+      title="Create Issue"
+      onClose={onClose}
+      disabled={isPending}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={isPending || !title.trim()}
+          >
+            {isPending ? "Creating..." : "Create Issue"}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.field}>
+        <div className={styles.label}>Repository</div>
+        {showRepoSelect ? (
+          <div className={styles.repoList}>
+            {repos.map((r) => (
+              <button
+                key={`${r.owner}/${r.repo}`}
+                type="button"
+                className={styles.repoOption}
+                onClick={() => {
+                  setSelectedRepo(r);
+                  setShowRepoSelect(false);
+                }}
+              >
+                <span className={styles.repoDot} />
+                {r.owner}/{r.repo}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className={styles.repoDisplay}>
+            <span className={styles.repoDot} />
+            <span className={styles.repoName}>
+              {selectedRepo.owner}/{selectedRepo.repo}
+            </span>
+            {repos.length > 1 && (
+              <button
+                type="button"
+                className={styles.changeLink}
+                onClick={() => setShowRepoSelect(true)}
+              >
+                change
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className={styles.field}>
+        <div className={styles.label}>Title</div>
+        <input
+          className={styles.input}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Issue title"
+          autoFocus
+          disabled={isPending}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <div className={styles.label}>
+          Description <span className={styles.hint}>(markdown)</span>
+        </div>
+        <textarea
+          className={styles.textarea}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Describe the issue..."
+          disabled={isPending}
+        />
+      </div>
+
+      {availableLabels.length > 0 && (
+        <div className={styles.field}>
+          <div className={styles.label}>Labels</div>
+          <LabelSelector
+            available={availableLabels}
+            selected={selectedLabels}
+            onToggle={handleToggleLabel}
+            disabled={isPending}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div className={styles.error} role="alert">
+          {error}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/packages/web/components/issue/CreateIssueModal.tsx
+++ b/packages/web/components/issue/CreateIssueModal.tsx
@@ -6,7 +6,7 @@ import type { GitHubLabel } from "@issuectl/core";
 import { createIssue } from "@/lib/actions/issues";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
-import type { RepoOption } from "./NewIssueButton";
+import type { RepoOption } from "@/lib/types";
 import { LabelSelector } from "./LabelSelector";
 import styles from "./CreateIssueModal.module.css";
 

--- a/packages/web/components/issue/EditIssueForm.module.css
+++ b/packages/web/components/issue/EditIssueForm.module.css
@@ -1,0 +1,56 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.titleInput {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 600;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+}
+
+.titleInput:focus {
+  border-color: var(--accent-border);
+}
+
+.bodyInput {
+  width: 100%;
+  min-height: 200px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-mono), monospace;
+  line-height: 1.6;
+  outline: none;
+  resize: vertical;
+}
+
+.bodyInput:focus {
+  border-color: var(--accent-border);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.error {
+  padding: 8px 12px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius-md);
+  color: var(--red);
+  font-size: 12px;
+}

--- a/packages/web/components/issue/EditIssueForm.tsx
+++ b/packages/web/components/issue/EditIssueForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { GitHubIssue } from "@issuectl/core";
+import { updateIssue } from "@/lib/actions/issues";
+import { Button } from "@/components/ui/Button";
+import styles from "./EditIssueForm.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issue: GitHubIssue;
+  onDone: () => void;
+};
+
+export function EditIssueForm({ owner, repo, issue, onDone }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [title, setTitle] = useState(issue.title);
+  const [body, setBody] = useState(issue.body ?? "");
+
+  function handleSave() {
+    setError(null);
+    startTransition(async () => {
+      const result = await updateIssue({
+        owner,
+        repo,
+        number: issue.number,
+        title: title.trim(),
+        body,
+      });
+
+      if (!result.success) {
+        setError(result.error ?? "Failed to update issue");
+        return;
+      }
+
+      onDone();
+    });
+  }
+
+  return (
+    <div className={styles.form}>
+      <input
+        className={styles.titleInput}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Issue title"
+        disabled={isPending}
+        autoFocus
+      />
+      <textarea
+        className={styles.bodyInput}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Description (markdown)"
+        disabled={isPending}
+      />
+      {error && (
+        <div className={styles.error} role="alert">
+          {error}
+        </div>
+      )}
+      <div className={styles.actions}>
+        <Button variant="ghost" onClick={onDone} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={isPending || !title.trim()}
+        >
+          {isPending ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/issue/IssueDetailClient.module.css
+++ b/packages/web/components/issue/IssueDetailClient.module.css
@@ -1,0 +1,5 @@
+.editRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}

--- a/packages/web/components/issue/IssueDetailClient.tsx
+++ b/packages/web/components/issue/IssueDetailClient.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import type { GitHubIssue } from "@issuectl/core";
+import { Button } from "@/components/ui/Button";
+import { IssueBody } from "./IssueBody";
+import { EditIssueForm } from "./EditIssueForm";
+import styles from "./IssueDetailClient.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issue: GitHubIssue;
+};
+
+export function IssueDetailClient({ owner, repo, issue }: Props) {
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <EditIssueForm
+        owner={owner}
+        repo={repo}
+        issue={issue}
+        onDone={() => setEditing(false)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.editRow}>
+        {issue.state === "open" && (
+          <Button variant="ghost" onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+        )}
+      </div>
+      <IssueBody body={issue.body} />
+    </>
+  );
+}

--- a/packages/web/components/issue/IssueSidebar.module.css
+++ b/packages/web/components/issue/IssueSidebar.module.css
@@ -16,17 +16,3 @@
   flex-direction: column;
   gap: 12px;
 }
-
-.title {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-tertiary);
-}
-
-.labels {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}

--- a/packages/web/components/issue/IssueSidebar.tsx
+++ b/packages/web/components/issue/IssueSidebar.tsx
@@ -5,8 +5,8 @@ import type {
   GitHubLabel,
   Deployment,
 } from "@issuectl/core";
-import { Badge } from "@/components/ui/Badge";
 import { LaunchCard } from "./LaunchCard";
+import { LabelManager } from "./LabelManager";
 import { DeploymentTimeline } from "./DeploymentTimeline";
 import { ReferencedFiles } from "./ReferencedFiles";
 import { IssueDetails } from "./IssueDetails";
@@ -21,16 +21,8 @@ type Props = {
   owner: string;
   repo: string;
   repoLocalPath: string | null;
+  availableLabels?: GitHubLabel[];
 };
-
-function getDisplayLabels(labels: GitHubLabel[]): GitHubLabel[] {
-  return labels.filter(
-    (l) =>
-      l.name.toLowerCase() === "bug" ||
-      l.name.toLowerCase() === "enhancement" ||
-      l.name.startsWith("issuectl:"),
-  );
-}
 
 export function IssueSidebar({
   issue,
@@ -41,9 +33,8 @@ export function IssueSidebar({
   owner,
   repo,
   repoLocalPath,
+  availableLabels = [],
 }: Props) {
-  const displayLabels = getDisplayLabels(issue.labels);
-
   return (
     <div className={styles.sidebar}>
       <LaunchCard
@@ -55,16 +46,15 @@ export function IssueSidebar({
         deployments={deployments}
         referencedFiles={referencedFiles}
       />
-      {displayLabels.length > 0 && (
-        <div className={styles.card}>
-          <span className={styles.title}>Lifecycle</span>
-          <div className={styles.labels}>
-            {displayLabels.map((l) => (
-              <Badge key={l.name} label={l.name} color={l.color} />
-            ))}
-          </div>
-        </div>
-      )}
+      <div className={styles.card}>
+        <LabelManager
+          owner={owner}
+          repo={repo}
+          issueNumber={issue.number}
+          currentLabels={issue.labels}
+          availableLabels={availableLabels}
+        />
+      </div>
       <DeploymentTimeline deployments={deployments} linkedPRs={linkedPRs} />
       <ReferencedFiles files={referencedFiles} />
       <IssueDetails

--- a/packages/web/components/issue/LabelManager.module.css
+++ b/packages/web/components/issue/LabelManager.module.css
@@ -1,0 +1,52 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+}
+
+.editButton {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.editButton:hover {
+  color: var(--text-secondary);
+}
+
+.labels {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.selector {
+  padding-top: 4px;
+}
+
+.empty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.error {
+  font-size: 11px;
+  color: var(--red);
+}

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { GitHubLabel } from "@issuectl/core";
+import { toggleLabel } from "@/lib/actions/issues";
+import { separateLabels } from "@/lib/labels";
+import { Badge } from "@/components/ui/Badge";
+import { LabelSelector } from "./LabelSelector";
+import styles from "./LabelManager.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  currentLabels: GitHubLabel[];
+  availableLabels: GitHubLabel[];
+};
+
+export function LabelManager({
+  owner,
+  repo,
+  issueNumber,
+  currentLabels,
+  availableLabels,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [showSelector, setShowSelector] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { lifecycle: lifecycleLabels, regular: regularLabels } =
+    separateLabels(currentLabels);
+  const selectedNames = currentLabels.map((l) => l.name);
+
+  function handleToggle(label: string) {
+    setError(null);
+    const action = selectedNames.includes(label) ? "remove" : "add";
+    startTransition(async () => {
+      const result = await toggleLabel({
+        owner,
+        repo,
+        number: issueNumber,
+        label,
+        action,
+      });
+      if (!result.success) {
+        setError(result.error ?? "Failed to update label");
+      }
+    });
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.title}>Labels</span>
+        <button
+          type="button"
+          className={styles.editButton}
+          onClick={() => setShowSelector((s) => !s)}
+        >
+          {showSelector ? "Done" : "Edit"}
+        </button>
+      </div>
+
+      {regularLabels.length > 0 && (
+        <div className={styles.labels}>
+          {regularLabels.map((l) => (
+            <Badge key={l.name} label={l.name} color={l.color} />
+          ))}
+        </div>
+      )}
+
+      {lifecycleLabels.length > 0 && (
+        <div className={styles.labels}>
+          {lifecycleLabels.map((l) => (
+            <Badge key={l.name} label={l.name} color={l.color} />
+          ))}
+        </div>
+      )}
+
+      {regularLabels.length === 0 && lifecycleLabels.length === 0 && !showSelector && (
+        <span className={styles.empty}>No labels</span>
+      )}
+
+      {showSelector && (
+        <div className={styles.selector}>
+          <LabelSelector
+            available={availableLabels}
+            selected={selectedNames}
+            onToggle={handleToggle}
+            disabled={isPending}
+          />
+        </div>
+      )}
+
+      {error && (
+        <span className={styles.error} role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/issue/LabelSelector.module.css
+++ b/packages/web/components/issue/LabelSelector.module.css
@@ -1,0 +1,42 @@
+.chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  border: 1px solid var(--border);
+  transition: background 0.15s, color 0.15s;
+}
+
+.chip:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.chipSelected {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid;
+  transition: background 0.15s, color 0.15s;
+}
+
+.chipSelected:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.chip:disabled,
+.chipSelected:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/web/components/issue/LabelSelector.tsx
+++ b/packages/web/components/issue/LabelSelector.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { GitHubLabel } from "@issuectl/core";
+import { isLifecycleLabel } from "@/lib/labels";
+import styles from "./LabelSelector.module.css";
+
+type Props = {
+  available: GitHubLabel[];
+  selected: string[];
+  onToggle: (label: string) => void;
+  disabled?: boolean;
+};
+
+function selectedStyle(label: GitHubLabel): React.CSSProperties {
+  if (label.color) {
+    return {
+      background: `#${label.color}18`,
+      color: `#${label.color}`,
+      borderColor: `#${label.color}50`,
+    };
+  }
+  return {
+    background: "var(--accent-surface)",
+    color: "var(--accent)",
+    borderColor: "var(--accent-border)",
+  };
+}
+
+export function LabelSelector({
+  available,
+  selected,
+  onToggle,
+  disabled,
+}: Props) {
+  const toggleable = available.filter((l) => !isLifecycleLabel(l.name));
+
+  if (toggleable.length === 0) return null;
+
+  return (
+    <div className={styles.chips}>
+      {toggleable.map((label) => {
+        const isSelected = selected.includes(label.name);
+        return (
+          <button
+            key={label.name}
+            type="button"
+            className={isSelected ? styles.chipSelected : styles.chip}
+            style={isSelected ? selectedStyle(label) : undefined}
+            onClick={() => onToggle(label.name)}
+            aria-pressed={isSelected}
+            disabled={disabled}
+          >
+            {label.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/components/issue/NewIssueButton.tsx
+++ b/packages/web/components/issue/NewIssueButton.tsx
@@ -2,10 +2,9 @@
 
 import { useState } from "react";
 import type { GitHubLabel } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
 import { Button } from "@/components/ui/Button";
 import { CreateIssueModal } from "./CreateIssueModal";
-
-export type RepoOption = { owner: string; repo: string };
 
 type Props = {
   repos: RepoOption[];

--- a/packages/web/components/issue/NewIssueButton.tsx
+++ b/packages/web/components/issue/NewIssueButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import type { GitHubLabel } from "@issuectl/core";
+import { Button } from "@/components/ui/Button";
+import { CreateIssueModal } from "./CreateIssueModal";
+
+export type RepoOption = { owner: string; repo: string };
+
+type Props = {
+  repos: RepoOption[];
+  currentRepo: RepoOption;
+  availableLabels: GitHubLabel[];
+};
+
+export function NewIssueButton({ repos, currentRepo, availableLabels }: Props) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <Button variant="primary" onClick={() => setShowModal(true)}>
+        New Issue
+      </Button>
+      {showModal && (
+        <CreateIssueModal
+          repos={repos}
+          defaultRepo={currentRepo}
+          availableLabels={availableLabels}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/repo/RepoHeader.tsx
+++ b/packages/web/components/repo/RepoHeader.tsx
@@ -1,12 +1,14 @@
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { PageHeader } from "@/components/ui/PageHeader";
 
 type Props = {
   owner: string;
   repo: string;
+  actions?: ReactNode;
 };
 
-export function RepoHeader({ owner, repo }: Props) {
+export function RepoHeader({ owner, repo, actions }: Props) {
   return (
     <PageHeader
       title={repo}
@@ -19,6 +21,7 @@ export function RepoHeader({ owner, repo }: Props) {
           </span>
         </>
       }
+      actions={actions}
     />
   );
 }

--- a/packages/web/components/ui/ConfirmDialog.module.css
+++ b/packages/web/components/ui/ConfirmDialog.module.css
@@ -1,0 +1,22 @@
+.message {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.danger {
+  background: var(--red);
+  color: var(--text-inverse);
+  border-color: var(--red);
+}
+
+.danger:hover {
+  background: #e5443c;
+}
+
+.error {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: var(--red);
+}

--- a/packages/web/components/ui/ConfirmDialog.tsx
+++ b/packages/web/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+import styles from "./ConfirmDialog.module.css";
+
+type Props = {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending?: boolean;
+  error?: string | null;
+};
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = "Confirm",
+  onConfirm,
+  onCancel,
+  isPending,
+  error,
+}: Props) {
+  return (
+    <Modal
+      title={title}
+      width={440}
+      onClose={onCancel}
+      disabled={isPending}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            disabled={isPending}
+            className={styles.danger}
+          >
+            {isPending ? `${confirmLabel}...` : confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      <p className={styles.message}>{message}</p>
+      {error && (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      )}
+    </Modal>
+  );
+}

--- a/packages/web/components/ui/ConfirmDialog.tsx
+++ b/packages/web/components/ui/ConfirmDialog.tsx
@@ -11,7 +11,7 @@ type Props = {
   onConfirm: () => void;
   onCancel: () => void;
   isPending?: boolean;
-  error?: string | null;
+  error?: string;
 };
 
 export function ConfirmDialog({

--- a/packages/web/components/ui/Modal.module.css
+++ b/packages/web/components/ui/Modal.module.css
@@ -1,0 +1,60 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
+}
+
+.header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-family: var(--font-display), sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.close {
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 18px;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.body {
+  padding: 20px 24px;
+}
+
+.footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/packages/web/components/ui/Modal.tsx
+++ b/packages/web/components/ui/Modal.tsx
@@ -20,13 +20,17 @@ export function Modal({
   onClose,
   disabled,
 }: Props) {
+  // Stable ref avoids re-registering the keydown listener when onClose identity changes
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
   useEffect(() => {
     if (disabled) return;
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onCloseRef.current();
+      if (e.key === "Escape") {
+        e.stopImmediatePropagation();
+        onCloseRef.current();
+      }
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);

--- a/packages/web/components/ui/Modal.tsx
+++ b/packages/web/components/ui/Modal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import styles from "./Modal.module.css";
+
+type Props = {
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  width?: number;
+  onClose: () => void;
+  disabled?: boolean;
+};
+
+export function Modal({
+  title,
+  children,
+  footer,
+  width = 600,
+  onClose,
+  disabled,
+}: Props) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (disabled) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onCloseRef.current();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [disabled]);
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={disabled ? undefined : onClose}
+    >
+      <div
+        className={styles.modal}
+        style={{ width }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.header}>
+          <span className={styles.title}>{title}</span>
+          <button
+            className={styles.close}
+            onClick={disabled ? undefined : onClose}
+            disabled={disabled}
+          >
+            &times;
+          </button>
+        </div>
+        <div className={styles.body}>{children}</div>
+        {footer && <div className={styles.footer}>{footer}</div>}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -4,9 +4,74 @@ import { revalidatePath } from "next/cache";
 import {
   getDb,
   getOctokit,
+  createIssue as coreCreateIssue,
+  updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,
+  addLabel as coreAddLabel,
+  removeLabel as coreRemoveLabel,
   clearCacheKey,
 } from "@issuectl/core";
+
+export async function createIssue(data: {
+  owner: string;
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+}): Promise<{ success: boolean; issueNumber?: number; error?: string }> {
+  const { owner, repo, title, body, labels } = data;
+  if (!owner || !repo || !title.trim()) {
+    return { success: false, error: "Owner, repo, and title are required" };
+  }
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    const issue = await coreCreateIssue(octokit, owner, repo, {
+      title: title.trim(),
+      body: body?.trim() || undefined,
+      labels,
+    });
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+    revalidatePath(`/${owner}/${repo}`);
+    return { success: true, issueNumber: issue.number };
+  } catch (err) {
+    console.error("[issuectl] Failed to create issue:", err);
+    return { success: false, error: "Failed to create issue" };
+  }
+}
+
+export async function updateIssue(data: {
+  owner: string;
+  repo: string;
+  number: number;
+  title?: string;
+  body?: string;
+}): Promise<{ success: boolean; error?: string }> {
+  const { owner, repo, number, title, body } = data;
+  if (!owner || !repo || number <= 0) {
+    return { success: false, error: "Invalid input" };
+  }
+  if (title !== undefined && !title.trim()) {
+    return { success: false, error: "Title cannot be empty" };
+  }
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    await coreUpdateIssue(octokit, owner, repo, number, {
+      title: title?.trim(),
+      body: body !== undefined ? body.trim() : undefined,
+    });
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+  } catch (err) {
+    console.error("[issuectl] Failed to update issue:", err);
+    return { success: false, error: "Failed to update issue" };
+  }
+  revalidatePath(`/${owner}/${repo}/issues/${number}`);
+  return { success: true };
+}
 
 export async function closeIssue(
   owner: string,
@@ -26,6 +91,36 @@ export async function closeIssue(
   } catch (err) {
     console.error("[issuectl] Failed to close issue:", err);
     return { success: false, error: "Failed to close issue" };
+  }
+  revalidatePath(`/${owner}/${repo}/issues/${number}`);
+  return { success: true };
+}
+
+export async function toggleLabel(data: {
+  owner: string;
+  repo: string;
+  number: number;
+  label: string;
+  action: "add" | "remove";
+}): Promise<{ success: boolean; error?: string }> {
+  const { owner, repo, number, label, action } = data;
+  if (!owner || !repo || number <= 0 || !label) {
+    return { success: false, error: "Invalid input" };
+  }
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    if (action === "add") {
+      await coreAddLabel(octokit, owner, repo, number, label);
+    } else {
+      await coreRemoveLabel(octokit, owner, repo, number, label);
+    }
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+  } catch (err) {
+    console.error(`[issuectl] Failed to ${action} label:`, err);
+    return { success: false, error: `Failed to ${action} label` };
   }
   revalidatePath(`/${owner}/${repo}/issues/${number}`);
   return { success: true };

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -49,8 +49,8 @@ export async function updateIssue(data: {
   body?: string;
 }): Promise<{ success: boolean; error?: string }> {
   const { owner, repo, number, title, body } = data;
-  if (!owner || !repo || number <= 0) {
-    return { success: false, error: "Invalid input" };
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
+    return { success: false, error: "Valid owner, repo, and issue number are required" };
   }
   if (title !== undefined && !title.trim()) {
     return { success: false, error: "Title cannot be empty" };
@@ -78,8 +78,8 @@ export async function closeIssue(
   repo: string,
   number: number,
 ): Promise<{ success: boolean; error?: string }> {
-  if (!owner || !repo || number <= 0) {
-    return { success: false, error: "Invalid input" };
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
+    return { success: false, error: "Valid owner, repo, and issue number are required" };
   }
 
   try {
@@ -104,8 +104,8 @@ export async function toggleLabel(data: {
   action: "add" | "remove";
 }): Promise<{ success: boolean; error?: string }> {
   const { owner, repo, number, label, action } = data;
-  if (!owner || !repo || number <= 0 || !label) {
-    return { success: false, error: "Invalid input" };
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0 || !label) {
+    return { success: false, error: "Valid owner, repo, issue number, and label are required" };
   }
 
   try {

--- a/packages/web/lib/labels.ts
+++ b/packages/web/lib/labels.ts
@@ -1,0 +1,21 @@
+import type { GitHubLabel } from "@issuectl/core";
+
+export function isLifecycleLabel(name: string): boolean {
+  return name.startsWith("issuectl:");
+}
+
+export function separateLabels(labels: GitHubLabel[]): {
+  lifecycle: GitHubLabel[];
+  regular: GitHubLabel[];
+} {
+  const lifecycle: GitHubLabel[] = [];
+  const regular: GitHubLabel[] = [];
+  for (const l of labels) {
+    if (isLifecycleLabel(l.name)) {
+      lifecycle.push(l);
+    } else {
+      regular.push(l);
+    }
+  }
+  return { lifecycle, regular };
+}

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -1,5 +1,7 @@
 import type { Repo } from "@issuectl/core";
 
+export type RepoOption = { owner: string; repo: string };
+
 export type RepoWithStats = Repo & {
   issueCount: number;
   prCount: number;


### PR DESCRIPTION
## Summary

- **CreateIssueModal**: Full create issue modal with repo selector, title, description, and toggleable label chips. Opens from "New Issue" button on repo detail page.
- **EditIssueForm**: Inline edit mode for issue title + body on the issue detail page. "Edit" button switches to editable form with Save/Cancel.
- **CloseIssueButton**: Refactored to use new reusable `ConfirmDialog` modal instead of inline button swapping.
- **LabelManager**: Replaces static label display in sidebar with interactive label toggling. Lifecycle labels (`issuectl:*`) shown read-only, regular labels toggleable.
- **Reusable UI**: `Modal` (Escape key, ARIA dialog, backdrop click) and `ConfirmDialog` components extracted for shared use.
- **Server Actions**: `createIssue`, `updateIssue`, `toggleLabel` added to `lib/actions/issues.ts` with input validation, cache invalidation, and path revalidation.
- **Shared utility**: `isLifecycleLabel`/`separateLabels` in `lib/labels.ts` eliminates duplicated lifecycle checks.

## Test plan

- [ ] Navigate to repo detail page → "New Issue" button visible in header
- [ ] Click "New Issue" → modal opens with current repo pre-selected
- [ ] Change repo in selector (if multiple repos configured)
- [ ] Fill title + description, toggle labels, create → navigates to new issue
- [ ] Issue detail page → "Edit" button visible for open issues
- [ ] Click Edit → title + body become editable, Save/Cancel buttons appear
- [ ] Save edits → page revalidates with updated content
- [ ] Click "Close" → ConfirmDialog modal with "Close issue #N?" message
- [ ] Confirm close → issue state updates, button disappears
- [ ] Escape key dismisses any open modal
- [ ] Sidebar label section → "Edit" link opens label selector
- [ ] Toggle labels on/off → changes reflected after server round-trip
- [ ] Lifecycle labels (`issuectl:deployed`, etc.) not toggleable in selector
- [ ] Type-check: `pnpm turbo typecheck` passes clean
- [ ] Build: `pnpm turbo build` succeeds