### PR TITLE
fix: Ghostty alias expansion with interactive shell

### DIFF
--- a/packages/core/src/launch/terminals/ghostty.test.ts
+++ b/packages/core/src/launch/terminals/ghostty.test.ts
@@ -99,7 +99,7 @@ describe("buildGhosttyArgs", () => {
       "-na", "Ghostty.app",
       "--args",
       "--title=#42 — Fix auth",
-      "-e", "/bin/bash", "-lc", "cd '/tmp' && echo hello || exec $SHELL -l",
+      "-e", "/bin/bash", "-lic", "cd '/tmp' && echo hello || exec $SHELL -l",
     ]);
   });
 

--- a/packages/core/src/launch/terminals/ghostty.ts
+++ b/packages/core/src/launch/terminals/ghostty.ts
@@ -39,14 +39,15 @@ export function buildShellCommand(workspacePath: string, contextFilePath: string
 }
 
 export function buildGhosttyArgs(tabTitle: string, shellCommand: string): string[] {
-  // Use login shell so PATH includes user tools like claude.
+  // Use interactive login shell (-lic) so PATH includes user tools and
+  // shell aliases are expanded (aliases only work in interactive mode).
   // On failure, drop into an interactive shell so the user can see the error.
   const wrappedCommand = `${shellCommand} || exec $SHELL -l`;
   return [
     "-na", "Ghostty.app",
     "--args",
     `--title=${tabTitle}`,
-    "-e", "/bin/bash", "-lc", wrappedCommand,
+    "-e", "/bin/bash", "-lic", wrappedCommand,
   ];
 }
 


### PR DESCRIPTION
## Summary

- Fixes `bash: yolo: command not found` when launching with a user-defined alias
- Root cause: `bash -lc` runs a non-interactive login shell where aliases are not expanded
- Fix: change to `bash -lic` to enable interactive mode, which sources `.bashrc` and expands aliases
- Terminal.app and iTerm2 are unaffected — they inject commands into already-interactive sessions

## Test plan

- [x] 90 unit tests passing (updated `buildGhosttyArgs` expectation)
- [x] `pnpm turbo typecheck` clean
- [x] `pnpm turbo lint` clean
- [x] Code review: approved, no concerns with `-i` flag side effects

Closes #22