### PR TITLE
feat: paper reskin phase 5 — launch flow restyled + wired

### DIFF
--- a/docs/specs/2026-04-11-phase-5-launch-flow-plan.md
+++ b/docs/specs/2026-04-11-phase-5-launch-flow-plan.md
@@ -1,0 +1,71 @@
+# Paper Reskin Phase 5 Implementation Plan — Launch Flow
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Restyle the existing launch flow (modal + progress) in the Paper aesthetic and wire it into the Phase 4 issue detail view. Replace the `LaunchCardPlaceholder` with a live launch card. Add the new `/launch/[owner]/[repo]/[number]` progress route.
+
+**Architecture:** The launch backend (`executeLaunch`, `launchIssue` server action) is fully functional and stays unchanged. Phase 5 is purely a visual + wiring pass: swap CSS tokens from legacy to `--paper-*`, replace legacy `Button` imports with Paper `Button`, wire the issue detail page to pass real data to the launch card, and add the progress route.
+
+**Scope:** 8 CSS module rewrites + 4 TSX import swaps + 1 new launch card component + 1 new progress route + IssueDetail wiring. No core changes. No new tests (existing launch tests cover the backend).
+
+---
+
+## Tasks
+
+### Task 5.1: Restyle all 8 launch CSS modules to Paper tokens
+
+Batch operation — rewrite all CSS `var(--bg-surface)` / `var(--border)` / `var(--text-*)` / `var(--font-display)` / `var(--radius-*)` / etc. to their `--paper-*` equivalents across all 8 `.module.css` files in `packages/web/components/launch/`.
+
+Token mapping:
+| Legacy | Paper |
+|---|---|
+| `--bg-surface` | `--paper-bg` |
+| `--bg-elevated` | `--paper-bg-warm` |
+| `--bg-hover` | `--paper-bg-warm` |
+| `--border` | `--paper-line` |
+| `--border-subtle` | `--paper-line-soft` |
+| `--text-primary` | `--paper-ink` |
+| `--text-secondary` | `--paper-ink-soft` |
+| `--text-tertiary` | `--paper-ink-muted` |
+| `--font-display` | `--paper-serif` |
+| `--font-mono` | `--paper-mono` |
+| `--radius-sm` | `--paper-radius-sm` |
+| `--radius-md` | `--paper-radius-md` |
+| `--radius-lg` | `--paper-radius-lg` |
+| `--green` | `--paper-accent` |
+| `--green-surface` | `--paper-accent-soft` |
+| `--red` | `--paper-brick` |
+| `--red-surface` | `rgba(184, 74, 46, 0.08)` |
+| `--accent` (orange) | `--paper-accent` (green) |
+| `--accent-hover` | `--paper-accent-dim` |
+| `--accent-surface` | `--paper-accent-soft` |
+
+Also add Paper font styling: modal title becomes italic serif, body text in serif, mono for branch names.
+
+### Task 5.2: Swap legacy Button imports to Paper Button
+
+In 4 files, replace `import { Button } from "@/components/ui/Button"` with `import { Button } from "@/components/paper"`. The Paper Button has the same prop interface (children, variant, onClick, disabled) so no call-site changes needed — but verify the variant names match (legacy uses "primary"/"secondary"/"ghost"/"danger"; Paper uses "primary"/"accent"/"ghost"/"destructive"). Swap:
+- `variant="secondary"` → `variant="ghost"`
+- `variant="danger"` → `variant="destructive"`
+- No change for "primary" or "ghost"
+- The launch button should use `variant="accent"` (forest green, matching the mockup)
+
+### Task 5.3: Create `LaunchCard` component (replaces placeholder)
+
+New component at `packages/web/components/detail/LaunchCard.tsx` + `.module.css`. Shows "Ready to launch" with the forest-green left bar accent, and a real "launch →" button that opens the existing `LaunchModal` via a state toggle. Props: same as LaunchModal needs (owner, repo, repoLocalPath, issue, comments, deployments, referencedFiles).
+
+### Task 5.4: Wire `IssueDetail` to use `LaunchCard`
+
+Replace `LaunchCardPlaceholder` import with `LaunchCard`. Pass the required props through from the `IssueDetailPage` Server Component. The page already fetches `getIssueDetail` which returns `{ issue, comments, deployments, linkedPRs, referencedFiles }` — pass all of these plus `owner`, `repo`, and `repoLocalPath` (from `getRepo` in the same page).
+
+### Task 5.5: Add `/launch/[owner]/[repo]/[number]` progress route
+
+New Server Component page at `packages/web/app/launch/[owner]/[repo]/[number]/page.tsx`. Takes `?deploymentId=N` from the URL search params. Fetches the deployment from DB, fetches the issue detail for display context, renders `LaunchProgress` (already restyled in Task 5.1) inside a Paper container with the `DetailTopBar`.
+
+### Task 5.6: Update LaunchModal navigation target
+
+The existing `LaunchModal` navigates to `/${owner}/${repo}/issues/${issueNumber}/launch?deploymentId=${id}` on success. Update to navigate to `/launch/${owner}/${repo}/${issueNumber}?deploymentId=${id}` (the new Phase 5 route).
+
+### Task 5.7: Final verification
+
+Full turbo typecheck + build + lint. Eyeball the dev server.

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getDb, getOctokit, getIssueDetail } from "@issuectl/core";
+import { getDb, getOctokit, getIssueDetail, getRepo } from "@issuectl/core";
 import { IssueDetail } from "@/components/detail/IssueDetail";
 
 export const dynamic = "force-dynamic";
@@ -26,14 +26,17 @@ export default async function IssueDetailPage({
 
   try {
     const detail = await getIssueDetail(db, octokit, owner, repo, issueNumber);
+    const repoRecord = getRepo(db, owner, repo);
     return (
       <IssueDetail
         owner={owner}
         repoName={repo}
+        repoLocalPath={repoRecord?.localPath ?? null}
         issue={detail.issue}
         comments={detail.comments}
         deployments={detail.deployments}
         linkedPRs={detail.linkedPRs}
+        referencedFiles={detail.referencedFiles}
       />
     );
   } catch (err) {

--- a/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from "next/navigation";
+import {
+  getDb,
+  getOctokit,
+  getDeploymentById,
+  getIssueDetail,
+} from "@issuectl/core";
+import { DetailTopBar } from "@/components/detail/DetailTopBar";
+import { LaunchProgress } from "@/components/launch/LaunchProgress";
+
+export const dynamic = "force-dynamic";
+
+type Params = {
+  owner: string;
+  repo: string;
+  number: string;
+};
+
+export default async function LaunchProgressPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<Params>;
+  searchParams: Promise<{ deploymentId?: string }>;
+}) {
+  const { owner, repo, number } = await params;
+  const { deploymentId: idStr } = await searchParams;
+
+  const issueNumber = Number(number);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    notFound();
+  }
+
+  const deploymentId = idStr ? Number(idStr) : null;
+  if (!deploymentId || !Number.isInteger(deploymentId) || deploymentId <= 0) {
+    notFound();
+  }
+
+  const db = getDb();
+  const deployment = getDeploymentById(db, deploymentId);
+  if (!deployment) {
+    notFound();
+  }
+
+  const octokit = await getOctokit();
+  let commentCount = 0;
+  let fileCount = 0;
+  try {
+    const detail = await getIssueDetail(
+      db,
+      octokit,
+      owner,
+      repo,
+      issueNumber,
+    );
+    commentCount = detail.comments.length;
+    fileCount = detail.referencedFiles.length;
+  } catch {
+    // Non-fatal — we can still show the progress without exact counts.
+  }
+
+  return (
+    <div style={{ background: "var(--paper-bg)", minHeight: "100vh" }}>
+      <DetailTopBar
+        backHref={`/issues/${owner}/${repo}/${issueNumber}`}
+        crumb={
+          <>
+            {owner}/<b>{repo}</b> · #{issueNumber}
+          </>
+        }
+      />
+      <div
+        style={{
+          maxWidth: 820,
+          margin: "0 auto",
+          padding: "22px 24px 60px",
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: "var(--paper-serif)",
+            fontWeight: 500,
+            fontSize: 22,
+            fontStyle: "italic",
+            color: "var(--paper-ink)",
+            marginBottom: 4,
+          }}
+        >
+          {deployment.endedAt ? "launched" : "launching…"}
+        </h1>
+        <p
+          style={{
+            fontFamily: "var(--paper-serif)",
+            fontSize: 13,
+            color: "var(--paper-ink-muted)",
+            marginBottom: 24,
+          }}
+        >
+          {owner}/{repo} · #{issueNumber}
+        </p>
+        <LaunchProgress
+          deployment={deployment}
+          commentCount={commentCount}
+          fileCount={fileCount}
+        />
+        <div style={{ marginTop: 30, textAlign: "center" }}>
+          <a
+            href={`/issues/${owner}/${repo}/${issueNumber}`}
+            style={{
+              fontFamily: "var(--paper-serif)",
+              fontStyle: "italic",
+              fontSize: 13,
+              color: "var(--paper-ink-muted)",
+              textDecoration: "none",
+            }}
+          >
+            ‹ back to issue
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -14,16 +14,18 @@ import {
 } from "./DetailMeta";
 import { BodyText } from "./BodyText";
 import { CommentList } from "./CommentList";
-import { LaunchCardPlaceholder } from "./LaunchCardPlaceholder";
+import { LaunchCard } from "./LaunchCard";
 import styles from "./IssueDetail.module.css";
 
 type Props = {
   owner: string;
   repoName: string;
+  repoLocalPath: string | null;
   issue: GitHubIssue;
   comments: GitHubComment[];
   deployments: Deployment[];
   linkedPRs: GitHubPull[];
+  referencedFiles: string[];
 };
 
 function formatAge(updatedAt: string): string {
@@ -38,10 +40,12 @@ function formatAge(updatedAt: string): string {
 export function IssueDetail({
   owner,
   repoName,
+  repoLocalPath,
   issue,
   comments,
-  deployments: _deployments,
+  deployments,
   linkedPRs: _linkedPRs,
+  referencedFiles,
 }: Props) {
   const displayLabels = issue.labels.filter(
     (l) => !l.name.startsWith("issuectl:"),
@@ -77,7 +81,15 @@ export function IssueDetail({
           <span>{formatAge(issue.updatedAt)}</span>
         </DetailMeta>
 
-        <LaunchCardPlaceholder />
+        <LaunchCard
+          owner={owner}
+          repo={repoName}
+          repoLocalPath={repoLocalPath}
+          issue={issue}
+          comments={comments}
+          deployments={deployments}
+          referencedFiles={referencedFiles}
+        />
         <BodyText body={issue.body} />
         <CommentList comments={comments} />
       </div>

--- a/packages/web/components/detail/LaunchCard.tsx
+++ b/packages/web/components/detail/LaunchCard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  GitHubIssue,
+  GitHubComment,
+  Deployment,
+  WorkspaceMode,
+} from "@issuectl/core";
+import { Button } from "@/components/paper";
+import { LaunchModal } from "@/components/launch/LaunchModal";
+import styles from "./LaunchCardPlaceholder.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  repoLocalPath: string | null;
+  issue: GitHubIssue;
+  comments: GitHubComment[];
+  deployments: Deployment[];
+  referencedFiles: string[];
+  initialWorkspaceMode?: WorkspaceMode;
+};
+
+export function LaunchCard({
+  owner,
+  repo,
+  repoLocalPath,
+  issue,
+  comments,
+  deployments,
+  referencedFiles,
+  initialWorkspaceMode,
+}: Props) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <>
+      <div className={styles.card}>
+        <h4>Ready to launch</h4>
+        <p>
+          Open a Ghostty session with Claude Code pre-loaded. Creates a worktree
+          on a fresh branch.
+        </p>
+        <div className={styles.actions}>
+          <Button variant="accent" onClick={() => setModalOpen(true)}>
+            launch →
+          </Button>
+          <Button variant="ghost" onClick={() => setModalOpen(true)}>
+            configure
+          </Button>
+        </div>
+      </div>
+      {modalOpen && (
+        <LaunchModal
+          owner={owner}
+          repo={repo}
+          repoLocalPath={repoLocalPath}
+          issue={issue}
+          comments={comments}
+          deployments={deployments}
+          referencedFiles={referencedFiles}
+          initialWorkspaceMode={initialWorkspaceMode}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/launch/BranchInput.module.css
+++ b/packages/web/components/launch/BranchInput.module.css
@@ -4,7 +4,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -15,21 +15,21 @@
 .input {
   width: 100%;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-mono), monospace;
+  font-family: var(--paper-mono), monospace;
   outline: none;
 }
 
 .input:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .hint {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 4px;
 }

--- a/packages/web/components/launch/ClonePromptModal.module.css
+++ b/packages/web/components/launch/ClonePromptModal.module.css
@@ -10,29 +10,29 @@
 }
 
 .modal {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
   width: 500px;
   box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
 }
 
 .header {
   padding: 20px 24px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--paper-line);
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
 .title {
-  font-family: var(--font-display), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   font-size: 18px;
   font-weight: 700;
 }
 
 .close {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   cursor: pointer;
   font-size: 18px;
   background: none;
@@ -42,8 +42,8 @@
 }
 
 .close:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
 }
 
 .body {
@@ -52,7 +52,7 @@
 
 .footer {
   padding: 16px 24px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--paper-line);
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -64,13 +64,13 @@
   gap: 10px;
   margin-bottom: 16px;
   padding: 12px;
-  background: var(--yellow-surface);
-  border: 1px solid var(--yellow-border);
-  border-radius: var(--radius-md);
+  background: rgba(217, 165, 77, 0.12);
+  border: 1px solid var(--paper-butter);
+  border-radius: var(--paper-radius-md);
 }
 
 .warningIcon {
-  color: var(--yellow);
+  color: var(--paper-butter);
   font-size: 18px;
   font-weight: 700;
   flex-shrink: 0;
@@ -78,11 +78,11 @@
 
 .warningText {
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
 }
 
 .hint {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   line-height: 1.5;
 }

--- a/packages/web/components/launch/ClonePromptModal.tsx
+++ b/packages/web/components/launch/ClonePromptModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import styles from "./ClonePromptModal.module.css";
 
 type Props = {
@@ -40,7 +40,7 @@ export function ClonePromptModal({ owner, repo, onConfirm, onClose }: Props) {
         </div>
 
         <div className={styles.footer}>
-          <Button variant="secondary" onClick={onClose}>
+          <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
           <Button variant="primary" onClick={onConfirm}>

--- a/packages/web/components/launch/ContextToggles.module.css
+++ b/packages/web/components/launch/ContextToggles.module.css
@@ -4,7 +4,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -22,27 +22,27 @@
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   cursor: pointer;
 }
 
 .checkbox {
-  accent-color: var(--accent);
+  accent-color: var(--paper-accent);
 }
 
 .hint {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-left: auto;
 }
 
 .divider {
   height: 1px;
-  background: var(--border);
+  background: var(--paper-line);
   margin: 4px 0;
 }
 
 .filePath {
-  font-family: var(--font-mono), monospace;
-  color: var(--cyan);
+  font-family: var(--paper-mono), monospace;
+  color: var(--paper-accent);
   font-size: 11px;
 }

--- a/packages/web/components/launch/EndSessionButton.tsx
+++ b/packages/web/components/launch/EndSessionButton.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";
 
 type Props = {
@@ -26,7 +26,7 @@ export function EndSessionButton({ deploymentId, owner, repo, issueNumber }: Pro
   }
 
   return (
-    <Button variant="secondary" onClick={handleEnd} disabled={isPending}>
+    <Button variant="ghost" onClick={handleEnd} disabled={isPending}>
       {isPending ? "Ending..." : "End Session"}
     </Button>
   );

--- a/packages/web/components/launch/LaunchActiveBanner.module.css
+++ b/packages/web/components/launch/LaunchActiveBanner.module.css
@@ -5,8 +5,8 @@
     rgba(232, 113, 37, 0.08) 0%,
     rgba(232, 113, 37, 0.02) 100%
   );
-  border: 1px solid var(--accent-border);
-  border-radius: var(--radius-lg);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-lg);
   display: flex;
   align-items: center;
   gap: 14px;
@@ -15,8 +15,8 @@
 .spinner {
   width: 20px;
   height: 20px;
-  border: 2px solid var(--accent-border);
-  border-top-color: var(--accent);
+  border: 2px solid var(--paper-accent);
+  border-top-color: var(--paper-accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
   flex-shrink: 0;
@@ -35,20 +35,20 @@
 .title {
   font-size: 14px;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--paper-accent);
 }
 
 .sub {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 2px;
 }
 
 .bannerEnded {
   padding: 16px 20px;
-  background: var(--green-surface);
-  border: 1px solid var(--green-border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-accent-soft);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-lg);
   display: flex;
   align-items: center;
   gap: 14px;
@@ -60,7 +60,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--green);
+  color: var(--paper-accent);
   font-size: 16px;
   font-weight: 700;
   flex-shrink: 0;
@@ -69,5 +69,5 @@
 .titleEnded {
   font-size: 14px;
   font-weight: 600;
-  color: var(--green);
+  color: var(--paper-accent);
 }

--- a/packages/web/components/launch/LaunchButton.tsx
+++ b/packages/web/components/launch/LaunchButton.tsx
@@ -6,7 +6,7 @@ import type {
   GitHubComment,
   Deployment,
 } from "@issuectl/core";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { LaunchModal } from "./LaunchModal";
 import { ClonePromptModal } from "./ClonePromptModal";
 
@@ -54,7 +54,7 @@ export function LaunchButton({
 
   return (
     <>
-      <Button variant="launch" className={className} onClick={handleClick}>
+      <Button variant="accent" className={className} onClick={handleClick}>
         {hasLaunched ? "Re-launch" : "Launch to Claude Code"}
       </Button>
 

--- a/packages/web/components/launch/LaunchModal.module.css
+++ b/packages/web/components/launch/LaunchModal.module.css
@@ -10,9 +10,9 @@
 }
 
 .modal {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
   width: 620px;
   max-height: 90vh;
   overflow-y: auto;
@@ -21,20 +21,20 @@
 
 .header {
   padding: 20px 24px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--paper-line);
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
 .title {
-  font-family: var(--font-display), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   font-size: 18px;
   font-weight: 700;
 }
 
 .close {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   cursor: pointer;
   font-size: 18px;
   background: none;
@@ -44,8 +44,8 @@
 }
 
 .close:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
 }
 
 .body {
@@ -54,7 +54,7 @@
 
 .footer {
   padding: 16px 24px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--paper-line);
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -66,16 +66,16 @@
   gap: 10px;
   margin-bottom: 20px;
   padding: 12px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  border: 1px solid var(--paper-line);
 }
 
 .issueDot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--green);
+  background: var(--paper-accent);
   flex-shrink: 0;
 }
 
@@ -86,15 +86,15 @@
 
 .issueRepo {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .error {
   margin-top: 12px;
   padding: 8px 12px;
-  background: var(--red-surface);
+  background: rgba(184, 74, 46, 0.08);
   border: 1px solid rgba(248, 81, 73, 0.2);
-  border-radius: var(--radius-md);
-  color: var(--red);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-brick);
   font-size: 12px;
 }

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -11,7 +11,7 @@ import type {
 import { generateBranchName } from "@/lib/branch";
 import { launchIssue } from "@/lib/actions/launch";
 import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { BranchInput } from "./BranchInput";
 import { WorkspaceModeSelector } from "./WorkspaceModeSelector";
 import { ContextToggles } from "./ContextToggles";
@@ -104,7 +104,7 @@ export function LaunchModal({
       }
 
       router.push(
-        `/${owner}/${repo}/issues/${issue.number}/launch?deploymentId=${deploymentId}`,
+        `/launch/${owner}/${repo}/${issue.number}?deploymentId=${deploymentId}`,
       );
     });
   }
@@ -161,11 +161,11 @@ export function LaunchModal({
         </div>
 
         <div className={styles.footer}>
-          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+          <Button variant="ghost" onClick={onClose} disabled={isPending}>
             Cancel
           </Button>
           <Button
-            variant="launch"
+            variant="accent"
             onClick={handleLaunch}
             disabled={isPending || !branchName.trim()}
           >

--- a/packages/web/components/launch/LaunchProgress.module.css
+++ b/packages/web/components/launch/LaunchProgress.module.css
@@ -7,7 +7,7 @@
   align-items: flex-start;
   gap: 12px;
   padding: 12px 0;
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--paper-line-soft);
 }
 
 .step:last-child {
@@ -24,10 +24,10 @@
   justify-content: center;
   font-size: 11px;
   font-weight: 700;
-  font-family: var(--font-mono), monospace;
-  background: var(--green-surface);
-  color: var(--green);
-  border: 1px solid var(--green-border);
+  font-family: var(--paper-mono), monospace;
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+  border: 1px solid var(--paper-accent);
 }
 
 .numActive {
@@ -35,8 +35,8 @@
   height: 24px;
   border-radius: 50%;
   flex-shrink: 0;
-  border: 2px solid var(--accent-border);
-  border-top-color: var(--accent);
+  border: 2px solid var(--paper-accent);
+  border-top-color: var(--paper-accent);
   animation: spin 0.8s linear infinite;
 }
 
@@ -53,23 +53,23 @@
 .label {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--paper-ink);
   margin-bottom: 2px;
 }
 
 .labelActive {
   font-size: 13px;
   font-weight: 500;
-  color: var(--accent);
+  color: var(--paper-accent);
   margin-bottom: 2px;
 }
 
 .detail {
   font-size: 12px;
-  color: var(--text-tertiary);
-  font-family: var(--font-mono), monospace;
+  color: var(--paper-ink-muted);
+  font-family: var(--paper-mono), monospace;
 }
 
 .highlight {
-  color: var(--cyan);
+  color: var(--paper-accent);
 }

--- a/packages/web/components/launch/PreambleInput.module.css
+++ b/packages/web/components/launch/PreambleInput.module.css
@@ -4,7 +4,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -21,16 +21,16 @@
   width: 100%;
   height: 60px;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 12px;
-  font-family: var(--font-karla), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   outline: none;
   resize: vertical;
 }
 
 .textarea:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }

--- a/packages/web/components/launch/WorkspaceModeSelector.module.css
+++ b/packages/web/components/launch/WorkspaceModeSelector.module.css
@@ -4,7 +4,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -22,15 +22,15 @@
   align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   cursor: pointer;
 }
 
 .option.selected {
-  background: var(--accent-surface);
-  border-color: var(--accent-border);
+  background: var(--paper-accent-soft);
+  border-color: var(--paper-accent);
 }
 
 .option.disabled {
@@ -40,17 +40,17 @@
 
 .radio {
   margin-top: 2px;
-  accent-color: var(--accent);
+  accent-color: var(--paper-accent);
 }
 
 .optionLabel {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--paper-ink);
 }
 
 .optionDetail {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 1px;
 }


### PR DESCRIPTION
## Summary

Phase 5 of the `issuectl` Paper reskin. Restyles the existing launch flow in Paper and wires it into the Phase 4 issue detail view. Advances #32.

### Changes

- **8 launch CSS modules** rewritten from legacy tokens to `--paper-*` (cream bg, ink text, serif headings, forest green accent)
- **4 TSX files** swapped from legacy `ui/Button` to Paper `Button` with variant name normalization
- **LaunchCard** (new) replaces `LaunchCardPlaceholder` — live button that opens `LaunchModal`
- **IssueDetail** now passes `repoLocalPath` + `referencedFiles` through to `LaunchCard`
- **`/launch/[owner]/[repo]/[number]`** progress route added with Paper-styled `LaunchProgress`
- **LaunchModal** navigation target updated to the new route

No core changes. No new tests (existing launch backend tests cover the logic).

## Test Plan

- [x] `pnpm -F @issuectl/core test` — 183/183
- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo build` — clean, `/launch/[owner]/[repo]/[number]` visible in build output
- [x] `pnpm turbo lint` — clean
- [ ] Eyeball: issue detail shows live launch card with "launch →" and "configure" buttons
- [ ] Eyeball: clicking launch opens the modal with workspace mode, branch, preamble, context toggles