### PR TITLE
chore: default terminal to iTerm2

### DIFF
--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -3,7 +3,7 @@ import type { Setting, SettingKey } from "../types.js";
 
 const DEFAULT_SETTINGS: Setting[] = [
   { key: "branch_pattern", value: "issue-{number}-{slug}" },
-  { key: "terminal_app", value: "ghostty" },
+  { key: "terminal_app", value: "iterm2" },
   { key: "terminal_window_title", value: "issuectl" },
   { key: "terminal_tab_title_pattern", value: "#{number} — {title}" },
   { key: "cache_ttl", value: "300" },


### PR DESCRIPTION
## Summary

- Changes default terminal from Ghostty to iTerm2
- Ghostty's `-e` flag doesn't work correctly via `open -na` on macOS (tracked in #29)
- iTerm2 works reliably via AppleScript for alias expansion and command injection

## Test plan

- [x] 93 unit tests passing
- [x] E2E tested: iTerm2 launch with yolo alias works correctly