### PR TITLE
fix(web): stop masking transient errors as 404 on detail pages

### DIFF
--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -63,10 +63,12 @@ export default async function IssueDetailPage({
       />
     );
   } catch (err) {
-    const status = (err as { status?: number }).status;
+    const status = err !== null && err !== undefined && typeof err === "object" && "status" in err
+      ? (err as { status: number }).status
+      : undefined;
     if (status === 404 || status === 410) {
       notFound();
     }
-    throw err;
+    throw err instanceof Error ? new Error(err.message) : new Error(String(err));
   }
 }

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -63,10 +63,10 @@ export default async function IssueDetailPage({
       />
     );
   } catch (err) {
-    console.error(
-      `[issuectl] IssueDetailPage: failed to fetch ${owner}/${repo}#${issueNumber}`,
-      err,
-    );
-    notFound();
+    const status = (err as { status?: number }).status;
+    if (status === 404 || status === 410) {
+      notFound();
+    }
+    throw err;
   }
 }

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -69,6 +69,10 @@ export default async function IssueDetailPage({
     if (status === 404 || status === 410) {
       notFound();
     }
+    console.error(
+      `[issuectl] IssueDetailPage: unexpected error fetching ${owner}/${repo}#${issueNumber}`,
+      err,
+    );
     throw err instanceof Error ? new Error(err.message) : new Error(String(err));
   }
 }

--- a/packages/web/app/parse/page.tsx
+++ b/packages/web/app/parse/page.tsx
@@ -37,6 +37,7 @@ export default async function ParsePage() {
   let repos: RepoOption[] = [];
   const labelsPerRepo: Record<string, GitHubLabel[]> = {};
   let claudeAvailable = false;
+  let initError: string | undefined;
 
   try {
     const octokit = await getOctokit();
@@ -66,6 +67,7 @@ export default async function ParsePage() {
     claudeAvailable = claudeCheck;
   } catch (err) {
     console.error("[issuectl] Failed to load repos/labels:", err);
+    initError = err instanceof Error ? err.message : "Failed to connect to GitHub";
   }
 
   return (
@@ -76,6 +78,7 @@ export default async function ParsePage() {
           repos={repos}
           labelsPerRepo={labelsPerRepo}
           claudeAvailable={claudeAvailable}
+          initError={initError}
         />
       </div>
     </>

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -47,10 +47,10 @@ export default async function PullDetailPage({
       />
     );
   } catch (err) {
-    console.error(
-      `[issuectl] PullDetailPage: failed to fetch ${owner}/${repo}#${pullNumber}`,
-      err,
-    );
-    notFound();
+    const status = (err as { status?: number }).status;
+    if (status === 404 || status === 410) {
+      notFound();
+    }
+    throw err;
   }
 }

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -47,10 +47,12 @@ export default async function PullDetailPage({
       />
     );
   } catch (err) {
-    const status = (err as { status?: number }).status;
+    const status = err !== null && err !== undefined && typeof err === "object" && "status" in err
+      ? (err as { status: number }).status
+      : undefined;
     if (status === 404 || status === 410) {
       notFound();
     }
-    throw err;
+    throw err instanceof Error ? new Error(err.message) : new Error(String(err));
   }
 }

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -53,6 +53,10 @@ export default async function PullDetailPage({
     if (status === 404 || status === 410) {
       notFound();
     }
+    console.error(
+      `[issuectl] PullDetailPage: unexpected error fetching ${owner}/${repo}#${pullNumber}`,
+      err,
+    );
     throw err instanceof Error ? new Error(err.message) : new Error(String(err));
   }
 }

--- a/packages/web/components/parse/ParseFlow.tsx
+++ b/packages/web/components/parse/ParseFlow.tsx
@@ -14,12 +14,21 @@ type Props = {
   repos: RepoOption[];
   labelsPerRepo: Record<string, GitHubLabel[]>;
   claudeAvailable: boolean;
+  initError?: string;
 };
 
-export function ParseFlow({ repos, labelsPerRepo, claudeAvailable }: Props) {
+export function ParseFlow({ repos, labelsPerRepo, claudeAvailable, initError }: Props) {
   const [step, setStep] = useState<Step>("input");
   const [parsedData, setParsedData] = useState<ParsedIssuesResponse | null>(null);
   const [results, setResults] = useState<BatchCreateResult | null>(null);
+
+  if (initError) {
+    return (
+      <div className={styles.unavailable} role="alert">
+        {initError}
+      </div>
+    );
+  }
 
   if (!claudeAvailable) {
     return (

--- a/packages/web/components/parse/ParseFlow.tsx
+++ b/packages/web/components/parse/ParseFlow.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { GitHubLabel, ParsedIssuesResponse, BatchCreateResult } from "@issuectl/core";
 import type { RepoOption } from "@/lib/types";
+import { getErrorHint } from "@/lib/getErrorHint";
 import { ParseInput } from "./ParseInput";
 import { ParseReview } from "./ParseReview";
 import { ParseResults } from "./ParseResults";
@@ -23,9 +24,10 @@ export function ParseFlow({ repos, labelsPerRepo, claudeAvailable, initError }: 
   const [results, setResults] = useState<BatchCreateResult | null>(null);
 
   if (initError) {
+    const hint = getErrorHint(initError);
     return (
       <div className={styles.unavailable} role="alert">
-        {initError}
+        {hint ?? initError}
       </div>
     );
   }

--- a/packages/web/lib/getErrorHint.ts
+++ b/packages/web/lib/getErrorHint.ts
@@ -1,7 +1,10 @@
 export function getErrorHint(message: string): string | null {
   const lower = message.toLowerCase();
-  if (lower.includes("rate limit") || lower.includes("403")) {
+  if (lower.includes("rate limit")) {
     return "This may be a GitHub rate limit — wait a moment and try again.";
+  }
+  if (lower.includes("403")) {
+    return "GitHub denied access (403) — this could be a rate limit, or you may lack permission for this resource.";
   }
   if (lower.includes("401") || lower.includes("auth") || lower.includes("token")) {
     return "Your GitHub token may have expired — re-run `gh auth login` in your terminal.";

--- a/packages/web/lib/getErrorHint.ts
+++ b/packages/web/lib/getErrorHint.ts
@@ -1,10 +1,16 @@
 export function getErrorHint(message: string): string | null {
   const lower = message.toLowerCase();
-  if (lower.includes("rate limit")) {
+  if (lower.includes("rate limit") || lower.includes("403")) {
     return "This may be a GitHub rate limit — wait a moment and try again.";
   }
   if (lower.includes("401") || lower.includes("auth") || lower.includes("token")) {
     return "Your GitHub token may have expired — re-run `gh auth login` in your terminal.";
+  }
+  if (lower.includes("econnrefused") || lower.includes("enotfound") || lower.includes("fetch failed")) {
+    return "Could not reach GitHub — check your internet connection.";
+  }
+  if (lower.includes("timeout") || lower.includes("timedout")) {
+    return "The request to GitHub timed out — try again in a moment.";
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- **Issue/PR detail pages** were catching ALL errors and calling `notFound()`, showing a 404 page for rate limits, auth failures, network timeouts, and other transient errors. Now only actual 404/410 HTTP responses trigger `notFound()`; everything else propagates to the root error boundary (`error.tsx`) which shows the real error message with actionable hints.
- **Parse page** was silently swallowing auth/API errors into an empty form with "No repositories connected." Now captures and displays the actual error message inline.
- **`getErrorHint`** expanded with hints for 403 (rate limit), network errors (`ECONNREFUSED`, `ENOTFOUND`, `fetch failed`), and timeouts.

### Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| GitHub rate limit on issue page | 404 "Not found" | "Something went wrong" + "wait a moment and try again" |
| Auth token expired on PR page | 404 "Not found" | "Something went wrong" + "re-run `gh auth login`" |
| Network offline on issue page | 404 "Not found" | "Something went wrong" + "check your internet connection" |
| Actual missing issue | 404 "Not found" | 404 "Not found" (unchanged) |
| Auth failure on parse page | Empty form, "No repos" | Error message displayed inline |

## Test plan
- [x] `pnpm turbo typecheck` — zero errors
- [x] `pnpm turbo build` — production build succeeds
- [x] All routes return expected HTTP status codes
- [ ] Manual: visit `/issues/owner/repo/99999` — should still show 404
- [ ] Manual: with expired token, visit issue detail — should show error with auth hint