### PR TITLE
feat: paper reskin phase 1+2 — drafts, priority, paper primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .env
 .env.local
 .worktrees/
+.superpowers/

--- a/docs/mockups/paper-reskin.html
+++ b/docs/mockups/paper-reskin.html
@@ -1,0 +1,3334 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>issuectl — Paper, all mockups</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,500;1,9..144,600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  :root {
+    --shell: #1b1a1d;
+    --shell-surface: #232226;
+    --shell-border: #302f35;
+    --shell-text: #d9d6d0;
+    --shell-muted: #807d85;
+    --shell-accent: #f5efe1;
+  }
+  html, body {
+    background: var(--shell);
+    color: var(--shell-text);
+    font-family: 'Inter', system-ui, sans-serif;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+  body { padding: 40px 24px 120px; }
+
+  .page-head {
+    max-width: 1600px; margin: 0 auto 36px;
+  }
+  .page-head .eyebrow {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px; color: var(--shell-muted); letter-spacing: 1.4px;
+    text-transform: uppercase; margin-bottom: 6px;
+  }
+  .page-head h1 {
+    font-family: 'Fraunces', Georgia, serif; font-weight: 400;
+    font-size: 34px; font-style: italic; letter-spacing: -0.5px;
+    color: var(--shell-accent);
+    margin-bottom: 8px;
+  }
+  .page-head .sub {
+    font-size: 13px; color: var(--shell-muted); max-width: 760px; line-height: 1.6;
+  }
+
+  /* table of contents */
+  .toc {
+    max-width: 1600px; margin: 0 auto 44px;
+    padding: 16px 22px;
+    background: var(--shell-surface);
+    border: 1px solid var(--shell-border);
+    border-radius: 10px;
+    display: flex; gap: 24px; flex-wrap: wrap; align-items: center;
+  }
+  .toc-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px; color: var(--shell-muted); letter-spacing: 1.2px;
+    text-transform: uppercase;
+  }
+  .toc a {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 14px;
+    color: var(--shell-accent); text-decoration: none;
+  }
+  .toc a:hover { text-decoration: underline; text-decoration-color: var(--shell-muted); }
+  .toc .num {
+    font-family: 'IBM Plex Mono', monospace; font-style: normal;
+    font-size: 10px; color: var(--shell-muted); margin-right: 4px;
+  }
+
+  section.flow {
+    max-width: 1600px; margin: 0 auto 80px;
+    padding-top: 40px;
+    border-top: 1px solid var(--shell-border);
+    scroll-margin-top: 40px;
+  }
+  section.flow:first-of-type { border-top: none; padding-top: 0; }
+
+  .flow-head {
+    margin-bottom: 24px;
+  }
+  .flow-num {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px; color: var(--shell-muted); letter-spacing: 1.4px;
+    text-transform: uppercase; margin-bottom: 4px;
+  }
+  .flow-title {
+    font-family: 'Fraunces', serif; font-weight: 500; font-style: italic;
+    font-size: 28px; color: var(--shell-accent); letter-spacing: -0.3px;
+    margin-bottom: 6px;
+  }
+  .flow-desc {
+    font-size: 12.5px; color: var(--shell-muted); max-width: 680px; line-height: 1.6;
+  }
+
+  .frames {
+    display: flex; gap: 26px; align-items: flex-start; flex-wrap: wrap;
+    margin-top: 24px;
+  }
+
+  .frame-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px; letter-spacing: 1.3px;
+    text-transform: uppercase;
+    color: var(--shell-muted);
+    margin-bottom: 10px; padding-left: 4px;
+  }
+  .frame-label b { color: var(--shell-accent); font-weight: 600; }
+
+  /* Phone frame */
+  .phone {
+    width: 380px; height: 800px;
+    border-radius: 40px;
+    overflow: hidden;
+    box-shadow:
+      0 30px 80px rgba(0,0,0,0.5),
+      0 0 0 10px #0a0a0b,
+      0 0 0 11px rgba(255,255,255,0.06);
+    position: relative;
+  }
+  .phone-notch {
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    width: 104px; height: 26px; background: #0a0a0b; border-radius: 14px;
+    z-index: 50;
+  }
+  .phone-body {
+    width: 100%; height: 100%; overflow: hidden;
+    position: relative;
+  }
+
+  /* Desktop frame */
+  .desktop {
+    flex: 1; min-width: 680px; max-width: 1000px;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 30px 80px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.05);
+  }
+  .desktop-chrome {
+    background: #0a0a0b;
+    height: 30px; display: flex; align-items: center; padding: 0 12px; gap: 6px;
+  }
+  .desktop-chrome .dot { width: 10px; height: 10px; border-radius: 50%; }
+  .desktop-chrome .dot:nth-child(1) { background: #ff5f57; }
+  .desktop-chrome .dot:nth-child(2) { background: #febc2e; }
+  .desktop-chrome .dot:nth-child(3) { background: #28c840; }
+  .desktop-chrome .url {
+    margin-left: 14px; font-family: 'IBM Plex Mono', monospace;
+    font-size: 10.5px; color: #6a6a70;
+  }
+  .desktop-body {
+    height: 680px; overflow: hidden;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     PAPER THEME
+     ══════════════════════════════════════════════════════════════ */
+  .paper {
+    --bg: #f3ecd9;
+    --bg-warm: #ede5cf;
+    --bg-warmer: #e6dec4;
+    --ink: #1a1712;
+    --ink-soft: #3a342a;
+    --ink-muted: #8a7f63;
+    --ink-faint: #b5a88a;
+    --line: #e0d6bc;
+    --line-soft: #e9dfc6;
+    --accent: #2d5f3f;
+    --accent-dim: #4a7a5c;
+    --accent-soft: #dce8de;
+    --brick: #b84a2e;
+    --butter: #d9a54d;
+
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'Fraunces', Georgia, serif;
+    position: relative;
+  }
+  .paper::before {
+    content: ''; position: absolute; inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/></svg>");
+    background-size: 200px;
+    mix-blend-mode: multiply; opacity: 0.18;
+    pointer-events: none; z-index: 5;
+  }
+  .paper > * { position: relative; z-index: 6; }
+
+  /* ═════════ shared atoms ═════════ */
+  .repo {
+    font-family: 'IBM Plex Mono', monospace; font-weight: 600;
+    padding: 2px 8px; border-radius: 3px;
+    background: #e6dec4; color: #3a342a;
+    font-size: 10.5px; letter-spacing: 0.3px;
+  }
+  .repo.none {
+    background: transparent; color: #2d5f3f;
+    border: 1px dashed #2d5f3f; font-style: italic;
+    font-family: 'Fraunces', serif; font-weight: 500;
+  }
+
+  /* ═════════ main bar (top of phone) ═════════ */
+  .bar {
+    padding: 52px 24px 12px;
+    display: flex; justify-content: space-between; align-items: flex-end;
+  }
+  .bar .brand {
+    font-family: 'Fraunces', serif; font-weight: 500; font-style: italic;
+    font-size: 34px; line-height: 1; letter-spacing: -0.8px;
+  }
+  .bar .brand .dot {
+    display: inline-block; width: 10px; height: 10px;
+    background: var(--accent); border-radius: 50%;
+    margin-left: 3px; vertical-align: 6px;
+  }
+  .bar .date {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 11px; color: var(--ink-muted); font-weight: 500;
+    text-align: right; line-height: 1.3;
+  }
+  .bar .date b {
+    display: block; color: var(--ink-soft); font-style: normal;
+    font-weight: 600; font-size: 13px; font-family: 'Fraunces', serif;
+  }
+
+  /* ═════════ tabs ═════════ */
+  .tabs {
+    padding: 18px 24px 0;
+    display: flex; gap: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .tab {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 14px; font-weight: 500;
+    color: var(--ink-muted); padding: 10px 2px 12px;
+    margin-right: 26px; position: relative; cursor: pointer;
+  }
+  .tab.on { color: var(--ink); }
+  .tab.on::after {
+    content: ''; position: absolute; left: -4px; right: -4px; bottom: -1px;
+    height: 2px; background: var(--ink);
+  }
+  .tab .c {
+    font-family: 'IBM Plex Mono', monospace;
+    font-style: normal; font-size: 10px;
+    margin-left: 6px; color: var(--ink-faint); font-weight: 500;
+  }
+
+  /* ═════════ search ═════════ */
+  .srch {
+    padding: 14px 24px 0;
+    position: relative;
+  }
+  .srch-input {
+    width: 100%; padding: 8px 12px 8px 32px;
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    font-family: 'Fraunces', serif; font-size: 13px; color: var(--ink);
+    font-style: italic;
+  }
+  .srch-input::placeholder { color: var(--ink-faint); }
+  .srch::before {
+    content: '⌕';
+    position: absolute; left: 36px; top: 22px;
+    color: var(--ink-faint); font-size: 16px;
+    z-index: 1;
+  }
+
+  /* ═════════ list section ═════════ */
+  .list { padding: 12px 0 120px; }
+
+  .section {
+    padding: 22px 24px 6px;
+    display: flex; align-items: baseline; gap: 10px;
+  }
+  .section h3 {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-weight: 500; font-size: 13px;
+    color: var(--ink-soft);
+  }
+  .section .rule { flex: 1; height: 1px; background: var(--line); }
+  .section .cnt {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px; color: var(--ink-faint); font-weight: 500;
+  }
+
+  /* ═════════ row item ═════════ */
+  .item {
+    padding: 16px 24px 16px 58px;
+    position: relative;
+    border-bottom: 1px solid var(--line-soft);
+    display: block;
+  }
+  .item.swiped {
+    transform: translateX(-110px);
+    transition: transform 0.3s ease;
+  }
+  .item .check {
+    position: absolute; left: 24px; top: 18px;
+    width: 20px; height: 20px;
+  }
+  .item .check svg { width: 100%; height: 100%; }
+  .item .check .box {
+    fill: transparent; stroke: var(--ink-muted); stroke-width: 1.5;
+    stroke-linecap: round; stroke-linejoin: round;
+  }
+  .item .check.flight .box { stroke: var(--accent); stroke-width: 2; }
+  .item .check.flight .fill {
+    fill: var(--accent); opacity: 0.35;
+    animation: pulse 1.8s infinite;
+  }
+  @keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 0.75; } }
+  .item .check.done .box { fill: var(--accent); stroke: var(--accent); }
+  .item .check.done .tick {
+    fill: none; stroke: var(--bg); stroke-width: 2.3;
+    stroke-linecap: round; stroke-linejoin: round;
+  }
+  .item .title {
+    font-family: 'Fraunces', serif; font-weight: 400;
+    font-size: 17px; line-height: 1.3; color: var(--ink);
+    margin-bottom: 6px; letter-spacing: -0.1px;
+  }
+  .item .title.done {
+    color: var(--ink-muted);
+    text-decoration: line-through;
+    text-decoration-color: var(--accent);
+    text-decoration-thickness: 1.5px;
+  }
+  .item .meta {
+    display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+    font-family: 'Inter', sans-serif; font-size: 11px;
+    color: var(--ink-muted);
+  }
+  .item .meta .num { font-family: 'IBM Plex Mono', monospace; color: var(--ink-faint); }
+  .item .meta .lbl-bug { color: var(--brick); }
+  .item .meta .lbl-feat { color: var(--butter); }
+  .item .meta .sep { color: var(--ink-faint); }
+
+  /* swipe reveal */
+  .item .reveal {
+    position: absolute; right: -110px; top: 0; bottom: 0;
+    width: 110px;
+    background: var(--accent); color: var(--bg);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 4px;
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 14px; font-weight: 600;
+  }
+  .item .reveal .arr {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 18px; font-style: normal; font-weight: 400; opacity: 0.9;
+  }
+
+  /* FAB */
+  .fab {
+    position: absolute; right: 24px; bottom: 30px;
+    width: 60px; height: 60px; border-radius: 50%;
+    background: var(--ink); color: var(--bg);
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Fraunces', serif; font-weight: 400; font-size: 34px;
+    line-height: 1; padding-bottom: 4px;
+    box-shadow: 0 16px 40px rgba(26,23,18,0.35), 0 0 0 6px rgba(26,23,18,0.06);
+    z-index: 10;
+  }
+
+  /* ═════════ assign sheet ═════════ */
+  .scrim {
+    position: absolute; inset: 0;
+    background: rgba(26,23,18,0.4);
+    z-index: 30;
+  }
+  .sheet {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    background: var(--bg);
+    border-top-left-radius: 24px; border-top-right-radius: 24px;
+    border-top: 1px solid var(--line);
+    padding: 12px 0 28px;
+    z-index: 31;
+    box-shadow: 0 -20px 60px rgba(0,0,0,0.25);
+  }
+  .sheet .grab {
+    width: 44px; height: 4px; background: var(--ink-faint);
+    border-radius: 3px; margin: 0 auto 10px;
+  }
+  .sheet .sheet-head {
+    padding: 10px 28px 4px;
+  }
+  .sheet .sheet-head h3 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 22px; letter-spacing: -0.3px; color: var(--ink);
+    margin-bottom: 4px;
+  }
+  .sheet .sheet-head p {
+    font-family: 'Fraunces', serif; font-size: 13px;
+    color: var(--ink-muted); font-weight: 400;
+  }
+  .sheet .sheet-head p em { color: var(--ink-soft); }
+  .sheet-list { padding: 12px 0 0; }
+  .sheet-row {
+    padding: 14px 28px;
+    display: flex; align-items: center; gap: 14px;
+    border-top: 1px solid var(--line-soft);
+  }
+  .sheet-row:first-child { border-top: 1px solid var(--line); }
+  .sheet-row .rdot {
+    width: 12px; height: 12px; border-radius: 3px;
+    background: var(--accent); flex-shrink: 0;
+  }
+  .sheet-row .rdot.alt1 { background: var(--brick); }
+  .sheet-row .rdot.alt2 { background: var(--butter); }
+  .sheet-row .rdot.alt3 { background: #6a88b5; }
+  .sheet-row .rname {
+    flex: 1;
+    font-family: 'Fraunces', serif;
+    font-size: 16px; font-weight: 400; color: var(--ink);
+  }
+  .sheet-row .rname em {
+    font-style: italic; color: var(--ink-muted); font-size: 12px; margin-left: 6px;
+  }
+  .sheet-row .rcount {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px; color: var(--ink-faint); font-weight: 500;
+  }
+  .sheet-cancel {
+    padding: 18px 28px 4px;
+    text-align: center;
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 14px; color: var(--ink-muted);
+  }
+
+  /* ═════════ desktop chrome for list view ═════════ */
+  .desk {
+    position: relative; height: 100%;
+  }
+  .desk-header {
+    padding: 36px 60px 24px;
+    max-width: 900px; margin: 0 auto;
+    display: flex; justify-content: space-between; align-items: flex-end;
+  }
+  .desk-brand {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-weight: 500; font-size: 40px; letter-spacing: -0.8px; line-height: 1;
+  }
+  .desk-brand .dot {
+    display: inline-block; width: 12px; height: 12px;
+    background: var(--accent); border-radius: 50%;
+    margin-left: 4px; vertical-align: 8px;
+  }
+  .desk-brand .ver {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px; color: var(--ink-faint); font-style: normal;
+    margin-left: 10px; vertical-align: 18px; font-weight: 500;
+  }
+  .desk-actions {
+    display: flex; gap: 12px; align-items: center;
+    font-family: 'Fraunces', serif;
+    font-size: 13px; color: var(--ink-muted);
+  }
+  .desk-actions .date b { color: var(--ink-soft); font-weight: 500; }
+  .desk-actions .btn {
+    padding: 10px 20px;
+    background: var(--ink); color: var(--bg);
+    border-radius: 6px; font-style: italic; font-size: 14px;
+    font-family: 'Fraunces', serif; font-weight: 500;
+    border: none;
+  }
+  .desk-tabs {
+    padding: 0 60px;
+    max-width: 900px; margin: 0 auto;
+    border-bottom: 1px solid var(--line);
+    display: flex; gap: 0;
+  }
+  .desk-tabs .tab { font-size: 15px; margin-right: 32px; }
+  .desk-list {
+    max-width: 900px; margin: 0 auto;
+    padding: 12px 60px 60px;
+  }
+  .desk-list .section { padding: 24px 0 6px; }
+  .desk-list .item { padding: 16px 0 16px 38px; }
+  .desk-list .item .check { left: 0; top: 18px; }
+  .desk-list .item .title { font-size: 18px; }
+  .desk-list .item .reveal { display: none; }
+  .desk-list .item .quick {
+    position: absolute; right: 0; top: 16px;
+    display: flex; gap: 6px; opacity: 0;
+    transition: opacity 0.15s;
+  }
+  .desk-list .item:hover .quick { opacity: 1; }
+  .desk-list .item .quick button {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 12px; padding: 5px 12px;
+    background: transparent; color: var(--ink-muted);
+    border: 1px solid var(--line); border-radius: 4px;
+  }
+  .desk-list .item .quick button:hover { color: var(--accent); border-color: var(--accent); }
+  .desk-list .item .quick button.go {
+    background: var(--ink); color: var(--bg); border-color: var(--ink);
+  }
+
+  /* always-show quick on first row of desktop for demo */
+  .desk-list .item.show-quick .quick { opacity: 1; }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 2 — ISSUE DETAIL
+     ══════════════════════════════════════════════════════════════ */
+  .d-bar {
+    padding: 52px 16px 12px;
+    display: flex; align-items: center; gap: 12px;
+    border-bottom: 1px solid var(--line);
+  }
+  .d-back {
+    width: 36px; height: 36px;
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Fraunces', serif; font-size: 22px;
+    color: var(--ink);
+  }
+  .d-crumb {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 13px; color: var(--ink-muted); flex: 1;
+  }
+  .d-crumb b { color: var(--ink-soft); font-style: normal; }
+  .d-menu {
+    width: 36px; height: 36px; display: flex; align-items: center; justify-content: center;
+    font-size: 20px; color: var(--ink-muted); letter-spacing: 2px;
+  }
+  .d-body { padding: 22px 24px 80px; }
+  .d-title {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 26px; line-height: 1.2; letter-spacing: -0.4px;
+    color: var(--ink); margin-bottom: 12px;
+  }
+  .d-meta {
+    display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+    font-size: 11.5px; color: var(--ink-muted); margin-bottom: 22px;
+    font-family: 'Inter', sans-serif;
+  }
+  .d-meta .num { font-family: 'IBM Plex Mono', monospace; color: var(--ink-faint); }
+  .d-meta .sep { color: var(--ink-faint); }
+  .d-meta .state { color: var(--accent); font-weight: 600; }
+  .d-meta .lbl-bug { color: var(--brick); }
+  .d-launch {
+    background: var(--bg-warm);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 28px;
+    position: relative;
+  }
+  .d-launch::before {
+    content: ''; position: absolute; left: 0; top: 14px; bottom: 14px;
+    width: 3px; background: var(--accent); border-radius: 2px;
+  }
+  .d-launch h4 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 15px; color: var(--ink); margin-bottom: 4px;
+  }
+  .d-launch p {
+    font-family: 'Fraunces', serif; font-size: 12.5px; color: var(--ink-muted);
+    margin-bottom: 14px; line-height: 1.5;
+  }
+  .d-launch p code { font-family: 'IBM Plex Mono', monospace; font-size: 11.5px; background: var(--bg-warmer); padding: 1px 5px; border-radius: 2px; }
+  .d-launch-actions { display: flex; gap: 8px; }
+  .d-launch-actions .btn-primary {
+    background: var(--accent); color: var(--bg);
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; padding: 9px 18px; border-radius: 6px;
+    border: none; flex: 1;
+  }
+  .d-launch-actions .btn-ghost {
+    background: transparent; color: var(--ink-soft);
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 12.5px; padding: 9px 14px; border-radius: 6px;
+    border: 1px solid var(--line);
+  }
+  .d-body-text {
+    font-family: 'Fraunces', serif; font-weight: 400;
+    font-size: 15.5px; line-height: 1.65; color: var(--ink-soft);
+    margin-bottom: 28px;
+  }
+  .d-body-text p { margin-bottom: 12px; }
+  .d-body-text code {
+    font-family: 'IBM Plex Mono', monospace; font-size: 13px;
+    background: var(--bg-warmer); padding: 1px 6px; border-radius: 3px;
+    color: var(--ink-soft);
+  }
+  .d-section-head {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 14px; color: var(--ink-soft);
+    padding: 10px 0 12px; border-top: 1px solid var(--line);
+    display: flex; align-items: baseline; gap: 8px; margin-bottom: 14px;
+  }
+  .d-section-head .cnt { font-family: 'IBM Plex Mono', monospace; font-size: 10px; color: var(--ink-faint); font-style: normal; }
+  .d-comment {
+    padding-bottom: 18px; margin-bottom: 18px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .d-comment:last-child { border-bottom: none; }
+  .d-comment-head {
+    display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  }
+  .d-comment-avi {
+    width: 26px; height: 26px; border-radius: 50%;
+    background: var(--bg-warmer); border: 1px solid var(--line);
+    font-family: 'Fraunces', serif; font-weight: 600; font-style: italic;
+    font-size: 11px; color: var(--ink-soft);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .d-comment-who {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 13px; color: var(--ink);
+  }
+  .d-comment-time {
+    font-family: 'Inter', sans-serif; font-size: 11px;
+    color: var(--ink-faint); margin-left: auto;
+  }
+  .d-comment-body {
+    font-family: 'Fraunces', serif; font-size: 14px;
+    line-height: 1.55; color: var(--ink-soft);
+  }
+  .d-comment-body code { font-family: 'IBM Plex Mono', monospace; font-size: 12px; background: var(--bg-warmer); padding: 1px 5px; border-radius: 3px; }
+  .d-composer {
+    border-top: 1px solid var(--line);
+    padding: 16px 20px; background: var(--bg-warm);
+    display: flex; gap: 10px; align-items: flex-end;
+    position: absolute; left: 0; right: 0; bottom: 0;
+  }
+  .d-composer input {
+    flex: 1; background: transparent; border: none;
+    font-family: 'Fraunces', serif; font-size: 14px;
+    color: var(--ink); font-style: italic;
+    padding: 6px 0;
+  }
+  .d-composer input::placeholder { color: var(--ink-faint); }
+  .d-composer .send {
+    background: var(--ink); color: var(--bg);
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 12px; padding: 6px 14px; border-radius: 5px;
+    border: none;
+  }
+
+  /* desktop detail */
+  .dd { padding: 32px 0 0; max-width: 820px; margin: 0 auto; }
+  .dd-bar {
+    display: flex; align-items: center; gap: 16px;
+    padding: 0 40px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+  .dd-back {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 13px; color: var(--ink-muted);
+  }
+  .dd-back::before { content: '← '; }
+  .dd-close { margin-left: auto; font-size: 20px; color: var(--ink-muted); }
+  .dd-body { padding: 32px 40px 40px; }
+  .dd-title {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 36px; line-height: 1.15; letter-spacing: -0.7px;
+    color: var(--ink); margin-bottom: 14px;
+  }
+  .dd-meta {
+    display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+    font-size: 12px; color: var(--ink-muted); margin-bottom: 28px;
+    font-family: 'Inter', sans-serif;
+  }
+  .dd-meta .num { font-family: 'IBM Plex Mono', monospace; color: var(--ink-faint); }
+  .dd-meta .state { color: var(--accent); font-weight: 600; }
+  .dd-meta .lbl-bug { color: var(--brick); padding: 1px 6px; background: rgba(184,74,46,0.08); border-radius: 3px; font-size: 10.5px; font-weight: 500; }
+  .dd-grid { display: grid; grid-template-columns: 1fr 240px; gap: 36px; }
+  .dd-launch {
+    background: var(--bg-warm);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px 18px;
+    position: relative;
+    margin-bottom: 20px;
+  }
+  .dd-launch::before {
+    content: ''; position: absolute; left: 0; top: 14px; bottom: 14px;
+    width: 3px; background: var(--accent); border-radius: 2px;
+  }
+  .dd-launch h4 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 13px; color: var(--ink); margin-bottom: 3px;
+  }
+  .dd-launch p {
+    font-family: 'Fraunces', serif; font-size: 11.5px; color: var(--ink-muted);
+    margin-bottom: 12px; line-height: 1.5;
+  }
+  .dd-launch .btn {
+    background: var(--accent); color: var(--bg);
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 12px; padding: 8px 14px; border-radius: 5px;
+    border: none; display: block; width: 100%;
+    margin-bottom: 6px;
+  }
+  .dd-launch .btn-sec {
+    background: transparent; color: var(--ink-muted);
+    border: 1px solid var(--line);
+  }
+  .dd-side-block {
+    font-size: 11.5px; color: var(--ink-muted);
+    padding: 12px 0; border-top: 1px solid var(--line);
+  }
+  .dd-side-block .lbl {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-faint); display: block; margin-bottom: 4px;
+  }
+  .dd-side-block .val {
+    font-family: 'Fraunces', serif; font-size: 13px; color: var(--ink);
+  }
+  .dd-text {
+    font-family: 'Fraunces', serif; font-size: 15px;
+    line-height: 1.65; color: var(--ink-soft);
+    margin-bottom: 28px;
+  }
+  .dd-text p { margin-bottom: 12px; }
+  .dd-text code {
+    font-family: 'IBM Plex Mono', monospace; font-size: 12.5px;
+    background: var(--bg-warmer); padding: 1px 6px; border-radius: 3px;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 3 — NEW ISSUE
+     ══════════════════════════════════════════════════════════════ */
+  .n-bar {
+    padding: 50px 18px 14px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+  }
+  .n-close { font-size: 24px; color: var(--ink-muted); }
+  .n-title {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 16px; color: var(--ink);
+  }
+  .n-save {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; color: var(--ink-muted);
+  }
+  .n-body { padding: 26px 24px 120px; }
+  .n-title-input {
+    width: 100%;
+    font-family: 'Fraunces', serif; font-weight: 400;
+    font-size: 26px; line-height: 1.2; letter-spacing: -0.4px;
+    color: var(--ink); border: none; background: transparent;
+    margin-bottom: 8px; padding: 4px 0; outline: none;
+  }
+  .n-title-input::placeholder { color: var(--ink-faint); font-style: italic; }
+  .n-body-input {
+    width: 100%; height: 120px; resize: none;
+    font-family: 'Fraunces', serif; font-weight: 400;
+    font-size: 15px; line-height: 1.55;
+    color: var(--ink-soft); border: none; background: transparent;
+    padding: 8px 0; outline: none;
+  }
+  .n-body-input::placeholder { color: var(--ink-faint); font-style: italic; }
+  .n-divider { height: 1px; background: var(--line); margin: 20px 0; }
+  .n-field {
+    padding: 14px 0;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .n-field-lbl {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 13px; color: var(--ink-muted);
+  }
+  .n-field-val {
+    font-family: 'Fraunces', serif; font-size: 14px;
+    color: var(--ink); display: flex; align-items: center; gap: 8px;
+  }
+  .n-field-val.none { color: var(--accent); font-style: italic; }
+  .n-field-val.disabled { color: var(--ink-faint); font-style: italic; }
+  .n-field-arrow { color: var(--ink-faint); font-size: 16px; }
+  .n-actions {
+    padding: 20px 24px 30px;
+    position: absolute; left: 0; right: 0; bottom: 0;
+    background: var(--bg-warm); border-top: 1px solid var(--line);
+    display: flex; gap: 10px;
+  }
+  .n-actions .btn-ghost {
+    flex: 1; padding: 12px 16px;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; color: var(--ink-soft);
+    background: transparent; border: 1px solid var(--line); border-radius: 6px;
+  }
+  .n-actions .btn-primary {
+    flex: 1.3; padding: 12px 16px;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; color: var(--bg);
+    background: var(--ink); border: none; border-radius: 6px;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 4 — LAUNCH (mobile full-screen form)
+     ══════════════════════════════════════════════════════════════ */
+  .ml-bar {
+    padding: 50px 18px 14px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+  }
+  .ml-back {
+    font-family: 'Fraunces', serif; font-size: 22px; color: var(--ink);
+    width: 36px; display: flex; align-items: center;
+  }
+  .ml-title {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 16px; color: var(--ink);
+  }
+  .ml-go {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 700;
+    font-size: 13px; color: var(--accent);
+  }
+  .ml-issue {
+    padding: 18px 24px 16px;
+    background: var(--bg-warm);
+    border-bottom: 1px solid var(--line);
+    position: relative;
+  }
+  .ml-issue::before {
+    content: ''; position: absolute; left: 0; top: 20px; bottom: 16px;
+    width: 3px; background: var(--accent); border-radius: 2px;
+  }
+  .ml-eyebrow {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-muted); margin-bottom: 3px;
+  }
+  .ml-issue-title {
+    font-family: 'Fraunces', serif; font-weight: 500; font-size: 18px;
+    color: var(--ink); margin-bottom: 6px; line-height: 1.25;
+    letter-spacing: -0.2px;
+  }
+  .ml-issue-meta {
+    display: flex; gap: 8px; align-items: center;
+    font-size: 11px; color: var(--ink-muted);
+    font-family: 'Inter', sans-serif;
+  }
+  .ml-issue-meta .lbl-bug { color: var(--brick); }
+  .ml-issue-meta .sep { color: var(--ink-faint); }
+  .ml-form {
+    padding: 4px 24px 40px;
+    overflow-y: auto;
+    max-height: calc(100% - 220px);
+  }
+
+  /* desktop launch modal */
+  .lm-scrim {
+    position: absolute; inset: 0;
+    background: rgba(26,23,18,0.45);
+  }
+  .lm-modal {
+    position: absolute;
+    top: 30px; left: 50%; transform: translateX(-50%);
+    width: 580px;
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    box-shadow: 0 40px 100px rgba(0,0,0,0.4);
+  }
+  .lm-modal::before {
+    content: ''; position: absolute; inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/></svg>");
+    background-size: 200px;
+    mix-blend-mode: multiply; opacity: 0.18;
+    pointer-events: none; border-radius: 14px;
+  }
+  .lm-modal > * { position: relative; }
+  .lm-head {
+    padding: 22px 28px 18px;
+    border-bottom: 1px solid var(--line);
+  }
+  .lm-head .eyebrow {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 12px;
+    color: var(--ink-muted); margin-bottom: 2px;
+  }
+  .lm-head h2 {
+    font-family: 'Fraunces', serif; font-weight: 500; font-size: 22px;
+    letter-spacing: -0.3px; color: var(--ink);
+  }
+  .lm-head .x {
+    position: absolute; right: 20px; top: 18px;
+    font-size: 22px; color: var(--ink-muted);
+  }
+  .lm-form { padding: 18px 28px 8px; }
+  .lm-field { padding: 12px 0; border-bottom: 1px solid var(--line-soft); }
+  .lm-field:last-child { border-bottom: none; }
+  .lm-field .lbl {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11.5px;
+    color: var(--ink-muted); display: block; margin-bottom: 4px;
+    letter-spacing: 0.2px;
+  }
+  .lm-radio { display: flex; gap: 8px; margin-top: 6px; }
+  .lm-radio-opt {
+    flex: 1; padding: 10px 14px;
+    border: 1px solid var(--line); border-radius: 6px;
+    font-family: 'Fraunces', serif; font-size: 12.5px;
+    color: var(--ink-soft);
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .lm-radio-opt.on {
+    border-color: var(--accent); background: var(--accent-soft);
+    color: var(--ink);
+  }
+  .lm-radio-opt .t { font-weight: 600; font-style: italic; }
+  .lm-radio-opt .d { font-size: 10.5px; color: var(--ink-muted); }
+  .lm-toggles { display: flex; gap: 8px; flex-wrap: wrap; }
+  .lm-toggle {
+    padding: 5px 12px; border-radius: 14px;
+    border: 1px solid var(--line);
+    font-family: 'Fraunces', serif; font-size: 11.5px; font-style: italic;
+    color: var(--ink-muted);
+  }
+  .lm-toggle.on {
+    background: var(--ink); color: var(--bg); border-color: var(--ink);
+    font-weight: 600;
+  }
+  .lm-input {
+    background: transparent; border: none; width: 100%;
+    font-family: 'IBM Plex Mono', monospace; font-size: 12.5px;
+    color: var(--ink); padding: 4px 0; outline: none;
+  }
+  .lm-preamble {
+    background: var(--bg-warm);
+    border: 1px solid var(--line); border-radius: 6px;
+    padding: 10px 12px;
+    font-family: 'Fraunces', serif; font-size: 12.5px;
+    color: var(--ink-soft); line-height: 1.5;
+    min-height: 60px;
+  }
+  .lm-preamble em { color: var(--ink); font-style: italic; }
+  .lm-foot {
+    padding: 18px 28px 22px;
+    border-top: 1px solid var(--line);
+    display: flex; gap: 10px; justify-content: flex-end;
+  }
+  .lm-foot .btn-ghost {
+    padding: 11px 18px; background: transparent;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; color: var(--ink-soft);
+    border: 1px solid var(--line); border-radius: 6px;
+  }
+  .lm-foot .btn-go {
+    padding: 11px 26px;
+    background: var(--accent); color: var(--bg);
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; border: none; border-radius: 6px;
+  }
+  .lm-foot .btn-go::after { content: ' →'; font-family: 'IBM Plex Mono', monospace; }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 5 — EMPTY / FIRST RUN
+     ══════════════════════════════════════════════════════════════ */
+  .fr {
+    display: flex; flex-direction: column; align-items: center;
+    padding: 90px 30px 40px; text-align: center;
+    height: 100%;
+  }
+  .fr-brand {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 60px; letter-spacing: -1.2px; line-height: 1;
+    color: var(--ink);
+  }
+  .fr-brand .dot {
+    display: inline-block; width: 14px; height: 14px;
+    background: var(--accent); border-radius: 50%;
+    margin-left: 4px; vertical-align: 12px;
+  }
+  .fr-tag {
+    font-family: 'Fraunces', serif; font-size: 16px;
+    color: var(--ink-muted); max-width: 280px;
+    line-height: 1.5; margin: 24px 0 36px;
+  }
+  .fr-tag em { color: var(--ink-soft); }
+  .fr-status {
+    display: flex; align-items: center; gap: 8px;
+    padding: 9px 16px; border-radius: 20px;
+    background: var(--accent-soft);
+    border: 1px solid var(--accent);
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 12.5px;
+    color: var(--accent); margin-bottom: 20px;
+  }
+  .fr-status .fdot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--accent);
+  }
+  .fr-cta {
+    padding: 14px 32px;
+    background: var(--ink); color: var(--bg);
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 15px; border-radius: 8px; border: none;
+    margin-bottom: 16px;
+  }
+  .fr-hint {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11.5px;
+    color: var(--ink-faint);
+  }
+
+  .el-empty { text-align: center; padding: 80px 20px 60px; }
+  .el-empty .mark {
+    font-family: 'Fraunces', serif; font-weight: 500; font-style: italic;
+    font-size: 36px; line-height: 1; color: var(--accent); margin-bottom: 18px;
+  }
+  .el-empty h3 {
+    font-family: 'Fraunces', serif; font-weight: 500; font-style: italic;
+    font-size: 22px; letter-spacing: -0.3px; color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .el-empty p {
+    font-family: 'Fraunces', serif; font-size: 14px;
+    color: var(--ink-muted); max-width: 280px; margin: 0 auto;
+    line-height: 1.55;
+  }
+  .el-empty p em { color: var(--ink-soft); }
+
+  /* notes card */
+  .note {
+    width: 380px;
+    background: var(--shell-surface);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
+    padding: 22px;
+  }
+  .note h4 {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 18px;
+    color: var(--shell-accent); margin-bottom: 14px;
+  }
+  .note h4 + ul { margin-top: -4px; }
+  .note ul {
+    font-size: 12.5px; line-height: 1.7;
+    color: var(--shell-text); padding-left: 20px;
+  }
+  .note ul + h4 { margin-top: 20px; }
+  .note li { margin-bottom: 6px; }
+  .note b { color: var(--shell-accent); }
+  .note em { font-style: italic; }
+
+  /* final wrap-up notes */
+  .open-questions {
+    max-width: 1600px; margin: 48px auto 0;
+    background: var(--shell-surface);
+    border: 1px solid var(--shell-border);
+    border-radius: 12px;
+    padding: 24px 28px;
+  }
+  .open-questions h3 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 18px; color: var(--shell-accent); margin-bottom: 12px;
+  }
+  .open-questions ul {
+    padding-left: 20px; font-size: 13px; line-height: 1.7;
+    color: var(--shell-text);
+  }
+  .open-questions li { margin-bottom: 6px; }
+  .open-questions b { color: var(--shell-accent); }
+  .open-questions em { font-style: italic; }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 6 — SETTINGS
+     ══════════════════════════════════════════════════════════════ */
+  .s-bar {
+    padding: 50px 18px 14px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+  }
+  .s-bar .back { font-size: 22px; color: var(--ink); width: 36px; }
+  .s-bar h2 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 16px; color: var(--ink);
+  }
+  .s-bar .spacer { width: 36px; }
+  .s-section {
+    padding: 22px 24px;
+    border-bottom: 1px solid var(--line);
+  }
+  .s-section-head {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 13px; color: var(--ink-soft);
+    margin-bottom: 14px; display: flex; align-items: baseline; gap: 8px;
+  }
+  .s-section-head .cnt {
+    font-family: 'IBM Plex Mono', monospace; font-size: 10px;
+    color: var(--ink-faint); font-style: normal;
+  }
+  .s-section-head .rule { flex: 1; height: 1px; background: var(--line); }
+  .s-repo {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 12px;
+  }
+  .s-repo:last-child { border-bottom: none; }
+  .s-repo .dot {
+    width: 10px; height: 10px; border-radius: 3px;
+    background: var(--accent); flex-shrink: 0;
+  }
+  .s-repo .dot.brick { background: var(--brick); }
+  .s-repo .dot.butter { background: var(--butter); }
+  .s-repo .body { flex: 1; min-width: 0; }
+  .s-repo .nm {
+    font-family: 'Fraunces', serif; font-size: 14px;
+    color: var(--ink); margin-bottom: 2px;
+  }
+  .s-repo .pth {
+    font-family: 'IBM Plex Mono', monospace; font-size: 10px;
+    color: var(--ink-faint);
+  }
+  .s-repo .edit {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-muted);
+  }
+  .s-add {
+    padding: 12px 0; display: flex; align-items: center; gap: 12px;
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 13px;
+    color: var(--accent);
+  }
+  .s-add .plus {
+    width: 10px; height: 10px; border: 1.5px dashed var(--accent);
+    border-radius: 3px; font-style: normal; font-family: 'IBM Plex Mono', monospace;
+    font-size: 10px; text-align: center; line-height: 7px;
+  }
+  .s-field {
+    padding: 12px 0; border-bottom: 1px solid var(--line-soft);
+  }
+  .s-field:last-child { border-bottom: none; }
+  .s-field .lbl {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11.5px;
+    color: var(--ink-muted); display: block; margin-bottom: 4px;
+  }
+  .s-field .val {
+    font-family: 'IBM Plex Mono', monospace; font-size: 12.5px;
+    color: var(--ink);
+  }
+  .s-field .val.italic {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 13px;
+  }
+  .s-field .hint {
+    font-family: 'Fraunces', serif; font-size: 11px; color: var(--ink-faint);
+    margin-top: 2px;
+  }
+  .s-wt {
+    padding: 10px 0;
+    display: flex; align-items: center; gap: 10px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .s-wt:last-child { border-bottom: none; }
+  .s-wt .wt-path {
+    flex: 1; font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    color: var(--ink-soft);
+  }
+  .s-wt .wt-age {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-muted);
+  }
+  .s-wt .wt-rm {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--brick);
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 7 — QUICK CREATE
+     ══════════════════════════════════════════════════════════════ */
+  .qc-bar {
+    padding: 50px 18px 14px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+  }
+  .qc-bar .close { font-size: 22px; color: var(--ink-muted); width: 28px; }
+  .qc-bar h2 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 15px;
+  }
+  .qc-bar .next {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 700;
+    font-size: 13px; color: var(--accent);
+  }
+  .qc-bar .next.dim { color: var(--ink-faint); font-weight: 500; }
+  .qc-stepper {
+    padding: 10px 24px 0;
+    display: flex; gap: 6px; align-items: center;
+  }
+  .qc-stepper .step {
+    flex: 1; height: 3px; background: var(--line); border-radius: 2px;
+  }
+  .qc-stepper .step.on { background: var(--accent); }
+  .qc-body { padding: 22px 24px; }
+  .qc-prompt {
+    font-family: 'Fraunces', serif; font-weight: 500; font-style: italic;
+    font-size: 22px; color: var(--ink); margin-bottom: 14px;
+    letter-spacing: -0.3px;
+  }
+  .qc-sub {
+    font-family: 'Fraunces', serif; font-size: 13px;
+    color: var(--ink-muted); margin-bottom: 20px; line-height: 1.5;
+  }
+  .qc-textarea {
+    width: 100%; min-height: 220px; resize: none;
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 10px; padding: 16px;
+    font-family: 'Fraunces', serif; font-size: 14px; line-height: 1.55;
+    color: var(--ink-soft); outline: none;
+  }
+  .qc-textarea::placeholder { color: var(--ink-faint); font-style: italic; }
+  .qc-parse-btn {
+    margin-top: 20px;
+    width: 100%; padding: 13px;
+    background: var(--ink); color: var(--bg);
+    border: none; border-radius: 8px;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 14px;
+  }
+  .qc-card {
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 10px; padding: 14px 16px;
+    margin-bottom: 12px; position: relative;
+  }
+  .qc-card::before {
+    content: ''; position: absolute; left: 0; top: 14px; bottom: 14px;
+    width: 2px; background: var(--accent); border-radius: 2px;
+  }
+  .qc-card .t {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 14px; color: var(--ink); margin-bottom: 4px; line-height: 1.3;
+  }
+  .qc-card .b {
+    font-family: 'Fraunces', serif; font-size: 11.5px;
+    color: var(--ink-muted); margin-bottom: 8px; line-height: 1.5;
+  }
+  .qc-card .m {
+    display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+    font-size: 10px; font-family: 'Inter', sans-serif;
+  }
+  .qc-card .m .repo-pick {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 10.5px;
+    color: var(--accent);
+  }
+  .qc-card .m .lbl-bug { color: var(--brick); font-family: 'IBM Plex Mono', monospace; font-size: 9.5px; }
+  .qc-card .m .lbl-feat { color: var(--butter); font-family: 'IBM Plex Mono', monospace; font-size: 9.5px; }
+  .qc-results-ok {
+    padding: 30px 24px 20px; text-align: center;
+  }
+  .qc-results-ok .mark {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 56px; color: var(--accent); line-height: 0.8;
+    margin-bottom: 14px;
+  }
+  .qc-results-ok h3 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 22px; color: var(--ink); margin-bottom: 6px;
+  }
+  .qc-results-ok p {
+    font-family: 'Fraunces', serif; font-size: 13px;
+    color: var(--ink-muted);
+  }
+  .qc-result-row {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 12px;
+  }
+  .qc-result-row .check {
+    width: 14px; height: 14px; border-radius: 50%;
+    background: var(--accent); flex-shrink: 0; position: relative;
+  }
+  .qc-result-row .check::after {
+    content: ''; position: absolute; left: 3px; top: 4px;
+    width: 6px; height: 3px;
+    border-left: 1.5px solid var(--bg);
+    border-bottom: 1.5px solid var(--bg);
+    transform: rotate(-45deg);
+  }
+  .qc-result-row .t {
+    flex: 1; font-family: 'Fraunces', serif; font-size: 13px;
+    color: var(--ink);
+  }
+  .qc-result-row .n {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    color: var(--ink-faint);
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 8 — PR DETAIL
+     ══════════════════════════════════════════════════════════════ */
+  .pr-check-list {
+    margin: 0 0 24px;
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 8px; padding: 4px 14px;
+  }
+  .pr-check {
+    display: flex; align-items: center; gap: 10px;
+    padding: 9px 0;
+    border-bottom: 1px solid var(--line-soft);
+    font-family: 'Fraunces', serif; font-size: 12.5px;
+    color: var(--ink-soft);
+  }
+  .pr-check:last-child { border-bottom: none; }
+  .pr-check .dot {
+    width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
+  }
+  .pr-check .dot.pass { background: var(--accent); }
+  .pr-check .dot.fail { background: var(--brick); }
+  .pr-check .dot.pending { background: var(--butter); }
+  .pr-check .name { flex: 1; }
+  .pr-check .meta { font-family: 'Inter', sans-serif; font-size: 10.5px; color: var(--ink-faint); }
+  .pr-files {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    color: var(--ink-soft); line-height: 1.7;
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 8px; padding: 12px 14px;
+    margin-bottom: 20px;
+  }
+  .pr-files .line {
+    display: flex; gap: 12px; align-items: center;
+  }
+  .pr-files .add { color: var(--accent); font-family: 'Fraunces', serif; font-style: italic; font-size: 10px; font-weight: 600; }
+  .pr-files .del { color: var(--brick); font-family: 'Fraunces', serif; font-style: italic; font-size: 10px; font-weight: 600; }
+  .pr-merge-btn {
+    width: 100%; padding: 12px;
+    background: var(--accent); color: var(--bg); border: none;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 14px; border-radius: 8px;
+    margin-bottom: 20px;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 9 — LAUNCH PROGRESS
+     ══════════════════════════════════════════════════════════════ */
+  .lp-bar {
+    padding: 50px 18px 14px;
+    border-bottom: 1px solid var(--line);
+  }
+  .lp-bar .eyebrow {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-muted); margin-bottom: 2px;
+  }
+  .lp-bar h2 {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 20px; letter-spacing: -0.3px;
+  }
+  .lp-bar .sub {
+    font-family: 'Fraunces', serif; font-size: 11.5px; color: var(--ink-muted);
+    margin-top: 3px;
+  }
+  .lp-body { padding: 32px 24px; }
+  .lp-step {
+    display: flex; align-items: center; gap: 14px;
+    padding: 14px 0;
+    position: relative;
+  }
+  .lp-step + .lp-step::before {
+    content: ''; position: absolute;
+    left: 11px; top: -14px; height: 28px;
+    width: 1.5px; background: var(--line);
+  }
+  .lp-step.done + .lp-step::before { background: var(--accent); }
+  .lp-step .mark {
+    width: 22px; height: 22px; border-radius: 50%;
+    border: 1.5px solid var(--line);
+    background: var(--bg);
+    flex-shrink: 0;
+    position: relative; z-index: 2;
+  }
+  .lp-step.done .mark {
+    background: var(--accent); border-color: var(--accent);
+  }
+  .lp-step.done .mark::after {
+    content: ''; position: absolute;
+    left: 5px; top: 7px; width: 9px; height: 4px;
+    border-left: 2px solid var(--bg); border-bottom: 2px solid var(--bg);
+    transform: rotate(-45deg);
+  }
+  .lp-step.active .mark {
+    border-color: var(--accent);
+    border-width: 2px;
+  }
+  .lp-step.active .mark::after {
+    content: ''; position: absolute; inset: 3px;
+    background: var(--accent); border-radius: 50%;
+    animation: pulse 1.5s infinite;
+  }
+  .lp-step .label {
+    font-family: 'Fraunces', serif; font-size: 15px;
+    color: var(--ink);
+  }
+  .lp-step .detail {
+    font-family: 'Fraunces', serif; font-size: 11px;
+    color: var(--ink-muted); margin-top: 2px;
+  }
+  .lp-step.pending .label { color: var(--ink-faint); }
+  .lp-note {
+    margin-top: 30px; padding: 14px 16px;
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 8px;
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 12px;
+    color: var(--ink-muted); line-height: 1.55;
+    text-align: center;
+  }
+  .lp-note em { color: var(--ink-soft); }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 10 — AUTH ERROR
+     ══════════════════════════════════════════════════════════════ */
+  .ae {
+    padding: 80px 30px 40px;
+    text-align: center; height: 100%;
+  }
+  .ae-icon {
+    width: 68px; height: 68px; border-radius: 50%;
+    background: rgba(184, 74, 46, 0.08);
+    border: 1.5px dashed var(--brick);
+    margin: 0 auto 26px;
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Fraunces', serif; font-weight: 700;
+    font-size: 32px; color: var(--brick); line-height: 1;
+  }
+  .ae h2 {
+    font-family: 'Fraunces', serif; font-weight: 500;
+    font-size: 24px; line-height: 1.2; letter-spacing: -0.3px;
+    color: var(--ink); margin-bottom: 10px;
+  }
+  .ae p {
+    font-family: 'Fraunces', serif; font-size: 14px;
+    color: var(--ink-muted); max-width: 300px;
+    margin: 0 auto 26px; line-height: 1.55;
+  }
+  .ae p em { color: var(--ink-soft); }
+  .ae-steps {
+    text-align: left;
+    background: var(--bg-warm); border: 1px solid var(--line);
+    border-radius: 10px; padding: 16px 18px;
+    margin-bottom: 22px;
+  }
+  .ae-step {
+    padding: 8px 0;
+    display: flex; gap: 12px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .ae-step:last-child { border-bottom: none; }
+  .ae-step .n {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 13px; color: var(--accent);
+    width: 20px; flex-shrink: 0;
+  }
+  .ae-step .c {
+    flex: 1;
+    font-family: 'Fraunces', serif; font-size: 13px;
+    color: var(--ink-soft); line-height: 1.4;
+  }
+  .ae-step .c code {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11.5px;
+    background: var(--bg); padding: 1px 6px; border-radius: 3px;
+    color: var(--ink);
+  }
+  .ae-retry {
+    width: calc(100% - 40px); margin: 0 20px;
+    padding: 12px; background: var(--ink); color: var(--bg);
+    border: none; border-radius: 8px;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 14px;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 11 — MODAL ANTHOLOGY
+     ══════════════════════════════════════════════════════════════ */
+  .ma-stage {
+    background: var(--bg);
+    padding: 30px;
+    border-radius: 14px;
+    position: relative;
+  }
+  .ma-stage::before {
+    content: ''; position: absolute; inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/></svg>");
+    background-size: 200px;
+    mix-blend-mode: multiply; opacity: 0.15;
+    pointer-events: none; border-radius: 14px;
+  }
+  .ma-stage > * { position: relative; z-index: 2; }
+  .ma-grid {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+  @media (max-width: 1100px) { .ma-grid { grid-template-columns: 1fr; } }
+  .ma-modal {
+    background: #faf4e1;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 22px 24px 20px;
+    box-shadow: 0 16px 40px rgba(26,23,18,0.12);
+    position: relative;
+  }
+  .ma-modal .ma-label {
+    font-family: 'IBM Plex Mono', monospace; font-size: 9.5px;
+    color: var(--ink-faint); text-transform: uppercase; letter-spacing: 1.2px;
+    margin-bottom: 10px;
+  }
+  .ma-modal h4 {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 17px; color: var(--ink); margin-bottom: 6px;
+    letter-spacing: -0.2px;
+  }
+  .ma-modal p {
+    font-family: 'Fraunces', serif; font-size: 12.5px;
+    color: var(--ink-muted); margin-bottom: 16px; line-height: 1.55;
+  }
+  .ma-modal p em { color: var(--ink-soft); }
+  .ma-modal .ma-actions {
+    display: flex; gap: 8px; justify-content: flex-end;
+  }
+  .ma-modal .btn {
+    padding: 8px 16px; border-radius: 6px;
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 600;
+    font-size: 12.5px; border: 1px solid var(--line);
+    background: transparent; color: var(--ink-soft);
+  }
+  .ma-modal .btn.danger { background: var(--brick); color: var(--bg); border-color: var(--brick); }
+  .ma-modal .btn.primary { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  .ma-modal .btn.accent { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .ma-field {
+    padding: 10px 0; border-bottom: 1px solid var(--line-soft);
+  }
+  .ma-field:last-of-type { border-bottom: none; margin-bottom: 10px; }
+  .ma-field .lbl {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 10.5px;
+    color: var(--ink-muted); display: block; margin-bottom: 2px;
+  }
+  .ma-field .val {
+    font-family: 'IBM Plex Mono', monospace; font-size: 11.5px;
+    color: var(--ink);
+  }
+  .ma-field .val.italic {
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 12.5px;
+  }
+  .ma-labels {
+    display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px;
+  }
+  .ma-lbl-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 6px 0;
+    font-family: 'Fraunces', serif; font-size: 12.5px;
+  }
+  .ma-lbl-row .cb {
+    width: 13px; height: 13px; border-radius: 2px;
+    border: 1.5px solid var(--ink-muted);
+  }
+  .ma-lbl-row.on .cb { background: var(--accent); border-color: var(--accent); position: relative; }
+  .ma-lbl-row.on .cb::after {
+    content: ''; position: absolute; left: 2px; top: 3px;
+    width: 6px; height: 3px;
+    border-left: 1.2px solid var(--bg); border-bottom: 1.2px solid var(--bg);
+    transform: rotate(-45deg);
+  }
+  .ma-lbl-row .lbl-text {
+    flex: 1; color: var(--ink-soft);
+  }
+  .ma-lbl-row .lbl-color {
+    width: 10px; height: 10px; border-radius: 50%;
+  }
+  .ma-warn {
+    display: flex; gap: 10px; padding: 10px 12px;
+    background: rgba(184,74,46,0.08);
+    border: 1px solid rgba(184,74,46,0.3);
+    border-radius: 6px; margin-bottom: 14px;
+  }
+  .ma-warn .icon {
+    font-family: 'Fraunces', serif; font-weight: 700; color: var(--brick);
+    font-size: 16px; line-height: 1; flex-shrink: 0;
+  }
+  .ma-warn .text {
+    font-family: 'Fraunces', serif; font-size: 11.5px; color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  .ma-warn .text code {
+    font-family: 'IBM Plex Mono', monospace; font-size: 10.5px;
+    background: var(--bg-warm); padding: 1px 4px; border-radius: 2px;
+  }
+
+  /* ══════════════════════════════════════════════════════════════
+     FLOW 12 — SUPPLEMENTS (nav drawer, PR tab, priority picker)
+     ══════════════════════════════════════════════════════════════ */
+
+  /* menu icon */
+  .menu-icon {
+    width: 30px; height: 30px; display: flex; align-items: center; justify-content: center;
+    font-family: 'IBM Plex Mono', monospace; font-size: 18px;
+    color: var(--ink-muted); letter-spacing: 1px;
+  }
+
+  /* nav drawer */
+  .nd-drawer {
+    position: absolute; right: 0; top: 0; bottom: 0;
+    width: 300px;
+    background: var(--bg);
+    border-left: 1px solid var(--line);
+    z-index: 41;
+    box-shadow: -20px 0 60px rgba(0,0,0,0.3);
+  }
+  .nd-head {
+    padding: 52px 22px 18px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line);
+  }
+  .nd-head .brand {
+    font-family: 'Fraunces', serif; font-style: italic; font-weight: 500;
+    font-size: 22px; letter-spacing: -0.4px;
+  }
+  .nd-head .brand .dot {
+    display: inline-block; width: 7px; height: 7px;
+    background: var(--accent); border-radius: 50%;
+    margin-left: 2px; vertical-align: 3px;
+  }
+  .nd-head .x { font-size: 22px; color: var(--ink-muted); }
+  .nd-item {
+    padding: 16px 22px;
+    display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid var(--line-soft);
+    font-family: 'Fraunces', serif; font-size: 15px;
+    color: var(--ink);
+  }
+  .nd-item.on { color: var(--accent); font-style: italic; }
+  .nd-item.on::before {
+    content: '› '; color: var(--accent); margin-right: 2px;
+  }
+  .nd-item .arr { color: var(--ink-faint); font-size: 14px; font-family: 'IBM Plex Mono', monospace; }
+  .nd-section {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 11px; color: var(--ink-faint);
+    padding: 18px 22px 6px;
+  }
+  .nd-footer {
+    position: absolute; bottom: 22px; left: 22px; right: 22px;
+    font-family: 'Fraunces', serif; font-style: italic; font-size: 11px;
+    color: var(--ink-muted); line-height: 1.6;
+    padding-top: 14px; border-top: 1px solid var(--line-soft);
+  }
+  .nd-footer .row { display: flex; justify-content: space-between; padding: 2px 0; }
+  .nd-footer .auth { color: var(--accent); }
+  .nd-footer .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); display: inline-block; margin-right: 5px; vertical-align: 2px; }
+  .nd-footer .mono { font-family: 'IBM Plex Mono', monospace; font-style: normal; font-size: 9.5px; color: var(--ink-faint); }
+
+  /* PR status dots (reuses .item structure) */
+  .item .pr-stat {
+    position: absolute; left: 24px; top: 17px;
+    width: 18px; height: 18px; border-radius: 50%;
+    border: 1.5px solid var(--ink-muted);
+    background: var(--bg);
+  }
+  .item .pr-stat.pass {
+    background: var(--accent); border-color: var(--accent);
+  }
+  .item .pr-stat.pass::after {
+    content: ''; position: absolute;
+    left: 4px; top: 6px; width: 7px; height: 3.5px;
+    border-left: 1.8px solid var(--bg);
+    border-bottom: 1.8px solid var(--bg);
+    transform: rotate(-45deg);
+  }
+  .item .pr-stat.fail {
+    border-color: var(--brick); background: transparent;
+  }
+  .item .pr-stat.fail::after {
+    content: '×'; position: absolute; inset: 0;
+    color: var(--brick); font-family: 'Fraunces', serif; font-weight: 700;
+    font-size: 16px; text-align: center; line-height: 14px;
+  }
+  .item .pr-stat.pending {
+    border-color: var(--butter); background: transparent;
+  }
+  .item .pr-stat.pending::after {
+    content: ''; position: absolute; inset: 3px;
+    background: var(--butter); border-radius: 50%;
+    animation: pulse 1.8s infinite;
+  }
+  .item .pr-stat.merged {
+    background: #8a6db5; border-color: #8a6db5;
+  }
+  .item .pr-stat.merged::after {
+    content: ''; position: absolute;
+    left: 4px; top: 6px; width: 7px; height: 3.5px;
+    border-left: 1.8px solid var(--bg);
+    border-bottom: 1.8px solid var(--bg);
+    transform: rotate(-45deg);
+  }
+
+  /* priority picker rows (reuses sheet styles, adds custom icons) */
+  .pp-icon {
+    width: 30px; height: 30px; border-radius: 50%;
+    background: var(--bg-warm); border: 1.5px solid var(--line);
+    display: flex; align-items: center; justify-content: center;
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 16px; color: var(--ink-soft); flex-shrink: 0;
+  }
+  .pp-icon.on { background: var(--accent); border-color: var(--accent); color: var(--bg); }
+  .pp-icon.high::before { content: '↑'; font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-style: normal; }
+  .pp-icon.normal::before { content: '–'; font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-style: normal; }
+  .pp-icon.low::before { content: '↓'; font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-style: normal; }
+
+  /* priority marker on list rows (for high-priority items) */
+  .item .prio {
+    display: inline-block;
+    font-family: 'IBM Plex Mono', monospace; font-weight: 700;
+    font-size: 11px; color: var(--accent);
+    margin-right: 6px;
+    vertical-align: 1px;
+  }
+
+</style>
+</head>
+<body>
+
+<div class="page-head">
+  <div class="eyebrow">paper palette · all mockups</div>
+  <h1>issuectl &mdash; the full picture</h1>
+  <p class="sub">Every screen we've designed so far, consolidated in one place. The main list is the home, then: issue detail, new issue creation, Claude launch (mobile queues, desktop runs), and the first-run / empty states. "Issue" everywhere — never "task."</p>
+</div>
+
+<div class="toc">
+  <span class="toc-label">jump to</span>
+  <a href="#flow1"><span class="num">01</span>main list</a>
+  <a href="#flow2"><span class="num">02</span>issue detail</a>
+  <a href="#flow3"><span class="num">03</span>new issue</a>
+  <a href="#flow4"><span class="num">04</span>claude launch</a>
+  <a href="#flow5"><span class="num">05</span>first run &amp; empty</a>
+  <a href="#flow6"><span class="num">06</span>settings</a>
+  <a href="#flow7"><span class="num">07</span>quick create</a>
+  <a href="#flow8"><span class="num">08</span>pr detail</a>
+  <a href="#flow9"><span class="num">09</span>launch progress</a>
+  <a href="#flow10"><span class="num">10</span>auth error</a>
+  <a href="#flow11"><span class="num">11</span>modal anthology</a>
+  <a href="#flow12"><span class="num">12</span>supplements</a>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 1 — MAIN LIST                                             -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow1">
+  <div class="flow-head">
+    <div class="flow-num">flow 01</div>
+    <div class="flow-title">Main list &mdash; the home</div>
+    <div class="flow-desc">A single cross-repo list of issues grouped into <em>unassigned</em>, <em>in focus</em>, <em>in flight</em>, and <em>shipped</em>. Mobile swipe-from-right reveals a green "assign →" action; tapping it opens the assign sheet. Desktop is the same column, centered in the viewport, with hover reveals instead of swipe.</div>
+  </div>
+
+  <div class="frames">
+
+    <!-- Phone: list with swiped row -->
+    <div>
+      <div class="frame-label">mobile · <b>default list, row swiped</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="bar">
+            <div class="brand">issuectl<span class="dot"></span></div>
+            <div class="date">friday<b>apr 10</b></div>
+          </div>
+          <div class="tabs">
+            <div class="tab on">Issues<span class="c">7</span></div>
+            <div class="tab">Pull requests<span class="c">3</span></div>
+          </div>
+          <div class="srch"><input class="srch-input" placeholder="filter your list…"></div>
+          <div class="list">
+
+            <div class="section"><h3>unassigned</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item swiped">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Rate limit the export endpoint</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+              <div class="reveal"><span>assign</span><span class="arr">→</span></div>
+            </div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Migrate stale email templates to MDX</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+            </div>
+
+            <div class="section"><h3>in focus</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Fix flaky auth middleware under load</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#214</span><span class="sep">·</span><span class="lbl-bug">bug</span><span class="sep">·</span><span>2d</span></div>
+            </div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Add retry logic to webhook dispatcher</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#220</span><span class="sep">·</span><span class="lbl-feat">feat</span><span class="sep">·</span><span>1d</span></div>
+            </div>
+
+            <div class="section"><h3>in flight</h3><div class="rule"></div><span class="cnt">1</span></div>
+            <div class="item">
+              <div class="check flight"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/><rect class="fill" x="5" y="5" width="10" height="10" rx="1"/></svg></div>
+              <div class="title">Investigate intermittent SSE drops</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#225</span><span class="sep">·</span><span class="lbl-bug">bug</span><span class="sep">·</span><span>launched 4h ago</span></div>
+            </div>
+
+            <div class="section"><h3>shipped</h3><div class="rule"></div><span class="cnt">1</span></div>
+            <div class="item">
+              <div class="check done"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/><path class="tick" d="M6 10.5 l2.8 2.8 L14.5 7"/></svg></div>
+              <div class="title done">Polish empty state copy on onboarding</div>
+              <div class="meta"><span class="repo">web</span><span class="num">#48</span><span class="sep">·</span><span>deployed</span></div>
+            </div>
+
+          </div>
+          <div class="fab">+</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Phone: assign sheet -->
+    <div>
+      <div class="frame-label">mobile · <b>assign sheet (post-swipe)</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="bar">
+            <div class="brand">issuectl<span class="dot"></span></div>
+            <div class="date">friday<b>apr 10</b></div>
+          </div>
+          <div class="tabs">
+            <div class="tab on">Issues<span class="c">7</span></div>
+            <div class="tab">Pull requests<span class="c">3</span></div>
+          </div>
+          <div class="srch"><input class="srch-input" placeholder="filter your list…"></div>
+          <div class="list">
+            <div class="section"><h3>unassigned</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Rate limit the export endpoint</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+            </div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Migrate stale email templates to MDX</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+            </div>
+          </div>
+          <div class="scrim"></div>
+          <div class="sheet">
+            <div class="grab"></div>
+            <div class="sheet-head">
+              <h3>Assign to a repo</h3>
+              <p><em>Rate limit the export endpoint</em> will be pushed to GitHub as a new issue in the chosen repo.</p>
+            </div>
+            <div class="sheet-list">
+              <div class="sheet-row">
+                <div class="rdot"></div>
+                <div class="rname">neonwatty/api <em>· the one you're thinking of</em></div>
+                <div class="rcount">12 open</div>
+              </div>
+              <div class="sheet-row">
+                <div class="rdot alt1"></div>
+                <div class="rname">neonwatty/web</div>
+                <div class="rcount">5 open</div>
+              </div>
+              <div class="sheet-row">
+                <div class="rdot alt2"></div>
+                <div class="rname">neonwatty/docs</div>
+                <div class="rcount">2 open</div>
+              </div>
+              <div class="sheet-row">
+                <div class="rdot alt3"></div>
+                <div class="rname">neonwatty/workers</div>
+                <div class="rcount">0 open</div>
+              </div>
+            </div>
+            <div class="sheet-cancel">cancel</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>Row anatomy</h4>
+      <ul>
+        <li><b>Checkbox</b> — open (hollow), in flight (filled, pulsing), done (filled check). All in forest green.</li>
+        <li><b>Title</b> — Fraunces 17px. Strikethrough in green when done.</li>
+        <li><b>Repo chip</b> — mono, warm surface. Dashed italic green when unassigned.</li>
+        <li><b>#num</b> — IBM Plex Mono, muted.</li>
+        <li><b>Label</b> — brick red for bugs, butter yellow for features.</li>
+        <li><b>Age</b> — sans, relative ("2d", "launched 4h ago").</li>
+      </ul>
+      <h4>Swipe behavior</h4>
+      <ul>
+        <li><b>Swipe from right:</b> row slides left ~110px, reveals green "assign →" on the right.</li>
+        <li><b>Short swipe:</b> reveals button — tap to open the assign sheet.</li>
+        <li><b>Long swipe past threshold:</b> opens the sheet immediately.</li>
+        <li><b>Tap outside:</b> row snaps back.</li>
+        <li><b>Assigned issues:</b> swipe opens the same sheet but with a "move to a different repo" warning.</li>
+      </ul>
+    </div>
+
+  </div>
+
+  <!-- Desktop for main list -->
+  <div style="margin-top: 28px;">
+    <div class="frame-label">desktop · <b>centered column, no sidebar, hover reveals actions</b></div>
+    <div class="desktop">
+      <div class="desktop-chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">localhost:3847</span>
+      </div>
+      <div class="desktop-body paper">
+        <div class="desk">
+          <div class="desk-header">
+            <div class="desk-brand">issuectl<span class="dot"></span><span class="ver">v0.4</span></div>
+            <div class="desk-actions">
+              <div class="date">friday · <b>apr 10</b></div>
+              <button class="btn">+ new issue</button>
+            </div>
+          </div>
+          <div class="desk-tabs">
+            <div class="tab on">Issues<span class="c">7</span></div>
+            <div class="tab">Pull requests<span class="c">3</span></div>
+            <div class="tab">Settings</div>
+          </div>
+          <div class="desk-list">
+            <div class="section"><h3>unassigned</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item show-quick">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Rate limit the export endpoint</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+              <div class="quick"><button>assign</button></div>
+            </div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Migrate stale email templates to MDX</div>
+              <div class="meta"><span class="repo none">no repo</span><span class="sep">·</span><span>local draft</span></div>
+              <div class="quick"><button>assign</button></div>
+            </div>
+            <div class="section"><h3>in focus</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Fix flaky auth middleware under load</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#214</span><span class="sep">·</span><span class="lbl-bug">bug</span><span class="sep">·</span><span>2d</span></div>
+              <div class="quick"><button>reassign</button><button class="go">launch</button></div>
+            </div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Add retry logic to webhook dispatcher</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#220</span><span class="sep">·</span><span class="lbl-feat">feat</span><span class="sep">·</span><span>1d</span></div>
+              <div class="quick"><button>reassign</button><button class="go">launch</button></div>
+            </div>
+            <div class="section"><h3>in flight</h3><div class="rule"></div><span class="cnt">1</span></div>
+            <div class="item">
+              <div class="check flight"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/><rect class="fill" x="5" y="5" width="10" height="10" rx="1"/></svg></div>
+              <div class="title">Investigate intermittent SSE drops</div>
+              <div class="meta"><span class="repo">api</span><span class="num">#225</span><span class="sep">·</span><span class="lbl-bug">bug</span><span class="sep">·</span><span>launched 4h ago</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 2 — ISSUE DETAIL                                          -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow2">
+  <div class="flow-head">
+    <div class="flow-num">flow 02</div>
+    <div class="flow-title">Issue detail</div>
+    <div class="flow-desc">Tap a row → full-screen on mobile, centered 820px column on desktop. Title dominates, launch card is the only loud element, body and comments share the same serif. Mobile has a sticky composer at the bottom; desktop puts the launch card and metadata in a side column.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>full-screen detail</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="d-bar">
+            <div class="d-back">‹</div>
+            <div class="d-crumb">neonwatty/<b>api</b></div>
+            <div class="d-menu">···</div>
+          </div>
+          <div class="d-body">
+            <div class="d-title">Fix flaky auth middleware under load</div>
+            <div class="d-meta">
+              <span class="repo">api</span>
+              <span class="num">#214</span>
+              <span class="sep">·</span>
+              <span class="state">open</span>
+              <span class="sep">·</span>
+              <span class="lbl-bug">bug</span>
+              <span class="sep">·</span>
+              <span>2d old</span>
+            </div>
+
+            <div class="d-launch">
+              <h4>Ready to launch</h4>
+              <p>Open a Ghostty session with Claude Code pre-loaded. Creates a worktree on <code>issue-214-auth</code>.</p>
+              <div class="d-launch-actions">
+                <button class="btn-primary">launch →</button>
+                <button class="btn-ghost">configure</button>
+              </div>
+            </div>
+
+            <div class="d-body-text">
+              <p>Under 50+ concurrent requests the auth middleware starts returning 401s intermittently. Happens in both staging and prod, doesn't reproduce with fewer than ~30 parallel requests.</p>
+              <p>Looks like the token refresh lock in <code>authClient.ts</code> isn't re-entrant — one request can enter the critical section, another can observe the old token before the refresh completes, and the second one gets rejected.</p>
+            </div>
+
+            <div class="d-section-head">comments <span class="cnt">3</span></div>
+
+            <div class="d-comment">
+              <div class="d-comment-head">
+                <div class="d-comment-avi">mw</div>
+                <div class="d-comment-who">mean-weasel</div>
+                <div class="d-comment-time">yesterday</div>
+              </div>
+              <div class="d-comment-body">Can repro on the staging load test at 48 req/s. Errors cluster around the refresh boundary every 15 min.</div>
+            </div>
+            <div class="d-comment">
+              <div class="d-comment-head">
+                <div class="d-comment-avi">nw</div>
+                <div class="d-comment-who">neonwatty</div>
+                <div class="d-comment-time">4h ago</div>
+              </div>
+              <div class="d-comment-body">I'd start by reading <code>authClient.ts</code> lines 140-180 &mdash; the Promise.resolve fallback is suspicious.</div>
+            </div>
+          </div>
+          <div class="d-composer">
+            <input placeholder="add a comment…">
+            <button class="send">send</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="desktop">
+      <div class="desktop-chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">localhost:3847/api/issues/214</span>
+      </div>
+      <div class="desktop-body paper">
+        <div class="dd">
+          <div class="dd-bar">
+            <div class="dd-back">back to list</div>
+            <div class="dd-close">×</div>
+          </div>
+          <div class="dd-body">
+            <div class="dd-title">Fix flaky auth middleware under load</div>
+            <div class="dd-meta">
+              <span class="repo">api</span>
+              <span class="num">#214</span>
+              <span class="state">open</span>
+              <span class="lbl-bug">bug</span>
+              <span>opened 2d ago · last updated 4h ago</span>
+            </div>
+            <div class="dd-grid">
+              <div>
+                <div class="dd-text">
+                  <p>Under 50+ concurrent requests the auth middleware starts returning 401s intermittently. Happens in both staging and prod, doesn't reproduce with fewer than ~30 parallel requests.</p>
+                  <p>Looks like the token refresh lock in <code>authClient.ts</code> isn't re-entrant — one request can enter the critical section, another can observe the old token before the refresh completes, and the second one gets rejected.</p>
+                </div>
+                <div class="d-section-head">comments <span class="cnt">3</span></div>
+                <div class="d-comment">
+                  <div class="d-comment-head">
+                    <div class="d-comment-avi">mw</div>
+                    <div class="d-comment-who">mean-weasel</div>
+                    <div class="d-comment-time">yesterday</div>
+                  </div>
+                  <div class="d-comment-body">Can repro on the staging load test at 48 req/s. Errors cluster around the refresh boundary every 15 min.</div>
+                </div>
+                <div class="d-comment">
+                  <div class="d-comment-head">
+                    <div class="d-comment-avi">nw</div>
+                    <div class="d-comment-who">neonwatty</div>
+                    <div class="d-comment-time">4h ago</div>
+                  </div>
+                  <div class="d-comment-body">I'd start by reading <code>authClient.ts</code> lines 140-180 — the Promise.resolve fallback is suspicious.</div>
+                </div>
+              </div>
+              <aside>
+                <div class="dd-launch">
+                  <h4>Ready to launch</h4>
+                  <p>Open Ghostty with Claude Code pre-loaded on a new worktree.</p>
+                  <button class="btn">launch →</button>
+                  <button class="btn btn-sec">configure</button>
+                </div>
+                <div class="dd-side-block"><span class="lbl">assignee</span><span class="val">—</span></div>
+                <div class="dd-side-block"><span class="lbl">milestone</span><span class="val">0.5.0</span></div>
+                <div class="dd-side-block"><span class="lbl">labels</span><span class="val"><span class="lbl-bug" style="padding:1px 6px;background:rgba(184,74,46,0.08);border-radius:3px;font-size:10.5px;">bug</span></span></div>
+                <div class="dd-side-block"><span class="lbl">referenced files</span><span class="val" style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:1.6;">src/auth/authClient.ts<br>src/middleware/auth.ts</span></div>
+              </aside>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 3 — NEW ISSUE                                             -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow3">
+  <div class="flow-head">
+    <div class="flow-num">flow 03</div>
+    <div class="flow-title">New issue creation</div>
+    <div class="flow-desc">Tap the FAB (mobile) or the "+ new issue" button (desktop). Title and body feel like writing in a notebook — big serif, no borders, just placeholders that fade out as you type. Repo assignment and labels are secondary fields below the divider. Save as a local draft OR assign immediately.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>new issue form</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="n-bar">
+            <div class="n-close">×</div>
+            <div class="n-title">New issue</div>
+            <div class="n-save">save</div>
+          </div>
+          <div class="n-body">
+            <input class="n-title-input" value="Rate limit the export endpoint">
+            <textarea class="n-body-input">Users are hammering /api/exports and we're hitting connection limits on the shared db. Need a per-user token bucket, probably 10 exports/hour.
+
+Related: #185 (the original export endpoint).</textarea>
+            <div class="n-divider"></div>
+            <div class="n-field">
+              <span class="n-field-lbl">repo</span>
+              <span class="n-field-val none">unassigned &nbsp;<span class="n-field-arrow">›</span></span>
+            </div>
+            <div class="n-field">
+              <span class="n-field-lbl">labels</span>
+              <span class="n-field-val disabled">assign a repo first</span>
+            </div>
+            <div class="n-field">
+              <span class="n-field-lbl">priority</span>
+              <span class="n-field-val">normal &nbsp;<span class="n-field-arrow">›</span></span>
+            </div>
+          </div>
+          <div class="n-actions">
+            <button class="btn-ghost">save draft</button>
+            <button class="btn-primary">assign &amp; save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>How it feels</h4>
+      <ul>
+        <li><b>Title is the hero.</b> 26px serif, no border, no label. Placeholder is italic, value is upright. Tap and you're writing.</li>
+        <li><b>Body is a longer version.</b> Same serif, 15px, multi-line. No toolbar, no markdown preview. Raw markdown until it's pushed to GitHub.</li>
+        <li><b>Repo selector is optional.</b> Tapping it opens the same assign sheet from the main list. You can close the form entirely unassigned.</li>
+        <li><b>Labels wait.</b> Until a repo is chosen, the labels field reads "assign a repo first" — we can't show real labels without a target.</li>
+        <li><b>Two save paths</b>: <em>save draft</em> (quiet, stays local) and <em>assign &amp; save</em> (opens the repo sheet, then syncs to GitHub on pick).</li>
+      </ul>
+      <h4>Desktop version</h4>
+      <ul>
+        <li><b>Same form in a 640px modal</b>, centered over a scrim. Esc closes. Cmd+Enter saves.</li>
+        <li><b>Layout is identical</b> — this form doesn't need to grow sideways. Writing prefers narrow columns.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 4 — LAUNCH                                                -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow4">
+  <div class="flow-head">
+    <div class="flow-num">flow 04</div>
+    <div class="flow-title">Claude Code launch</div>
+    <div class="flow-desc">Launching opens Ghostty on the machine where <em>issuectl</em> is running. The mobile viewport is just a narrower view of the same local app — whether you're in a narrow browser window on your Mac or on your phone over LAN, the server triggers Ghostty on the Mac. Same flow, two layouts: mobile gets a full-screen form, desktop gets a centered modal.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>full-screen launch form</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="ml-bar">
+            <div class="ml-back">‹</div>
+            <div class="ml-title">Launch</div>
+            <div class="ml-go">launch →</div>
+          </div>
+          <div class="ml-issue">
+            <div class="ml-eyebrow">launching</div>
+            <div class="ml-issue-title">Fix flaky auth middleware under load</div>
+            <div class="ml-issue-meta">
+              <span class="repo">api</span>
+              <span class="sep">·</span>
+              <span>#214</span>
+              <span class="sep">·</span>
+              <span class="lbl-bug">bug</span>
+            </div>
+          </div>
+          <div class="ml-form">
+            <div class="lm-field">
+              <span class="lbl">workspace</span>
+              <div class="lm-radio">
+                <div class="lm-radio-opt on">
+                  <div class="t">new worktree</div>
+                  <div class="d">fresh branch</div>
+                </div>
+                <div class="lm-radio-opt">
+                  <div class="t">existing clone</div>
+                  <div class="d">~/code/api</div>
+                </div>
+              </div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">branch</span>
+              <input class="lm-input" value="issue-214-auth-middleware">
+            </div>
+            <div class="lm-field">
+              <span class="lbl">preamble</span>
+              <div class="lm-preamble">You're working on issue #214 in the <em>api</em> repo. The bug is that auth middleware returns 401s intermittently under load. Start by reading src/auth/authClient.ts.</div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">context</span>
+              <div class="lm-toggles">
+                <span class="lm-toggle on">comments</span>
+                <span class="lm-toggle on">referenced files</span>
+                <span class="lm-toggle">linked PRs</span>
+              </div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">claude extra args</span>
+              <input class="lm-input" value="--model opus-4.6">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="desktop">
+      <div class="desktop-chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">localhost:3847/api/issues/214</span>
+      </div>
+      <div class="desktop-body paper">
+        <div style="padding: 30px 60px; opacity: 0.25; pointer-events: none;">
+          <div style="font-family: 'Fraunces', serif; font-size: 34px; font-style: italic;">issuectl<span style="color: var(--accent);">.</span></div>
+          <div style="margin-top: 20px; font-family: 'Fraunces', serif; font-style: italic; font-size: 13px; color: var(--ink-muted);">— in focus</div>
+          <div style="padding: 14px 0; font-family: 'Fraunces', serif; font-size: 17px;">Fix flaky auth middleware under load</div>
+          <div style="padding: 14px 0; font-family: 'Fraunces', serif; font-size: 17px;">Add retry logic to webhook dispatcher</div>
+        </div>
+        <div class="lm-scrim"></div>
+        <div class="lm-modal">
+          <div class="lm-head">
+            <div class="eyebrow">launching</div>
+            <h2>Fix flaky auth middleware under load</h2>
+            <div class="x">×</div>
+          </div>
+          <div class="lm-form">
+            <div class="lm-field">
+              <span class="lbl">workspace</span>
+              <div class="lm-radio">
+                <div class="lm-radio-opt on">
+                  <div class="t">new worktree</div>
+                  <div class="d">fresh branch from main</div>
+                </div>
+                <div class="lm-radio-opt">
+                  <div class="t">existing clone</div>
+                  <div class="d">~/code/api</div>
+                </div>
+              </div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">branch</span>
+              <input class="lm-input" value="issue-214-auth-middleware">
+            </div>
+            <div class="lm-field">
+              <span class="lbl">preamble</span>
+              <div class="lm-preamble">You're working on issue #214 in the <em>api</em> repo. The bug is that auth middleware returns 401s intermittently under load. Start by reading src/auth/authClient.ts and src/middleware/auth.ts. Check if the refresh lock is re-entrant.</div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">context</span>
+              <div class="lm-toggles">
+                <span class="lm-toggle on">include comments</span>
+                <span class="lm-toggle on">referenced files</span>
+                <span class="lm-toggle">linked PRs</span>
+                <span class="lm-toggle">issue history</span>
+              </div>
+            </div>
+            <div class="lm-field">
+              <span class="lbl">claude extra args</span>
+              <input class="lm-input" value="--model opus-4.6">
+            </div>
+          </div>
+          <div class="lm-foot">
+            <button class="btn-ghost">save as default</button>
+            <button class="btn-go">launch</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 5 — FIRST RUN / EMPTY                                     -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow5">
+  <div class="flow-head">
+    <div class="flow-num">flow 05</div>
+    <div class="flow-title">First run &amp; empty states</div>
+    <div class="flow-desc">How the app introduces itself on the first open, and how the main list looks when you're caught up. Both lean into the paper metaphor — calm, generous, no confetti.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>first run welcome</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="fr">
+            <div class="fr-brand">issuectl<span class="dot"></span></div>
+            <div class="fr-tag">every issue, every repo.<br><em>launch any of them with Claude Code.</em></div>
+            <div class="fr-status">
+              <span class="fdot"></span>
+              GitHub CLI — authenticated as <strong style="font-weight:600;margin-left:4px;">neonwatty</strong>
+            </div>
+            <button class="fr-cta">add your first repo</button>
+            <div class="fr-hint">or <em>create a draft</em> without a repo</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="frame-label">mobile · <b>all clear (empty list)</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="bar">
+            <div class="brand">issuectl<span class="dot"></span></div>
+            <div class="date">friday<b>apr 10</b></div>
+          </div>
+          <div class="tabs">
+            <div class="tab on">Issues<span class="c">0</span></div>
+            <div class="tab">Pull requests<span class="c">0</span></div>
+          </div>
+          <div class="el-empty">
+            <div class="mark" style="font-size: 62px; line-height: 0.75; margin-bottom: 16px;">❧</div>
+            <h3>all clear</h3>
+            <p>nothing on your plate today. <em>breathe, or draft the next one.</em></p>
+          </div>
+          <div class="fab">+</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>Voice guidelines</h4>
+      <ul>
+        <li><b>Short, lowercase, italic</b> for secondary copy — "a quiet place," "breathe, or draft the next thing"</li>
+        <li><b>No emoji, no exclamation marks</b>. The paper aesthetic carries the mood.</li>
+        <li><b>Italic fragments punctuate</b>; they don't narrate.</li>
+        <li><b>Brand signature</b>: the word <em>issuectl</em> in italic serif, followed by a small green dot like a period.</li>
+        <li><b>Status chips</b> use the accent color with soft surface for a "keeping watch" feel.</li>
+        <li><b>Error states</b> use brick red sparingly — only when something actually broke. Expected empty states stay calm.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 6 — SETTINGS                                              -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow6">
+  <div class="flow-head">
+    <div class="flow-num">flow 06</div>
+    <div class="flow-title">Settings</div>
+    <div class="flow-desc">One settings surface with four sections: tracked repos (add/edit/remove + local path), defaults (branch pattern, cache TTL, terminal), claude config (extra args, preamble template), and worktree cleanup. Mobile: full-screen stacked sections. Desktop: same layout in the centered column.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>settings, top of page</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper" style="overflow-y: auto;">
+          <div class="s-bar">
+            <div class="back">‹</div>
+            <h2>Settings</h2>
+            <div class="spacer"></div>
+          </div>
+
+          <div class="s-section">
+            <div class="s-section-head">tracked repos <div class="rule"></div><span class="cnt">4</span></div>
+            <div class="s-repo">
+              <div class="dot"></div>
+              <div class="body">
+                <div class="nm">neonwatty/api</div>
+                <div class="pth">~/code/api</div>
+              </div>
+              <div class="edit">edit</div>
+            </div>
+            <div class="s-repo">
+              <div class="dot brick"></div>
+              <div class="body">
+                <div class="nm">neonwatty/web</div>
+                <div class="pth">~/code/web</div>
+              </div>
+              <div class="edit">edit</div>
+            </div>
+            <div class="s-repo">
+              <div class="dot butter"></div>
+              <div class="body">
+                <div class="nm">neonwatty/docs</div>
+                <div class="pth">no local path</div>
+              </div>
+              <div class="edit">edit</div>
+            </div>
+            <div class="s-add"><div class="plus">+</div> add a repo</div>
+          </div>
+
+          <div class="s-section">
+            <div class="s-section-head">defaults <div class="rule"></div></div>
+            <div class="s-field">
+              <span class="lbl">branch pattern</span>
+              <span class="val">issue-{number}-{slug}</span>
+              <div class="hint">used when creating a worktree for launch</div>
+            </div>
+            <div class="s-field">
+              <span class="lbl">cache ttl</span>
+              <span class="val">300 seconds</span>
+            </div>
+            <div class="s-field">
+              <span class="lbl">terminal</span>
+              <span class="val italic">Ghostty · v1</span>
+              <div class="hint">hard-coded for v1 &mdash; other terminals in v2</div>
+            </div>
+          </div>
+
+          <div class="s-section">
+            <div class="s-section-head">claude config <div class="rule"></div></div>
+            <div class="s-field">
+              <span class="lbl">extra args</span>
+              <span class="val">--model opus-4.6</span>
+            </div>
+            <div class="s-field">
+              <span class="lbl">default preamble</span>
+              <span class="val italic" style="display:block;margin-top:2px;">You're working on issue {num} in the {repo} repo…</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="frame-label">mobile · <b>settings, worktree + about</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper" style="overflow-y: auto;">
+          <div class="s-bar">
+            <div class="back">‹</div>
+            <h2>Settings</h2>
+            <div class="spacer"></div>
+          </div>
+
+          <div class="s-section">
+            <div class="s-section-head">worktree cleanup <div class="rule"></div><span class="cnt">2 stale</span></div>
+            <div class="s-wt">
+              <div class="wt-path">~/code/api-issue-198-rate</div>
+              <div class="wt-age">12d · merged</div>
+              <div class="wt-rm">remove</div>
+            </div>
+            <div class="s-wt">
+              <div class="wt-path">~/code/web-issue-42-hero</div>
+              <div class="wt-age">9d · closed</div>
+              <div class="wt-rm">remove</div>
+            </div>
+            <div class="s-add"><div class="plus" style="border-style:solid;">⟳</div> remove all stale</div>
+          </div>
+
+          <div class="s-section">
+            <div class="s-section-head">about <div class="rule"></div></div>
+            <div class="s-field">
+              <span class="lbl">github auth</span>
+              <span class="val italic" style="color:var(--accent);">✓ neonwatty (via gh cli)</span>
+            </div>
+            <div class="s-field">
+              <span class="lbl">version</span>
+              <span class="val">0.4.1 · 2026-04-10</span>
+            </div>
+            <div class="s-field">
+              <span class="lbl">data</span>
+              <span class="val">~/.issuectl/issuectl.db</span>
+              <div class="hint">4.2 MB · last vacuumed 3d ago</div>
+            </div>
+            <div class="s-field">
+              <span class="lbl">network</span>
+              <span class="val">bound to 192.168.1.42:3847</span>
+              <div class="hint">reachable from this LAN and over your vpn</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>Settings decisions</h4>
+      <ul>
+        <li><b>One page, four sections</b> — repos, defaults, claude config, worktree cleanup. A small "about" footer shows auth + version + data location + bound address.</li>
+        <li><b>Repos are first</b> — it's the most edited section; goes at the top.</li>
+        <li><b>Terminal is read-only</b> in v1 — shown as <em>Ghostty · v1</em> with a hint about v2.</li>
+        <li><b>Worktree cleanup</b> surfaces stale worktrees (linked to merged/closed issues) with per-row remove and a "remove all stale" bulk action.</li>
+        <li><b>Network row</b> shows the LAN-bound address so you know the URL to hit from your phone.</li>
+        <li><b>No save button</b> — fields commit on blur, with a subtle "saved" flash on the field itself.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 7 — QUICK CREATE                                          -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow7">
+  <div class="flow-head">
+    <div class="flow-num">flow 07</div>
+    <div class="flow-title">Quick create &mdash; Claude-parsed issues</div>
+    <div class="flow-desc">The existing natural-language flow, restyled. Type freeform text describing one or more issues, Claude parses and auto-routes them to repos, you review, then batch-create. Three steps shown side-by-side: input → review → results.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">step 1 · <b>input (natural language)</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="qc-bar">
+            <div class="close">×</div>
+            <h2>Quick Create</h2>
+            <div class="next dim">parse →</div>
+          </div>
+          <div class="qc-stepper">
+            <div class="step on"></div>
+            <div class="step"></div>
+            <div class="step"></div>
+          </div>
+          <div class="qc-body">
+            <div class="qc-prompt">What's on your mind?</div>
+            <div class="qc-sub">Describe one or more issues in plain language. Claude will parse them into structured issues, auto-route to the right repo, and let you review before creating.</div>
+            <textarea class="qc-textarea">Two things today:
+
+1. We need to rate limit /api/exports — hitting the shared DB too hard. Per-user bucket, ~10/hour cap. Goes in the api repo.
+
+2. The onboarding welcome screen copy is too precious. Pull it back to something more functional. That's in the web repo — low priority.</textarea>
+            <button class="qc-parse-btn">parse with Claude →</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="frame-label">step 2 · <b>review parsed issues</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="qc-bar">
+            <div class="close">‹</div>
+            <h2>Review &middot; 2</h2>
+            <div class="next">create →</div>
+          </div>
+          <div class="qc-stepper">
+            <div class="step on"></div>
+            <div class="step on"></div>
+            <div class="step"></div>
+          </div>
+          <div class="qc-body">
+            <div class="qc-sub" style="margin-bottom: 14px;">Claude parsed your input into <em>2 issues</em>. Review, edit, and pick a repo for each before creating.</div>
+
+            <div class="qc-card">
+              <div class="t">Rate limit the export endpoint</div>
+              <div class="b">Add per-user token bucket to /api/exports with ~10/hour cap. Prevents shared DB overload.</div>
+              <div class="m">
+                <span class="repo-pick">› api</span>
+                <span class="lbl-bug">bug</span>
+                <span style="color: var(--ink-faint);">suggested</span>
+              </div>
+            </div>
+
+            <div class="qc-card">
+              <div class="t">Soften onboarding welcome copy</div>
+              <div class="b">Current copy is too precious. Pull back to something more functional and practical.</div>
+              <div class="m">
+                <span class="repo-pick">› web</span>
+                <span class="lbl-feat">copy</span>
+                <span style="color: var(--ink-faint);">low priority</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="frame-label">step 3 · <b>results</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="qc-bar">
+            <div class="close">×</div>
+            <h2>Created</h2>
+            <div class="next dim">done</div>
+          </div>
+          <div class="qc-stepper">
+            <div class="step on"></div>
+            <div class="step on"></div>
+            <div class="step on"></div>
+          </div>
+          <div class="qc-results-ok">
+            <div class="mark">❧</div>
+            <h3>both created</h3>
+            <p>pushed to GitHub &middot; added to your list</p>
+          </div>
+          <div style="padding: 0 24px;">
+            <div class="qc-result-row">
+              <div class="check"></div>
+              <div class="t">Rate limit the export endpoint</div>
+              <div class="n">api · #226</div>
+            </div>
+            <div class="qc-result-row">
+              <div class="check"></div>
+              <div class="t">Soften onboarding welcome copy</div>
+              <div class="n">web · #49</div>
+            </div>
+          </div>
+          <div style="padding: 24px; text-align: center;">
+            <button class="qc-parse-btn" style="margin-top:0;">back to list</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 8 — PR DETAIL                                             -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow8">
+  <div class="flow-head">
+    <div class="flow-num">flow 08</div>
+    <div class="flow-title">PR detail</div>
+    <div class="flow-desc">Sibling of the issue detail. Same top bar, same serif, same side column. The differences: CI check list replaces the launch card, files changed list replaces the "referenced files," and a merge button replaces the launch button (when the CI is green). Mobile + desktop follow the same adaptation pattern.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>PR detail, CI + files</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="d-bar">
+            <div class="d-back">‹</div>
+            <div class="d-crumb">neonwatty/<b>api</b></div>
+            <div class="d-menu">···</div>
+          </div>
+          <div class="d-body">
+            <div class="d-title">Add rate limiting to /api/exports</div>
+            <div class="d-meta">
+              <span class="repo">api</span>
+              <span class="num">#224</span>
+              <span class="sep">·</span>
+              <span class="state">open</span>
+              <span class="sep">·</span>
+              <span>closes #214 · 3d old</span>
+            </div>
+
+            <button class="pr-merge-btn">merge pull request →</button>
+
+            <div class="pr-check-list">
+              <div class="pr-check">
+                <div class="dot pass"></div>
+                <div class="name">CI / build</div>
+                <div class="meta">2m 14s</div>
+              </div>
+              <div class="pr-check">
+                <div class="dot pass"></div>
+                <div class="name">CI / test</div>
+                <div class="meta">3m 42s</div>
+              </div>
+              <div class="pr-check">
+                <div class="dot pass"></div>
+                <div class="name">CI / typecheck</div>
+                <div class="meta">0m 48s</div>
+              </div>
+              <div class="pr-check">
+                <div class="dot pending"></div>
+                <div class="name">Deploy preview</div>
+                <div class="meta">building…</div>
+              </div>
+            </div>
+
+            <div class="d-body-text">
+              <p>Adds a per-user token bucket to <code>/api/exports</code> — configurable rate, defaulting to 10/hour. Uses an in-memory map with a small TTL cleanup sweeper.</p>
+              <p>Closes #214. Does not address the broader webhook dispatcher retry (that's #220).</p>
+            </div>
+
+            <div class="d-section-head">files changed <span class="cnt">4</span></div>
+            <div class="pr-files">
+              <div class="line"><span class="add">+52</span> <span class="del">-8</span> src/middleware/rateLimit.ts</div>
+              <div class="line"><span class="add">+14</span> <span class="del">-2</span> src/routes/exports.ts</div>
+              <div class="line"><span class="add">+38</span> <span class="del">-0</span> src/middleware/__tests__/rateLimit.test.ts</div>
+              <div class="line"><span class="add">+2</span> <span class="del">-0</span> src/config.ts</div>
+            </div>
+          </div>
+          <div class="d-composer">
+            <input placeholder="add a review comment…">
+            <button class="send">send</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="desktop">
+      <div class="desktop-chrome">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="url">localhost:3847/api/pulls/224</span>
+      </div>
+      <div class="desktop-body paper">
+        <div class="dd">
+          <div class="dd-bar">
+            <div class="dd-back">back to list</div>
+            <div class="dd-close">×</div>
+          </div>
+          <div class="dd-body">
+            <div class="dd-title">Add rate limiting to /api/exports</div>
+            <div class="dd-meta">
+              <span class="repo">api</span>
+              <span class="num">#224</span>
+              <span class="state">open</span>
+              <span>closes #214 · opened 3d ago · mean-weasel</span>
+            </div>
+            <div class="dd-grid">
+              <div>
+                <div class="dd-text">
+                  <p>Adds a per-user token bucket to <code>/api/exports</code> — configurable rate, defaulting to 10/hour. Uses an in-memory map with a small TTL cleanup sweeper.</p>
+                  <p>Closes #214. Does not address the broader webhook dispatcher retry (that's #220).</p>
+                </div>
+                <div class="d-section-head">files changed <span class="cnt">4</span></div>
+                <div class="pr-files">
+                  <div class="line"><span class="add">+52</span> <span class="del">-8</span> src/middleware/rateLimit.ts</div>
+                  <div class="line"><span class="add">+14</span> <span class="del">-2</span> src/routes/exports.ts</div>
+                  <div class="line"><span class="add">+38</span> <span class="del">-0</span> src/middleware/__tests__/rateLimit.test.ts</div>
+                  <div class="line"><span class="add">+2</span> <span class="del">-0</span> src/config.ts</div>
+                </div>
+                <div class="d-section-head">review comments <span class="cnt">1</span></div>
+                <div class="d-comment">
+                  <div class="d-comment-head">
+                    <div class="d-comment-avi">nw</div>
+                    <div class="d-comment-who">neonwatty</div>
+                    <div class="d-comment-time">1h ago</div>
+                  </div>
+                  <div class="d-comment-body">Nit: the TTL sweeper interval feels long. Fine to merge — follow-up in a separate PR.</div>
+                </div>
+              </div>
+              <aside>
+                <div class="dd-launch">
+                  <h4>CI status</h4>
+                  <p>3 passing · 1 building · closes #214</p>
+                  <button class="btn">merge →</button>
+                  <button class="btn btn-sec">view on github</button>
+                </div>
+                <div class="dd-side-block"><span class="lbl">base</span><span class="val" style="font-family:'IBM Plex Mono',monospace;font-size:11px;">main ← rate-limit-exports</span></div>
+                <div class="dd-side-block"><span class="lbl">linked issue</span><span class="val">#214 — Fix flaky auth middleware</span></div>
+                <div class="dd-side-block"><span class="lbl">labels</span><span class="val"><span class="lbl-bug" style="padding:1px 6px;background:rgba(184,74,46,0.08);border-radius:3px;font-size:10.5px;">bug</span></span></div>
+              </aside>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 9 — LAUNCH PROGRESS                                       -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow9">
+  <div class="flow-head">
+    <div class="flow-num">flow 09</div>
+    <div class="flow-title">Launch progress</div>
+    <div class="flow-desc">Shown after the launch form is submitted. A stepped checklist of what the server is doing in the background — assembling context, creating worktree, checking out branch, applying the <code>issuectl:launched</code> label, opening Ghostty. The current step pulses; completed steps fill green.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>launch in progress</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="lp-bar">
+            <div class="eyebrow">launching</div>
+            <h2>Fix flaky auth middleware under load</h2>
+            <div class="sub">api · #214 · <em>step 4 of 5</em></div>
+          </div>
+          <div class="lp-body">
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Assembled context</div>
+                <div class="detail">4 comments · 2 referenced files</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Created worktree</div>
+                <div class="detail">~/code/api-issue-214-auth</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Checked out branch</div>
+                <div class="detail">issue-214-auth-middleware</div>
+              </div>
+            </div>
+            <div class="lp-step active">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Opening Ghostty…</div>
+                <div class="detail">with Claude Code pre-loaded</div>
+              </div>
+            </div>
+            <div class="lp-step pending">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Apply "launched" label</div>
+                <div class="detail">on GitHub issue</div>
+              </div>
+            </div>
+
+            <div class="lp-note">
+              this window stays open while the server works. <em>a new Ghostty window will appear on your Mac</em> when it's ready.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="frame-label">mobile · <b>launch complete</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="lp-bar">
+            <div class="eyebrow">launched</div>
+            <h2>Fix flaky auth middleware under load</h2>
+            <div class="sub">api · #214 · <em>in flight</em></div>
+          </div>
+          <div class="lp-body">
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Assembled context</div>
+                <div class="detail">4 comments · 2 referenced files</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Created worktree</div>
+                <div class="detail">~/code/api-issue-214-auth</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Checked out branch</div>
+                <div class="detail">issue-214-auth-middleware</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Opened Ghostty</div>
+                <div class="detail">claude code running</div>
+              </div>
+            </div>
+            <div class="lp-step done">
+              <div class="mark"></div>
+              <div>
+                <div class="label">Applied "launched" label</div>
+                <div class="detail">#214 is now in flight</div>
+              </div>
+            </div>
+
+            <div class="lp-note" style="background: var(--accent-soft); border-color: var(--accent);">
+              <span style="color: var(--accent); font-weight: 600;">ready to go.</span> <em>Claude is working in the Ghostty window on your Mac.</em>
+            </div>
+
+            <div style="margin-top: 20px; text-align: center;">
+              <a href="#" style="font-family: 'Fraunces', serif; font-style: italic; font-size: 13px; color: var(--ink-muted); text-decoration: none;">‹ back to list</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>Progress behavior</h4>
+      <ul>
+        <li><b>Stepped checklist</b> instead of a generic spinner — tells you what's happening at each stage.</li>
+        <li><b>Active step pulses</b> the inner dot in accent green. Completed steps fill and show a check. Pending steps stay faint.</li>
+        <li><b>Step details</b> show concrete values (worktree path, branch name, file count) so you can sanity-check.</li>
+        <li><b>Same view on mobile and desktop</b> — the form-to-progress transition happens inside the same modal/sheet, just with larger type and padding on desktop.</li>
+        <li><b>Bailout path</b>: if any step fails, the active step turns brick red, shows the error, and offers a retry or "open logs" action. (Not mocked here — same visual vocabulary.)</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 10 — AUTH ERROR                                           -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow10">
+  <div class="flow-head">
+    <div class="flow-num">flow 10</div>
+    <div class="flow-title">Auth error &mdash; <code>gh</code> not ready</div>
+    <div class="flow-desc">Shown on app load if the <code>gh</code> CLI isn't installed or isn't authenticated. Blocks the app until fixed. Stays in the Paper aesthetic — brick red for the single error signal, three clear remediation steps, a retry button.</div>
+  </div>
+
+  <div class="frames">
+    <div>
+      <div class="frame-label">mobile · <b>auth error</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="ae">
+            <div class="ae-icon">!</div>
+            <h2>GitHub CLI not ready</h2>
+            <p><em>issuectl</em> reads your GitHub credentials from the <code style="font-family: 'IBM Plex Mono', monospace; font-size: 12px; background: var(--bg-warm); padding: 1px 5px; border-radius: 3px;">gh</code> CLI. It isn't installed or isn't authenticated.</p>
+            <div class="ae-steps">
+              <div class="ae-step">
+                <span class="n">1.</span>
+                <span class="c">install it: <code>brew install gh</code></span>
+              </div>
+              <div class="ae-step">
+                <span class="n">2.</span>
+                <span class="c">authenticate: <code>gh auth login</code></span>
+              </div>
+              <div class="ae-step">
+                <span class="n">3.</span>
+                <span class="c">hit retry &mdash; we'll pick up the new token automatically.</span>
+              </div>
+            </div>
+          </div>
+          <button class="ae-retry">retry →</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <h4>Error state notes</h4>
+      <ul>
+        <li><b>Brick red is the only error color</b> — used sparingly (dashed circle + the "!" glyph), not flooding the whole screen. Keeps the paper mood.</li>
+        <li><b>Three steps, numbered</b> — concrete shell commands in monospace, shown in a warm card to feel "copy this."</li>
+        <li><b>Retry button</b> fires a fresh auth check without reloading the app. If it still fails, it stays on this screen with a small subtle message: "<em>still not seeing a token</em>."</li>
+        <li><b>Same pattern reused</b> for other fatal startup errors (SQLite inaccessible, port in use). Different glyph, same layout.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 11 — MODAL ANTHOLOGY                                      -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow11">
+  <div class="flow-head">
+    <div class="flow-num">flow 11</div>
+    <div class="flow-title">Modal anthology</div>
+    <div class="flow-desc">Five small overlays that share one pattern: warm paper background, serif italic title, short muted explanation, action row at the bottom right. Brick red for destructive, forest green for primary, ink for neutral primary, ghost for cancel. Shown here at desktop size; on mobile they become full-screen sheets.</div>
+  </div>
+
+  <div class="frames" style="flex-direction: column; gap: 0;">
+    <div class="ma-stage paper" style="background: #d9d2be;">
+
+      <div class="ma-grid">
+
+        <!-- 1. Close issue -->
+        <div class="ma-modal">
+          <div class="ma-label">01 · close issue confirmation</div>
+          <h4>Close issue #214?</h4>
+          <p><em>"Fix flaky auth middleware under load"</em> will be closed on GitHub. You can reopen it later if needed.</p>
+          <div class="ma-actions">
+            <button class="btn">cancel</button>
+            <button class="btn danger">close issue</button>
+          </div>
+        </div>
+
+        <!-- 2. Edit issue -->
+        <div class="ma-modal">
+          <div class="ma-label">02 · edit issue</div>
+          <h4 style="margin-bottom: 10px;">Edit issue</h4>
+          <div class="ma-field">
+            <span class="lbl">title</span>
+            <span class="val italic">Fix flaky auth middleware under load</span>
+          </div>
+          <div class="ma-field">
+            <span class="lbl">body</span>
+            <span class="val italic">Under 50+ concurrent requests the auth middleware starts returning 401s intermittently…</span>
+          </div>
+          <div class="ma-actions">
+            <button class="btn">cancel</button>
+            <button class="btn primary">save changes</button>
+          </div>
+        </div>
+
+        <!-- 3. Label manager -->
+        <div class="ma-modal">
+          <div class="ma-label">03 · label manager</div>
+          <h4>Labels</h4>
+          <p>Pick labels from the <em>api</em> repo. Changes sync to GitHub on save.</p>
+          <div class="ma-labels">
+            <div class="ma-lbl-row on">
+              <div class="cb"></div>
+              <span class="lbl-text">bug</span>
+              <div class="lbl-color" style="background: var(--brick);"></div>
+            </div>
+            <div class="ma-lbl-row">
+              <div class="cb"></div>
+              <span class="lbl-text">enhancement</span>
+              <div class="lbl-color" style="background: var(--butter);"></div>
+            </div>
+            <div class="ma-lbl-row on">
+              <div class="cb"></div>
+              <span class="lbl-text">needs repro</span>
+              <div class="lbl-color" style="background: #6a88b5;"></div>
+            </div>
+            <div class="ma-lbl-row">
+              <div class="cb"></div>
+              <span class="lbl-text">good first issue</span>
+              <div class="lbl-color" style="background: var(--accent);"></div>
+            </div>
+          </div>
+          <div class="ma-actions">
+            <button class="btn">cancel</button>
+            <button class="btn accent">apply</button>
+          </div>
+        </div>
+
+        <!-- 4. Repo add/edit -->
+        <div class="ma-modal">
+          <div class="ma-label">04 · add a repo</div>
+          <h4>Add a repo</h4>
+          <div class="ma-field">
+            <span class="lbl">owner/name</span>
+            <span class="val">neonwatty/workers</span>
+          </div>
+          <div class="ma-field">
+            <span class="lbl">local path <em style="font-style: italic; color: var(--ink-faint); font-family: 'Fraunces', serif;">(optional)</em></span>
+            <span class="val">~/code/workers</span>
+          </div>
+          <div class="ma-field">
+            <span class="lbl">branch pattern override</span>
+            <span class="val italic" style="color: var(--ink-faint);">use default (issue-{number}-{slug})</span>
+          </div>
+          <div class="ma-actions">
+            <button class="btn">cancel</button>
+            <button class="btn primary">add repo</button>
+          </div>
+        </div>
+
+        <!-- 5. Clone prompt -->
+        <div class="ma-modal" style="grid-column: 1 / -1;">
+          <div class="ma-label">05 · clone prompt (no local path)</div>
+          <h4>No local path set for <em>neonwatty/docs</em></h4>
+          <div class="ma-warn">
+            <span class="icon">!</span>
+            <span class="text">Launching requires a local clone. You can clone it now to <code>~/code/docs</code>, or cancel and set a different path in settings first.</span>
+          </div>
+          <div class="ma-actions">
+            <button class="btn">cancel</button>
+            <button class="btn">set path manually</button>
+            <button class="btn accent">clone &amp; launch →</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="note" style="width: 100%; max-width: 1000px; margin-top: 20px;">
+      <h4>Modal vocabulary</h4>
+      <ul>
+        <li><b>Warm paper card</b> slightly brighter than the page (#faf4e1) so it floats a touch. Sits over a dimmed paper scrim.</li>
+        <li><b>Label eyebrow</b> in IBM Plex Mono at 9.5px, uppercase, muted — numbers each modal so you can reference them in code.</li>
+        <li><b>Serif italic title</b>, short muted explanation (optional), then the action row at bottom right.</li>
+        <li><b>Button hierarchy:</b> ghost for cancel, ink for neutral primary (save), accent green for primary (apply/clone), brick red for destructive (close).</li>
+        <li><b>Clone prompt</b> spans both columns because its action row has 3 buttons — designed slightly wider to breathe.</li>
+        <li><b>On mobile</b>, all five collapse to full-screen sheets with the same button row at the bottom (sticky). Header pattern is identical.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════════ -->
+<!-- FLOW 12 — SUPPLEMENTS                                          -->
+<!-- ══════════════════════════════════════════════════════════════ -->
+<section class="flow" id="flow12">
+  <div class="flow-head">
+    <div class="flow-num">flow 12</div>
+    <div class="flow-title">Supplements &mdash; nav, PRs, priority</div>
+    <div class="flow-desc">Three gap-fillers I flagged in the coverage review: (1) a mobile navigation drawer so you can reach Settings and Quick Create from the main list, (2) the <em>Pull requests</em> tab variant of the main list with PR-specific row anatomy, and (3) a priority picker that drives list order within each section.</div>
+  </div>
+
+  <div class="frames">
+
+    <!-- 12a · Mobile nav drawer -->
+    <div>
+      <div class="frame-label">mobile · <b>nav drawer open</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <!-- main list visible behind drawer, slightly dimmed -->
+          <div class="bar" style="opacity: 0.4;">
+            <div class="brand">issuectl<span class="dot"></span></div>
+            <div class="menu-icon">···</div>
+          </div>
+          <div class="tabs" style="opacity: 0.4;">
+            <div class="tab on">Issues<span class="c">7</span></div>
+            <div class="tab">Pull requests<span class="c">3</span></div>
+          </div>
+          <div class="list" style="opacity: 0.4;">
+            <div class="section"><h3>unassigned</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item">
+              <div class="check"><svg viewBox="0 0 20 20"><rect class="box" x="2" y="2" width="16" height="16" rx="2"/></svg></div>
+              <div class="title">Rate limit the export endpoint</div>
+              <div class="meta"><span class="repo none">no repo</span></div>
+            </div>
+          </div>
+
+          <div class="scrim"></div>
+          <div class="nd-drawer">
+            <div class="nd-head">
+              <div class="brand">issuectl<span class="dot"></span></div>
+              <div class="x">×</div>
+            </div>
+
+            <div class="nd-section">main views</div>
+            <div class="nd-item on">All issues<span class="arr">›</span></div>
+            <div class="nd-item">Pull requests<span class="arr">›</span></div>
+
+            <div class="nd-section">actions</div>
+            <div class="nd-item">Quick Create<span class="arr">›</span></div>
+            <div class="nd-item">Settings<span class="arr">›</span></div>
+
+            <div class="nd-footer">
+              <div class="row"><span><span class="dot"></span>neonwatty</span><span class="auth">gh ✓</span></div>
+              <div class="row"><span>v0.4.1</span><span class="mono">192.168.1.42:3847</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 12b · PR tab variant -->
+    <div>
+      <div class="frame-label">mobile · <b>pull requests tab</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="bar">
+            <div class="brand">issuectl<span class="dot"></span></div>
+            <div class="menu-icon">···</div>
+          </div>
+          <div class="tabs">
+            <div class="tab">Issues<span class="c">7</span></div>
+            <div class="tab on">Pull requests<span class="c">4</span></div>
+          </div>
+          <div class="srch"><input class="srch-input" placeholder="filter your list…"></div>
+          <div class="list">
+
+            <div class="section"><h3>ready to merge</h3><div class="rule"></div><span class="cnt">1</span></div>
+            <div class="item">
+              <div class="pr-stat pass"></div>
+              <div class="title">Add rate limiting to /api/exports</div>
+              <div class="meta">
+                <span class="repo">api</span>
+                <span class="num">#224</span>
+                <span class="sep">·</span>
+                <span>closes #214</span>
+                <span class="sep">·</span>
+                <span style="color: var(--accent);">CI ✓</span>
+              </div>
+            </div>
+
+            <div class="section"><h3>in review</h3><div class="rule"></div><span class="cnt">2</span></div>
+            <div class="item">
+              <div class="pr-stat pending"></div>
+              <div class="title">Refactor the webhook dispatcher</div>
+              <div class="meta">
+                <span class="repo">api</span>
+                <span class="num">#227</span>
+                <span class="sep">·</span>
+                <span>closes #220</span>
+                <span class="sep">·</span>
+                <span style="color: var(--butter);">CI building…</span>
+              </div>
+            </div>
+            <div class="item">
+              <div class="pr-stat fail"></div>
+              <div class="title">Upgrade Next.js to 15.3</div>
+              <div class="meta">
+                <span class="repo">web</span>
+                <span class="num">#51</span>
+                <span class="sep">·</span>
+                <span style="color: var(--brick);">typecheck failed</span>
+              </div>
+            </div>
+
+            <div class="section"><h3>shipped</h3><div class="rule"></div><span class="cnt">1</span></div>
+            <div class="item">
+              <div class="pr-stat merged"></div>
+              <div class="title done">Polish onboarding empty state</div>
+              <div class="meta">
+                <span class="repo">web</span>
+                <span class="num">#48</span>
+                <span class="sep">·</span>
+                <span>merged 2d ago</span>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 12c · Priority picker -->
+    <div>
+      <div class="frame-label">mobile · <b>priority picker (from detail)</b></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="phone-body paper">
+          <div class="d-bar">
+            <div class="d-back">‹</div>
+            <div class="d-crumb">neonwatty/<b>api</b></div>
+            <div class="d-menu">···</div>
+          </div>
+          <div class="d-body">
+            <div class="d-title">Fix flaky auth middleware under load</div>
+            <div class="d-meta">
+              <span class="repo">api</span>
+              <span class="num">#214</span>
+              <span class="sep">·</span>
+              <span class="state">open</span>
+              <span class="sep">·</span>
+              <span style="color: var(--accent); font-weight: 600;">↑ high priority</span>
+            </div>
+            <div class="d-launch">
+              <h4>Ready to launch</h4>
+              <p>Open Ghostty with Claude Code pre-loaded.</p>
+              <div class="d-launch-actions">
+                <button class="btn-primary">launch →</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="scrim"></div>
+          <div class="sheet">
+            <div class="grab"></div>
+            <div class="sheet-head">
+              <h3>Priority</h3>
+              <p>Drives the order within each section. <em>High</em> bubbles to the top of <em>in focus</em>.</p>
+            </div>
+            <div class="sheet-list">
+              <div class="sheet-row" style="gap: 16px;">
+                <div class="pp-icon on high"></div>
+                <div style="flex: 1;">
+                  <div style="font-family: 'Fraunces', serif; font-size: 16px; color: var(--ink);">high</div>
+                  <div style="font-family: 'Fraunces', serif; font-style: italic; font-size: 11px; color: var(--ink-muted); margin-top: 2px;">bubble to the top</div>
+                </div>
+                <div style="font-family: 'Fraunces', serif; font-style: italic; font-size: 11px; color: var(--accent);">current</div>
+              </div>
+              <div class="sheet-row" style="gap: 16px;">
+                <div class="pp-icon normal"></div>
+                <div style="flex: 1;">
+                  <div style="font-family: 'Fraunces', serif; font-size: 16px; color: var(--ink);">normal</div>
+                  <div style="font-family: 'Fraunces', serif; font-style: italic; font-size: 11px; color: var(--ink-muted); margin-top: 2px;">sort by last updated</div>
+                </div>
+              </div>
+              <div class="sheet-row" style="gap: 16px;">
+                <div class="pp-icon low"></div>
+                <div style="flex: 1;">
+                  <div style="font-family: 'Fraunces', serif; font-size: 16px; color: var(--ink);">low</div>
+                  <div style="font-family: 'Fraunces', serif; font-style: italic; font-size: 11px; color: var(--ink-muted); margin-top: 2px;">sink to the bottom</div>
+                </div>
+              </div>
+            </div>
+            <div class="sheet-cancel">cancel</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="frames" style="margin-top: 8px;">
+    <div class="note">
+      <h4>Mobile navigation</h4>
+      <ul>
+        <li><b>Top-right ···</b> icon opens the drawer from the right.</li>
+        <li><b>Drawer covers ~80% width</b>, scrim behind dims the list. Tap scrim or × to close.</li>
+        <li><b>Two sections</b>: main views (All issues, PRs) and actions (Quick Create, Settings).</li>
+        <li><b>Footer</b> shows auth status, version, and the LAN-bound address so you can tell someone else the URL.</li>
+      </ul>
+    </div>
+    <div class="note">
+      <h4>PR row anatomy</h4>
+      <ul>
+        <li><b>Status dot replaces checkbox</b> — a filled ✓ circle for CI pass, a brick × for CI fail, a pulsing yellow dot for CI pending, a purple filled ✓ for merged.</li>
+        <li><b>Meta line</b>: repo · #num · <em>closes #X</em> · CI status + age.</li>
+        <li><b>Sections renamed</b> for PRs: <em>ready to merge / in review / shipped</em> (no "unassigned," no "in flight").</li>
+        <li><b>Swipe on a PR row</b> goes to the PR detail (no assign action — PRs are always on a repo).</li>
+      </ul>
+    </div>
+    <div class="note">
+      <h4>Priority &amp; order</h4>
+      <ul>
+        <li><b>Three levels</b>: high / normal / low. Default is normal. Local-only, never synced to GitHub.</li>
+        <li><b>Sort rule within a section</b>: high first, then normal, then low. Ties break by updated-at.</li>
+        <li><b>No manual drag-to-reorder</b> — changing priority is how you reorder. Simpler than a drag gesture, works on desktop too.</li>
+        <li><b>Visual marker</b> on high-priority rows only: small <code>↑</code> glyph on the meta row (seen on the detail page in this frame). Normal and low have no marker — position in the list carries the signal.</li>
+        <li><b>Picker triggered</b> from the detail page (tap the priority indicator in the meta row) and from the new-issue form (priority field below the repo field).</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="open-questions">
+  <h3>Decisions so far</h3>
+  <ul>
+    <li><b>Network model:</b> app runs locally on a PC/Mac and binds to the LAN interface so phones on the same network can reach it directly. Remote access is user-managed via VPN. No auth shim in v1 — trust the LAN/VPN.</li>
+    <li><b>Priority default:</b> new drafts start at <em>normal</em>.</li>
+    <li><b>Welcome copy:</b> pulled back from "quiet place" to something more functional — <em>"every issue, every repo. launch any of them with Claude Code."</em></li>
+    <li><b>Empty-list mark:</b> replaced ✓ with <b>❧</b> (hedera, a classical typographic ornament marking "end of section"). More paper-notebook, less checkmark.</li>
+    <li><b>Section names:</b> keeping <em>unassigned / in focus / in flight / shipped</em> for v1.</li>
+  </ul>
+  <h3 style="margin-top: 22px;">Screen coverage</h3>
+  <ul>
+    <li><b>Complete.</b> Two audit agents compared the current app code, the spec, and the original mockup against this set. All essential v1 screens are now mocked: main list, issue detail, new issue, Claude launch (form + progress), first run, empty state, settings, quick create (3-step), PR detail, auth error, and the 5 small modal patterns (close / edit / labels / add repo / clone prompt).</li>
+    <li><b>Intentionally deferred to the design doc as text-only:</b> 404 page, generic error boundary, loading skeletons, inline comment form (visible in issue detail), PR tab variant of the main list (trivial variant).</li>
+  </ul>
+</div>
+
+</body>
+</html>

--- a/docs/specs/2026-04-10-todo-reskin-design.md
+++ b/docs/specs/2026-04-10-todo-reskin-design.md
@@ -371,15 +371,18 @@ Toast notifications use a small bottom-center sheet pattern (not mocked in Flow 
 
 ## Testing
 
-No test framework is currently set up. When adding one (Vitest is the intended choice), prioritize:
+**Correction to earlier draft:** Vitest is already set up in `packages/core` (see `package.json`'s `test` / `test:integration` scripts and the many `*.test.ts` files under `packages/core/src/db/`). New core code for this reskin follows the existing convention: `*.test.ts` alongside each source file, using the `createTestDb()` helper from `src/db/test-helpers.ts`.
 
-1. **Draft lifecycle** — `createDraft` → `assignDraftToRepo` → verify the GitHub issue was created with the expected title/body and the draft row was deleted.
-2. **Priority ordering** — verify `listIssues` returns rows sorted by `priority DESC, updated_at DESC` within each section.
-3. **Section assignment rules** — unit test the logic that groups issues into `unassigned / in focus / in flight / shipped`.
-4. **Swipe gesture handler** — unit test threshold detection and reveal/trigger states.
-5. **Launch progress streaming** — integration test that `/launch/...` emits the five steps in order for a happy path, and that an error on any step transitions that step to the error state.
+The web package does not currently have a component test framework. Phase 2 primitives and Phase 3+ components are validated by visual inspection and downstream usage rather than unit tests — consistent with the existing web package convention. Adding a React testing setup (Vitest + `@testing-library/react`) is a reasonable follow-up but out of scope for this reskin.
 
-Visual regression tests are out of scope for v1.
+Priority test surfaces for the reskin work:
+
+1. **Draft lifecycle** — `createDraft` → `assignDraftToRepo` → verify the GitHub issue was created with the expected title/body and the draft row was deleted. Use a fake Octokit object in the test.
+2. **Priority store** — `setPriority`, `getPriority` (with `normal` fallback), `deletePriority`, `listPrioritiesForRepo`.
+3. **Section assignment rules** — unit test the logic (added in Phase 3) that groups issues into `unassigned / in focus / in flight / shipped`.
+4. **Swipe gesture handler** — unit test threshold detection and reveal/trigger states (Phase 3).
+
+Since `issuectl` is a single-user tool, hand testing is the primary quality gate beyond the core unit tests; end-to-end and visual regression tests are out of scope for v1.
 
 ---
 

--- a/docs/specs/2026-04-10-todo-reskin-design.md
+++ b/docs/specs/2026-04-10-todo-reskin-design.md
@@ -35,6 +35,7 @@ The change is primarily visual and informational. The data model grows (drafts, 
 - Preserving the old dashboard or per-repo pages.
 - Offline mode — still online-first with SQLite-backed read cache.
 - Dark mode — Paper *is* the theme.
+- Multi-user coordination, feature flagging, or gradual rollout — `issuectl` is a single-user tool (the author); we ship in one go.
 
 ---
 
@@ -384,14 +385,24 @@ Visual regression tests are out of scope for v1.
 
 ## Rollout
 
-This is a breaking UI change. There is no backwards-compat mode.
+This is a breaking UI change. No backwards-compat mode, no feature flag: `issuectl` is a single-user tool (the author), so there's no coordination required and no other users to protect. We ship in one go.
 
 1. The DB migration to v5 runs automatically on first start after the update, adding `drafts` and `issue_metadata`.
-2. Old routes and components are deleted in the same PR that adds the new ones.
+2. Old routes and components are deleted in the same PRs that add their replacements.
 3. Existing repos, settings, deployments, and cached issues/PRs are preserved — the new UI reads from the same underlying tables.
-4. One-shot cutover. No feature flag. The user base is small enough that maintaining both codepaths would add more complexity than it saves.
 
-The implementation plan should decompose this into phases that keep the app in a working state between merges — e.g., add data layer first (drafts + priority) behind no UI change, then replace the dashboard, then replace the detail pages, then delete the old routes.
+The implementation plan should still decompose this into phases — not for continuous availability, but for **reviewability**. Smaller PRs are easier to review, revert, and bisect when something goes wrong. A reasonable decomposition:
+
+1. **Data layer** — `drafts` and `issue_metadata` tables, core CRUD functions, priority-aware query helpers, schema migration to v5. No UI changes.
+2. **Paper design tokens + shared primitives** — `globals.css` Paper tokens; reusable primitives like `Chip`, `Row`, `Sheet`, `Drawer`, button variants. Can coexist with the old UI.
+3. **Main list** — replace `app/page.tsx` with the flat cross-repo list, its swipe handler, and its section/priority logic. At this point the old dashboard is gone.
+4. **Issue + PR detail** — add `/issues/[owner]/[repo]/[number]` and `/pulls/[owner]/[repo]/[number]` routes with the new Paper detail views.
+5. **Launch flow UI** — new `/launch/...` progress route; update the launch form to Paper; wire the new progress streaming.
+6. **Settings + Quick Create + Auth error + empty states** — restyle these surfaces; backend unchanged.
+7. **Mobile nav drawer + PR tab variant + priority picker sheet** — the supplementary flows from `#flow12`.
+8. **Cleanup** — delete the old `components/dashboard/`, `components/repo/`, `components/sidebar/` directories and the orphaned `[owner]/[repo]/...` routes.
+
+The app may be in a partly-broken state between phases 3 and 8 — that's acceptable since there's only one user.
 
 ---
 

--- a/docs/specs/2026-04-10-todo-reskin-design.md
+++ b/docs/specs/2026-04-10-todo-reskin-design.md
@@ -1,0 +1,415 @@
+# issuectl — Todo-List Reskin (Paper Edition)
+
+**Date:** 2026-04-10
+**Status:** Draft (for review)
+**Supersedes:** Visual layer of `docs/specs/2026-04-06-issuectl-design.md`. Monorepo structure, launch flow backend, Octokit integration, `gh auth` reliance, and SQLite cache are preserved.
+**Mockups:** `docs/mockups/paper-reskin.html` — open directly in a browser. Flow anchors `#flow1` through `#flow12` correspond to the numbered sections below.
+
+---
+
+## Overview
+
+Reskin `issuectl` from a GitHub-browser aesthetic (dashboard with repo grid + per-repo issue tables) into a **cross-repo personal todo list**: a single flat list of issues across every tracked repo, mobile-first, in a distinctive "Paper" visual language. Introduce **local draft issues** — author an issue inside the app without a target repo, then assign it to a repo later, at which point it syncs to GitHub as a real issue. Introduce **local priority** (high / normal / low) that drives list ordering within each section.
+
+The change is primarily visual and informational. The data model grows (drafts, priority) but the launch flow backend, Octokit calls, `gh auth` reliance, SQLite cache, and Claude CLI parse pipeline all remain intact. The old dashboard, per-repo pages, and sidebar are removed.
+
+---
+
+## Goals
+
+1. **Single cross-repo list** as the primary (and nearly only) view. No repo grid, no per-repo drill-down.
+2. **Mobile-first responsive layout.** Same web app, same local server, different viewport widths. Phones reach the app via the LAN IP (same network) or the user's own VPN (remote).
+3. **Distinctive "Paper" visual language** — warm cream background, deep ink text, forest green accent, italic Fraunces serif display, Inter body, IBM Plex Mono identifiers. Intentional and non-generic.
+4. **Local draft issues** — create an issue inside the app without a target repo. Persisted to local SQLite. Assigning to a repo pushes it to GitHub as a real issue.
+5. **Local priority** drives list ordering. Three levels (high / normal / low), default normal. Within a section: high first, then normal by updated-at, then low.
+6. **Swipe-from-right to assign** on mobile (signature interaction). Desktop equivalent: hover on a row reveals quick-action buttons.
+7. **LAN-bound server.** Next.js binds to the machine's LAN interface by default so phones on the same network can reach it directly.
+
+## Non-goals
+
+- Native mobile app (we're a web app running on the user's PC/Mac).
+- Auth shim, login flow, or per-device approval — trust the LAN / VPN in v1.
+- Deployed / hosted / multi-tenant mode.
+- Keyboard shortcuts in the web UI.
+- Manual drag-to-reorder (priority handles ordering).
+- Preserving the old dashboard or per-repo pages.
+- Offline mode — still online-first with SQLite-backed read cache.
+- Dark mode — Paper *is* the theme.
+
+---
+
+## Vocabulary
+
+The reskin uses **"issue"** everywhere, never "task." Additional terms:
+
+- **Draft** — a local issue that has not yet been pushed to GitHub. Has a title, body, and priority; no repo assignment.
+- **Assigned** — a draft after it's been pushed to a repo. Becomes a normal GitHub issue with a number.
+- **Launched** — an issue that has had a Claude Code session opened for it. The session can be active or ended.
+- **In flight** — an issue with an active launch.
+- **Shipped** — an issue that is closed or has a merged linked PR.
+- **Sections** — fixed for v1: `unassigned` / `in focus` / `in flight` / `shipped`.
+
+---
+
+## Information architecture
+
+### Routes
+
+| Route | Purpose |
+|---|---|
+| `/` | Main list (Issues tab, cross-repo). `?tab=prs` switches to Pull requests. |
+| `/settings` | Settings page. |
+| `/create` | Quick Create natural-language parse flow. |
+| `/drafts/[draftId]` | Local draft detail (pre-assignment). |
+| `/issues/[owner]/[repo]/[number]` | Issue detail. |
+| `/pulls/[owner]/[repo]/[number]` | PR detail. |
+| `/launch/[owner]/[repo]/[number]` | Launch progress view (shown while the server provisions and opens Ghostty). |
+
+All old routes under `/[owner]/[repo]/...` are removed.
+
+### Navigation
+
+- **Desktop**: a top tab bar inside the main list header — `Issues / Pull requests / Quick Create / Settings`. A `+ new issue` button sits to the right of the date. (The Flow 01 desktop mockup shows three tabs for visual compactness; the Quick Create tab is in scope.)
+- **Mobile**: the main list top bar has a `···` menu icon in the top right. Tapping it slides a drawer in from the right with `All issues` (active), `Pull requests`, `Quick Create`, `Settings`. The drawer footer shows auth status (`gh ✓`), version, and the LAN-bound address so the user can tell someone else the URL.
+- **Detail → list**: a `‹` back arrow on mobile, a `back to list` text link on desktop.
+
+---
+
+## Visual language
+
+All tokens live in `packages/web/app/globals.css` as CSS custom properties. Component styles use CSS Modules referencing those tokens. The `frontend-design` skill handles the actual CSS authoring during implementation.
+
+### Color tokens
+
+| Token | Hex | Use |
+|---|---|---|
+| `--bg` | `#f3ecd9` | Primary background — warm cream. |
+| `--bg-warm` | `#ede5cf` | Slightly recessed surface (launch card, modal card). |
+| `--bg-warmer` | `#e6dec4` | Repo chip background, tag surfaces. |
+| `--ink` | `#1a1712` | Primary text — deep warm near-black. |
+| `--ink-soft` | `#3a342a` | Body text. |
+| `--ink-muted` | `#8a7f63` | Secondary text, labels. |
+| `--ink-faint` | `#b5a88a` | Tertiary text, placeholders, hints. |
+| `--line` | `#e0d6bc` | Borders, section dividers. |
+| `--line-soft` | `#e9dfc6` | Row dividers (subtler). |
+| `--accent` | `#2d5f3f` | Forest green — primary action, done state, active tab underline. |
+| `--accent-soft` | `#dce8de` | Green-tinted chip surface. |
+| `--brick` | `#b84a2e` | Error, destructive actions, bug label, CI failure. |
+| `--butter` | `#d9a54d` | Feature label, CI pending / building state. |
+
+A subtle paper-noise SVG overlay at 18% opacity + `mix-blend-mode: multiply` sits under all content on `.paper` surfaces. Not kitschy — just enough texture to keep the cream from feeling flat.
+
+### Typography
+
+| Family | Use |
+|---|---|
+| **Fraunces** (variable serif, italic + roman, 400–700) | Brand, display titles, section headers, tabs, row titles, body text, italic italic italic — the signature voice. |
+| **Inter** (400–600) | Meta rows, dates, small UI text. |
+| **IBM Plex Mono** (400–600) | Repo names, issue numbers, file paths, counts, any identifier. |
+
+Key sizes: 34px mobile brand (40px desktop), 26px mobile detail title (36px desktop), 17px row title, 13–14px meta, 11–12px labels. Generous leading everywhere.
+
+### Spacing & radii
+
+Base 4px. Common paddings: 22–24px top bar, 24px list horizontal, 16px row vertical, 12–14px card inner. Radii: 3px tags, 6px buttons, 8px inputs, 10–14px cards, 40px phone frame, 50% avatars.
+
+### Accent usage rules
+
+- **Forest green** only for *action* or *progress*: launch buttons, assign reveal, checkbox fills, "in flight" pulse, active tab underline, `gh ✓` authenticated indicator.
+- **Brick red** only for *error* or *destructive*: bug label, close-issue button, CI failure dot, auth error icon.
+- **Butter yellow** only for *pending*: feature label, CI building dot.
+- **Ink** for *neutral primary* buttons (save, edit, send) and the FAB.
+- Everything else is the ink → muted → faint grayscale on cream.
+
+---
+
+## Data model changes
+
+### New table: `drafts`
+
+```sql
+CREATE TABLE drafts (
+  id          TEXT PRIMARY KEY,                      -- uuid v4
+  title       TEXT NOT NULL,
+  body        TEXT NOT NULL DEFAULT '',
+  priority    TEXT NOT NULL DEFAULT 'normal'
+              CHECK (priority IN ('low', 'normal', 'high')),
+  created_at  INTEGER NOT NULL,                      -- unix seconds
+  updated_at  INTEGER NOT NULL
+);
+```
+
+A draft has no `repo_id` — the absence is what makes it a draft. On assignment, the draft is pushed to the chosen repo via Octokit, the returned GitHub issue is cached, and the draft row is deleted.
+
+### New table: `issue_metadata`
+
+```sql
+CREATE TABLE issue_metadata (
+  repo_id       INTEGER NOT NULL,
+  issue_number  INTEGER NOT NULL,
+  priority      TEXT NOT NULL DEFAULT 'normal'
+                CHECK (priority IN ('low', 'normal', 'high')),
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (repo_id, issue_number),
+  FOREIGN KEY (repo_id) REFERENCES repos(id) ON DELETE CASCADE
+);
+```
+
+Local-only metadata keyed to a GitHub issue. Never synced. A row exists only when a non-default priority has been set (absence means `normal`).
+
+### Section assignment (computed, not stored)
+
+Sections are derived at query time, not stored:
+
+| Section | Rule |
+|---|---|
+| `unassigned` | Rows from the `drafts` table. |
+| `in focus` | Open GitHub issues that are NOT "in flight" and NOT recently shipped. |
+| `in flight` | Open GitHub issues with an active launch (row in `deployments` with `ended_at IS NULL`). |
+| `shipped` | Issues that are closed OR have a merged linked PR (via `linked_pr` in the cache). |
+
+Within each section, order is `priority DESC, updated_at DESC`. Priority for issues with no `issue_metadata` row is `normal`. Draft priority comes from `drafts.priority`.
+
+### Existing tables
+
+Unchanged: `repos`, `settings`, `deployments`, `cache_*`. The `claude_aliases` table was already dropped in the pre-reskin work (replaced by `claude_extra_args`). Schema version bumps from v4 → v5 with the new tables.
+
+---
+
+## Flows
+
+Each flow references a named anchor in the mockup file `paper-all.html`.
+
+### Flow 01 — Main list (the home) — `#flow1`
+
+The landing page. Cross-repo flat list grouped into sections, with tabs for Issues and Pull requests.
+
+- **Mobile**: single column. Top bar has brand + date + `···` menu icon. Below: Issues / PRs tabs (with mono counts). Below that: an italic-serif search input. Then the list. A floating `+` button (FAB, ink circle) anchors the bottom right for creating a new draft.
+- **Desktop**: centered column (max ~900px), no sidebar. Top bar has brand + version + date + `+ new issue` button. Tabs include `Settings`. Hover on a row reveals quick-action buttons (`assign` / `reassign` / `launch`) flush-right.
+- **Sections**: `unassigned` (only shown when drafts exist) / `in focus` / `in flight` / `shipped` (only shown when there's anything shipped).
+- **Row anatomy**: checkbox (4 states: open, in-flight pulsing, done, draft) · Fraunces 17px title (strikethrough in accent green when done) · meta row with repo chip (or dashed italic "no repo") · mono `#num` · label (brick for bug, butter for feature) · relative age.
+
+### Flow 02 — Issue detail — `#flow2`
+
+- **Mobile**: full-screen. Top bar: `‹` back · `owner/`**repo** breadcrumb · `···` menu. Body: title · meta · launch card · body text · comments · sticky composer pinned to the bottom.
+- **Desktop**: centered 820px column with a right side column (240px) holding the launch card + metadata blocks (assignee, milestone, labels, referenced files).
+- **Launch card**: forest-green left bar, "Ready to launch" heading, one-line description mentioning the would-be worktree path, `launch →` primary and `configure` ghost button.
+- **Comments**: threaded, monogram avatar, author name, relative time, body. All Fraunces, warm card surfaces.
+- **Composer**: a sticky italic input anchored to the bottom on mobile; an inline textarea on desktop.
+
+### Flow 03 — New issue creation (drafts) — `#flow3`
+
+Tapping the FAB (mobile) or `+ new issue` (desktop) opens a full-screen form on mobile or a 640px modal on desktop. The title input is the hero: 26px Fraunces with an italic placeholder that fades as you type. Body is a multi-line version of the same. Below a divider: `repo` field (defaults to italic green dashed "unassigned"), `labels` field (disabled with "assign a repo first" until a repo is picked), `priority` field (defaults to normal, tap opens the picker). Two save paths: `save draft` (quiet, stays local) and `assign & save` (opens the assign sheet, then pushes to GitHub).
+
+### Flow 04 — Claude Code launch — `#flow4`
+
+- **Mobile**: full-screen launch form. Top bar has `‹` back · `Launch` · `launch →` in accent green. An issue reference block (with forest-green left bar) sits at the top. Form fields below: workspace (`new worktree` / `existing clone`), branch, preamble, context toggles (comments, referenced files, linked PRs), claude extra args.
+- **Desktop**: centered 580px modal with the same fields, `save as default` ghost and `launch →` accent button at the bottom.
+- **Mobile and desktop behave identically on submit**: the request hits the local server running on the user's Mac, which spawns Ghostty on the Mac. Mobile is just a narrower viewport of the same local app.
+
+### Flow 05 — First run & empty states — `#flow5`
+
+- **Welcome screen** (first open, no repos yet): huge italic brand, functional tagline *"every issue, every repo. launch any of them with Claude Code."*, a green `gh ✓ authenticated` pill, `add your first repo` CTA, hint to create a draft without a repo.
+- **All-clear empty list**: `❧` hedera ornament in accent green, "all clear" heading, hint line *"breathe, or draft the next one."*
+
+### Flow 06 — Settings — `#flow6`
+
+One settings surface with four sections and a footer:
+
+1. **Tracked repos** — list with colored dot, name, local path, edit. `+ add a repo` row at the bottom opens the repo add modal (Flow 11).
+2. **Defaults** — branch pattern, cache TTL, terminal (`Ghostty · v1`, read-only with a v2 hint).
+3. **Claude config** — extra args, default preamble template.
+4. **Worktree cleanup** — list of stale worktrees (linked to merged/closed issues) with per-row remove and a `remove all stale` bulk action.
+5. **About** (footer block) — auth status (green ✓), version, data file path + size, network-bound address.
+
+No global "save" button — fields commit on blur with a subtle "saved" flash on the field itself.
+
+### Flow 07 — Quick Create — `#flow7`
+
+The existing 3-step natural-language parse flow, restyled. Input → Review → Results, with a three-dot stepper at the top of each step. Backend is unchanged (still uses the Claude CLI).
+
+### Flow 08 — PR detail — `#flow8`
+
+Sibling of the issue detail. CI check list replaces the launch card. Files changed diff list replaces the referenced-files sidebar block. Merge button (accent green) sits where the launch button would be, shown only when CI is green. Same top bar, same composer, same side-column pattern.
+
+### Flow 09 — Launch progress — `#flow9`
+
+Shown at `/launch/[owner]/[repo]/[number]` after the launch form submits. A stepped checklist of what the server is doing:
+
+1. Assembled context (with count of comments + files)
+2. Created worktree (with path)
+3. Checked out branch (with branch name)
+4. Opening Ghostty…
+5. Apply "launched" label
+
+Active step pulses its inner dot in accent green. Completed steps fill and show a check. Pending steps stay faint. A calm footer message reminds the user the Ghostty window appears on their Mac, not in the browser. On error, the active step turns brick red and shows a `retry` / `open logs` action.
+
+### Flow 10 — Auth error — `#flow10`
+
+Shown on app load if `gh` CLI is missing or unauthenticated. Full-screen Paper page: brick-red dashed circle with `!` glyph, "GitHub CLI not ready" heading, three numbered remediation steps with mono `code` spans, `retry →` button. Blocks the app until auth is fixed.
+
+The same layout pattern applies to other fatal startup errors (SQLite inaccessible, port in use) with different glyphs and copy.
+
+### Flow 11 — Modal anthology — `#flow11`
+
+Five small overlays that share one pattern: warm paper card on a darker paper scrim, monospace eyebrow label, italic serif title, muted explanation, action row at bottom right. Button hierarchy: ghost for cancel, ink for neutral primary (save), accent green for primary (apply, clone), brick red for destructive (close).
+
+1. **Close issue confirmation** — destructive, brick red button.
+2. **Edit issue** — reuses new-issue form shape with existing values pre-filled; `save changes` ink button.
+3. **Label manager** — checkbox list scoped to the target repo's available labels with color dots; `apply` accent button.
+4. **Add a repo** — owner/name, local path (optional), branch pattern override; `add repo` ink button.
+5. **Clone prompt** — warning card shown when launching an issue in a repo with no local path; choices: `cancel` / `set path manually` / `clone & launch →`.
+
+On mobile, all five collapse to full-screen sheets with the same button row sticky at the bottom.
+
+### Flow 12 — Supplements — `#flow12`
+
+- **Mobile nav drawer** — the `···` top-right icon opens a right-side drawer with `All issues` (on), `Pull requests`, `Quick Create`, `Settings`. Footer shows auth + version + LAN-bound address.
+- **PR tab variant of the main list** — `Pull requests` tab active, PR-specific row anatomy: status dot replaces the checkbox (✓ passing / × failing / pulsing butter building / purple merged). Sections rename to `ready to merge / in review / shipped`.
+- **Priority picker** — bottom sheet triggered from the detail page meta row or the new-issue form. Three options (high / normal / low), current selection marked, short italic descriptions. On the detail meta row, a high-priority issue gets a small `↑` glyph before "high priority." Normal and low have no glyph on the detail page. The **list rows show no priority glyph at all** — position within the section is the signal.
+
+---
+
+## What's being removed
+
+| File / component | Disposition |
+|---|---|
+| `app/page.tsx` (dashboard repo grid) | Rewritten to the flat list. |
+| `app/[owner]/[repo]/page.tsx` | Deleted; replaced by the flat list. |
+| `app/[owner]/[repo]/issues/[number]/page.tsx` | Moved to `/issues/[owner]/[repo]/[number]`. |
+| `app/[owner]/[repo]/pulls/[number]/page.tsx` | Moved to `/pulls/[owner]/[repo]/[number]`. |
+| `components/dashboard/RepoGrid.tsx` | Deleted. |
+| `components/dashboard/RepoCard.tsx` | Deleted. |
+| `components/dashboard/DashboardCacheStatus.tsx` | Deleted. Cache/auth status moves into the Settings "about" block. |
+| `components/dashboard/CacheBar.tsx` | Deleted. |
+| `components/repo/RepoHeader.tsx` | Deleted. |
+| `components/repo/IssuesTable.tsx` | Replaced by the new cross-repo list component. |
+| `components/repo/PullsTable.tsx` | Replaced by the PR variant of the same list. |
+| `components/repo/TabBar.tsx` | Replaced by the new top tabs inside the list header. |
+| `components/sidebar/Sidebar.tsx` | Replaced by mobile nav drawer + desktop top tabs. |
+
+## What's being added
+
+- **Cross-repo list component suite** under `components/list/` — `List.tsx`, `ListSection.tsx`, `ListRow.tsx`, `PrRow.tsx`, `RowActions.tsx`.
+- **Assign sheet** (`components/list/AssignSheet.tsx`) — bottom sheet reused for assign and reassign.
+- **Priority picker sheet** (`components/list/PrioritySheet.tsx`).
+- **Nav drawer** (`components/nav/NavDrawer.tsx`).
+- **Draft store** in core (`packages/core/src/db/drafts.ts`): `createDraft`, `listDrafts`, `getDraft`, `updateDraft`, `deleteDraft`, `assignDraftToRepo`.
+- **Priority store** in core (`packages/core/src/db/priority.ts`): `setPriority`, `getPriority`, `deletePriority`.
+- **DB migration** — schema version v4 → v5 adding `drafts` and `issue_metadata` tables.
+- **LAN binding** — the `issuectl web` command binds Next.js to the machine's LAN interface by default, with a `--host` override and a `--local-only` flag to revert to loopback. Prints the bound URL at startup.
+- **Paper CSS tokens** — all color / type / spacing values in `app/globals.css` as custom properties.
+- **Swipe gesture handler** — a small touch-event utility for list rows (threshold-based reveal + trigger).
+- **`/launch/[owner]/[repo]/[number]` route** — the launch progress view with streaming step updates.
+- **`/drafts/[draftId]` route** — local draft detail view.
+- **Loading, 404, error boundary** — Paper-styled `loading.tsx`, `not-found.tsx`, `error.tsx` at the root and at each relevant nested level.
+
+## What stays (backend mostly unchanged)
+
+- **Launch flow backend** — context building (`core/launch/context.ts`), branch creation, Ghostty spawning. The new `/launch/` route wraps it with step-by-step progress streaming but the logic is unchanged.
+- **Octokit integration** — all GitHub calls remain. One new server action: `createIssueFromDraft(draft, targetRepo)` wraps `octokit.issues.create`.
+- **`gh auth token` integration** — unchanged.
+- **SQLite cache** — unchanged; new tables are purely additive.
+- **Claude CLI parse flow** — unchanged backend, restyled UI.
+- **Settings backend** — `claude_extra_args`, `cache_ttl`, `branch_pattern`, `terminal` stay in the `settings` table.
+
+---
+
+## Network & auth
+
+### Server binding
+
+The Next.js server currently binds to `127.0.0.1`. Change `issuectl web` to:
+
+1. Detect the primary LAN interface (e.g., via `os.networkInterfaces()`).
+2. Bind Next.js to `0.0.0.0` so it accepts connections from any interface.
+3. Print both the LAN URL and the loopback URL at startup. Example:
+   ```
+   issuectl web
+     →  http://192.168.1.42:3847  (LAN — reachable from phones on this network)
+     →  http://localhost:3847     (loopback)
+   ```
+4. Accept a `--host` flag to override the bound address.
+5. Accept a `--local-only` flag to force loopback-only binding for untrusted networks.
+
+The Settings → About → "network" field shows the currently-bound address so the user can copy it to their phone.
+
+### Auth
+
+No auth shim in v1. The user is responsible for network access control:
+
+- **Same network** → direct LAN URL works.
+- **Remote** → user's own VPN.
+- **Untrusted network (coffee shop)** → use `--local-only` or disconnect from that network.
+
+This is documented in the startup banner and in Settings → About. A v2 could add a token-in-URL or per-device approval.
+
+### Security considerations
+
+- The `gh auth token` used by the server is **never exposed to the client.** All GitHub API calls run server-side via Server Actions.
+- Cached issue / PR data in SQLite contains no secrets — only body text and GitHub metadata.
+- Launching Claude Code triggers a shell command on the server (`open -na Ghostty ...`). This is reachable via any client that can hit the bound server. Relies on the LAN/VPN trust model.
+- `gh` command execution from the server uses argv-array invocation (not shell interpolation) — already the case in the existing code.
+
+---
+
+## Error handling
+
+| Situation | Handling |
+|---|---|
+| `gh` CLI missing or unauthenticated | Flow 10 screen blocks the app. |
+| GitHub API network error on list fetch | Show cached data with a small "updated N ago" indicator; retry button in the top bar. |
+| Launch step failure | Flow 09's active step turns brick red, shows error text + `retry` / `open logs` actions. |
+| Draft assign failure (GitHub push error) | Toast + keep the draft in its unassigned state with an error flag; user can retry from the detail page. |
+| 404 | Paper-styled `not-found.tsx` with link back to the list. |
+| Uncaught error | `app/error.tsx` in Paper vocabulary; shows error message in development only. |
+
+Toast notifications use a small bottom-center sheet pattern (not mocked in Flow 11's anthology; will be designed inline with implementation). The design vocabulary is: ink card with forest green check for success, brick red `!` for error, ~4s auto-dismiss, tap to dismiss.
+
+---
+
+## Testing
+
+No test framework is currently set up. When adding one (Vitest is the intended choice), prioritize:
+
+1. **Draft lifecycle** — `createDraft` → `assignDraftToRepo` → verify the GitHub issue was created with the expected title/body and the draft row was deleted.
+2. **Priority ordering** — verify `listIssues` returns rows sorted by `priority DESC, updated_at DESC` within each section.
+3. **Section assignment rules** — unit test the logic that groups issues into `unassigned / in focus / in flight / shipped`.
+4. **Swipe gesture handler** — unit test threshold detection and reveal/trigger states.
+5. **Launch progress streaming** — integration test that `/launch/...` emits the five steps in order for a happy path, and that an error on any step transitions that step to the error state.
+
+Visual regression tests are out of scope for v1.
+
+---
+
+## Rollout
+
+This is a breaking UI change. There is no backwards-compat mode.
+
+1. The DB migration to v5 runs automatically on first start after the update, adding `drafts` and `issue_metadata`.
+2. Old routes and components are deleted in the same PR that adds the new ones.
+3. Existing repos, settings, deployments, and cached issues/PRs are preserved — the new UI reads from the same underlying tables.
+4. One-shot cutover. No feature flag. The user base is small enough that maintaining both codepaths would add more complexity than it saves.
+
+The implementation plan should decompose this into phases that keep the app in a working state between merges — e.g., add data layer first (drafts + priority) behind no UI change, then replace the dashboard, then replace the detail pages, then delete the old routes.
+
+---
+
+## Open questions / future work
+
+- **Drag-to-reorder** — deferred. Priority is the v1 answer.
+- **Native mobile app** — deferred. Web at LAN/VPN is v1.
+- **Keyboard shortcuts** — non-goal for v1.
+- **Toast pattern visual design** — described above; will be designed inline during implementation.
+- **Priority beyond 3 levels** — unlikely; stay at low/normal/high.
+- **Labels on drafts** — disabled until assignment in v1. A v2 could pre-suggest labels based on the target repo.
+- **PR section naming** — `ready to merge / in review / shipped` is a guess. If it feels wrong in use, revisit.
+- **Launched labels beyond "issuectl:launched"** — the existing lifecycle label system (`issuectl:launched`, `issuectl:deployed`) is preserved unchanged.
+
+---
+
+## Mockup reference
+
+The full mockup file is committed at `docs/mockups/paper-reskin.html`. Open it directly in a browser — no server needed. The flows anchor at `#flow1` through `#flow12`, matching the numbered flow sections above.
+
+The mockup is the visual reference for implementation. The `frontend-design` skill should be invoked during the UI implementation phase to author the actual CSS Modules and component code from these tokens and frames.

--- a/docs/specs/2026-04-10-todo-reskin-implementation-plan.md
+++ b/docs/specs/2026-04-10-todo-reskin-implementation-plan.md
@@ -1,0 +1,2331 @@
+# Paper Reskin Implementation Plan — Phase 1 & 2
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the foundation for the Paper reskin by adding the data-layer support for local drafts and per-issue priority, plus the Paper visual design tokens and shared primitives that every Phase 3+ screen will build on.
+
+**Architecture:** Phase 1 is pure backend — new SQLite tables, CRUD functions, and a workflow function that pushes a draft to GitHub. Phase 2 is pure CSS + atomic React components — no routes change, no data flows, just new primitives ready to use. After these two phases, the app still runs unchanged visually but has everything needed for Phase 3 to replace the dashboard.
+
+**Tech Stack:** pnpm workspaces + Turborepo · TypeScript (strict) · better-sqlite3 · Vitest (already set up in `@issuectl/core`) · Octokit · Next.js App Router · CSS Modules.
+
+**Scope:** Phase 1 (Data Layer) + Phase 2 (Paper Tokens + Primitives) from the 8-phase rollout in `docs/specs/2026-04-10-todo-reskin-design.md`. Phases 3–8 will be planned in follow-up documents once these foundations land.
+
+---
+
+## Overview
+
+This plan implements two of the eight phases from the Paper reskin spec. Each task is a bite-sized TDD cycle where applicable, with exact file paths, complete code, and explicit commands.
+
+**Phase 1 — Data Layer.** Add `drafts` and `issue_metadata` tables, their CRUD functions, and the `assignDraftToRepo` workflow function that pushes a draft to GitHub via Octokit. Follows the existing core package convention: explicit `db` parameter, explicit `octokit` parameter, Vitest unit tests alongside each file.
+
+**Phase 2 — Paper Tokens + Shared Primitives.** Replace the existing `globals.css` light/dark theme with the Paper palette (warm cream + forest green accent + italic serif display). Add Google Fonts imports via `next/font`. Create atomic primitives — `Chip`, `Button`, `Sheet`, `Drawer` — that Phase 3 screens will compose. No component tests (existing web convention).
+
+**Convention reminders** (from `CLAUDE.md`):
+- ESM everywhere. Strict TypeScript.
+- No classes — plain functions and objects.
+- DB functions take `db: Database.Database` as first param. GitHub functions take `octokit: Octokit` as first param. No globals.
+- Test files live next to the code (`foo.test.ts` alongside `foo.ts`).
+- CSS Modules per component, tokens in `app/globals.css`.
+
+## Prerequisites
+
+- [ ] Clean working tree on `main`: run `git status` — should show no modifications
+- [ ] `pnpm install` completes without errors
+- [ ] `pnpm turbo typecheck` passes
+- [ ] `pnpm turbo build` passes
+- [ ] `pnpm -F @issuectl/core test` passes (existing Vitest suite is green)
+- [ ] `gh auth status` shows an authenticated user
+
+Read these before starting:
+
+1. `docs/specs/2026-04-10-todo-reskin-design.md` — the spec this plan implements
+2. `docs/mockups/paper-reskin.html` — the visual reference (open in a browser; see anchors `#flow1`–`#flow12`)
+3. `packages/core/src/db/schema.ts` — current schema + version
+4. `packages/core/src/db/migrations.ts` — migration pattern to follow
+5. `packages/core/src/db/settings.ts` + `settings.test.ts` — CRUD + test pattern to follow
+6. `packages/core/src/db/test-helpers.ts` — the `createTestDb()` helper
+7. `packages/core/src/types.ts` — where to add new types
+8. `packages/core/src/index.ts` — where to add new exports
+9. `packages/web/app/globals.css` — the file you'll rewrite in Phase 2
+10. `packages/web/app/layout.tsx` — where font imports go
+
+---
+
+## Phase 1: Data Layer
+
+Twelve tasks. Order matters — tasks build on each other (types → migration → CRUD → workflow → exports). Each task is a single TDD cycle ending in a commit.
+
+---
+
+### Task 1.1: Add `Draft` and `Priority` types
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+
+- [ ] **Step 1: Open `packages/core/src/types.ts` and append the new types at the bottom of the file**
+
+```typescript
+export type Priority = "low" | "normal" | "high";
+
+export type Draft = {
+  id: string;
+  title: string;
+  body: string;
+  priority: Priority;
+  createdAt: number; // unix seconds
+  updatedAt: number; // unix seconds
+};
+
+export type DraftInput = {
+  title: string;
+  body?: string;
+  priority?: Priority;
+};
+
+export type IssuePriority = {
+  repoId: number;
+  issueNumber: number;
+  priority: Priority;
+  updatedAt: number; // unix seconds
+};
+```
+
+- [ ] **Step 2: Run typecheck to verify the file still compiles**
+
+Run: `pnpm -F @issuectl/core typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/types.ts
+git commit -m "feat(core): add Draft and Priority types"
+```
+
+---
+
+### Task 1.2: Add v5 schema migration (drafts + issue_metadata tables)
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts`
+- Modify: `packages/core/src/db/migrations.ts`
+- Modify: `packages/core/src/db/schema.test.ts` (or create if structure differs)
+
+- [ ] **Step 1: Read `packages/core/src/db/schema.test.ts` to understand the existing test pattern for schema**
+
+Run: `cat packages/core/src/db/schema.test.ts`
+Keep the file open mentally as a template for the new test.
+
+- [ ] **Step 2: Write a failing test for the v5 migration**
+
+Append to `packages/core/src/db/schema.test.ts` (or add a new `describe` block):
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createTestDb, createRawTestDb } from "./test-helpers.js";
+import { initSchema, getSchemaVersion } from "./schema.js";
+import { runMigrations } from "./migrations.js";
+
+describe("schema v5 — drafts and issue_metadata", () => {
+  it("initSchema on a fresh DB produces schema version 5", () => {
+    const db = createRawTestDb();
+    initSchema(db);
+    expect(getSchemaVersion(db)).toBe(5);
+  });
+
+  it("fresh schema includes the drafts table", () => {
+    const db = createTestDb();
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
+      )
+      .get();
+    expect(row).toBeDefined();
+  });
+
+  it("fresh schema includes the issue_metadata table", () => {
+    const db = createTestDb();
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'issue_metadata'",
+      )
+      .get();
+    expect(row).toBeDefined();
+  });
+
+  it("drafts table enforces the priority CHECK constraint", () => {
+    const db = createTestDb();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO drafts (id, title, body, priority, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .run("abc", "t", "b", "bogus", 1, 1),
+    ).toThrow();
+  });
+
+  it("migration from v4 → v5 adds drafts and issue_metadata to an existing DB", () => {
+    const db = createRawTestDb();
+    // Simulate a v4 DB: run the v4-era schema manually
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (4);
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        local_path TEXT,
+        branch_pattern TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(owner, name)
+      );
+    `);
+    expect(getSchemaVersion(db)).toBe(4);
+
+    runMigrations(db);
+
+    expect(getSchemaVersion(db)).toBe(5);
+    const drafts = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
+      )
+      .get();
+    expect(drafts).toBeDefined();
+    const meta = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'issue_metadata'",
+      )
+      .get();
+    expect(meta).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test schema`
+Expected: Failures mentioning `drafts` and `issue_metadata` tables not existing, and the schema version still being 4.
+
+- [ ] **Step 4: Update `packages/core/src/db/schema.ts` — bump SCHEMA_VERSION to 5 and add the new tables to `CREATE_TABLES`**
+
+Replace the `SCHEMA_VERSION = 4` line and the `CREATE_TABLES` string:
+
+```typescript
+import type Database from "better-sqlite3";
+
+const SCHEMA_VERSION = 5;
+
+const CREATE_TABLES = `
+  CREATE TABLE IF NOT EXISTS repos (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner          TEXT NOT NULL,
+    name           TEXT NOT NULL,
+    local_path     TEXT,
+    branch_pattern TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(owner, name)
+  );
+
+  CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS deployments (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id          INTEGER NOT NULL REFERENCES repos(id),
+    issue_number     INTEGER NOT NULL,
+    branch_name      TEXT NOT NULL,
+    workspace_mode   TEXT NOT NULL,
+    workspace_path   TEXT NOT NULL,
+    linked_pr_number INTEGER,
+    launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at         TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS cache (
+    key        TEXT PRIMARY KEY,
+    data       TEXT NOT NULL,
+    fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS drafts (
+    id         TEXT PRIMARY KEY,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    priority   TEXT NOT NULL DEFAULT 'normal'
+               CHECK (priority IN ('low', 'normal', 'high')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS issue_metadata (
+    repo_id      INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    issue_number INTEGER NOT NULL,
+    priority     TEXT NOT NULL DEFAULT 'normal'
+                 CHECK (priority IN ('low', 'normal', 'high')),
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (repo_id, issue_number)
+  );
+
+  CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+  );
+`;
+
+export function initSchema(db: Database.Database): void {
+  db.exec(CREATE_TABLES);
+
+  const row = db.prepare("SELECT version FROM schema_version").get() as
+    | { version: number }
+    | undefined;
+
+  if (!row) {
+    db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(
+      SCHEMA_VERSION,
+    );
+  }
+}
+
+export function getSchemaVersion(db: Database.Database): number {
+  const row = db.prepare("SELECT version FROM schema_version").get() as
+    | { version: number }
+    | undefined;
+  return row?.version ?? 0;
+}
+```
+
+- [ ] **Step 5: Add the v5 migration entry to `packages/core/src/db/migrations.ts`**
+
+Append a new entry to the `migrations` array (after the existing `version: 4` entry):
+
+```typescript
+  {
+    version: 5,
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS drafts (
+          id         TEXT PRIMARY KEY,
+          title      TEXT NOT NULL,
+          body       TEXT NOT NULL DEFAULT '',
+          priority   TEXT NOT NULL DEFAULT 'normal'
+                     CHECK (priority IN ('low', 'normal', 'high')),
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS issue_metadata (
+          repo_id      INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+          issue_number INTEGER NOT NULL,
+          priority     TEXT NOT NULL DEFAULT 'normal'
+                       CHECK (priority IN ('low', 'normal', 'high')),
+          updated_at   INTEGER NOT NULL,
+          PRIMARY KEY (repo_id, issue_number)
+        );
+      `);
+    },
+  },
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test schema`
+Expected: All schema tests pass, including the new v5 tests.
+
+- [ ] **Step 7: Run the full core test suite to verify no regressions**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: All existing tests still pass.
+
+- [ ] **Step 8: Run typecheck and lint**
+
+Run: `pnpm -F @issuectl/core typecheck && pnpm -F @issuectl/core lint`
+Expected: Zero errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/db/schema.ts packages/core/src/db/schema.test.ts packages/core/src/db/migrations.ts
+git commit -m "feat(core): schema v5 — drafts and issue_metadata tables"
+```
+
+---
+
+### Task 1.3: Implement `createDraft`
+
+**Files:**
+- Create: `packages/core/src/db/drafts.ts`
+- Create: `packages/core/src/db/drafts.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/db/drafts.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import { createDraft } from "./drafts.js";
+
+describe("createDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("creates a draft with the given title and default body/priority", () => {
+    const draft = createDraft(db, { title: "Fix the bug" });
+
+    expect(draft.id).toMatch(/^[0-9a-f-]{36}$/); // uuid v4
+    expect(draft.title).toBe("Fix the bug");
+    expect(draft.body).toBe("");
+    expect(draft.priority).toBe("normal");
+    expect(draft.createdAt).toBeGreaterThan(0);
+    expect(draft.updatedAt).toBe(draft.createdAt);
+  });
+
+  it("respects a provided body and priority", () => {
+    const draft = createDraft(db, {
+      title: "Add retry logic",
+      body: "Webhook dispatcher needs exponential backoff.",
+      priority: "high",
+    });
+
+    expect(draft.body).toBe("Webhook dispatcher needs exponential backoff.");
+    expect(draft.priority).toBe("high");
+  });
+
+  it("persists the draft to the database", () => {
+    const draft = createDraft(db, { title: "Persisted" });
+    const row = db
+      .prepare("SELECT * FROM drafts WHERE id = ?")
+      .get(draft.id) as { id: string; title: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row?.title).toBe("Persisted");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — module `./drafts.js` not found.
+
+- [ ] **Step 3: Implement `createDraft`**
+
+Create `packages/core/src/db/drafts.ts`:
+
+```typescript
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Draft, DraftInput, Priority } from "../types.js";
+
+type DraftRow = {
+  id: string;
+  title: string;
+  body: string;
+  priority: Priority;
+  created_at: number;
+  updated_at: number;
+};
+
+function rowToDraft(row: DraftRow): Draft {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    priority: row.priority,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function createDraft(db: Database.Database, input: DraftInput): Draft {
+  const id = randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+  const body = input.body ?? "";
+  const priority = input.priority ?? "normal";
+
+  db.prepare(
+    `INSERT INTO drafts (id, title, body, priority, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, input.title, body, priority, now, now);
+
+  return {
+    id,
+    title: input.title,
+    body,
+    priority,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All `createDraft` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement createDraft"
+```
+
+---
+
+### Task 1.4: Implement `listDrafts`
+
+**Files:**
+- Modify: `packages/core/src/db/drafts.ts`
+- Modify: `packages/core/src/db/drafts.test.ts`
+
+- [ ] **Step 1: Append a failing test**
+
+Add to `packages/core/src/db/drafts.test.ts`:
+
+```typescript
+import { createDraft, listDrafts } from "./drafts.js";
+
+describe("listDrafts", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns an empty array when no drafts exist", () => {
+    expect(listDrafts(db)).toEqual([]);
+  });
+
+  it("returns all drafts ordered by updated_at DESC", () => {
+    const d1 = createDraft(db, { title: "First" });
+    // Force distinct timestamps by advancing the DB value
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      100,
+      d1.id,
+    );
+    const d2 = createDraft(db, { title: "Second" });
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      200,
+      d2.id,
+    );
+
+    const all = listDrafts(db);
+    expect(all).toHaveLength(2);
+    expect(all[0].id).toBe(d2.id); // newest first
+    expect(all[1].id).toBe(d1.id);
+  });
+});
+```
+
+**Important:** Update the import at the top of the existing import block in `drafts.test.ts` so both `createDraft` and `listDrafts` are imported together. Replace the line `import { createDraft } from "./drafts.js";` (added in Task 1.3) with `import { createDraft, listDrafts } from "./drafts.js";`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — `listDrafts` is not exported.
+
+- [ ] **Step 3: Implement `listDrafts` in `packages/core/src/db/drafts.ts`**
+
+Append after `createDraft`:
+
+```typescript
+export function listDrafts(db: Database.Database): Draft[] {
+  const rows = db
+    .prepare(
+      `SELECT id, title, body, priority, created_at, updated_at
+       FROM drafts
+       ORDER BY updated_at DESC`,
+    )
+    .all() as DraftRow[];
+  return rows.map(rowToDraft);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement listDrafts"
+```
+
+---
+
+### Task 1.5: Implement `getDraft`
+
+**Files:**
+- Modify: `packages/core/src/db/drafts.ts`
+- Modify: `packages/core/src/db/drafts.test.ts`
+
+- [ ] **Step 1: Append a failing test to `drafts.test.ts`**
+
+```typescript
+import { createDraft, listDrafts, getDraft } from "./drafts.js";
+
+describe("getDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns the draft with the given id", () => {
+    const created = createDraft(db, { title: "Find me" });
+    const found = getDraft(db, created.id);
+    expect(found).toEqual(created);
+  });
+
+  it("returns null for a non-existent id", () => {
+    expect(getDraft(db, "does-not-exist")).toBeNull();
+  });
+});
+```
+
+Update the import line for `./drafts.js` in the test file to include `getDraft`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — `getDraft` not exported.
+
+- [ ] **Step 3: Implement `getDraft` in `drafts.ts`**
+
+Append:
+
+```typescript
+export function getDraft(db: Database.Database, id: string): Draft | null {
+  const row = db
+    .prepare(
+      `SELECT id, title, body, priority, created_at, updated_at
+       FROM drafts
+       WHERE id = ?`,
+    )
+    .get(id) as DraftRow | undefined;
+  return row ? rowToDraft(row) : null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement getDraft"
+```
+
+---
+
+### Task 1.6: Implement `updateDraft`
+
+**Files:**
+- Modify: `packages/core/src/db/drafts.ts`
+- Modify: `packages/core/src/db/drafts.test.ts`
+
+- [ ] **Step 1: Append a failing test**
+
+```typescript
+import { createDraft, listDrafts, getDraft, updateDraft } from "./drafts.js";
+
+describe("updateDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("updates the provided fields and bumps updated_at", () => {
+    const created = createDraft(db, { title: "Original", body: "old" });
+    // Force updated_at to a known past value
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      100,
+      created.id,
+    );
+
+    const updated = updateDraft(db, created.id, {
+      title: "New title",
+      body: "new body",
+      priority: "high",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.title).toBe("New title");
+    expect(updated?.body).toBe("new body");
+    expect(updated?.priority).toBe("high");
+    expect(updated?.updatedAt).toBeGreaterThan(100);
+    expect(updated?.createdAt).toBe(created.createdAt);
+  });
+
+  it("supports partial updates — only provided fields change", () => {
+    const created = createDraft(db, {
+      title: "Keep",
+      body: "keep body",
+      priority: "low",
+    });
+    const updated = updateDraft(db, created.id, { title: "Changed only" });
+    expect(updated?.title).toBe("Changed only");
+    expect(updated?.body).toBe("keep body");
+    expect(updated?.priority).toBe("low");
+  });
+
+  it("returns null when the draft doesn't exist", () => {
+    expect(updateDraft(db, "missing", { title: "x" })).toBeNull();
+  });
+});
+```
+
+Update the import line to include `updateDraft`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — `updateDraft` not exported.
+
+- [ ] **Step 3: Implement `updateDraft` in `drafts.ts`**
+
+Append:
+
+```typescript
+export type DraftUpdate = Partial<Pick<Draft, "title" | "body" | "priority">>;
+
+export function updateDraft(
+  db: Database.Database,
+  id: string,
+  update: DraftUpdate,
+): Draft | null {
+  const existing = getDraft(db, id);
+  if (!existing) return null;
+
+  const next: Draft = {
+    ...existing,
+    ...update,
+    updatedAt: Math.floor(Date.now() / 1000),
+  };
+
+  db.prepare(
+    `UPDATE drafts
+     SET title = ?, body = ?, priority = ?, updated_at = ?
+     WHERE id = ?`,
+  ).run(next.title, next.body, next.priority, next.updatedAt, id);
+
+  return next;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement updateDraft"
+```
+
+---
+
+### Task 1.7: Implement `deleteDraft`
+
+**Files:**
+- Modify: `packages/core/src/db/drafts.ts`
+- Modify: `packages/core/src/db/drafts.test.ts`
+
+- [ ] **Step 1: Append a failing test**
+
+```typescript
+import {
+  createDraft,
+  listDrafts,
+  getDraft,
+  updateDraft,
+  deleteDraft,
+} from "./drafts.js";
+
+describe("deleteDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("removes the draft and returns true", () => {
+    const created = createDraft(db, { title: "Goodbye" });
+    const removed = deleteDraft(db, created.id);
+    expect(removed).toBe(true);
+    expect(getDraft(db, created.id)).toBeNull();
+  });
+
+  it("returns false when the draft doesn't exist", () => {
+    expect(deleteDraft(db, "missing")).toBe(false);
+  });
+});
+```
+
+Update the import line to include `deleteDraft`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — `deleteDraft` not exported.
+
+- [ ] **Step 3: Implement `deleteDraft`**
+
+Append to `drafts.ts`:
+
+```typescript
+export function deleteDraft(db: Database.Database, id: string): boolean {
+  const info = db.prepare("DELETE FROM drafts WHERE id = ?").run(id);
+  return info.changes > 0;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run the full core suite to check for regressions**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: Everything green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement deleteDraft"
+```
+
+---
+
+### Task 1.8: Implement `setPriority`
+
+**Files:**
+- Create: `packages/core/src/db/priority.ts`
+- Create: `packages/core/src/db/priority.test.ts`
+
+- [ ] **Step 1: Write a failing test**
+
+Create `packages/core/src/db/priority.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import { addRepo } from "./repos.js";
+import { setPriority } from "./priority.js";
+
+describe("setPriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // addRepo signature: takes { owner, name, localPath?, branchPattern? }.
+    // localPath and branchPattern are optional — pass as undefined (or omit).
+    const repo = addRepo(db, {
+      owner: "neonwatty",
+      name: "test",
+    });
+    repoId = repo.id;
+  });
+
+  it("inserts a new priority row", () => {
+    setPriority(db, repoId, 42, "high");
+    const row = db
+      .prepare(
+        "SELECT * FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 42) as { priority: string } | undefined;
+    expect(row?.priority).toBe("high");
+  });
+
+  it("upserts — overwrites an existing priority", () => {
+    setPriority(db, repoId, 42, "high");
+    setPriority(db, repoId, 42, "low");
+    const row = db
+      .prepare(
+        "SELECT priority FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 42) as { priority: string };
+    expect(row.priority).toBe("low");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: Failure — module `./priority.js` not found.
+
+- [ ] **Step 3: Implement `setPriority`**
+
+Create `packages/core/src/db/priority.ts`:
+
+```typescript
+import type Database from "better-sqlite3";
+import type { Priority, IssuePriority } from "../types.js";
+
+type IssuePriorityRow = {
+  repo_id: number;
+  issue_number: number;
+  priority: Priority;
+  updated_at: number;
+};
+
+function rowToIssuePriority(row: IssuePriorityRow): IssuePriority {
+  return {
+    repoId: row.repo_id,
+    issueNumber: row.issue_number,
+    priority: row.priority,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function setPriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+  priority: Priority,
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(
+    `INSERT INTO issue_metadata (repo_id, issue_number, priority, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (repo_id, issue_number)
+     DO UPDATE SET priority = excluded.priority, updated_at = excluded.updated_at`,
+  ).run(repoId, issueNumber, priority, now);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/priority.ts packages/core/src/db/priority.test.ts
+git commit -m "feat(core): implement setPriority"
+```
+
+---
+
+### Task 1.9: Implement `getPriority` (with `normal` fallback)
+
+**Files:**
+- Modify: `packages/core/src/db/priority.ts`
+- Modify: `packages/core/src/db/priority.test.ts`
+
+- [ ] **Step 1: Append a failing test**
+
+Append to `priority.test.ts`:
+
+```typescript
+import { setPriority, getPriority } from "./priority.js";
+
+describe("getPriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("returns 'normal' when no row exists for the issue", () => {
+    expect(getPriority(db, repoId, 999)).toBe("normal");
+  });
+
+  it("returns the stored priority when a row exists", () => {
+    setPriority(db, repoId, 42, "high");
+    expect(getPriority(db, repoId, 42)).toBe("high");
+  });
+
+  it("returns the stored priority after an upsert", () => {
+    setPriority(db, repoId, 42, "high");
+    setPriority(db, repoId, 42, "low");
+    expect(getPriority(db, repoId, 42)).toBe("low");
+  });
+});
+```
+
+Update the import to include `getPriority`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: Failure — `getPriority` not exported.
+
+- [ ] **Step 3: Implement `getPriority`**
+
+Append to `priority.ts`:
+
+```typescript
+export function getPriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): Priority {
+  const row = db
+    .prepare(
+      `SELECT priority FROM issue_metadata
+       WHERE repo_id = ? AND issue_number = ?`,
+    )
+    .get(repoId, issueNumber) as { priority: Priority } | undefined;
+  return row?.priority ?? "normal";
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/priority.ts packages/core/src/db/priority.test.ts
+git commit -m "feat(core): implement getPriority with normal fallback"
+```
+
+---
+
+### Task 1.10: Implement `deletePriority` and `listPrioritiesForRepo`
+
+**Files:**
+- Modify: `packages/core/src/db/priority.ts`
+- Modify: `packages/core/src/db/priority.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `priority.test.ts`:
+
+```typescript
+import {
+  setPriority,
+  getPriority,
+  deletePriority,
+  listPrioritiesForRepo,
+} from "./priority.js";
+
+describe("deletePriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("removes the row and returns true", () => {
+    setPriority(db, repoId, 42, "high");
+    expect(deletePriority(db, repoId, 42)).toBe(true);
+    expect(getPriority(db, repoId, 42)).toBe("normal");
+  });
+
+  it("returns false when no row exists", () => {
+    expect(deletePriority(db, repoId, 999)).toBe(false);
+  });
+});
+
+describe("listPrioritiesForRepo", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("returns all priority rows for the repo", () => {
+    setPriority(db, repoId, 1, "high");
+    setPriority(db, repoId, 2, "low");
+    setPriority(db, repoId, 3, "normal");
+
+    const all = listPrioritiesForRepo(db, repoId);
+    expect(all).toHaveLength(3);
+    const byNum = new Map(all.map((r) => [r.issueNumber, r.priority]));
+    expect(byNum.get(1)).toBe("high");
+    expect(byNum.get(2)).toBe("low");
+    expect(byNum.get(3)).toBe("normal");
+  });
+
+  it("returns an empty array when no priorities exist", () => {
+    expect(listPrioritiesForRepo(db, repoId)).toEqual([]);
+  });
+});
+```
+
+Update the import to include `deletePriority` and `listPrioritiesForRepo`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: Failure — functions not exported.
+
+- [ ] **Step 3: Implement the functions**
+
+Append to `priority.ts`:
+
+```typescript
+export function deletePriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): boolean {
+  const info = db
+    .prepare(
+      `DELETE FROM issue_metadata WHERE repo_id = ? AND issue_number = ?`,
+    )
+    .run(repoId, issueNumber);
+  return info.changes > 0;
+}
+
+export function listPrioritiesForRepo(
+  db: Database.Database,
+  repoId: number,
+): IssuePriority[] {
+  const rows = db
+    .prepare(
+      `SELECT repo_id, issue_number, priority, updated_at
+       FROM issue_metadata
+       WHERE repo_id = ?`,
+    )
+    .all(repoId) as IssuePriorityRow[];
+  return rows.map(rowToIssuePriority);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test priority`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/priority.ts packages/core/src/db/priority.test.ts
+git commit -m "feat(core): implement deletePriority and listPrioritiesForRepo"
+```
+
+---
+
+### Task 1.11: Implement `assignDraftToRepo` (the workflow function)
+
+**Files:**
+- Modify: `packages/core/src/db/drafts.ts`
+- Modify: `packages/core/src/db/drafts.test.ts`
+
+This is the workflow function that pushes a draft to GitHub and deletes the local draft on success. It takes both a `db` and an `octokit` parameter. Follows the pattern used by `launch/launch.ts` — workflow functions live alongside their primary store.
+
+- [ ] **Step 1: Read the existing `createIssue` signature to know what to call**
+
+Run: `cat packages/core/src/github/issues.ts`
+Identify the `createIssue` function: it should take `(octokit, owner, repo, { title, body, labels? })` and return a `GitHubIssue`.
+
+- [ ] **Step 2: Write a failing test**
+
+Append to `drafts.test.ts`:
+
+```typescript
+import { assignDraftToRepo } from "./drafts.js";
+import { addRepo, getRepoById } from "./repos.js";
+
+describe("assignDraftToRepo", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "api" });
+    repoId = repo.id;
+  });
+
+  it("pushes the draft to GitHub, deletes the draft, and returns the created issue info", async () => {
+    const draft = createDraft(db, {
+      title: "Fix the bug",
+      body: "full body text",
+      priority: "high",
+    });
+
+    // Fake octokit: record the call and return a fake issue
+    const calls: Array<{
+      owner: string;
+      repo: string;
+      title: string;
+      body: string;
+    }> = [];
+    const fakeOctokit = {
+      rest: {
+        issues: {
+          create: async (params: {
+            owner: string;
+            repo: string;
+            title: string;
+            body: string;
+          }) => {
+            calls.push(params);
+            return {
+              data: {
+                number: 214,
+                title: params.title,
+                body: params.body,
+                state: "open",
+                html_url: `https://github.com/${params.owner}/${params.repo}/issues/214`,
+              },
+            };
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = await assignDraftToRepo(db, fakeOctokit, draft.id, repoId);
+
+    // 1. Octokit was called with the right args
+    expect(calls).toHaveLength(1);
+    expect(calls[0].owner).toBe("neonwatty");
+    expect(calls[0].repo).toBe("api");
+    expect(calls[0].title).toBe("Fix the bug");
+    expect(calls[0].body).toBe("full body text");
+
+    // 2. Returned issue info
+    expect(result.issueNumber).toBe(214);
+    expect(result.repoId).toBe(repoId);
+
+    // 3. Draft is deleted
+    expect(getDraft(db, draft.id)).toBeNull();
+
+    // 4. Priority carried over to issue_metadata
+    const metaRow = db
+      .prepare(
+        "SELECT priority FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 214) as { priority: string } | undefined;
+    expect(metaRow?.priority).toBe("high");
+  });
+
+  it("leaves the draft in place if the GitHub call throws", async () => {
+    const draft = createDraft(db, { title: "Will fail" });
+
+    const fakeOctokit = {
+      rest: {
+        issues: {
+          create: async () => {
+            throw new Error("network down");
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, draft.id, repoId),
+    ).rejects.toThrow("network down");
+
+    expect(getDraft(db, draft.id)).not.toBeNull();
+  });
+
+  it("throws if the draft doesn't exist", async () => {
+    const fakeOctokit = {
+      rest: { issues: { create: async () => ({ data: {} }) } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, "missing", repoId),
+    ).rejects.toThrow(/draft/i);
+  });
+
+  it("throws if the repo doesn't exist", async () => {
+    const draft = createDraft(db, { title: "x" });
+
+    const fakeOctokit = {
+      rest: { issues: { create: async () => ({ data: {} }) } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, draft.id, 99999),
+    ).rejects.toThrow(/repo/i);
+  });
+});
+```
+
+**Note:** `getRepoById` is imported for readability but not directly used in the test — the `addRepo` return value provides `repoId`. Remove the unused import if lint complains.
+
+Update the `./drafts.js` import to include `assignDraftToRepo`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: Failure — `assignDraftToRepo` not exported.
+
+- [ ] **Step 4: Implement `assignDraftToRepo`**
+
+Add to `drafts.ts`. First, add the imports at the top:
+
+```typescript
+import type { Octokit } from "@octokit/rest";
+import { getRepoById } from "./repos.js";
+import { setPriority } from "./priority.js";
+```
+
+Then append the function:
+
+```typescript
+export type AssignDraftResult = {
+  repoId: number;
+  issueNumber: number;
+  issueUrl: string;
+};
+
+export async function assignDraftToRepo(
+  db: Database.Database,
+  octokit: Octokit,
+  draftId: string,
+  repoId: number,
+): Promise<AssignDraftResult> {
+  const draft = getDraft(db, draftId);
+  if (!draft) {
+    throw new Error(`No draft with id '${draftId}'`);
+  }
+
+  const repo = getRepoById(db, repoId);
+  if (!repo) {
+    throw new Error(`No tracked repo with id ${repoId}`);
+  }
+
+  // Create the issue on GitHub first. If this throws, we leave the draft
+  // in place so the user can retry — do not delete the draft until we know
+  // the push succeeded.
+  const response = await octokit.rest.issues.create({
+    owner: repo.owner,
+    repo: repo.name,
+    title: draft.title,
+    body: draft.body,
+  });
+
+  const issueNumber = response.data.number;
+  const issueUrl = response.data.html_url;
+
+  // Carry the local priority over to issue_metadata if it wasn't 'normal'.
+  // Priority is local-only metadata — the GitHub issue itself has no concept
+  // of it, so we key it under (repoId, issueNumber) on this side.
+  if (draft.priority !== "normal") {
+    setPriority(db, repoId, issueNumber, draft.priority);
+  }
+
+  // Finally, remove the local draft now that the GitHub issue exists.
+  deleteDraft(db, draftId);
+
+  return { repoId, issueNumber, issueUrl };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm -F @issuectl/core test drafts`
+Expected: All tests pass.
+
+- [ ] **Step 6: Run the full core suite for regressions**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: Everything green.
+
+- [ ] **Step 7: Run typecheck + lint**
+
+Run: `pnpm -F @issuectl/core typecheck && pnpm -F @issuectl/core lint`
+Expected: Zero errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/db/drafts.ts packages/core/src/db/drafts.test.ts
+git commit -m "feat(core): implement assignDraftToRepo workflow"
+```
+
+---
+
+### Task 1.12: Export new functions from the core package index
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add the new type exports**
+
+In `packages/core/src/index.ts`, find the first `export type` line at the top:
+
+```typescript
+export type { Repo, Setting, SettingKey, Deployment, CacheEntry } from "./types.js";
+```
+
+Replace it with:
+
+```typescript
+export type {
+  Repo,
+  Setting,
+  SettingKey,
+  Deployment,
+  CacheEntry,
+  Draft,
+  DraftInput,
+  Priority,
+  IssuePriority,
+} from "./types.js";
+```
+
+- [ ] **Step 2: Add the new function exports**
+
+Find the `export { ... } from "./db/settings.js";` block and add two new blocks after it (before the GitHub client exports):
+
+```typescript
+export {
+  createDraft,
+  listDrafts,
+  getDraft,
+  updateDraft,
+  deleteDraft,
+  assignDraftToRepo,
+  type DraftUpdate,
+  type AssignDraftResult,
+} from "./db/drafts.js";
+export {
+  setPriority,
+  getPriority,
+  deletePriority,
+  listPrioritiesForRepo,
+} from "./db/priority.js";
+```
+
+- [ ] **Step 3: Run build to verify the package still builds cleanly**
+
+Run: `pnpm -F @issuectl/core build`
+Expected: Build succeeds with new exports in the generated `.d.ts`.
+
+- [ ] **Step 4: Run typecheck on the full monorepo to catch any downstream issues**
+
+Run: `pnpm turbo typecheck`
+Expected: Zero errors across core, cli, and web.
+
+- [ ] **Step 5: Run the full core test suite**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/index.ts
+git commit -m "feat(core): export drafts and priority functions"
+```
+
+---
+
+## Phase 2: Paper Design Tokens + Shared Primitives
+
+Seven tasks. No test-first here — Phase 2 is pure visual work and the existing `packages/web/` has no component test convention. Primitives are validated in Phase 3 when screens compose them.
+
+Before starting Phase 2, open `docs/mockups/paper-reskin.html` in a browser and scroll to Flow 01 and Flow 11 — they're the visual reference for the tokens and the `Chip` / `Button` / `Sheet` / `Drawer` primitives respectively.
+
+---
+
+### Task 2.1: Add Paper tokens to `globals.css` (additively)
+
+**Files:**
+- Modify: `packages/web/app/globals.css`
+
+The current `globals.css` has a dual light/dark theme system with an orange accent that existing components (Sidebar, dashboard, everything else) depend on. Per the spec's Phase 2 guarantee — *"Paper design tokens + primitives can coexist with the old UI"* — we add Paper tokens additively under a `--paper-*` prefix instead of replacing. The old dashboard continues to work unchanged. Phase 8 cleanup will strip the prefix once the old tokens are gone.
+
+- [ ] **Step 1: Open `packages/web/app/globals.css` and append the Paper block at the bottom of the `:root` selector**
+
+Find the existing `:root { ... }` block in `globals.css`. Immediately **inside** the closing `}` of `:root`, append the following Paper tokens:
+
+```css
+  /* ═══ PAPER palette (2026-04-10 reskin) ═══════════════════════════
+   * Additive — coexists with the legacy light/dark tokens above.
+   * Used by components under packages/web/components/paper/.
+   * Phase 8 cleanup will strip the --paper- prefix once the legacy
+   * tokens are gone. */
+  --paper-bg:           #f3ecd9;
+  --paper-bg-warm:      #ede5cf;
+  --paper-bg-warmer:    #e6dec4;
+  --paper-ink:          #1a1712;
+  --paper-ink-soft:     #3a342a;
+  --paper-ink-muted:    #8a7f63;
+  --paper-ink-faint:    #b5a88a;
+  --paper-line:         #e0d6bc;
+  --paper-line-soft:    #e9dfc6;
+  --paper-accent:       #2d5f3f;
+  --paper-accent-dim:   #4a7a5c;
+  --paper-accent-soft:  #dce8de;
+  --paper-brick:        #b84a2e;
+  --paper-butter:       #d9a54d;
+
+  --paper-radius-sm:    3px;
+  --paper-radius-md:    6px;
+  --paper-radius-lg:    10px;
+  --paper-radius-xl:    14px;
+
+  --paper-shadow-card:  0 12px 30px rgba(26, 23, 18, 0.08);
+  --paper-shadow-modal: 0 40px 100px rgba(26, 23, 18, 0.35);
+
+  /* Font families — these reference the next/font variables injected
+   * in Task 2.2. Falls back to system fonts if next/font isn't wired yet. */
+  --paper-serif:  var(--font-serif), Georgia, serif;
+  --paper-sans:   var(--font-sans), system-ui, -apple-system, sans-serif;
+  --paper-mono:   var(--font-mono), ui-monospace, SFMono-Regular, monospace;
+```
+
+Do NOT touch any existing token. Do NOT remove or modify `--bg-base`, `--text-primary`, `--accent` (orange), or any other existing token. Old components must continue to render correctly.
+
+- [ ] **Step 2: At the very end of `globals.css` (after all existing rules), append the paper-surface utility class**
+
+```css
+/* ═══ Paper noise surface utility ═══════════════════════════
+ * Apply class="paperSurface" (or composed via CSS Modules) to a
+ * container to give it a subtle fractal-noise texture on a cream
+ * background. Positions children above the noise layer. */
+.paperSurface {
+  position: relative;
+  background: var(--paper-bg);
+  color: var(--paper-ink);
+}
+
+.paperSurface::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.18;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/></svg>");
+  background-size: 200px;
+}
+
+.paperSurface > * {
+  position: relative;
+  z-index: 1;
+}
+```
+
+- [ ] **Step 3: Start the dev server and verify nothing broke**
+
+Run (separate terminal): `pnpm -F @issuectl/web dev`
+Open `http://localhost:3847` in a browser.
+Expected: The existing dashboard looks **identical to before**. The Paper tokens are present in the CSS but no component uses them yet, so there's no visible difference. If anything looks different, the additive change broke something — stop and investigate. Stop the dev server after verifying (Ctrl+C).
+
+- [ ] **Step 4: Run typecheck and build**
+
+Run: `pnpm turbo typecheck && pnpm -F @issuectl/web build`
+Expected: Both pass cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/globals.css
+git commit -m "feat(web): add Paper palette tokens (additive) and paperSurface utility"
+```
+
+---
+
+### Task 2.2: Add Paper fonts via `next/font` (surgical swap in `layout.tsx`)
+
+**Files:**
+- Modify: `packages/web/app/layout.tsx`
+
+The existing `layout.tsx` imports Karla, Syne, and Source Code Pro (for the old UI), and wraps children in `ThemeProvider`, `ToastProvider`, `Sidebar`, etc. Phase 2 is purely additive — we add the three Paper font imports (`Fraunces`, `Inter`, `IBM_Plex_Mono`) alongside the existing ones, expose their CSS variables on `<html>`, and leave everything else untouched. Old components continue to use Karla/Syne/Source Code Pro. New Paper primitives will reference the `--font-serif`, `--font-sans`, `--font-mono` CSS variables (which `globals.css` aliases to `--paper-serif`, `--paper-sans`, `--paper-mono`).
+
+- [ ] **Step 1: Add the three Paper font imports at the top of `packages/web/app/layout.tsx`**
+
+Find this import line in `layout.tsx`:
+
+```typescript
+import { Karla, Syne, Source_Code_Pro } from "next/font/google";
+```
+
+Replace it with:
+
+```typescript
+import {
+  Karla,
+  Syne,
+  Source_Code_Pro,
+  Fraunces,
+  Inter,
+  IBM_Plex_Mono,
+} from "next/font/google";
+```
+
+- [ ] **Step 2: Add the three Paper font configurations below the existing ones**
+
+Find this block near the top of `layout.tsx`:
+
+```typescript
+const karla = Karla({
+  subsets: ["latin"],
+  variable: "--font-karla",
+});
+
+const syne = Syne({
+  subsets: ["latin"],
+  variable: "--font-display",
+});
+
+const sourceCodePro = Source_Code_Pro({
+  subsets: ["latin"],
+  variable: "--font-mono",
+});
+```
+
+**Carefully** insert the three Paper font configurations immediately after. Note: the existing `sourceCodePro` already uses variable `--font-mono`. To avoid collision, the Paper IBM Plex Mono will use variable `--font-mono-paper` and `globals.css` will be updated in Step 4 to reference it. Append this block after the `sourceCodePro` declaration:
+
+```typescript
+// Paper fonts (2026-04-10 reskin) — used by components under
+// packages/web/components/paper/. Loaded alongside the legacy fonts so
+// the old UI stays intact during Phase 2.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal", "italic"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-mono-paper",
+  display: "swap",
+});
+```
+
+- [ ] **Step 3: Add the three new font variable classes to the `<html>` element**
+
+Find the `<html>` element inside `RootLayout`. It currently looks like this:
+
+```typescript
+<html lang="en" data-theme={theme === "system" ? undefined : theme} className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
+```
+
+Replace it with (appending the three new variable classes, preserving the existing ones):
+
+```typescript
+<html
+  lang="en"
+  data-theme={theme === "system" ? undefined : theme}
+  className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable} ${fraunces.variable} ${inter.variable} ${ibmPlexMono.variable}`}
+>
+```
+
+Do NOT touch the `<head>`, `<body>`, `ThemeProvider`, `ToastProvider`, `Sidebar`, `AuthErrorScreen`, or the `THEME_SCRIPT`. Only the import block, font configs, and the `<html>` className attribute change.
+
+- [ ] **Step 4: Update the Paper font variable references in `globals.css`**
+
+In `packages/web/app/globals.css`, find the Paper font block added in Task 2.1:
+
+```css
+  --paper-serif:  var(--font-serif), Georgia, serif;
+  --paper-sans:   var(--font-sans), system-ui, -apple-system, sans-serif;
+  --paper-mono:   var(--font-mono), ui-monospace, SFMono-Regular, monospace;
+```
+
+The `--font-mono` reference collides with the legacy Source Code Pro mono variable (both configured to `--font-mono` in the original `layout.tsx`). Since the Paper IBM Plex Mono was configured to `--font-mono-paper` in Step 2 above, update the Paper mono alias to use the right variable:
+
+```css
+  --paper-serif:  var(--font-serif), Georgia, serif;
+  --paper-sans:   var(--font-sans), system-ui, -apple-system, sans-serif;
+  --paper-mono:   var(--font-mono-paper), ui-monospace, SFMono-Regular, monospace;
+```
+
+- [ ] **Step 5: Run typecheck and build**
+
+Run: `pnpm turbo typecheck && pnpm -F @issuectl/web build`
+Expected: Both pass cleanly.
+
+- [ ] **Step 6: Start the dev server and verify the old UI still looks correct**
+
+Run (separate terminal): `pnpm -F @issuectl/web dev`
+Open `http://localhost:3847` in a browser.
+Expected: The existing dashboard looks **identical to before** — Karla body text, Syne headers, Source Code Pro monospace. The Paper fonts are loaded (check the Network tab for `fraunces-*.woff2`, `inter-*.woff2`, `ibm-plex-mono-*.woff2` under `/_next/static/media/`) but no component uses them yet. Stop the dev server.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/app/layout.tsx packages/web/app/globals.css
+git commit -m "feat(web): load Fraunces, Inter, IBM Plex Mono alongside legacy fonts"
+```
+
+---
+
+### Task 2.3: Create the `Chip` primitive
+
+**Files:**
+- Create: `packages/web/components/paper/Chip.tsx`
+- Create: `packages/web/components/paper/Chip.module.css`
+
+The `Chip` primitive represents a compact tag or label. Used for repo chips (`api`, `web`), labels (`bug`, `feat`), and status markers (`no repo`, `draft`, `open`). Three visual variants: `default` (warm beige), `dashed` (italic green dashed outline, used for "no repo"), and `tinted` (a colored background matching the variant color — used for labels).
+
+- [ ] **Step 1: Create the CSS module**
+
+Create `packages/web/components/paper/Chip.module.css`:
+
+```css
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.default {
+  background: var(--paper-bg-warmer);
+  color: var(--paper-ink-soft);
+}
+
+.dashed {
+  background: transparent;
+  color: var(--paper-accent);
+  border: 1px dashed var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.tinted {
+  font-family: var(--paper-mono);
+  font-weight: 600;
+}
+
+.tinted.brick {
+  background: rgba(184, 74, 46, 0.08);
+  color: var(--paper-brick);
+}
+
+.tinted.butter {
+  background: rgba(217, 165, 77, 0.12);
+  color: #9a6b1f; /* darker butter for readability on cream */
+}
+
+.tinted.accent {
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+Create `packages/web/components/paper/Chip.tsx`:
+
+```typescript
+import type { ReactNode } from "react";
+import styles from "./Chip.module.css";
+
+type ChipVariant = "default" | "dashed" | "tinted";
+type ChipTint = "brick" | "butter" | "accent";
+
+type Props = {
+  children: ReactNode;
+  variant?: ChipVariant;
+  tint?: ChipTint; // only meaningful when variant === "tinted"
+};
+
+export function Chip({ children, variant = "default", tint }: Props) {
+  const className =
+    variant === "tinted" && tint
+      ? `${styles.chip} ${styles.tinted} ${styles[tint]}`
+      : `${styles.chip} ${styles[variant]}`;
+
+  return <span className={className}>{children}</span>;
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/paper/Chip.tsx packages/web/components/paper/Chip.module.css
+git commit -m "feat(web): add Chip primitive (default, dashed, tinted)"
+```
+
+---
+
+### Task 2.4: Create the `Button` primitive (four variants)
+
+**Files:**
+- Create: `packages/web/components/paper/Button.tsx`
+- Create: `packages/web/components/paper/Button.module.css`
+
+Four variants: `primary` (ink background, cream text — neutral primary like "save"), `accent` (forest green — "launch", "apply"), `ghost` (transparent with border — "cancel"), `destructive` (brick red — "close issue"). Titles are italic serif, matching Paper's editorial voice.
+
+- [ ] **Step 1: Create the CSS module**
+
+Create `packages/web/components/paper/Button.module.css`:
+
+```css
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 20px;
+  border-radius: var(--paper-radius-md);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+  border: 1px solid transparent;
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: nowrap;
+}
+
+.btn:hover:not(:disabled) {
+  opacity: 0.92;
+}
+
+.btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.primary {
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+}
+
+.accent {
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--paper-ink-soft);
+  border-color: var(--paper-line);
+}
+
+.ghost:hover:not(:disabled) {
+  color: var(--paper-accent);
+  border-color: var(--paper-accent);
+  opacity: 1;
+}
+
+.destructive {
+  background: var(--paper-brick);
+  color: var(--paper-bg);
+}
+
+/* size variants */
+.sm {
+  padding: 7px 14px;
+  font-size: 12.5px;
+}
+
+.md {
+  /* default — already set on .btn */
+}
+
+.lg {
+  padding: 13px 28px;
+  font-size: 15px;
+}
+
+.fullWidth {
+  width: 100%;
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+Create `packages/web/components/paper/Button.tsx`:
+
+```typescript
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import styles from "./Button.module.css";
+
+type Variant = "primary" | "accent" | "ghost" | "destructive";
+type Size = "sm" | "md" | "lg";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+  variant?: Variant;
+  size?: Size;
+  fullWidth?: boolean;
+};
+
+export function Button({
+  children,
+  variant = "primary",
+  size = "md",
+  fullWidth,
+  className,
+  ...rest
+}: Props) {
+  const classes = [
+    styles.btn,
+    styles[variant],
+    styles[size],
+    fullWidth ? styles.fullWidth : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/paper/Button.tsx packages/web/components/paper/Button.module.css
+git commit -m "feat(web): add Button primitive (primary, accent, ghost, destructive)"
+```
+
+---
+
+### Task 2.5: Create the `Sheet` primitive (bottom sheet)
+
+**Files:**
+- Create: `packages/web/components/paper/Sheet.tsx`
+- Create: `packages/web/components/paper/Sheet.module.css`
+
+The bottom sheet is used for the assign flow (Flow 01, second phone), the priority picker (Flow 12), and future "choose one of many" patterns. It renders a dimmed scrim covering the viewport + a warm paper card that slides up from the bottom.
+
+For v1, no animation library — CSS transitions are fine.
+
+- [ ] **Step 1: Create the CSS module**
+
+Create `packages/web/components/paper/Sheet.module.css`:
+
+```css
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 23, 18, 0.4);
+  z-index: 1000;
+}
+
+.sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--paper-bg);
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  border-top: 1px solid var(--paper-line);
+  box-shadow: 0 -20px 60px rgba(0, 0, 0, 0.25);
+  padding: 12px 0 28px;
+  z-index: 1001;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.grab {
+  width: 44px;
+  height: 4px;
+  background: var(--paper-ink-faint);
+  border-radius: 3px;
+  margin: 0 auto 10px;
+}
+
+.head {
+  padding: 10px 28px 14px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: -0.3px;
+  color: var(--paper-ink);
+  margin-bottom: 4px;
+}
+
+.description {
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-ink-muted);
+}
+
+.description em {
+  color: var(--paper-ink-soft);
+  font-style: italic;
+}
+
+.body {
+  padding: 0;
+}
+
+/* Desktop adaptation — cap the width and center */
+@media (min-width: 768px) {
+  .sheet {
+    left: 50%;
+    right: auto;
+    bottom: 40px;
+    transform: translateX(-50%);
+    width: 560px;
+    max-width: calc(100vw - 64px);
+    border-radius: 16px;
+    border: 1px solid var(--paper-line);
+  }
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+Create `packages/web/components/paper/Sheet.tsx`:
+
+```typescript
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import styles from "./Sheet.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+};
+
+export function Sheet({ open, onClose, title, description, children }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className={styles.scrim}
+        onClick={onClose}
+        role="presentation"
+      />
+      <div className={styles.sheet} role="dialog" aria-modal="true">
+        <div className={styles.grab} />
+        <div className={styles.head}>
+          <h2 className={styles.title}>{title}</h2>
+          {description && <p className={styles.description}>{description}</p>}
+        </div>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/paper/Sheet.tsx packages/web/components/paper/Sheet.module.css
+git commit -m "feat(web): add Sheet primitive (bottom sheet with scrim)"
+```
+
+---
+
+### Task 2.6: Create the `Drawer` primitive (right-side drawer)
+
+**Files:**
+- Create: `packages/web/components/paper/Drawer.tsx`
+- Create: `packages/web/components/paper/Drawer.module.css`
+
+Used for the mobile navigation drawer (Flow 12a). Slides in from the right, covering ~80% of the width with a dimmed scrim behind. Same scrim + Escape-to-close pattern as `Sheet`.
+
+- [ ] **Step 1: Create the CSS module**
+
+Create `packages/web/components/paper/Drawer.module.css`:
+
+```css
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 23, 18, 0.5);
+  z-index: 1000;
+}
+
+.drawer {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 300px;
+  max-width: 85vw;
+  background: var(--paper-bg);
+  border-left: 1px solid var(--paper-line);
+  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.3);
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.head {
+  padding: 52px 22px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--paper-line);
+  flex-shrink: 0;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: var(--paper-ink-muted);
+  font-size: 22px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.body {
+  flex: 1;
+  padding: 0;
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+Create `packages/web/components/paper/Drawer.tsx`:
+
+```typescript
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import styles from "./Drawer.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+};
+
+export function Drawer({ open, onClose, title, children }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={styles.scrim} onClick={onClose} role="presentation" />
+      <aside className={styles.drawer} role="dialog" aria-modal="true">
+        <div className={styles.head}>
+          <div className={styles.title}>{title}</div>
+          <button
+            className={styles.close}
+            onClick={onClose}
+            aria-label="Close navigation"
+          >
+            ×
+          </button>
+        </div>
+        <div className={styles.body}>{children}</div>
+      </aside>
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/paper/Drawer.tsx packages/web/components/paper/Drawer.module.css
+git commit -m "feat(web): add Drawer primitive (right-side with scrim)"
+```
+
+---
+
+### Task 2.7: Create the `paper` barrel export + final verification
+
+**Files:**
+- Create: `packages/web/components/paper/index.ts`
+
+- [ ] **Step 1: Create the barrel export**
+
+Create `packages/web/components/paper/index.ts`:
+
+```typescript
+export { Chip } from "./Chip.js";
+export { Button } from "./Button.js";
+export { Sheet } from "./Sheet.js";
+export { Drawer } from "./Drawer.js";
+```
+
+**Note:** the `.js` extensions are required for ESM even though the source files are `.ts` — Next.js / TypeScript handle this automatically in this project. Confirm by checking an existing barrel file like `packages/core/src/index.ts`.
+
+- [ ] **Step 2: Run full monorepo typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: Zero errors across core, cli, web.
+
+- [ ] **Step 3: Run the full build**
+
+Run: `pnpm turbo build`
+Expected: All packages build.
+
+- [ ] **Step 4: Run lint across all packages**
+
+Run: `pnpm turbo lint`
+Expected: Zero errors.
+
+- [ ] **Step 5: Run the core test suite one final time**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: All 20+ new tests plus existing tests pass.
+
+- [ ] **Step 6: Eyeball the dev server**
+
+Run (separate terminal): `pnpm -F @issuectl/web dev`
+Open `http://localhost:3847`.
+Expected: The app loads on a warm cream background with the Paper fonts active. The existing dashboard's layout is broken (this is expected — Phase 3 will fix it) but nothing crashes. Stop the dev server.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/components/paper/index.ts
+git commit -m "feat(web): add paper primitives barrel export"
+```
+
+---
+
+## Phase 1 + 2 complete — what's next
+
+After all 19 tasks land, you have:
+
+- A schema at version 5 with `drafts` and `issue_metadata` tables
+- Fully tested draft CRUD: `createDraft`, `listDrafts`, `getDraft`, `updateDraft`, `deleteDraft`
+- Fully tested priority CRUD: `setPriority`, `getPriority`, `deletePriority`, `listPrioritiesForRepo`
+- The `assignDraftToRepo` workflow function that pushes to GitHub and carries priority over
+- Paper palette + fonts in `globals.css` + `layout.tsx`
+- Four primitives — `Chip`, `Button`, `Sheet`, `Drawer` — ready for Phase 3 screens
+- Everything exported and accessible
+
+The app will render on the new Paper background but the existing dashboard will look broken. That's expected and acceptable per the spec's single-user rollout decision.
+
+**Follow-up plans will be written** for Phase 3 (main list) → Phase 4 (issue + PR detail) → Phase 5 (launch flow UI) → Phase 6 (settings + quick create) → Phase 7 (supplements) → Phase 8 (cleanup). Each phase gets its own plan document once the preceding phase lands so the plan reflects actual code state, not guesses.
+
+---
+
+## Self-Review Checklist
+
+Before executing this plan, verify:
+
+- [ ] **Spec coverage** — every line item from §"Data model changes" and §"Visual language" of the spec maps to a task here. Section-by-section:
+  - Draft table → Task 1.2 ✓
+  - issue_metadata table → Task 1.2 ✓
+  - Draft CRUD → Tasks 1.3–1.7 ✓
+  - Priority CRUD → Tasks 1.8–1.10 ✓
+  - assignDraftToRepo workflow → Task 1.11 ✓
+  - Package exports → Task 1.12 ✓
+  - Color tokens → Task 2.1 ✓
+  - Typography (Fraunces, Inter, IBM Plex Mono) → Task 2.2 ✓
+  - Paper noise overlay → Task 2.1 (embedded in `body::before`) ✓
+  - Chip primitive → Task 2.3 ✓
+  - Button variants → Task 2.4 ✓
+  - Sheet primitive → Task 2.5 ✓
+  - Drawer primitive → Task 2.6 ✓
+
+- [ ] **Placeholders** — no "TBD", "TODO", "fill in details" anywhere
+
+- [ ] **Type consistency** — `Draft`, `DraftInput`, `DraftUpdate`, `Priority`, `IssuePriority` used consistently. `AssignDraftResult` defined and used.
+
+- [ ] **Test conventions** — all Phase 1 tests use `createTestDb()` from `test-helpers.ts`, match the `describe`/`beforeEach` pattern in `settings.test.ts`
+
+- [ ] **Commands** — every "Run:" line is an actual command that exists in this monorepo (`pnpm -F @issuectl/core test`, `pnpm -F @issuectl/web dev`, `pnpm turbo typecheck`, `pnpm turbo build`, `pnpm turbo lint`)
+
+- [ ] **Phase 2 scope discipline** — no Phase 3 work leaks in. No routes created, no existing components deleted, no list/detail components built.
+
+If any of the above fail, fix inline before starting execution.

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { createDraft, listDrafts, getDraft, updateDraft, deleteDraft } from "./drafts.js";
+import {
+  createDraft,
+  listDrafts,
+  getDraft,
+  updateDraft,
+  deleteDraft,
+  assignDraftToRepo,
+} from "./drafts.js";
+import { addRepo } from "./repos.js";
 
 describe("createDraft", () => {
   let db: Database.Database;
@@ -153,5 +161,125 @@ describe("deleteDraft", () => {
 
   it("returns false when the draft doesn't exist", () => {
     expect(deleteDraft(db, "missing")).toBe(false);
+  });
+});
+
+describe("assignDraftToRepo", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "api" });
+    repoId = repo.id;
+  });
+
+  it("pushes the draft to GitHub, deletes the draft, and returns the created issue info", async () => {
+    const draft = createDraft(db, {
+      title: "Fix the bug",
+      body: "full body text",
+      priority: "high",
+    });
+
+    // Fake octokit: record the call and return a fake issue
+    const calls: Array<{
+      owner: string;
+      repo: string;
+      title: string;
+      body: string;
+    }> = [];
+    const fakeOctokit = {
+      rest: {
+        issues: {
+          create: async (params: {
+            owner: string;
+            repo: string;
+            title: string;
+            body: string;
+          }) => {
+            calls.push(params);
+            return {
+              data: {
+                number: 214,
+                title: params.title,
+                body: params.body,
+                state: "open",
+                html_url: `https://github.com/${params.owner}/${params.repo}/issues/214`,
+              },
+            };
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = await assignDraftToRepo(db, fakeOctokit, draft.id, repoId);
+
+    // 1. Octokit was called with the right args
+    expect(calls).toHaveLength(1);
+    expect(calls[0].owner).toBe("neonwatty");
+    expect(calls[0].repo).toBe("api");
+    expect(calls[0].title).toBe("Fix the bug");
+    expect(calls[0].body).toBe("full body text");
+
+    // 2. Returned issue info
+    expect(result.issueNumber).toBe(214);
+    expect(result.repoId).toBe(repoId);
+
+    // 3. Draft is deleted
+    expect(getDraft(db, draft.id)).toBeNull();
+
+    // 4. Priority carried over to issue_metadata
+    const metaRow = db
+      .prepare(
+        "SELECT priority FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 214) as { priority: string } | undefined;
+    expect(metaRow?.priority).toBe("high");
+  });
+
+  it("leaves the draft in place if the GitHub call throws", async () => {
+    const draft = createDraft(db, { title: "Will fail" });
+
+    const fakeOctokit = {
+      rest: {
+        issues: {
+          create: async () => {
+            throw new Error("network down");
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, draft.id, repoId),
+    ).rejects.toThrow("network down");
+
+    expect(getDraft(db, draft.id)).not.toBeNull();
+  });
+
+  it("throws if the draft doesn't exist", async () => {
+    const fakeOctokit = {
+      rest: { issues: { create: async () => ({ data: {} }) } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, "missing", repoId),
+    ).rejects.toThrow(/draft/i);
+  });
+
+  it("throws if the repo doesn't exist", async () => {
+    const draft = createDraft(db, { title: "x" });
+
+    const fakeOctokit = {
+      rest: { issues: { create: async () => ({ data: {} }) } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      assignDraftToRepo(db, fakeOctokit, draft.id, 99999),
+    ).rejects.toThrow(/repo/i);
   });
 });

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { createDraft } from "./drafts.js";
+import { createDraft, listDrafts } from "./drafts.js";
 
 describe("createDraft", () => {
   let db: Database.Database;
@@ -39,5 +39,36 @@ describe("createDraft", () => {
       .get(draft.id) as { id: string; title: string } | undefined;
     expect(row).toBeDefined();
     expect(row?.title).toBe("Persisted");
+  });
+});
+
+describe("listDrafts", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns an empty array when no drafts exist", () => {
+    expect(listDrafts(db)).toEqual([]);
+  });
+
+  it("returns all drafts ordered by updated_at DESC", () => {
+    const d1 = createDraft(db, { title: "First" });
+    // Force distinct timestamps by advancing the DB value
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      100,
+      d1.id,
+    );
+    const d2 = createDraft(db, { title: "Second" });
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      200,
+      d2.id,
+    );
+
+    const all = listDrafts(db);
+    expect(all).toHaveLength(2);
+    expect(all[0].id).toBe(d2.id); // newest first
+    expect(all[1].id).toBe(d1.id);
   });
 });

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { createDraft, listDrafts, getDraft } from "./drafts.js";
+import { createDraft, listDrafts, getDraft, updateDraft } from "./drafts.js";
 
 describe("createDraft", () => {
   let db: Database.Database;
@@ -88,5 +88,51 @@ describe("getDraft", () => {
 
   it("returns null for a non-existent id", () => {
     expect(getDraft(db, "does-not-exist")).toBeNull();
+  });
+});
+
+describe("updateDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("updates the provided fields and bumps updated_at", () => {
+    const created = createDraft(db, { title: "Original", body: "old" });
+    // Force updated_at to a known past value
+    db.prepare("UPDATE drafts SET updated_at = ? WHERE id = ?").run(
+      100,
+      created.id,
+    );
+
+    const updated = updateDraft(db, created.id, {
+      title: "New title",
+      body: "new body",
+      priority: "high",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.title).toBe("New title");
+    expect(updated?.body).toBe("new body");
+    expect(updated?.priority).toBe("high");
+    expect(updated?.updatedAt).toBeGreaterThan(100);
+    expect(updated?.createdAt).toBe(created.createdAt);
+  });
+
+  it("supports partial updates — only provided fields change", () => {
+    const created = createDraft(db, {
+      title: "Keep",
+      body: "keep body",
+      priority: "low",
+    });
+    const updated = updateDraft(db, created.id, { title: "Changed only" });
+    expect(updated?.title).toBe("Changed only");
+    expect(updated?.body).toBe("keep body");
+    expect(updated?.priority).toBe("low");
+  });
+
+  it("returns null when the draft doesn't exist", () => {
+    expect(updateDraft(db, "missing", { title: "x" })).toBeNull();
   });
 });

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import { createDraft } from "./drafts.js";
+
+describe("createDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("creates a draft with the given title and default body/priority", () => {
+    const draft = createDraft(db, { title: "Fix the bug" });
+
+    expect(draft.id).toMatch(/^[0-9a-f-]{36}$/); // uuid v4
+    expect(draft.title).toBe("Fix the bug");
+    expect(draft.body).toBe("");
+    expect(draft.priority).toBe("normal");
+    expect(draft.createdAt).toBeGreaterThan(0);
+    expect(draft.updatedAt).toBe(draft.createdAt);
+  });
+
+  it("respects a provided body and priority", () => {
+    const draft = createDraft(db, {
+      title: "Add retry logic",
+      body: "Webhook dispatcher needs exponential backoff.",
+      priority: "high",
+    });
+
+    expect(draft.body).toBe("Webhook dispatcher needs exponential backoff.");
+    expect(draft.priority).toBe("high");
+  });
+
+  it("persists the draft to the database", () => {
+    const draft = createDraft(db, { title: "Persisted" });
+    const row = db
+      .prepare("SELECT * FROM drafts WHERE id = ?")
+      .get(draft.id) as { id: string; title: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row?.title).toBe("Persisted");
+  });
+});

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -48,6 +48,15 @@ describe("createDraft", () => {
     expect(row).toBeDefined();
     expect(row?.title).toBe("Persisted");
   });
+
+  it("rejects an empty title", () => {
+    expect(() => createDraft(db, { title: "" })).toThrow(/title/i);
+  });
+
+  it("rejects a whitespace-only title", () => {
+    expect(() => createDraft(db, { title: "   " })).toThrow(/title/i);
+    expect(() => createDraft(db, { title: "\t\n " })).toThrow(/title/i);
+  });
 });
 
 describe("listDrafts", () => {
@@ -79,6 +88,25 @@ describe("listDrafts", () => {
     expect(all[0].id).toBe(d2.id); // newest first
     expect(all[1].id).toBe(d1.id);
   });
+
+  it("orders deterministically when updated_at values are equal", () => {
+    // unix-seconds precision means two drafts created within the same
+    // second would share an updated_at. Verify the secondary sort by id
+    // gives a deterministic result across multiple calls.
+    const d1 = createDraft(db, { title: "First" });
+    const d2 = createDraft(db, { title: "Second" });
+    db.prepare("UPDATE drafts SET updated_at = 100").run();
+
+    const first = listDrafts(db);
+    const second = listDrafts(db);
+
+    expect(first).toHaveLength(2);
+    expect(first.map((d) => d.id).sort()).toEqual(
+      [d1.id, d2.id].sort(),
+    );
+    // Identical order across calls → deterministic
+    expect(second.map((d) => d.id)).toEqual(first.map((d) => d.id));
+  });
 });
 
 describe("getDraft", () => {
@@ -94,8 +122,8 @@ describe("getDraft", () => {
     expect(found).toEqual(created);
   });
 
-  it("returns null for a non-existent id", () => {
-    expect(getDraft(db, "does-not-exist")).toBeNull();
+  it("returns undefined for a non-existent id", () => {
+    expect(getDraft(db, "does-not-exist")).toBeUndefined();
   });
 });
 
@@ -120,7 +148,7 @@ describe("updateDraft", () => {
       priority: "high",
     });
 
-    expect(updated).not.toBeNull();
+    expect(updated).not.toBeUndefined();
     expect(updated?.title).toBe("New title");
     expect(updated?.body).toBe("new body");
     expect(updated?.priority).toBe("high");
@@ -140,8 +168,8 @@ describe("updateDraft", () => {
     expect(updated?.priority).toBe("low");
   });
 
-  it("returns null when the draft doesn't exist", () => {
-    expect(updateDraft(db, "missing", { title: "x" })).toBeNull();
+  it("returns undefined when the draft doesn't exist", () => {
+    expect(updateDraft(db, "missing", { title: "x" })).toBeUndefined();
   });
 });
 
@@ -156,7 +184,7 @@ describe("deleteDraft", () => {
     const created = createDraft(db, { title: "Goodbye" });
     const removed = deleteDraft(db, created.id);
     expect(removed).toBe(true);
-    expect(getDraft(db, created.id)).toBeNull();
+    expect(getDraft(db, created.id)).toBeUndefined();
   });
 
   it("returns false when the draft doesn't exist", () => {
@@ -227,7 +255,7 @@ describe("assignDraftToRepo", () => {
     expect(result.repoId).toBe(repoId);
 
     // 3. Draft is deleted
-    expect(getDraft(db, draft.id)).toBeNull();
+    expect(getDraft(db, draft.id)).toBeUndefined();
 
     // 4. Priority carried over to issue_metadata
     const metaRow = db
@@ -256,7 +284,7 @@ describe("assignDraftToRepo", () => {
       assignDraftToRepo(db, fakeOctokit, draft.id, repoId),
     ).rejects.toThrow("network down");
 
-    expect(getDraft(db, draft.id)).not.toBeNull();
+    expect(getDraft(db, draft.id)).not.toBeUndefined();
   });
 
   it("throws if the draft doesn't exist", async () => {

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { createDraft, listDrafts } from "./drafts.js";
+import { createDraft, listDrafts, getDraft } from "./drafts.js";
 
 describe("createDraft", () => {
   let db: Database.Database;
@@ -70,5 +70,23 @@ describe("listDrafts", () => {
     expect(all).toHaveLength(2);
     expect(all[0].id).toBe(d2.id); // newest first
     expect(all[1].id).toBe(d1.id);
+  });
+});
+
+describe("getDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns the draft with the given id", () => {
+    const created = createDraft(db, { title: "Find me" });
+    const found = getDraft(db, created.id);
+    expect(found).toEqual(created);
+  });
+
+  it("returns null for a non-existent id", () => {
+    expect(getDraft(db, "does-not-exist")).toBeNull();
   });
 });

--- a/packages/core/src/db/drafts.test.ts
+++ b/packages/core/src/db/drafts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { createDraft, listDrafts, getDraft, updateDraft } from "./drafts.js";
+import { createDraft, listDrafts, getDraft, updateDraft, deleteDraft } from "./drafts.js";
 
 describe("createDraft", () => {
   let db: Database.Database;
@@ -134,5 +134,24 @@ describe("updateDraft", () => {
 
   it("returns null when the draft doesn't exist", () => {
     expect(updateDraft(db, "missing", { title: "x" })).toBeNull();
+  });
+});
+
+describe("deleteDraft", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("removes the draft and returns true", () => {
+    const created = createDraft(db, { title: "Goodbye" });
+    const removed = deleteDraft(db, created.id);
+    expect(removed).toBe(true);
+    expect(getDraft(db, created.id)).toBeNull();
+  });
+
+  it("returns false when the draft doesn't exist", () => {
+    expect(deleteDraft(db, "missing")).toBe(false);
   });
 });

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -42,3 +42,14 @@ export function createDraft(db: Database.Database, input: DraftInput): Draft {
     updatedAt: now,
   };
 }
+
+export function listDrafts(db: Database.Database): Draft[] {
+  const rows = db
+    .prepare(
+      `SELECT id, title, body, priority, created_at, updated_at
+       FROM drafts
+       ORDER BY updated_at DESC`,
+    )
+    .all() as DraftRow[];
+  return rows.map(rowToDraft);
+}

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -64,3 +64,28 @@ export function getDraft(db: Database.Database, id: string): Draft | null {
     .get(id) as DraftRow | undefined;
   return row ? rowToDraft(row) : null;
 }
+
+export type DraftUpdate = Partial<Pick<Draft, "title" | "body" | "priority">>;
+
+export function updateDraft(
+  db: Database.Database,
+  id: string,
+  update: DraftUpdate,
+): Draft | null {
+  const existing = getDraft(db, id);
+  if (!existing) return null;
+
+  const next: Draft = {
+    ...existing,
+    ...update,
+    updatedAt: Math.floor(Date.now() / 1000),
+  };
+
+  db.prepare(
+    `UPDATE drafts
+     SET title = ?, body = ?, priority = ?, updated_at = ?
+     WHERE id = ?`,
+  ).run(next.title, next.body, next.priority, next.updatedAt, id);
+
+  return next;
+}

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 import type { Draft, DraftInput, Priority } from "../types.js";
+import type { Octokit } from "@octokit/rest";
+import { getRepoById } from "./repos.js";
+import { setPriority } from "./priority.js";
 
 type DraftRow = {
   id: string;
@@ -93,4 +96,52 @@ export function updateDraft(
 export function deleteDraft(db: Database.Database, id: string): boolean {
   const info = db.prepare("DELETE FROM drafts WHERE id = ?").run(id);
   return info.changes > 0;
+}
+
+export type AssignDraftResult = {
+  repoId: number;
+  issueNumber: number;
+  issueUrl: string;
+};
+
+export async function assignDraftToRepo(
+  db: Database.Database,
+  octokit: Octokit,
+  draftId: string,
+  repoId: number,
+): Promise<AssignDraftResult> {
+  const draft = getDraft(db, draftId);
+  if (!draft) {
+    throw new Error(`No draft with id '${draftId}'`);
+  }
+
+  const repo = getRepoById(db, repoId);
+  if (!repo) {
+    throw new Error(`No tracked repo with id ${repoId}`);
+  }
+
+  // Create the issue on GitHub first. If this throws, we leave the draft
+  // in place so the user can retry — do not delete the draft until we know
+  // the push succeeded.
+  const response = await octokit.rest.issues.create({
+    owner: repo.owner,
+    repo: repo.name,
+    title: draft.title,
+    body: draft.body,
+  });
+
+  const issueNumber = response.data.number;
+  const issueUrl = response.data.html_url;
+
+  // Carry the local priority over to issue_metadata if it wasn't 'normal'.
+  // Priority is local-only metadata — the GitHub issue itself has no concept
+  // of it, so we key it under (repoId, issueNumber) on this side.
+  if (draft.priority !== "normal") {
+    setPriority(db, repoId, issueNumber, draft.priority);
+  }
+
+  // Finally, remove the local draft now that the GitHub issue exists.
+  deleteDraft(db, draftId);
+
+  return { repoId, issueNumber, issueUrl };
 }

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
-import type { Draft, DraftInput, Priority } from "../types.js";
 import type { Octokit } from "@octokit/rest";
+import type { Draft, DraftInput } from "../types.js";
 import { getRepoById } from "./repos.js";
-import { setPriority } from "./priority.js";
+import { parsePriority, setPriority } from "./priority.js";
 
 type DraftRow = {
   id: string;
   title: string;
   body: string;
-  priority: Priority;
+  priority: string;
   created_at: number;
   updated_at: number;
 };
@@ -19,13 +19,17 @@ function rowToDraft(row: DraftRow): Draft {
     id: row.id,
     title: row.title,
     body: row.body,
-    priority: row.priority,
+    priority: parsePriority(row.priority),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
 }
 
 export function createDraft(db: Database.Database, input: DraftInput): Draft {
+  if (input.title.trim().length === 0) {
+    throw new Error("Draft title must not be empty or whitespace-only");
+  }
+
   const id = randomUUID();
   const now = Math.floor(Date.now() / 1000);
   const body = input.body ?? "";
@@ -47,17 +51,23 @@ export function createDraft(db: Database.Database, input: DraftInput): Draft {
 }
 
 export function listDrafts(db: Database.Database): Draft[] {
+  // Secondary sort by id ensures deterministic ordering when two drafts
+  // share an updated_at (unix seconds has second precision, so two drafts
+  // created in the same second would otherwise have undefined order).
   const rows = db
     .prepare(
       `SELECT id, title, body, priority, created_at, updated_at
        FROM drafts
-       ORDER BY updated_at DESC`,
+       ORDER BY updated_at DESC, id DESC`,
     )
     .all() as DraftRow[];
   return rows.map(rowToDraft);
 }
 
-export function getDraft(db: Database.Database, id: string): Draft | null {
+export function getDraft(
+  db: Database.Database,
+  id: string,
+): Draft | undefined {
   const row = db
     .prepare(
       `SELECT id, title, body, priority, created_at, updated_at
@@ -65,7 +75,7 @@ export function getDraft(db: Database.Database, id: string): Draft | null {
        WHERE id = ?`,
     )
     .get(id) as DraftRow | undefined;
-  return row ? rowToDraft(row) : null;
+  return row ? rowToDraft(row) : undefined;
 }
 
 export type DraftUpdate = Partial<Pick<Draft, "title" | "body" | "priority">>;
@@ -74,9 +84,9 @@ export function updateDraft(
   db: Database.Database,
   id: string,
   update: DraftUpdate,
-): Draft | null {
+): Draft | undefined {
   const existing = getDraft(db, id);
-  if (!existing) return null;
+  if (!existing) return undefined;
 
   const next: Draft = {
     ...existing,
@@ -133,15 +143,19 @@ export async function assignDraftToRepo(
   const issueNumber = response.data.number;
   const issueUrl = response.data.html_url;
 
-  // Carry the local priority over to issue_metadata if it wasn't 'normal'.
-  // Priority is local-only metadata — the GitHub issue itself has no concept
-  // of it, so we key it under (repoId, issueNumber) on this side.
-  if (draft.priority !== "normal") {
-    setPriority(db, repoId, issueNumber, draft.priority);
-  }
-
-  // Finally, remove the local draft now that the GitHub issue exists.
-  deleteDraft(db, draftId);
+  // Run the two local writes (priority carryover + draft delete) in a
+  // single DB transaction after the network call succeeds. If either
+  // throws, both roll back and the draft stays intact locally — but the
+  // GitHub issue already exists. The caller should surface the error so
+  // the user can manually reconcile (the issueNumber is recoverable from
+  // the exception context if needed).
+  const localCommit = db.transaction(() => {
+    if (draft.priority !== "normal") {
+      setPriority(db, repoId, issueNumber, draft.priority);
+    }
+    deleteDraft(db, draftId);
+  });
+  localCommit();
 
   return { repoId, issueNumber, issueUrl };
 }

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -89,3 +89,8 @@ export function updateDraft(
 
   return next;
 }
+
+export function deleteDraft(db: Database.Database, id: string): boolean {
+  const info = db.prepare("DELETE FROM drafts WHERE id = ?").run(id);
+  return info.changes > 0;
+}

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { Draft, DraftInput, Priority } from "../types.js";
+
+type DraftRow = {
+  id: string;
+  title: string;
+  body: string;
+  priority: Priority;
+  created_at: number;
+  updated_at: number;
+};
+
+function rowToDraft(row: DraftRow): Draft {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    priority: row.priority,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function createDraft(db: Database.Database, input: DraftInput): Draft {
+  const id = randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+  const body = input.body ?? "";
+  const priority = input.priority ?? "normal";
+
+  db.prepare(
+    `INSERT INTO drafts (id, title, body, priority, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(id, input.title, body, priority, now, now);
+
+  return {
+    id,
+    title: input.title,
+    body,
+    priority,
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -53,3 +53,14 @@ export function listDrafts(db: Database.Database): Draft[] {
     .all() as DraftRow[];
   return rows.map(rowToDraft);
 }
+
+export function getDraft(db: Database.Database, id: string): Draft | null {
+  const row = db
+    .prepare(
+      `SELECT id, title, body, priority, created_at, updated_at
+       FROM drafts
+       WHERE id = ?`,
+    )
+    .get(id) as DraftRow | undefined;
+  return row ? rowToDraft(row) : null;
+}

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -54,6 +54,11 @@ const migrations: Migration[] = [
   {
     version: 5,
     up(db) {
+      // Adds two new tables for the Paper reskin: drafts (local-only
+      // scratchpad for issues not yet pushed to GitHub) and issue_metadata
+      // (per-issue local annotations — currently just priority, since
+      // GitHub has no native priority field). Both tables enforce the
+      // priority CHECK constraint matching the TypeScript Priority union.
       db.exec(`
         CREATE TABLE IF NOT EXISTS drafts (
           id         TEXT PRIMARY KEY,

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -51,6 +51,31 @@ const migrations: Migration[] = [
       db.exec(`DROP TABLE IF EXISTS claude_aliases;`);
     },
   },
+  {
+    version: 5,
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS drafts (
+          id         TEXT PRIMARY KEY,
+          title      TEXT NOT NULL,
+          body       TEXT NOT NULL DEFAULT '',
+          priority   TEXT NOT NULL DEFAULT 'normal'
+                     CHECK (priority IN ('low', 'normal', 'high')),
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS issue_metadata (
+          repo_id      INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+          issue_number INTEGER NOT NULL,
+          priority     TEXT NOT NULL DEFAULT 'normal'
+                       CHECK (priority IN ('low', 'normal', 'high')),
+          updated_at   INTEGER NOT NULL,
+          PRIMARY KEY (repo_id, issue_number)
+        );
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/priority.test.ts
+++ b/packages/core/src/db/priority.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
 import { addRepo } from "./repos.js";
-import { setPriority } from "./priority.js";
+import { setPriority, getPriority } from "./priority.js";
 
 describe("setPriority", () => {
   let db: Database.Database;
@@ -33,5 +33,31 @@ describe("setPriority", () => {
       )
       .get(repoId, 42) as { priority: string };
     expect(row.priority).toBe("low");
+  });
+});
+
+describe("getPriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("returns 'normal' when no row exists for the issue", () => {
+    expect(getPriority(db, repoId, 999)).toBe("normal");
+  });
+
+  it("returns the stored priority when a row exists", () => {
+    setPriority(db, repoId, 42, "high");
+    expect(getPriority(db, repoId, 42)).toBe("high");
+  });
+
+  it("returns the stored priority after an upsert", () => {
+    setPriority(db, repoId, 42, "high");
+    setPriority(db, repoId, 42, "low");
+    expect(getPriority(db, repoId, 42)).toBe("low");
   });
 });

--- a/packages/core/src/db/priority.test.ts
+++ b/packages/core/src/db/priority.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import { addRepo } from "./repos.js";
+import { setPriority } from "./priority.js";
+
+describe("setPriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("inserts a new priority row", () => {
+    setPriority(db, repoId, 42, "high");
+    const row = db
+      .prepare(
+        "SELECT * FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 42) as { priority: string } | undefined;
+    expect(row?.priority).toBe("high");
+  });
+
+  it("upserts — overwrites an existing priority", () => {
+    setPriority(db, repoId, 42, "high");
+    setPriority(db, repoId, 42, "low");
+    const row = db
+      .prepare(
+        "SELECT priority FROM issue_metadata WHERE repo_id = ? AND issue_number = ?",
+      )
+      .get(repoId, 42) as { priority: string };
+    expect(row.priority).toBe("low");
+  });
+});

--- a/packages/core/src/db/priority.test.ts
+++ b/packages/core/src/db/priority.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
 import { addRepo } from "./repos.js";
-import { setPriority, getPriority } from "./priority.js";
+import {
+  setPriority,
+  getPriority,
+  deletePriority,
+  listPrioritiesForRepo,
+} from "./priority.js";
 
 describe("setPriority", () => {
   let db: Database.Database;
@@ -59,5 +64,54 @@ describe("getPriority", () => {
     setPriority(db, repoId, 42, "high");
     setPriority(db, repoId, 42, "low");
     expect(getPriority(db, repoId, 42)).toBe("low");
+  });
+});
+
+describe("deletePriority", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("removes the row and returns true", () => {
+    setPriority(db, repoId, 42, "high");
+    expect(deletePriority(db, repoId, 42)).toBe(true);
+    expect(getPriority(db, repoId, 42)).toBe("normal");
+  });
+
+  it("returns false when no row exists", () => {
+    expect(deletePriority(db, repoId, 999)).toBe(false);
+  });
+});
+
+describe("listPrioritiesForRepo", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("returns all priority rows for the repo", () => {
+    setPriority(db, repoId, 1, "high");
+    setPriority(db, repoId, 2, "low");
+    setPriority(db, repoId, 3, "normal");
+
+    const all = listPrioritiesForRepo(db, repoId);
+    expect(all).toHaveLength(3);
+    const byNum = new Map(all.map((r) => [r.issueNumber, r.priority]));
+    expect(byNum.get(1)).toBe("high");
+    expect(byNum.get(2)).toBe("low");
+    expect(byNum.get(3)).toBe("normal");
+  });
+
+  it("returns an empty array when no priorities exist", () => {
+    expect(listPrioritiesForRepo(db, repoId)).toEqual([]);
   });
 });

--- a/packages/core/src/db/priority.test.ts
+++ b/packages/core/src/db/priority.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
-import { addRepo } from "./repos.js";
+import { addRepo, removeRepo } from "./repos.js";
 import {
   setPriority,
   getPriority,
@@ -113,5 +113,63 @@ describe("listPrioritiesForRepo", () => {
 
   it("returns an empty array when no priorities exist", () => {
     expect(listPrioritiesForRepo(db, repoId)).toEqual([]);
+  });
+
+  it("only returns rows for the requested repo", () => {
+    // Add a second repo and set priorities on both — verify the query
+    // is scoped so a caller never sees rows from another repo.
+    const other = addRepo(db, { owner: "neonwatty", name: "web" });
+    setPriority(db, repoId, 1, "high");
+    setPriority(db, repoId, 2, "low");
+    setPriority(db, other.id, 10, "high");
+    setPriority(db, other.id, 20, "low");
+
+    const mine = listPrioritiesForRepo(db, repoId);
+    expect(mine).toHaveLength(2);
+    expect(mine.every((row) => row.repoId === repoId)).toBe(true);
+
+    const theirs = listPrioritiesForRepo(db, other.id);
+    expect(theirs).toHaveLength(2);
+    expect(theirs.every((row) => row.repoId === other.id)).toBe(true);
+  });
+});
+
+describe("issue_metadata ON DELETE CASCADE", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const repo = addRepo(db, { owner: "neonwatty", name: "test" });
+    repoId = repo.id;
+  });
+
+  it("deletes issue_metadata rows when the parent repo is removed", () => {
+    setPriority(db, repoId, 1, "high");
+    setPriority(db, repoId, 2, "low");
+    expect(listPrioritiesForRepo(db, repoId)).toHaveLength(2);
+
+    removeRepo(db, repoId);
+
+    // After the repo is removed, all its metadata rows should be gone
+    // via ON DELETE CASCADE on issue_metadata.repo_id.
+    const remaining = db
+      .prepare(
+        "SELECT COUNT(*) as n FROM issue_metadata WHERE repo_id = ?",
+      )
+      .get(repoId) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+
+  it("leaves unrelated repos' metadata intact on repo removal", () => {
+    const other = addRepo(db, { owner: "neonwatty", name: "keep-me" });
+    setPriority(db, repoId, 1, "high");
+    setPriority(db, other.id, 1, "low");
+
+    removeRepo(db, repoId);
+
+    // Only the removed repo's rows cascade; the other repo is untouched.
+    expect(listPrioritiesForRepo(db, other.id)).toHaveLength(1);
+    expect(listPrioritiesForRepo(db, other.id)[0].priority).toBe("low");
   });
 });

--- a/packages/core/src/db/priority.ts
+++ b/packages/core/src/db/priority.ts
@@ -31,3 +31,17 @@ export function setPriority(
      DO UPDATE SET priority = excluded.priority, updated_at = excluded.updated_at`,
   ).run(repoId, issueNumber, priority, now);
 }
+
+export function getPriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): Priority {
+  const row = db
+    .prepare(
+      `SELECT priority FROM issue_metadata
+       WHERE repo_id = ? AND issue_number = ?`,
+    )
+    .get(repoId, issueNumber) as { priority: Priority } | undefined;
+  return row?.priority ?? "normal";
+}

--- a/packages/core/src/db/priority.ts
+++ b/packages/core/src/db/priority.ts
@@ -1,10 +1,29 @@
 import type Database from "better-sqlite3";
 import type { Priority, IssuePriority } from "../types.js";
 
+const PRIORITIES: readonly Priority[] = ["low", "normal", "high"];
+
+// Narrowing helper for values coming out of SQLite. The CHECK constraint
+// on the drafts and issue_metadata tables prevents invalid writes, so this
+// is defense-in-depth for row reads that bypass the type system via casts.
+export function parsePriority(value: unknown): Priority {
+  if (
+    typeof value === "string" &&
+    (PRIORITIES as readonly string[]).includes(value)
+  ) {
+    return value as Priority;
+  }
+  throw new Error(
+    `Invalid priority value: ${JSON.stringify(value)}. Expected one of ${PRIORITIES.join(
+      ", ",
+    )}.`,
+  );
+}
+
 type IssuePriorityRow = {
   repo_id: number;
   issue_number: number;
-  priority: Priority;
+  priority: string;
   updated_at: number;
 };
 
@@ -12,7 +31,7 @@ function rowToIssuePriority(row: IssuePriorityRow): IssuePriority {
   return {
     repoId: row.repo_id,
     issueNumber: row.issue_number,
-    priority: row.priority,
+    priority: parsePriority(row.priority),
     updatedAt: row.updated_at,
   };
 }
@@ -42,8 +61,8 @@ export function getPriority(
       `SELECT priority FROM issue_metadata
        WHERE repo_id = ? AND issue_number = ?`,
     )
-    .get(repoId, issueNumber) as { priority: Priority } | undefined;
-  return row?.priority ?? "normal";
+    .get(repoId, issueNumber) as { priority: string } | undefined;
+  return row ? parsePriority(row.priority) : "normal";
 }
 
 export function deletePriority(

--- a/packages/core/src/db/priority.ts
+++ b/packages/core/src/db/priority.ts
@@ -1,0 +1,33 @@
+import type Database from "better-sqlite3";
+import type { Priority, IssuePriority } from "../types.js";
+
+type IssuePriorityRow = {
+  repo_id: number;
+  issue_number: number;
+  priority: Priority;
+  updated_at: number;
+};
+
+function rowToIssuePriority(row: IssuePriorityRow): IssuePriority {
+  return {
+    repoId: row.repo_id,
+    issueNumber: row.issue_number,
+    priority: row.priority,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function setPriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+  priority: Priority,
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(
+    `INSERT INTO issue_metadata (repo_id, issue_number, priority, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (repo_id, issue_number)
+     DO UPDATE SET priority = excluded.priority, updated_at = excluded.updated_at`,
+  ).run(repoId, issueNumber, priority, now);
+}

--- a/packages/core/src/db/priority.ts
+++ b/packages/core/src/db/priority.ts
@@ -45,3 +45,30 @@ export function getPriority(
     .get(repoId, issueNumber) as { priority: Priority } | undefined;
   return row?.priority ?? "normal";
 }
+
+export function deletePriority(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): boolean {
+  const info = db
+    .prepare(
+      `DELETE FROM issue_metadata WHERE repo_id = ? AND issue_number = ?`,
+    )
+    .run(repoId, issueNumber);
+  return info.changes > 0;
+}
+
+export function listPrioritiesForRepo(
+  db: Database.Database,
+  repoId: number,
+): IssuePriority[] {
+  const rows = db
+    .prepare(
+      `SELECT repo_id, issue_number, priority, updated_at
+       FROM issue_metadata
+       WHERE repo_id = ?`,
+    )
+    .all(repoId) as IssuePriorityRow[];
+  return rows.map(rowToIssuePriority);
+}

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type Database from "better-sqlite3";
-import { createRawTestDb } from "./test-helpers.js";
+import { createRawTestDb, createTestDb } from "./test-helpers.js";
 import { initSchema, getSchemaVersion } from "./schema.js";
 import { runMigrations } from "./migrations.js";
 
@@ -24,21 +24,23 @@ describe("initSchema", () => {
     expect(names).toEqual([
       "cache",
       "deployments",
+      "drafts",
+      "issue_metadata",
       "repos",
       "schema_version",
       "settings",
     ]);
   });
 
-  it("sets schema_version to 4", () => {
+  it("sets schema_version to 5", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
   });
 });
 
@@ -55,10 +57,10 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
   });
 
-  it("migrates v1 schema through v4 and drops claude_aliases", () => {
+  it("migrates v1 schema through v5 and drops claude_aliases", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -71,14 +73,14 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v2 schema to v4 (adds ended_at, drops claude_aliases)", () => {
+  it("migrates v2 schema to v5 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE claude_aliases (id INTEGER PRIMARY KEY, command TEXT, description TEXT, is_default INTEGER, created_at TEXT);
@@ -89,7 +91,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -97,7 +99,7 @@ describe("runMigrations", () => {
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v3 schema to v4 and drops populated claude_aliases (data loss is intentional)", () => {
+  it("migrates v3 schema to v5 and drops populated claude_aliases (data loss is intentional)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -132,7 +134,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(4);
+    expect(getSchemaVersion(db)).toBe(5);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -144,5 +146,79 @@ describe("runMigrations", () => {
     );
 
     warnSpy.mockRestore();
+  });
+});
+
+describe("schema v5 — drafts and issue_metadata", () => {
+  it("initSchema on a fresh DB produces schema version 5", () => {
+    const db = createRawTestDb();
+    initSchema(db);
+    expect(getSchemaVersion(db)).toBe(5);
+  });
+
+  it("fresh schema includes the drafts table", () => {
+    const db = createTestDb();
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
+      )
+      .get();
+    expect(row).toBeDefined();
+  });
+
+  it("fresh schema includes the issue_metadata table", () => {
+    const db = createTestDb();
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'issue_metadata'",
+      )
+      .get();
+    expect(row).toBeDefined();
+  });
+
+  it("drafts table enforces the priority CHECK constraint", () => {
+    const db = createTestDb();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO drafts (id, title, body, priority, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .run("abc", "t", "b", "bogus", 1, 1),
+    ).toThrow();
+  });
+
+  it("migration from v4 → v5 adds drafts and issue_metadata to an existing DB", () => {
+    const db = createRawTestDb();
+    // Simulate a v4 DB: run the v4-era schema manually
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (4);
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        local_path TEXT,
+        branch_pattern TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(owner, name)
+      );
+    `);
+    expect(getSchemaVersion(db)).toBe(4);
+
+    runMigrations(db);
+
+    expect(getSchemaVersion(db)).toBe(5);
+    const drafts = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
+      )
+      .get();
+    expect(drafts).toBeDefined();
+    const meta = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'issue_metadata'",
+      )
+      .get();
+    expect(meta).toBeDefined();
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -34,6 +34,25 @@ const CREATE_TABLES = `
     key        TEXT PRIMARY KEY,
     data       TEXT NOT NULL,
     fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS drafts (
+    id         TEXT PRIMARY KEY,
+    title      TEXT NOT NULL,
+    body       TEXT NOT NULL DEFAULT '',
+    priority   TEXT NOT NULL DEFAULT 'normal'
+               CHECK (priority IN ('low', 'normal', 'high')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS issue_metadata (
+    repo_id      INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    issue_number INTEGER NOT NULL,
+    priority     TEXT NOT NULL DEFAULT 'normal'
+                 CHECK (priority IN ('low', 'normal', 'high')),
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (repo_id, issue_number)
   );
 
   CREATE TABLE IF NOT EXISTS schema_version (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,14 @@
-export type { Repo, Setting, SettingKey, Deployment, CacheEntry } from "./types.js";
+export type {
+  Repo,
+  Setting,
+  SettingKey,
+  Deployment,
+  CacheEntry,
+  Draft,
+  DraftInput,
+  Priority,
+  IssuePriority,
+} from "./types.js";
 
 export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
 export { initSchema, getSchemaVersion } from "./db/schema.js";
@@ -17,6 +27,22 @@ export {
   getSettings,
   seedDefaults,
 } from "./db/settings.js";
+export {
+  createDraft,
+  listDrafts,
+  getDraft,
+  updateDraft,
+  deleteDraft,
+  assignDraftToRepo,
+  type DraftUpdate,
+  type AssignDraftResult,
+} from "./db/drafts.js";
+export {
+  setPriority,
+  getPriority,
+  deletePriority,
+  listPrioritiesForRepo,
+} from "./db/priority.js";
 export {
   recordDeployment,
   getDeploymentById,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,3 +39,27 @@ export type CacheEntry<T = unknown> = {
   data: T;
   fetchedAt: Date;
 };
+
+export type Priority = "low" | "normal" | "high";
+
+export type Draft = {
+  id: string;
+  title: string;
+  body: string;
+  priority: Priority;
+  createdAt: number; // unix seconds
+  updatedAt: number; // unix seconds
+};
+
+export type DraftInput = {
+  title: string;
+  body?: string;
+  priority?: Priority;
+};
+
+export type IssuePriority = {
+  repoId: number;
+  issueNumber: number;
+  priority: Priority;
+  updatedAt: number; // unix seconds
+};

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -34,6 +34,40 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+
+  /* ═══ PAPER palette (2026-04-10 reskin) ═══════════════════════════
+   * Additive — coexists with the legacy light/dark tokens above.
+   * Used by components under packages/web/components/paper/.
+   * Phase 8 cleanup will strip the --paper- prefix once the legacy
+   * tokens are gone. */
+  --paper-bg:           #f3ecd9;
+  --paper-bg-warm:      #ede5cf;
+  --paper-bg-warmer:    #e6dec4;
+  --paper-ink:          #1a1712;
+  --paper-ink-soft:     #3a342a;
+  --paper-ink-muted:    #8a7f63;
+  --paper-ink-faint:    #b5a88a;
+  --paper-line:         #e0d6bc;
+  --paper-line-soft:    #e9dfc6;
+  --paper-accent:       #2d5f3f;
+  --paper-accent-dim:   #4a7a5c;
+  --paper-accent-soft:  #dce8de;
+  --paper-brick:        #b84a2e;
+  --paper-butter:       #d9a54d;
+
+  --paper-radius-sm:    3px;
+  --paper-radius-md:    6px;
+  --paper-radius-lg:    10px;
+  --paper-radius-xl:    14px;
+
+  --paper-shadow-card:  0 12px 30px rgba(26, 23, 18, 0.08);
+  --paper-shadow-modal: 0 40px 100px rgba(26, 23, 18, 0.35);
+
+  /* Font families — these reference the next/font variables injected
+   * in Task 2.2. Falls back to system fonts if next/font isn't wired yet. */
+  --paper-serif:  var(--font-serif), Georgia, serif;
+  --paper-sans:   var(--font-sans), system-ui, -apple-system, sans-serif;
+  --paper-mono:   var(--font-mono-paper), ui-monospace, SFMono-Regular, monospace;
 }
 
 [data-theme="dark"] {
@@ -154,4 +188,32 @@ a {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--border-accent);
+}
+
+/* ═══ Paper noise surface utility ═══════════════════════════
+ * Apply className="paperSurface" to a container to give it a subtle
+ * fractal-noise texture on a warm cream background. Children are
+ * positioned above the noise layer. Used by Paper primitives and
+ * pages that want the Paper aesthetic. */
+.paperSurface {
+  position: relative;
+  background: var(--paper-bg);
+  color: var(--paper-ink);
+}
+
+.paperSurface::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.18;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.28'/></svg>");
+  background-size: 200px;
+}
+
+.paperSurface > * {
+  position: relative;
+  z-index: 1;
 }

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -35,11 +35,10 @@
   --radius-md: 8px;
   --radius-lg: 12px;
 
-  /* ═══ PAPER palette (2026-04-10 reskin) ═══════════════════════════
-   * Additive — coexists with the legacy light/dark tokens above.
-   * Used by components under packages/web/components/paper/.
-   * Phase 8 cleanup will strip the --paper- prefix once the legacy
-   * tokens are gone. */
+  /* ═══ PAPER palette ═══════════════════════════════════════════════
+   * Prefixed with --paper- to coexist with the legacy light/dark
+   * tokens above. Used by components under packages/web/components/paper/.
+   * The prefix can be dropped if/when the legacy palette is removed. */
   --paper-bg:           #f3ecd9;
   --paper-bg-warm:      #ede5cf;
   --paper-bg-warmer:    #e6dec4;
@@ -60,11 +59,14 @@
   --paper-radius-lg:    10px;
   --paper-radius-xl:    14px;
 
-  --paper-shadow-card:  0 12px 30px rgba(26, 23, 18, 0.08);
-  --paper-shadow-modal: 0 40px 100px rgba(26, 23, 18, 0.35);
+  --paper-shadow-card:   0 12px 30px rgba(26, 23, 18, 0.08);
+  --paper-shadow-modal:  0 40px 100px rgba(26, 23, 18, 0.35);
+  /* Shadow for a bottom sheet — cast upward from the sheet's top edge. */
+  --paper-shadow-sheet:  0 -20px 60px rgba(0, 0, 0, 0.25);
+  /* Shadow for a side drawer — cast horizontally from the drawer's edge. */
+  --paper-shadow-drawer: -20px 0 60px rgba(0, 0, 0, 0.3);
 
-  /* Font families — these reference the next/font variables injected
-   * in Task 2.2. Falls back to system fonts if next/font isn't wired yet. */
+  /* Font variables are injected by next/font in app/layout.tsx. */
   --paper-serif:  var(--font-serif), Georgia, serif;
   --paper-sans:   var(--font-sans), system-ui, -apple-system, sans-serif;
   --paper-mono:   var(--font-mono-paper), ui-monospace, SFMono-Regular, monospace;

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -32,9 +32,9 @@ const sourceCodePro = Source_Code_Pro({
   variable: "--font-mono",
 });
 
-// Paper fonts (2026-04-10 reskin) — used by components under
-// packages/web/components/paper/. Loaded alongside the legacy fonts
-// so the old UI stays intact during Phase 2.
+// Paper fonts — used by components under packages/web/components/paper/.
+// Loaded alongside the legacy Karla/Syne/Source Code Pro fonts so both
+// sets are available simultaneously.
 const fraunces = Fraunces({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import { Karla, Syne, Source_Code_Pro } from "next/font/google";
+import {
+  Karla,
+  Syne,
+  Source_Code_Pro,
+  Fraunces,
+  Inter,
+  IBM_Plex_Mono,
+} from "next/font/google";
 import { cookies } from "next/headers";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { AuthErrorScreen } from "@/components/auth/AuthErrorScreen";
@@ -25,6 +32,31 @@ const sourceCodePro = Source_Code_Pro({
   variable: "--font-mono",
 });
 
+// Paper fonts (2026-04-10 reskin) — used by components under
+// packages/web/components/paper/. Loaded alongside the legacy fonts
+// so the old UI stays intact during Phase 2.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal", "italic"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-mono-paper",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
   title: "issuectl",
   description: "Cross-repo GitHub issue command center",
@@ -43,7 +75,11 @@ export default async function RootLayout({ children }: Props) {
   const theme: Theme = themeCookie === "dark" || themeCookie === "light" ? themeCookie : "system";
 
   return (
-    <html lang="en" data-theme={theme === "system" ? undefined : theme} className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable}`}>
+    <html
+      lang="en"
+      data-theme={theme === "system" ? undefined : theme}
+      className={`${karla.variable} ${syne.variable} ${sourceCodePro.variable} ${fraunces.variable} ${inter.variable} ${ibmPlexMono.variable}`}
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
       </head>

--- a/packages/web/components/paper/Button.module.css
+++ b/packages/web/components/paper/Button.module.css
@@ -1,0 +1,74 @@
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 20px;
+  border-radius: var(--paper-radius-md);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+  border: 1px solid transparent;
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: nowrap;
+}
+
+.btn:hover:not(:disabled) {
+  opacity: 0.92;
+}
+
+.btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.primary {
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+}
+
+.accent {
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--paper-ink-soft);
+  border-color: var(--paper-line);
+}
+
+.ghost:hover:not(:disabled) {
+  color: var(--paper-accent);
+  border-color: var(--paper-accent);
+  opacity: 1;
+}
+
+.destructive {
+  background: var(--paper-brick);
+  color: var(--paper-bg);
+}
+
+.sm {
+  padding: 7px 14px;
+  font-size: 12.5px;
+}
+
+.md {
+  /* default — already set on .btn */
+}
+
+.lg {
+  padding: 13px 28px;
+  font-size: 15px;
+}
+
+.fullWidth {
+  width: 100%;
+}

--- a/packages/web/components/paper/Button.tsx
+++ b/packages/web/components/paper/Button.tsx
@@ -1,0 +1,37 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import styles from "./Button.module.css";
+
+type Variant = "primary" | "accent" | "ghost" | "destructive";
+type Size = "sm" | "md" | "lg";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+  variant?: Variant;
+  size?: Size;
+  fullWidth?: boolean;
+};
+
+export function Button({
+  children,
+  variant = "primary",
+  size = "md",
+  fullWidth,
+  className,
+  ...rest
+}: Props) {
+  const classes = [
+    styles.btn,
+    styles[variant],
+    styles[size],
+    fullWidth ? styles.fullWidth : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/packages/web/components/paper/Chip.module.css
+++ b/packages/web/components/paper/Chip.module.css
@@ -1,0 +1,48 @@
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.default {
+  background: var(--paper-bg-warmer);
+  color: var(--paper-ink-soft);
+}
+
+.dashed {
+  background: transparent;
+  color: var(--paper-accent);
+  border: 1px dashed var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.tinted {
+  font-family: var(--paper-mono);
+  font-weight: 600;
+}
+
+.tinted.brick {
+  background: rgba(184, 74, 46, 0.08);
+  color: var(--paper-brick);
+}
+
+.tinted.butter {
+  background: rgba(217, 165, 77, 0.12);
+  color: #9a6b1f; /* darker butter for readability on cream */
+}
+
+.tinted.accent {
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+}

--- a/packages/web/components/paper/Chip.tsx
+++ b/packages/web/components/paper/Chip.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import styles from "./Chip.module.css";
+
+type ChipVariant = "default" | "dashed" | "tinted";
+type ChipTint = "brick" | "butter" | "accent";
+
+type Props = {
+  children: ReactNode;
+  variant?: ChipVariant;
+  tint?: ChipTint; // only meaningful when variant === "tinted"
+};
+
+export function Chip({ children, variant = "default", tint }: Props) {
+  const className =
+    variant === "tinted" && tint
+      ? `${styles.chip} ${styles.tinted} ${styles[tint]}`
+      : `${styles.chip} ${styles[variant]}`;
+
+  return <span className={className}>{children}</span>;
+}

--- a/packages/web/components/paper/Chip.tsx
+++ b/packages/web/components/paper/Chip.tsx
@@ -1,20 +1,32 @@
 import type { ReactNode } from "react";
 import styles from "./Chip.module.css";
 
-type ChipVariant = "default" | "dashed" | "tinted";
 type ChipTint = "brick" | "butter" | "accent";
 
-type Props = {
-  children: ReactNode;
-  variant?: ChipVariant;
-  tint?: ChipTint; // only meaningful when variant === "tinted"
-};
+// Discriminated union: when variant is "tinted", tint is required;
+// for "default"/"dashed", tint must not be provided. This prevents
+// the silent-invisible case where <Chip variant="tinted"> renders
+// with no background color.
+type Props = { children: ReactNode } & (
+  | { variant?: "default" | "dashed"; tint?: never }
+  | { variant: "tinted"; tint: ChipTint }
+);
 
-export function Chip({ children, variant = "default", tint }: Props) {
-  const className =
-    variant === "tinted" && tint
-      ? `${styles.chip} ${styles.tinted} ${styles[tint]}`
-      : `${styles.chip} ${styles[variant]}`;
+export function Chip(props: Props) {
+  if (props.variant === "tinted") {
+    return (
+      <span
+        className={`${styles.chip} ${styles.tinted} ${styles[props.tint]}`}
+      >
+        {props.children}
+      </span>
+    );
+  }
 
-  return <span className={className}>{children}</span>;
+  const variant = props.variant ?? "default";
+  return (
+    <span className={`${styles.chip} ${styles[variant]}`}>
+      {props.children}
+    </span>
+  );
 }

--- a/packages/web/components/paper/Drawer.module.css
+++ b/packages/web/components/paper/Drawer.module.css
@@ -1,0 +1,55 @@
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 23, 18, 0.5);
+  z-index: 1000;
+}
+
+.drawer {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 300px;
+  max-width: 85vw;
+  background: var(--paper-bg);
+  border-left: 1px solid var(--paper-line);
+  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.3);
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.head {
+  padding: 52px 22px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--paper-line);
+  flex-shrink: 0;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: var(--paper-ink-muted);
+  font-size: 22px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.body {
+  flex: 1;
+  padding: 0;
+}

--- a/packages/web/components/paper/Drawer.module.css
+++ b/packages/web/components/paper/Drawer.module.css
@@ -14,7 +14,7 @@
   max-width: 85vw;
   background: var(--paper-bg);
   border-left: 1px solid var(--paper-line);
-  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--paper-shadow-drawer);
   z-index: 1001;
   display: flex;
   flex-direction: column;

--- a/packages/web/components/paper/Drawer.tsx
+++ b/packages/web/components/paper/Drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useId, useRef } from "react";
 import styles from "./Drawer.module.css";
 
 type Props = {
@@ -11,11 +11,59 @@ type Props = {
   children: ReactNode;
 };
 
+// Tabbable elements inside a dialog container. Excludes disabled and
+// explicit -1 tabindex. Keeps focus cycling predictable for the trap.
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
 export function Drawer({ open, onClose, title, children }: Props) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLElement>(null);
+
+  // Focus management: capture → focus first → restore on close.
+  useEffect(() => {
+    if (!open) return;
+    const toRestore = document.activeElement as HTMLElement | null;
+    const dialog = dialogRef.current;
+    if (dialog) {
+      const focusables = getFocusable(dialog);
+      (focusables[0] ?? dialog).focus();
+    }
+    return () => {
+      toRestore?.focus();
+    };
+  }, [open]);
+
+  // Escape + Tab trap.
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusables = getFocusable(dialog);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
@@ -25,10 +73,23 @@ export function Drawer({ open, onClose, title, children }: Props) {
 
   return (
     <>
-      <div className={styles.scrim} onClick={onClose} role="presentation" />
-      <aside className={styles.drawer} role="dialog" aria-modal="true">
+      <div
+        className={styles.scrim}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        ref={dialogRef}
+        className={styles.drawer}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
         <div className={styles.head}>
-          <div className={styles.title}>{title}</div>
+          <div id={titleId} className={styles.title}>
+            {title}
+          </div>
           <button
             className={styles.close}
             onClick={onClose}

--- a/packages/web/components/paper/Drawer.tsx
+++ b/packages/web/components/paper/Drawer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import styles from "./Drawer.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+};
+
+export function Drawer({ open, onClose, title, children }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={styles.scrim} onClick={onClose} role="presentation" />
+      <aside className={styles.drawer} role="dialog" aria-modal="true">
+        <div className={styles.head}>
+          <div className={styles.title}>{title}</div>
+          <button
+            className={styles.close}
+            onClick={onClose}
+            aria-label="Close navigation"
+          >
+            ×
+          </button>
+        </div>
+        <div className={styles.body}>{children}</div>
+      </aside>
+    </>
+  );
+}

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -1,0 +1,72 @@
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 23, 18, 0.4);
+  z-index: 1000;
+}
+
+.sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--paper-bg);
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  border-top: 1px solid var(--paper-line);
+  box-shadow: 0 -20px 60px rgba(0, 0, 0, 0.25);
+  padding: 12px 0 28px;
+  z-index: 1001;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.grab {
+  width: 44px;
+  height: 4px;
+  background: var(--paper-ink-faint);
+  border-radius: 3px;
+  margin: 0 auto 10px;
+}
+
+.head {
+  padding: 10px 28px 14px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: -0.3px;
+  color: var(--paper-ink);
+  margin-bottom: 4px;
+}
+
+.description {
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-ink-muted);
+}
+
+.description em {
+  color: var(--paper-ink-soft);
+  font-style: italic;
+}
+
+.body {
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .sheet {
+    left: 50%;
+    right: auto;
+    bottom: 40px;
+    transform: translateX(-50%);
+    width: 560px;
+    max-width: calc(100vw - 64px);
+    border-radius: 16px;
+    border: 1px solid var(--paper-line);
+  }
+}

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -14,7 +14,7 @@
   border-top-left-radius: 24px;
   border-top-right-radius: 24px;
   border-top: 1px solid var(--paper-line);
-  box-shadow: 0 -20px 60px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--paper-shadow-sheet);
   padding: 12px 0 28px;
   z-index: 1001;
   max-height: 85vh;

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import styles from "./Sheet.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+};
+
+export function Sheet({ open, onClose, title, description, children }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className={styles.scrim}
+        onClick={onClose}
+        role="presentation"
+      />
+      <div className={styles.sheet} role="dialog" aria-modal="true">
+        <div className={styles.grab} />
+        <div className={styles.head}>
+          <h2 className={styles.title}>{title}</h2>
+          {description && <p className={styles.description}>{description}</p>}
+        </div>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useId, useRef } from "react";
 import styles from "./Sheet.module.css";
 
 type Props = {
@@ -12,11 +12,63 @@ type Props = {
   children: ReactNode;
 };
 
+// Tabbable elements inside a dialog container. Excludes disabled and
+// explicit -1 tabindex. Keeps focus cycling predictable for the trap.
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
 export function Sheet({ open, onClose, title, description, children }: Props) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus management: on open, move focus into the dialog and capture the
+  // previously-focused element so we can restore it on close. This effect
+  // is intentionally scoped to `[open]` — rerunning it on `onClose` identity
+  // change would re-capture mid-session and land focus back inside the
+  // dialog instead of on the trigger that opened it.
+  useEffect(() => {
+    if (!open) return;
+    const toRestore = document.activeElement as HTMLElement | null;
+    const dialog = dialogRef.current;
+    if (dialog) {
+      const focusables = getFocusable(dialog);
+      (focusables[0] ?? dialog).focus();
+    }
+    return () => {
+      toRestore?.focus();
+    };
+  }, [open]);
+
+  // Keyboard handling: Escape closes, Tab/Shift+Tab cycle within the dialog.
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusables = getFocusable(dialog);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
@@ -29,12 +81,21 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
       <div
         className={styles.scrim}
         onClick={onClose}
-        role="presentation"
+        aria-hidden="true"
       />
-      <div className={styles.sheet} role="dialog" aria-modal="true">
+      <div
+        ref={dialogRef}
+        className={styles.sheet}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
         <div className={styles.grab} />
         <div className={styles.head}>
-          <h2 className={styles.title}>{title}</h2>
+          <h2 id={titleId} className={styles.title}>
+            {title}
+          </h2>
           {description && <p className={styles.description}>{description}</p>}
         </div>
         <div className={styles.body}>{children}</div>

--- a/packages/web/components/paper/index.ts
+++ b/packages/web/components/paper/index.ts
@@ -1,4 +1,4 @@
-export { Chip } from "./Chip.js";
-export { Button } from "./Button.js";
-export { Sheet } from "./Sheet.js";
-export { Drawer } from "./Drawer.js";
+export { Chip } from "./Chip";
+export { Button } from "./Button";
+export { Sheet } from "./Sheet";
+export { Drawer } from "./Drawer";

--- a/packages/web/components/paper/index.ts
+++ b/packages/web/components/paper/index.ts
@@ -1,0 +1,4 @@
+export { Chip } from "./Chip.js";
+export { Button } from "./Button.js";
+export { Sheet } from "./Sheet.js";
+export { Drawer } from "./Drawer.js";


### PR DESCRIPTION
## Summary

Phase 1 + Phase 2 of the `issuectl` Paper reskin. Closes #32 once Phase 3–8 land.

**Spec:** `docs/specs/2026-04-10-todo-reskin-design.md`
**Plan:** `docs/specs/2026-04-10-todo-reskin-implementation-plan.md`
**Mockup reference:** `docs/mockups/paper-reskin.html`

This PR is **purely additive** — the existing dashboard, sidebar, fonts, and color tokens are untouched. Everything new is scoped under `--paper-*` CSS tokens and `packages/web/components/paper/` so Phase 3 can adopt incrementally.

### Phase 1 — Core data layer (12 commits)
- Schema v5 migration adding `drafts` and `issue_metadata` tables
- Full draft CRUD: `createDraft` / `listDrafts` / `getDraft` / `updateDraft` / `deleteDraft`
- Priority CRUD: `setPriority` / `getPriority` (with `"normal"` fallback) / `deletePriority` / `listPrioritiesForRepo`
- `assignDraftToRepo` workflow: pushes a draft to GitHub via Octokit, carries non-default priority into `issue_metadata`, deletes the local draft on success. Local writes wrapped in a single `db.transaction` after the network call so they commit atomically or roll back together.
- `parsePriority` helper narrows row data at the boundary (defense-in-depth on top of the schema `CHECK` constraint)
- All new functions + types exported from `@issuectl/core`

### Phase 2 — Paper tokens + shared primitives (7 commits)
- `--paper-*` palette tokens in `globals.css` (additive, prefixed, coexists with legacy)
- `.paperSurface` utility with a subtle fractal-noise texture
- `Fraunces` / `Inter` / `IBM_Plex_Mono` loaded via `next/font` alongside the existing `Karla` / `Syne` / `Source_Code_Pro`
- Four primitives under `components/paper/`:
  - `Chip` (default / dashed / tinted — discriminated union forbids `variant="tinted"` without `tint`)
  - `Button` (primary / accent / ghost / destructive × sm / md / lg + fullWidth)
  - `Sheet` (bottom sheet, desktop-responsive, focus trap, `aria-labelledby`, focus restoration)
  - `Drawer` (right-side drawer, same a11y treatment, visible close button)
- `--paper-shadow-card` / `--paper-shadow-modal` / `--paper-shadow-sheet` / `--paper-shadow-drawer` tokens wired into the primitives

### PR-review follow-ups (4 commits)
After the initial 19 commits a `pr-review-toolkit` sweep surfaced tightening opportunities, all addressed:
- `fix(core): tighten draft + priority type enforcement` — `null`→`undefined` for getters, `parsePriority` boundary narrowing, empty-title rejection in `createDraft`, deterministic `listDrafts` secondary sort, transaction wrapping in `assignDraftToRepo`
- `test(core): ON DELETE CASCADE coverage and v5 migration comment` — `issue_metadata` cascade verified, `listPrioritiesForRepo` cross-repo scoping pinned, v5 migration documented
- `fix(web): paper primitive hygiene pass` — Chip discriminated union, barrel drops `.js` extensions, shadow tokens consumed, stale/dated comments cleaned up
- `feat(web): Sheet + Drawer focus trap and aria-labelledby` — full modal dialog a11y before Phase 3 consumers wire them up

## Test Plan

- [x] `pnpm -F @issuectl/core test` — **169/169 passing** (was 133 before Phase 1; +36 new tests)
- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo build` — clean
- [x] `pnpm turbo lint` — zero warnings
- [ ] Start `pnpm -F @issuectl/web dev` and eyeball the existing dashboard at `localhost:3847` — the old UI should render exactly as before (Paper tokens are additive and no primitives are wired yet)
- [ ] Confirm the new Paper primitives can be imported via `@/components/paper` from a Phase 3 consumer

## What's next (Phase 3–8)

Follow-up plans will cover, in order:
1. **Phase 3** — main cross-repo list (replaces dashboard)
2. **Phase 4** — issue + PR detail routes
3. **Phase 5** — launch flow UI + progress route
4. **Phase 6** — settings + Quick Create + auth error + empty states
5. **Phase 7** — mobile nav drawer + PR tab variant + priority picker
6. **Phase 8** — delete old `components/dashboard/`, `components/repo/`, `components/sidebar/` and legacy tokens

Each follow-up plan will be written against the actual code state after this PR merges, not speculatively against the plan.