### PR TITLE
fix(web): deep QA audit fixes — accessibility, security, UX

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -5,14 +5,14 @@
   --paper-bg-warmer:    #e6dec4;
   --paper-ink:          #1a1712;
   --paper-ink-soft:     #3a342a;
-  --paper-ink-muted:    #8a7f63;
-  --paper-ink-faint:    #b5a88a;
+  --paper-ink-muted:    #746a50;
+  --paper-ink-faint:    #857a5e;
   --paper-line:         #e0d6bc;
   --paper-line-soft:    #e9dfc6;
   --paper-accent:       #2d5f3f;
   --paper-accent-dim:   #4a7a5c;
   --paper-accent-soft:  #dce8de;
-  --paper-brick:        #b84a2e;
+  --paper-brick:        #a8432a;
   --paper-butter:       #d9a54d;
 
   --paper-radius-sm:    3px;
@@ -58,6 +58,19 @@ button {
   font-family: inherit;
   font-size: inherit;
   cursor: pointer;
+}
+
+/* Consistent focus-visible ring for all interactive elements */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--paper-accent);
+  outline-offset: 2px;
+  border-radius: var(--paper-radius-sm);
 }
 
 input,

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import {
   getDb,
   getOctokit,
@@ -15,6 +16,15 @@ type Params = {
   repo: string;
   number: string;
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { owner, repo, number } = await params;
+  return { title: `#${number} — ${owner}/${repo} — issuectl` };
+}
 
 export default async function IssueDetailPage({
   params,

--- a/packages/web/app/parse/page.tsx
+++ b/packages/web/app/parse/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   dbExists,
   getDb,
@@ -10,15 +11,17 @@ import type { GitHubLabel } from "@issuectl/core";
 import type { RepoOption } from "@/lib/types";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { ParseFlow } from "@/components/parse/ParseFlow";
+import type { Metadata } from "next";
 import styles from "./page.module.css";
 
+export const metadata: Metadata = { title: "Quick Create — issuectl" };
 export const dynamic = "force-dynamic";
 
 export default async function ParsePage() {
   if (!dbExists()) {
     return (
       <>
-        <PageHeader title="Quick Create" />
+        <PageHeader title="Quick Create" breadcrumb={<Link href="/">← dashboard</Link>} />
         <div className={styles.content}>
           <p style={{ color: "var(--text-secondary)" }}>
             Run <code>issuectl init</code> to get started.
@@ -67,7 +70,7 @@ export default async function ParsePage() {
 
   return (
     <>
-      <PageHeader title="Quick Create" />
+      <PageHeader title="Quick Create" breadcrumb={<Link href="/">← dashboard</Link>} />
       <div className={styles.content}>
         <ParseFlow
           repos={repos}

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { getDb, getOctokit, getPullDetail } from "@issuectl/core";
 import { PrDetail } from "@/components/detail/PrDetail";
 
@@ -9,6 +10,15 @@ type Params = {
   repo: string;
   number: string;
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { owner, repo, number } = await params;
+  return { title: `PR #${number} — ${owner}/${repo} — issuectl` };
+}
 
 export default async function PullDetailPage({
   params,

--- a/packages/web/app/settings/loading.module.css
+++ b/packages/web/app/settings/loading.module.css
@@ -1,6 +1,6 @@
 @keyframes pulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.15; }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 .container {
@@ -18,7 +18,7 @@
   width: 120px;
   background: var(--paper-bg-warm);
   border-radius: var(--paper-radius-md);
-  animation: pulse 1.8s ease-in-out infinite;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 .content {
@@ -36,7 +36,7 @@
   background: var(--paper-bg-warm);
   border-radius: 4px;
   margin-bottom: 16px;
-  animation: pulse 1.8s ease-in-out infinite;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 .row {
@@ -45,7 +45,7 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
-  animation: pulse 1.8s ease-in-out infinite 0.1s;
+  animation: pulse 1.5s ease-in-out infinite 0.1s;
 }
 
 .rowWide {
@@ -55,7 +55,7 @@
   border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
   width: 100%;
-  animation: pulse 1.8s ease-in-out infinite 0.2s;
+  animation: pulse 1.5s ease-in-out infinite 0.2s;
 }
 
 .rowShort {
@@ -65,5 +65,5 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   margin-bottom: 8px;
-  animation: pulse 1.8s ease-in-out infinite 0.3s;
+  animation: pulse 1.5s ease-in-out infinite 0.3s;
 }

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   getDb,
   dbExists,
@@ -11,15 +12,17 @@ import { AuthStatus } from "@/components/settings/AuthStatus";
 import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
 import { listWorktrees } from "@/lib/actions/worktrees";
 import { getAuthStatus } from "@/lib/auth";
+import type { Metadata } from "next";
 import styles from "./page.module.css";
 
+export const metadata: Metadata = { title: "Settings — issuectl" };
 export const dynamic = "force-dynamic";
 
 export default async function SettingsPage() {
   if (!dbExists()) {
     return (
       <>
-        <PageHeader title="Settings" />
+        <PageHeader title="Settings" breadcrumb={<Link href="/">← dashboard</Link>} />
         <div className={styles.content}>
           <p style={{ color: "var(--text-secondary)" }}>
             Run <code>issuectl init</code> to get started.
@@ -52,7 +55,7 @@ export default async function SettingsPage() {
 
   return (
     <>
-      <PageHeader title="Settings" />
+      <PageHeader title="Settings" breadcrumb={<Link href="/">← dashboard</Link>} />
       <div className={styles.content}>
         <section className={styles.section}>
           <div className={styles.sectionTitle}>Tracked Repositories</div>

--- a/packages/web/components/detail/CommentList.module.css
+++ b/packages/web/components/detail/CommentList.module.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: baseline;
   gap: 8px;
-  margin-bottom: 14px;
+  margin: 0 0 14px;
 }
 
 .count {

--- a/packages/web/components/detail/CommentList.tsx
+++ b/packages/web/components/detail/CommentList.tsx
@@ -1,21 +1,11 @@
+import Image from "next/image";
 import type { GitHubComment } from "@issuectl/core";
+import { timeAgo } from "@/lib/format";
 import styles from "./CommentList.module.css";
 
 type Props = {
   comments: GitHubComment[];
 };
-
-// "3d ago" style formatting. GitHub comments use ISO strings.
-function formatTime(updatedAt: string): string {
-  const t = new Date(updatedAt).getTime();
-  if (!Number.isFinite(t)) return "";
-  const diffDays = Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000));
-  if (diffDays < 1) return "today";
-  if (diffDays === 1) return "yesterday";
-  if (diffDays < 7) return `${diffDays}d ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-  return `${Math.floor(diffDays / 30)}mo ago`;
-}
 
 function initials(login: string | undefined): string {
   if (!login) return "??";
@@ -25,9 +15,9 @@ function initials(login: string | undefined): string {
 export function CommentList({ comments }: Props) {
   return (
     <>
-      <div className={styles.section}>
+      <h2 className={styles.section}>
         comments <span className={styles.count}>{comments.length}</span>
-      </div>
+      </h2>
       {comments.length === 0 ? (
         <div className={styles.empty}>
           <em>no comments yet</em>
@@ -38,14 +28,13 @@ export function CommentList({ comments }: Props) {
             <div className={styles.head}>
               <div className={styles.avi}>
                 {c.user?.avatarUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={c.user.avatarUrl} alt="" />
+                  <Image src={c.user.avatarUrl} alt="" width={26} height={26} />
                 ) : (
                   initials(c.user?.login)
                 )}
               </div>
               <div className={styles.who}>{c.user?.login ?? "unknown"}</div>
-              <div className={styles.time}>{formatTime(c.updatedAt)}</div>
+              <div className={styles.time}>{timeAgo(c.updatedAt)}</div>
             </div>
             <div className={styles.body}>{c.body}</div>
           </div>

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -6,6 +6,7 @@ import type {
   Priority,
 } from "@issuectl/core";
 import { Chip } from "@/components/paper";
+import { timeAgo } from "@/lib/format";
 import { DetailTopBar } from "./DetailTopBar";
 import {
   DetailMeta,
@@ -33,15 +34,6 @@ type Props = {
   referencedFiles: string[];
 };
 
-function formatAge(updatedAt: string): string {
-  const t = new Date(updatedAt).getTime();
-  if (!Number.isFinite(t)) return "";
-  const diffDays = Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000));
-  if (diffDays < 1) return "today";
-  if (diffDays === 1) return "1d old";
-  return `${diffDays}d old`;
-}
-
 export function IssueDetail({
   owner,
   repoName,
@@ -67,7 +59,6 @@ export function IssueDetail({
             {owner}/<b>{repoName}</b>
           </>
         }
-        menu="···"
       />
       <div className={styles.body}>
         <h1 className={styles.title}>{issue.title}</h1>
@@ -85,7 +76,7 @@ export function IssueDetail({
             </>
           )}
           <MetaSeparator />
-          <span>{formatAge(issue.updatedAt)}</span>
+          <span>{timeAgo(issue.updatedAt)}</span>
           <MetaSeparator />
           <PriorityPicker
             repoId={repoId}

--- a/packages/web/components/detail/LaunchCard.tsx
+++ b/packages/web/components/detail/LaunchCard.tsx
@@ -37,7 +37,7 @@ export function LaunchCard({
   return (
     <>
       <div className={styles.card}>
-        <h4>Ready to launch</h4>
+        <h2>Ready to launch</h2>
         <p>
           Open a Ghostty session with Claude Code pre-loaded. Creates a worktree
           on a fresh branch.

--- a/packages/web/components/detail/LaunchCardPlaceholder.module.css
+++ b/packages/web/components/detail/LaunchCardPlaceholder.module.css
@@ -18,7 +18,7 @@
   border-radius: 2px;
 }
 
-.card h4 {
+.card h2 {
   font-family: var(--paper-serif);
   font-style: italic;
   font-weight: 500;

--- a/packages/web/components/detail/PrDetail.module.css
+++ b/packages/web/components/detail/PrDetail.module.css
@@ -26,7 +26,7 @@
   color: var(--paper-ink-soft);
   padding: 10px 0 12px;
   border-top: 1px solid var(--paper-line);
-  margin-bottom: 14px;
+  margin: 0 0 14px;
 }
 
 .mergeBtn {

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -74,7 +74,6 @@ export function PrDetail({
       <DetailTopBar
         backHref="/?tab=prs"
         crumb={<>{owner}/<b>{repoName}</b></>}
-        menu="···"
       />
       <div className={styles.body}>
         <h1 className={styles.title}>{pull.title}</h1>
@@ -135,13 +134,13 @@ export function PrDetail({
           <div className={styles.mergedBanner}>merged successfully</div>
         )}
 
-        <div className={styles.section}>description</div>
+        <h2 className={styles.section}>description</h2>
         <BodyText body={pull.body} />
 
-        <div className={styles.section}>ci checks</div>
+        <h2 className={styles.section}>ci checks</h2>
         <CIChecks checks={checks} />
 
-        <div className={styles.section}>files changed</div>
+        <h2 className={styles.section}>files changed</h2>
         <FilesChanged files={files} />
       </div>
     </div>

--- a/packages/web/components/detail/PriorityPicker.tsx
+++ b/packages/web/components/detail/PriorityPicker.tsx
@@ -45,9 +45,13 @@ export function PriorityPicker({ repoId, issueNumber, currentPriority }: Props) 
     setSetting(next);
     setError(null);
     try {
-      await setPriorityAction(repoId, issueNumber, next);
-      setPriority(next);
-      setOpen(false);
+      const result = await setPriorityAction(repoId, issueNumber, next);
+      if (result.success) {
+        setPriority(next);
+        setOpen(false);
+      } else {
+        setError(result.error ?? "Failed to update priority");
+      }
     } catch {
       setError("Failed to update priority");
     } finally {

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -67,7 +67,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           <Button variant="ghost" onClick={handleClose} disabled={saving}>
             cancel
           </Button>
-          <Button variant="primary" onClick={handleSave} disabled={saving}>
+          <Button variant="primary" onClick={handleSave} disabled={saving || title.trim().length === 0}>
             {saving ? "saving…" : "save draft"}
           </Button>
         </div>

--- a/packages/web/lib/actions/priority.ts
+++ b/packages/web/lib/actions/priority.ts
@@ -9,22 +9,23 @@ export async function setPriorityAction(
   repoId: number,
   issueNumber: number,
   priority: Priority,
-): Promise<void> {
+): Promise<{ success: boolean; error?: string }> {
   if (typeof repoId !== "number" || !Number.isInteger(repoId) || repoId <= 0) {
-    throw new Error("repoId must be a positive integer");
+    return { success: false, error: "repoId must be a positive integer" };
   }
   if (
     typeof issueNumber !== "number" ||
     !Number.isInteger(issueNumber) ||
     issueNumber <= 0
   ) {
-    throw new Error("issueNumber must be a positive integer");
+    return { success: false, error: "issueNumber must be a positive integer" };
   }
   if (!(VALID_PRIORITIES as readonly string[]).includes(priority)) {
-    throw new Error(`Invalid priority: ${String(priority)}`);
+    return { success: false, error: "Invalid priority value" };
   }
 
   const db = getDb();
   setPriority(db, repoId, issueNumber, priority);
   revalidatePath("/");
+  return { success: true };
 }

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getOctokit } from "@issuectl/core";
+import { getDb, getOctokit, getRepo } from "@issuectl/core";
 
 export async function mergePullAction(
   owner: string,
@@ -16,6 +16,12 @@ export async function mergePullAction(
   }
   if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
     return { success: false, error: "Invalid pull request number" };
+  }
+
+  const db = getDb();
+  const tracked = getRepo(db, owner, repo);
+  if (!tracked) {
+    return { success: false, error: "Repository is not tracked" };
   }
 
   try {

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -5,6 +5,7 @@ import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import {
   getDb,
+  getOctokit,
   addRepo as coreAddRepo,
   removeRepo as coreRemoveRepo,
   updateRepo as coreUpdateRepo,
@@ -24,6 +25,13 @@ export async function addRepo(
   }
   if (!/^[a-zA-Z0-9._-]+$/.test(owner) || !/^[a-zA-Z0-9._-]+$/.test(name)) {
     return { success: false, error: "Invalid owner/repo format" };
+  }
+
+  try {
+    const octokit = await getOctokit();
+    await octokit.rest.repos.get({ owner, repo: name });
+  } catch {
+    return { success: false, error: `Repository ${owner}/${name} not found on GitHub (or not accessible with your token)` };
   }
 
   try {

--- a/packages/web/lib/actions/settings.ts
+++ b/packages/web/lib/actions/settings.ts
@@ -54,10 +54,16 @@ function validateOne(
   if (trimmed === "" && !ALLOW_EMPTY.has(key)) {
     return { ok: false, error: "Value cannot be empty" };
   }
+  if (trimmed.length > 500) {
+    return { ok: false, error: "Value is too long (max 500 characters)" };
+  }
   if (key === "cache_ttl") {
     const num = Number(trimmed);
     if (!Number.isFinite(num) || num < 0) {
       return { ok: false, error: "Cache TTL must be a non-negative number" };
+    }
+    if (num > 604800) {
+      return { ok: false, error: "Cache TTL cannot exceed 604800 seconds (7 days)" };
     }
   }
   if (key === "claude_extra_args") {

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,11 +1,24 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
   transpilePackages: ["@issuectl/core"],
   images: {
     remotePatterns: [
       { hostname: "avatars.githubusercontent.com" },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary

Ran three QA audits (UX auditor, performance profiler, adversarial breaker) against the web dashboard and fixed all actionable findings.

**Accessibility (MAJOR → fixed):**
- Darkened `ink-muted`, `ink-faint`, `brick` color tokens to pass WCAG AA 4.5:1 contrast ratio
- Added global `:focus-visible` ring (2px solid accent, 2px offset) for all interactive elements
- Fixed heading hierarchy: `h4`→`h2` in LaunchCard, `div`→`h2` for section labels in PrDetail/CommentList
- Replaced raw `<img>` with `next/image` for comment avatars

**Security (HIGH/MEDIUM → fixed):**
- Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy` headers
- Disabled `X-Powered-By` header
- `addRepo` now validates repo exists on GitHub before inserting into SQLite (prevents phantom repo errors)
- `mergePullAction` now checks repo is tracked before merging
- `setPriorityAction` returns error objects instead of throwing (prevents raw input in error boundary)
- Settings validation now enforces max 500 char length and cache TTL cap of 7 days

**UX (MINOR → fixed):**
- Per-page `<title>` tags (Settings, Quick Create, issue/PR detail)
- Back navigation breadcrumb on Settings and Quick Create pages
- Removed non-functional "..." menu from detail top bars
- Unified date formatting to shared `timeAgo()` across all detail views
- Save-draft button disabled when title is empty
- Loading skeleton animations aligned (speed and opacity) across pages

**Performance profiler notes (informational, not fixed here):**
- JS bundle sizes reported as >2MB are dev-mode inflation; production build shows 102KB shared JS
- TTFB concerns (359ms–1,173ms) traced to `force-dynamic` + sequential GitHub API calls — optimization deferred

## Test plan
- [ ] Verify color contrast passes WCAG AA (use browser devtools contrast checker)
- [ ] Tab through all pages with keyboard — focus ring should be visible on every interactive element
- [ ] Navigate to issue/PR detail — heading hierarchy should be H1 → H2 (no skips)
- [ ] Add a non-existent repo in Settings — should get "not found" error
- [ ] Check page titles update in browser tab on each route
- [ ] Settings/Quick Create pages should show "← dashboard" breadcrumb
- [ ] Response headers should include X-Frame-Options, X-Content-Type-Options
- [ ] `pnpm turbo build` passes clean