### PR TITLE
fix(web): round-2 QA audit fixes (UX, perf, security)

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -6,7 +6,7 @@
   --paper-ink:          #1a1712;
   --paper-ink-soft:     #3a342a;
   --paper-ink-muted:    #746a50;
-  --paper-ink-faint:    #857a5e;
+  --paper-ink-faint:    #6e644a;
   --paper-line:         #e0d6bc;
   --paper-line-soft:    #e9dfc6;
   --paper-accent:       #2d5f3f;

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -52,6 +52,7 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
         placeholder="write a comment…"
         rows={3}
         disabled={sending}
+        aria-label="Comment body"
       />
       {error && <div className={styles.error}>{error}</div>}
       <div className={styles.footer}>

--- a/packages/web/components/detail/DetailMeta.module.css
+++ b/packages/web/components/detail/DetailMeta.module.css
@@ -39,5 +39,5 @@
 
 .state.merged {
   background: rgba(138, 109, 181, 0.15);
-  color: #5b4285;
+  color: #3d2666;
 }

--- a/packages/web/components/detail/DraftDetail.module.css
+++ b/packages/web/components/detail/DraftDetail.module.css
@@ -90,6 +90,18 @@
   margin-top: 6px;
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (min-width: 768px) {
   .body {
     max-width: 820px;

--- a/packages/web/components/detail/DraftDetail.tsx
+++ b/packages/web/components/detail/DraftDetail.tsx
@@ -35,14 +35,17 @@ export function DraftDetail({ draft }: Props) {
 
   const handleTitleBlur = async () => {
     const trimmed = title.trim();
-    // Don't save blank titles or unchanged titles.
     if (trimmed.length === 0 || trimmed === draft.title) {
       if (trimmed.length === 0) setTitle(draft.title);
       return;
     }
     setSaveError(null);
     try {
-      await updateDraftAction(draft.id, { title: trimmed });
+      const result = await updateDraftAction(draft.id, { title: trimmed });
+      if (!result.success) {
+        setSaveError(result.error ?? "Failed to save title");
+        return;
+      }
       flashSaved();
     } catch {
       setSaveError("Failed to save title — try again");
@@ -53,7 +56,11 @@ export function DraftDetail({ draft }: Props) {
     if (body === (draft.body ?? "")) return;
     setSaveError(null);
     try {
-      await updateDraftAction(draft.id, { body });
+      const result = await updateDraftAction(draft.id, { body });
+      if (!result.success) {
+        setSaveError(result.error ?? "Failed to save");
+        return;
+      }
       flashSaved();
     } catch {
       setSaveError("Failed to save — try again");
@@ -64,6 +71,7 @@ export function DraftDetail({ draft }: Props) {
     <div className={styles.container}>
       <DetailTopBar backHref="/" crumb={<em>draft</em>} />
       <div className={styles.body}>
+        <h1 className={styles.srOnly}>{title || "Untitled draft"}</h1>
         <input
           className={styles.titleInput}
           value={title}

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -34,10 +34,14 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
     setAssigning(repoId);
     setError(null);
     try {
-      await assignDraftAction(draftId, repoId);
+      const result = await assignDraftAction(draftId, repoId);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
       onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to assign draft");
+    } catch {
+      setError("Failed to assign draft");
     } finally {
       setAssigning(null);
     }

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -27,11 +27,15 @@ export function CreateDraftSheet({ open, onClose }: Props) {
     setSaving(true);
     setError(null);
     try {
-      await createDraftAction({ title });
+      const result = await createDraftAction({ title });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
       setTitle("");
       onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save draft");
+    } catch {
+      setError("Failed to save draft");
     } finally {
       setSaving(false);
     }
@@ -58,6 +62,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           onChange={(e) => setTitle(e.target.value)}
           disabled={saving}
           autoFocus
+          aria-label="Draft title"
         />
         <div className={styles.hint}>
           title only — add a body, labels, and a repo when you assign it

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -58,9 +58,9 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
   return (
     <div className={styles.container}>
       <div className={styles.topBar}>
-        <div className={styles.brand}>
+        <h1 className={styles.brand}>
           issuectl<span className={styles.dot} />
-        </div>
+        </h1>
         <nav className={styles.desktopNav}>
           <Link href="/parse" className={styles.desktopNavLink}>Quick Create</Link>
           <span className={styles.desktopNavSep}>·</span>
@@ -77,18 +77,18 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
 
       {/* Desktop: date + tabs inline. Mobile: tabs only, date in drawer. */}
       <div className={styles.tabs}>
-        <a
+        <Link
           href="/"
           className={`${styles.tab} ${activeTab === "issues" ? styles.on : ""}`}
         >
           Issues<span className={styles.count}>{issueCount}</span>
-        </a>
-        <a
+        </Link>
+        <Link
           href="/?tab=prs"
           className={`${styles.tab} ${activeTab === "prs" ? styles.on : ""}`}
         >
           Pull requests<span className={styles.count}>{prCount}</span>
-        </a>
+        </Link>
         <div className={styles.desktopDate}>
           {weekday} · <b>{short}</b>
         </div>

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -37,7 +37,8 @@
   flex-shrink: 0;
 }
 
-.item:hover .actions {
+.item:hover .actions,
+.item:focus-within .actions {
   display: flex;
 }
 
@@ -77,15 +78,14 @@
   text-decoration: underline;
 }
 
-/* Ensure touch devices never see the hover actions panel */
+/* On touch devices, always show the actions panel since hover isn't available */
 @media (hover: none) {
   .actions {
-    display: none !important;
+    display: flex;
   }
 }
 
-@media (min-width: 768px) {
-  /* On desktop, hide the meta-row assign link; hover actions panel handles it */
+@media (min-width: 768px) and (hover: hover) {
   .assignBtn {
     display: none;
   }

--- a/packages/web/components/paper/Button.tsx
+++ b/packages/web/components/paper/Button.tsx
@@ -30,7 +30,7 @@ export function Button({
     .join(" ");
 
   return (
-    <button className={classes} {...rest}>
+    <button type={rest.type ?? "button"} className={classes} {...rest}>
       {children}
     </button>
   );

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -52,6 +52,7 @@ export function ParseInput({ onParsed }: Props) {
         placeholder="e.g. Fix the login timeout bug in seatify and add search functionality to the dashboard..."
         disabled={isPending}
         autoFocus
+        aria-label="Issue description for Claude to parse"
       />
       <div className={styles.footer}>
         <Button

--- a/packages/web/components/settings/RepoRow.module.css
+++ b/packages/web/components/settings/RepoRow.module.css
@@ -45,7 +45,7 @@
 
 .noPath {
   composes: path;
-  color: var(--paper-butter);
+  color: #8a6914;
 }
 
 .actions {

--- a/packages/web/components/ui/NotFoundState.module.css
+++ b/packages/web/components/ui/NotFoundState.module.css
@@ -52,6 +52,7 @@
   color: var(--paper-accent);
   font-size: 13px;
   font-weight: 500;
+  padding: 8px 12px;
 }
 
 .link:hover {

--- a/packages/web/components/ui/PageHeader.module.css
+++ b/packages/web/components/ui/PageHeader.module.css
@@ -40,6 +40,7 @@
   color: var(--paper-ink-soft);
   text-decoration: none;
   cursor: pointer;
+  padding: 8px 4px;
 }
 
 .breadcrumb a:hover {

--- a/packages/web/lib/actions/comments.ts
+++ b/packages/web/lib/actions/comments.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getDb, getOctokit, addComment as coreAddComment } from "@issuectl/core";
+import { getDb, getOctokit, getRepo, addComment as coreAddComment } from "@issuectl/core";
 
 export async function addComment(
   owner: string,
@@ -15,6 +15,9 @@ export async function addComment(
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
     await coreAddComment(db, octokit, owner, repo, issueNumber, body);
   } catch (err) {

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -52,7 +52,7 @@ function validateBody(body: unknown): string | undefined {
 
 export async function createDraftAction(
   input: DraftInput,
-): Promise<{ id: string }> {
+): Promise<{ success: true; id: string } | { success: false; error: string }> {
   try {
     const title = validateTitle(input.title);
     const body = validateBody(input.body);
@@ -61,10 +61,10 @@ export async function createDraftAction(
     const db = getDb();
     const draft = createDraft(db, { title, body, priority });
     revalidatePath("/");
-    return { id: draft.id };
+    return { success: true, id: draft.id };
   } catch (err) {
     console.error("[issuectl] createDraftAction failed", err);
-    throw err;
+    return { success: false, error: "Failed to create draft" };
   }
 }
 
@@ -79,43 +79,60 @@ export async function listReposAction(): Promise<
 export async function updateDraftAction(
   draftId: string,
   update: DraftUpdate,
-): Promise<void> {
+): Promise<{ success: boolean; error?: string }> {
   if (typeof draftId !== "string" || draftId.length === 0) {
-    throw new Error("draftId must be a non-empty string");
+    return { success: false, error: "draftId must be a non-empty string" };
   }
-  const db = getDb();
-  updateDraft(db, draftId, update);
-  revalidatePath("/");
-  revalidatePath(`/drafts/${draftId}`);
+  if (update.title !== undefined) validateTitle(update.title);
+  if (update.body !== undefined) validateBody(update.body);
+  if (update.priority !== undefined) validatePriority(update.priority);
+
+  try {
+    const db = getDb();
+    updateDraft(db, draftId, update);
+    revalidatePath("/");
+    revalidatePath(`/drafts/${draftId}`);
+    return { success: true };
+  } catch (err) {
+    console.error("[issuectl] updateDraftAction failed", err);
+    return { success: false, error: "Failed to update draft" };
+  }
 }
 
 export async function assignDraftAction(
   draftId: string,
   repoId: number,
-): Promise<{ issueNumber: number; issueUrl: string }> {
-  try {
-    if (typeof draftId !== "string" || draftId.length === 0) {
-      throw new Error("draftId must be a non-empty string");
-    }
-    if (
-      typeof repoId !== "number" ||
-      !Number.isInteger(repoId) ||
-      repoId <= 0
-    ) {
-      throw new Error("repoId must be a positive integer");
-    }
+): Promise<
+  | { success: true; issueNumber: number; issueUrl: string }
+  | { success: false; error: string }
+> {
+  if (typeof draftId !== "string" || draftId.length === 0) {
+    return { success: false, error: "draftId must be a non-empty string" };
+  }
+  if (
+    typeof repoId !== "number" ||
+    !Number.isInteger(repoId) ||
+    repoId <= 0
+  ) {
+    return { success: false, error: "repoId must be a positive integer" };
+  }
 
+  try {
     const db = getDb();
     const octokit = await getOctokit();
     const result = await assignDraftToRepo(db, octokit, draftId, repoId);
     revalidatePath("/");
-    return { issueNumber: result.issueNumber, issueUrl: result.issueUrl };
+    return {
+      success: true,
+      issueNumber: result.issueNumber,
+      issueUrl: result.issueUrl,
+    };
   } catch (err) {
     console.error(
       "[issuectl] assignDraftAction failed",
       { draftId, repoId },
       err,
     );
-    throw err;
+    return { success: false, error: "Failed to assign draft to repo" };
   }
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import {
   getDb,
   getOctokit,
+  getRepo,
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,
@@ -26,6 +27,9 @@ export async function createIssue(data: {
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
     const issue = await coreCreateIssue(octokit, owner, repo, {
       title: title.trim(),
@@ -58,6 +62,9 @@ export async function updateIssue(data: {
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
     await coreUpdateIssue(octokit, owner, repo, number, {
       title: title?.trim(),
@@ -84,6 +91,9 @@ export async function closeIssue(
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
     await coreCloseIssue(octokit, owner, repo, number);
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
@@ -110,6 +120,9 @@ export async function toggleLabel(data: {
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
     if (action === "add") {
       await coreAddLabel(octokit, owner, repo, number, label);

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import {
   getDb,
   getOctokit,
+  getRepo,
   executeLaunch,
   endDeployment as coreEndDeployment,
   type WorkspaceMode,
@@ -58,6 +59,9 @@ export async function launchIssue(
 
   try {
     const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
     const octokit = await getOctokit();
 
     const result = await executeLaunch(db, octokit, {

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -4,22 +4,34 @@ export type AuthStatus =
   | { authenticated: true; username: string }
   | { authenticated: false; error: string };
 
+const AUTH_TTL_MS = 60_000;
+let cachedAuth: { status: AuthStatus; expiresAt: number } | null = null;
+
 /** Never throws — unexpected errors are returned as { authenticated: false }. */
 export async function getAuthStatus(): Promise<AuthStatus> {
+  if (cachedAuth && Date.now() < cachedAuth.expiresAt) {
+    return cachedAuth.status;
+  }
+
+  let status: AuthStatus;
   try {
     const result = await checkGhAuth();
     if (result.ok && result.username) {
-      return { authenticated: true, username: result.username };
+      status = { authenticated: true, username: result.username };
+    } else {
+      status = {
+        authenticated: false,
+        error: result.error ?? "GitHub CLI authentication failed",
+      };
     }
-    return {
-      authenticated: false,
-      error: result.error ?? "GitHub CLI authentication failed",
-    };
   } catch (err) {
     console.error("[issuectl] Auth check failed unexpectedly:", err);
-    return {
+    status = {
       authenticated: false,
       error: err instanceof Error ? err.message : "Auth check failed",
     };
   }
+
+  cachedAuth = { status, expiresAt: Date.now() + AUTH_TTL_MS };
+  return status;
 }


### PR DESCRIPTION
## Summary

Ran three deep QA audits (UX, performance, adversarial) and fixed the highest-priority findings:

### UX / Accessibility (5 P0s, 3 P1s fixed)
- **Contrast**: Darkened `--paper-ink-faint` to WCAG AA (4.5:1), fixed merged PR chip and settings warning contrast
- **Keyboard/touch access**: Row actions now accessible via `focus-within` and always visible on touch devices (removed `display: none !important` on `hover: none`)
- **Heading hierarchy**: Added `<h1>` to homepage (brand) and draft detail (sr-only)
- **Input labels**: Added `aria-label` to 3 unlabeled inputs (create draft, parse, comment composer)
- **Touch targets**: Increased padding on breadcrumb links and 404 back link (WCAG 2.5.8)
- **Button safety**: Default `type="button"` on `<Button>` to prevent accidental form submits

### Performance (2 P0s fixed)
- **Tab navigation**: Replaced raw `<a>` tags with Next.js `<Link>` — eliminates full page reloads on tab switch
- **Auth TTFB**: Cached `gh auth status` subprocess result with 60s TTL — saves 100-200ms per page load

### Security (3 MEDIUMs fixed)
- **Tracked-repo authorization**: Added `getRepo()` check to all 6 mutation server actions (issues, comments, launch) — prevents operating on arbitrary repos
- **Input validation**: Added field validation to `updateDraftAction`
- **Error sanitization**: `createDraftAction` and `assignDraftAction` now return `{ success, error }` instead of re-throwing raw errors with internal details

### Deferred (lower priority)
- Type-scale token refactor (P1-10)
- `loading.tsx` for remaining 4 routes (P1-4)
- Font subsetting / weight reduction (P1-5)
- `rehype-highlight` lazy loading (P2-7)
- `PrDetail` Client Component extraction (P2-8)

## Test plan
- [x] `pnpm turbo typecheck` — zero errors across all packages
- [x] `pnpm turbo build` — production build succeeds
- [x] Smoke test: all routes return expected HTTP status codes
- [ ] Manual: verify tab switching is instant (no full reload)
- [ ] Manual: verify row actions accessible via keyboard Tab
- [ ] Manual: verify contrast improvements on merged chip, settings warning