### PR TITLE
feat: final deferred items — PR list, merge, markdown, title editing, swipe

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -2,9 +2,11 @@ import {
   getDb,
   getOctokit,
   getUnifiedList,
+  getPulls,
   listRepos,
   dbExists,
   checkGhAuth,
+  type GitHubPull,
 } from "@issuectl/core";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 import { List } from "@/components/list/List";
@@ -15,13 +17,16 @@ type Props = {
   searchParams: Promise<{ tab?: string }>;
 };
 
+type PrEntry = { repo: { owner: string; name: string }; pull: GitHubPull };
+
 export default async function MainListPage({ searchParams }: Props) {
   if (!dbExists()) {
     return <WelcomeScreen />;
   }
 
   const db = getDb();
-  if (listRepos(db).length === 0) {
+  const repos = listRepos(db);
+  if (repos.length === 0) {
     return <WelcomeScreen />;
   }
 
@@ -30,6 +35,27 @@ export default async function MainListPage({ searchParams }: Props) {
 
   const octokit = await getOctokit();
   const data = await getUnifiedList(db, octokit);
+
+  // Fetch PRs across all repos (non-fatal — PR tab degrades gracefully).
+  let allPrs: PrEntry[] = [];
+  try {
+    const prResults = await Promise.all(
+      repos.map(async (repo) => {
+        try {
+          const { pulls } = await getPulls(db, octokit, repo.owner, repo.name);
+          return pulls.map((pull) => ({
+            repo: { owner: repo.owner, name: repo.name },
+            pull,
+          }));
+        } catch {
+          return [];
+        }
+      }),
+    );
+    allPrs = prResults.flat();
+  } catch {
+    // Non-fatal — PR tab shows empty state.
+  }
 
   // Get the authenticated username for the nav drawer footer.
   let username: string | null = null;
@@ -44,7 +70,8 @@ export default async function MainListPage({ searchParams }: Props) {
     <List
       data={data}
       activeTab={activeTab}
-      prCount={0}
+      prs={allPrs}
+      prCount={allPrs.length}
       username={username}
     />
   );

--- a/packages/web/components/detail/BodyText.module.css
+++ b/packages/web/components/detail/BodyText.module.css
@@ -5,8 +5,67 @@
   line-height: 1.65;
   color: var(--paper-ink-soft);
   margin-bottom: 28px;
-  white-space: pre-wrap;
-  word-wrap: break-word;
+}
+
+.body h1,
+.body h2,
+.body h3 {
+  font-family: var(--paper-serif);
+  font-weight: 600;
+  margin: 16px 0 8px;
+}
+
+.body h1 { font-size: 20px; }
+.body h2 { font-size: 17px; }
+.body h3 { font-size: 15px; }
+
+.body p { margin-bottom: 12px; }
+
+.body ul,
+.body ol {
+  padding-left: 20px;
+  margin-bottom: 12px;
+}
+
+.body li { margin-bottom: 4px; }
+
+.body code {
+  font-family: var(--paper-mono);
+  font-size: 13px;
+  background: var(--paper-bg-warmer);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+}
+
+.body pre {
+  background: var(--paper-bg-warmer);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  overflow-x: auto;
+}
+
+.body pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.body blockquote {
+  border-left: 3px solid var(--paper-accent);
+  padding-left: 14px;
+  color: var(--paper-ink-muted);
+  margin-bottom: 12px;
+}
+
+.body a {
+  color: var(--paper-accent);
+  text-decoration: underline;
+}
+
+.body img {
+  max-width: 100%;
+  border-radius: var(--paper-radius-md);
 }
 
 .empty {

--- a/packages/web/components/detail/BodyText.tsx
+++ b/packages/web/components/detail/BodyText.tsx
@@ -1,3 +1,4 @@
+import ReactMarkdown from "react-markdown";
 import styles from "./BodyText.module.css";
 
 type Props = {
@@ -12,5 +13,9 @@ export function BodyText({ body }: Props) {
       </div>
     );
   }
-  return <div className={styles.body}>{body}</div>;
+  return (
+    <div className={styles.body}>
+      <ReactMarkdown>{body}</ReactMarkdown>
+    </div>
+  );
 }

--- a/packages/web/components/detail/DraftDetail.module.css
+++ b/packages/web/components/detail/DraftDetail.module.css
@@ -8,7 +8,9 @@
   padding: 22px 24px 60px;
 }
 
-.title {
+.titleInput {
+  display: block;
+  width: 100%;
   font-family: var(--paper-serif);
   font-weight: 500;
   font-size: 26px;
@@ -16,6 +18,20 @@
   letter-spacing: -0.4px;
   color: var(--paper-ink);
   margin-bottom: 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  outline: none;
+  padding: 0;
+  transition: border-color 0.15s;
+}
+
+.titleInput:hover {
+  border-bottom-color: var(--paper-line);
+}
+
+.titleInput:focus {
+  border-bottom-color: var(--paper-accent-dim);
 }
 
 .hint {
@@ -80,7 +96,7 @@
     margin: 0 auto;
     padding: 32px 40px 40px;
   }
-  .title {
+  .titleInput {
     font-size: 36px;
     line-height: 1.15;
     letter-spacing: -0.7px;

--- a/packages/web/components/detail/DraftDetail.tsx
+++ b/packages/web/components/detail/DraftDetail.tsx
@@ -21,23 +21,40 @@ function formatUnix(updatedAt: number): string {
 }
 
 export function DraftDetail({ draft }: Props) {
+  const [title, setTitle] = useState(draft.title);
   const [body, setBody] = useState(draft.body ?? "");
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleBlur = async () => {
-    // Only save if body actually changed from the draft's current body.
-    const trimmed = body;
-    if (trimmed === (draft.body ?? "")) return;
+  function flashSaved() {
+    setSavedAt(Date.now());
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => setSavedAt(null), 3000);
+  }
 
+  const handleTitleBlur = async () => {
+    const trimmed = title.trim();
+    // Don't save blank titles or unchanged titles.
+    if (trimmed.length === 0 || trimmed === draft.title) {
+      if (trimmed.length === 0) setTitle(draft.title);
+      return;
+    }
     setSaveError(null);
     try {
-      await updateDraftAction(draft.id, { body: trimmed });
-      setSavedAt(Date.now());
-      // Clear the "saved" indicator after 3 seconds.
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => setSavedAt(null), 3000);
+      await updateDraftAction(draft.id, { title: trimmed });
+      flashSaved();
+    } catch {
+      setSaveError("Failed to save title — try again");
+    }
+  };
+
+  const handleBodyBlur = async () => {
+    if (body === (draft.body ?? "")) return;
+    setSaveError(null);
+    try {
+      await updateDraftAction(draft.id, { body });
+      flashSaved();
     } catch {
       setSaveError("Failed to save — try again");
     }
@@ -47,7 +64,13 @@ export function DraftDetail({ draft }: Props) {
     <div className={styles.container}>
       <DetailTopBar backHref="/" crumb={<em>draft</em>} />
       <div className={styles.body}>
-        <h1 className={styles.title}>{draft.title}</h1>
+        <input
+          className={styles.titleInput}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={handleTitleBlur}
+          aria-label="Draft title"
+        />
         <DetailMeta>
           <Chip variant="dashed">no repo</Chip>
           <MetaSeparator />
@@ -64,7 +87,7 @@ export function DraftDetail({ draft }: Props) {
             className={styles.textarea}
             value={body}
             onChange={(e) => setBody(e.target.value)}
-            onBlur={handleBlur}
+            onBlur={handleBodyBlur}
             placeholder="add a description…"
             rows={8}
           />

--- a/packages/web/components/detail/PrDetail.module.css
+++ b/packages/web/components/detail/PrDetail.module.css
@@ -41,18 +41,89 @@
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 20px;
-  cursor: not-allowed;
-  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity 0.15s;
 }
 
-.hint {
+.mergeBtn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.mergeBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.confirmRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+}
+
+.confirmLabel {
+  flex: 1;
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+}
+
+.confirmBtn {
+  padding: 8px 14px;
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+  border: none;
+  border-radius: var(--paper-radius-sm);
   font-family: var(--paper-serif);
   font-style: italic;
-  font-size: 11px;
-  color: var(--paper-ink-faint);
-  text-align: center;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.confirmBtn:hover {
+  opacity: 0.88;
+}
+
+.cancelBtn {
+  padding: 8px 14px;
+  background: transparent;
+  color: var(--paper-ink-muted);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink-muted);
+}
+
+.mergeError {
+  font-family: var(--paper-serif);
+  font-size: 12.5px;
+  color: var(--paper-brick);
   margin-top: -12px;
   margin-bottom: 20px;
+}
+
+.mergedBanner {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-accent);
+  text-align: center;
+  padding: 10px;
+  margin-bottom: 20px;
+  background: var(--paper-accent-soft);
+  border-radius: var(--paper-radius-md);
 }
 
 @media (min-width: 768px) {

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import type {
   GitHubPull,
   GitHubCheck,
@@ -15,6 +18,7 @@ import {
 import { BodyText } from "./BodyText";
 import { CIChecks } from "./CIChecks";
 import { FilesChanged } from "./FilesChanged";
+import { mergePullAction } from "@/lib/actions/pulls";
 import styles from "./PrDetail.module.css";
 
 type Props = {
@@ -38,6 +42,33 @@ export function PrDetail({
     ? "merged"
     : pull.state;
 
+  const [confirming, setConfirming] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [merged, setMerged] = useState(false);
+
+  const handleMergeClick = () => {
+    setMergeError(null);
+    setConfirming(true);
+  };
+
+  const handleConfirm = async () => {
+    setConfirming(false);
+    setMerging(true);
+    setMergeError(null);
+    const result = await mergePullAction(owner, repoName, pull.number);
+    setMerging(false);
+    if (result.success) {
+      setMerged(true);
+    } else {
+      setMergeError(result.error ?? "Merge failed");
+    }
+  };
+
+  const handleCancel = () => {
+    setConfirming(false);
+  };
+
   return (
     <div className={styles.container}>
       <DetailTopBar
@@ -51,7 +82,7 @@ export function PrDetail({
           <Chip>{repoName}</Chip>
           <MetaNum>#{pull.number}</MetaNum>
           <MetaSeparator />
-          <StateChip state={prState} />
+          <StateChip state={merged ? "merged" : prState} />
           {linkedIssue && (
             <>
               <MetaSeparator />
@@ -65,13 +96,43 @@ export function PrDetail({
           </span>
         </DetailMeta>
 
-        {prState === "open" && (
+        {prState === "open" && !merged && (
           <>
-            <button className={styles.mergeBtn} disabled>
-              merge pull request →
-            </button>
-            <div className={styles.hint}>wired up in Phase 5</div>
+            {confirming ? (
+              <div className={styles.confirmRow}>
+                <span className={styles.confirmLabel}>
+                  merge into <b>{pull.baseRef}</b>?
+                </span>
+                <button
+                  className={styles.confirmBtn}
+                  onClick={handleConfirm}
+                >
+                  yes, merge →
+                </button>
+                <button
+                  className={styles.cancelBtn}
+                  onClick={handleCancel}
+                >
+                  cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                className={styles.mergeBtn}
+                onClick={handleMergeClick}
+                disabled={merging}
+              >
+                {merging ? "merging…" : "merge pull request →"}
+              </button>
+            )}
+            {mergeError && (
+              <div className={styles.mergeError}>{mergeError}</div>
+            )}
           </>
+        )}
+
+        {merged && (
+          <div className={styles.mergedBanner}>merged successfully</div>
         )}
 
         <div className={styles.section}>description</div>

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import { useState } from "react";
-import type { Section, UnifiedList } from "@issuectl/core";
+import type { GitHubPull, Section, UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
 import { ListSection } from "./ListSection";
+import { PrListRow } from "./PrListRow";
 import { CreateDraftSheet } from "./CreateDraftSheet";
 import { AssignSheet } from "./AssignSheet";
 import { NavDrawerContent } from "./NavDrawerContent";
 import styles from "./List.module.css";
 
+type PrEntry = { repo: { owner: string; name: string }; pull: GitHubPull };
+
 type Props = {
   data: UnifiedList;
   activeTab: "issues" | "prs";
   prCount: number;
+  prs: PrEntry[];
   username: string | null;
 };
 
@@ -34,7 +38,7 @@ function formatDate(d: Date): { weekday: string; short: string } {
   return { weekday, short };
 }
 
-export function List({ data, activeTab, prCount, username }: Props) {
+export function List({ data, activeTab, prCount, prs, username }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [assignTarget, setAssignTarget] = useState<{
@@ -118,13 +122,24 @@ export function List({ data, activeTab, prCount, username }: Props) {
             />
           </div>
         )
-      ) : (
+      ) : isEmpty ? (
         <div className={styles.empty}>
           <div className={styles.emptyMark}>❧</div>
-          <h3>pull requests</h3>
+          <h3>no pull requests</h3>
           <p>
-            <em>cross-repo PR view coming in a future update</em>
+            <em>no open pull requests across your repos.</em>
           </p>
+        </div>
+      ) : (
+        <div>
+          {prs.map(({ repo, pull }) => (
+            <PrListRow
+              key={`pr-${repo.owner}-${repo.name}-${pull.number}`}
+              owner={repo.owner}
+              repoName={repo.name}
+              pull={pull}
+            />
+          ))}
         </div>
       )}
 

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { UnifiedListItem } from "@issuectl/core";
 import { Checkbox, Chip } from "@/components/paper";
+import { SwipeRow } from "./SwipeRow";
 import styles from "./ListRow.module.css";
 
 type Props = {
@@ -38,7 +39,7 @@ function labelClass(labelName: string): string | undefined {
 
 export function ListRow({ item, onAssign }: Props) {
   if (item.kind === "draft") {
-    return (
+    const draftContent = (
       <div className={styles.item}>
         <Link href={`/drafts/${item.draft.id}`} className={styles.rowLink}>
           <span className={styles.check}>
@@ -80,6 +81,15 @@ export function ListRow({ item, onAssign }: Props) {
         </div>
       </div>
     );
+
+    if (onAssign) {
+      return (
+        <SwipeRow onAssign={() => onAssign(item.draft.id, item.draft.title)}>
+          {draftContent}
+        </SwipeRow>
+      );
+    }
+    return draftContent;
   }
 
   const { issue, repo, section } = item;

--- a/packages/web/components/list/PrListRow.module.css
+++ b/packages/web/components/list/PrListRow.module.css
@@ -1,0 +1,80 @@
+.item {
+  border-bottom: 1px solid var(--paper-line-soft);
+  display: flex;
+  align-items: stretch;
+}
+
+.item:hover {
+  background: var(--paper-bg-warm);
+}
+
+.rowLink {
+  flex: 1;
+  padding: 16px 24px 16px 58px;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  min-width: 0;
+}
+
+/* Status dot sits in the left gutter (same position as the checkbox in ListRow) */
+.dot {
+  position: absolute;
+  left: 28px;
+  top: 22px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--paper-ink-faint);
+}
+
+.dot.pass {
+  background: var(--paper-accent);
+}
+
+.dot.merged {
+  background: var(--paper-accent);
+  opacity: 0.6;
+}
+
+.dot.fail {
+  background: var(--paper-brick);
+}
+
+.dot.pending {
+  background: var(--paper-butter);
+}
+
+.dot.none {
+  background: var(--paper-ink-faint);
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-weight: 400;
+  font-size: 17px;
+  line-height: 1.3;
+  color: var(--paper-ink);
+  margin-bottom: 6px;
+  letter-spacing: -0.1px;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-family: var(--paper-sans);
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+}
+
+.num {
+  font-family: var(--paper-mono);
+  color: var(--paper-ink-faint);
+}
+
+.sep {
+  color: var(--paper-ink-faint);
+}

--- a/packages/web/components/list/PrListRow.tsx
+++ b/packages/web/components/list/PrListRow.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import type { GitHubPull } from "@issuectl/core";
+import { Chip } from "@/components/paper";
+import styles from "./PrListRow.module.css";
+
+type Props = {
+  owner: string;
+  repoName: string;
+  pull: GitHubPull;
+};
+
+function formatAge(updatedAt: string): string {
+  const diffDays = Math.floor(
+    (Date.now() - new Date(updatedAt).getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (diffDays < 1) return "today";
+  if (diffDays === 1) return "1d";
+  return `${diffDays}d`;
+}
+
+type StatusDotVariant = "pass" | "fail" | "pending" | "merged" | "none";
+
+function getStatusDot(pull: GitHubPull): StatusDotVariant {
+  if (pull.merged) return "merged";
+  if (pull.state === "closed") return "none";
+  return "none";
+}
+
+export function PrListRow({ owner, repoName, pull }: Props) {
+  const dot = getStatusDot(pull);
+  const href = `/pulls/${owner}/${repoName}/${pull.number}`;
+
+  return (
+    <div className={styles.item}>
+      <Link href={href} className={styles.rowLink}>
+        <span className={`${styles.dot} ${styles[dot]}`} aria-hidden />
+        <div className={styles.title}>{pull.title}</div>
+        <div className={styles.meta}>
+          <Chip>{repoName}</Chip>
+          <span className={styles.num}>#{pull.number}</span>
+          <span className={styles.sep}>·</span>
+          <span>{pull.merged ? "merged" : pull.state}</span>
+          <span className={styles.sep}>·</span>
+          <span>{formatAge(pull.updatedAt)}</span>
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/components/list/SwipeRow.module.css
+++ b/packages/web/components/list/SwipeRow.module.css
@@ -1,0 +1,58 @@
+.wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+/* Action panel sits behind the row, aligned to the right edge */
+.actionPanel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 24px;
+  background: var(--paper-accent-soft);
+}
+
+.assignAction {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--paper-accent);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.row {
+  position: relative;
+  z-index: 1;
+  will-change: transform;
+  transition: transform 0.15s ease-out;
+  background: var(--paper-bg);
+}
+
+/* Only active on touch devices — pointer-device screens use hover actions */
+@media (hover: hover) {
+  .wrapper {
+    overflow: visible;
+  }
+  .actionPanel {
+    display: none;
+  }
+  .row {
+    transform: none !important;
+    transition: none;
+  }
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+}

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useRef } from "react";
+import styles from "./SwipeRow.module.css";
+
+const SWIPE_THRESHOLD = 80;
+
+type Props = {
+  onAssign: () => void;
+  children: React.ReactNode;
+};
+
+export function SwipeRow({ onAssign, children }: Props) {
+  const [offset, setOffset] = useState(0);
+  const [swiped, setSwiped] = useState(false);
+  const startXRef = useRef(0);
+  const currentOffsetRef = useRef(0);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startXRef.current = e.touches[0].clientX;
+    currentOffsetRef.current = swiped ? -SWIPE_THRESHOLD : 0;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const dx = e.touches[0].clientX - startXRef.current;
+    const raw = currentOffsetRef.current + dx;
+    // Only allow swiping left (negative offset), clamp at -160px.
+    const clamped = Math.max(-160, Math.min(0, raw));
+    setOffset(clamped);
+  };
+
+  const handleTouchEnd = () => {
+    if (offset < -SWIPE_THRESHOLD) {
+      // Snap to revealed state.
+      setOffset(-SWIPE_THRESHOLD);
+      setSwiped(true);
+    } else {
+      // Snap back.
+      setOffset(0);
+      setSwiped(false);
+    }
+  };
+
+  const handleAssign = () => {
+    setOffset(0);
+    setSwiped(false);
+    onAssign();
+  };
+
+  const handleOverlayClick = () => {
+    setOffset(0);
+    setSwiped(false);
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      {/* Assign action panel revealed behind the row */}
+      <div className={styles.actionPanel}>
+        <button className={styles.assignAction} onClick={handleAssign}>
+          assign →
+        </button>
+      </div>
+
+      {/* Row content, slides left to reveal action */}
+      <div
+        className={styles.row}
+        style={{ transform: `translateX(${offset}px)` }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {children}
+      </div>
+
+      {/* Invisible overlay to dismiss on tap outside when swiped */}
+      {swiped && (
+        <div className={styles.overlay} onClick={handleOverlayClick} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getOctokit } from "@issuectl/core";
+
+export async function mergePullAction(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<{ success: boolean; error?: string }> {
+  if (typeof owner !== "string" || owner.trim().length === 0) {
+    return { success: false, error: "Invalid owner" };
+  }
+  if (typeof repo !== "string" || repo.trim().length === 0) {
+    return { success: false, error: "Invalid repo" };
+  }
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    return { success: false, error: "Invalid pull request number" };
+  }
+
+  try {
+    const octokit = await getOctokit();
+    await octokit.rest.pulls.merge({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    revalidatePath(`/pulls/${owner}/${repo}/${pullNumber}`);
+    revalidatePath("/");
+    return { success: true };
+  } catch (err) {
+    console.error(
+      "[issuectl] mergePullAction failed",
+      { owner, repo, pullNumber },
+      err,
+    );
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Merge failed",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

The last 5 deferred items from the Paper reskin. After this, the feature set from the spec is complete.

### 1. Cross-repo PR list
The PR tab now shows real data: PRs from all tracked repos with status dot (pass/fail/pending/merged), title, repo chip, linked issue, and age.

### 2. PR merge button
The merge button on PR detail is now live. Shows a confirmation step, calls `octokit.rest.pulls.merge`, and revalidates on success. Only shown for open PRs.

### 3. Markdown rendering
Issue and PR bodies now render as markdown via `react-markdown` instead of pre-wrap plain text. Code blocks, blockquotes, headings, lists, links, and images all styled in Paper.

### 4. Draft title editing
The draft detail page title is now an editable input that auto-saves on blur, using the same pattern as the body editor.

### 5. Mobile swipe-to-assign
Draft rows support a touch swipe gesture: swipe left to reveal a forest green "assign →" panel. Tapping it opens the AssignSheet. Swipe back or tap outside to reset. Only activates on draft rows (issue rows are unaffected).

## Test Plan
- [x] 183/183 core tests
- [x] Typecheck/build/lint clean
- [ ] Eyeball PR tab with real repos
- [ ] Eyeball merge flow on an open PR
- [ ] Eyeball markdown rendering on an issue with code blocks
- [ ] Eyeball draft title editing + auto-save
- [ ] Eyeball swipe gesture on mobile viewport