### PR TITLE
feat: paper reskin phase 6 — settings, parse, auth, onboarding restyled

### DIFF
--- a/packages/web/app/loading.module.css
+++ b/packages/web/app/loading.module.css
@@ -10,14 +10,14 @@
 .titleBar {
   height: 32px;
   width: 220px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
   animation: pulse 1.5s ease-in-out infinite;
 }
 
 .cacheBarSkeleton {
   height: 32px;
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--paper-line-soft);
   margin-bottom: 20px;
 }
 
@@ -28,9 +28,9 @@
 }
 
 .cardSkeleton {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
   padding: 20px;
   height: 160px;
   animation: pulse 1.5s ease-in-out infinite;

--- a/packages/web/app/settings/loading.module.css
+++ b/packages/web/app/settings/loading.module.css
@@ -16,8 +16,8 @@
 .titleBar {
   height: 32px;
   width: 120px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
   animation: pulse 1.8s ease-in-out infinite;
 }
 
@@ -33,7 +33,7 @@
 .sectionTitle {
   width: 180px;
   height: 16px;
-  background: var(--bg-elevated);
+  background: var(--paper-bg-warm);
   border-radius: 4px;
   margin-bottom: 16px;
   animation: pulse 1.8s ease-in-out infinite;
@@ -41,18 +41,18 @@
 
 .row {
   height: 40px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
   animation: pulse 1.8s ease-in-out infinite 0.1s;
 }
 
 .rowWide {
   height: 40px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
   width: 100%;
   animation: pulse 1.8s ease-in-out infinite 0.2s;
@@ -61,9 +61,9 @@
 .rowShort {
   height: 40px;
   width: 200px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
   animation: pulse 1.8s ease-in-out infinite 0.3s;
 }

--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -8,7 +8,7 @@
 }
 
 .sectionTitle {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 16px;

--- a/packages/web/components/auth/AuthErrorScreen.module.css
+++ b/packages/web/components/auth/AuthErrorScreen.module.css
@@ -18,45 +18,45 @@
 .icon {
   width: 56px;
   height: 56px;
-  background: var(--red-surface);
+  background: rgba(184, 74, 46, 0.08);
   border: 1px solid rgba(248, 81, 73, 0.2);
   border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 28px;
-  color: var(--red);
+  color: var(--paper-brick);
   font-weight: 700;
 }
 
 .title {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.5px;
 }
 
 .description {
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   font-size: 14px;
   line-height: 1.7;
 }
 
 .inlineCode {
-  font-family: var(--font-mono);
-  background: var(--bg-elevated);
+  font-family: var(--paper-mono);
+  background: var(--paper-bg-warm);
   padding: 2px 7px;
   border-radius: 4px;
   font-size: 12px;
-  color: var(--cyan);
-  border: 1px solid var(--border);
+  color: var(--paper-accent);
+  border: 1px solid var(--paper-line);
 }
 
 .card {
   width: 100%;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
   padding: 24px;
   text-align: left;
   display: flex;
@@ -65,7 +65,7 @@
 }
 
 .cardTitle {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 15px;
   font-weight: 600;
 }
@@ -80,15 +80,15 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 11px;
   font-weight: 700;
-  font-family: var(--font-mono);
-  color: var(--text-secondary);
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-soft);
   flex-shrink: 0;
 }
 
@@ -100,13 +100,13 @@
 .stepCommand {
   display: block;
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 2px;
-  font-family: var(--font-mono);
+  font-family: var(--paper-mono);
 }
 
 .stepDetail {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 2px;
 }

--- a/packages/web/components/auth/RefreshButton.tsx
+++ b/packages/web/components/auth/RefreshButton.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 
 export function RefreshButton() {
   const router = useRouter();
   return (
-    <Button variant="secondary" onClick={() => router.refresh()}>
+    <Button variant="ghost" onClick={() => router.refresh()}>
       Try again
     </Button>
   );

--- a/packages/web/components/onboarding/WelcomeScreen.module.css
+++ b/packages/web/components/onboarding/WelcomeScreen.module.css
@@ -17,40 +17,40 @@
 .logoMark {
   width: 56px;
   height: 56px;
-  background: var(--accent);
+  background: var(--paper-accent);
   border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-mono);
+  font-family: var(--paper-mono);
   font-weight: 700;
   font-size: 24px;
-  color: var(--text-inverse);
+  color: var(--paper-bg);
   letter-spacing: -1px;
 }
 
 .title {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 28px;
   font-weight: 700;
   letter-spacing: -0.5px;
 }
 
 .accent {
-  color: var(--accent);
+  color: var(--paper-accent);
 }
 
 .description {
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   font-size: 14px;
   line-height: 1.7;
 }
 
 .card {
   width: 100%;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
   padding: 24px;
   text-align: left;
   display: flex;
@@ -59,7 +59,7 @@
 }
 
 .cardTitle {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 16px;
   font-weight: 600;
 }
@@ -67,7 +67,7 @@
 .label {
   display: block;
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -77,10 +77,10 @@
 .input {
   width: 100%;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
   font-family: inherit;
   outline: none;
@@ -88,21 +88,21 @@
 }
 
 .input:focus {
-  border-color: var(--border-accent);
+  border-color: var(--paper-accent);
 }
 
 .input::placeholder {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .error {
   font-size: 13px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .warning {
   font-size: 13px;
-  color: var(--yellow);
+  color: var(--paper-butter);
 }
 
 .submitBtn {
@@ -112,15 +112,15 @@
 
 .hint {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .inlineCode {
-  font-family: var(--font-mono);
-  background: var(--bg-elevated);
+  font-family: var(--paper-mono);
+  background: var(--paper-bg-warm);
   padding: 2px 7px;
   border-radius: 4px;
   font-size: 11px;
-  color: var(--cyan);
-  border: 1px solid var(--border);
+  color: var(--paper-accent);
+  border: 1px solid var(--paper-line);
 }

--- a/packages/web/components/onboarding/WelcomeScreen.tsx
+++ b/packages/web/components/onboarding/WelcomeScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { addRepo } from "@/lib/actions/repos";
 import styles from "./WelcomeScreen.module.css";
 

--- a/packages/web/components/parse/ParseFlow.module.css
+++ b/packages/web/components/parse/ParseFlow.module.css
@@ -1,16 +1,16 @@
 .unavailable {
   padding: 16px 20px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  color: var(--text-secondary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
+  color: var(--paper-ink-soft);
   font-size: 13px;
   line-height: 1.6;
 }
 
 .unavailable code {
-  background: var(--bg-hover);
+  background: var(--paper-bg-warm);
   padding: 2px 6px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--paper-radius-sm);
   font-size: 12px;
 }

--- a/packages/web/components/parse/ParseInput.module.css
+++ b/packages/web/components/parse/ParseInput.module.css
@@ -6,7 +6,7 @@
 
 .description {
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   line-height: 1.5;
 }
 
@@ -14,23 +14,23 @@
   width: 100%;
   min-height: 160px;
   padding: 12px 14px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   outline: none;
   resize: vertical;
   line-height: 1.5;
 }
 
 .textarea:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .textarea::placeholder {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .footer {
@@ -42,8 +42,8 @@
 .spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
+  border: 2px solid var(--paper-line);
+  border-top-color: var(--paper-accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -56,14 +56,14 @@
 
 .parsingText {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .error {
   padding: 8px 12px;
-  background: var(--red-surface);
+  background: rgba(184, 74, 46, 0.08);
   border: 1px solid rgba(248, 81, 73, 0.2);
-  border-radius: var(--radius-md);
-  color: var(--red);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-brick);
   font-size: 12px;
 }

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import type { ParsedIssuesResponse } from "@issuectl/core";
 import { parseNaturalLanguage } from "@/lib/actions/parse";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import styles from "./ParseInput.module.css";
 
 type Props = {

--- a/packages/web/components/parse/ParseIssueCard.module.css
+++ b/packages/web/components/parse/ParseIssueCard.module.css
@@ -1,7 +1,7 @@
 .card {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-elevated);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-lg);
+  background: var(--paper-bg-warm);
   overflow: hidden;
 }
 
@@ -20,8 +20,8 @@
   align-items: center;
   gap: 10px;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-base);
+  border-bottom: 1px solid var(--paper-line);
+  background: var(--paper-bg);
 }
 
 .typeBadge {
@@ -30,15 +30,15 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  background: var(--accent-surface);
-  color: var(--accent);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
   flex-shrink: 0;
 }
 
 .confidenceHigh {
   font-size: 11px;
-  color: var(--green);
+  color: var(--paper-accent);
   flex-shrink: 0;
 }
 
@@ -50,7 +50,7 @@
 
 .confidenceLow {
   font-size: 11px;
-  color: var(--red);
+  color: var(--paper-brick);
   flex-shrink: 0;
 }
 
@@ -61,22 +61,22 @@
 .toggleButton {
   font-size: 11px;
   padding: 3px 10px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
+  border-radius: var(--paper-radius-sm);
+  border: 1px solid var(--paper-line);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink-soft);
   cursor: pointer;
 }
 
 .toggleButton:hover {
-  background: var(--bg-hover);
+  background: var(--paper-bg-warm);
 }
 
 .toggleButtonActive {
   composes: toggleButton;
-  background: var(--green-surface);
-  border-color: var(--green-border);
-  color: var(--green);
+  background: var(--paper-accent-soft);
+  border-color: var(--paper-accent);
+  color: var(--paper-accent);
 }
 
 .body {
@@ -94,7 +94,7 @@
 
 .fieldLabel {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -103,53 +103,53 @@
 .input {
   width: 100%;
   padding: 7px 10px;
-  background: var(--bg-base);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   outline: none;
 }
 
 .input:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .textarea {
   width: 100%;
   min-height: 100px;
   padding: 8px 10px;
-  background: var(--bg-base);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 12px;
-  font-family: var(--font-mono), monospace;
+  font-family: var(--paper-mono), monospace;
   outline: none;
   resize: vertical;
   line-height: 1.5;
 }
 
 .textarea:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .select {
   width: 100%;
   padding: 7px 10px;
-  background: var(--bg-base);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla), sans-serif;
+  font-family: var(--paper-serif), sans-serif;
   outline: none;
   cursor: pointer;
 }
 
 .select:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .selectUnmatched {
@@ -166,10 +166,10 @@
 
 .originalText {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-style: italic;
   padding: 6px 10px;
-  background: var(--bg-base);
-  border-radius: var(--radius-sm);
-  border-left: 2px solid var(--border);
+  background: var(--paper-bg);
+  border-radius: var(--paper-radius-sm);
+  border-left: 2px solid var(--paper-line);
 }

--- a/packages/web/components/parse/ParseResults.module.css
+++ b/packages/web/components/parse/ParseResults.module.css
@@ -6,7 +6,7 @@
 
 .summaryBase {
   padding: 16px 20px;
-  border-radius: var(--radius-lg);
+  border-radius: var(--paper-radius-lg);
   display: flex;
   align-items: center;
   gap: 12px;
@@ -14,8 +14,8 @@
 
 .summarySuccess {
   composes: summaryBase;
-  background: var(--green-surface);
-  border: 1px solid var(--green-border);
+  background: var(--paper-accent-soft);
+  border: 1px solid var(--paper-accent);
 }
 
 .summaryPartial {
@@ -36,7 +36,7 @@
 
 .summaryIconSuccess {
   composes: summaryIcon;
-  color: var(--green);
+  color: var(--paper-accent);
 }
 
 .summaryIconPartial {
@@ -47,7 +47,7 @@
 .summaryText {
   font-size: 14px;
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--paper-ink);
 }
 
 .list {
@@ -61,20 +61,20 @@
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
 }
 
 .resultSuccess {
-  color: var(--green);
+  color: var(--paper-accent);
   font-weight: 700;
   font-size: 14px;
   flex-shrink: 0;
 }
 
 .resultFailed {
-  color: var(--red);
+  color: var(--paper-brick);
   font-weight: 700;
   font-size: 14px;
   flex-shrink: 0;
@@ -82,12 +82,12 @@
 
 .resultRepo {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .resultLink {
   font-size: 13px;
-  color: var(--accent);
+  color: var(--paper-accent);
   text-decoration: none;
   font-weight: 500;
 }
@@ -98,7 +98,7 @@
 
 .resultError {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .resultSpacer {

--- a/packages/web/components/parse/ParseResults.tsx
+++ b/packages/web/components/parse/ParseResults.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { BatchCreateResult } from "@issuectl/core";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import styles from "./ParseResults.module.css";
 
 type Props = {

--- a/packages/web/components/parse/ParseReview.module.css
+++ b/packages/web/components/parse/ParseReview.module.css
@@ -6,7 +6,7 @@
 
 .summary {
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
 }
 
 .cards {
@@ -24,9 +24,9 @@
 
 .error {
   padding: 8px 12px;
-  background: var(--red-surface);
+  background: rgba(184, 74, 46, 0.08);
   border: 1px solid rgba(248, 81, 73, 0.2);
-  border-radius: var(--radius-md);
-  color: var(--red);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-brick);
   font-size: 12px;
 }

--- a/packages/web/components/parse/ParseReview.tsx
+++ b/packages/web/components/parse/ParseReview.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import type { GitHubLabel, ParsedIssuesResponse, BatchCreateResult } from "@issuectl/core";
 import type { RepoOption } from "@/lib/types";
 import { batchCreateIssues } from "@/lib/actions/parse";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { ParseIssueCard, type IssueCardState } from "./ParseIssueCard";
 import styles from "./ParseReview.module.css";
 
@@ -112,7 +112,7 @@ export function ParseReview({
       )}
 
       <div className={styles.footer}>
-        <Button variant="secondary" onClick={onBack} disabled={isPending}>
+        <Button variant="ghost" onClick={onBack} disabled={isPending}>
           Back
         </Button>
         <Button

--- a/packages/web/components/settings/AddRepoForm.module.css
+++ b/packages/web/components/settings/AddRepoForm.module.css
@@ -3,9 +3,9 @@
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--accent-border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
 }
 
@@ -20,7 +20,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-bottom: 4px;
   font-weight: 600;
   text-transform: uppercase;
@@ -30,17 +30,17 @@
 .input {
   width: 100%;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla);
+  font-family: var(--paper-serif);
   outline: none;
 }
 
 .input:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .actions {
@@ -51,11 +51,11 @@
 
 .error {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .pathHint {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 2px;
 }

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useRef, useEffect } from "react";
 import { addRepo } from "@/lib/actions/repos";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
 import styles from "./AddRepoForm.module.css";
 

--- a/packages/web/components/settings/AuthStatus.module.css
+++ b/packages/web/components/settings/AuthStatus.module.css
@@ -3,9 +3,9 @@
   align-items: center;
   gap: 10px;
   padding: 12px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
 }
 
 .dot {
@@ -17,29 +17,29 @@
 
 .dotOk {
   composes: dot;
-  background: var(--green);
+  background: var(--paper-accent);
 }
 
 .dotError {
   composes: dot;
-  background: var(--red);
+  background: var(--paper-brick);
 }
 
 .text {
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
 }
 
 .username {
-  color: var(--text-primary);
+  color: var(--paper-ink);
   font-weight: 600;
 }
 
 .code {
-  font-family: var(--font-mono);
+  font-family: var(--paper-mono);
   font-size: 12px;
-  color: var(--cyan);
-  background: var(--bg-elevated);
+  color: var(--paper-accent);
+  background: var(--paper-bg-warm);
   padding: 2px 6px;
   border-radius: 3px;
 }

--- a/packages/web/components/settings/RepoRow.module.css
+++ b/packages/web/components/settings/RepoRow.module.css
@@ -3,9 +3,9 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
 }
 
@@ -23,7 +23,7 @@
 
 .dotNoPath {
   composes: dot;
-  background: var(--text-tertiary);
+  background: var(--paper-ink-muted);
 }
 
 .name {
@@ -33,19 +33,19 @@
 
 .nameNoPath {
   composes: name;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
 }
 
 .path {
   font-size: 12px;
-  font-family: var(--font-mono);
-  color: var(--text-tertiary);
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-muted);
   flex: 1;
 }
 
 .noPath {
   composes: path;
-  color: var(--yellow);
+  color: var(--paper-butter);
 }
 
 .actions {
@@ -60,7 +60,7 @@
 
 .dangerBtn {
   composes: actionBtn;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .editForm {
@@ -68,9 +68,9 @@
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--accent-border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
 }
 
@@ -85,7 +85,7 @@
 
 .editLabel {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-bottom: 4px;
   font-weight: 600;
   text-transform: uppercase;
@@ -95,17 +95,17 @@
 .editInput {
   width: 100%;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla);
+  font-family: var(--paper-serif);
   outline: none;
 }
 
 .editInput:focus {
-  border-color: var(--accent-border);
+  border-color: var(--paper-accent);
 }
 
 .editActions {
@@ -116,7 +116,7 @@
 
 .error {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .confirmOverlay {
@@ -124,16 +124,16 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--red-surface);
-  border: 1px solid var(--red);
-  border-radius: var(--radius-md);
+  background: rgba(184, 74, 46, 0.08);
+  border: 1px solid var(--paper-brick);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
 }
 
 .confirmText {
   flex: 1;
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
 }
 
 .confirmActions {

--- a/packages/web/components/settings/RepoRow.tsx
+++ b/packages/web/components/settings/RepoRow.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { removeRepo, updateRepo } from "@/lib/actions/repos";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import type { Repo } from "@issuectl/core";
 import styles from "./RepoRow.module.css";
 
@@ -59,7 +59,7 @@ export function RepoRow({ repo, color }: Props) {
             Cancel
           </Button>
           <Button
-            variant="secondary"
+            variant="ghost"
             onClick={handleRemove}
             disabled={isPending}
             className={styles.dangerBtn}

--- a/packages/web/components/settings/SettingsForm.module.css
+++ b/packages/web/components/settings/SettingsForm.module.css
@@ -3,7 +3,7 @@
 }
 
 .sectionTitle {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 16px;
@@ -21,7 +21,7 @@
 
 .label {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-bottom: 6px;
   font-weight: 600;
   text-transform: uppercase;
@@ -32,30 +32,30 @@
   width: 100%;
   max-width: 320px;
   padding: 8px 12px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
   font-size: 13px;
-  font-family: var(--font-karla);
+  font-family: var(--paper-serif);
   transition: border-color 0.15s;
 }
 
 .input:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--paper-accent);
 }
 
 .inputReadonly {
   composes: input;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   cursor: default;
   max-width: 240px;
 }
 
 .help {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   margin-top: 4px;
 }
 
@@ -68,17 +68,17 @@
 
 .error {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .fieldError {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
   margin-top: 6px;
 }
 
 .fieldWarning {
   font-size: 12px;
-  color: var(--yellow);
+  color: var(--paper-butter);
   margin-top: 6px;
 }

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { updateSettings } from "@/lib/actions/settings";
 import { useToast } from "@/components/ui/ToastProvider";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { validateClaudeArgs } from "@issuectl/core/validation";
 import type { SettingKey } from "@issuectl/core";
 import styles from "./SettingsForm.module.css";

--- a/packages/web/components/settings/TrackedRepos.tsx
+++ b/packages/web/components/settings/TrackedRepos.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import type { Repo } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import { RepoRow } from "./RepoRow";
 import { AddRepoForm } from "./AddRepoForm";
 import styles from "./TrackedRepos.module.css";
@@ -28,7 +28,7 @@ export function TrackedRepos({ repos }: Props) {
         <AddRepoForm onClose={() => setShowAdd(false)} />
       ) : (
         <Button
-          variant="secondary"
+          variant="ghost"
           className={styles.addBtn}
           onClick={() => setShowAdd(true)}
         >

--- a/packages/web/components/settings/WorktreeCleanup.module.css
+++ b/packages/web/components/settings/WorktreeCleanup.module.css
@@ -1,10 +1,10 @@
 .empty {
   font-size: 13px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   padding: 12px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
 }
 
 .row {
@@ -12,15 +12,15 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
 }
 
 .rowStale {
   composes: row;
-  border-color: var(--yellow);
+  border-color: var(--paper-butter);
   border-style: dashed;
 }
 
@@ -38,26 +38,26 @@
 
 .badgeStale {
   composes: badge;
-  color: var(--yellow);
-  background: var(--yellow-surface);
+  color: var(--paper-butter);
+  background: rgba(217, 165, 77, 0.12);
 }
 
 .badgeActive {
   composes: badge;
-  color: var(--green);
-  background: var(--green-surface);
+  color: var(--paper-accent);
+  background: var(--paper-accent-soft);
 }
 
 .issue {
   font-size: 12px;
-  font-family: var(--font-mono);
-  color: var(--text-tertiary);
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-muted);
 }
 
 .deleteBtn {
   font-size: 11px;
   padding: 4px 8px;
-  color: var(--red);
+  color: var(--paper-brick);
 }
 
 .bulkBar {
@@ -69,7 +69,7 @@
 
 .staleCount {
   font-size: 13px;
-  color: var(--yellow);
+  color: var(--paper-butter);
 }
 
 .cleanAllBtn {
@@ -79,12 +79,12 @@
 
 .error {
   font-size: 12px;
-  color: var(--red);
+  color: var(--paper-brick);
   margin-top: 4px;
 }
 
 .success {
   font-size: 12px;
-  color: var(--green);
+  color: var(--paper-accent);
   margin-top: 4px;
 }

--- a/packages/web/components/settings/WorktreeCleanup.tsx
+++ b/packages/web/components/settings/WorktreeCleanup.tsx
@@ -3,7 +3,7 @@
 import { useTransition, useState } from "react";
 import { cleanupWorktree, cleanupStaleWorktrees } from "@/lib/actions/worktrees";
 import type { WorktreeInfo } from "@/lib/actions/worktrees";
-import { Button } from "@/components/ui/Button";
+import { Button } from "@/components/paper";
 import styles from "./WorktreeCleanup.module.css";
 
 type Props = {
@@ -54,7 +54,7 @@ export function WorktreeCleanup({ worktrees }: Props) {
             {staleCount} stale worktree{staleCount > 1 ? "s" : ""}
           </span>
           <Button
-            variant="secondary"
+            variant="ghost"
             className={styles.cleanAllBtn}
             onClick={handleCleanAll}
             disabled={isPending}

--- a/packages/web/components/ui/ErrorState.module.css
+++ b/packages/web/components/ui/ErrorState.module.css
@@ -18,35 +18,35 @@
 .icon {
   width: 56px;
   height: 56px;
-  background: var(--red-surface);
+  background: rgba(184, 74, 46, 0.08);
   border: 1px solid rgba(248, 81, 73, 0.2);
   border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 28px;
-  color: var(--red);
+  color: var(--paper-brick);
   font-weight: 700;
 }
 
 .title {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.5px;
 }
 
 .message {
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   font-size: 14px;
   line-height: 1.7;
 }
 
 .hint {
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-size: 12px;
   line-height: 1.6;
-  font-family: var(--font-mono);
+  font-family: var(--paper-mono);
 }
 
 .actions {
@@ -56,7 +56,7 @@
 }
 
 .link {
-  color: var(--accent);
+  color: var(--paper-accent);
   font-size: 13px;
   font-weight: 500;
 }

--- a/packages/web/components/ui/NotFoundState.module.css
+++ b/packages/web/components/ui/NotFoundState.module.css
@@ -18,26 +18,26 @@
 .icon {
   width: 56px;
   height: 56px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
   border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 28px;
-  color: var(--text-tertiary);
+  color: var(--paper-ink-muted);
   font-weight: 700;
 }
 
 .title {
-  font-family: var(--font-display);
+  font-family: var(--paper-serif);
   font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.5px;
 }
 
 .message {
-  color: var(--text-secondary);
+  color: var(--paper-ink-soft);
   font-size: 14px;
   line-height: 1.7;
 }
@@ -49,7 +49,7 @@
 }
 
 .link {
-  color: var(--accent);
+  color: var(--paper-accent);
   font-size: 13px;
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary

Phase 6 of the `issuectl` Paper reskin. Restyles all remaining non-list, non-detail, non-launch surfaces. Advances #32.

### Changes

- **19 CSS modules** batch-swapped from legacy tokens to `--paper-*`
- **10 TSX files** swapped from legacy `ui/Button` to Paper `Button` with variant normalization
- Covers: Settings page (6 sub-components), Quick Create / Parse flow (5 sub-components), Auth error screen, Onboarding welcome, Error/NotFound/Loading states

No core changes. No new tests. 183/183 tests, typecheck/build/lint all clean.

## Test Plan

- [x] All CI gates pass
- [ ] Eyeball: Settings page renders in Paper palette (cream bg, serif headers, forest green accents)
- [ ] Eyeball: Quick Create flow renders in Paper
- [ ] Eyeball: Auth error screen shows brick-red accent on paper cream
- [ ] Eyeball: WelcomeScreen (first run) renders in Paper