### PR TITLE
feat: paper reskin phase 7 — nav drawer, PR tab routing

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -4,15 +4,18 @@ import {
   getUnifiedList,
   listRepos,
   dbExists,
+  checkGhAuth,
 } from "@issuectl/core";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 import { List } from "@/components/list/List";
 
 export const dynamic = "force-dynamic";
 
-export default async function MainListPage() {
-  // Preserve the existing first-run behavior: no DB, or no tracked repos,
-  // falls back to the WelcomeScreen onboarding flow.
+type Props = {
+  searchParams: Promise<{ tab?: string }>;
+};
+
+export default async function MainListPage({ searchParams }: Props) {
   if (!dbExists()) {
     return <WelcomeScreen />;
   }
@@ -22,8 +25,27 @@ export default async function MainListPage() {
     return <WelcomeScreen />;
   }
 
+  const { tab } = await searchParams;
+  const activeTab = tab === "prs" ? "prs" : "issues";
+
   const octokit = await getOctokit();
   const data = await getUnifiedList(db, octokit);
 
-  return <List data={data} />;
+  // Get the authenticated username for the nav drawer footer.
+  let username: string | null = null;
+  try {
+    const auth = await checkGhAuth();
+    username = auth.username ?? null;
+  } catch {
+    // Non-fatal — the drawer just won't show the username.
+  }
+
+  return (
+    <List
+      data={data}
+      activeTab={activeTab}
+      prCount={0}
+      username={username}
+    />
+  );
 }

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -34,18 +34,35 @@
   vertical-align: 6px;
 }
 
-.date {
+.menuBtn {
+  background: transparent;
+  border: none;
+  font-family: var(--paper-mono);
+  font-size: 18px;
+  color: var(--paper-ink-muted);
+  letter-spacing: 1px;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: var(--paper-radius-sm);
+}
+
+.menuBtn:hover {
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
+}
+
+/* Desktop: show the date inline in the tabs row instead of in the top bar */
+.desktopDate {
+  display: none;
   font-family: var(--paper-serif);
   font-style: italic;
   font-size: 11px;
   color: var(--paper-ink-muted);
-  font-weight: 500;
-  text-align: right;
-  line-height: 1.3;
+  margin-left: auto;
+  align-self: center;
 }
 
-.date b {
-  display: block;
+.desktopDate b {
   color: var(--paper-ink-soft);
   font-style: normal;
   font-weight: 600;
@@ -131,4 +148,24 @@
 
 .empty p em {
   color: var(--paper-ink-soft);
+}
+
+.drawerDot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: var(--paper-accent);
+  border-radius: 50%;
+  margin-left: 2px;
+  vertical-align: 3px;
+}
+
+@media (min-width: 768px) {
+  .menuBtn {
+    display: none;
+  }
+
+  .desktopDate {
+    display: block;
+  }
 }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -2,21 +2,19 @@
 
 import { useState } from "react";
 import type { Section, UnifiedList } from "@issuectl/core";
-import { Fab } from "@/components/paper";
+import { Drawer, Fab } from "@/components/paper";
 import { ListSection } from "./ListSection";
 import { CreateDraftSheet } from "./CreateDraftSheet";
+import { NavDrawerContent } from "./NavDrawerContent";
 import styles from "./List.module.css";
 
 type Props = {
   data: UnifiedList;
+  activeTab: "issues" | "prs";
+  prCount: number;
+  username: string | null;
 };
 
-// Display labels for each section. Kept local to the web package so the
-// import of `Section` stays type-only — importing a runtime const from
-// @issuectl/core pulls the whole core barrel (including better-sqlite3,
-// fs, child_process) into the client bundle. `Record<Section, ...>`
-// enforces exhaustiveness at compile time, so a new section variant
-// can't land without adding its label here.
 const SECTION_LABEL: Record<Section, string> = {
   unassigned: "unassigned",
   in_focus: "in focus",
@@ -24,8 +22,7 @@ const SECTION_LABEL: Record<Section, string> = {
   shipped: "shipped",
 };
 
-// Lowercase is intentional — matches the Paper mockup typography. Do not
-// "fix" this to Title Case without updating the design.
+// Lowercase is intentional — matches the Paper mockup typography.
 function formatDate(d: Date): { weekday: string; short: string } {
   const weekday = d
     .toLocaleDateString("en-US", { weekday: "long" })
@@ -36,8 +33,9 @@ function formatDate(d: Date): { weekday: string; short: string } {
   return { weekday, short };
 }
 
-export function List({ data }: Props) {
+export function List({ data, activeTab, prCount, username }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const issueCount =
     data.unassigned.length +
@@ -45,7 +43,7 @@ export function List({ data }: Props) {
     data.in_flight.length +
     data.shipped.length;
   const { weekday, short } = formatDate(new Date());
-  const isEmpty = issueCount === 0;
+  const isEmpty = activeTab === "issues" ? issueCount === 0 : prCount === 0;
 
   return (
     <div className={styles.container}>
@@ -53,46 +51,98 @@ export function List({ data }: Props) {
         <div className={styles.brand}>
           issuectl<span className={styles.dot} />
         </div>
-        <div className={styles.date}>
-          {weekday}
-          <b>{short}</b>
-        </div>
+        <button
+          className={styles.menuBtn}
+          onClick={() => setDrawerOpen(true)}
+          aria-label="Open navigation"
+        >
+          ···
+        </button>
       </div>
+
+      {/* Desktop: date + tabs inline. Mobile: tabs only, date in drawer. */}
       <div className={styles.tabs}>
-        <div className={`${styles.tab} ${styles.on}`}>
+        <a
+          href="/"
+          className={`${styles.tab} ${activeTab === "issues" ? styles.on : ""}`}
+        >
           Issues<span className={styles.count}>{issueCount}</span>
-        </div>
-        <div className={styles.tab}>
-          Pull requests<span className={styles.count}>0</span>
+        </a>
+        <a
+          href="/?tab=prs"
+          className={`${styles.tab} ${activeTab === "prs" ? styles.on : ""}`}
+        >
+          Pull requests<span className={styles.count}>{prCount}</span>
+        </a>
+        <div className={styles.desktopDate}>
+          {weekday} · <b>{short}</b>
         </div>
       </div>
 
-      {isEmpty ? (
+      {activeTab === "issues" ? (
+        isEmpty ? (
+          <div className={styles.empty}>
+            <div className={styles.emptyMark}>❧</div>
+            <h3>all clear</h3>
+            <p>
+              nothing on your plate today.{" "}
+              <em>breathe, or draft the next one.</em>
+            </p>
+          </div>
+        ) : (
+          <div>
+            <ListSection
+              title={SECTION_LABEL.unassigned}
+              items={data.unassigned}
+            />
+            <ListSection
+              title={SECTION_LABEL.in_focus}
+              items={data.in_focus}
+            />
+            <ListSection
+              title={SECTION_LABEL.in_flight}
+              items={data.in_flight}
+            />
+            <ListSection
+              title={SECTION_LABEL.shipped}
+              items={data.shipped}
+            />
+          </div>
+        )
+      ) : (
         <div className={styles.empty}>
           <div className={styles.emptyMark}>❧</div>
-          <h3>all clear</h3>
+          <h3>pull requests</h3>
           <p>
-            nothing on your plate today.{" "}
-            <em>breathe, or draft the next one.</em>
+            <em>cross-repo PR view coming in a future update</em>
           </p>
-        </div>
-      ) : (
-        <div>
-          <ListSection
-            title={SECTION_LABEL.unassigned}
-            items={data.unassigned}
-          />
-          <ListSection title={SECTION_LABEL.in_focus} items={data.in_focus} />
-          <ListSection
-            title={SECTION_LABEL.in_flight}
-            items={data.in_flight}
-          />
-          <ListSection title={SECTION_LABEL.shipped} items={data.shipped} />
         </div>
       )}
 
-      <Fab aria-label="Create a new draft" onClick={() => setCreateOpen(true)} />
-      <CreateDraftSheet open={createOpen} onClose={() => setCreateOpen(false)} />
+      {activeTab === "issues" && (
+        <>
+          <Fab
+            aria-label="Create a new draft"
+            onClick={() => setCreateOpen(true)}
+          />
+          <CreateDraftSheet
+            open={createOpen}
+            onClose={() => setCreateOpen(false)}
+          />
+        </>
+      )}
+
+      <Drawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        title={
+          <>
+            issuectl<span className={styles.drawerDot} />
+          </>
+        }
+      >
+        <NavDrawerContent activeTab={activeTab} username={username} />
+      </Drawer>
     </div>
   );
 }

--- a/packages/web/components/list/NavDrawerContent.module.css
+++ b/packages/web/components/list/NavDrawerContent.module.css
@@ -1,0 +1,69 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.sectionLabel {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+  padding: 18px 22px 6px;
+}
+
+.item {
+  padding: 16px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--paper-line-soft);
+  font-family: var(--paper-serif);
+  font-size: 15px;
+  color: var(--paper-ink);
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--paper-bg-warm);
+}
+
+.item.on {
+  color: var(--paper-accent);
+  font-style: italic;
+}
+
+.arrow {
+  color: var(--paper-ink-faint);
+  font-size: 14px;
+  font-family: var(--paper-mono);
+}
+
+.footer {
+  margin-top: auto;
+  padding: 16px 22px;
+  border-top: 1px solid var(--paper-line-soft);
+}
+
+.footerRow {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+}
+
+.dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--paper-accent);
+  margin-right: 5px;
+  vertical-align: 2px;
+}
+
+.auth {
+  color: var(--paper-accent);
+}

--- a/packages/web/components/list/NavDrawerContent.tsx
+++ b/packages/web/components/list/NavDrawerContent.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import styles from "./NavDrawerContent.module.css";
+
+type Props = {
+  activeTab: "issues" | "prs";
+  username: string | null;
+};
+
+export function NavDrawerContent({ activeTab, username }: Props) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.sectionLabel}>main views</div>
+      <Link
+        href="/"
+        className={`${styles.item} ${activeTab === "issues" ? styles.on : ""}`}
+      >
+        All issues<span className={styles.arrow}>›</span>
+      </Link>
+      <Link
+        href="/?tab=prs"
+        className={`${styles.item} ${activeTab === "prs" ? styles.on : ""}`}
+      >
+        Pull requests<span className={styles.arrow}>›</span>
+      </Link>
+
+      <div className={styles.sectionLabel}>actions</div>
+      <Link href="/parse" className={styles.item}>
+        Quick Create<span className={styles.arrow}>›</span>
+      </Link>
+      <Link href="/settings" className={styles.item}>
+        Settings<span className={styles.arrow}>›</span>
+      </Link>
+
+      <div className={styles.footer}>
+        {username && (
+          <div className={styles.footerRow}>
+            <span>
+              <span className={styles.dot} />
+              {username}
+            </span>
+            <span className={styles.auth}>gh ✓</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 7 of the Paper reskin. Adds mobile nav drawer + PR tab routing. Advances #32.

- **Mobile nav drawer** with `···` toggle, Paper Drawer primitive, nav links, auth footer
- **PR tab routing** via `?tab=prs` query param (placeholder content for now)
- **Tab UI** converted from static divs to real anchors with active state
- **Desktop date** relocated from top bar to tabs row

Priority picker sheet and desktop hover quick actions deferred to follow-up.

## Test Plan

- [x] 183/183 tests, typecheck/build/lint clean
- [ ] Eyeball: mobile viewport shows `···` menu → drawer slides in from right
- [ ] Eyeball: desktop viewport hides `···`, shows date in tabs row
- [ ] Eyeball: clicking "Pull requests" tab shows placeholder