### PR TITLE
fix: add End Session button to resolve stuck running state

### DIFF
--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -8,6 +8,7 @@ import {
   getDeploymentsForIssue,
   getDeploymentsByRepo,
   updateLinkedPR,
+  endDeployment,
 } from "./deployments.js";
 
 function seedRepo(db: Database.Database) {
@@ -39,6 +40,7 @@ describe("recordDeployment", () => {
     expect(dep.workspaceMode).toBe("existing");
     expect(dep.workspacePath).toBe("/home/dev/api");
     expect(dep.linkedPrNumber).toBeNull();
+    expect(dep.endedAt).toBeNull();
     expect(dep.launchedAt).toBeTruthy();
   });
 
@@ -214,6 +216,37 @@ describe("updateLinkedPR", () => {
   it("throws when deployment does not exist", () => {
     expect(() => updateLinkedPR(db, 999, 1)).toThrow(
       "No deployment found with id 999 to link PR",
+    );
+  });
+});
+
+describe("endDeployment", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("sets ended_at on a deployment", () => {
+    const repo = seedRepo(db);
+    const dep = recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 1,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+
+    expect(dep.endedAt).toBeNull();
+    endDeployment(db, dep.id);
+
+    const updated = getDeploymentById(db, dep.id);
+    expect(updated!.endedAt).toBeTruthy();
+  });
+
+  it("throws when deployment does not exist", () => {
+    expect(() => endDeployment(db, 999)).toThrow(
+      "No deployment found with id 999",
     );
   });
 });

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -10,6 +10,7 @@ type DeploymentRow = {
   workspace_path: string;
   linked_pr_number: number | null;
   launched_at: string;
+  ended_at: string | null;
 };
 
 function rowToDeployment(row: DeploymentRow): Deployment {
@@ -22,6 +23,7 @@ function rowToDeployment(row: DeploymentRow): Deployment {
     workspacePath: row.workspace_path,
     linkedPrNumber: row.linked_pr_number,
     launchedAt: row.launched_at,
+    endedAt: row.ended_at,
   };
 }
 
@@ -100,5 +102,17 @@ export function updateLinkedPR(
     throw new Error(
       `No deployment found with id ${deploymentId} to link PR`,
     );
+  }
+}
+
+export function endDeployment(
+  db: Database.Database,
+  deploymentId: number,
+): void {
+  const result = db
+    .prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?")
+    .run(deploymentId);
+  if (result.changes === 0) {
+    throw new Error(`No deployment found with id ${deploymentId}`);
   }
 }

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -21,6 +21,12 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 3,
+    up(db) {
+      db.exec(`ALTER TABLE deployments ADD COLUMN ended_at TEXT;`);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -33,13 +33,13 @@ describe("initSchema", () => {
 
   it("sets schema_version to 2", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
   });
 });
 
@@ -56,12 +56,11 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
   });
 
-  it("migrates v1 schema to v2 by adding claude_aliases table", () => {
+  it("migrates v1 schema through v2 and v3", () => {
     const db = createRawTestDb();
-    // Simulate a v1 database (no claude_aliases table)
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
       CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
@@ -73,10 +72,24 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(2);
+    expect(getSchemaVersion(db)).toBe(3);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(1);
+  });
+
+  it("migrates v2 schema to v3 by adding ended_at column", () => {
+    const db = createRawTestDb();
+    db.exec(`
+      CREATE TABLE deployments (id INTEGER PRIMARY KEY, repo_id INTEGER, issue_number INTEGER, branch_name TEXT, workspace_mode TEXT, workspace_path TEXT, linked_pr_number INTEGER, launched_at TEXT);
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (2);
+    `);
+
+    runMigrations(db);
+
+    expect(getSchemaVersion(db)).toBe(3);
+    db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -26,7 +26,8 @@ const CREATE_TABLES = `
     workspace_mode   TEXT NOT NULL,
     workspace_path   TEXT NOT NULL,
     linked_pr_number INTEGER,
-    launched_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at         TEXT
   );
 
   CREATE TABLE IF NOT EXISTS cache (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
   getDeploymentsForIssue,
   getDeploymentsByRepo,
   updateLinkedPR,
+  endDeployment,
 } from "./db/deployments.js";
 export {
   getCacheTtl,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,7 @@ export type Deployment = {
   workspacePath: string;
   linkedPrNumber: number | null;
   launchedAt: string;
+  endedAt: string | null;
 };
 
 export type CacheEntry<T = unknown> = {

--- a/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
+++ b/packages/web/app/[owner]/[repo]/issues/[number]/launch/page.tsx
@@ -86,7 +86,14 @@ export default async function LaunchActivePage({
         }
       />
       <div className={styles.content}>
-        <LaunchActiveBanner branchName={deployment.branchName} />
+        <LaunchActiveBanner
+          deploymentId={deployment.id}
+          branchName={deployment.branchName}
+          endedAt={deployment.endedAt}
+          owner={owner}
+          repo={repo}
+          issueNumber={issueNumber}
+        />
 
         <LaunchProgress
           deployment={deployment}

--- a/packages/web/components/issue/DeploymentTimeline.tsx
+++ b/packages/web/components/issue/DeploymentTimeline.tsx
@@ -31,9 +31,9 @@ function buildEntries(
 
   for (const dep of deployments) {
     entries.push({
-      label: "Launched to Claude Code",
+      label: dep.endedAt ? "Session ended" : "Claude Code active",
       ref: dep.branchName,
-      date: dep.launchedAt,
+      date: dep.endedAt ?? dep.launchedAt,
       type: "launched",
     });
   }

--- a/packages/web/components/launch/EndSessionButton.tsx
+++ b/packages/web/components/launch/EndSessionButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { endSession } from "@/lib/actions/launch";
+
+type Props = {
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export function EndSessionButton({ deploymentId, owner, repo, issueNumber }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleEnd() {
+    startTransition(async () => {
+      const result = await endSession(deploymentId, owner, repo, issueNumber);
+      if (result.success) {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <Button variant="secondary" onClick={handleEnd} disabled={isPending}>
+      {isPending ? "Ending..." : "End Session"}
+    </Button>
+  );
+}

--- a/packages/web/components/launch/LaunchActiveBanner.module.css
+++ b/packages/web/components/launch/LaunchActiveBanner.module.css
@@ -43,3 +43,31 @@
   color: var(--text-tertiary);
   margin-top: 2px;
 }
+
+.bannerEnded {
+  padding: 16px 20px;
+  background: var(--green-surface);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.checkmark {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--green);
+  font-size: 16px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.titleEnded {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--green);
+}

--- a/packages/web/components/launch/LaunchActiveBanner.tsx
+++ b/packages/web/components/launch/LaunchActiveBanner.tsx
@@ -1,19 +1,45 @@
+import { EndSessionButton } from "./EndSessionButton";
 import styles from "./LaunchActiveBanner.module.css";
 
 type Props = {
+  deploymentId: number;
   branchName: string;
+  endedAt: string | null;
+  owner: string;
+  repo: string;
+  issueNumber: number;
 };
 
-export function LaunchActiveBanner({ branchName }: Props) {
+export function LaunchActiveBanner({ deploymentId, branchName, endedAt, owner, repo, issueNumber }: Props) {
+  if (endedAt) {
+    return (
+      <div className={styles.bannerEnded}>
+        <div className={styles.checkmark}>{"\u2713"}</div>
+        <div className={styles.text}>
+          <div className={styles.titleEnded}>Session ended</div>
+          <div className={styles.sub}>
+            branch: {branchName}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.banner}>
       <div className={styles.spinner} />
       <div className={styles.text}>
         <div className={styles.title}>Claude Code session active</div>
         <div className={styles.sub}>
-          Opened in Ghostty &middot; branch: {branchName}
+          branch: {branchName}
         </div>
       </div>
+      <EndSessionButton
+        deploymentId={deploymentId}
+        owner={owner}
+        repo={repo}
+        issueNumber={issueNumber}
+      />
     </div>
   );
 }

--- a/packages/web/components/launch/LaunchProgress.tsx
+++ b/packages/web/components/launch/LaunchProgress.tsx
@@ -16,6 +16,7 @@ type Props = {
 };
 
 export function LaunchProgress({ deployment, commentCount, fileCount }: Props) {
+  const ended = deployment.endedAt !== null;
   const steps: Step[] = [
     {
       label: "Assembled issue context",
@@ -39,10 +40,10 @@ export function LaunchProgress({ deployment, commentCount, fileCount }: Props) {
       status: "done",
     },
     {
-      label: "Claude Code running",
+      label: ended ? "Session ended" : "Claude Code running",
       detail: deployment.workspacePath,
       highlightDetail: true,
-      status: "active",
+      status: ended ? "done" : "active",
     },
   ];
 

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -5,6 +5,7 @@ import {
   getDb,
   getOctokit,
   executeLaunch,
+  endDeployment as coreEndDeployment,
   type WorkspaceMode,
 } from "@issuectl/core";
 
@@ -83,4 +84,22 @@ export async function launchIssue(
       err instanceof Error ? err.message : "Launch failed unexpectedly";
     return { success: false, error: message };
   }
+}
+
+export async function endSession(
+  deploymentId: number,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const db = getDb();
+    coreEndDeployment(db, deploymentId);
+  } catch (err) {
+    console.error("[issuectl] Failed to end session:", err);
+    return { success: false, error: err instanceof Error ? err.message : "Failed to end session" };
+  }
+  revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
+  revalidatePath(`/${owner}/${repo}/issues/${issueNumber}/launch`);
+  return { success: true };
 }


### PR DESCRIPTION
## Summary

- Adds `ended_at` column to `deployments` table (migration v2->v3)
- "End Session" button on the launch status page sets `ended_at`
- Launch page shows green "Session ended" banner when ended, spinner when active
- LaunchProgress step changes from "Claude Code running" to "Session ended"
- Issue detail sidebar shows "Session ended" vs "Claude Code active" in deployment timeline

## Test plan

- [x] 93 unit tests passing (new: `endDeployment` set/throw, `endedAt` null on create, v2->v3 migration)
- [x] `pnpm turbo typecheck` clean
- [x] `pnpm turbo lint` clean

Closes #24