### PR TITLE
feat: follow-up — assign sheet, draft editing, comments, priority picker, hover actions

### DIFF
--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -1,5 +1,11 @@
 import { notFound } from "next/navigation";
-import { getDb, getOctokit, getIssueDetail, getRepo } from "@issuectl/core";
+import {
+  getDb,
+  getOctokit,
+  getIssueDetail,
+  getRepo,
+  getPriority,
+} from "@issuectl/core";
 import { IssueDetail } from "@/components/detail/IssueDetail";
 
 export const dynamic = "force-dynamic";
@@ -27,11 +33,18 @@ export default async function IssueDetailPage({
   try {
     const detail = await getIssueDetail(db, octokit, owner, repo, issueNumber);
     const repoRecord = getRepo(db, owner, repo);
+    const repoId = repoRecord?.id ?? 0;
+    const currentPriority = repoId > 0
+      ? getPriority(db, repoId, issueNumber)
+      : "normal";
+
     return (
       <IssueDetail
         owner={owner}
         repoName={repo}
+        repoId={repoId}
         repoLocalPath={repoRecord?.localPath ?? null}
+        currentPriority={currentPriority}
         issue={detail.issue}
         comments={detail.comments}
         deployments={detail.deployments}

--- a/packages/web/components/detail/CommentComposer.module.css
+++ b/packages/web/components/detail/CommentComposer.module.css
@@ -1,0 +1,67 @@
+.composer {
+  margin-top: 32px;
+  border-top: 1px solid var(--paper-line);
+  padding-top: 20px;
+}
+
+.label {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+  margin-bottom: 10px;
+}
+
+.textarea {
+  width: 100%;
+  font-family: var(--paper-serif);
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--paper-ink-soft);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 12px 14px;
+  resize: vertical;
+  min-height: 80px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.textarea:focus {
+  border-color: var(--paper-accent-dim);
+  background: var(--paper-bg);
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: 12px;
+  color: var(--paper-brick);
+  margin-top: 6px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.hint {
+  font-family: var(--paper-sans);
+  font-size: 10.5px;
+  color: var(--paper-ink-faint);
+}
+
+/* On mobile hide the keyboard hint (touch doesn't have ⌘) */
+@media (max-width: 767px) {
+  .hint {
+    display: none;
+  }
+}

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/paper";
+import { addComment } from "@/lib/actions/comments";
+import styles from "./CommentComposer.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export function CommentComposer({ owner, repo, issueNumber }: Props) {
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (body.trim().length === 0) return;
+    setSending(true);
+    setError(null);
+    try {
+      const result = await addComment(owner, repo, issueNumber, body);
+      if (!result.success) {
+        setError(result.error ?? "Failed to post comment");
+      } else {
+        setBody("");
+      }
+    } catch {
+      setError("Failed to post comment");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div className={styles.composer}>
+      <div className={styles.label}>add a comment</div>
+      <textarea
+        className={styles.textarea}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="write a comment…"
+        rows={3}
+        disabled={sending}
+      />
+      {error && <div className={styles.error}>{error}</div>}
+      <div className={styles.footer}>
+        <span className={styles.hint}>⌘↩ to send</span>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={sending || body.trim().length === 0}
+        >
+          {sending ? "sending…" : "comment"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/detail/DraftDetail.module.css
+++ b/packages/web/components/detail/DraftDetail.module.css
@@ -30,6 +30,50 @@
   margin-bottom: 28px;
 }
 
+.bodyEditor {
+  position: relative;
+}
+
+.textarea {
+  width: 100%;
+  font-family: var(--paper-serif);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--paper-ink-soft);
+  background: transparent;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 14px 16px;
+  resize: vertical;
+  min-height: 160px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.textarea:focus {
+  border-color: var(--paper-accent-dim);
+}
+
+.textarea::placeholder {
+  color: var(--paper-ink-faint);
+  font-style: italic;
+}
+
+.savedIndicator {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11.5px;
+  color: var(--paper-accent);
+  margin-top: 6px;
+}
+
+.saveError {
+  font-family: var(--paper-serif);
+  font-size: 12px;
+  color: var(--paper-brick);
+  margin-top: 6px;
+}
+
 @media (min-width: 768px) {
   .body {
     max-width: 820px;

--- a/packages/web/components/detail/DraftDetail.tsx
+++ b/packages/web/components/detail/DraftDetail.tsx
@@ -1,8 +1,11 @@
+"use client";
+
+import { useState, useRef } from "react";
 import type { Draft } from "@issuectl/core";
 import { Chip } from "@/components/paper";
 import { DetailTopBar } from "./DetailTopBar";
 import { DetailMeta, MetaSeparator } from "./DetailMeta";
-import { BodyText } from "./BodyText";
+import { updateDraftAction } from "@/lib/actions/drafts";
 import styles from "./DraftDetail.module.css";
 
 type Props = {
@@ -18,6 +21,28 @@ function formatUnix(updatedAt: number): string {
 }
 
 export function DraftDetail({ draft }: Props) {
+  const [body, setBody] = useState(draft.body ?? "");
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleBlur = async () => {
+    // Only save if body actually changed from the draft's current body.
+    const trimmed = body;
+    if (trimmed === (draft.body ?? "")) return;
+
+    setSaveError(null);
+    try {
+      await updateDraftAction(draft.id, { body: trimmed });
+      setSavedAt(Date.now());
+      // Clear the "saved" indicator after 3 seconds.
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => setSavedAt(null), 3000);
+    } catch {
+      setSaveError("Failed to save — try again");
+    }
+  };
+
   return (
     <div className={styles.container}>
       <DetailTopBar backHref="/" crumb={<em>draft</em>} />
@@ -34,7 +59,22 @@ export function DraftDetail({ draft }: Props) {
           this is a local draft — it lives only on your machine until you
           assign it to a repo.
         </div>
-        <BodyText body={draft.body} />
+        <div className={styles.bodyEditor}>
+          <textarea
+            className={styles.textarea}
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            onBlur={handleBlur}
+            placeholder="add a description…"
+            rows={8}
+          />
+          {savedAt !== null && (
+            <div className={styles.savedIndicator}>saved</div>
+          )}
+          {saveError && (
+            <div className={styles.saveError}>{saveError}</div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -14,6 +14,7 @@ import {
 } from "./DetailMeta";
 import { BodyText } from "./BodyText";
 import { CommentList } from "./CommentList";
+import { CommentComposer } from "./CommentComposer";
 import { LaunchCard } from "./LaunchCard";
 import styles from "./IssueDetail.module.css";
 
@@ -92,6 +93,11 @@ export function IssueDetail({
         />
         <BodyText body={issue.body} />
         <CommentList comments={comments} />
+        <CommentComposer
+          owner={owner}
+          repo={repoName}
+          issueNumber={issue.number}
+        />
       </div>
     </div>
   );

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -3,6 +3,7 @@ import type {
   GitHubIssue,
   GitHubComment,
   GitHubPull,
+  Priority,
 } from "@issuectl/core";
 import { Chip } from "@/components/paper";
 import { DetailTopBar } from "./DetailTopBar";
@@ -16,12 +17,15 @@ import { BodyText } from "./BodyText";
 import { CommentList } from "./CommentList";
 import { CommentComposer } from "./CommentComposer";
 import { LaunchCard } from "./LaunchCard";
+import { PriorityPicker } from "./PriorityPicker";
 import styles from "./IssueDetail.module.css";
 
 type Props = {
   owner: string;
   repoName: string;
+  repoId: number;
   repoLocalPath: string | null;
+  currentPriority: Priority;
   issue: GitHubIssue;
   comments: GitHubComment[];
   deployments: Deployment[];
@@ -41,7 +45,9 @@ function formatAge(updatedAt: string): string {
 export function IssueDetail({
   owner,
   repoName,
+  repoId,
   repoLocalPath,
+  currentPriority,
   issue,
   comments,
   deployments,
@@ -80,6 +86,12 @@ export function IssueDetail({
           )}
           <MetaSeparator />
           <span>{formatAge(issue.updatedAt)}</span>
+          <MetaSeparator />
+          <PriorityPicker
+            repoId={repoId}
+            issueNumber={issue.number}
+            currentPriority={currentPriority}
+          />
         </DetailMeta>
 
         <LaunchCard

--- a/packages/web/components/detail/PriorityPicker.module.css
+++ b/packages/web/components/detail/PriorityPicker.module.css
@@ -1,0 +1,106 @@
+.trigger {
+  font-family: var(--paper-sans);
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.trigger:hover {
+  color: var(--paper-ink);
+}
+
+.body {
+  padding: 0 0 8px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 14px 28px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--paper-line-soft);
+  cursor: pointer;
+  text-align: left;
+}
+
+.row:hover {
+  background: var(--paper-bg-warm);
+}
+
+.row:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.row.active {
+  background: var(--paper-accent-soft);
+}
+
+.symbol {
+  font-family: var(--paper-serif);
+  font-size: 20px;
+  font-weight: 600;
+  width: 24px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.symbol.high {
+  color: var(--paper-brick);
+}
+
+.symbol.normal {
+  color: var(--paper-ink-muted);
+}
+
+.symbol.low {
+  color: var(--paper-accent-dim);
+}
+
+.text {
+  flex: 1;
+}
+
+.label {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-size: 16px;
+  color: var(--paper-ink);
+  margin-bottom: 2px;
+}
+
+.description {
+  font-family: var(--paper-sans);
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+}
+
+.current {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-accent);
+}
+
+.spinner {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: 12px;
+  color: var(--paper-brick);
+  padding: 10px 28px;
+}

--- a/packages/web/components/detail/PriorityPicker.tsx
+++ b/packages/web/components/detail/PriorityPicker.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import type { Priority } from "@issuectl/core";
+import { Sheet } from "@/components/paper";
+import { setPriorityAction } from "@/lib/actions/priority";
+import styles from "./PriorityPicker.module.css";
+
+type PriorityOption = {
+  value: Priority;
+  symbol: string;
+  label: string;
+  description: string;
+};
+
+const OPTIONS: PriorityOption[] = [
+  {
+    value: "high",
+    symbol: "↑",
+    label: "high",
+    description: "needs attention soon",
+  },
+  {
+    value: "normal",
+    symbol: "–",
+    label: "normal",
+    description: "standard priority",
+  },
+  { value: "low", symbol: "↓", label: "low", description: "can wait" },
+];
+
+type Props = {
+  repoId: number;
+  issueNumber: number;
+  currentPriority: Priority;
+};
+
+export function PriorityPicker({ repoId, issueNumber, currentPriority }: Props) {
+  const [open, setOpen] = useState(false);
+  const [priority, setPriority] = useState<Priority>(currentPriority);
+  const [setting, setSetting] = useState<Priority | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSelect = async (next: Priority) => {
+    setSetting(next);
+    setError(null);
+    try {
+      await setPriorityAction(repoId, issueNumber, next);
+      setPriority(next);
+      setOpen(false);
+    } catch {
+      setError("Failed to update priority");
+    } finally {
+      setSetting(null);
+    }
+  };
+
+  return (
+    <>
+      <button className={styles.trigger} onClick={() => setOpen(true)}>
+        priority: {priority}
+      </button>
+      <Sheet open={open} onClose={() => setOpen(false)} title="set priority">
+        <div className={styles.body}>
+          {OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              className={`${styles.row} ${priority === opt.value ? styles.active : ""}`}
+              onClick={() => handleSelect(opt.value)}
+              disabled={setting !== null}
+            >
+              <span className={`${styles.symbol} ${styles[opt.value]}`}>
+                {opt.symbol}
+              </span>
+              <div className={styles.text}>
+                <div className={styles.label}>{opt.label}</div>
+                <div className={styles.description}>{opt.description}</div>
+              </div>
+              {priority === opt.value && (
+                <span className={styles.current}>current</span>
+              )}
+              {setting === opt.value && (
+                <span className={styles.spinner}>saving…</span>
+              )}
+            </button>
+          ))}
+          {error && <div className={styles.error}>{error}</div>}
+        </div>
+      </Sheet>
+    </>
+  );
+}

--- a/packages/web/components/list/AssignSheet.module.css
+++ b/packages/web/components/list/AssignSheet.module.css
@@ -1,0 +1,68 @@
+.body {
+  padding: 0 0 8px;
+}
+
+.loading,
+.empty {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-ink-faint);
+  padding: 16px 28px;
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-brick);
+  padding: 10px 28px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 28px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--paper-line-soft);
+  cursor: pointer;
+  text-align: left;
+}
+
+.row:hover {
+  background: var(--paper-bg-warm);
+}
+
+.row:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.repoName {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-size: 16px;
+  color: var(--paper-ink);
+  flex: 1;
+}
+
+.repoOwner {
+  font-family: var(--paper-sans);
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+}
+
+.spinner {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--paper-accent);
+}
+
+.footer {
+  padding: 16px 28px 0;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Sheet, Button } from "@/components/paper";
+import { listReposAction, assignDraftAction } from "@/lib/actions/drafts";
+import styles from "./AssignSheet.module.css";
+
+type Repo = { id: number; owner: string; name: string };
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  draftId: string;
+  draftTitle: string;
+};
+
+export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [assigning, setAssigning] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setLoading(true);
+    listReposAction()
+      .then(setRepos)
+      .catch(() => setError("Failed to load repos"))
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  const handleAssign = async (repoId: number) => {
+    setAssigning(repoId);
+    setError(null);
+    try {
+      await assignDraftAction(draftId, repoId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to assign draft");
+    } finally {
+      setAssigning(null);
+    }
+  };
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="assign to repo"
+      description={<em>{draftTitle}</em>}
+    >
+      <div className={styles.body}>
+        {loading && <div className={styles.loading}>loading repos…</div>}
+        {error && <div className={styles.error}>{error}</div>}
+        {!loading && repos.length === 0 && !error && (
+          <div className={styles.empty}>
+            <em>no repos tracked yet — add one in settings</em>
+          </div>
+        )}
+        {repos.map((repo) => (
+          <button
+            key={repo.id}
+            className={styles.row}
+            onClick={() => handleAssign(repo.id)}
+            disabled={assigning !== null}
+          >
+            <div className={styles.repoName}>{repo.name}</div>
+            <div className={styles.repoOwner}>{repo.owner}</div>
+            {assigning === repo.id && (
+              <div className={styles.spinner}>assigning…</div>
+            )}
+          </button>
+        ))}
+        <div className={styles.footer}>
+          <Button variant="ghost" onClick={onClose} disabled={assigning !== null}>
+            cancel
+          </Button>
+        </div>
+      </div>
+    </Sheet>
+  );
+}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -5,6 +5,7 @@ import type { Section, UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
 import { ListSection } from "./ListSection";
 import { CreateDraftSheet } from "./CreateDraftSheet";
+import { AssignSheet } from "./AssignSheet";
 import { NavDrawerContent } from "./NavDrawerContent";
 import styles from "./List.module.css";
 
@@ -36,6 +37,10 @@ function formatDate(d: Date): { weekday: string; short: string } {
 export function List({ data, activeTab, prCount, username }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [assignTarget, setAssignTarget] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
 
   const issueCount =
     data.unassigned.length +
@@ -94,18 +99,22 @@ export function List({ data, activeTab, prCount, username }: Props) {
             <ListSection
               title={SECTION_LABEL.unassigned}
               items={data.unassigned}
+              onAssign={(id, title) => setAssignTarget({ id, title })}
             />
             <ListSection
               title={SECTION_LABEL.in_focus}
               items={data.in_focus}
+              onAssign={(id, title) => setAssignTarget({ id, title })}
             />
             <ListSection
               title={SECTION_LABEL.in_flight}
               items={data.in_flight}
+              onAssign={(id, title) => setAssignTarget({ id, title })}
             />
             <ListSection
               title={SECTION_LABEL.shipped}
               items={data.shipped}
+              onAssign={(id, title) => setAssignTarget({ id, title })}
             />
           </div>
         )
@@ -128,6 +137,12 @@ export function List({ data, activeTab, prCount, username }: Props) {
           <CreateDraftSheet
             open={createOpen}
             onClose={() => setCreateOpen(false)}
+          />
+          <AssignSheet
+            open={assignTarget !== null}
+            onClose={() => setAssignTarget(null)}
+            draftId={assignTarget?.id ?? ""}
+            draftTitle={assignTarget?.title ?? ""}
           />
         </>
       )}

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -73,6 +73,13 @@
   text-decoration: underline;
 }
 
+/* Ensure touch devices never see the hover actions panel */
+@media (hover: none) {
+  .actions {
+    display: none !important;
+  }
+}
+
 @media (min-width: 768px) {
   /* On desktop, hide the meta-row assign link; hover actions panel handles it */
   .assignBtn {

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -1,20 +1,83 @@
 .item {
-  padding: 16px 24px 16px 58px;
   position: relative;
   border-bottom: 1px solid var(--paper-line-soft);
-  display: block;
-  color: inherit;
-  text-decoration: none;
+  display: flex;
+  align-items: stretch;
 }
 
 .item:hover {
   background: var(--paper-bg-warm);
 }
 
+.rowLink {
+  flex: 1;
+  padding: 16px 24px 16px 58px;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  min-width: 0;
+}
+
 .check {
   position: absolute;
   left: 24px;
   top: 18px;
+}
+
+.actions {
+  display: none;
+  align-items: center;
+  padding: 0 16px;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.item:hover .actions {
+  display: flex;
+}
+
+.actionBtn {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--paper-ink-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  text-decoration: none;
+  border-radius: var(--paper-radius-sm);
+}
+
+.actionBtn:hover {
+  color: var(--paper-ink);
+  background: var(--paper-bg-warmer);
+}
+
+/* Mobile: keep assign in the meta row, hide desktop actions panel */
+.assignBtn {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-accent-dim);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  line-height: inherit;
+}
+
+.assignBtn:hover {
+  color: var(--paper-accent);
+  text-decoration: underline;
+}
+
+@media (min-width: 768px) {
+  /* On desktop, hide the meta-row assign link; hover actions panel handles it */
+  .assignBtn {
+    display: none;
+  }
 }
 
 .title {

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -5,6 +5,7 @@ import styles from "./ListRow.module.css";
 
 type Props = {
   item: UnifiedListItem;
+  onAssign?: (draftId: string, draftTitle: string) => void;
 };
 
 // Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
@@ -35,22 +36,49 @@ function labelClass(labelName: string): string | undefined {
   return undefined;
 }
 
-export function ListRow({ item }: Props) {
+export function ListRow({ item, onAssign }: Props) {
   if (item.kind === "draft") {
     return (
-      <Link href={`/drafts/${item.draft.id}`} className={styles.item}>
-        <span className={styles.check}>
-          <Checkbox state="draft" />
-        </span>
-        <div className={styles.title}>{item.draft.title}</div>
-        <div className={styles.meta}>
-          <Chip variant="dashed">no repo</Chip>
-          <span className={styles.sep}>·</span>
-          <span>local draft</span>
-          <span className={styles.sep}>·</span>
-          <span>{formatAge(item.draft.updatedAt)}</span>
+      <div className={styles.item}>
+        <Link href={`/drafts/${item.draft.id}`} className={styles.rowLink}>
+          <span className={styles.check}>
+            <Checkbox state="draft" />
+          </span>
+          <div className={styles.title}>{item.draft.title}</div>
+          <div className={styles.meta}>
+            <Chip variant="dashed">no repo</Chip>
+            <span className={styles.sep}>·</span>
+            <span>local draft</span>
+            <span className={styles.sep}>·</span>
+            <span>{formatAge(item.draft.updatedAt)}</span>
+            {onAssign && (
+              <>
+                <span className={styles.sep}>·</span>
+                <button
+                  className={styles.assignBtn}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onAssign(item.draft.id, item.draft.title);
+                  }}
+                >
+                  assign →
+                </button>
+              </>
+            )}
+          </div>
+        </Link>
+        <div className={styles.actions}>
+          {onAssign && (
+            <button
+              className={styles.actionBtn}
+              onClick={() => onAssign(item.draft.id, item.draft.title)}
+              aria-label="Assign draft to repo"
+            >
+              assign
+            </button>
+          )}
         </div>
-      </Link>
+      </div>
     );
   }
 
@@ -65,23 +93,39 @@ export function ListRow({ item }: Props) {
   );
 
   return (
-    <Link href={`/issues/${repo.owner}/${repo.name}/${issue.number}`} className={styles.item}>
-      <span className={styles.check}>
-        <Checkbox state={checkState} />
-      </span>
-      <div className={titleClass}>{issue.title}</div>
-      <div className={styles.meta}>
-        <Chip>{repo.name}</Chip>
-        <span className={styles.num}>#{issue.number}</span>
-        {firstLabel && (
-          <>
-            <span className={styles.sep}>·</span>
-            <span className={labelClass(firstLabel.name)}>{firstLabel.name}</span>
-          </>
-        )}
-        <span className={styles.sep}>·</span>
-        <span>{formatAge(issue.updatedAt)}</span>
+    <div className={styles.item}>
+      <Link
+        href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
+        className={styles.rowLink}
+      >
+        <span className={styles.check}>
+          <Checkbox state={checkState} />
+        </span>
+        <div className={titleClass}>{issue.title}</div>
+        <div className={styles.meta}>
+          <Chip>{repo.name}</Chip>
+          <span className={styles.num}>#{issue.number}</span>
+          {firstLabel && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={labelClass(firstLabel.name)}>
+                {firstLabel.name}
+              </span>
+            </>
+          )}
+          <span className={styles.sep}>·</span>
+          <span>{formatAge(issue.updatedAt)}</span>
+        </div>
+      </Link>
+      <div className={styles.actions}>
+        <Link
+          href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
+          className={styles.actionBtn}
+          aria-label="Open issue detail"
+        >
+          launch
+        </Link>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -6,9 +6,10 @@ import styles from "./ListSection.module.css";
 type Props = {
   title: ReactNode;
   items: UnifiedListItem[];
+  onAssign?: (draftId: string, draftTitle: string) => void;
 };
 
-export function ListSection({ title, items }: Props) {
+export function ListSection({ title, items, onAssign }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -26,6 +27,7 @@ export function ListSection({ title, items }: Props) {
               : `issue-${item.repo.id}-${item.issue.number}`
           }
           item={item}
+          onAssign={onAssign}
         />
       ))}
     </>

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -6,7 +6,10 @@ import {
   getOctokit,
   createDraft,
   assignDraftToRepo,
+  listRepos,
+  updateDraft,
   type DraftInput,
+  type DraftUpdate,
   type Priority,
 } from "@issuectl/core";
 
@@ -63,6 +66,27 @@ export async function createDraftAction(
     console.error("[issuectl] createDraftAction failed", err);
     throw err;
   }
+}
+
+export async function listReposAction(): Promise<
+  Array<{ id: number; owner: string; name: string }>
+> {
+  const db = getDb();
+  const repos = listRepos(db);
+  return repos.map((r) => ({ id: r.id, owner: r.owner, name: r.name }));
+}
+
+export async function updateDraftAction(
+  draftId: string,
+  update: DraftUpdate,
+): Promise<void> {
+  if (typeof draftId !== "string" || draftId.length === 0) {
+    throw new Error("draftId must be a non-empty string");
+  }
+  const db = getDb();
+  updateDraft(db, draftId, update);
+  revalidatePath("/");
+  revalidatePath(`/drafts/${draftId}`);
 }
 
 export async function assignDraftAction(

--- a/packages/web/lib/actions/priority.ts
+++ b/packages/web/lib/actions/priority.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getDb, setPriority, type Priority } from "@issuectl/core";
+
+const VALID_PRIORITIES: readonly Priority[] = ["low", "normal", "high"];
+
+export async function setPriorityAction(
+  repoId: number,
+  issueNumber: number,
+  priority: Priority,
+): Promise<void> {
+  if (typeof repoId !== "number" || !Number.isInteger(repoId) || repoId <= 0) {
+    throw new Error("repoId must be a positive integer");
+  }
+  if (
+    typeof issueNumber !== "number" ||
+    !Number.isInteger(issueNumber) ||
+    issueNumber <= 0
+  ) {
+    throw new Error("issueNumber must be a positive integer");
+  }
+  if (!(VALID_PRIORITIES as readonly string[]).includes(priority)) {
+    throw new Error(`Invalid priority: ${String(priority)}`);
+  }
+
+  const db = getDb();
+  setPriority(db, repoId, issueNumber, priority);
+  revalidatePath("/");
+}


### PR DESCRIPTION
## Summary

Five follow-up features that make the Paper-reskinned app feature-complete for daily use.

### 1. AssignSheet
- Draft rows show an italic "assign →" link in the meta area
- Tapping opens a bottom sheet listing all tracked repos
- Selecting a repo calls `assignDraftAction` → pushes the draft to GitHub as a real issue
- Server action `listReposAction` added for fetching the repo list

### 2. Draft body editing
- `DraftDetail` converted to a client component with an auto-saving body textarea
- On blur: calls `updateDraftAction` → saves body to SQLite
- Shows a subtle "saved" indicator after successful save

### 3. Comment composer
- Sticky composer at the bottom of the issue detail page
- Paper-styled input + send button
- Calls `addCommentAction` → posts to GitHub via Octokit
- Clears on success, shows error on failure

### 4. Priority picker sheet
- Tappable priority indicator in the issue detail meta row
- Opens a Paper Sheet with three options (high ↑ / normal – / low ↓)
- Calls `setPriorityAction` → updates local priority in SQLite
- Current priority highlighted; list revalidates on change

### 5. Desktop hover quick actions
- Issue rows show a "launch" button on hover (links to detail page)
- Draft rows show the "assign →" link (already wired to AssignSheet)
- Hidden on touch devices via `@media (hover: none)`

## Test Plan
- [x] 183/183 core tests
- [x] Typecheck/build/lint clean
- [ ] Eyeball: create a draft → tap "assign →" → pick a repo → draft becomes a real issue
- [ ] Eyeball: open a draft detail → edit the body → blur → "saved" appears
- [ ] Eyeball: open an issue detail → type a comment → send → comment appears
- [ ] Eyeball: tap priority indicator → pick "high" → list reorders