### PR TITLE
feat: add onboarding + auth error edge states (Phase 14)

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Karla, Syne, Source_Code_Pro } from "next/font/google";
 import { Sidebar } from "@/components/sidebar/Sidebar";
+import { AuthErrorScreen } from "@/components/auth/AuthErrorScreen";
+import { getAuthStatus } from "@/lib/auth";
 import "./globals.css";
 import styles from "./layout.module.css";
 
@@ -29,14 +31,20 @@ type Props = {
   children: ReactNode;
 };
 
-export default function RootLayout({ children }: Props) {
+export default async function RootLayout({ children }: Props) {
+  const auth = await getAuthStatus();
+
   return (
     <html lang="en" className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
       <body className={karla.className}>
-        <div className={styles.app}>
-          <Sidebar />
-          <main className={styles.content}>{children}</main>
-        </div>
+        {auth.authenticated ? (
+          <div className={styles.app}>
+            <Sidebar username={auth.username} />
+            <main className={styles.content}>{children}</main>
+          </div>
+        ) : (
+          <AuthErrorScreen />
+        )}
       </body>
     </html>
   );

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -13,8 +13,8 @@ export default async function DashboardPage() {
 
   const db = getDb();
 
-  // Check DB for configured repos — don't rely on getDashboardData result,
-  // which may return empty repos[] due to a transient API error
+  // Distinguish "no repos configured" from "API failure" — the catch block
+  // below also produces repos: [], which would incorrectly show WelcomeScreen
   if (listRepos(db).length === 0) {
     return <WelcomeScreen />;
   }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,29 +1,30 @@
-import { getDb, getOctokit, getDashboardData, dbExists } from "@issuectl/core";
+import { getDb, getOctokit, getDashboardData, dbExists, listRepos } from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { RepoGrid } from "@/components/dashboard/RepoGrid";
 import { CacheBar } from "@/components/dashboard/CacheBar";
+import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
-  // Not initialized — show genuine empty state
   if (!dbExists()) {
-    return (
-      <>
-        <PageHeader title="Getting Started" />
-        <RepoGrid repos={[]} />
-      </>
-    );
+    return <WelcomeScreen />;
   }
 
   const db = getDb();
+
+  // Check DB for configured repos — don't rely on getDashboardData result,
+  // which may return empty repos[] due to a transient API error
+  if (listRepos(db).length === 0) {
+    return <WelcomeScreen />;
+  }
+
   let data;
 
   try {
     const octokit = await getOctokit();
     data = await getDashboardData(db, octokit);
   } catch (err) {
-    // Auth or API failure — log and show empty state with error context
     console.error("[issuectl] Dashboard data fetch failed:", err);
     data = { repos: [], totalIssues: 0, totalPRs: 0, cachedAt: null };
   }

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -3,7 +3,6 @@ import {
   dbExists,
   listRepos,
   getSettings,
-  checkGhAuth,
 } from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { TrackedRepos } from "@/components/settings/TrackedRepos";
@@ -12,6 +11,7 @@ import { TerminalSettings } from "@/components/settings/TerminalSettings";
 import { AuthStatus } from "@/components/settings/AuthStatus";
 import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
 import { listWorktrees } from "@/lib/actions/worktrees";
+import { getAuthStatus } from "@/lib/auth";
 import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
@@ -42,13 +42,13 @@ export default async function SettingsPage() {
   const terminalMode = settingMap.terminal_mode ?? "window";
 
   const [authResult, worktrees] = await Promise.all([
-    checkGhAuth().catch(() => ({ ok: false, username: undefined })),
+    getAuthStatus(),
     listWorktrees().catch((err) => {
       console.error("[issuectl] Failed to list worktrees:", err);
       return [] as Awaited<ReturnType<typeof listWorktrees>>;
     }),
   ]);
-  const username = authResult.username ?? null;
+  const username = authResult.authenticated ? authResult.username : null;
 
   return (
     <>

--- a/packages/web/components/auth/AuthErrorScreen.module.css
+++ b/packages/web/components/auth/AuthErrorScreen.module.css
@@ -1,0 +1,112 @@
+.container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.inner {
+  max-width: 480px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.icon {
+  width: 56px;
+  height: 56px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  color: var(--red);
+  font-weight: 700;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.inlineCode {
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--cyan);
+  border: 1px solid var(--border);
+}
+
+.card {
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cardTitle {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.stepNumber {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.stepTitle {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.stepCommand {
+  display: block;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+  font-family: var(--font-mono);
+}
+
+.stepDetail {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}

--- a/packages/web/components/auth/AuthErrorScreen.tsx
+++ b/packages/web/components/auth/AuthErrorScreen.tsx
@@ -1,0 +1,45 @@
+import { RefreshButton } from "./RefreshButton";
+import styles from "./AuthErrorScreen.module.css";
+
+const STEPS = [
+  { title: "Install the GitHub CLI", command: "brew install gh" },
+  { title: "Authenticate", command: "gh auth login" },
+  {
+    title: "Restart issuectl",
+    detail: "Refresh this page or restart the CLI",
+  },
+] as const;
+
+export function AuthErrorScreen() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <div className={styles.icon}>!</div>
+        <h1 className={styles.title}>GitHub authentication required</h1>
+        <p className={styles.description}>
+          issuectl uses the GitHub CLI for authentication. It looks like{" "}
+          <code className={styles.inlineCode}>gh</code> is not authenticated.
+        </p>
+
+        <div className={styles.card}>
+          <div className={styles.cardTitle}>To fix this:</div>
+          {STEPS.map((step, i) => (
+            <div key={i} className={styles.step}>
+              <span className={styles.stepNumber}>{i + 1}</span>
+              <div>
+                <div className={styles.stepTitle}>{step.title}</div>
+                {"command" in step ? (
+                  <code className={styles.stepCommand}>{step.command}</code>
+                ) : (
+                  <div className={styles.stepDetail}>{step.detail}</div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <RefreshButton />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/auth/RefreshButton.tsx
+++ b/packages/web/components/auth/RefreshButton.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+
+export function RefreshButton() {
+  const router = useRouter();
+  return (
+    <Button variant="secondary" onClick={() => router.refresh()}>
+      Try again
+    </Button>
+  );
+}

--- a/packages/web/components/onboarding/WelcomeScreen.module.css
+++ b/packages/web/components/onboarding/WelcomeScreen.module.css
@@ -1,0 +1,126 @@
+.container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inner {
+  max-width: 480px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.logoMark {
+  width: 56px;
+  height: 56px;
+  background: var(--accent);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 24px;
+  color: var(--text-inverse);
+  letter-spacing: -1px;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.description {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.card {
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cardTitle {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input:focus {
+  border-color: var(--border-accent);
+}
+
+.input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.error {
+  font-size: 13px;
+  color: var(--red);
+}
+
+.warning {
+  font-size: 13px;
+  color: var(--yellow);
+}
+
+.submitBtn {
+  width: 100%;
+  justify-content: center;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.inlineCode {
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--cyan);
+  border: 1px solid var(--border);
+}

--- a/packages/web/components/onboarding/WelcomeScreen.tsx
+++ b/packages/web/components/onboarding/WelcomeScreen.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { addRepo } from "@/lib/actions/repos";
+import styles from "./WelcomeScreen.module.css";
+
+export function WelcomeScreen() {
+  const router = useRouter();
+  const [repo, setRepo] = useState("");
+  const [localPath, setLocalPath] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setError(null);
+    setWarning(null);
+
+    const parts = repo.trim().split("/");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      setError("Enter a valid repository in owner/repo format");
+      return;
+    }
+
+    setSubmitting(true);
+    const result = await addRepo(parts[0], parts[1], localPath.trim() || undefined);
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error ?? "Failed to add repository");
+      return;
+    }
+
+    if (result.warning) {
+      setWarning(result.warning);
+    }
+
+    router.refresh();
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <div className={styles.logoMark}>ic</div>
+        <h1 className={styles.title}>
+          Welcome to <span className={styles.accent}>issuectl</span>
+        </h1>
+        <p className={styles.description}>
+          Manage GitHub issues and PRs across all your repos from one place.
+          Launch any issue directly into Claude Code with a single click.
+        </p>
+
+        <div className={styles.card}>
+          <div className={styles.cardTitle}>Add your first repository</div>
+
+          <div>
+            <label className={styles.label}>Repository</label>
+            <input
+              className={styles.input}
+              placeholder="owner/repo (e.g., mean-weasel/seatify)"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className={styles.label}>Local path (optional)</label>
+            <input
+              className={styles.input}
+              placeholder="~/Desktop/seatify"
+              value={localPath}
+              onChange={(e) => setLocalPath(e.target.value)}
+            />
+          </div>
+
+          {error && <div className={styles.error}>{error}</div>}
+          {warning && <div className={styles.warning}>{warning}</div>}
+
+          <Button variant="primary" disabled={submitting} className={styles.submitBtn} onClick={handleSubmit}>
+            {submitting ? "Adding..." : "Add Repository"}
+          </Button>
+        </div>
+
+        <p className={styles.hint}>
+          Or run{" "}
+          <code className={styles.inlineCode}>issuectl repo add owner/repo</code>{" "}
+          from the CLI
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/onboarding/WelcomeScreen.tsx
+++ b/packages/web/components/onboarding/WelcomeScreen.tsx
@@ -25,19 +25,25 @@ export function WelcomeScreen() {
     }
 
     setSubmitting(true);
-    const result = await addRepo(parts[0], parts[1], localPath.trim() || undefined);
-    setSubmitting(false);
+    try {
+      const result = await addRepo(parts[0], parts[1], localPath.trim() || undefined);
 
-    if (!result.success) {
-      setError(result.error ?? "Failed to add repository");
-      return;
+      if (!result.success) {
+        setError(result.error ?? "Failed to add repository");
+        return;
+      }
+
+      if (result.warning) {
+        setWarning(result.warning);
+        return;
+      }
+
+      router.refresh();
+    } catch {
+      setError("Something went wrong. Check your connection and try again.");
+    } finally {
+      setSubmitting(false);
     }
-
-    if (result.warning) {
-      setWarning(result.warning);
-    }
-
-    router.refresh();
   }
 
   return (

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -1,13 +1,16 @@
 import Link from "next/link";
-import { getDb, listRepos, checkGhAuth, getCached } from "@issuectl/core";
+import { getDb, listRepos, getCached } from "@issuectl/core";
 import type { GitHubIssue, GitHubPull } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
 import { SidebarRepoList } from "./SidebarRepoList";
 import styles from "./Sidebar.module.css";
 
-export async function Sidebar() {
+type Props = {
+  username: string;
+};
+
+export async function Sidebar({ username }: Props) {
   let repos: Array<{ owner: string; name: string; issueCount: number }> = [];
-  let username = "unknown";
   let totalIssues = 0;
   let totalPRs = 0;
 
@@ -23,7 +26,6 @@ export async function Sidebar() {
     });
     totalIssues = repos.reduce((sum, r) => sum + r.issueCount, 0);
 
-    // Get PR counts from cache
     for (const r of dbRepos) {
       const cached = getCached<GitHubPull[]>(db, `pulls:${r.owner}/${r.name}`);
       if (cached) {
@@ -31,14 +33,7 @@ export async function Sidebar() {
       }
     }
   } catch (err) {
-    // DB may not exist yet (first run before init)
     console.warn("[issuectl] Sidebar failed to load repos:", err);
-  }
-
-  // checkGhAuth returns errors as values — no try-catch needed
-  const auth = await checkGhAuth();
-  if (auth.ok && auth.username) {
-    username = auth.username;
   }
 
   return (

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -33,6 +33,7 @@ export async function Sidebar({ username }: Props) {
       }
     }
   } catch (err) {
+    // DB may not exist on first run (before 'issuectl init')
     console.warn("[issuectl] Sidebar failed to load repos:", err);
   }
 

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -4,13 +4,22 @@ export type AuthStatus =
   | { authenticated: true; username: string }
   | { authenticated: false; error: string };
 
+/** Never throws — unexpected errors are returned as { authenticated: false }. */
 export async function getAuthStatus(): Promise<AuthStatus> {
-  const result = await checkGhAuth();
-  if (result.ok && result.username) {
-    return { authenticated: true, username: result.username };
+  try {
+    const result = await checkGhAuth();
+    if (result.ok && result.username) {
+      return { authenticated: true, username: result.username };
+    }
+    return {
+      authenticated: false,
+      error: result.error ?? "GitHub CLI authentication failed",
+    };
+  } catch (err) {
+    console.error("[issuectl] Auth check failed unexpectedly:", err);
+    return {
+      authenticated: false,
+      error: err instanceof Error ? err.message : "Auth check failed",
+    };
   }
-  return {
-    authenticated: false,
-    error: result.error ?? "GitHub CLI authentication failed",
-  };
 }

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -1,0 +1,16 @@
+import { checkGhAuth } from "@issuectl/core";
+
+export type AuthStatus =
+  | { authenticated: true; username: string }
+  | { authenticated: false; error: string };
+
+export async function getAuthStatus(): Promise<AuthStatus> {
+  const result = await checkGhAuth();
+  if (result.ok && result.username) {
+    return { authenticated: true, username: result.username };
+  }
+  return {
+    authenticated: false,
+    error: result.error ?? "GitHub CLI authentication failed",
+  };
+}


### PR DESCRIPTION
## Summary
- **Auth error screen**: Layout-level gate renders `AuthErrorScreen` when `gh` is not authenticated, with step-by-step fix instructions and a "Try again" button that re-checks auth
- **Welcome/onboarding screen**: Shows when no repos are configured, with an inline "Add your first repository" form that calls the existing `addRepo` server action
- **Performance**: Sidebar now receives `username` as a prop from the layout, eliminating a redundant `gh auth status` subprocess spawn per page load; settings page migrated to use centralized `getAuthStatus()` wrapper

## Test plan
- [ ] With `gh` authenticated and repos configured: dashboard renders normally (no regression)
- [ ] Run `gh auth logout`, refresh — auth error screen appears with 3 fix steps
- [ ] Click "Try again" on auth error screen — re-checks auth (shows dashboard if now authenticated)
- [ ] With `gh` authenticated but no repos in DB: welcome screen renders with "Add your first repository" form
- [ ] Enter a valid `owner/repo` on the welcome screen, click "Add Repository" — transitions to dashboard
- [ ] Enter an invalid format (e.g., just `repo`) — shows validation error
- [ ] Enter a repo with a non-existent local path — shows warning after adding
- [ ] Settings page still shows correct auth status
- [ ] Sidebar username displays correctly (passed from layout)