### PR TITLE
feat: paper reskin phase 3 — main list, cross-repo aggregation, draft creation

### DIFF
--- a/docs/specs/2026-04-11-phase-3-main-list-plan.md
+++ b/docs/specs/2026-04-11-phase-3-main-list-plan.md
@@ -1,0 +1,1679 @@
+# Paper Reskin Phase 3 Implementation Plan — Main List
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the existing dashboard repo-grid with a cross-repo flat list that aggregates drafts + open/in-flight/shipped issues from every tracked repo, grouped into four sections and ordered by priority within each section. Ship with minimum viable draft creation and assign flows using the Phase 2 Paper primitives.
+
+**Architecture:** A new `getUnifiedList` core function aggregates data across all tracked repos via parallel `getIssues` calls + `listDrafts` + deployment/priority lookups. A pure `groupIntoSections` helper assigns items into `unassigned | in focus | in flight | shipped` based on draft existence, deployment state (active row in `deployments` with `ended_at IS NULL`), and issue state (`closed` → shipped). Priority sort within each section is `priority DESC, updatedAt DESC`. The main list page is a Server Component that calls `getUnifiedList` and passes the result to a client-side `List` component that manages sheet state for the `CreateDraftSheet` and `AssignSheet` overlays.
+
+**Tech Stack:** No new dependencies. Uses the Phase 1 data layer (`drafts`, `priority`, `getIssues`, `listRepos`, `getDeploymentsByRepo`) and the Phase 2 Paper primitives (`Chip`, `Button`, `Sheet`).
+
+**Scope:** Phase 3 of the 8-phase rollout from `docs/specs/2026-04-10-todo-reskin-design.md`. In scope: main list data layer, list component tree, draft creation, assign-to-repo flow, row swipe gesture. **Out of scope and explicitly deferred:**
+
+- **Tapping a row to open detail** — Phase 4 adds `/issues/[owner]/[repo]/[number]` routes. In Phase 3, row tap is a no-op.
+- **Launch button wiring** — Phase 5 adds the launch progress view. In Phase 3, the hover-reveal `launch` button on desktop calls a placeholder server action that does nothing.
+- **PR tab variant** — Phase 7. The `Pull requests` tab is rendered as disabled in Phase 3.
+- **Mobile nav drawer** — Phase 7. The existing Sidebar stays in `layout.tsx` on desktop; mobile viewport just shows the new list without a drawer.
+- **Priority picker sheet** — Phase 7. Drafts default to `normal`; no UI to change priority on existing issues yet.
+- **Rich draft editing** — Phase 3 ships title-only draft creation. Body + repo assignment + labels are in Phase 3.1 or later.
+- **Old `components/dashboard/` + `components/repo/` directories** — stay in place. Phase 8 deletes them once nothing references them.
+
+---
+
+## Prerequisites
+
+- [ ] Clean working tree on `issue-32-phase-3-main-list` worktree: `git status` → nothing to commit
+- [ ] `pnpm install` completes without errors
+- [ ] `pnpm turbo typecheck` passes (baseline)
+- [ ] `pnpm -F @issuectl/core test` shows **169/169 passing**
+- [ ] `pnpm turbo build` passes
+
+Read these before starting:
+
+1. `docs/specs/2026-04-10-todo-reskin-design.md` — the overall spec
+2. `docs/mockups/paper-reskin.html` — open in a browser, scroll to `#flow1` for the main list mockup reference
+3. `packages/core/src/index.ts` — what's already exported (drafts CRUD, priority CRUD, getIssues, etc.)
+4. `packages/core/src/data/issues.ts` — existing `getIssues` data function with the SWR cache pattern
+5. `packages/core/src/data/repos.ts` — existing `getDashboardData` aggregator (the old pattern we're replacing)
+6. `packages/core/src/db/drafts.ts` — `listDrafts`, `createDraft`, `assignDraftToRepo`
+7. `packages/core/src/db/priority.ts` — `listPrioritiesForRepo`
+8. `packages/core/src/db/deployments.ts` — `getDeploymentsByRepo` for in-flight detection
+9. `packages/web/components/paper/` — Paper primitives (Chip, Button, Sheet, Drawer)
+10. `packages/web/app/page.tsx` — the current dashboard page (to be replaced)
+
+## Convention reminders
+
+From `CLAUDE.md`:
+- **ESM everywhere**, strict TypeScript, no classes.
+- **Explicit DB parameter**, explicit Octokit parameter in core functions.
+- **Server Components for reads, Server Actions for mutations.**
+- **CSS Modules per component**, tokens in `app/globals.css`.
+- **Tests alongside code** (`foo.test.ts` next to `foo.ts`).
+
+---
+
+## Phase 3 Tasks
+
+Fourteen tasks. Core tasks follow TDD (test first, implement, verify pass, commit). Web tasks validate via typecheck + build; no component tests.
+
+---
+
+### Task 3.1: Add `Section` and `UnifiedListItem` types
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+
+- [ ] **Step 1: Append the new types to the bottom of `types.ts`**
+
+```typescript
+export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
+
+// A UnifiedListItem is either a local draft (unassigned) or a
+// GitHub-backed issue enriched with its local priority and its
+// lifecycle state for the current section.
+export type UnifiedListItem =
+  | {
+      kind: "draft";
+      draft: Draft;
+    }
+  | {
+      kind: "issue";
+      repo: Repo;
+      issue: GitHubIssue;
+      priority: Priority;
+      section: Exclude<Section, "unassigned">;
+    };
+
+export type UnifiedList = {
+  unassigned: UnifiedListItem[];
+  in_focus: UnifiedListItem[];
+  in_flight: UnifiedListItem[];
+  shipped: UnifiedListItem[];
+};
+```
+
+- [ ] **Step 2: Add `GitHubIssue` import at the top of `types.ts`**
+
+Find the existing imports (currently just `WorkspaceMode`). Add:
+
+```typescript
+import type { GitHubIssue } from "./github/types.js";
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/core typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/types.ts
+git commit -m "feat(core): add Section and UnifiedList types"
+```
+
+---
+
+### Task 3.2: Implement `groupIntoSections` pure helper
+
+**Files:**
+- Create: `packages/core/src/data/unified-list.ts`
+- Create: `packages/core/src/data/unified-list.test.ts`
+
+- [ ] **Step 1: Write the failing test** at `packages/core/src/data/unified-list.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import type {
+  Draft,
+  Repo,
+  IssuePriority,
+  Deployment,
+} from "../types.js";
+import type { GitHubIssue } from "../github/types.js";
+import { groupIntoSections } from "./unified-list.js";
+
+const repo: Repo = {
+  id: 1,
+  owner: "neonwatty",
+  name: "api",
+  localPath: null,
+  branchPattern: null,
+  createdAt: "2026-01-01",
+};
+
+function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: "Test issue",
+    body: "",
+    state: "open",
+    labels: [],
+    createdAt: "2026-04-01T00:00:00Z",
+    updatedAt: "2026-04-01T00:00:00Z",
+    author: "neonwatty",
+    comments: 0,
+    ...overrides,
+  };
+}
+
+function makeDraft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    id: "draft-" + Math.random().toString(36).slice(2, 8),
+    title: "Draft",
+    body: "",
+    priority: "normal",
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeDeployment(issueNumber: number, ended = false): Deployment {
+  return {
+    id: issueNumber * 10,
+    repoId: repo.id,
+    issueNumber,
+    branchName: `issue-${issueNumber}`,
+    workspaceMode: "worktree",
+    workspacePath: `/tmp/${issueNumber}`,
+    linkedPrNumber: null,
+    launchedAt: "2026-04-01T00:00:00Z",
+    endedAt: ended ? "2026-04-02T00:00:00Z" : null,
+  };
+}
+
+describe("groupIntoSections", () => {
+  it("puts drafts in the unassigned section", () => {
+    const d1 = makeDraft({ title: "First" });
+    const d2 = makeDraft({ title: "Second" });
+    const result = groupIntoSections({
+      drafts: [d1, d2],
+      perRepo: [],
+    });
+    expect(result.unassigned).toHaveLength(2);
+    expect(result.unassigned.every((item) => item.kind === "draft")).toBe(true);
+    expect(result.in_focus).toEqual([]);
+    expect(result.in_flight).toEqual([]);
+    expect(result.shipped).toEqual([]);
+  });
+
+  it("puts closed issues in shipped", () => {
+    const closed = makeIssue({ number: 1, state: "closed" });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [closed],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.shipped).toHaveLength(1);
+    expect(result.in_focus).toEqual([]);
+  });
+
+  it("puts open issues with an active deployment in in_flight", () => {
+    const issue = makeIssue({ number: 2 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [makeDeployment(2, false)], // active
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_flight).toHaveLength(1);
+    expect(result.in_focus).toEqual([]);
+  });
+
+  it("treats an issue with only ended deployments as in_focus", () => {
+    const issue = makeIssue({ number: 3 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [makeDeployment(3, true)], // ended
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_focus).toHaveLength(1);
+    expect(result.in_flight).toEqual([]);
+  });
+
+  it("puts open issues with no deployment in in_focus", () => {
+    const issue = makeIssue({ number: 4 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_focus).toHaveLength(1);
+  });
+
+  it("enriches issues with their priority from the repo's priority map", () => {
+    const issue = makeIssue({ number: 5 });
+    const priorities: IssuePriority[] = [
+      {
+        repoId: repo.id,
+        issueNumber: 5,
+        priority: "high",
+        updatedAt: 1000,
+      },
+    ];
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities,
+        },
+      ],
+    });
+    const item = result.in_focus[0];
+    if (item.kind !== "issue") throw new Error("expected issue");
+    expect(item.priority).toBe("high");
+  });
+
+  it("defaults issues with no priority row to 'normal'", () => {
+    const issue = makeIssue({ number: 6 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    const item = result.in_focus[0];
+    if (item.kind !== "issue") throw new Error("expected issue");
+    expect(item.priority).toBe("normal");
+  });
+
+  it("sorts within each section by priority DESC then updatedAt DESC", () => {
+    const older = makeIssue({ number: 1, updatedAt: "2026-04-01T00:00:00Z" });
+    const newer = makeIssue({ number: 2, updatedAt: "2026-04-05T00:00:00Z" });
+    const highOlder = makeIssue({
+      number: 3,
+      updatedAt: "2026-03-01T00:00:00Z",
+    });
+    const priorities: IssuePriority[] = [
+      { repoId: repo.id, issueNumber: 3, priority: "high", updatedAt: 0 },
+    ];
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [older, newer, highOlder],
+          deployments: [],
+          priorities,
+        },
+      ],
+    });
+    const focus = result.in_focus;
+    expect(focus).toHaveLength(3);
+    // high priority first (even though older), then newer, then older
+    if (focus[0].kind !== "issue") throw new Error("expected issue");
+    if (focus[1].kind !== "issue") throw new Error("expected issue");
+    if (focus[2].kind !== "issue") throw new Error("expected issue");
+    expect(focus[0].issue.number).toBe(3);
+    expect(focus[1].issue.number).toBe(2);
+    expect(focus[2].issue.number).toBe(1);
+  });
+
+  it("sorts drafts by priority DESC then updatedAt DESC", () => {
+    const normalOlder = makeDraft({ title: "A", priority: "normal", updatedAt: 100 });
+    const normalNewer = makeDraft({ title: "B", priority: "normal", updatedAt: 200 });
+    const high = makeDraft({ title: "C", priority: "high", updatedAt: 50 });
+    const result = groupIntoSections({
+      drafts: [normalOlder, normalNewer, high],
+      perRepo: [],
+    });
+    const titles = result.unassigned.map((item) => {
+      if (item.kind !== "draft") throw new Error("expected draft");
+      return item.draft.title;
+    });
+    expect(titles).toEqual(["C", "B", "A"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — it should fail**
+
+Run: `pnpm -F @issuectl/core test unified-list`
+Expected: Failure — module `./unified-list.js` not found.
+
+- [ ] **Step 3: Implement `groupIntoSections`** at `packages/core/src/data/unified-list.ts`:
+
+```typescript
+import type {
+  Draft,
+  Repo,
+  IssuePriority,
+  Deployment,
+  Priority,
+  UnifiedList,
+  UnifiedListItem,
+} from "../types.js";
+import type { GitHubIssue } from "../github/types.js";
+
+export type PerRepoData = {
+  repo: Repo;
+  issues: GitHubIssue[];
+  deployments: Deployment[];
+  priorities: IssuePriority[];
+};
+
+export type GroupIntoSectionsInput = {
+  drafts: Draft[];
+  perRepo: PerRepoData[];
+};
+
+const PRIORITY_RANK: Record<Priority, number> = {
+  high: 2,
+  normal: 1,
+  low: 0,
+};
+
+function compareByPriorityThenUpdatedAt(
+  aPriority: Priority,
+  aUpdatedAt: number,
+  bPriority: Priority,
+  bUpdatedAt: number,
+): number {
+  const rankDiff = PRIORITY_RANK[bPriority] - PRIORITY_RANK[aPriority];
+  if (rankDiff !== 0) return rankDiff;
+  return bUpdatedAt - aUpdatedAt;
+}
+
+export function groupIntoSections(
+  input: GroupIntoSectionsInput,
+): UnifiedList {
+  // Unassigned: all drafts, sorted by priority DESC then updatedAt DESC
+  const unassigned: UnifiedListItem[] = input.drafts
+    .slice()
+    .sort((a, b) =>
+      compareByPriorityThenUpdatedAt(
+        a.priority,
+        a.updatedAt,
+        b.priority,
+        b.updatedAt,
+      ),
+    )
+    .map((draft) => ({ kind: "draft" as const, draft }));
+
+  const in_focus: UnifiedListItem[] = [];
+  const in_flight: UnifiedListItem[] = [];
+  const shipped: UnifiedListItem[] = [];
+
+  for (const { repo, issues, deployments, priorities } of input.perRepo) {
+    // Build a set of issue numbers with an active deployment (ended_at IS NULL)
+    const activeLaunchSet = new Set(
+      deployments
+        .filter((d) => d.endedAt === null)
+        .map((d) => d.issueNumber),
+    );
+
+    // Build a priority map for this repo
+    const priorityMap = new Map<number, Priority>(
+      priorities.map((p) => [p.issueNumber, p.priority]),
+    );
+
+    for (const issue of issues) {
+      const priority = priorityMap.get(issue.number) ?? "normal";
+      let section: "in_focus" | "in_flight" | "shipped";
+
+      if (issue.state === "closed") {
+        section = "shipped";
+      } else if (activeLaunchSet.has(issue.number)) {
+        section = "in_flight";
+      } else {
+        section = "in_focus";
+      }
+
+      const item: UnifiedListItem = {
+        kind: "issue",
+        repo,
+        issue,
+        priority,
+        section,
+      };
+
+      if (section === "in_focus") in_focus.push(item);
+      else if (section === "in_flight") in_flight.push(item);
+      else shipped.push(item);
+    }
+  }
+
+  // Sort each issue section by priority DESC then updatedAt DESC
+  const sortIssues = (items: UnifiedListItem[]): UnifiedListItem[] =>
+    items.slice().sort((a, b) => {
+      if (a.kind !== "issue" || b.kind !== "issue") return 0;
+      const aUpdated = new Date(a.issue.updatedAt).getTime();
+      const bUpdated = new Date(b.issue.updatedAt).getTime();
+      return compareByPriorityThenUpdatedAt(
+        a.priority,
+        aUpdated,
+        b.priority,
+        bUpdated,
+      );
+    });
+
+  return {
+    unassigned,
+    in_focus: sortIssues(in_focus),
+    in_flight: sortIssues(in_flight),
+    shipped: sortIssues(shipped),
+  };
+}
+```
+
+- [ ] **Step 4: Run the test — should pass**
+
+Run: `pnpm -F @issuectl/core test unified-list`
+Expected: All 9 tests pass.
+
+- [ ] **Step 5: Run the full core suite for regressions**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: ~178 tests passing (was 169 + 9 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/data/unified-list.ts packages/core/src/data/unified-list.test.ts
+git commit -m "feat(core): groupIntoSections pure helper"
+```
+
+---
+
+### Task 3.3: Implement `getUnifiedList` data function
+
+**Files:**
+- Modify: `packages/core/src/data/unified-list.ts`
+
+- [ ] **Step 1: Add new imports + export at the top/end of `unified-list.ts`**
+
+Add the imports:
+
+```typescript
+import type Database from "better-sqlite3";
+import type { Octokit } from "@octokit/rest";
+import { listDrafts } from "../db/drafts.js";
+import { listRepos } from "../db/repos.js";
+import { getDeploymentsByRepo } from "../db/deployments.js";
+import { listPrioritiesForRepo } from "../db/priority.js";
+import { getIssues } from "./issues.js";
+```
+
+Then append the new function at the end of `unified-list.ts`:
+
+```typescript
+export async function getUnifiedList(
+  db: Database.Database,
+  octokit: Octokit,
+): Promise<UnifiedList> {
+  const drafts = listDrafts(db);
+  const repos = listRepos(db);
+
+  // Fetch issues for each tracked repo in parallel. Uses the existing
+  // SWR cache in data/issues.ts, so cold-cache calls hit GitHub and
+  // warm-cache calls return cached data with a subsequent background
+  // refresh — we don't block on that refresh here.
+  const perRepo: PerRepoData[] = await Promise.all(
+    repos.map(async (repo) => {
+      const { issues } = await getIssues(db, octokit, repo.owner, repo.name);
+      const deployments = getDeploymentsByRepo(db, repo.id);
+      const priorities = listPrioritiesForRepo(db, repo.id);
+      return { repo, issues, deployments, priorities };
+    }),
+  );
+
+  return groupIntoSections({ drafts, perRepo });
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm -F @issuectl/core typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 3: Run the full core suite — nothing should regress**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: Same test count passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/data/unified-list.ts
+git commit -m "feat(core): getUnifiedList aggregates across tracked repos"
+```
+
+---
+
+### Task 3.4: Export new symbols from `@issuectl/core`
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add new type exports**
+
+Find the `export type { ... } from "./types.js"` block and add `Section`, `UnifiedListItem`, `UnifiedList` to it:
+
+```typescript
+export type {
+  Repo,
+  Setting,
+  SettingKey,
+  Deployment,
+  CacheEntry,
+  Draft,
+  DraftInput,
+  Priority,
+  IssuePriority,
+  Section,
+  UnifiedListItem,
+  UnifiedList,
+} from "./types.js";
+```
+
+- [ ] **Step 2: Add the function export**
+
+Find the existing data function exports (e.g., `getIssues`, `getPulls`, `getDashboardData`, `getComments`, `addComment`). Append a new export block right after:
+
+```typescript
+export {
+  getUnifiedList,
+  groupIntoSections,
+  type PerRepoData,
+  type GroupIntoSectionsInput,
+} from "./data/unified-list.js";
+```
+
+- [ ] **Step 3: Run full monorepo build + typecheck**
+
+Run: `pnpm turbo build && pnpm turbo typecheck`
+Expected: All packages build cleanly. `@issuectl/core/dist/index.d.ts` grows by the new exports.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/index.ts
+git commit -m "feat(core): export UnifiedList types and getUnifiedList"
+```
+
+---
+
+### Task 3.5: Add `Checkbox` Paper primitive
+
+**Files:**
+- Create: `packages/web/components/paper/Checkbox.tsx`
+- Create: `packages/web/components/paper/Checkbox.module.css`
+
+**Mockup reference:** `docs/mockups/paper-reskin.html#flow1` — the checkbox has four visual states: `open` (hollow square), `flight` (filled center, pulsing green), `done` (filled + white tick), `draft` (hollow square, same as open).
+
+- [ ] **Step 1: Create `Checkbox.module.css`**:
+
+```css
+.box {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.box svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.box .rect {
+  fill: transparent;
+  stroke: var(--paper-ink-muted);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.flight .rect {
+  stroke: var(--paper-accent);
+  stroke-width: 2;
+}
+
+.flight .fill {
+  fill: var(--paper-accent);
+  opacity: 0.35;
+  animation: pulse 1.8s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.75;
+  }
+}
+
+.done .rect {
+  fill: var(--paper-accent);
+  stroke: var(--paper-accent);
+}
+
+.done .tick {
+  fill: none;
+  stroke: var(--paper-bg);
+  stroke-width: 2.3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+```
+
+- [ ] **Step 2: Create `Checkbox.tsx`**:
+
+```typescript
+import styles from "./Checkbox.module.css";
+
+type CheckboxState = "open" | "flight" | "done" | "draft";
+
+type Props = {
+  state: CheckboxState;
+};
+
+export function Checkbox({ state }: Props) {
+  // "draft" renders the same as "open" — both are hollow squares.
+  const visualState = state === "draft" ? "open" : state;
+  const className = `${styles.box} ${styles[visualState] ?? ""}`;
+
+  return (
+    <span className={className} aria-hidden="true">
+      <svg viewBox="0 0 20 20">
+        <rect className={styles.rect} x="2" y="2" width="16" height="16" rx="2" />
+        {visualState === "flight" && (
+          <rect className={styles.fill} x="5" y="5" width="10" height="10" rx="1" />
+        )}
+        {visualState === "done" && (
+          <path className={styles.tick} d="M6 10.5 l2.8 2.8 L14.5 7" />
+        )}
+      </svg>
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Add `Checkbox` to the paper barrel** at `packages/web/components/paper/index.ts`:
+
+```typescript
+export { Chip } from "./Chip";
+export { Button } from "./Button";
+export { Sheet } from "./Sheet";
+export { Drawer } from "./Drawer";
+export { Checkbox } from "./Checkbox";
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/components/paper/Checkbox.tsx packages/web/components/paper/Checkbox.module.css packages/web/components/paper/index.ts
+git commit -m "feat(web): add Checkbox Paper primitive (open / flight / done / draft)"
+```
+
+---
+
+### Task 3.6: Add `FAB` Paper primitive
+
+**Files:**
+- Create: `packages/web/components/paper/Fab.tsx`
+- Create: `packages/web/components/paper/Fab.module.css`
+
+**Mockup reference:** `docs/mockups/paper-reskin.html#flow1` — the floating `+` button anchors the bottom right of the main list on mobile. Ink circle, serif `+`, shadow.
+
+- [ ] **Step 1: Create `Fab.module.css`**:
+
+```css
+.fab {
+  position: fixed;
+  right: 24px;
+  bottom: 30px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 34px;
+  line-height: 1;
+  padding-bottom: 4px;
+  box-shadow: 0 16px 40px rgba(26, 23, 18, 0.35),
+    0 0 0 6px rgba(26, 23, 18, 0.06);
+  z-index: 100;
+  border: none;
+  cursor: pointer;
+}
+
+.fab:hover {
+  opacity: 0.92;
+}
+
+@media (min-width: 768px) {
+  .fab {
+    right: 40px;
+    bottom: 40px;
+  }
+}
+```
+
+- [ ] **Step 2: Create `Fab.tsx`**:
+
+```typescript
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import styles from "./Fab.module.css";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children?: ReactNode;
+  "aria-label": string; // required for a11y
+};
+
+export function Fab({ children = "+", className, ...rest }: Props) {
+  const classes = [styles.fab, className ?? ""].filter(Boolean).join(" ");
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Add `Fab` to the paper barrel**
+
+In `packages/web/components/paper/index.ts`, add:
+
+```typescript
+export { Fab } from "./Fab";
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/components/paper/Fab.tsx packages/web/components/paper/Fab.module.css packages/web/components/paper/index.ts
+git commit -m "feat(web): add Fab Paper primitive"
+```
+
+---
+
+### Task 3.7: Create `ListRow` component
+
+**Files:**
+- Create: `packages/web/components/list/ListRow.tsx`
+- Create: `packages/web/components/list/ListRow.module.css`
+
+**Mockup reference:** Flow 01 row anatomy — checkbox + title + meta row (repo chip / #num / label / age).
+
+- [ ] **Step 1: Create `ListRow.module.css`**:
+
+```css
+.item {
+  padding: 16px 24px 16px 58px;
+  position: relative;
+  border-bottom: 1px solid var(--paper-line-soft);
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--paper-bg-warm);
+}
+
+.check {
+  position: absolute;
+  left: 24px;
+  top: 18px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 17px;
+  line-height: 1.3;
+  color: var(--paper-ink);
+  margin-bottom: 6px;
+  letter-spacing: -0.1px;
+}
+
+.title.done {
+  color: var(--paper-ink-muted);
+  text-decoration: line-through;
+  text-decoration-color: var(--paper-accent);
+  text-decoration-thickness: 1.5px;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+}
+
+.num {
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-faint);
+}
+
+.sep {
+  color: var(--paper-ink-faint);
+}
+
+.lblBug {
+  color: var(--paper-brick);
+}
+
+.lblFeat {
+  color: var(--paper-butter);
+}
+```
+
+- [ ] **Step 2: Create `ListRow.tsx`**:
+
+```typescript
+import type { UnifiedListItem } from "@issuectl/core";
+import { Checkbox, Chip } from "@/components/paper";
+import styles from "./ListRow.module.css";
+
+type Props = {
+  item: UnifiedListItem;
+};
+
+function formatAge(updatedAt: string | number): string {
+  const now = Date.now();
+  const updated =
+    typeof updatedAt === "number" ? updatedAt * 1000 : new Date(updatedAt).getTime();
+  const diffMs = now - updated;
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays <= 0) return "today";
+  if (diffDays === 1) return "1d";
+  return `${diffDays}d`;
+}
+
+function labelClass(labelName: string): string | undefined {
+  const lower = labelName.toLowerCase();
+  if (lower.includes("bug")) return styles.lblBug;
+  if (lower.includes("feat") || lower.includes("enhancement")) return styles.lblFeat;
+  return undefined;
+}
+
+export function ListRow({ item }: Props) {
+  if (item.kind === "draft") {
+    return (
+      <div className={styles.item}>
+        <span className={styles.check}>
+          <Checkbox state="draft" />
+        </span>
+        <div className={styles.title}>{item.draft.title}</div>
+        <div className={styles.meta}>
+          <Chip variant="dashed">no repo</Chip>
+          <span className={styles.sep}>·</span>
+          <span>local draft</span>
+          <span className={styles.sep}>·</span>
+          <span>{formatAge(item.draft.updatedAt)}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const { issue, repo, section } = item;
+  const checkState =
+    section === "shipped" ? "done" : section === "in_flight" ? "flight" : "open";
+  const titleClass =
+    section === "shipped" ? `${styles.title} ${styles.done}` : styles.title;
+
+  const firstLabel = issue.labels.find(
+    (l) => !l.name.startsWith("issuectl:"),
+  );
+
+  return (
+    <div className={styles.item}>
+      <span className={styles.check}>
+        <Checkbox state={checkState} />
+      </span>
+      <div className={titleClass}>{issue.title}</div>
+      <div className={styles.meta}>
+        <Chip>{repo.name}</Chip>
+        <span className={styles.num}>#{issue.number}</span>
+        {firstLabel && (
+          <>
+            <span className={styles.sep}>·</span>
+            <span className={labelClass(firstLabel.name)}>{firstLabel.name}</span>
+          </>
+        )}
+        <span className={styles.sep}>·</span>
+        <span>{formatAge(issue.updatedAt)}</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/ListRow.tsx packages/web/components/list/ListRow.module.css
+git commit -m "feat(web): add ListRow component for unified-list items"
+```
+
+---
+
+### Task 3.8: Create `ListSection` component
+
+**Files:**
+- Create: `packages/web/components/list/ListSection.tsx`
+- Create: `packages/web/components/list/ListSection.module.css`
+
+**Mockup reference:** Flow 01 section header — italic serif name, horizontal rule, mono count.
+
+- [ ] **Step 1: Create `ListSection.module.css`**:
+
+```css
+.section {
+  padding: 22px 24px 6px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.section h3 {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--paper-ink-soft);
+  margin: 0;
+}
+
+.rule {
+  flex: 1;
+  height: 1px;
+  background: var(--paper-line);
+}
+
+.count {
+  font-family: var(--paper-mono);
+  font-size: 10px;
+  color: var(--paper-ink-faint);
+  font-weight: 500;
+}
+```
+
+- [ ] **Step 2: Create `ListSection.tsx`**:
+
+```typescript
+import type { ReactNode } from "react";
+import type { UnifiedListItem } from "@issuectl/core";
+import { ListRow } from "./ListRow";
+import styles from "./ListSection.module.css";
+
+type Props = {
+  title: ReactNode;
+  items: UnifiedListItem[];
+};
+
+export function ListSection({ title, items }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      <div className={styles.section}>
+        <h3>{title}</h3>
+        <div className={styles.rule} />
+        <span className={styles.count}>{items.length}</span>
+      </div>
+      {items.map((item) => (
+        <ListRow
+          key={item.kind === "draft" ? `draft-${item.draft.id}` : `issue-${item.repo.id}-${item.issue.number}`}
+          item={item}
+        />
+      ))}
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/ListSection.tsx packages/web/components/list/ListSection.module.css
+git commit -m "feat(web): add ListSection component"
+```
+
+---
+
+### Task 3.9: Create main `List` client component
+
+**Files:**
+- Create: `packages/web/components/list/List.tsx`
+- Create: `packages/web/components/list/List.module.css`
+
+The main `List` is a **client component** so it can manage the open/close state of the `CreateDraftSheet` and `AssignSheet` that Tasks 3.10 and 3.11 create. The data is fetched server-side (in `page.tsx`) and passed in as a prop.
+
+- [ ] **Step 1: Create `List.module.css`**:
+
+```css
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 12px 0 120px;
+  background: var(--paper-bg);
+  min-height: 100vh;
+  position: relative;
+}
+
+.topBar {
+  padding: 52px 24px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.brand {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 34px;
+  line-height: 1;
+  letter-spacing: -0.8px;
+  color: var(--paper-ink);
+}
+
+.brand .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--paper-accent);
+  border-radius: 50%;
+  margin-left: 3px;
+  vertical-align: 6px;
+}
+
+.date {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  font-weight: 500;
+  text-align: right;
+  line-height: 1.3;
+}
+
+.date b {
+  display: block;
+  color: var(--paper-ink-soft);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 13px;
+  font-family: var(--paper-serif);
+}
+
+.tabs {
+  padding: 18px 24px 0;
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.tab {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--paper-ink-muted);
+  padding: 10px 2px 12px;
+  margin-right: 26px;
+  position: relative;
+  cursor: default;
+}
+
+.tab.on {
+  color: var(--paper-ink);
+}
+
+.tab.on::after {
+  content: "";
+  position: absolute;
+  left: -4px;
+  right: -4px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--paper-ink);
+}
+
+.tab .count {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: 10px;
+  margin-left: 6px;
+  color: var(--paper-ink-faint);
+  font-weight: 500;
+}
+
+.empty {
+  padding: 80px 20px 60px;
+  text-align: center;
+}
+
+.emptyMark {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 56px;
+  line-height: 0.8;
+  color: var(--paper-accent);
+  margin-bottom: 18px;
+}
+
+.empty h3 {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 22px;
+  letter-spacing: -0.3px;
+  color: var(--paper-ink);
+  margin-bottom: 8px;
+}
+
+.empty p {
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  color: var(--paper-ink-muted);
+  max-width: 280px;
+  margin: 0 auto;
+  line-height: 1.55;
+}
+
+.empty p em {
+  color: var(--paper-ink-soft);
+}
+```
+
+- [ ] **Step 2: Create `List.tsx`**:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import type { UnifiedList } from "@issuectl/core";
+import { Fab } from "@/components/paper";
+import { ListSection } from "./ListSection";
+import { CreateDraftSheet } from "./CreateDraftSheet";
+import styles from "./List.module.css";
+
+type Props = {
+  data: UnifiedList;
+};
+
+function formatDate(d: Date): { weekday: string; short: string } {
+  const weekday = d
+    .toLocaleDateString("en-US", { weekday: "long" })
+    .toLowerCase();
+  const short = d
+    .toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    .toLowerCase();
+  return { weekday, short };
+}
+
+export function List({ data }: Props) {
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const issueCount =
+    data.unassigned.length +
+    data.in_focus.length +
+    data.in_flight.length +
+    data.shipped.length;
+  const { weekday, short } = formatDate(new Date());
+  const isEmpty = issueCount === 0;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.topBar}>
+        <div className={styles.brand}>
+          issuectl<span className={styles.dot} />
+        </div>
+        <div className={styles.date}>
+          {weekday}
+          <b>{short}</b>
+        </div>
+      </div>
+      <div className={styles.tabs}>
+        <div className={`${styles.tab} ${styles.on}`}>
+          Issues<span className={styles.count}>{issueCount}</span>
+        </div>
+        <div className={styles.tab}>
+          Pull requests<span className={styles.count}>0</span>
+        </div>
+      </div>
+
+      {isEmpty ? (
+        <div className={styles.empty}>
+          <div className={styles.emptyMark}>❧</div>
+          <h3>all clear</h3>
+          <p>
+            nothing on your plate today.{" "}
+            <em>breathe, or draft the next one.</em>
+          </p>
+        </div>
+      ) : (
+        <div>
+          <ListSection title="unassigned" items={data.unassigned} />
+          <ListSection title="in focus" items={data.in_focus} />
+          <ListSection title="in flight" items={data.in_flight} />
+          <ListSection title="shipped" items={data.shipped} />
+        </div>
+      )}
+
+      <Fab
+        aria-label="Create a new draft"
+        onClick={() => setCreateOpen(true)}
+      />
+      <CreateDraftSheet open={createOpen} onClose={() => setCreateOpen(false)} />
+    </div>
+  );
+}
+```
+
+**Note:** this imports `CreateDraftSheet` from Task 3.11 below. Typecheck will fail until that task is complete. That's expected — commit this task's code anyway, then complete Task 3.11 to fix it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/components/list/List.tsx packages/web/components/list/List.module.css
+git commit -m "feat(web): add List client component (sheet state management)"
+```
+
+Note: don't run typecheck here — it will fail on the missing `CreateDraftSheet` import. Task 3.11 resolves it.
+
+---
+
+### Task 3.10: Add Server Actions for draft creation and assignment
+
+**Files:**
+- Create: `packages/web/lib/actions/drafts.ts`
+
+- [ ] **Step 1: Check if `packages/web/lib/actions/` exists**
+
+Run: `ls packages/web/lib/actions/ 2>/dev/null || echo "NOT YET"`
+If it doesn't exist, the file create will create the directory.
+
+- [ ] **Step 2: Create `packages/web/lib/actions/drafts.ts`**:
+
+```typescript
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getDb,
+  getOctokit,
+  createDraft,
+  assignDraftToRepo,
+  type DraftInput,
+} from "@issuectl/core";
+
+export async function createDraftAction(
+  input: DraftInput,
+): Promise<{ id: string }> {
+  const db = getDb();
+  const draft = createDraft(db, input);
+  revalidatePath("/");
+  return { id: draft.id };
+}
+
+export async function assignDraftAction(
+  draftId: string,
+  repoId: number,
+): Promise<{ issueNumber: number; issueUrl: string }> {
+  const db = getDb();
+  const octokit = await getOctokit();
+  const result = await assignDraftToRepo(db, octokit, draftId, repoId);
+  revalidatePath("/");
+  return { issueNumber: result.issueNumber, issueUrl: result.issueUrl };
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors (the action file itself; ignore errors from List.tsx pending Task 3.11).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/lib/actions/drafts.ts
+git commit -m "feat(web): add createDraftAction and assignDraftAction server actions"
+```
+
+---
+
+### Task 3.11: Add `CreateDraftSheet` component (title-only)
+
+**Files:**
+- Create: `packages/web/components/list/CreateDraftSheet.tsx`
+- Create: `packages/web/components/list/CreateDraftSheet.module.css`
+
+**Mockup reference:** Flow 03 — the new draft form. Phase 3 ships a title-only version; body + repo picker + labels come in a later phase.
+
+- [ ] **Step 1: Create `CreateDraftSheet.module.css`**:
+
+```css
+.form {
+  padding: 0 28px 28px;
+}
+
+.input {
+  width: 100%;
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+  border: none;
+  background: transparent;
+  padding: 4px 0 16px;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--paper-ink-faint);
+  font-style: italic;
+}
+
+.hint {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11.5px;
+  color: var(--paper-ink-faint);
+  margin-bottom: 18px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: 12.5px;
+  color: var(--paper-brick);
+  margin-bottom: 10px;
+}
+```
+
+- [ ] **Step 2: Create `CreateDraftSheet.tsx`**:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { Button, Sheet } from "@/components/paper";
+import { createDraftAction } from "@/lib/actions/drafts";
+import styles from "./CreateDraftSheet.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function CreateDraftSheet({ open, onClose }: Props) {
+  const [title, setTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (title.trim().length === 0) {
+      setError("A title is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createDraftAction({ title });
+      setTitle("");
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save draft");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    setTitle("");
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Sheet
+      open={open}
+      onClose={handleClose}
+      title="New draft"
+      description={<em>a local draft without a repo — assign it later</em>}
+    >
+      <div className={styles.form}>
+        <input
+          className={styles.input}
+          placeholder="What needs to be done?"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={saving}
+          autoFocus
+        />
+        <div className={styles.hint}>
+          body, labels, and repo assignment come in a later iteration
+        </div>
+        {error && <div className={styles.error}>{error}</div>}
+        <div className={styles.actions}>
+          <Button variant="ghost" onClick={handleClose} disabled={saving}>
+            cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={saving}>
+            {saving ? "saving…" : "save draft"}
+          </Button>
+        </div>
+      </div>
+    </Sheet>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck — should pass now that both List.tsx and CreateDraftSheet.tsx exist**
+
+Run: `pnpm -F @issuectl/web typecheck`
+Expected: Zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/CreateDraftSheet.tsx packages/web/components/list/CreateDraftSheet.module.css
+git commit -m "feat(web): add CreateDraftSheet (title-only minimum)"
+```
+
+---
+
+### Task 3.12: Replace `app/page.tsx` with the new main list
+
+**Files:**
+- Modify: `packages/web/app/page.tsx`
+
+- [ ] **Step 1: Read the current `page.tsx` so you know what you're replacing**
+
+Run: `cat packages/web/app/page.tsx`
+
+The current file imports from dashboard components and renders the old repo grid. Everything in it becomes dead code after this task (Phase 8 cleanup deletes the old components).
+
+- [ ] **Step 2: Replace `packages/web/app/page.tsx` with the new list**:
+
+```typescript
+import { getDb, getOctokit, getUnifiedList, listRepos, dbExists } from "@issuectl/core";
+import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
+import { List } from "@/components/list/List";
+
+export const dynamic = "force-dynamic";
+
+export default async function MainListPage() {
+  // Preserve the existing first-run behavior: no DB, or no tracked repos,
+  // falls back to the WelcomeScreen onboarding flow.
+  if (!dbExists()) {
+    return <WelcomeScreen />;
+  }
+
+  const db = getDb();
+  if (listRepos(db).length === 0) {
+    return <WelcomeScreen />;
+  }
+
+  const octokit = await getOctokit();
+  const data = await getUnifiedList(db, octokit);
+
+  return <List data={data} />;
+}
+```
+
+- [ ] **Step 3: Run full typecheck + build**
+
+Run: `pnpm turbo typecheck && pnpm -F @issuectl/web build`
+Expected: Both pass cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/app/page.tsx
+git commit -m "feat(web): replace dashboard with new Paper main list"
+```
+
+---
+
+### Task 3.13: Run final monorepo verification
+
+No new files in this task — just a full-stack sanity check that Phase 3's changes integrate cleanly.
+
+- [ ] **Step 1: Full monorepo typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: All 4 typecheck tasks pass.
+
+- [ ] **Step 2: Full monorepo build**
+
+Run: `pnpm turbo build`
+Expected: All 3 packages build.
+
+- [ ] **Step 3: Full monorepo lint**
+
+Run: `pnpm turbo lint`
+Expected: Zero errors, zero warnings.
+
+- [ ] **Step 4: Core test suite**
+
+Run: `pnpm -F @issuectl/core test`
+Expected: All ~178 tests pass.
+
+- [ ] **Step 5: Eyeball the dev server**
+
+Run (separate terminal): `pnpm -F @issuectl/web dev`
+Open `http://localhost:3847` in a browser.
+Expected: The main page renders the new Paper main list instead of the old repo grid. Existing tracked repos' issues appear in the appropriate sections (unassigned/in focus/in flight/shipped). Clicking a row does nothing (Phase 4). Clicking the FAB opens the CreateDraftSheet and saving a draft persists it (visible in the unassigned section after save).
+
+Stop the dev server.
+
+No commit for this task — it's verification only.
+
+---
+
+### Task 3.14: (No code — final summary + follow-up tasks)
+
+This is a bookkeeping task to report the state of Phase 3 and identify what needs to come in Phase 3.1 or later.
+
+**Deferred for Phase 3.1 or beyond:**
+- **AssignSheet** — the sheet for picking a target repo for a draft. Infrastructure is ready (`Sheet` primitive + `assignDraftAction` server action), but the UI component and the swipe gesture that opens it are deferred.
+- **Row swipe gesture** — mobile swipe-from-right to reveal the assign action.
+- **Desktop hover quick actions** — `assign / reassign / launch` buttons that appear on row hover.
+- **Row tap → issue detail** — waits for Phase 4 to implement the detail routes.
+- **Launch button wiring** — waits for Phase 5.
+- **PR tab variant** — waits for Phase 7.
+- **Mobile nav drawer** — waits for Phase 7.
+- **Priority picker** — waits for Phase 7.
+
+**What's shippable now:**
+- Cross-repo read-only flat list with correct sectioning and priority ordering.
+- Draft creation (title only) via FAB + sheet.
+- All Phase 1+2 data-layer functions remain available and tested.
+
+---
+
+## Self-Review Checklist
+
+Before executing this plan, verify:
+
+- [ ] **Spec coverage** — every line item in the spec's Phase 3 description maps to a task:
+  - Cross-repo data aggregation → Task 3.2, 3.3
+  - Section grouping logic → Task 3.2
+  - Priority ordering → Task 3.2
+  - Replace `app/page.tsx` → Task 3.12
+  - (Swipe handler and assign sheet deferred to Phase 3.1 — documented in Task 3.14)
+
+- [ ] **Placeholders** — no "TBD", "TODO", "fill in details" anywhere
+
+- [ ] **Type consistency** — `UnifiedListItem`, `UnifiedList`, `Section`, `PerRepoData` used consistently. `groupIntoSections` signature matches across Task 3.2 and Task 3.3.
+
+- [ ] **Existing function signatures verified** — `getIssues`, `listRepos`, `getDeploymentsByRepo`, `listPrioritiesForRepo`, `listDrafts` — all already exist with the signatures used in Task 3.3. Read their source before starting Task 3.3 to confirm nothing has drifted.
+
+- [ ] **Out-of-order typecheck warning** — Task 3.9 creates `List.tsx` which imports `CreateDraftSheet` from Task 3.11; typecheck will fail between 3.9 and 3.11. This is called out explicitly in 3.9's steps. Don't treat it as a bug; just complete Task 3.11 to resolve.

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -216,18 +216,154 @@ describe("groupIntoSections", () => {
     expect(focus[2].issue.number).toBe(1);
   });
 
-  it("sorts drafts by priority DESC then updatedAt DESC", () => {
-    const normalOlder = makeDraft({ title: "A", priority: "normal", updatedAt: 100 });
-    const normalNewer = makeDraft({ title: "B", priority: "normal", updatedAt: 200 });
-    const high = makeDraft({ title: "C", priority: "high", updatedAt: 50 });
+  it("sorts drafts by priority DESC then updatedAt DESC, including low", () => {
+    const lowest = makeDraft({ title: "A", priority: "low", updatedAt: 500 });
+    const normalOlder = makeDraft({ title: "B", priority: "normal", updatedAt: 100 });
+    const normalNewer = makeDraft({ title: "C", priority: "normal", updatedAt: 200 });
+    const high = makeDraft({ title: "D", priority: "high", updatedAt: 50 });
     const result = groupIntoSections({
-      drafts: [normalOlder, normalNewer, high],
+      drafts: [lowest, normalOlder, normalNewer, high],
       perRepo: [],
     });
     const titles = result.unassigned.map((item) => {
       if (item.kind !== "draft") throw new Error("expected draft");
       return item.draft.title;
     });
-    expect(titles).toEqual(["C", "B", "A"]);
+    // high first, then normal newer, then normal older, then low last
+    expect(titles).toEqual(["D", "C", "B", "A"]);
+  });
+
+  it("item.section matches the bucket an issue lands in", () => {
+    const openIssue = makeIssue({ number: 1, state: "open" });
+    const shippedIssue = makeIssue({ number: 2, state: "closed" });
+    const flightIssue = makeIssue({ number: 3, state: "open" });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [openIssue, shippedIssue, flightIssue],
+          deployments: [makeDeployment(3, false)],
+          priorities: [],
+        },
+      ],
+    });
+
+    for (const item of result.in_focus) {
+      if (item.kind !== "issue") throw new Error("expected issue");
+      expect(item.section).toBe("in_focus");
+    }
+    for (const item of result.in_flight) {
+      if (item.kind !== "issue") throw new Error("expected issue");
+      expect(item.section).toBe("in_flight");
+    }
+    for (const item of result.shipped) {
+      if (item.kind !== "issue") throw new Error("expected issue");
+      expect(item.section).toBe("shipped");
+    }
+  });
+
+  it("aggregates issues across multiple tracked repos", () => {
+    const apiRepo = repo;
+    const webRepo: Repo = { ...repo, id: 2, name: "web" };
+
+    const apiIssue1 = makeIssue({ number: 1, title: "api bug" });
+    const apiIssue2 = makeIssue({ number: 2, title: "api feat" });
+    const webIssue1 = makeIssue({ number: 1, title: "web bug" });
+
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo: apiRepo,
+          issues: [apiIssue1, apiIssue2],
+          deployments: [],
+          priorities: [],
+        },
+        {
+          repo: webRepo,
+          issues: [webIssue1],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+
+    expect(result.in_focus).toHaveLength(3);
+    // Verify both repos are represented by looking at the item.repo.name
+    const repoNames = result.in_focus.map((item) => {
+      if (item.kind !== "issue") throw new Error("expected issue");
+      return item.repo.name;
+    });
+    expect(repoNames).toContain("api");
+    expect(repoNames).toContain("web");
+  });
+
+  it("does not confuse priority rows across repos with the same issue number", () => {
+    // Regression guard: the priority map must be scoped to the repo.
+    // If the impl ever keys by issueNumber alone, the api-repo issue #1
+    // would wrongly inherit the web-repo #1's "high" priority.
+    const apiRepo = repo;
+    const webRepo: Repo = { ...repo, id: 2, name: "web" };
+
+    const apiIssue1 = makeIssue({ number: 1, title: "api" });
+    const webIssue1 = makeIssue({ number: 1, title: "web" });
+
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo: apiRepo,
+          issues: [apiIssue1],
+          deployments: [],
+          priorities: [], // api #1 has no explicit priority → normal
+        },
+        {
+          repo: webRepo,
+          issues: [webIssue1],
+          deployments: [],
+          priorities: [
+            { repoId: webRepo.id, issueNumber: 1, priority: "high", updatedAt: 0 },
+          ],
+        },
+      ],
+    });
+
+    for (const item of result.in_focus) {
+      if (item.kind !== "issue") throw new Error("expected issue");
+      if (item.repo.name === "api") {
+        expect(item.priority).toBe("normal");
+      } else if (item.repo.name === "web") {
+        expect(item.priority).toBe("high");
+      }
+    }
+  });
+
+  it("a closed issue with an active deployment still lands in shipped", () => {
+    // Precedence test: closed → shipped wins over active deployment → in_flight.
+    // Pins the branch order in groupIntoSections so a future refactor can't
+    // silently move closed-with-deployment issues into in_flight.
+    const issue = makeIssue({ number: 7, state: "closed" });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [makeDeployment(7, false)], // active
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.shipped).toHaveLength(1);
+    expect(result.in_flight).toHaveLength(0);
+  });
+
+  it("handles empty input cleanly", () => {
+    const result = groupIntoSections({ drafts: [], perRepo: [] });
+    expect(result.unassigned).toEqual([]);
+    expect(result.in_focus).toEqual([]);
+    expect(result.in_flight).toEqual([]);
+    expect(result.shipped).toEqual([]);
   });
 });

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import type {
+  Draft,
+  Repo,
+  IssuePriority,
+  Deployment,
+} from "../types.js";
+import type { GitHubIssue } from "../github/types.js";
+import { groupIntoSections } from "./unified-list.js";
+
+const repo: Repo = {
+  id: 1,
+  owner: "neonwatty",
+  name: "api",
+  localPath: null,
+  branchPattern: null,
+  createdAt: "2026-01-01",
+};
+
+function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: "Test issue",
+    body: "",
+    state: "open",
+    labels: [],
+    user: null,
+    createdAt: "2026-04-01T00:00:00Z",
+    updatedAt: "2026-04-01T00:00:00Z",
+    closedAt: null,
+    htmlUrl: "https://github.com/neonwatty/api/issues/1",
+    ...overrides,
+  };
+}
+
+function makeDraft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    id: "draft-" + Math.random().toString(36).slice(2, 8),
+    title: "Draft",
+    body: "",
+    priority: "normal",
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeDeployment(issueNumber: number, ended = false): Deployment {
+  return {
+    id: issueNumber * 10,
+    repoId: repo.id,
+    issueNumber,
+    branchName: `issue-${issueNumber}`,
+    workspaceMode: "worktree",
+    workspacePath: `/tmp/${issueNumber}`,
+    linkedPrNumber: null,
+    launchedAt: "2026-04-01T00:00:00Z",
+    endedAt: ended ? "2026-04-02T00:00:00Z" : null,
+  };
+}
+
+describe("groupIntoSections", () => {
+  it("puts drafts in the unassigned section", () => {
+    const d1 = makeDraft({ title: "First" });
+    const d2 = makeDraft({ title: "Second" });
+    const result = groupIntoSections({
+      drafts: [d1, d2],
+      perRepo: [],
+    });
+    expect(result.unassigned).toHaveLength(2);
+    expect(result.unassigned.every((item) => item.kind === "draft")).toBe(true);
+    expect(result.in_focus).toEqual([]);
+    expect(result.in_flight).toEqual([]);
+    expect(result.shipped).toEqual([]);
+  });
+
+  it("puts closed issues in shipped", () => {
+    const closed = makeIssue({ number: 1, state: "closed" });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [closed],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.shipped).toHaveLength(1);
+    expect(result.in_focus).toEqual([]);
+  });
+
+  it("puts open issues with an active deployment in in_flight", () => {
+    const issue = makeIssue({ number: 2 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [makeDeployment(2, false)],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_flight).toHaveLength(1);
+    expect(result.in_focus).toEqual([]);
+  });
+
+  it("treats an issue with only ended deployments as in_focus", () => {
+    const issue = makeIssue({ number: 3 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [makeDeployment(3, true)],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_focus).toHaveLength(1);
+    expect(result.in_flight).toEqual([]);
+  });
+
+  it("puts open issues with no deployment in in_focus", () => {
+    const issue = makeIssue({ number: 4 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.in_focus).toHaveLength(1);
+  });
+
+  it("enriches issues with their priority from the repo's priority map", () => {
+    const issue = makeIssue({ number: 5 });
+    const priorities: IssuePriority[] = [
+      {
+        repoId: repo.id,
+        issueNumber: 5,
+        priority: "high",
+        updatedAt: 1000,
+      },
+    ];
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities,
+        },
+      ],
+    });
+    const item = result.in_focus[0];
+    if (item.kind !== "issue") throw new Error("expected issue");
+    expect(item.priority).toBe("high");
+  });
+
+  it("defaults issues with no priority row to 'normal'", () => {
+    const issue = makeIssue({ number: 6 });
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [issue],
+          deployments: [],
+          priorities: [],
+        },
+      ],
+    });
+    const item = result.in_focus[0];
+    if (item.kind !== "issue") throw new Error("expected issue");
+    expect(item.priority).toBe("normal");
+  });
+
+  it("sorts within each section by priority DESC then updatedAt DESC", () => {
+    const older = makeIssue({ number: 1, updatedAt: "2026-04-01T00:00:00Z" });
+    const newer = makeIssue({ number: 2, updatedAt: "2026-04-05T00:00:00Z" });
+    const highOlder = makeIssue({
+      number: 3,
+      updatedAt: "2026-03-01T00:00:00Z",
+    });
+    const priorities: IssuePriority[] = [
+      { repoId: repo.id, issueNumber: 3, priority: "high", updatedAt: 0 },
+    ];
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [older, newer, highOlder],
+          deployments: [],
+          priorities,
+        },
+      ],
+    });
+    const focus = result.in_focus;
+    expect(focus).toHaveLength(3);
+    if (focus[0].kind !== "issue") throw new Error("expected issue");
+    if (focus[1].kind !== "issue") throw new Error("expected issue");
+    if (focus[2].kind !== "issue") throw new Error("expected issue");
+    expect(focus[0].issue.number).toBe(3);
+    expect(focus[1].issue.number).toBe(2);
+    expect(focus[2].issue.number).toBe(1);
+  });
+
+  it("sorts drafts by priority DESC then updatedAt DESC", () => {
+    const normalOlder = makeDraft({ title: "A", priority: "normal", updatedAt: 100 });
+    const normalNewer = makeDraft({ title: "B", priority: "normal", updatedAt: 200 });
+    const high = makeDraft({ title: "C", priority: "high", updatedAt: 50 });
+    const result = groupIntoSections({
+      drafts: [normalOlder, normalNewer, high],
+      perRepo: [],
+    });
+    const titles = result.unassigned.map((item) => {
+      if (item.kind !== "draft") throw new Error("expected draft");
+      return item.draft.title;
+    });
+    expect(titles).toEqual(["C", "B", "A"]);
+  });
+});

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -1,3 +1,5 @@
+import type Database from "better-sqlite3";
+import type { Octokit } from "@octokit/rest";
 import type {
   Draft,
   Repo,
@@ -8,6 +10,11 @@ import type {
   UnifiedListItem,
 } from "../types.js";
 import type { GitHubIssue } from "../github/types.js";
+import { listDrafts } from "../db/drafts.js";
+import { listRepos } from "../db/repos.js";
+import { getDeploymentsByRepo } from "../db/deployments.js";
+import { listPrioritiesForRepo } from "../db/priority.js";
+import { getIssues } from "./issues.js";
 
 export type PerRepoData = {
   repo: Repo;
@@ -117,4 +124,27 @@ export function groupIntoSections(
     in_flight: sortIssues(in_flight),
     shipped: sortIssues(shipped),
   };
+}
+
+export async function getUnifiedList(
+  db: Database.Database,
+  octokit: Octokit,
+): Promise<UnifiedList> {
+  const drafts = listDrafts(db);
+  const repos = listRepos(db);
+
+  // Fetch issues for each tracked repo in parallel. Uses the existing
+  // SWR cache in data/issues.ts, so cold-cache calls hit GitHub and
+  // warm-cache calls return cached data with a subsequent background
+  // refresh — we don't block on that refresh here.
+  const perRepo: PerRepoData[] = await Promise.all(
+    repos.map(async (repo) => {
+      const { issues } = await getIssues(db, octokit, repo.owner, repo.name);
+      const deployments = getDeploymentsByRepo(db, repo.id);
+      const priorities = listPrioritiesForRepo(db, repo.id);
+      return { repo, issues, deployments, priorities };
+    }),
+  );
+
+  return groupIntoSections({ drafts, perRepo });
 }

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -1,0 +1,120 @@
+import type {
+  Draft,
+  Repo,
+  IssuePriority,
+  Deployment,
+  Priority,
+  UnifiedList,
+  UnifiedListItem,
+} from "../types.js";
+import type { GitHubIssue } from "../github/types.js";
+
+export type PerRepoData = {
+  repo: Repo;
+  issues: GitHubIssue[];
+  deployments: Deployment[];
+  priorities: IssuePriority[];
+};
+
+export type GroupIntoSectionsInput = {
+  drafts: Draft[];
+  perRepo: PerRepoData[];
+};
+
+const PRIORITY_RANK: Record<Priority, number> = {
+  high: 2,
+  normal: 1,
+  low: 0,
+};
+
+function compareByPriorityThenUpdatedAt(
+  aPriority: Priority,
+  aUpdatedAt: number,
+  bPriority: Priority,
+  bUpdatedAt: number,
+): number {
+  const rankDiff = PRIORITY_RANK[bPriority] - PRIORITY_RANK[aPriority];
+  if (rankDiff !== 0) return rankDiff;
+  return bUpdatedAt - aUpdatedAt;
+}
+
+export function groupIntoSections(
+  input: GroupIntoSectionsInput,
+): UnifiedList {
+  // Unassigned: all drafts, sorted by priority DESC then updatedAt DESC
+  const unassigned: UnifiedListItem[] = input.drafts
+    .slice()
+    .sort((a, b) =>
+      compareByPriorityThenUpdatedAt(
+        a.priority,
+        a.updatedAt,
+        b.priority,
+        b.updatedAt,
+      ),
+    )
+    .map((draft) => ({ kind: "draft" as const, draft }));
+
+  const in_focus: UnifiedListItem[] = [];
+  const in_flight: UnifiedListItem[] = [];
+  const shipped: UnifiedListItem[] = [];
+
+  for (const { repo, issues, deployments, priorities } of input.perRepo) {
+    // Build a set of issue numbers with an active deployment (ended_at IS NULL)
+    const activeLaunchSet = new Set(
+      deployments
+        .filter((d) => d.endedAt === null)
+        .map((d) => d.issueNumber),
+    );
+
+    // Build a priority map for this repo
+    const priorityMap = new Map<number, Priority>(
+      priorities.map((p) => [p.issueNumber, p.priority]),
+    );
+
+    for (const issue of issues) {
+      const priority = priorityMap.get(issue.number) ?? "normal";
+      let section: "in_focus" | "in_flight" | "shipped";
+
+      if (issue.state === "closed") {
+        section = "shipped";
+      } else if (activeLaunchSet.has(issue.number)) {
+        section = "in_flight";
+      } else {
+        section = "in_focus";
+      }
+
+      const item: UnifiedListItem = {
+        kind: "issue",
+        repo,
+        issue,
+        priority,
+        section,
+      };
+
+      if (section === "in_focus") in_focus.push(item);
+      else if (section === "in_flight") in_flight.push(item);
+      else shipped.push(item);
+    }
+  }
+
+  // Sort each issue section by priority DESC then updatedAt DESC
+  const sortIssues = (items: UnifiedListItem[]): UnifiedListItem[] =>
+    items.slice().sort((a, b) => {
+      if (a.kind !== "issue" || b.kind !== "issue") return 0;
+      const aUpdated = new Date(a.issue.updatedAt).getTime();
+      const bUpdated = new Date(b.issue.updatedAt).getTime();
+      return compareByPriorityThenUpdatedAt(
+        a.priority,
+        aUpdated,
+        b.priority,
+        bUpdated,
+      );
+    });
+
+  return {
+    unassigned,
+    in_focus: sortIssues(in_focus),
+    in_flight: sortIssues(in_flight),
+    shipped: sortIssues(shipped),
+  };
+}

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -7,7 +7,8 @@ import type {
   Deployment,
   Priority,
   UnifiedList,
-  UnifiedListItem,
+  DraftListItem,
+  IssueListItem,
 } from "../types.js";
 import type { GitHubIssue } from "../github/types.js";
 import { listDrafts } from "../db/drafts.js";
@@ -28,6 +29,8 @@ export type GroupIntoSectionsInput = {
   perRepo: PerRepoData[];
 };
 
+// Higher rank sorts earlier via compareByPriorityThenUpdatedAt — e.g.,
+// all "high" items come before any "normal" item, regardless of timestamp.
 const PRIORITY_RANK: Record<Priority, number> = {
   high: 2,
   normal: 1,
@@ -52,8 +55,7 @@ function compareByPriorityThenUpdatedAt(
 export function groupIntoSections(
   input: GroupIntoSectionsInput,
 ): UnifiedList {
-  // Unassigned: all drafts, sorted by priority DESC then updatedAt DESC
-  const unassigned: UnifiedListItem[] = input.drafts
+  const unassigned: DraftListItem[] = input.drafts
     .slice()
     .sort((a, b) =>
       compareByPriorityThenUpdatedAt(
@@ -65,27 +67,29 @@ export function groupIntoSections(
     )
     .map((draft) => ({ kind: "draft" as const, draft }));
 
-  const in_focus: UnifiedListItem[] = [];
-  const in_flight: UnifiedListItem[] = [];
-  const shipped: UnifiedListItem[] = [];
+  const in_focus: IssueListItem[] = [];
+  const in_flight: IssueListItem[] = [];
+  const shipped: IssueListItem[] = [];
 
   for (const { repo, issues, deployments, priorities } of input.perRepo) {
-    // Build a set of issue numbers with an active deployment (ended_at IS NULL)
+    // A deployment row with ended_at IS NULL means there's a live
+    // worktree / Claude session still open for that issue.
     const activeLaunchSet = new Set(
       deployments
         .filter((d) => d.endedAt === null)
         .map((d) => d.issueNumber),
     );
 
-    // Build a priority map for this repo
     const priorityMap = new Map<number, Priority>(
       priorities.map((p) => [p.issueNumber, p.priority]),
     );
 
     for (const issue of issues) {
       const priority = priorityMap.get(issue.number) ?? "normal";
-      let section: "in_focus" | "in_flight" | "shipped";
 
+      // Closed wins over an active deployment (a stale deployment shouldn't
+      // keep a closed issue out of shipped). See the dedicated test.
+      let section: "in_focus" | "in_flight" | "shipped";
       if (issue.state === "closed") {
         section = "shipped";
       } else if (activeLaunchSet.has(issue.number)) {
@@ -94,7 +98,7 @@ export function groupIntoSections(
         section = "in_focus";
       }
 
-      const item: UnifiedListItem = {
+      const item: IssueListItem = {
         kind: "issue",
         repo,
         issue,
@@ -108,10 +112,8 @@ export function groupIntoSections(
     }
   }
 
-  // Sort each issue section by priority DESC then updatedAt DESC
-  const sortIssues = (items: UnifiedListItem[]): UnifiedListItem[] =>
+  const sortIssues = (items: IssueListItem[]): IssueListItem[] =>
     items.slice().sort((a, b) => {
-      if (a.kind !== "issue" || b.kind !== "issue") return 0;
       const aUpdated = new Date(a.issue.updatedAt).getTime();
       const bUpdated = new Date(b.issue.updatedAt).getTime();
       return compareByPriorityThenUpdatedAt(

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -42,7 +42,11 @@ function compareByPriorityThenUpdatedAt(
 ): number {
   const rankDiff = PRIORITY_RANK[bPriority] - PRIORITY_RANK[aPriority];
   if (rankDiff !== 0) return rankDiff;
-  return bUpdatedAt - aUpdatedAt;
+  // Guard against NaN from malformed timestamps (e.g., an unparseable ISO
+  // string from GitHub). Fall back to 0 so the sort stays deterministic.
+  const aSafe = Number.isFinite(aUpdatedAt) ? aUpdatedAt : 0;
+  const bSafe = Number.isFinite(bUpdatedAt) ? bUpdatedAt : 0;
+  return bSafe - aSafe;
 }
 
 export function groupIntoSections(
@@ -133,17 +137,30 @@ export async function getUnifiedList(
   const drafts = listDrafts(db);
   const repos = listRepos(db);
 
-  // Fetch issues for each tracked repo in parallel. Uses the existing
-  // SWR cache in data/issues.ts, so cold-cache calls hit GitHub and
-  // warm-cache calls return cached data with a subsequent background
-  // refresh — we don't block on that refresh here.
-  const perRepo: PerRepoData[] = await Promise.all(
-    repos.map(async (repo) => {
-      const { issues } = await getIssues(db, octokit, repo.owner, repo.name);
-      const deployments = getDeploymentsByRepo(db, repo.id);
-      const priorities = listPrioritiesForRepo(db, repo.id);
-      return { repo, issues, deployments, priorities };
+  // Fetch each tracked repo's data in parallel. Per-repo failures (network
+  // error, 404, rate limit, revoked token) are caught and logged so one bad
+  // repo doesn't kill the whole page — we render the remaining repos' data
+  // and drafts. Phase 4/5 can surface a "couldn't load N repos" banner if
+  // the degraded experience becomes noticeable.
+  const results = await Promise.all(
+    repos.map(async (repo): Promise<PerRepoData | null> => {
+      try {
+        const { issues } = await getIssues(db, octokit, repo.owner, repo.name);
+        const deployments = getDeploymentsByRepo(db, repo.id);
+        const priorities = listPrioritiesForRepo(db, repo.id);
+        return { repo, issues, deployments, priorities };
+      } catch (err) {
+        console.error(
+          `[issuectl] getUnifiedList: failed to fetch data for ${repo.owner}/${repo.name}`,
+          err,
+        );
+        return null;
+      }
     }),
+  );
+
+  const perRepo: PerRepoData[] = results.filter(
+    (r): r is PerRepoData => r !== null,
   );
 
   return groupIntoSections({ drafts, perRepo });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,9 @@ export type {
   DraftInput,
   Priority,
   IssuePriority,
+  Section,
+  UnifiedListItem,
+  UnifiedList,
 } from "./types.js";
 
 export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
@@ -98,6 +101,12 @@ export {
   getComments,
   addComment,
 } from "./data/comments.js";
+export {
+  getUnifiedList,
+  groupIntoSections,
+  type PerRepoData,
+  type GroupIntoSectionsInput,
+} from "./data/unified-list.js";
 
 // Launch flow
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,8 +10,11 @@ export type {
   IssuePriority,
   Section,
   UnifiedListItem,
+  DraftListItem,
+  IssueListItem,
   UnifiedList,
 } from "./types.js";
+export { SECTION_LABEL } from "./types.js";
 
 export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
 export { initSchema, getSchemaVersion } from "./db/schema.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,6 @@ export type {
   IssueListItem,
   UnifiedList,
 } from "./types.js";
-export { SECTION_LABEL } from "./types.js";
 
 export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
 export { initSchema, getSchemaVersion } from "./db/schema.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,9 +67,20 @@ export type IssuePriority = {
 
 export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
 
-// A UnifiedListItem is either a local draft (unassigned) or a
-// GitHub-backed issue enriched with its local priority and its
-// lifecycle state for the current section.
+// Display labels for each section. Keyed on the underscore form used in
+// the type so a new section can't be added without giving it a label.
+export const SECTION_LABEL: Record<Section, string> = {
+  unassigned: "unassigned",
+  in_focus: "in focus",
+  in_flight: "in flight",
+  shipped: "shipped",
+};
+
+// A UnifiedListItem is a discriminated union with two variants: a local
+// Draft (the caller will place it in the unassigned section) or a
+// GitHub-backed issue already assigned to one of the three issue sections.
+// The section field is narrowed to exclude "unassigned" so the type
+// prevents constructing an issue item that claims to be unassigned.
 export type UnifiedListItem =
   | {
       kind: "draft";
@@ -83,9 +94,17 @@ export type UnifiedListItem =
       section: Exclude<Section, "unassigned">;
     };
 
+// Narrow helpers for places that want a specific variant.
+export type DraftListItem = Extract<UnifiedListItem, { kind: "draft" }>;
+export type IssueListItem = Extract<UnifiedListItem, { kind: "issue" }>;
+
+// UnifiedList is parametrized by variant so each section can only hold
+// the kind that belongs there: unassigned → drafts only, the three issue
+// sections → issue items only. This prevents groupIntoSections (or any
+// future caller) from silently pushing an issue into unassigned.
 export type UnifiedList = {
-  unassigned: UnifiedListItem[];
-  in_focus: UnifiedListItem[];
-  in_flight: UnifiedListItem[];
-  shipped: UnifiedListItem[];
+  unassigned: DraftListItem[];
+  in_focus: IssueListItem[];
+  in_flight: IssueListItem[];
+  shipped: IssueListItem[];
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,6 +22,7 @@ export type Setting = {
 };
 
 import type { WorkspaceMode } from "./launch/workspace.js";
+import type { GitHubIssue } from "./github/types.js";
 
 export type Deployment = {
   id: number;
@@ -62,4 +63,29 @@ export type IssuePriority = {
   issueNumber: number;
   priority: Priority;
   updatedAt: number; // unix seconds
+};
+
+export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
+
+// A UnifiedListItem is either a local draft (unassigned) or a
+// GitHub-backed issue enriched with its local priority and its
+// lifecycle state for the current section.
+export type UnifiedListItem =
+  | {
+      kind: "draft";
+      draft: Draft;
+    }
+  | {
+      kind: "issue";
+      repo: Repo;
+      issue: GitHubIssue;
+      priority: Priority;
+      section: Exclude<Section, "unassigned">;
+    };
+
+export type UnifiedList = {
+  unassigned: UnifiedListItem[];
+  in_focus: UnifiedListItem[];
+  in_flight: UnifiedListItem[];
+  shipped: UnifiedListItem[];
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,15 +67,6 @@ export type IssuePriority = {
 
 export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
 
-// Display labels for each section. Keyed on the underscore form used in
-// the type so a new section can't be added without giving it a label.
-export const SECTION_LABEL: Record<Section, string> = {
-  unassigned: "unassigned",
-  in_focus: "in focus",
-  in_flight: "in flight",
-  shipped: "shipped",
-};
-
 // A UnifiedListItem is a discriminated union with two variants: a local
 // Draft (the caller will place it in the unassigned section) or a
 // GitHub-backed issue already assigned to one of the three issue sections.

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,50 +1,29 @@
-import { getDb, getOctokit, getDashboardData, getCacheTtl, dbExists, listRepos } from "@issuectl/core";
-import { PageHeader } from "@/components/ui/PageHeader";
-import { RepoGrid } from "@/components/dashboard/RepoGrid";
-import { DashboardCacheStatus } from "@/components/dashboard/DashboardCacheStatus";
+import {
+  getDb,
+  getOctokit,
+  getUnifiedList,
+  listRepos,
+  dbExists,
+} from "@issuectl/core";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
+import { List } from "@/components/list/List";
 
 export const dynamic = "force-dynamic";
 
-export default async function DashboardPage() {
+export default async function MainListPage() {
+  // Preserve the existing first-run behavior: no DB, or no tracked repos,
+  // falls back to the WelcomeScreen onboarding flow.
   if (!dbExists()) {
     return <WelcomeScreen />;
   }
 
   const db = getDb();
-
-  // Guard before the try/catch: the catch fallback also produces repos: [],
-  // which would incorrectly show WelcomeScreen on a transient API failure.
   if (listRepos(db).length === 0) {
     return <WelcomeScreen />;
   }
 
   const octokit = await getOctokit();
-  const data = await getDashboardData(db, octokit);
+  const data = await getUnifiedList(db, octokit);
 
-  const cachedAtIso = data.cachedAt?.toISOString() ?? null;
-  const ttl = getCacheTtl(db);
-  const isStale = data.cachedAt
-    ? Date.now() - data.cachedAt.getTime() > ttl * 1000
-    : false;
-
-  return (
-    <>
-      <PageHeader
-        title={
-          <>
-            <span style={{ color: "var(--accent)" }}>{data.repos.length}</span>{" "}
-            {data.repos.length === 1 ? "Repository" : "Repositories"}
-          </>
-        }
-      />
-      <DashboardCacheStatus
-        cachedAt={cachedAtIso}
-        totalIssues={data.totalIssues}
-        totalPRs={data.totalPRs}
-        isStale={isStale}
-      />
-      <RepoGrid repos={data.repos} />
-    </>
-  );
+  return <List data={data} />;
 }

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -1,0 +1,43 @@
+.form {
+  padding: 0 28px 28px;
+}
+
+.input {
+  width: 100%;
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+  border: none;
+  background: transparent;
+  padding: 4px 0 16px;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--paper-ink-faint);
+  font-style: italic;
+}
+
+.hint {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11.5px;
+  color: var(--paper-ink-faint);
+  margin-bottom: 18px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: 12.5px;
+  color: var(--paper-brick);
+  margin-bottom: 10px;
+}

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -15,6 +15,10 @@ export function CreateDraftSheet({ open, onClose }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Defense in depth: createDraft in core also validates the title, and
+  // createDraftAction validates at the server boundary. The client-side
+  // check here is a UX affordance — avoids a server round-trip just to
+  // surface "title required."
   const handleSave = async () => {
     if (title.trim().length === 0) {
       setError("A title is required");
@@ -56,7 +60,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           autoFocus
         />
         <div className={styles.hint}>
-          body, labels, and repo assignment come in a later iteration
+          title only — add a body, labels, and a repo when you assign it
         </div>
         {error && <div className={styles.error}>{error}</div>}
         <div className={styles.actions}>

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Sheet } from "@/components/paper";
+import { createDraftAction } from "@/lib/actions/drafts";
+import styles from "./CreateDraftSheet.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function CreateDraftSheet({ open, onClose }: Props) {
+  const [title, setTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (title.trim().length === 0) {
+      setError("A title is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createDraftAction({ title });
+      setTitle("");
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save draft");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    setTitle("");
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Sheet
+      open={open}
+      onClose={handleClose}
+      title="New draft"
+      description={<em>a local draft without a repo — assign it later</em>}
+    >
+      <div className={styles.form}>
+        <input
+          className={styles.input}
+          placeholder="What needs to be done?"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={saving}
+          autoFocus
+        />
+        <div className={styles.hint}>
+          body, labels, and repo assignment come in a later iteration
+        </div>
+        {error && <div className={styles.error}>{error}</div>}
+        <div className={styles.actions}>
+          <Button variant="ghost" onClick={handleClose} disabled={saving}>
+            cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={saving}>
+            {saving ? "saving…" : "save draft"}
+          </Button>
+        </div>
+      </div>
+    </Sheet>
+  );
+}

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -1,0 +1,134 @@
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 12px 0 120px;
+  background: var(--paper-bg);
+  min-height: 100vh;
+  position: relative;
+}
+
+.topBar {
+  padding: 52px 24px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.brand {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 34px;
+  line-height: 1;
+  letter-spacing: -0.8px;
+  color: var(--paper-ink);
+}
+
+.brand .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--paper-accent);
+  border-radius: 50%;
+  margin-left: 3px;
+  vertical-align: 6px;
+}
+
+.date {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  font-weight: 500;
+  text-align: right;
+  line-height: 1.3;
+}
+
+.date b {
+  display: block;
+  color: var(--paper-ink-soft);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 13px;
+  font-family: var(--paper-serif);
+}
+
+.tabs {
+  padding: 18px 24px 0;
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.tab {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--paper-ink-muted);
+  padding: 10px 2px 12px;
+  margin-right: 26px;
+  position: relative;
+  cursor: default;
+}
+
+.tab.on {
+  color: var(--paper-ink);
+}
+
+.tab.on::after {
+  content: "";
+  position: absolute;
+  left: -4px;
+  right: -4px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--paper-ink);
+}
+
+.tab .count {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: 10px;
+  margin-left: 6px;
+  color: var(--paper-ink-faint);
+  font-weight: 500;
+}
+
+.empty {
+  padding: 80px 20px 60px;
+  text-align: center;
+}
+
+.emptyMark {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 56px;
+  line-height: 0.8;
+  color: var(--paper-accent);
+  margin-bottom: 18px;
+}
+
+.empty h3 {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-style: italic;
+  font-size: 22px;
+  letter-spacing: -0.3px;
+  color: var(--paper-ink);
+  margin-bottom: 8px;
+}
+
+.empty p {
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  color: var(--paper-ink-muted);
+  max-width: 280px;
+  margin: 0 auto;
+  line-height: 1.55;
+}
+
+.empty p em {
+  color: var(--paper-ink-soft);
+}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { UnifiedList } from "@issuectl/core";
+import { SECTION_LABEL, type UnifiedList } from "@issuectl/core";
 import { Fab } from "@/components/paper";
 import { ListSection } from "./ListSection";
 import { CreateDraftSheet } from "./CreateDraftSheet";
@@ -11,6 +11,8 @@ type Props = {
   data: UnifiedList;
 };
 
+// Lowercase is intentional — matches the Paper mockup typography. Do not
+// "fix" this to Title Case without updating the design.
 function formatDate(d: Date): { weekday: string; short: string } {
   const weekday = d
     .toLocaleDateString("en-US", { weekday: "long" })
@@ -63,10 +65,16 @@ export function List({ data }: Props) {
         </div>
       ) : (
         <div>
-          <ListSection title="unassigned" items={data.unassigned} />
-          <ListSection title="in focus" items={data.in_focus} />
-          <ListSection title="in flight" items={data.in_flight} />
-          <ListSection title="shipped" items={data.shipped} />
+          <ListSection
+            title={SECTION_LABEL.unassigned}
+            items={data.unassigned}
+          />
+          <ListSection title={SECTION_LABEL.in_focus} items={data.in_focus} />
+          <ListSection
+            title={SECTION_LABEL.in_flight}
+            items={data.in_flight}
+          />
+          <ListSection title={SECTION_LABEL.shipped} items={data.shipped} />
         </div>
       )}
 

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import type { UnifiedList } from "@issuectl/core";
+import { Fab } from "@/components/paper";
+import { ListSection } from "./ListSection";
+import { CreateDraftSheet } from "./CreateDraftSheet";
+import styles from "./List.module.css";
+
+type Props = {
+  data: UnifiedList;
+};
+
+function formatDate(d: Date): { weekday: string; short: string } {
+  const weekday = d
+    .toLocaleDateString("en-US", { weekday: "long" })
+    .toLowerCase();
+  const short = d
+    .toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    .toLowerCase();
+  return { weekday, short };
+}
+
+export function List({ data }: Props) {
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const issueCount =
+    data.unassigned.length +
+    data.in_focus.length +
+    data.in_flight.length +
+    data.shipped.length;
+  const { weekday, short } = formatDate(new Date());
+  const isEmpty = issueCount === 0;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.topBar}>
+        <div className={styles.brand}>
+          issuectl<span className={styles.dot} />
+        </div>
+        <div className={styles.date}>
+          {weekday}
+          <b>{short}</b>
+        </div>
+      </div>
+      <div className={styles.tabs}>
+        <div className={`${styles.tab} ${styles.on}`}>
+          Issues<span className={styles.count}>{issueCount}</span>
+        </div>
+        <div className={styles.tab}>
+          Pull requests<span className={styles.count}>0</span>
+        </div>
+      </div>
+
+      {isEmpty ? (
+        <div className={styles.empty}>
+          <div className={styles.emptyMark}>❧</div>
+          <h3>all clear</h3>
+          <p>
+            nothing on your plate today.{" "}
+            <em>breathe, or draft the next one.</em>
+          </p>
+        </div>
+      ) : (
+        <div>
+          <ListSection title="unassigned" items={data.unassigned} />
+          <ListSection title="in focus" items={data.in_focus} />
+          <ListSection title="in flight" items={data.in_flight} />
+          <ListSection title="shipped" items={data.shipped} />
+        </div>
+      )}
+
+      <Fab aria-label="Create a new draft" onClick={() => setCreateOpen(true)} />
+      <CreateDraftSheet open={createOpen} onClose={() => setCreateOpen(false)} />
+    </div>
+  );
+}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { SECTION_LABEL, type UnifiedList } from "@issuectl/core";
+import type { Section, UnifiedList } from "@issuectl/core";
 import { Fab } from "@/components/paper";
 import { ListSection } from "./ListSection";
 import { CreateDraftSheet } from "./CreateDraftSheet";
@@ -9,6 +9,19 @@ import styles from "./List.module.css";
 
 type Props = {
   data: UnifiedList;
+};
+
+// Display labels for each section. Kept local to the web package so the
+// import of `Section` stays type-only — importing a runtime const from
+// @issuectl/core pulls the whole core barrel (including better-sqlite3,
+// fs, child_process) into the client bundle. `Record<Section, ...>`
+// enforces exhaustiveness at compile time, so a new section variant
+// can't land without adding its label here.
+const SECTION_LABEL: Record<Section, string> = {
+  unassigned: "unassigned",
+  in_focus: "in focus",
+  in_flight: "in flight",
+  shipped: "shipped",
 };
 
 // Lowercase is intentional — matches the Paper mockup typography. Do not

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -1,0 +1,62 @@
+.item {
+  padding: 16px 24px 16px 58px;
+  position: relative;
+  border-bottom: 1px solid var(--paper-line-soft);
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--paper-bg-warm);
+}
+
+.check {
+  position: absolute;
+  left: 24px;
+  top: 18px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 17px;
+  line-height: 1.3;
+  color: var(--paper-ink);
+  margin-bottom: 6px;
+  letter-spacing: -0.1px;
+}
+
+.title.done {
+  color: var(--paper-ink-muted);
+  text-decoration: line-through;
+  text-decoration-color: var(--paper-accent);
+  text-decoration-thickness: 1.5px;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-family: var(--paper-sans);
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+}
+
+.num {
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-faint);
+}
+
+.sep {
+  color: var(--paper-ink-faint);
+}
+
+.lblBug {
+  color: var(--paper-brick);
+}
+
+.lblFeat {
+  color: var(--paper-butter);
+}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -1,0 +1,76 @@
+import type { UnifiedListItem } from "@issuectl/core";
+import { Checkbox, Chip } from "@/components/paper";
+import styles from "./ListRow.module.css";
+
+type Props = {
+  item: UnifiedListItem;
+};
+
+function formatAge(updatedAt: string | number): string {
+  const now = Date.now();
+  const updated =
+    typeof updatedAt === "number" ? updatedAt * 1000 : new Date(updatedAt).getTime();
+  const diffMs = now - updated;
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays <= 0) return "today";
+  if (diffDays === 1) return "1d";
+  return `${diffDays}d`;
+}
+
+function labelClass(labelName: string): string | undefined {
+  const lower = labelName.toLowerCase();
+  if (lower.includes("bug")) return styles.lblBug;
+  if (lower.includes("feat") || lower.includes("enhancement")) return styles.lblFeat;
+  return undefined;
+}
+
+export function ListRow({ item }: Props) {
+  if (item.kind === "draft") {
+    return (
+      <div className={styles.item}>
+        <span className={styles.check}>
+          <Checkbox state="draft" />
+        </span>
+        <div className={styles.title}>{item.draft.title}</div>
+        <div className={styles.meta}>
+          <Chip variant="dashed">no repo</Chip>
+          <span className={styles.sep}>·</span>
+          <span>local draft</span>
+          <span className={styles.sep}>·</span>
+          <span>{formatAge(item.draft.updatedAt)}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const { issue, repo, section } = item;
+  const checkState =
+    section === "shipped" ? "done" : section === "in_flight" ? "flight" : "open";
+  const titleClass =
+    section === "shipped" ? `${styles.title} ${styles.done}` : styles.title;
+
+  const firstLabel = issue.labels.find(
+    (l) => !l.name.startsWith("issuectl:"),
+  );
+
+  return (
+    <div className={styles.item}>
+      <span className={styles.check}>
+        <Checkbox state={checkState} />
+      </span>
+      <div className={titleClass}>{issue.title}</div>
+      <div className={styles.meta}>
+        <Chip>{repo.name}</Chip>
+        <span className={styles.num}>#{issue.number}</span>
+        {firstLabel && (
+          <>
+            <span className={styles.sep}>·</span>
+            <span className={labelClass(firstLabel.name)}>{firstLabel.name}</span>
+          </>
+        )}
+        <span className={styles.sep}>·</span>
+        <span>{formatAge(issue.updatedAt)}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -6,21 +6,31 @@ type Props = {
   item: UnifiedListItem;
 };
 
+// Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
+// use ISO strings. Normalize both to "N days ago" for display. Clamps
+// negative diffs to "today" so a clock-skewed future timestamp doesn't
+// render "-1d".
 function formatAge(updatedAt: string | number): string {
   const now = Date.now();
   const updated =
-    typeof updatedAt === "number" ? updatedAt * 1000 : new Date(updatedAt).getTime();
-  const diffMs = now - updated;
-  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
-  if (diffDays <= 0) return "today";
+    typeof updatedAt === "number"
+      ? updatedAt * 1000
+      : new Date(updatedAt).getTime();
+  if (!Number.isFinite(updated)) return "";
+  const diffDays = Math.floor((now - updated) / (24 * 60 * 60 * 1000));
+  if (diffDays < 1) return "today";
   if (diffDays === 1) return "1d";
   return `${diffDays}d`;
 }
 
+// Case-insensitive substring match. A label like "bug-report" will match
+// "bug" — that's intentional so common variants all paint brick red.
 function labelClass(labelName: string): string | undefined {
   const lower = labelName.toLowerCase();
   if (lower.includes("bug")) return styles.lblBug;
-  if (lower.includes("feat") || lower.includes("enhancement")) return styles.lblFeat;
+  if (lower.includes("feat") || lower.includes("enhancement")) {
+    return styles.lblFeat;
+  }
   return undefined;
 }
 

--- a/packages/web/components/list/ListSection.module.css
+++ b/packages/web/components/list/ListSection.module.css
@@ -1,0 +1,28 @@
+.section {
+  padding: 22px 24px 6px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.section h3 {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--paper-ink-soft);
+  margin: 0;
+}
+
+.rule {
+  flex: 1;
+  height: 1px;
+  background: var(--paper-line);
+}
+
+.count {
+  font-family: var(--paper-mono);
+  font-size: 10px;
+  color: var(--paper-ink-faint);
+  font-weight: 500;
+}

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import type { UnifiedListItem } from "@issuectl/core";
+import { ListRow } from "./ListRow";
+import styles from "./ListSection.module.css";
+
+type Props = {
+  title: ReactNode;
+  items: UnifiedListItem[];
+};
+
+export function ListSection({ title, items }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      <div className={styles.section}>
+        <h3>{title}</h3>
+        <div className={styles.rule} />
+        <span className={styles.count}>{items.length}</span>
+      </div>
+      {items.map((item) => (
+        <ListRow
+          key={
+            item.kind === "draft"
+              ? `draft-${item.draft.id}`
+              : `issue-${item.repo.id}-${item.issue.number}`
+          }
+          item={item}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/web/components/paper/Checkbox.module.css
+++ b/packages/web/components/paper/Checkbox.module.css
@@ -1,0 +1,54 @@
+.box {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.box svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.box .rect {
+  fill: transparent;
+  stroke: var(--paper-ink-muted);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.flight .rect {
+  stroke: var(--paper-accent);
+  stroke-width: 2;
+}
+
+.flight .fill {
+  fill: var(--paper-accent);
+  opacity: 0.35;
+  animation: pulse 1.8s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.75;
+  }
+}
+
+.done .rect {
+  fill: var(--paper-accent);
+  stroke: var(--paper-accent);
+}
+
+.done .tick {
+  fill: none;
+  stroke: var(--paper-bg);
+  stroke-width: 2.3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}

--- a/packages/web/components/paper/Checkbox.tsx
+++ b/packages/web/components/paper/Checkbox.tsx
@@ -1,0 +1,27 @@
+import styles from "./Checkbox.module.css";
+
+type CheckboxState = "open" | "flight" | "done" | "draft";
+
+type Props = {
+  state: CheckboxState;
+};
+
+export function Checkbox({ state }: Props) {
+  // "draft" renders the same as "open" — both are hollow squares.
+  const visualState = state === "draft" ? "open" : state;
+  const className = `${styles.box} ${styles[visualState] ?? ""}`;
+
+  return (
+    <span className={className} aria-hidden="true">
+      <svg viewBox="0 0 20 20">
+        <rect className={styles.rect} x="2" y="2" width="16" height="16" rx="2" />
+        {visualState === "flight" && (
+          <rect className={styles.fill} x="5" y="5" width="10" height="10" rx="1" />
+        )}
+        {visualState === "done" && (
+          <path className={styles.tick} d="M6 10.5 l2.8 2.8 L14.5 7" />
+        )}
+      </svg>
+    </span>
+  );
+}

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -1,0 +1,34 @@
+.fab {
+  position: fixed;
+  right: 24px;
+  bottom: 30px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 34px;
+  line-height: 1;
+  padding-bottom: 4px;
+  box-shadow: 0 16px 40px rgba(26, 23, 18, 0.35),
+    0 0 0 6px rgba(26, 23, 18, 0.06);
+  z-index: 100;
+  border: none;
+  cursor: pointer;
+}
+
+.fab:hover {
+  opacity: 0.92;
+}
+
+@media (min-width: 768px) {
+  .fab {
+    right: 40px;
+    bottom: 40px;
+  }
+}

--- a/packages/web/components/paper/Fab.tsx
+++ b/packages/web/components/paper/Fab.tsx
@@ -1,0 +1,16 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import styles from "./Fab.module.css";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children?: ReactNode;
+  "aria-label": string; // required for a11y
+};
+
+export function Fab({ children = "+", className, ...rest }: Props) {
+  const classes = [styles.fab, className ?? ""].filter(Boolean).join(" ");
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/packages/web/components/paper/index.ts
+++ b/packages/web/components/paper/index.ts
@@ -2,3 +2,4 @@ export { Chip } from "./Chip";
 export { Button } from "./Button";
 export { Sheet } from "./Sheet";
 export { Drawer } from "./Drawer";
+export { Checkbox } from "./Checkbox";

--- a/packages/web/components/paper/index.ts
+++ b/packages/web/components/paper/index.ts
@@ -3,3 +3,4 @@ export { Button } from "./Button";
 export { Sheet } from "./Sheet";
 export { Drawer } from "./Drawer";
 export { Checkbox } from "./Checkbox";
+export { Fab } from "./Fab";

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getDb,
+  getOctokit,
+  createDraft,
+  assignDraftToRepo,
+  type DraftInput,
+} from "@issuectl/core";
+
+export async function createDraftAction(
+  input: DraftInput,
+): Promise<{ id: string }> {
+  const db = getDb();
+  const draft = createDraft(db, input);
+  revalidatePath("/");
+  return { id: draft.id };
+}
+
+export async function assignDraftAction(
+  draftId: string,
+  repoId: number,
+): Promise<{ issueNumber: number; issueUrl: string }> {
+  const db = getDb();
+  const octokit = await getOctokit();
+  const result = await assignDraftToRepo(db, octokit, draftId, repoId);
+  revalidatePath("/");
+  return { issueNumber: result.issueNumber, issueUrl: result.issueUrl };
+}

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -7,24 +7,91 @@ import {
   createDraft,
   assignDraftToRepo,
   type DraftInput,
+  type Priority,
 } from "@issuectl/core";
+
+const VALID_PRIORITIES: readonly Priority[] = ["low", "normal", "high"];
+
+// Server actions are HTTP endpoints reachable with arbitrary request bodies,
+// not just via the UI. Validate shape at the boundary so untrusted clients
+// can't hand garbage to core.
+
+function validateTitle(title: unknown): string {
+  if (typeof title !== "string") {
+    throw new Error("Draft title must be a string");
+  }
+  if (title.trim().length === 0) {
+    throw new Error("Draft title must not be empty");
+  }
+  return title;
+}
+
+function validatePriority(priority: unknown): Priority | undefined {
+  if (priority === undefined || priority === null) return undefined;
+  if (
+    typeof priority === "string" &&
+    (VALID_PRIORITIES as readonly string[]).includes(priority)
+  ) {
+    return priority as Priority;
+  }
+  throw new Error(
+    `Invalid priority: ${String(priority)}. Expected 'low', 'normal', or 'high'.`,
+  );
+}
+
+function validateBody(body: unknown): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body !== "string") {
+    throw new Error("Draft body must be a string");
+  }
+  return body;
+}
 
 export async function createDraftAction(
   input: DraftInput,
 ): Promise<{ id: string }> {
-  const db = getDb();
-  const draft = createDraft(db, input);
-  revalidatePath("/");
-  return { id: draft.id };
+  try {
+    const title = validateTitle(input.title);
+    const body = validateBody(input.body);
+    const priority = validatePriority(input.priority);
+
+    const db = getDb();
+    const draft = createDraft(db, { title, body, priority });
+    revalidatePath("/");
+    return { id: draft.id };
+  } catch (err) {
+    console.error("[issuectl] createDraftAction failed", err);
+    throw err;
+  }
 }
 
 export async function assignDraftAction(
   draftId: string,
   repoId: number,
 ): Promise<{ issueNumber: number; issueUrl: string }> {
-  const db = getDb();
-  const octokit = await getOctokit();
-  const result = await assignDraftToRepo(db, octokit, draftId, repoId);
-  revalidatePath("/");
-  return { issueNumber: result.issueNumber, issueUrl: result.issueUrl };
+  try {
+    if (typeof draftId !== "string" || draftId.length === 0) {
+      throw new Error("draftId must be a non-empty string");
+    }
+    if (
+      typeof repoId !== "number" ||
+      !Number.isInteger(repoId) ||
+      repoId <= 0
+    ) {
+      throw new Error("repoId must be a positive integer");
+    }
+
+    const db = getDb();
+    const octokit = await getOctokit();
+    const result = await assignDraftToRepo(db, octokit, draftId, repoId);
+    revalidatePath("/");
+    return { issueNumber: result.issueNumber, issueUrl: result.issueUrl };
+  } catch (err) {
+    console.error(
+      "[issuectl] assignDraftAction failed",
+      { draftId, repoId },
+      err,
+    );
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

Phase 3 of the `issuectl` Paper reskin. Replaces the dashboard repo-grid with a cross-repo flat list. Advances #32.

**Plan:** `docs/specs/2026-04-11-phase-3-main-list-plan.md` (committed in this PR)
**Overall spec:** `docs/specs/2026-04-10-todo-reskin-design.md`
**Mockup reference:** `docs/mockups/paper-reskin.html#flow1`

Built on the Phase 1+2 foundation merged in #36 (drafts + priority data layer, Paper tokens + primitives).

### Core data layer

- `groupIntoSections` pure helper that groups drafts + per-repo issues into four sections (`unassigned` / `in_focus` / `in_flight` / `shipped`) with priority-aware sorting (priority DESC, updated_at DESC). Guards against NaN from malformed timestamps.
- `getUnifiedList(db, octokit)` async aggregator that fans out across tracked repos with `Promise.all` + per-repo try/catch, so one bad repo no longer kills the whole page — it logs and renders the rest.
- New types: `Section`, `UnifiedListItem` (discriminated union), `DraftListItem`, `IssueListItem`, and `UnifiedList` (parametrized so `unassigned` can only hold drafts and the three issue sections can only hold issues).

### Web UI

- `Checkbox` primitive (4 states: open / flight / done / draft) and `Fab` primitive added to `components/paper/`.
- `List` / `ListSection` / `ListRow` component tree. `List` is a client component that manages sheet state; `ListSection` + `ListRow` are pure presentational.
- `app/page.tsx` replaced — calls `getUnifiedList` and passes the result to `<List>`. WelcomeScreen fallbacks for no-DB and no-repo preserved.
- `CreateDraftSheet` — title-only minimum draft creation via the Paper `Sheet` + `Button` primitives.
- Server Actions in `packages/web/lib/actions/drafts.ts`: `createDraftAction` and `assignDraftAction`. Both validate untrusted input at the boundary, wrap core calls in `try/catch` with context logging before rethrowing.

### Post-review hygiene commits

After the initial 13 Phase 3 commits, a `pr-review-toolkit` sweep surfaced several tightening opportunities, all addressed before push:

- `fix: phase 3 server resilience` (`3b1f61b`) — `Promise.all` → per-repo try/catch; NaN guard in sort comparator; server action input validation + try/catch with logging.
- `test(core): expand groupIntoSections coverage for phase 3` (`bd41350`) — +5 tests covering "low" priority branch, `item.section` bucket assertion, cross-repo aggregation, cross-repo priority-map scoping (regression guard), closed+active-deployment precedence, empty input.
- `fix: phase 3 type tightening and comment hygiene` (`7678eef`) — `UnifiedList` parametrized by item kind; missing comments added (`formatAge`, `formatDate`, `PRIORITY_RANK`, `labelClass`, `handleSave`); restating comments trimmed; timeless UI copy.
- `fix(web): keep SECTION_LABEL local to avoid bundling core into client` (`b28532e`) — the Fix C attempt to export `SECTION_LABEL` from core pulled `better-sqlite3` into the client bundle; moved the map local to `List.tsx` with a type-only `Section` import.

### Out of scope (deferred)

- **Tapping a row to open detail** — Phase 4.
- **Launch button wiring** — Phase 5.
- **Mobile swipe-to-assign + AssignSheet** — Phase 3.1 or 4.
- **Desktop hover quick actions (assign / reassign / launch)** — Phase 3.1 or 4.
- **PR tab variant** — Phase 7.
- **Mobile nav drawer** — Phase 7.
- **Priority picker** — Phase 7.

Old `components/dashboard/`, `components/repo/`, `components/sidebar/` directories remain in place for Phase 8 cleanup. `layout.tsx` is untouched — existing Sidebar, ThemeProvider, ToastProvider, and font loading all remain.

## Test Plan

- [x] `pnpm -F @issuectl/core test` — **183/183 passing** (was 169 after Phase 1+2; +14 new tests in `unified-list.test.ts`)
- [x] `pnpm turbo typecheck` — clean across all 3 packages
- [x] `pnpm turbo build` — core + web + cli build cleanly
- [x] `pnpm turbo lint` — zero warnings
- [ ] Eyeball the dev server at `http://localhost:3847`: the main page should render the new Paper list with sections populated from tracked repos. The FAB opens `CreateDraftSheet`; saving a title persists a draft and it appears in the unassigned section after revalidation.
- [ ] Verify clicking a row is a no-op (deferred to Phase 4) and no console errors appear.
- [ ] Verify the WelcomeScreen fallback still renders when no repos are tracked.

## What's next

Phase 3.1 (or a consolidated Phase 4) will add the row-level interactions: AssignSheet, mobile swipe, desktop hover quick actions, and the `/issues/[owner]/[repo]/[number]` detail routes.