### PR TITLE
chore: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.tsbuildinfo
 .env
 .env.local
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` to `.gitignore` so git worktrees created under the project root don't pollute `git status`.

Small quality-of-life fix — came up while setting up isolated worktrees for the #33 implementation.

## Test plan
- [x] `git check-ignore .worktrees/` returns exit 0