### PR TITLE
fix(resilience): R6 error classifier + R10/R11/R13 easy wins

### DIFF
--- a/packages/core/src/github/errors.test.ts
+++ b/packages/core/src/github/errors.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { classifyGitHubError, formatErrorForUser } from "./errors.js";
+
+function apiError(
+  status: number,
+  message: string,
+  headers: Record<string, string | number | undefined> = {},
+): Error & { status: number; response: { headers: typeof headers } } {
+  const err = new Error(message) as Error & {
+    status: number;
+    response: { headers: typeof headers };
+  };
+  err.status = status;
+  err.response = { headers };
+  return err;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("classifyGitHubError", () => {
+  it("classifies 401 as auth_expired", () => {
+    const result = classifyGitHubError(apiError(401, "Bad credentials"));
+    expect(result.kind).toBe("auth_expired");
+    expect(result.status).toBe(401);
+    expect(result.message).toContain("gh auth refresh");
+  });
+
+  it("classifies 429 as rate_limited with retry-after header", () => {
+    const result = classifyGitHubError(
+      apiError(429, "Too Many Requests", { "retry-after": "42" }),
+    );
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAfterSec).toBe(42);
+    expect(result.message).toContain("42s");
+  });
+
+  it("classifies 429 without retry-after as rate_limited without countdown", () => {
+    const result = classifyGitHubError(apiError(429, "Too Many Requests"));
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAfterSec).toBeUndefined();
+    expect(result.message).toContain("wait");
+  });
+
+  it("classifies 403 with x-ratelimit-remaining:0 as rate_limited", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-12T00:00:00Z"));
+    const resetEpoch = Math.floor(Date.now() / 1000) + 60;
+    const result = classifyGitHubError(
+      apiError(403, "API rate limit exceeded", {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": String(resetEpoch),
+      }),
+    );
+    expect(result.kind).toBe("rate_limited");
+    expect(result.retryAfterSec).toBe(60);
+  });
+
+  it("classifies 403 without rate-limit headers as forbidden", () => {
+    const result = classifyGitHubError(
+      apiError(403, "Resource not accessible by integration"),
+    );
+    expect(result.kind).toBe("forbidden");
+    expect(result.message).toContain("Resource not accessible");
+  });
+
+  it("classifies 404 as not_found", () => {
+    const result = classifyGitHubError(apiError(404, "Not Found"));
+    expect(result.kind).toBe("not_found");
+    expect(result.message).toMatch(/not found/i);
+  });
+
+  it("classifies 422 as validation with the original message", () => {
+    const result = classifyGitHubError(
+      apiError(422, "Validation Failed: title is too long"),
+    );
+    expect(result.kind).toBe("validation");
+    expect(result.message).toContain("title is too long");
+  });
+
+  it("classifies 500+ as unknown server error", () => {
+    const result = classifyGitHubError(apiError(503, "Service Unavailable"));
+    expect(result.kind).toBe("unknown");
+    expect(result.message).toContain("503");
+  });
+
+  it("classifies Node network errors (ECONNREFUSED) as network", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    const result = classifyGitHubError(err);
+    expect(result.kind).toBe("network");
+    expect(result.message).toContain("Network error");
+  });
+
+  it("classifies ENOTFOUND as network", () => {
+    const err = Object.assign(new Error("dns failure"), { code: "ENOTFOUND" });
+    expect(classifyGitHubError(err).kind).toBe("network");
+  });
+
+  it("classifies AbortError as timeout", () => {
+    const err = new Error("operation aborted");
+    err.name = "AbortError";
+    const result = classifyGitHubError(err);
+    expect(result.kind).toBe("timeout");
+    expect(result.message).toContain("timed out");
+  });
+
+  it("classifies plain Error as unknown with message", () => {
+    const result = classifyGitHubError(new Error("something weird happened"));
+    expect(result.kind).toBe("unknown");
+    expect(result.message).toBe("something weird happened");
+  });
+
+  it("classifies non-Error values as unknown with a fallback message", () => {
+    expect(classifyGitHubError("a string").kind).toBe("unknown");
+    expect(classifyGitHubError(null).kind).toBe("unknown");
+    expect(classifyGitHubError(undefined).kind).toBe("unknown");
+  });
+
+  it("preserves the original error as cause", () => {
+    const err = apiError(401, "Bad credentials");
+    const result = classifyGitHubError(err);
+    expect(result.cause).toBe(err);
+  });
+});
+
+describe("formatErrorForUser", () => {
+  it("returns the classified message", () => {
+    expect(formatErrorForUser(apiError(401, "Bad credentials"))).toContain(
+      "gh auth refresh",
+    );
+    expect(formatErrorForUser(new Error("boom"))).toBe("boom");
+  });
+});

--- a/packages/core/src/github/errors.ts
+++ b/packages/core/src/github/errors.ts
@@ -1,0 +1,205 @@
+/**
+ * Classify errors thrown by Octokit (or our own network/subprocess layer) into
+ * a small, stable set of user-actionable kinds. Action handlers route caught
+ * errors through `classifyGitHubError` and surface `.message` to the UI.
+ *
+ * Kinds are deliberately coarse — we only need enough resolution to give the
+ * user a recovery hint (refresh auth, wait for rate limit, retry, etc.).
+ */
+export type GitHubErrorKind =
+  | "rate_limited"
+  | "auth_expired"
+  | "forbidden"
+  | "not_found"
+  | "validation"
+  | "network"
+  | "timeout"
+  | "unknown";
+
+export type ClassifiedError = {
+  kind: GitHubErrorKind;
+  /** User-facing, actionable message. Safe to surface verbatim to the UI. */
+  message: string;
+  /** HTTP status if the error came from an API response. */
+  status?: number;
+  /** Seconds to wait before retrying. Only set for rate_limited. */
+  retryAfterSec?: number;
+  cause: unknown;
+};
+
+type MaybeResponseLike = {
+  status?: number;
+  message?: string;
+  response?: { headers?: Record<string, string | number | undefined> };
+};
+
+function hasStatus(err: unknown): err is MaybeResponseLike {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    ("status" in err || "response" in err)
+  );
+}
+
+function getHeader(
+  err: MaybeResponseLike,
+  name: string,
+): string | undefined {
+  const headers = err.response?.headers;
+  if (!headers) return undefined;
+  const raw = headers[name] ?? headers[name.toLowerCase()];
+  return raw === undefined ? undefined : String(raw);
+}
+
+function parseRetryAfter(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseRateLimitReset(
+  value: string | undefined,
+): number | undefined {
+  if (!value) return undefined;
+  const reset = Number(value);
+  if (!Number.isFinite(reset)) return undefined;
+  const delta = reset - Math.floor(Date.now() / 1000);
+  return delta > 0 ? delta : 0;
+}
+
+export function classifyGitHubError(err: unknown): ClassifiedError {
+  if (hasStatus(err)) {
+    const status = err.status;
+    const origMessage = err.message ?? "";
+
+    if (status === 401) {
+      return {
+        kind: "auth_expired",
+        message:
+          "GitHub authentication expired. Run `gh auth refresh` and try again.",
+        status,
+        cause: err,
+      };
+    }
+
+    if (status === 429) {
+      const retryAfterSec = parseRetryAfter(getHeader(err, "retry-after"));
+      return {
+        kind: "rate_limited",
+        message:
+          retryAfterSec !== undefined
+            ? `GitHub rate limit reached. Retry in ${retryAfterSec}s.`
+            : "GitHub rate limit reached. Please wait and retry.",
+        status,
+        retryAfterSec,
+        cause: err,
+      };
+    }
+
+    if (status === 403) {
+      const remaining = getHeader(err, "x-ratelimit-remaining");
+      if (remaining === "0") {
+        const retryAfterSec = parseRateLimitReset(
+          getHeader(err, "x-ratelimit-reset"),
+        );
+        return {
+          kind: "rate_limited",
+          message:
+            retryAfterSec !== undefined
+              ? `GitHub rate limit reached. Retry in ${retryAfterSec}s.`
+              : "GitHub rate limit reached. Please wait and retry.",
+          status,
+          retryAfterSec,
+          cause: err,
+        };
+      }
+      return {
+        kind: "forbidden",
+        message: origMessage
+          ? `GitHub denied the request: ${origMessage}`
+          : "GitHub denied the request. Check your permissions on this repository.",
+        status,
+        cause: err,
+      };
+    }
+
+    if (status === 404) {
+      return {
+        kind: "not_found",
+        message: "Not found on GitHub. The resource may have been deleted or renamed.",
+        status,
+        cause: err,
+      };
+    }
+
+    if (status === 422) {
+      return {
+        kind: "validation",
+        message: origMessage
+          ? `GitHub rejected the request: ${origMessage}`
+          : "GitHub rejected the request as invalid.",
+        status,
+        cause: err,
+      };
+    }
+
+    if (typeof status === "number" && status >= 500) {
+      return {
+        kind: "unknown",
+        message: `GitHub server error (${status}). Try again shortly.`,
+        status,
+        cause: err,
+      };
+    }
+  }
+
+  // Node network-layer errors (Octokit re-throws these as-is on connection
+  // failures, and our own subprocess code uses the same `code` convention).
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    if (
+      code === "ECONNREFUSED" ||
+      code === "ETIMEDOUT" ||
+      code === "ENOTFOUND" ||
+      code === "EAI_AGAIN" ||
+      code === "ECONNRESET"
+    ) {
+      return {
+        kind: "network",
+        message:
+          "Network error contacting GitHub. Check your connection and try again.",
+        cause: err,
+      };
+    }
+  }
+
+  // AbortController / AbortSignal timeouts surface as AbortError.
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    (err as { name?: unknown }).name === "AbortError"
+  ) {
+    return {
+      kind: "timeout",
+      message: "The request timed out. Try again.",
+      cause: err,
+    };
+  }
+
+  const message =
+    err instanceof Error && err.message ? err.message : "Unexpected error.";
+  return { kind: "unknown", message, cause: err };
+}
+
+/**
+ * Shorthand: classify and return the user-facing message.
+ * Intended for use in server action catch blocks:
+ *
+ *   catch (err) {
+ *     return { success: false, error: formatErrorForUser(err) };
+ *   }
+ */
+export function formatErrorForUser(err: unknown): string {
+  return classifyGitHubError(err).message;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,12 @@ export type {
 export { getGhToken, checkGhAuth } from "./github/auth.js";
 export { getOctokit, resetOctokit } from "./github/client.js";
 export {
+  classifyGitHubError,
+  formatErrorForUser,
+  type ClassifiedError,
+  type GitHubErrorKind,
+} from "./github/errors.js";
+export {
   createIssue,
   updateIssue,
   closeIssue,

--- a/packages/core/src/parse/claude-cli.ts
+++ b/packages/core/src/parse/claude-cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { writeFile, unlink } from "node:fs/promises";
+import { writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ParsedIssuesResponse } from "./types.js";
@@ -50,6 +50,23 @@ export async function parseIssues(
     };
   }
 
+  // Guarantee the temp prompt file is removed regardless of how the child
+  // process exits — timeout kill, error event, close event, or the caller
+  // being cancelled. `rm` with force:true swallows ENOENT so a duplicate
+  // cleanup is harmless.
+  try {
+    return await runClaudeCli(promptFilePath, contextPrompt, userInput, timeoutMs);
+  } finally {
+    await rm(promptFilePath, { force: true }).catch(() => {});
+  }
+}
+
+function runClaudeCli(
+  promptFilePath: string,
+  contextPrompt: string,
+  userInput: string,
+  timeoutMs: number,
+): Promise<ParseResult> {
   const fullPrompt = `${contextPrompt}\n\n---\n\n## User Input\n\n${userInput}`;
 
   const args = [
@@ -83,7 +100,6 @@ export async function parseIssues(
     const finish = (result: ParseResult) => {
       if (settled) return;
       settled = true;
-      unlink(promptFilePath).catch(() => {});
       resolve(result);
     };
 

--- a/packages/web/app/drafts/[draftId]/page.tsx
+++ b/packages/web/app/drafts/[draftId]/page.tsx
@@ -8,12 +8,21 @@ type Params = {
   draftId: string;
 };
 
+// Draft IDs come from randomUUID() (see packages/core/src/db/drafts.ts).
+// Reject anything that doesn't match before touching the DB so malformed
+// path segments (null bytes, path-traversal attempts, arbitrary strings)
+// short-circuit to 404 without a query round-trip.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export default async function DraftDetailPage({
   params,
 }: {
   params: Promise<Params>;
 }) {
   const { draftId } = await params;
+  if (!UUID_RE.test(draftId)) {
+    notFound();
+  }
   const db = getDb();
   const draft = getDraft(db, draftId);
   if (!draft) {

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -64,6 +64,7 @@ export function AddRepoForm({ onClose }: Props) {
             value={ownerRepo}
             onChange={(e) => setOwnerRepo(e.target.value)}
             placeholder="owner/repo (e.g., mean-weasel/seatify)"
+            disabled={isPending}
             autoFocus
           />
         </div>
@@ -74,6 +75,7 @@ export function AddRepoForm({ onClose }: Props) {
             value={localPath}
             onChange={(e) => setLocalPath(e.target.value)}
             placeholder="~/Desktop/seatify"
+            disabled={isPending}
           />
           <div className={styles.pathHint}>Leave blank to prompt on launch</div>
         </div>


### PR DESCRIPTION
Phase 1+2 of the resilience-audit triage queue. See `qa-reports/resilience-audit.md` (local-only; not committed) for the full audit — 13 findings, all prioritized \`fix now\`. This PR is the foundation layer (R6) plus three small, independent fixes that don't touch the error-handling refactor coming in Phase 3.

## Summary

- **R6 (Medium, foundation)** — `classifyGitHubError()` in `packages/core/src/github/errors.ts`. Maps Octokit/network errors to a stable set of kinds (\`auth_expired\`, \`rate_limited\`, \`forbidden\`, \`not_found\`, \`validation\`, \`network\`, \`timeout\`, \`unknown\`) with user-actionable messages. Parses \`retry-after\` and \`x-ratelimit-reset\` headers, distinguishes 403-rate-limit from 403-forbidden, handles Node \`ECONNREFUSED\`/\`ENOTFOUND\`/\`ETIMEDOUT\` and \`AbortError\`. 15-test spec. Exported from \`@issuectl/core\` for use by server actions in subsequent phases.

- **R10 (Medium)** — parse temp file leak on timeout. Restructured \`claude-cli.ts\` so the prompt file is cleaned up in an outer try/finally around the child-process Promise. Previously the cleanup hung off the \`finish()\` callback inside the Promise body; on unusual exit paths the callback could be dropped. Also switched \`unlink\` → \`rm({force:true})\` so a duplicate cleanup is harmless.

- **R11 (Low)** — \`AddRepoForm\` was the only form in the app whose text inputs stayed editable during \`isPending\`. Added \`disabled={isPending}\` to both. Brings the form in line with every other form component (\`LaunchModal\`, \`CommentForm\`, \`CreateIssueModal\`, \`EditIssueForm\`, \`CloseIssueButton\`).

- **R13 (Low)** — \`/drafts/[draftId]\` now rejects non-UUID segments at the route layer before touching the DB. Draft IDs come from \`randomUUID()\` in core, so anything else is a bad path (null bytes, path traversal, user-typed garbage) and should short-circuit to 404. The previous fall-through via \`getDraft\` → \`notFound()\` worked but was defensive-in-depth rather than defensive-up-front.

## Why not more in one PR

The remaining 9 findings (R1–R5, R7, R8, R9, R12) all converge on the server action catch blocks and will land in Phase 3 as a single error-handling pass. Batching R6 alongside them would put this PR in the path of a larger refactor; keeping it separate means R6 can merge fast and unblock the Phase 3 work.

Phase 3 (coming next): \`withAuthRetry\`, subprocess timeouts, typed partial-commit errors, length caps, worktree cleanup surfacing, label retry, and the \`revalidateSafely\` helper. Phase 4: R2 deployment pending-state. Phase 5: R1 idempotency sentinel.

## Test plan

- [x] \`pnpm turbo typecheck\` — 4/4 pass
- [x] \`pnpm turbo test\` — 262 core tests pass (including 15 new \`errors.test.ts\` tests); 17 web tests pass
- [x] \`pnpm turbo build\` — all 3 packages build
- [ ] Manual spot-check in browser: visit \`/drafts/nonsense-string\` → 404, submit \`AddRepoForm\` and confirm inputs disable, trigger a parse and confirm temp files in \`/tmp/issuectl-parse-prompt-*\` are cleaned up on success