### PR TITLE
perf(web): loading skeletons + Suspense streaming for settings

### DIFF
--- a/packages/web/app/drafts/[draftId]/loading.module.css
+++ b/packages/web/app/drafts/[draftId]/loading.module.css
@@ -9,7 +9,8 @@
 }
 
 .header {
-  padding: 24px 32px 0;
+  padding: 52px 16px 12px;
+  border-bottom: 1px solid var(--paper-line);
 }
 
 .breadcrumb {
@@ -17,7 +18,6 @@
   height: 14px;
   background: var(--paper-bg-warm);
   border-radius: 4px;
-  margin-bottom: 16px;
   animation: pulse 1.5s ease-in-out infinite;
 }
 
@@ -77,6 +77,12 @@
 }
 
 @media (min-width: 768px) {
+  .header {
+    padding: 36px 40px 20px;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+
   .body {
     max-width: 820px;
     margin: 0 auto;

--- a/packages/web/app/drafts/[draftId]/loading.module.css
+++ b/packages/web/app/drafts/[draftId]/loading.module.css
@@ -1,0 +1,89 @@
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.container {
+  min-height: 100vh;
+  background: var(--paper-bg);
+}
+
+.header {
+  padding: 24px 32px 0;
+}
+
+.breadcrumb {
+  width: 100px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.body {
+  padding: 22px 24px 60px;
+}
+
+.title {
+  width: 50%;
+  height: 28px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 14px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.metaChip {
+  width: 60px;
+  height: 20px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-sm);
+  animation: pulse 1.5s ease-in-out infinite 0.1s;
+}
+
+.metaText {
+  width: 70px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  align-self: center;
+  animation: pulse 1.5s ease-in-out infinite 0.2s;
+}
+
+.hint {
+  width: 100%;
+  height: 44px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 28px;
+  animation: pulse 1.5s ease-in-out infinite 0.3s;
+}
+
+.textarea {
+  width: 100%;
+  height: 160px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  animation: pulse 1.5s ease-in-out infinite 0.4s;
+}
+
+@media (min-width: 768px) {
+  .body {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 32px 40px 40px;
+  }
+
+  .title {
+    height: 36px;
+  }
+}

--- a/packages/web/app/drafts/[draftId]/loading.tsx
+++ b/packages/web/app/drafts/[draftId]/loading.tsx
@@ -1,0 +1,21 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.breadcrumb} />
+      </div>
+      <div className={styles.body}>
+        <div className={styles.title} />
+        <div className={styles.meta}>
+          <div className={styles.metaChip} />
+          <div className={styles.metaText} />
+          <div className={styles.metaText} />
+        </div>
+        <div className={styles.hint} />
+        <div className={styles.textarea} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
@@ -1,0 +1,90 @@
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.container {
+  min-height: 100vh;
+  background: var(--paper-bg);
+}
+
+.header {
+  padding: 24px 32px 0;
+}
+
+.breadcrumb {
+  width: 120px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.body {
+  padding: 22px 24px 60px;
+}
+
+.title {
+  width: 70%;
+  height: 28px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 14px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.metaChip {
+  width: 60px;
+  height: 20px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-sm);
+  animation: pulse 1.5s ease-in-out infinite 0.1s;
+}
+
+.metaText {
+  width: 80px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  align-self: center;
+  animation: pulse 1.5s ease-in-out infinite 0.2s;
+}
+
+.bodyBlock {
+  width: 100%;
+  height: 120px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 24px;
+  animation: pulse 1.5s ease-in-out infinite 0.3s;
+}
+
+.commentBlock {
+  width: 100%;
+  height: 60px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 12px;
+  animation: pulse 1.5s ease-in-out infinite 0.4s;
+}
+
+@media (min-width: 768px) {
+  .body {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 32px 40px 40px;
+  }
+
+  .title {
+    height: 36px;
+  }
+}

--- a/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,8 @@
 }
 
 .header {
-  padding: 24px 32px 0;
+  padding: 52px 16px 12px;
+  border-bottom: 1px solid var(--paper-line);
 }
 
 .breadcrumb {
@@ -17,7 +18,6 @@
   height: 14px;
   background: var(--paper-bg-warm);
   border-radius: 4px;
-  margin-bottom: 16px;
   animation: pulse 1.5s ease-in-out infinite;
 }
 
@@ -78,6 +78,12 @@
 }
 
 @media (min-width: 768px) {
+  .header {
+    padding: 36px 40px 20px;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+
   .body {
     max-width: 820px;
     margin: 0 auto;

--- a/packages/web/app/issues/[owner]/[repo]/[number]/loading.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/loading.tsx
@@ -1,0 +1,22 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.breadcrumb} />
+      </div>
+      <div className={styles.body}>
+        <div className={styles.title} />
+        <div className={styles.meta}>
+          <div className={styles.metaChip} />
+          <div className={styles.metaText} />
+          <div className={styles.metaText} />
+        </div>
+        <div className={styles.bodyBlock} />
+        <div className={styles.commentBlock} />
+        <div className={styles.commentBlock} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/parse/loading.module.css
+++ b/packages/web/app/parse/loading.module.css
@@ -1,0 +1,58 @@
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.headerSkeleton {
+  padding: 24px 32px 0;
+  margin-bottom: 16px;
+}
+
+.breadcrumb {
+  width: 120px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.titleBar {
+  width: 160px;
+  height: 28px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.content {
+  padding: 20px 32px 32px;
+  max-width: 800px;
+}
+
+.description {
+  width: 100%;
+  height: 40px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite 0.1s;
+}
+
+.textarea {
+  width: 100%;
+  height: 140px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite 0.2s;
+}
+
+.button {
+  width: 160px;
+  height: 40px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  animation: pulse 1.5s ease-in-out infinite 0.3s;
+}

--- a/packages/web/app/parse/loading.tsx
+++ b/packages/web/app/parse/loading.tsx
@@ -1,0 +1,17 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <>
+      <div className={styles.headerSkeleton}>
+        <div className={styles.breadcrumb} />
+        <div className={styles.titleBar} />
+      </div>
+      <div className={styles.content}>
+        <div className={styles.description} />
+        <div className={styles.textarea} />
+        <div className={styles.button} />
+      </div>
+    </>
+  );
+}

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
@@ -1,0 +1,99 @@
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.container {
+  min-height: 100vh;
+  background: var(--paper-bg);
+}
+
+.header {
+  padding: 24px 32px 0;
+}
+
+.breadcrumb {
+  width: 120px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  margin-bottom: 16px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.body {
+  padding: 22px 24px 60px;
+}
+
+.title {
+  width: 65%;
+  height: 28px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 14px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.meta {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.metaChip {
+  width: 60px;
+  height: 20px;
+  background: var(--paper-bg-warm);
+  border-radius: var(--paper-radius-sm);
+  animation: pulse 1.5s ease-in-out infinite 0.1s;
+}
+
+.metaText {
+  width: 80px;
+  height: 14px;
+  background: var(--paper-bg-warm);
+  border-radius: 4px;
+  align-self: center;
+  animation: pulse 1.5s ease-in-out infinite 0.2s;
+}
+
+.bodyBlock {
+  width: 100%;
+  height: 100px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 24px;
+  animation: pulse 1.5s ease-in-out infinite 0.3s;
+}
+
+.checksBlock {
+  width: 100%;
+  height: 48px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  margin-bottom: 12px;
+  animation: pulse 1.5s ease-in-out infinite 0.4s;
+}
+
+.filesBlock {
+  width: 100%;
+  height: 160px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  animation: pulse 1.5s ease-in-out infinite 0.5s;
+}
+
+@media (min-width: 768px) {
+  .body {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 32px 40px 40px;
+  }
+
+  .title {
+    height: 36px;
+  }
+}

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,8 @@
 }
 
 .header {
-  padding: 24px 32px 0;
+  padding: 52px 16px 12px;
+  border-bottom: 1px solid var(--paper-line);
 }
 
 .breadcrumb {
@@ -17,7 +18,6 @@
   height: 14px;
   background: var(--paper-bg-warm);
   border-radius: 4px;
-  margin-bottom: 16px;
   animation: pulse 1.5s ease-in-out infinite;
 }
 
@@ -87,6 +87,12 @@
 }
 
 @media (min-width: 768px) {
+  .header {
+    padding: 36px 40px 20px;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+
   .body {
     max-width: 820px;
     margin: 0 auto;

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/loading.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/loading.tsx
@@ -1,0 +1,22 @@
+import styles from "./loading.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.breadcrumb} />
+      </div>
+      <div className={styles.body}>
+        <div className={styles.title} />
+        <div className={styles.meta}>
+          <div className={styles.metaChip} />
+          <div className={styles.metaText} />
+          <div className={styles.metaText} />
+        </div>
+        <div className={styles.bodyBlock} />
+        <div className={styles.checksBlock} />
+        <div className={styles.filesBlock} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/settings/AuthSection.tsx
+++ b/packages/web/app/settings/AuthSection.tsx
@@ -1,0 +1,9 @@
+import { AuthStatus } from "@/components/settings/AuthStatus";
+import { getAuthStatus } from "@/lib/auth";
+
+export async function AuthSection() {
+  const authResult = await getAuthStatus();
+  const username = authResult.authenticated ? authResult.username : null;
+
+  return <AuthStatus username={username} />;
+}

--- a/packages/web/app/settings/AuthSection.tsx
+++ b/packages/web/app/settings/AuthSection.tsx
@@ -3,7 +3,9 @@ import { getAuthStatus } from "@/lib/auth";
 
 export async function AuthSection() {
   const authResult = await getAuthStatus();
-  const username = authResult.authenticated ? authResult.username : null;
 
-  return <AuthStatus username={username} />;
+  if (authResult.authenticated) {
+    return <AuthStatus username={authResult.username} />;
+  }
+  return <AuthStatus username={null} error={authResult.error} />;
 }

--- a/packages/web/app/settings/WorktreeSection.tsx
+++ b/packages/web/app/settings/WorktreeSection.tsx
@@ -1,0 +1,11 @@
+import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
+import { listWorktrees } from "@/lib/actions/worktrees";
+
+export async function WorktreeSection() {
+  const worktrees = await listWorktrees().catch((err) => {
+    console.error("[issuectl] Failed to list worktrees:", err);
+    return [] as Awaited<ReturnType<typeof listWorktrees>>;
+  });
+
+  return <WorktreeCleanup worktrees={worktrees} />;
+}

--- a/packages/web/app/settings/WorktreeSection.tsx
+++ b/packages/web/app/settings/WorktreeSection.tsx
@@ -1,11 +1,19 @@
 import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
 import { listWorktrees } from "@/lib/actions/worktrees";
+import type { WorktreeInfo } from "@/lib/actions/worktrees";
 
 export async function WorktreeSection() {
-  const worktrees = await listWorktrees().catch((err) => {
+  let worktrees: WorktreeInfo[];
+  try {
+    worktrees = await listWorktrees();
+  } catch (err) {
     console.error("[issuectl] Failed to list worktrees:", err);
-    return [] as Awaited<ReturnType<typeof listWorktrees>>;
-  });
+    return (
+      <div role="alert" style={{ color: "var(--paper-brick)", fontSize: 13 }}>
+        Failed to load worktrees. Check that the database is accessible.
+      </div>
+    );
+  }
 
   return <WorktreeCleanup worktrees={worktrees} />;
 }

--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -16,3 +16,16 @@
   align-items: center;
   justify-content: space-between;
 }
+
+.sectionSkeleton {
+  height: 40px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import {
   getDb,
@@ -8,15 +9,17 @@ import {
 import { PageHeader } from "@/components/ui/PageHeader";
 import { TrackedRepos } from "@/components/settings/TrackedRepos";
 import { SettingsForm } from "@/components/settings/SettingsForm";
-import { AuthStatus } from "@/components/settings/AuthStatus";
-import { WorktreeCleanup } from "@/components/settings/WorktreeCleanup";
-import { listWorktrees } from "@/lib/actions/worktrees";
-import { getAuthStatus } from "@/lib/auth";
+import { WorktreeSection } from "./WorktreeSection";
+import { AuthSection } from "./AuthSection";
 import type { Metadata } from "next";
 import styles from "./page.module.css";
 
 export const metadata: Metadata = { title: "Settings — issuectl" };
 export const dynamic = "force-dynamic";
+
+function SectionSkeleton() {
+  return <div className={styles.sectionSkeleton} />;
+}
 
 export default async function SettingsPage() {
   if (!dbExists()) {
@@ -35,7 +38,6 @@ export default async function SettingsPage() {
   const db = getDb();
   const repos = listRepos(db);
   const settings = getSettings(db);
-  // Fallback defaults match DEFAULT_SETTINGS in core/db/settings.ts
   const settingMap = Object.fromEntries(settings.map((s) => [s.key, s.value]));
   const branchPattern = settingMap.branch_pattern ?? "issue-{number}-{slug}";
   const cacheTTL = settingMap.cache_ttl ?? "300";
@@ -43,15 +45,6 @@ export default async function SettingsPage() {
   const windowTitle = settingMap.terminal_window_title ?? "issuectl";
   const tabTitlePattern = settingMap.terminal_tab_title_pattern ?? "#{number} — {title}";
   const claudeExtraArgs = settingMap.claude_extra_args ?? "";
-
-  const [authResult, worktrees] = await Promise.all([
-    getAuthStatus(),
-    listWorktrees().catch((err) => {
-      console.error("[issuectl] Failed to list worktrees:", err);
-      return [] as Awaited<ReturnType<typeof listWorktrees>>;
-    }),
-  ]);
-  const username = authResult.authenticated ? authResult.username : null;
 
   return (
     <>
@@ -73,12 +66,16 @@ export default async function SettingsPage() {
 
         <section className={styles.section}>
           <div className={styles.sectionTitle}>Worktrees</div>
-          <WorktreeCleanup worktrees={worktrees} />
+          <Suspense fallback={<SectionSkeleton />}>
+            <WorktreeSection />
+          </Suspense>
         </section>
 
         <section className={styles.section}>
           <div className={styles.sectionTitle}>Authentication</div>
-          <AuthStatus username={username} />
+          <Suspense fallback={<SectionSkeleton />}>
+            <AuthSection />
+          </Suspense>
         </section>
       </div>
     </>

--- a/packages/web/components/settings/AuthStatus.tsx
+++ b/packages/web/components/settings/AuthStatus.tsx
@@ -2,15 +2,17 @@ import styles from "./AuthStatus.module.css";
 
 type Props = {
   username: string | null;
+  error?: string;
 };
 
-export function AuthStatus({ username }: Props) {
+export function AuthStatus({ username, error }: Props) {
   if (!username) {
     return (
       <div className={styles.card}>
         <span className={styles.dotError} />
         <span className={styles.text}>
-          Not authenticated — run <code className={styles.code}>gh auth login</code>
+          {error ?? "Not authenticated — run"}{" "}
+          {!error && <code className={styles.code}>gh auth login</code>}
         </span>
       </div>
     );


### PR DESCRIPTION
## Summary

- **Loading skeletons** for 4 routes that were missing them: issue detail, PR detail, draft detail, and parse. Users now see instant Paper-styled skeleton UI instead of a blank screen during SSR.
- **Settings Suspense split**: repos + settings form (local DB reads) render instantly; worktree staleness checks and auth status stream in asynchronously via `<Suspense>`. Eliminates the ~911ms blocking TTFB from N GitHub API calls for worktree staleness.

### Routes with new loading states
| Route | Before | After |
|-------|--------|-------|
| `/issues/[owner]/[repo]/[number]` | Blank screen during SSR | Skeleton with breadcrumb, title, meta, body, comment blocks |
| `/pulls/[owner]/[repo]/[number]` | Blank screen during SSR | Skeleton with breadcrumb, title, meta, body, checks, files blocks |
| `/drafts/[draftId]` | Blank screen during SSR | Skeleton with breadcrumb, title, meta, hint, textarea |
| `/parse` | Blank screen during SSR | Skeleton with breadcrumb, title, description, textarea, button |

### Settings streaming
| Section | Render strategy |
|---------|----------------|
| Tracked Repositories | Instant (local DB) |
| Settings Form | Instant (local DB) |
| Worktrees | Suspense → streams after GitHub API calls complete |
| Authentication | Suspense → streams after auth check (usually cached) |

## Test plan
- [x] `pnpm turbo typecheck` — zero errors
- [x] `pnpm turbo build` — production build succeeds, bundle sizes stable
- [x] All routes return expected HTTP status codes
- [x] Settings page HTML contains Suspense fallback skeleton
- [ ] Manual: navigate to issue/PR/draft detail — verify skeleton appears briefly
- [ ] Manual: settings page renders repos + form instantly, worktrees streams in