### PR TITLE
feat: Quick Create — natural language to GitHub issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,23 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo lint
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm turbo test
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [typecheck, lint]
+    needs: [typecheck, lint, test]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,3 +119,20 @@ export {
   type ReconcileResult,
   type LinkedPRState,
 } from "./lifecycle/reconcile.js";
+
+// Parse flow (NL → structured issues)
+export type {
+  ParsedIssue,
+  ParsedIssueType,
+  ParsedIssueClarity,
+  ParsedIssuesResponse,
+  ReviewedIssue,
+  BatchCreateResult,
+} from "./parse/index.js";
+export {
+  PARSED_ISSUES_SCHEMA,
+  parseIssues,
+  checkClaudeCliAvailable,
+  formatRepoContext,
+  type RepoWithLabels,
+} from "./parse/index.js";

--- a/packages/core/src/parse/claude-cli.ts
+++ b/packages/core/src/parse/claude-cli.ts
@@ -129,6 +129,12 @@ export async function parseIssues(
     claude.on("close", (code) => {
       clearTimeout(timer);
 
+      if (code !== 0 && finalResult) {
+        console.warn(
+          `[issuectl] Claude CLI exited with code ${code} but produced a result. stderr: ${stderrBuffer.trim()}`,
+        );
+      }
+
       if (code !== 0 && !finalResult) {
         finish({
           success: false,

--- a/packages/core/src/parse/claude-cli.ts
+++ b/packages/core/src/parse/claude-cli.ts
@@ -1,0 +1,167 @@
+import { spawn } from "node:child_process";
+import { writeFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ParsedIssuesResponse } from "./types.js";
+import { PARSED_ISSUES_SCHEMA } from "./schema.js";
+import { ISSUE_PARSER_PROMPT } from "./prompt-text.js";
+
+type ParseResult =
+  | { success: true; data: ParsedIssuesResponse; sessionId: string; cost: number }
+  | { success: false; error: string };
+
+type ClaudeResultEvent = {
+  type: "result";
+  session_id: string;
+  result: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  structured_output?: any;
+  total_cost_usd: number;
+  duration_ms: number;
+  num_turns: number;
+};
+
+export async function checkClaudeCliAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn("claude", ["--version"], { stdio: "ignore" });
+    proc.on("error", () => resolve(false));
+    proc.on("close", (code) => resolve(code === 0));
+  });
+}
+
+export async function parseIssues(
+  userInput: string,
+  contextPrompt: string,
+  options?: { timeoutMs?: number },
+): Promise<ParseResult> {
+  const timeoutMs = options?.timeoutMs ?? 90_000;
+
+  const promptFilePath = join(
+    tmpdir(),
+    `issuectl-parse-prompt-${Date.now()}.txt`,
+  );
+
+  try {
+    await writeFile(promptFilePath, ISSUE_PARSER_PROMPT, "utf-8");
+  } catch (err) {
+    return {
+      success: false,
+      error: `Failed to write prompt file: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const fullPrompt = `${contextPrompt}\n\n---\n\n## User Input\n\n${userInput}`;
+
+  const args = [
+    "-p",
+    fullPrompt,
+    "--append-system-prompt-file",
+    promptFilePath,
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--json-schema",
+    JSON.stringify(PARSED_ISSUES_SCHEMA),
+    "--max-turns",
+    "6",
+    "--allowedTools",
+    "Bash",
+    "--print",
+  ];
+
+  return new Promise((resolve) => {
+    const claude = spawn("claude", args, {
+      env: { ...process.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdoutBuffer = "";
+    let stderrBuffer = "";
+    let finalResult: ClaudeResultEvent | null = null;
+    let settled = false;
+
+    const finish = (result: ParseResult) => {
+      if (settled) return;
+      settled = true;
+      unlink(promptFilePath).catch(() => {});
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      claude.kill("SIGTERM");
+      finish({ success: false, error: "Claude CLI timed out" });
+    }, timeoutMs);
+
+    claude.stdout.on("data", (data: Buffer) => {
+      stdoutBuffer += data.toString();
+
+      const lines = stdoutBuffer.split("\n");
+      stdoutBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as { type: string };
+          if (event.type === "result") {
+            finalResult = event as ClaudeResultEvent;
+          }
+        } catch {
+          // Not valid JSON line, skip
+        }
+      }
+    });
+
+    claude.stderr.on("data", (data: Buffer) => {
+      stderrBuffer += data.toString();
+    });
+
+    claude.on("error", (err) => {
+      clearTimeout(timer);
+      finish({
+        success: false,
+        error:
+          err.message === "spawn claude ENOENT"
+            ? "Claude CLI is not installed. Install from https://docs.anthropic.com/en/docs/claude-code"
+            : `Claude CLI error: ${err.message}`,
+      });
+    });
+
+    claude.on("close", (code) => {
+      clearTimeout(timer);
+
+      if (code !== 0 && !finalResult) {
+        finish({
+          success: false,
+          error: `Claude CLI exited with code ${code}: ${stderrBuffer.trim() || "(no output)"}`,
+        });
+        return;
+      }
+
+      if (!finalResult) {
+        finish({
+          success: false,
+          error: "Claude CLI produced no result event",
+        });
+        return;
+      }
+
+      const parsed = finalResult.structured_output as
+        | ParsedIssuesResponse
+        | undefined;
+      if (!parsed || !Array.isArray(parsed.issues)) {
+        finish({
+          success: false,
+          error: "Claude CLI returned invalid structured output",
+        });
+        return;
+      }
+
+      finish({
+        success: true,
+        data: parsed,
+        sessionId: finalResult.session_id,
+        cost: finalResult.total_cost_usd,
+      });
+    });
+  });
+}

--- a/packages/core/src/parse/context.test.ts
+++ b/packages/core/src/parse/context.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { formatRepoContext } from "./context.js";
+
+describe("formatRepoContext", () => {
+  it("formats multiple repos with labels", () => {
+    const result = formatRepoContext([
+      { owner: "acme", name: "api", labels: ["bug", "feature", "P0"] },
+      { owner: "acme", name: "web", labels: ["frontend", "backend"] },
+    ]);
+
+    expect(result).toContain("## Connected Repositories");
+    expect(result).toContain("### acme/api");
+    expect(result).toContain("- Owner: acme");
+    expect(result).toContain("- Repo: api");
+    expect(result).toContain("- Available labels: bug, feature, P0");
+    expect(result).toContain("### acme/web");
+    expect(result).toContain("- Available labels: frontend, backend");
+  });
+
+  it("handles empty repo list", () => {
+    const result = formatRepoContext([]);
+
+    expect(result).toContain("No repositories are connected");
+    expect(result).not.toContain("###");
+  });
+
+  it("handles repos with no labels", () => {
+    const result = formatRepoContext([
+      { owner: "acme", name: "empty", labels: [] },
+    ]);
+
+    expect(result).toContain("### acme/empty");
+    expect(result).toContain("- Available labels: (none)");
+  });
+
+  it("formats single repo correctly", () => {
+    const result = formatRepoContext([
+      { owner: "mean-weasel", name: "issuectl", labels: ["bug"] },
+    ]);
+
+    expect(result).toContain("### mean-weasel/issuectl");
+    expect(result).toContain("- Owner: mean-weasel");
+    expect(result).toContain("- Repo: issuectl");
+    expect(result).toContain("- Available labels: bug");
+  });
+});

--- a/packages/core/src/parse/context.ts
+++ b/packages/core/src/parse/context.ts
@@ -1,0 +1,27 @@
+export type RepoWithLabels = {
+  owner: string;
+  name: string;
+  labels: string[];
+};
+
+export function formatRepoContext(repos: RepoWithLabels[]): string {
+  if (repos.length === 0) {
+    return "## Connected Repositories\n\nNo repositories are connected. All parsed issues will need manual repo assignment.\n";
+  }
+
+  const sections = ["## Connected Repositories\n"];
+
+  for (const repo of repos) {
+    sections.push(`### ${repo.owner}/${repo.name}`);
+    sections.push(`- Owner: ${repo.owner}`);
+    sections.push(`- Repo: ${repo.name}`);
+    if (repo.labels.length > 0) {
+      sections.push(`- Available labels: ${repo.labels.join(", ")}`);
+    } else {
+      sections.push("- Available labels: (none)");
+    }
+    sections.push("");
+  }
+
+  return sections.join("\n");
+}

--- a/packages/core/src/parse/index.ts
+++ b/packages/core/src/parse/index.ts
@@ -1,0 +1,11 @@
+export type {
+  ParsedIssue,
+  ParsedIssueType,
+  ParsedIssueClarity,
+  ParsedIssuesResponse,
+  ReviewedIssue,
+  BatchCreateResult,
+} from "./types.js";
+export { PARSED_ISSUES_SCHEMA } from "./schema.js";
+export { parseIssues, checkClaudeCliAvailable } from "./claude-cli.js";
+export { formatRepoContext, type RepoWithLabels } from "./context.js";

--- a/packages/core/src/parse/parse.integration.test.ts
+++ b/packages/core/src/parse/parse.integration.test.ts
@@ -43,9 +43,10 @@ afterAll(async () => {
 });
 
 describe("batch issue creation via GitHub API", () => {
-  it("creates a single issue and verifies it", async () => {
+  it("creates a single issue and verifies it", async (ctx) => {
     if (skipReason) {
-      return expect.soft(true).toBe(true);
+      ctx.skip();
+      return;
     }
 
     const issue = await createIssue(octokit, TEST_OWNER, TEST_REPO, {
@@ -62,9 +63,10 @@ describe("batch issue creation via GitHub API", () => {
     expect(issue.labels.some((l) => l.name === "documentation")).toBe(true);
   });
 
-  it("creates multiple issues in parallel (batch pattern)", async () => {
+  it("creates multiple issues in parallel (batch pattern)", async (ctx) => {
     if (skipReason) {
-      return expect.soft(true).toBe(true);
+      ctx.skip();
+      return;
     }
 
     const fixtures = [

--- a/packages/core/src/parse/parse.integration.test.ts
+++ b/packages/core/src/parse/parse.integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { Octokit } from "@octokit/rest";
+import { createIssue } from "../github/issues.js";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+const TEST_PREFIX = "[integration-test]";
+
+let octokit: Octokit;
+let skipReason: string | undefined;
+const createdIssueNumbers: number[] = [];
+
+beforeAll(async () => {
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "token"]);
+    const token = stdout.trim();
+    octokit = new Octokit({ auth: token });
+  } catch {
+    skipReason = "gh auth not configured";
+  }
+});
+
+afterAll(async () => {
+  for (const num of createdIssueNumbers) {
+    try {
+      await execFileAsync("gh", [
+        "issue",
+        "close",
+        String(num),
+        "--repo",
+        `${TEST_OWNER}/${TEST_REPO}`,
+        "--reason",
+        "not planned",
+      ]);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+});
+
+describe("batch issue creation via GitHub API", () => {
+  it("creates a single issue and verifies it", async () => {
+    if (skipReason) {
+      return expect.soft(true).toBe(true);
+    }
+
+    const issue = await createIssue(octokit, TEST_OWNER, TEST_REPO, {
+      title: `${TEST_PREFIX} Test issue creation`,
+      body: "## Description\n\nAutomated integration test — this issue should be closed automatically.",
+      labels: ["documentation"],
+    });
+
+    createdIssueNumbers.push(issue.number);
+
+    expect(issue.number).toBeGreaterThan(0);
+    expect(issue.title).toBe(`${TEST_PREFIX} Test issue creation`);
+    expect(issue.state).toBe("open");
+    expect(issue.labels.some((l) => l.name === "documentation")).toBe(true);
+  });
+
+  it("creates multiple issues in parallel (batch pattern)", async () => {
+    if (skipReason) {
+      return expect.soft(true).toBe(true);
+    }
+
+    const fixtures = [
+      {
+        title: `${TEST_PREFIX} Batch issue A`,
+        body: "First issue in batch test.",
+      },
+      {
+        title: `${TEST_PREFIX} Batch issue B`,
+        body: "Second issue in batch test.",
+      },
+    ];
+
+    const results = await Promise.all(
+      fixtures.map((data) =>
+        createIssue(octokit, TEST_OWNER, TEST_REPO, data),
+      ),
+    );
+
+    for (const issue of results) {
+      createdIssueNumbers.push(issue.number);
+    }
+
+    expect(results).toHaveLength(2);
+    expect(results[0].title).toBe(`${TEST_PREFIX} Batch issue A`);
+    expect(results[1].title).toBe(`${TEST_PREFIX} Batch issue B`);
+    expect(results[0].number).not.toBe(results[1].number);
+  });
+});

--- a/packages/core/src/parse/prompt-text.ts
+++ b/packages/core/src/parse/prompt-text.ts
@@ -1,0 +1,156 @@
+export const ISSUE_PARSER_PROMPT = `# GitHub Issue Parser for issuectl
+
+You are a specialized GitHub issue parser. Your job is to take free-form natural language input and convert it into well-structured GitHub issues, each matched to the correct repository from a list of connected repos.
+
+## Your Responsibilities
+
+1. **Parse** the user's input into one or more discrete GitHub issues
+2. **Match** each issue to the correct connected repository
+3. **Generate** a clean title and full markdown body for each issue
+4. **Suggest** appropriate labels from the matched repo's available labels
+5. **Assess** your confidence in each repo match
+
+## Input Format
+
+You will receive:
+1. A list of connected repositories with their owner, name, and available labels
+2. The user's free-form text describing one or more issues
+
+## Parsing Guidelines
+
+### Splitting Input into Issues
+
+- Each distinct problem, feature request, or task becomes its own issue
+- Look for conjunctions ("and", "also", "plus"), sentence boundaries, and topic changes
+- A single sentence can describe multiple issues if it mentions multiple distinct tasks
+- Questions should be converted to actionable issue titles
+
+### Issue Title
+
+- Write clear, concise titles in imperative form (e.g., "Fix authentication timeout", "Add dark mode toggle")
+- Do NOT prefix with repo name or type — those are separate fields
+- Keep under 80 characters
+
+### Issue Body
+
+Generate a full GitHub-quality markdown body. Structure depends on issue type:
+
+**Bug:**
+\`\`\`markdown
+## Description
+[What's broken and what the expected behavior should be]
+
+## Steps to Reproduce
+1. [Step 1]
+2. [Step 2]
+
+## Expected Behavior
+[What should happen]
+
+## Actual Behavior
+[What happens instead]
+\`\`\`
+
+**Feature:**
+\`\`\`markdown
+## Description
+[What the feature should do and why it's needed]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+\`\`\`
+
+**Enhancement / Refactor / Docs / Chore:**
+\`\`\`markdown
+## Description
+[What needs to change and why]
+
+## Details
+[Additional context, approach suggestions, or constraints]
+\`\`\`
+
+If the user provides detailed context, include it. If the description is brief, generate reasonable placeholder content that the user can refine.
+
+### Repo Matching
+
+Match each issue to a connected repository using these rules:
+
+**Confidence Levels:**
+- **0.9 – 1.0**: User explicitly names the repo (e.g., "in seatify", "for mean-weasel/dashboard")
+- **0.7 – 0.89**: Strong keyword match — repo name appears in context, or the issue topic clearly relates to one repo
+- **0.5 – 0.69**: Weak match — could be this repo based on general topic
+- **Below 0.5**: Guessing — do NOT assign, set repoOwner/repoName to null
+
+**Matching Priority:**
+1. Explicit repo mention by name or owner/name
+2. Keyword match against repo names
+3. Topic/domain match based on repo names (e.g., "auth bug" might match a repo named "auth-service")
+
+If you cannot confidently match (confidence < 0.5), set \`repoOwner\` and \`repoName\` to \`null\` and \`clarity\` to \`"unknown_repo"\`.
+
+If a match is possible but ambiguous (could be multiple repos), set \`clarity\` to \`"ambiguous"\` and use the best-guess repo.
+
+### Label Suggestions
+
+- ONLY suggest labels from the matched repo's available label set (provided in context)
+- If the repo has no labels or no match, use an empty array
+- Match by issue type: "bug" type → look for "bug" label, "feature" → "enhancement" or "feature", etc.
+- Be conservative — only suggest labels you're confident about
+
+### GitHub Repo Verification (Bash Tool)
+
+If the user mentions a repo that is NOT in the connected list, you may use the Bash tool to verify it exists:
+
+\`\`\`bash
+gh repo view OWNER/REPO --json name,description,url 2>/dev/null
+\`\`\`
+
+This helps distinguish between typos and real repos that aren't connected yet. If the repo exists on GitHub but isn't connected, still set repoOwner/repoName to null and clarity to "unknown_repo" — the user must manually assign it in the review step.
+
+## Output Requirements
+
+Return a JSON object matching the ParsedIssuesResponse schema with:
+- \`issues\`: Array of parsed issues
+- \`suggestedOrder\`: Array of issue IDs in recommended creation order (dependencies first, then by priority)
+
+Each issue must have:
+- \`id\`: A unique UUID string
+- \`originalText\`: The portion of input this issue was parsed from
+- \`title\`: Clean issue title
+- \`body\`: Full markdown issue body
+- \`type\`: One of "bug", "feature", "enhancement", "refactor", "docs", "chore"
+- \`repoOwner\`: Matched repo owner or null
+- \`repoName\`: Matched repo name or null
+- \`repoConfidence\`: 0-1 confidence score
+- \`suggestedLabels\`: Array of label names from the matched repo's set
+- \`clarity\`: "clear", "ambiguous", or "unknown_repo"
+
+## Examples
+
+### Example 1: Multi-repo, clear matches
+
+**Input:** "Fix the login timeout bug in seatify and add search functionality to the dashboard"
+
+**Connected repos:** neonwatty/seatify (labels: bug, enhancement, P0), mean-weasel/dashboard (labels: feature, frontend)
+
+**Expected output:** Two issues:
+1. Bug in neonwatty/seatify with confidence 0.95, labels ["bug"], clarity "clear"
+2. Feature in mean-weasel/dashboard with confidence 0.9, labels ["feature", "frontend"], clarity "clear"
+
+### Example 2: Unknown repo
+
+**Input:** "We need to update the README for the new-project repo"
+
+**Connected repos:** neonwatty/seatify, mean-weasel/dashboard
+
+**Expected output:** One issue with repoOwner: null, repoName: null, clarity: "unknown_repo", confidence: 0
+
+### Example 3: Ambiguous match
+
+**Input:** "Fix the CSS styling issues"
+
+**Connected repos:** neonwatty/seatify, mean-weasel/dashboard, mean-weasel/landing-page
+
+**Expected output:** One issue with best-guess repo, clarity: "ambiguous", confidence: 0.5-0.6
+`;

--- a/packages/core/src/parse/schema.test.ts
+++ b/packages/core/src/parse/schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { PARSED_ISSUES_SCHEMA } from "./schema.js";
+
+describe("PARSED_ISSUES_SCHEMA", () => {
+  it("requires issues and suggestedOrder at top level", () => {
+    expect(PARSED_ISSUES_SCHEMA.required).toContain("issues");
+    expect(PARSED_ISSUES_SCHEMA.required).toContain("suggestedOrder");
+  });
+
+  it("defines issues as an array", () => {
+    expect(PARSED_ISSUES_SCHEMA.properties.issues.type).toBe("array");
+  });
+
+  it("defines suggestedOrder as an array of strings", () => {
+    expect(PARSED_ISSUES_SCHEMA.properties.suggestedOrder.type).toBe("array");
+    expect(PARSED_ISSUES_SCHEMA.properties.suggestedOrder.items.type).toBe("string");
+  });
+
+  it("issue items have all required fields", () => {
+    const itemSchema = PARSED_ISSUES_SCHEMA.properties.issues.items;
+    const required = itemSchema.required;
+
+    expect(required).toContain("id");
+    expect(required).toContain("originalText");
+    expect(required).toContain("title");
+    expect(required).toContain("body");
+    expect(required).toContain("type");
+    expect(required).toContain("repoOwner");
+    expect(required).toContain("repoName");
+    expect(required).toContain("repoConfidence");
+    expect(required).toContain("suggestedLabels");
+    expect(required).toContain("clarity");
+  });
+
+  it("type enum matches ParsedIssueType values", () => {
+    const typeEnum = PARSED_ISSUES_SCHEMA.properties.issues.items.properties.type.enum;
+
+    expect(typeEnum).toEqual([
+      "bug",
+      "feature",
+      "enhancement",
+      "refactor",
+      "docs",
+      "chore",
+    ]);
+  });
+
+  it("clarity enum matches ParsedIssueClarity values", () => {
+    const clarityEnum = PARSED_ISSUES_SCHEMA.properties.issues.items.properties.clarity.enum;
+
+    expect(clarityEnum).toEqual(["clear", "ambiguous", "unknown_repo"]);
+  });
+
+  it("repoOwner and repoName allow null", () => {
+    const props = PARSED_ISSUES_SCHEMA.properties.issues.items.properties;
+
+    expect(props.repoOwner.type).toContain("null");
+    expect(props.repoName.type).toContain("null");
+  });
+
+  it("repoConfidence has min 0 and max 1", () => {
+    const conf = PARSED_ISSUES_SCHEMA.properties.issues.items.properties.repoConfidence;
+
+    expect(conf.minimum).toBe(0);
+    expect(conf.maximum).toBe(1);
+  });
+});

--- a/packages/core/src/parse/schema.ts
+++ b/packages/core/src/parse/schema.ts
@@ -60,7 +60,8 @@ export const PARSED_ISSUES_SCHEMA = {
           clarity: {
             type: "string",
             enum: ["clear", "ambiguous", "unknown_repo"],
-            description: "How confident the parsing is",
+            description:
+              "Repo match assessment: clear = confident single match, ambiguous = multiple possible repos, unknown_repo = no match found",
           },
         },
         required: [

--- a/packages/core/src/parse/schema.ts
+++ b/packages/core/src/parse/schema.ts
@@ -1,0 +1,87 @@
+export const PARSED_ISSUES_SCHEMA = {
+  type: "object",
+  properties: {
+    issues: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description: "Unique identifier for this issue (UUID format)",
+          },
+          originalText: {
+            type: "string",
+            description: "The portion of the original input this issue came from",
+          },
+          title: {
+            type: "string",
+            description: "Clean, actionable GitHub issue title",
+          },
+          body: {
+            type: "string",
+            description:
+              "Full GitHub-quality markdown issue body with appropriate sections",
+          },
+          type: {
+            type: "string",
+            enum: [
+              "bug",
+              "feature",
+              "enhancement",
+              "refactor",
+              "docs",
+              "chore",
+            ],
+            description: "Issue type category",
+          },
+          repoOwner: {
+            type: ["string", "null"],
+            description:
+              "GitHub repo owner matched from connected repos, or null if unknown",
+          },
+          repoName: {
+            type: ["string", "null"],
+            description:
+              "GitHub repo name matched from connected repos, or null if unknown",
+          },
+          repoConfidence: {
+            type: "number",
+            minimum: 0,
+            maximum: 1,
+            description: "Confidence score for repo match (0-1)",
+          },
+          suggestedLabels: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Labels suggested from the matched repo's available label set",
+          },
+          clarity: {
+            type: "string",
+            enum: ["clear", "ambiguous", "unknown_repo"],
+            description: "How confident the parsing is",
+          },
+        },
+        required: [
+          "id",
+          "originalText",
+          "title",
+          "body",
+          "type",
+          "repoOwner",
+          "repoName",
+          "repoConfidence",
+          "suggestedLabels",
+          "clarity",
+        ],
+      },
+    },
+    suggestedOrder: {
+      type: "array",
+      items: { type: "string" },
+      description: "Issue IDs in recommended creation order",
+    },
+  },
+  required: ["issues", "suggestedOrder"],
+} as const;

--- a/packages/core/src/parse/types.ts
+++ b/packages/core/src/parse/types.ts
@@ -1,0 +1,44 @@
+export type ParsedIssueType = "bug" | "feature" | "enhancement" | "refactor" | "docs" | "chore";
+
+export type ParsedIssueClarity = "clear" | "ambiguous" | "unknown_repo";
+
+export type ParsedIssue = {
+  id: string;
+  originalText: string;
+  title: string;
+  body: string;
+  type: ParsedIssueType;
+  repoOwner: string | null;
+  repoName: string | null;
+  repoConfidence: number;
+  suggestedLabels: string[];
+  clarity: ParsedIssueClarity;
+};
+
+export type ParsedIssuesResponse = {
+  issues: ParsedIssue[];
+  suggestedOrder: string[];
+};
+
+export type ReviewedIssue = {
+  id: string;
+  title: string;
+  body: string;
+  owner: string;
+  repo: string;
+  labels: string[];
+  accepted: boolean;
+};
+
+export type BatchCreateResult = {
+  created: number;
+  failed: number;
+  results: Array<{
+    id: string;
+    success: boolean;
+    issueNumber?: number;
+    error?: string;
+    owner: string;
+    repo: string;
+  }>;
+};

--- a/packages/web/app/parse/page.module.css
+++ b/packages/web/app/parse/page.module.css
@@ -1,0 +1,4 @@
+.content {
+  padding: 20px 32px 32px;
+  max-width: 800px;
+}

--- a/packages/web/app/parse/page.tsx
+++ b/packages/web/app/parse/page.tsx
@@ -1,0 +1,76 @@
+import {
+  dbExists,
+  getDb,
+  getOctokit,
+  listRepos,
+  listLabels,
+  checkClaudeCliAvailable,
+} from "@issuectl/core";
+import type { GitHubLabel } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { ParseFlow } from "@/components/parse/ParseFlow";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+export default async function ParsePage() {
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Quick Create" />
+        <div className={styles.content}>
+          <p style={{ color: "var(--text-secondary)" }}>
+            Run <code>issuectl init</code> to get started.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  const db = getDb();
+  const dbRepos = listRepos(db);
+
+  let repos: RepoOption[] = [];
+  const labelsPerRepo: Record<string, GitHubLabel[]> = {};
+  let claudeAvailable = false;
+
+  try {
+    const octokit = await getOctokit();
+    repos = dbRepos.map((r) => ({ owner: r.owner, repo: r.name }));
+
+    const [labelResults, claudeCheck] = await Promise.all([
+      Promise.all(
+        dbRepos.map(async (r) => {
+          try {
+            const labels = await listLabels(octokit, r.owner, r.name);
+            return { key: `${r.owner}/${r.name}`, labels };
+          } catch {
+            return { key: `${r.owner}/${r.name}`, labels: [] as GitHubLabel[] };
+          }
+        }),
+      ),
+      checkClaudeCliAvailable().catch(() => false),
+    ]);
+
+    for (const { key, labels } of labelResults) {
+      labelsPerRepo[key] = labels;
+    }
+    claudeAvailable = claudeCheck;
+  } catch (err) {
+    console.error("[issuectl] Failed to load repos/labels:", err);
+  }
+
+  return (
+    <>
+      <PageHeader title="Quick Create" />
+      <div className={styles.content}>
+        <ParseFlow
+          repos={repos}
+          labelsPerRepo={labelsPerRepo}
+          claudeAvailable={claudeAvailable}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/parse/page.tsx
+++ b/packages/web/app/parse/page.tsx
@@ -45,7 +45,11 @@ export default async function ParsePage() {
           try {
             const labels = await listLabels(octokit, r.owner, r.name);
             return { key: `${r.owner}/${r.name}`, labels };
-          } catch {
+          } catch (err) {
+            console.warn(
+              `[issuectl] Failed to fetch labels for ${r.owner}/${r.name}:`,
+              err instanceof Error ? err.message : err,
+            );
             return { key: `${r.owner}/${r.name}`, labels: [] as GitHubLabel[] };
           }
         }),

--- a/packages/web/components/parse/ParseFlow.module.css
+++ b/packages/web/components/parse/ParseFlow.module.css
@@ -1,0 +1,16 @@
+.unavailable {
+  padding: 16px 20px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.unavailable code {
+  background: var(--bg-hover);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}

--- a/packages/web/components/parse/ParseFlow.tsx
+++ b/packages/web/components/parse/ParseFlow.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import type { GitHubLabel, ParsedIssuesResponse, BatchCreateResult } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
+import { ParseInput } from "./ParseInput";
+import { ParseReview } from "./ParseReview";
+import { ParseResults } from "./ParseResults";
+import styles from "./ParseFlow.module.css";
+
+type Step = "input" | "review" | "results";
+
+type Props = {
+  repos: RepoOption[];
+  labelsPerRepo: Record<string, GitHubLabel[]>;
+  claudeAvailable: boolean;
+};
+
+export function ParseFlow({ repos, labelsPerRepo, claudeAvailable }: Props) {
+  const [step, setStep] = useState<Step>("input");
+  const [parsedData, setParsedData] = useState<ParsedIssuesResponse | null>(null);
+  const [results, setResults] = useState<BatchCreateResult | null>(null);
+
+  if (!claudeAvailable) {
+    return (
+      <div className={styles.unavailable}>
+        Claude CLI is not installed. Quick Create uses the Claude CLI to parse
+        natural language into GitHub issues.
+        <br />
+        <br />
+        Install it with: <code>npm install -g @anthropic-ai/claude-code</code>
+      </div>
+    );
+  }
+
+  if (repos.length === 0) {
+    return (
+      <div className={styles.unavailable}>
+        No repositories connected. Add repos in Settings before using Quick Create.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {step === "input" && (
+        <ParseInput
+          onParsed={(data) => {
+            setParsedData(data);
+            setStep("review");
+          }}
+        />
+      )}
+      {step === "review" && parsedData && (
+        <ParseReview
+          parsed={parsedData}
+          repos={repos}
+          labelsPerRepo={labelsPerRepo}
+          onConfirm={(batchResult) => {
+            setResults(batchResult);
+            setStep("results");
+          }}
+          onBack={() => setStep("input")}
+        />
+      )}
+      {step === "results" && results && (
+        <ParseResults
+          results={results}
+          onReset={() => {
+            setParsedData(null);
+            setResults(null);
+            setStep("input");
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/parse/ParseInput.module.css
+++ b/packages/web/components/parse/ParseInput.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.description {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 160px;
+  padding: 12px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.textarea:focus {
+  border-color: var(--accent-border);
+}
+
+.textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.parsingText {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.error {
+  padding: 8px 12px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius-md);
+  color: var(--red);
+  font-size: 12px;
+}

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { ParsedIssuesResponse } from "@issuectl/core";
+import { parseNaturalLanguage } from "@/lib/actions/parse";
+import { Button } from "@/components/ui/Button";
+import styles from "./ParseInput.module.css";
+
+type Props = {
+  onParsed: (data: ParsedIssuesResponse) => void;
+};
+
+export function ParseInput({ onParsed }: Props) {
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleParse() {
+    setError(null);
+    startTransition(async () => {
+      const result = await parseNaturalLanguage(input);
+      if (!result.success) {
+        setError(result.error ?? "Failed to parse input");
+        return;
+      }
+      if (result.data!.parsed.issues.length === 0) {
+        setError("No issues were parsed from the input. Try being more specific.");
+        return;
+      }
+      onParsed(result.data!.parsed);
+    });
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.description}>
+        Describe one or more issues in plain language. Claude will parse them
+        into structured GitHub issues and match them to your connected repos.
+      </div>
+      <textarea
+        className={styles.textarea}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="e.g. Fix the login timeout bug in seatify and add search functionality to the dashboard..."
+        disabled={isPending}
+        autoFocus
+      />
+      <div className={styles.footer}>
+        <Button
+          variant="primary"
+          onClick={handleParse}
+          disabled={isPending || !input.trim()}
+        >
+          {isPending ? "Parsing..." : "Parse with Claude"}
+        </Button>
+        {isPending && (
+          <>
+            <div className={styles.spinner} />
+            <span className={styles.parsingText}>
+              Claude is analyzing your input...
+            </span>
+          </>
+        )}
+      </div>
+      {error && (
+        <div className={styles.error} role="alert">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -18,16 +18,24 @@ export function ParseInput({ onParsed }: Props) {
   function handleParse() {
     setError(null);
     startTransition(async () => {
-      const result = await parseNaturalLanguage(input);
-      if (!result.success) {
-        setError(result.error ?? "Failed to parse input");
-        return;
+      try {
+        const result = await parseNaturalLanguage(input);
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+        if (result.data.parsed.issues.length === 0) {
+          setError("No issues were parsed from the input. Try being more specific.");
+          return;
+        }
+        onParsed(result.data.parsed);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? `Connection error: ${err.message}`
+            : "An unexpected error occurred. Please try again.",
+        );
       }
-      if (result.data!.parsed.issues.length === 0) {
-        setError("No issues were parsed from the input. Try being more specific.");
-        return;
-      }
-      onParsed(result.data!.parsed);
     });
   }
 

--- a/packages/web/components/parse/ParseIssueCard.module.css
+++ b/packages/web/components/parse/ParseIssueCard.module.css
@@ -1,0 +1,175 @@
+.card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+
+.cardRejected {
+  composes: card;
+  opacity: 0.5;
+}
+
+.cardUnmatched {
+  composes: card;
+  border-color: var(--yellow-border, rgba(210, 153, 34, 0.3));
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-base);
+}
+
+.typeBadge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-surface);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.confidenceHigh {
+  font-size: 11px;
+  color: var(--green);
+  flex-shrink: 0;
+}
+
+.confidenceMedium {
+  font-size: 11px;
+  color: var(--yellow, #d29922);
+  flex-shrink: 0;
+}
+
+.confidenceLow {
+  font-size: 11px;
+  color: var(--red);
+  flex-shrink: 0;
+}
+
+.headerSpacer {
+  flex: 1;
+}
+
+.toggleButton {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.toggleButton:hover {
+  background: var(--bg-hover);
+}
+
+.toggleButtonActive {
+  composes: toggleButton;
+  background: var(--green-surface);
+  border-color: var(--green-border);
+  color: var(--green);
+}
+
+.body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.input {
+  width: 100%;
+  padding: 7px 10px;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.textarea {
+  width: 100%;
+  min-height: 100px;
+  padding: 8px 10px;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-mono), monospace;
+  outline: none;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.textarea:focus {
+  border-color: var(--accent-border);
+}
+
+.select {
+  width: 100%;
+  padding: 7px 10px;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-karla), sans-serif;
+  outline: none;
+  cursor: pointer;
+}
+
+.select:focus {
+  border-color: var(--accent-border);
+}
+
+.selectUnmatched {
+  composes: select;
+  border-color: var(--yellow-border, rgba(210, 153, 34, 0.3));
+  color: var(--yellow, #d29922);
+}
+
+.labelsRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.originalText {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: 6px 10px;
+  background: var(--bg-base);
+  border-radius: var(--radius-sm);
+  border-left: 2px solid var(--border);
+}

--- a/packages/web/components/parse/ParseIssueCard.tsx
+++ b/packages/web/components/parse/ParseIssueCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { GitHubLabel, ParsedIssueType, ParsedIssueClarity } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
+import { LabelSelector } from "@/components/issue/LabelSelector";
+import styles from "./ParseIssueCard.module.css";
+
+export type IssueCardState = {
+  id: string;
+  title: string;
+  body: string;
+  type: ParsedIssueType;
+  owner: string | null;
+  repo: string | null;
+  labels: string[];
+  accepted: boolean;
+  confidence: number;
+  clarity: ParsedIssueClarity;
+  originalText: string;
+};
+
+type Props = {
+  issue: IssueCardState;
+  repos: RepoOption[];
+  labelsPerRepo: Record<string, GitHubLabel[]>;
+  onChange: (updated: IssueCardState) => void;
+};
+
+function confidenceLabel(confidence: number) {
+  if (confidence >= 0.7) return { text: `${Math.round(confidence * 100)}%`, className: styles.confidenceHigh };
+  if (confidence >= 0.5) return { text: `${Math.round(confidence * 100)}%`, className: styles.confidenceMedium };
+  return { text: "unmatched", className: styles.confidenceLow };
+}
+
+export function ParseIssueCard({ issue, repos, labelsPerRepo, onChange }: Props) {
+  const repoKey = issue.owner && issue.repo ? `${issue.owner}/${issue.repo}` : "";
+  const availableLabels = repoKey ? (labelsPerRepo[repoKey] ?? []) : [];
+  const isUnmatched = !issue.owner || !issue.repo;
+  const conf = confidenceLabel(issue.confidence);
+
+  function handleRepoChange(value: string) {
+    if (!value) {
+      onChange({ ...issue, owner: null, repo: null, labels: [] });
+      return;
+    }
+    const [owner, repo] = value.split("/");
+    const newRepoLabels = labelsPerRepo[value] ?? [];
+    const newLabelNames = new Set(newRepoLabels.map((l) => l.name));
+    const validLabels = issue.labels.filter((l) => newLabelNames.has(l));
+    onChange({ ...issue, owner, repo, labels: validLabels });
+  }
+
+  function handleToggleLabel(label: string) {
+    const labels = issue.labels.includes(label)
+      ? issue.labels.filter((l) => l !== label)
+      : [...issue.labels, label];
+    onChange({ ...issue, labels });
+  }
+
+  let cardClass = styles.card;
+  if (!issue.accepted) cardClass = styles.cardRejected;
+  else if (isUnmatched) cardClass = styles.cardUnmatched;
+
+  return (
+    <div className={cardClass}>
+      <div className={styles.header}>
+        <span className={styles.typeBadge}>{issue.type}</span>
+        <span className={conf.className}>{conf.text}</span>
+        <div className={styles.headerSpacer} />
+        <button
+          type="button"
+          className={issue.accepted ? styles.toggleButtonActive : styles.toggleButton}
+          onClick={() => onChange({ ...issue, accepted: !issue.accepted })}
+        >
+          {issue.accepted ? "Included" : "Excluded"}
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.originalText}>{issue.originalText}</div>
+
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>Title</label>
+          <input
+            className={styles.input}
+            value={issue.title}
+            onChange={(e) => onChange({ ...issue, title: e.target.value })}
+            disabled={!issue.accepted}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>Body (markdown)</label>
+          <textarea
+            className={styles.textarea}
+            value={issue.body}
+            onChange={(e) => onChange({ ...issue, body: e.target.value })}
+            disabled={!issue.accepted}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>Repository</label>
+          <select
+            className={isUnmatched ? styles.selectUnmatched : styles.select}
+            value={repoKey}
+            onChange={(e) => handleRepoChange(e.target.value)}
+            disabled={!issue.accepted}
+          >
+            <option value="">Select a repo...</option>
+            {repos.map((r) => (
+              <option key={`${r.owner}/${r.repo}`} value={`${r.owner}/${r.repo}`}>
+                {r.owner}/{r.repo}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {availableLabels.length > 0 && (
+          <div className={styles.labelsRow}>
+            <span className={styles.fieldLabel}>Labels</span>
+            <LabelSelector
+              available={availableLabels}
+              selected={issue.labels}
+              onToggle={handleToggleLabel}
+              disabled={!issue.accepted}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/parse/ParseResults.module.css
+++ b/packages/web/components/parse/ParseResults.module.css
@@ -1,0 +1,110 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summaryBase {
+  padding: 16px 20px;
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.summarySuccess {
+  composes: summaryBase;
+  background: var(--green-surface);
+  border: 1px solid var(--green-border);
+}
+
+.summaryPartial {
+  composes: summaryBase;
+  background: linear-gradient(
+    135deg,
+    rgba(210, 153, 34, 0.08) 0%,
+    rgba(210, 153, 34, 0.02) 100%
+  );
+  border: 1px solid rgba(210, 153, 34, 0.3);
+}
+
+.summaryIcon {
+  font-size: 18px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.summaryIconSuccess {
+  composes: summaryIcon;
+  color: var(--green);
+}
+
+.summaryIconPartial {
+  composes: summaryIcon;
+  color: var(--yellow, #d29922);
+}
+
+.summaryText {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.resultItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.resultSuccess {
+  color: var(--green);
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.resultFailed {
+  color: var(--red);
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.resultRepo {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.resultLink {
+  font-size: 13px;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.resultLink:hover {
+  text-decoration: underline;
+}
+
+.resultError {
+  font-size: 12px;
+  color: var(--red);
+}
+
+.resultSpacer {
+  flex: 1;
+}
+
+.footer {
+  padding-top: 8px;
+}

--- a/packages/web/components/parse/ParseResults.tsx
+++ b/packages/web/components/parse/ParseResults.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import type { BatchCreateResult } from "@issuectl/core";
+import { Button } from "@/components/ui/Button";
+import styles from "./ParseResults.module.css";
+
+type Props = {
+  results: BatchCreateResult;
+  onReset: () => void;
+};
+
+export function ParseResults({ results, onReset }: Props) {
+  const allSuccess = results.failed === 0;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={allSuccess ? styles.summarySuccess : styles.summaryPartial}>
+        <span className={allSuccess ? styles.summaryIconSuccess : styles.summaryIconPartial}>
+          {allSuccess ? "\u2713" : "!"}
+        </span>
+        <span className={styles.summaryText}>
+          {results.created} issue{results.created !== 1 ? "s" : ""} created
+          {results.failed > 0 &&
+            `, ${results.failed} failed`}
+        </span>
+      </div>
+
+      <div className={styles.list}>
+        {results.results.map((r) => (
+          <div key={r.id} className={styles.resultItem}>
+            <span className={r.success ? styles.resultSuccess : styles.resultFailed}>
+              {r.success ? "\u2713" : "\u2717"}
+            </span>
+            <span className={styles.resultRepo}>
+              {r.owner}/{r.repo}
+            </span>
+            <div className={styles.resultSpacer} />
+            {r.success && r.issueNumber !== undefined ? (
+              <Link
+                href={`/${r.owner}/${r.repo}/issues/${r.issueNumber}`}
+                className={styles.resultLink}
+              >
+                #{r.issueNumber}
+              </Link>
+            ) : (
+              <span className={styles.resultError}>
+                {r.error ?? "Failed"}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.footer}>
+        <Button variant="primary" onClick={onReset}>
+          Create More
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/parse/ParseReview.module.css
+++ b/packages/web/components/parse/ParseReview.module.css
@@ -1,0 +1,32 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.error {
+  padding: 8px 12px;
+  background: var(--red-surface);
+  border: 1px solid rgba(248, 81, 73, 0.2);
+  border-radius: var(--radius-md);
+  color: var(--red);
+  font-size: 12px;
+}

--- a/packages/web/components/parse/ParseReview.tsx
+++ b/packages/web/components/parse/ParseReview.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { GitHubLabel, ParsedIssuesResponse, BatchCreateResult } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
+import { batchCreateIssues } from "@/lib/actions/parse";
+import { Button } from "@/components/ui/Button";
+import { ParseIssueCard, type IssueCardState } from "./ParseIssueCard";
+import styles from "./ParseReview.module.css";
+
+type Props = {
+  parsed: ParsedIssuesResponse;
+  repos: RepoOption[];
+  labelsPerRepo: Record<string, GitHubLabel[]>;
+  onConfirm: (result: BatchCreateResult) => void;
+  onBack: () => void;
+};
+
+function initCardStates(parsed: ParsedIssuesResponse): IssueCardState[] {
+  const orderMap = new Map(parsed.suggestedOrder.map((id, i) => [id, i]));
+  return [...parsed.issues]
+    .sort((a, b) => (orderMap.get(a.id) ?? 999) - (orderMap.get(b.id) ?? 999))
+    .map((issue) => ({
+      id: issue.id,
+      title: issue.title,
+      body: issue.body,
+      type: issue.type,
+      owner: issue.repoOwner,
+      repo: issue.repoName,
+      labels: issue.suggestedLabels,
+      accepted: true,
+      confidence: issue.repoConfidence,
+      clarity: issue.clarity,
+      originalText: issue.originalText,
+    }));
+}
+
+export function ParseReview({
+  parsed,
+  repos,
+  labelsPerRepo,
+  onConfirm,
+  onBack,
+}: Props) {
+  const [cards, setCards] = useState(() => initCardStates(parsed));
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const acceptedCount = cards.filter((c) => c.accepted).length;
+  const unmatchedAccepted = cards.filter(
+    (c) => c.accepted && (!c.owner || !c.repo),
+  );
+
+  function handleCardChange(updated: IssueCardState) {
+    setCards((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+  }
+
+  function handleCreate() {
+    if (unmatchedAccepted.length > 0) {
+      setError("All included issues must have a repository selected.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const reviewed = cards
+        .filter((c) => c.accepted)
+        .map((c) => ({
+          id: c.id,
+          title: c.title,
+          body: c.body,
+          owner: c.owner ?? "",
+          repo: c.repo ?? "",
+          labels: c.labels,
+          accepted: true,
+        }));
+      const result = await batchCreateIssues(reviewed);
+      onConfirm(result);
+    });
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.summary}>
+        {parsed.issues.length} issue{parsed.issues.length !== 1 ? "s" : ""}{" "}
+        parsed &mdash; {acceptedCount} included for creation
+      </div>
+
+      <div className={styles.cards}>
+        {cards.map((card) => (
+          <ParseIssueCard
+            key={card.id}
+            issue={card}
+            repos={repos}
+            labelsPerRepo={labelsPerRepo}
+            onChange={handleCardChange}
+          />
+        ))}
+      </div>
+
+      {error && (
+        <div className={styles.error} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={styles.footer}>
+        <Button variant="secondary" onClick={onBack} disabled={isPending}>
+          Back
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleCreate}
+          disabled={isPending || acceptedCount === 0}
+        >
+          {isPending
+            ? "Creating..."
+            : `Create ${acceptedCount} Issue${acceptedCount !== 1 ? "s" : ""}`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/parse/ParseReview.tsx
+++ b/packages/web/components/parse/ParseReview.tsx
@@ -62,19 +62,27 @@ export function ParseReview({
     }
     setError(null);
     startTransition(async () => {
-      const reviewed = cards
-        .filter((c) => c.accepted)
-        .map((c) => ({
-          id: c.id,
-          title: c.title,
-          body: c.body,
-          owner: c.owner ?? "",
-          repo: c.repo ?? "",
-          labels: c.labels,
-          accepted: true,
-        }));
-      const result = await batchCreateIssues(reviewed);
-      onConfirm(result);
+      try {
+        const reviewed = cards
+          .filter((c) => c.accepted)
+          .map((c) => ({
+            id: c.id,
+            title: c.title,
+            body: c.body,
+            owner: c.owner ?? "",
+            repo: c.repo ?? "",
+            labels: c.labels,
+            accepted: true,
+          }));
+        const result = await batchCreateIssues(reviewed);
+        onConfirm(result);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? `Failed to create issues: ${err.message}`
+            : "An unexpected error occurred while creating issues.",
+        );
+      }
     });
   }
 

--- a/packages/web/components/sidebar/Sidebar.tsx
+++ b/packages/web/components/sidebar/Sidebar.tsx
@@ -65,6 +65,10 @@ export async function Sidebar({ username }: Props) {
             <span className={styles.navBadge}>{totalPRs}</span>
           )}
         </Link>
+        <Link href="/parse" className={styles.navItem}>
+          <span className={styles.navIcon}>&#9889;</span>
+          Quick Create
+        </Link>
         <Link href="/settings" className={styles.navItem}>
           <span className={styles.navIcon}>&#9881;</span>
           Settings

--- a/packages/web/e2e/quick-create.spec.ts
+++ b/packages/web/e2e/quick-create.spec.ts
@@ -1,0 +1,283 @@
+import { test, expect } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_PORT = 3848;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// ── Skip conditions ─────────────────────────────────────────────────
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("claude", ["--version"]);
+  } catch {
+    return { ok: false, reason: "Claude CLI not installed" };
+  }
+
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+
+  return { ok: true };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS repos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      owner TEXT NOT NULL,
+      name TEXT NOT NULL,
+      local_path TEXT,
+      branch_pattern TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(owner, name)
+    );
+    CREATE TABLE IF NOT EXISTS deployments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_id INTEGER NOT NULL REFERENCES repos(id),
+      issue_number INTEGER NOT NULL,
+      branch_name TEXT NOT NULL,
+      workspace_mode TEXT NOT NULL,
+      workspace_path TEXT NOT NULL,
+      linked_pr_number INTEGER,
+      launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS cache (
+      key TEXT PRIMARY KEY,
+      data TEXT NOT NULL,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS claude_aliases (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      command TEXT NOT NULL UNIQUE,
+      description TEXT NOT NULL DEFAULT '',
+      is_default INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  db.prepare("INSERT OR IGNORE INTO schema_version (version) VALUES (?)").run(3);
+
+  const defaults = [
+    ["branch_pattern", "issue-{number}-{slug}"],
+    ["terminal_app", "iterm2"],
+    ["terminal_window_title", "issuectl"],
+    ["terminal_tab_title_pattern", "#{number} — {title}"],
+    ["cache_ttl", "300"],
+    ["worktree_dir", "~/.issuectl/worktrees/"],
+  ];
+  const insertSetting = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+  );
+  for (const [key, value] of defaults) {
+    insertSetting.run(key, value);
+  }
+
+  db.prepare(
+    "INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)",
+  ).run(TEST_OWNER, TEST_REPO);
+
+  db.close();
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+// ── Test suite ──────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+const createdIssueNumbers: number[] = [];
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-qc-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, ISSUECTL_DB_PATH: dbPath },
+    stdio: "pipe",
+  });
+
+  let serverStderr = "";
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderr += chunk.toString();
+  });
+
+  await waitForServer(`http://localhost:${TEST_PORT}`, 30000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderr.slice(-500)}`,
+    );
+  });
+});
+
+test.afterAll(async () => {
+  // Clean up created issues
+  for (const num of createdIssueNumbers) {
+    try {
+      await execFileAsync("gh", [
+        "issue",
+        "close",
+        String(num),
+        "--repo",
+        `${TEST_OWNER}/${TEST_REPO}`,
+        "--reason",
+        "not planned",
+      ]);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  if (server) {
+    const killTimeout = setTimeout(() => {
+      try {
+        server.kill("SIGKILL");
+      } catch {
+        /* already dead */
+      }
+    }, 5000);
+
+    server.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test.describe("Quick Create flow", () => {
+  test("page renders with textarea and disabled button", async ({ page }) => {
+    if (skipReason) {
+      test.skip(true, skipReason);
+    }
+
+    await page.goto(`http://localhost:${TEST_PORT}/parse`);
+
+    await expect(page.getByRole("heading", { name: "Quick Create" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(
+      page.getByPlaceholder("e.g. Fix the login timeout"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Parse with Claude" }),
+    ).toBeDisabled();
+  });
+
+  test("full flow: parse, review, create issues", async ({ page }) => {
+    if (skipReason) {
+      test.skip(true, skipReason);
+    }
+
+    await page.goto(`http://localhost:${TEST_PORT}/parse`);
+
+    await expect(page.getByRole("heading", { name: "Quick Create" })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Step 1: Input
+    const textarea = page.getByPlaceholder("e.g. Fix the login timeout");
+    await textarea.fill(
+      `Add a test health check endpoint to ${TEST_REPO}`,
+    );
+
+    const parseButton = page.getByRole("button", {
+      name: "Parse with Claude",
+    });
+    await expect(parseButton).toBeEnabled();
+    await parseButton.click();
+
+    // Wait for parsing to complete (Claude CLI can take up to 90s)
+    await expect(
+      page.getByRole("button", { name: "Parsing..." }),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByRole("button", { name: "Parsing..." }),
+    ).not.toBeVisible({ timeout: 90000 });
+
+    // Step 2: Review — should show at least one issue card
+    await expect(page.getByText("parsed")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("included for creation")).toBeVisible();
+
+    // Verify a Create button exists with a count
+    const createButton = page.getByRole("button", { name: /Create \d+ Issue/ });
+    await expect(createButton).toBeVisible();
+    await createButton.click();
+
+    // Step 3: Results
+    await expect(page.getByText("created")).toBeVisible({ timeout: 30000 });
+
+    // Extract created issue numbers from the links
+    const issueLinks = page.getByRole("link", { name: /^#\d+$/ });
+    const count = await issueLinks.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    for (let i = 0; i < count; i++) {
+      const text = await issueLinks.nth(i).textContent();
+      const num = Number(text?.replace("#", ""));
+      if (num > 0) {
+        createdIssueNumbers.push(num);
+      }
+    }
+
+    // Verify "Create More" button exists
+    await expect(
+      page.getByRole("button", { name: "Create More" }),
+    ).toBeVisible();
+  });
+});

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -15,7 +15,6 @@ import type {
   ParsedIssuesResponse,
   ReviewedIssue,
   BatchCreateResult,
-  GitHubLabel,
 } from "@issuectl/core";
 
 type ParseActionResult = {

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -1,0 +1,131 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getDb,
+  getOctokit,
+  listRepos,
+  listLabels,
+  createIssue as coreCreateIssue,
+  clearCacheKey,
+  parseIssues,
+  formatRepoContext,
+} from "@issuectl/core";
+import type {
+  ParsedIssuesResponse,
+  ReviewedIssue,
+  BatchCreateResult,
+  GitHubLabel,
+} from "@issuectl/core";
+
+type ParseActionResult = {
+  success: boolean;
+  data?: { parsed: ParsedIssuesResponse };
+  error?: string;
+};
+
+export async function parseNaturalLanguage(
+  input: string,
+): Promise<ParseActionResult> {
+  if (!input.trim()) {
+    return { success: false, error: "Input cannot be empty" };
+  }
+
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
+    const dbRepos = listRepos(db);
+
+    if (dbRepos.length === 0) {
+      return {
+        success: false,
+        error: "No repositories connected. Add repos in Settings first.",
+      };
+    }
+
+    const labelResults = await Promise.all(
+      dbRepos.map(async (r) => {
+        try {
+          const labels = await listLabels(octokit, r.owner, r.name);
+          return { owner: r.owner, name: r.name, labels: labels.map((l) => l.name) };
+        } catch {
+          return { owner: r.owner, name: r.name, labels: [] as string[] };
+        }
+      }),
+    );
+
+    const contextPrompt = formatRepoContext(labelResults);
+    const result = await parseIssues(input, contextPrompt);
+
+    if (!result.success) {
+      return { success: false, error: result.error };
+    }
+
+    return { success: true, data: { parsed: result.data } };
+  } catch (err) {
+    console.error("[issuectl] Failed to parse natural language:", err);
+    return { success: false, error: "Failed to parse input" };
+  }
+}
+
+export async function batchCreateIssues(
+  issues: ReviewedIssue[],
+): Promise<BatchCreateResult> {
+  const accepted = issues.filter((i) => i.accepted);
+
+  if (accepted.length === 0) {
+    return { created: 0, failed: 0, results: [] };
+  }
+
+  const db = getDb();
+  const octokit = await getOctokit();
+
+  const results = await Promise.all(
+    accepted.map(async (issue) => {
+      try {
+        const created = await coreCreateIssue(octokit, issue.owner, issue.repo, {
+          title: issue.title.trim(),
+          body: issue.body.trim() || undefined,
+          labels: issue.labels.length > 0 ? issue.labels : undefined,
+        });
+
+        clearCacheKey(db, `issues:${issue.owner}/${issue.repo}`);
+
+        return {
+          id: issue.id,
+          success: true as const,
+          issueNumber: created.number,
+          owner: issue.owner,
+          repo: issue.repo,
+        };
+      } catch (err) {
+        console.error(
+          `[issuectl] Failed to create issue "${issue.title}":`,
+          err,
+        );
+        return {
+          id: issue.id,
+          success: false as const,
+          error: err instanceof Error ? err.message : "Unknown error",
+          owner: issue.owner,
+          repo: issue.repo,
+        };
+      }
+    }),
+  );
+
+  const affectedRepos = new Set(
+    results
+      .filter((r) => r.success)
+      .map((r) => `/${r.owner}/${r.repo}`),
+  );
+  for (const repoPath of affectedRepos) {
+    revalidatePath(repoPath);
+  }
+
+  return {
+    created: results.filter((r) => r.success).length,
+    failed: results.filter((r) => !r.success).length,
+    results,
+  };
+}

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -17,11 +17,9 @@ import type {
   BatchCreateResult,
 } from "@issuectl/core";
 
-type ParseActionResult = {
-  success: boolean;
-  data?: { parsed: ParsedIssuesResponse };
-  error?: string;
-};
+type ParseActionResult =
+  | { success: true; data: { parsed: ParsedIssuesResponse } }
+  | { success: false; error: string };
 
 export async function parseNaturalLanguage(
   input: string,
@@ -47,7 +45,11 @@ export async function parseNaturalLanguage(
         try {
           const labels = await listLabels(octokit, r.owner, r.name);
           return { owner: r.owner, name: r.name, labels: labels.map((l) => l.name) };
-        } catch {
+        } catch (err) {
+          console.warn(
+            `[issuectl] Failed to fetch labels for ${r.owner}/${r.name}:`,
+            err instanceof Error ? err.message : err,
+          );
           return { owner: r.owner, name: r.name, labels: [] as string[] };
         }
       }),
@@ -63,7 +65,8 @@ export async function parseNaturalLanguage(
     return { success: true, data: { parsed: result.data } };
   } catch (err) {
     console.error("[issuectl] Failed to parse natural language:", err);
-    return { success: false, error: "Failed to parse input" };
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: `Failed to parse input: ${message}` };
   }
 }
 
@@ -76,55 +79,70 @@ export async function batchCreateIssues(
     return { created: 0, failed: 0, results: [] };
   }
 
-  const db = getDb();
-  const octokit = await getOctokit();
+  try {
+    const db = getDb();
+    const octokit = await getOctokit();
 
-  const results = await Promise.all(
-    accepted.map(async (issue) => {
-      try {
-        const created = await coreCreateIssue(octokit, issue.owner, issue.repo, {
-          title: issue.title.trim(),
-          body: issue.body.trim() || undefined,
-          labels: issue.labels.length > 0 ? issue.labels : undefined,
-        });
+    const results = await Promise.all(
+      accepted.map(async (issue) => {
+        if (!issue.owner || !issue.repo || !issue.title.trim()) {
+          return {
+            id: issue.id,
+            success: false as const,
+            error: "Owner, repo, and title are required",
+            owner: issue.owner,
+            repo: issue.repo,
+          };
+        }
 
-        clearCacheKey(db, `issues:${issue.owner}/${issue.repo}`);
+        try {
+          const created = await coreCreateIssue(octokit, issue.owner, issue.repo, {
+            title: issue.title.trim(),
+            body: issue.body.trim() || undefined,
+            labels: issue.labels.length > 0 ? issue.labels : undefined,
+          });
 
-        return {
-          id: issue.id,
-          success: true as const,
-          issueNumber: created.number,
-          owner: issue.owner,
-          repo: issue.repo,
-        };
-      } catch (err) {
-        console.error(
-          `[issuectl] Failed to create issue "${issue.title}":`,
-          err,
-        );
-        return {
-          id: issue.id,
-          success: false as const,
-          error: err instanceof Error ? err.message : "Unknown error",
-          owner: issue.owner,
-          repo: issue.repo,
-        };
-      }
-    }),
-  );
+          clearCacheKey(db, `issues:${issue.owner}/${issue.repo}`);
 
-  const affectedRepos = new Set(
-    results
-      .filter((r) => r.success)
-      .map((r) => `/${r.owner}/${r.repo}`),
-  );
-  for (const repoPath of affectedRepos) {
-    revalidatePath(repoPath);
+          return {
+            id: issue.id,
+            success: true as const,
+            issueNumber: created.number,
+            owner: issue.owner,
+            repo: issue.repo,
+          };
+        } catch (err) {
+          console.error(
+            `[issuectl] Failed to create issue "${issue.title}":`,
+            err,
+          );
+          return {
+            id: issue.id,
+            success: false as const,
+            error: err instanceof Error ? err.message : "Unknown error",
+            owner: issue.owner,
+            repo: issue.repo,
+          };
+        }
+      }),
+    );
+
+    const affectedRepos = new Set(
+      results
+        .filter((r) => r.success)
+        .map((r) => `/${r.owner}/${r.repo}`),
+    );
+    for (const repoPath of affectedRepos) {
+      revalidatePath(repoPath);
+    }
+
+    return {
+      created: results.filter((r) => r.success).length,
+      failed: results.filter((r) => !r.success).length,
+      results,
+    };
+  } catch (err) {
+    console.error("[issuectl] Failed to batch create issues:", err);
+    return { created: 0, failed: accepted.length, results: [] };
   }
-
-  return {
-    created: results.filter((r) => r.success).length,
-    failed: results.filter((r) => !r.success).length,
-    results,
-  };
 }


### PR DESCRIPTION
## Summary

- Adds a `/parse` page ("Quick Create") that uses the Claude CLI to parse free-form natural language into structured GitHub issues
- Parses multiple issues from a single input, matches each to connected repos by name with confidence scoring, suggests labels from each repo's available set
- 3-step UI flow: Input → Review (editable cards with title, body, repo dropdown, label selector) → Results (with links to created issues)
- Core parse module spawns `claude` CLI with `--json-schema` for structured output, `--allowedTools Bash` for repo verification via `gh`
- "Quick Create" nav link added to sidebar

## New files

- `packages/core/src/parse/` — types, JSON schema, system prompt, context formatting, Claude CLI spawning
- `packages/web/app/parse/` — Server Component page
- `packages/web/components/parse/` — ParseFlow, ParseInput, ParseIssueCard, ParseReview, ParseResults
- `packages/web/lib/actions/parse.ts` — Server Actions for parsing and batch creation

## Test plan

- [x] Page renders at `/parse` with textarea and disabled button
- [x] Button enables when text is entered
- [x] "Parse with Claude" spawns CLI, shows spinner, returns structured issues
- [x] Review step shows editable cards with repo dropdown, label selector, accept/reject toggle
- [x] Changing repo updates available labels
- [x] "Create N Issues" batch-creates on GitHub
- [x] Results step shows success/failure per issue with clickable links
- [x] Created issues verified on GitHub with correct title, body, and labels
- [x] Claude CLI unavailable shows graceful fallback message
- [x] No repos connected shows informative message