### PR TITLE
feat: add light/dark mode with system preference

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1,4 +1,42 @@
 :root {
+  /* Light theme (default) */
+  --bg-base: #f5f6f8;
+  --bg-surface: #ffffff;
+  --bg-elevated: #edeef1;
+  --bg-hover: #e4e5ea;
+  --bg-active: #d8dae0;
+  --border: #d0d3da;
+  --border-subtle: #e2e4e9;
+  --border-accent: #b0b5c0;
+  --text-primary: #1a1c20;
+  --text-secondary: #5c6070;
+  --text-tertiary: #8b8fa0;
+  --text-inverse: #ffffff;
+  --accent: #e87125;
+  --accent-hover: #d4651f;
+  --accent-surface: rgba(232, 113, 37, 0.06);
+  --accent-border: rgba(232, 113, 37, 0.2);
+  --green: #1a7f37;
+  --green-surface: rgba(26, 127, 55, 0.06);
+  --green-border: rgba(26, 127, 55, 0.2);
+  --yellow: #9a6700;
+  --yellow-surface: rgba(154, 103, 0, 0.06);
+  --yellow-border: rgba(154, 103, 0, 0.2);
+  --red: #cf222e;
+  --red-surface: rgba(207, 34, 46, 0.06);
+  --blue: #0969da;
+  --blue-surface: rgba(9, 105, 218, 0.06);
+  --blue-border: rgba(9, 105, 218, 0.2);
+  --purple: #8250df;
+  --purple-surface: rgba(130, 80, 223, 0.06);
+  --cyan: #1b7c83;
+  --noise-opacity: 0.01;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+[data-theme="dark"] {
   --bg-base: #0b0d10;
   --bg-surface: #111318;
   --bg-elevated: #161920;
@@ -29,9 +67,43 @@
   --purple: #bc8cff;
   --purple-surface: rgba(188, 140, 255, 0.08);
   --cyan: #39d0d6;
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --noise-opacity: 0.015;
+}
+
+/* System preference fallback for users without JS or before hydration */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-base: #0b0d10;
+    --bg-surface: #111318;
+    --bg-elevated: #161920;
+    --bg-hover: #1b1f28;
+    --bg-active: #21252f;
+    --border: #222630;
+    --border-subtle: #1a1e26;
+    --border-accent: #333844;
+    --text-primary: #e4e4ea;
+    --text-secondary: #8b8fa0;
+    --text-tertiary: #565b6e;
+    --text-inverse: #0b0d10;
+    --accent: #e87125;
+    --accent-hover: #f07e35;
+    --accent-surface: rgba(232, 113, 37, 0.08);
+    --accent-border: rgba(232, 113, 37, 0.2);
+    --green: #3fb950;
+    --green-surface: rgba(63, 185, 80, 0.08);
+    --green-border: rgba(63, 185, 80, 0.2);
+    --yellow: #d29922;
+    --yellow-surface: rgba(210, 153, 34, 0.08);
+    --yellow-border: rgba(210, 153, 34, 0.2);
+    --red: #f85149;
+    --red-surface: rgba(248, 81, 73, 0.08);
+    --blue: #58a6ff;
+    --blue-surface: rgba(88, 166, 255, 0.08);
+    --blue-border: rgba(88, 166, 255, 0.2);
+    --purple: #bc8cff;
+    --purple-surface: rgba(188, 140, 255, 0.08);
+    --cyan: #39d0d6;
+  }
 }
 
 *,
@@ -56,7 +128,7 @@ body::before {
   inset: 0;
   z-index: 9999;
   pointer-events: none;
-  opacity: 0.015;
+  opacity: var(--noise-opacity, 0.01);
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   background-size: 256px;
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Karla, Syne, Source_Code_Pro } from "next/font/google";
+import { cookies } from "next/headers";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { AuthErrorScreen } from "@/components/auth/AuthErrorScreen";
 import { ToastProvider } from "@/components/ui/ToastProvider";
+import { ThemeProvider, type Theme } from "@/components/ui/ThemeProvider";
 import { getAuthStatus } from "@/lib/auth";
 import "./globals.css";
 import styles from "./layout.module.css";
@@ -32,19 +34,29 @@ type Props = {
   children: ReactNode;
 };
 
+const THEME_SCRIPT = `(function(){try{var t=document.cookie.match(/(?:^|;)\\s*theme=(light|dark|system)/);var v=t?t[1]:"system";var r=v==="system"?window.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light":v;document.documentElement.setAttribute("data-theme",r)}catch(e){}})()`;
+
 export default async function RootLayout({ children }: Props) {
   const auth = await getAuthStatus();
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const theme: Theme = themeCookie === "dark" || themeCookie === "light" ? themeCookie : "system";
 
   return (
-    <html lang="en" className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
+    <html lang="en" data-theme={theme === "system" ? undefined : theme} className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
+      </head>
       <body className={karla.className}>
         {auth.authenticated ? (
-          <ToastProvider>
-            <div className={styles.app}>
-              <Sidebar username={auth.username} />
-              <main className={styles.content}>{children}</main>
-            </div>
-          </ToastProvider>
+          <ThemeProvider initial={theme}>
+            <ToastProvider>
+              <div className={styles.app}>
+                <Sidebar username={auth.username} />
+                <main className={styles.content}>{children}</main>
+              </div>
+            </ToastProvider>
+          </ThemeProvider>
         ) : (
           <AuthErrorScreen />
         )}

--- a/packages/web/components/sidebar/Sidebar.module.css
+++ b/packages/web/components/sidebar/Sidebar.module.css
@@ -164,6 +164,20 @@
   color: var(--text-tertiary);
 }
 
+.themeSection {
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.themeLabel {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--text-tertiary);
+  margin-bottom: 8px;
+}
+
 .footer {
   padding: 12px 14px;
   border-top: 1px solid var(--border);

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { getDb, listRepos, getCached } from "@issuectl/core";
 import type { GitHubIssue, GitHubPull } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
 import { SidebarRepoList } from "./SidebarRepoList";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import styles from "./Sidebar.module.css";
 
 type Props = {
@@ -74,6 +75,11 @@ export async function Sidebar({ username }: Props) {
       <div className={styles.sectionTitle}>Repositories</div>
 
       <SidebarRepoList repos={repos} colors={REPO_COLORS} />
+
+      <div className={styles.themeSection}>
+        <div className={styles.themeLabel}>Theme</div>
+        <ThemeToggle />
+      </div>
 
       <div className={styles.footer}>
         <span className={styles.authDot} />

--- a/packages/web/components/ui/ThemeProvider.tsx
+++ b/packages/web/components/ui/ThemeProvider.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useContext, useCallback, useEffect, useState, type ReactNode } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? getSystemTheme() : theme;
+  document.documentElement.setAttribute("data-theme", resolved);
+}
+
+function setCookie(theme: Theme) {
+  document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365};SameSite=Lax`;
+}
+
+export function ThemeProvider({ initial, children }: { initial: Theme; children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(initial);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+    applyTheme(t);
+    setCookie(t);
+  }, []);
+
+  // Listen for system preference changes when in "system" mode
+  useEffect(() => {
+    if (theme !== "system") return;
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  // Apply theme on mount (handles SSR mismatch)
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return ctx;
+}

--- a/packages/web/components/ui/ThemeToggle.module.css
+++ b/packages/web/components/ui/ThemeToggle.module.css
@@ -1,0 +1,34 @@
+.toggle {
+  display: flex;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  gap: 2px;
+}
+
+.option {
+  flex: 1;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-family: var(--font-karla);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.option:hover {
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+}
+
+.active {
+  composes: option;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}

--- a/packages/web/components/ui/ThemeToggle.tsx
+++ b/packages/web/components/ui/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTheme, type Theme } from "./ThemeProvider";
+import styles from "./ThemeToggle.module.css";
+
+const options: { value: Theme; label: string }[] = [
+  { value: "light", label: "Light" },
+  { value: "system", label: "System" },
+  { value: "dark", label: "Dark" },
+];
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className={styles.toggle}>
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          className={theme === opt.value ? styles.active : styles.option}
+          onClick={() => setTheme(opt.value)}
+          aria-pressed={theme === opt.value}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds light/dark theme support with system preference as default
- Three-way toggle (Light / System / Dark) in sidebar
- Theme persists via cookie for flash-free server-side rendering
- Inline `<script>` prevents flash-of-wrong-theme before hydration
- Light theme with accessible contrast colors; dark theme preserves original design
- Zero component CSS changes — all 66 module files already use `var(--*)` tokens

## Test plan

- [x] `pnpm turbo typecheck` clean
- [x] `pnpm turbo lint` clean
- [x] Light mode renders correctly (screenshots verified)
- [x] Dark mode renders correctly (screenshots verified)
- [x] System mode resolves based on OS preference
- [x] Theme persists across page reload via cookie
- [x] Toggle switches instantly with no flash
- [x] Dashboard and Settings pages verified in both modes