### PR TITLE
fix(resilience): Phase 3 — error handling, retries, timeouts, limits

### DIFF
--- a/packages/core/src/db/drafts.ts
+++ b/packages/core/src/db/drafts.ts
@@ -114,6 +114,37 @@ export type AssignDraftResult = {
   issueUrl: string;
 };
 
+/**
+ * Thrown when `assignDraftToRepo` successfully creates the GitHub issue but
+ * the follow-up local DB commit (priority carryover + draft delete) fails.
+ * The issue is already on GitHub, so the error carries enough context for
+ * the UI to tell the user where their work ended up and let them recover.
+ *
+ * Callers (server actions) should catch this explicitly and surface both
+ * the human message AND the `issueNumber` / `issueUrl` to the UI — a plain
+ * catch that returns `{success: false, error: "Failed to …"}` loses the
+ * information the user needs to find their issue.
+ */
+export class DraftPartialCommitError extends Error {
+  readonly issueNumber: number;
+  readonly issueUrl: string;
+  readonly repoId: number;
+
+  constructor(
+    result: AssignDraftResult,
+    cause: unknown,
+  ) {
+    super(
+      `Issue #${result.issueNumber} was created on GitHub but the local draft cleanup failed. See ${result.issueUrl} — the draft can be deleted manually.`,
+      { cause },
+    );
+    this.name = "DraftPartialCommitError";
+    this.issueNumber = result.issueNumber;
+    this.issueUrl = result.issueUrl;
+    this.repoId = result.repoId;
+  }
+}
+
 export async function assignDraftToRepo(
   db: Database.Database,
   octokit: Octokit,
@@ -140,22 +171,28 @@ export async function assignDraftToRepo(
     body: draft.body,
   });
 
-  const issueNumber = response.data.number;
-  const issueUrl = response.data.html_url;
+  const result: AssignDraftResult = {
+    repoId,
+    issueNumber: response.data.number,
+    issueUrl: response.data.html_url,
+  };
 
   // Run the two local writes (priority carryover + draft delete) in a
   // single DB transaction after the network call succeeds. If either
   // throws, both roll back and the draft stays intact locally — but the
-  // GitHub issue already exists. The caller should surface the error so
-  // the user can manually reconcile (the issueNumber is recoverable from
-  // the exception context if needed).
-  const localCommit = db.transaction(() => {
-    if (draft.priority !== "normal") {
-      setPriority(db, repoId, issueNumber, draft.priority);
-    }
-    deleteDraft(db, draftId);
-  });
-  localCommit();
+  // GitHub issue already exists. Wrap the failure in a typed error that
+  // carries the issue number/url so the UI can point the user at it.
+  try {
+    const localCommit = db.transaction(() => {
+      if (draft.priority !== "normal") {
+        setPriority(db, repoId, result.issueNumber, draft.priority);
+      }
+      deleteDraft(db, draftId);
+    });
+    localCommit();
+  } catch (err) {
+    throw new DraftPartialCommitError(result, err);
+  }
 
-  return { repoId, issueNumber, issueUrl };
+  return result;
 }

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const getGhTokenMock = vi.hoisted(() => vi.fn());
+vi.mock("./auth.js", () => ({
+  getGhToken: getGhTokenMock,
+  checkGhAuth: vi.fn(),
+}));
+
+import { withAuthRetry, resetOctokit, getOctokit } from "./client.js";
+
+beforeEach(() => {
+  resetOctokit();
+  getGhTokenMock.mockReset();
+  getGhTokenMock.mockResolvedValue("test-token-1");
+});
+
+afterEach(() => {
+  resetOctokit();
+});
+
+function authError() {
+  const err = new Error("Bad credentials") as Error & { status: number };
+  err.status = 401;
+  return err;
+}
+
+function notFoundError() {
+  const err = new Error("Not Found") as Error & { status: number };
+  err.status = 404;
+  return err;
+}
+
+describe("withAuthRetry", () => {
+  it("returns the value on first-try success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withAuthRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(getGhTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the cached Octokit and retries on 401", async () => {
+    getGhTokenMock
+      .mockResolvedValueOnce("test-token-1")
+      .mockResolvedValueOnce("test-token-2");
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(authError())
+      .mockResolvedValueOnce("recovered");
+
+    const result = await withAuthRetry(fn);
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(getGhTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a second 401 after retry", async () => {
+    getGhTokenMock
+      .mockResolvedValueOnce("test-token-1")
+      .mockResolvedValueOnce("test-token-2");
+    const fn = vi.fn().mockRejectedValue(authError());
+
+    await expect(withAuthRetry(fn)).rejects.toMatchObject({ status: 401 });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on non-auth errors", async () => {
+    const fn = vi.fn().mockRejectedValue(notFoundError());
+
+    await expect(withAuthRetry(fn)).rejects.toMatchObject({ status: 404 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(getGhTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on plain Error without status", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(withAuthRetry(fn)).rejects.toThrow("boom");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getOctokit caching", () => {
+  it("caches the Octokit instance across calls", async () => {
+    const a = await getOctokit();
+    const b = await getOctokit();
+    expect(a).toBe(b);
+    expect(getGhTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads the token after resetOctokit", async () => {
+    getGhTokenMock
+      .mockResolvedValueOnce("test-token-1")
+      .mockResolvedValueOnce("test-token-2");
+
+    const first = await getOctokit();
+    resetOctokit();
+    const second = await getOctokit();
+    expect(first).not.toBe(second);
+    expect(getGhTokenMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -13,3 +13,40 @@ export async function getOctokit(): Promise<Octokit> {
 export function resetOctokit(): void {
   instance = null;
 }
+
+/**
+ * Run a GitHub API call with automatic recovery from a stale cached token.
+ * If the underlying call throws a 401, discard the cached Octokit, re-read
+ * the token via `gh auth token`, and retry once. Any second failure (401 or
+ * otherwise) propagates to the caller.
+ *
+ * The Octokit singleton lives for the lifetime of the Next.js process — it
+ * is never re-instantiated on its own. If the user runs `gh auth refresh`
+ * or the token rotates, the cached instance silently breaks until the
+ * process restarts. This helper fixes that without forcing every action to
+ * manage the reset lifecycle.
+ */
+export async function withAuthRetry<T>(
+  fn: (octokit: Octokit) => Promise<T>,
+): Promise<T> {
+  const octokit = await getOctokit();
+  try {
+    return await fn(octokit);
+  } catch (err) {
+    if (isAuthError(err)) {
+      resetOctokit();
+      const fresh = await getOctokit();
+      return await fn(fresh);
+    }
+    throw err;
+  }
+}
+
+function isAuthError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    (err as { status?: number }).status === 401
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   updateDraft,
   deleteDraft,
   assignDraftToRepo,
+  DraftPartialCommitError,
   type DraftUpdate,
   type AssignDraftResult,
 } from "./db/drafts.js";
@@ -75,7 +76,7 @@ export type {
   GitHubPullFile,
 } from "./github/types.js";
 export { getGhToken, checkGhAuth } from "./github/auth.js";
-export { getOctokit, resetOctokit } from "./github/client.js";
+export { getOctokit, resetOctokit, withAuthRetry } from "./github/client.js";
 export {
   classifyGitHubError,
   formatErrorForUser,

--- a/packages/core/src/launch/exec-timeout.ts
+++ b/packages/core/src/launch/exec-timeout.ts
@@ -1,0 +1,66 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type TimedExecOptions = {
+  cwd?: string;
+  /** Timeout in milliseconds. Required — no unbounded subprocess calls. */
+  timeoutMs: number;
+  /**
+   * Short human-readable name for the step being run (e.g. "git fetch",
+   * "ghostty open"). Included in the thrown error so the user sees *what*
+   * timed out, not just a generic timeout.
+   */
+  step: string;
+};
+
+/**
+ * Thrown when a subprocess exceeds its timeout budget. Carries the step name
+ * so the classifier (and error messages) can pinpoint which git/ghostty call
+ * hung instead of saying "Launch failed."
+ */
+export class SubprocessTimeoutError extends Error {
+  readonly code = "ETIMEDOUT" as const;
+  readonly step: string;
+  readonly timeoutMs: number;
+  constructor(step: string, timeoutMs: number, cause?: unknown) {
+    super(`${step} timed out after ${timeoutMs / 1000}s`);
+    this.name = "SubprocessTimeoutError";
+    this.step = step;
+    this.timeoutMs = timeoutMs;
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
+ * Wrapper around `execFile` with a mandatory timeout. Node's native `timeout`
+ * option sends SIGTERM and rejects with `killed: true`; we normalise that to
+ * a `SubprocessTimeoutError` so callers can distinguish a timed-out `git
+ * fetch` from a `git fetch` that legitimately failed with non-zero exit.
+ */
+export async function timedExec(
+  file: string,
+  args: readonly string[],
+  options: TimedExecOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    const result = await execFileAsync(file, args as string[], {
+      cwd: options.cwd,
+      timeout: options.timeoutMs,
+    });
+    return result;
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "killed" in err &&
+      (err as { killed?: boolean }).killed === true
+    ) {
+      throw new SubprocessTimeoutError(options.step, options.timeoutMs, err);
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -30,6 +30,14 @@ export interface LaunchResult {
   branchName: string;
   workspacePath: string;
   contextFilePath: string;
+  /**
+   * Set when the `issuectl:deployed` label could not be applied after the
+   * retry budget was exhausted. Launch continues in that case — the workspace
+   * and deployment row are valid — but the lifecycle reconciler won't pick
+   * up this issue until the label is added by some other path. Surface this
+   * to the UI so the user knows the state has drifted.
+   */
+  labelWarning?: string;
 }
 
 function expandHome(p: string): string {
@@ -130,19 +138,27 @@ export async function executeLaunch(
 
   // Steps 7-9 have side effects — if one fails, earlier artifacts remain.
   // Workspace cleanup is not attempted since the branch/files may be valuable.
+  let labelWarning: string | undefined;
   try {
-    // 7. Apply issuectl:deployed label
+    // 7. Apply issuectl:deployed label. Retry up to 3 times because label
+    // failures are usually transient (rate limit, network blip) and a
+    // dropped label leaves the reconciler unable to advance this issue.
     await ensureLifecycleLabels(octokit, options.owner, options.repo);
-    await addLabel(
-      octokit,
-      options.owner,
-      options.repo,
-      options.issueNumber,
-      LIFECYCLE_LABEL.deployed,
+    await retryLabel(() =>
+      addLabel(
+        octokit,
+        options.owner,
+        options.repo,
+        options.issueNumber,
+        LIFECYCLE_LABEL.deployed,
+      ),
     );
   } catch (err) {
-    // Label failure is non-fatal — the workspace is ready, proceed anyway
-    console.warn("[issuectl] Failed to apply deployed label:", err);
+    // Final failure is non-fatal — the workspace is ready, proceed anyway
+    // but record a warning so the caller can tell the user.
+    const msg = err instanceof Error ? err.message : String(err);
+    labelWarning = `Could not apply the \`${LIFECYCLE_LABEL.deployed}\` label after 3 attempts (${msg}). Launch continued, but lifecycle status may not update automatically — you may need to add the label manually.`;
+    console.warn("[issuectl] Failed to apply deployed label after retries:", err);
   }
 
   // 8. Record deployment in DB
@@ -178,7 +194,24 @@ export async function executeLaunch(
     branchName: options.branchName,
     workspacePath: workspace.path,
     contextFilePath,
+    ...(labelWarning ? { labelWarning } : {}),
   };
+}
+
+async function retryLabel<T>(fn: () => Promise<T>): Promise<T> {
+  const delaysMs = [500, 1_000, 2_000];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < delaysMs.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < delaysMs.length - 1) {
+        await new Promise((r) => setTimeout(r, delaysMs[attempt]));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 const DANGEROUS_METACHARS = /[;&|<>`$\n\r\t()]/;

--- a/packages/core/src/launch/terminals/ghostty.ts
+++ b/packages/core/src/launch/terminals/ghostty.ts
@@ -1,8 +1,12 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { TerminalLauncher, TerminalLaunchOptions, TerminalSettings } from "../terminal.js";
+import { timedExec } from "../exec-timeout.js";
 
-const execFileAsync = promisify(execFile);
+// Timeout budgets for the handful of synchronous Ghostty-probing calls.
+// `open -na Ghostty.app` returns quickly once the application receives the
+// event — 10s is generous. `which` and `--version` are similarly fast.
+const WHICH_TIMEOUT_MS = 5_000;
+const VERSION_TIMEOUT_MS = 5_000;
+const OPEN_TIMEOUT_MS = 10_000;
 
 export type GhosttyVersion = { readonly major: number; readonly minor: number; readonly patch: number };
 
@@ -55,7 +59,10 @@ const GHOSTTY_APP_BINARY = "/Applications/Ghostty.app/Contents/MacOS/ghostty";
 
 export async function resolveGhosttyBinary(): Promise<string> {
   try {
-    await execFileAsync("which", ["ghostty"]);
+    await timedExec("which", ["ghostty"], {
+      timeoutMs: WHICH_TIMEOUT_MS,
+      step: "which ghostty",
+    });
     return "ghostty";
   } catch (err: unknown) {
     // "which" exits 1 when not found — only fall through for that case
@@ -64,7 +71,10 @@ export async function resolveGhosttyBinary(): Promise<string> {
   }
 
   try {
-    await execFileAsync(GHOSTTY_APP_BINARY, ["--version"]);
+    await timedExec(GHOSTTY_APP_BINARY, ["--version"], {
+      timeoutMs: VERSION_TIMEOUT_MS,
+      step: "ghostty --version",
+    });
     return GHOSTTY_APP_BINARY;
   } catch (err: unknown) {
     const code = (err as { code?: string }).code;
@@ -86,7 +96,10 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
       }
 
       const binary = await resolveGhosttyBinary();
-      const { stdout } = await execFileAsync(binary, ["--version"]);
+      const { stdout } = await timedExec(binary, ["--version"], {
+        timeoutMs: VERSION_TIMEOUT_MS,
+        step: "ghostty --version",
+      });
 
       const version = parseGhosttyVersion(stdout);
       if (!meetsMinVersion(version)) {
@@ -101,7 +114,10 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
       const shellCommand = buildShellCommand(options.workspacePath, options.contextFilePath, options.claudeCommand);
       const args = buildGhosttyArgs(tabTitle, shellCommand);
       try {
-        await execFileAsync("open", args);
+        await timedExec("open", args, {
+          timeoutMs: OPEN_TIMEOUT_MS,
+          step: "open -na Ghostty.app",
+        });
       } catch (err) {
         throw new Error(
           `Failed to launch Ghostty terminal. Ensure Ghostty.app is installed and accessible. ` +
@@ -112,3 +128,4 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
     },
   };
 }
+

--- a/packages/core/src/launch/workspace.ts
+++ b/packages/core/src/launch/workspace.ts
@@ -1,5 +1,3 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { mkdir, rm, access } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -7,8 +5,7 @@ import {
   isWorkingTreeClean,
   getDefaultBranch,
 } from "./branch.js";
-
-const execFileAsync = promisify(execFile);
+import { timedExec } from "./exec-timeout.js";
 
 export type WorkspaceMode = "existing" | "worktree" | "clone";
 
@@ -17,6 +14,18 @@ export interface WorkspaceResult {
   mode: WorkspaceMode;
   created: boolean;
 }
+
+// Timeout budgets (milliseconds). None of these are unbounded — a hung network
+// operation should fail loudly after a reasonable wait, not pin the Server
+// Action indefinitely. Values are tuned for "slow but plausible" — shallow
+// clones of medium repos, git fetches over a bad wifi, etc. If a repo is so
+// large that these are unrealistic, the right answer is to adjust them in one
+// place rather than dropping timeouts entirely.
+const GIT_FETCH_TIMEOUT_MS = 30_000;
+const GIT_CLONE_TIMEOUT_MS = 120_000;
+const GIT_WORKTREE_TIMEOUT_MS = 15_000;
+const GIT_BRANCH_OP_TIMEOUT_MS = 10_000;
+const GIT_REV_PARSE_TIMEOUT_MS = 5_000;
 
 async function pathExists(p: string): Promise<boolean> {
   try {
@@ -29,7 +38,11 @@ async function pathExists(p: string): Promise<boolean> {
 
 async function isGitRepo(p: string): Promise<boolean> {
   try {
-    await execFileAsync("git", ["rev-parse", "--git-dir"], { cwd: p });
+    await timedExec("git", ["rev-parse", "--git-dir"], {
+      cwd: p,
+      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+      step: "git rev-parse",
+    });
     return true;
   } catch {
     return false;
@@ -66,11 +79,18 @@ async function prepareExisting(
     );
   }
 
-  await execFileAsync("git", ["fetch", "origin"], { cwd: repoPath }).catch(
-    (err) => {
-      console.warn("[issuectl] git fetch failed, continuing with local state:", (err as Error).message);
-    },
-  );
+  await timedExec("git", ["fetch", "origin"], {
+    cwd: repoPath,
+    timeoutMs: GIT_FETCH_TIMEOUT_MS,
+    step: "git fetch",
+  }).catch((err) => {
+    // A failing fetch is non-fatal — we continue with local state — but if
+    // the failure was a timeout we want the warning to say so clearly.
+    console.warn(
+      "[issuectl] git fetch failed, continuing with local state:",
+      (err as Error).message,
+    );
+  });
 
   const baseBranch = await getDefaultBranch(repoPath);
   await createOrCheckoutBranch(repoPath, branchName, baseBranch);
@@ -101,10 +121,14 @@ async function prepareWorktree(options: {
   }
 
   try {
-    await execFileAsync(
+    await timedExec(
       "git",
       ["worktree", "add", worktreePath, "-b", options.branchName],
-      { cwd: options.repoPath },
+      {
+        cwd: options.repoPath,
+        timeoutMs: GIT_WORKTREE_TIMEOUT_MS,
+        step: "git worktree add",
+      },
     );
     return { path: worktreePath, mode: "worktree", created: true };
   } catch (err) {
@@ -113,22 +137,26 @@ async function prepareWorktree(options: {
     const message = err instanceof Error ? err.message : "";
     if (stderr.includes("already exists") || message.includes("already exists")) {
       try {
-        await execFileAsync(
+        await timedExec(
           "git",
           ["worktree", "add", worktreePath, options.branchName],
-          { cwd: options.repoPath },
+          {
+            cwd: options.repoPath,
+            timeoutMs: GIT_WORKTREE_TIMEOUT_MS,
+            step: "git worktree add (existing branch)",
+          },
         );
         return { path: worktreePath, mode: "worktree", created: true };
       } catch (retryErr) {
         await rm(worktreePath, { recursive: true, force: true }).catch((e) => {
-        console.warn("[issuectl] Failed to clean up worktree:", (e as Error).message);
-      });
+          console.warn("[issuectl] Failed to clean up worktree:", (e as Error).message);
+        });
         throw retryErr;
       }
     }
     await rm(worktreePath, { recursive: true, force: true }).catch((e) => {
-        console.warn("[issuectl] Failed to clean up worktree:", (e as Error).message);
-      });
+      console.warn("[issuectl] Failed to clean up worktree:", (e as Error).message);
+    });
     throw err;
   }
 }
@@ -149,11 +177,16 @@ async function prepareClone(options: {
   // If the directory already exists from a previous launch, reuse it
   if (await pathExists(clonePath)) {
     if (await isGitRepo(clonePath)) {
-      await execFileAsync("git", ["fetch", "origin"], { cwd: clonePath }).catch(
-        (err) => {
-          console.warn("[issuectl] git fetch failed on existing clone:", (err as Error).message);
-        },
-      );
+      await timedExec("git", ["fetch", "origin"], {
+        cwd: clonePath,
+        timeoutMs: GIT_FETCH_TIMEOUT_MS,
+        step: "git fetch (existing clone)",
+      }).catch((err) => {
+        console.warn(
+          "[issuectl] git fetch failed on existing clone:",
+          (err as Error).message,
+        );
+      });
       await createOrCheckoutBranch(clonePath, options.branchName);
       return { path: clonePath, mode: "clone", created: false };
     }
@@ -162,9 +195,14 @@ async function prepareClone(options: {
   }
 
   try {
-    await execFileAsync("git", ["clone", "--depth=1", cloneUrl, clonePath]);
-    await execFileAsync("git", ["checkout", "-b", options.branchName], {
+    await timedExec("git", ["clone", "--depth=1", cloneUrl, clonePath], {
+      timeoutMs: GIT_CLONE_TIMEOUT_MS,
+      step: "git clone",
+    });
+    await timedExec("git", ["checkout", "-b", options.branchName], {
       cwd: clonePath,
+      timeoutMs: GIT_BRANCH_OP_TIMEOUT_MS,
+      step: "git checkout",
     });
   } catch (err) {
     await rm(clonePath, { recursive: true, force: true }).catch(() => {});

--- a/packages/web/components/detail/DraftDetail.tsx
+++ b/packages/web/components/detail/DraftDetail.tsx
@@ -78,6 +78,7 @@ export function DraftDetail({ draft }: Props) {
           onChange={(e) => setTitle(e.target.value)}
           onBlur={handleTitleBlur}
           aria-label="Draft title"
+          maxLength={256}
         />
         <DetailMeta>
           <Chip variant="dashed">no repo</Chip>
@@ -98,6 +99,7 @@ export function DraftDetail({ draft }: Props) {
             onBlur={handleBodyBlur}
             placeholder="add a description…"
             rows={8}
+            maxLength={65536}
           />
           {savedAt !== null && (
             <div className={styles.savedIndicator}>saved</div>

--- a/packages/web/components/issue/CommentForm.tsx
+++ b/packages/web/components/issue/CommentForm.tsx
@@ -43,6 +43,7 @@ export function CommentForm({ owner, repo, issueNumber }: Props) {
         onChange={(e) => setBody(e.target.value)}
         rows={3}
         disabled={isPending}
+        maxLength={65536}
       />
       {error && (
         <div className={styles.error} role="alert">

--- a/packages/web/components/issue/CreateIssueModal.tsx
+++ b/packages/web/components/issue/CreateIssueModal.tsx
@@ -134,6 +134,7 @@ export function CreateIssueModal({
           placeholder="Issue title"
           autoFocus
           disabled={isPending}
+          maxLength={256}
         />
       </div>
 
@@ -147,6 +148,7 @@ export function CreateIssueModal({
           onChange={(e) => setBody(e.target.value)}
           placeholder="Describe the issue..."
           disabled={isPending}
+          maxLength={65536}
         />
       </div>
 

--- a/packages/web/components/issue/EditIssueForm.tsx
+++ b/packages/web/components/issue/EditIssueForm.tsx
@@ -51,6 +51,7 @@ export function EditIssueForm({ owner, repo, issue, onDone }: Props) {
         placeholder="Issue title"
         disabled={isPending}
         autoFocus
+        maxLength={256}
       />
       <textarea
         className={styles.bodyInput}
@@ -58,6 +59,7 @@ export function EditIssueForm({ owner, repo, issue, onDone }: Props) {
         onChange={(e) => setBody(e.target.value)}
         placeholder="Description (markdown)"
         disabled={isPending}
+        maxLength={65536}
       />
       {error && (
         <div className={styles.error} role="alert">

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -12,6 +12,7 @@ import { generateBranchName } from "@/lib/branch";
 import { launchIssue } from "@/lib/actions/launch";
 import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
 import { Button } from "@/components/paper";
+import { useToast } from "@/components/ui/ToastProvider";
 import { BranchInput } from "./BranchInput";
 import { WorkspaceModeSelector } from "./WorkspaceModeSelector";
 import { ContextToggles } from "./ContextToggles";
@@ -42,6 +43,7 @@ export function LaunchModal({
   onClose,
 }: Props) {
   const router = useRouter();
+  const { showToast } = useToast();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
@@ -101,6 +103,10 @@ export function LaunchModal({
       if (!deploymentId) {
         setError("Launch succeeded but deployment ID was not returned");
         return;
+      }
+
+      if (result.labelWarning) {
+        showToast(result.labelWarning, "warning");
       }
 
       router.push(

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Sheet, Button } from "@/components/paper";
 import { listReposAction, assignDraftAction } from "@/lib/actions/drafts";
+import { useToast } from "@/components/ui/ToastProvider";
 import styles from "./AssignSheet.module.css";
 
 type Repo = { id: number; owner: string; name: string };
@@ -15,6 +16,7 @@ type Props = {
 };
 
 export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
+  const { showToast } = useToast();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
   const [assigning, setAssigning] = useState<number | null>(null);
@@ -38,6 +40,11 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
       if (!result.success) {
         setError(result.error);
         return;
+      }
+      if (result.cleanupWarning) {
+        showToast(result.cleanupWarning, "warning");
+      } else {
+        showToast(`Issue #${result.issueNumber} created`, "success");
       }
       onClose();
     } catch {

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -63,6 +63,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           disabled={saving}
           autoFocus
           aria-label="Draft title"
+          maxLength={256}
         />
         <div className={styles.hint}>
           title only — add a body, labels, and a repo when you assign it

--- a/packages/web/components/ui/Toast.module.css
+++ b/packages/web/components/ui/Toast.module.css
@@ -29,6 +29,10 @@
   border-left: 3px solid var(--paper-brick);
 }
 
+.warning {
+  border-left: 3px solid var(--paper-amber, var(--paper-brick));
+}
+
 .message {
   flex: 1;
 }

--- a/packages/web/components/ui/Toast.tsx
+++ b/packages/web/components/ui/Toast.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
 import styles from "./Toast.module.css";
 
-export type ToastType = "success" | "error";
+export type ToastType = "success" | "error" | "warning";
 
 type ToastData = {
   message: string;
@@ -45,7 +45,7 @@ export function Toast({ toast, onDismiss }: Props) {
     <div
       className={cn(styles.toast, styles[toast.type])}
       data-exiting={exiting ? "true" : undefined}
-      role={toast.type === "error" ? "alert" : "status"}
+      role={toast.type === "error" || toast.type === "warning" ? "alert" : "status"}
     >
       <span className={styles.message}>{toast.message}</span>
       <button className={styles.dismiss} onClick={handleDismiss} aria-label="Dismiss">

--- a/packages/web/lib/actions/comments.ts
+++ b/packages/web/lib/actions/comments.ts
@@ -1,16 +1,30 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-import { getDb, getOctokit, getRepo, addComment as coreAddComment } from "@issuectl/core";
+import {
+  getDb,
+  getRepo,
+  addComment as coreAddComment,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
+
+const MAX_COMMENT_BODY = 65536;
 
 export async function addComment(
   owner: string,
   repo: string,
   issueNumber: number,
   body: string,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (!owner || !repo || issueNumber <= 0 || !body.trim()) {
     return { success: false, error: "Invalid input" };
+  }
+  if (body.length > MAX_COMMENT_BODY) {
+    return {
+      success: false,
+      error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer`,
+    };
   }
 
   try {
@@ -18,13 +32,16 @@ export async function addComment(
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
-    await coreAddComment(db, octokit, owner, repo, issueNumber, body);
+    await withAuthRetry((octokit) =>
+      coreAddComment(db, octokit, owner, repo, issueNumber, body),
+    );
   } catch (err) {
     console.error("[issuectl] Failed to add comment:", err);
-    return { success: false, error: "Failed to post comment" };
+    return { success: false, error: formatErrorForUser(err) };
   }
-  revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
-  revalidatePath(`/${owner}/${repo}/pulls/${issueNumber}`);
-  return { success: true };
+  const { stale } = revalidateSafely(
+    `/${owner}/${repo}/issues/${issueNumber}`,
+    `/${owner}/${repo}/pulls/${issueNumber}`,
+  );
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -1,19 +1,23 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import {
   getDb,
-  getOctokit,
   createDraft,
   assignDraftToRepo,
   listRepos,
   updateDraft,
+  withAuthRetry,
+  formatErrorForUser,
+  DraftPartialCommitError,
   type DraftInput,
   type DraftUpdate,
   type Priority,
 } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 const VALID_PRIORITIES: readonly Priority[] = ["low", "normal", "high"];
+const MAX_TITLE = 256;
+const MAX_BODY = 65536;
 
 // Server actions are HTTP endpoints reachable with arbitrary request bodies,
 // not just via the UI. Validate shape at the boundary so untrusted clients
@@ -25,6 +29,9 @@ function validateTitle(title: unknown): string {
   }
   if (title.trim().length === 0) {
     throw new Error("Draft title must not be empty");
+  }
+  if (title.length > MAX_TITLE) {
+    throw new Error(`Draft title must be ${MAX_TITLE} characters or fewer`);
   }
   return title;
 }
@@ -47,12 +54,19 @@ function validateBody(body: unknown): string | undefined {
   if (typeof body !== "string") {
     throw new Error("Draft body must be a string");
   }
+  if (body.length > MAX_BODY) {
+    throw new Error(`Draft body must be ${MAX_BODY} characters or fewer`);
+  }
   return body;
 }
 
 export async function createDraftAction(
   input: DraftInput,
-): Promise<{ success: true; id: string } | { success: false; error: string }> {
+): Promise<
+  | { success: true; id: string; cacheStale?: true }
+  | { success: false; error: string }
+> {
+  let draftId: string;
   try {
     const title = validateTitle(input.title);
     const body = validateBody(input.body);
@@ -60,12 +74,20 @@ export async function createDraftAction(
 
     const db = getDb();
     const draft = createDraft(db, { title, body, priority });
-    revalidatePath("/");
-    return { success: true, id: draft.id };
+    draftId = draft.id;
   } catch (err) {
     console.error("[issuectl] createDraftAction failed", err);
-    return { success: false, error: "Failed to create draft" };
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to create draft",
+    };
   }
+  const { stale } = revalidateSafely("/");
+  return {
+    success: true,
+    id: draftId,
+    ...(stale ? { cacheStale: true as const } : {}),
+  };
 }
 
 export async function listReposAction(): Promise<
@@ -79,31 +101,47 @@ export async function listReposAction(): Promise<
 export async function updateDraftAction(
   draftId: string,
   update: DraftUpdate,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (typeof draftId !== "string" || draftId.length === 0) {
     return { success: false, error: "draftId must be a non-empty string" };
   }
-  if (update.title !== undefined) validateTitle(update.title);
-  if (update.body !== undefined) validateBody(update.body);
-  if (update.priority !== undefined) validatePriority(update.priority);
+  try {
+    if (update.title !== undefined) validateTitle(update.title);
+    if (update.body !== undefined) validateBody(update.body);
+    if (update.priority !== undefined) validatePriority(update.priority);
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Invalid draft update",
+    };
+  }
 
   try {
     const db = getDb();
     updateDraft(db, draftId, update);
-    revalidatePath("/");
-    revalidatePath(`/drafts/${draftId}`);
-    return { success: true };
   } catch (err) {
     console.error("[issuectl] updateDraftAction failed", err);
     return { success: false, error: "Failed to update draft" };
   }
+  const { stale } = revalidateSafely("/", `/drafts/${draftId}`);
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
 export async function assignDraftAction(
   draftId: string,
   repoId: number,
 ): Promise<
-  | { success: true; issueNumber: number; issueUrl: string }
+  | {
+      success: true;
+      issueNumber: number;
+      issueUrl: string;
+      // Set when the GitHub issue was created successfully but the local
+      // draft cleanup failed (DraftPartialCommitError). The caller should
+      // show the user the issue URL AND surface the warning so they know
+      // to delete the lingering draft manually.
+      cleanupWarning?: string;
+      cacheStale?: true;
+    }
   | { success: false; error: string }
 > {
   if (typeof draftId !== "string" || draftId.length === 0) {
@@ -117,22 +155,45 @@ export async function assignDraftAction(
     return { success: false, error: "repoId must be a positive integer" };
   }
 
+  let issueNumber: number;
+  let issueUrl: string;
+  let cleanupWarning: string | undefined;
   try {
     const db = getDb();
-    const octokit = await getOctokit();
-    const result = await assignDraftToRepo(db, octokit, draftId, repoId);
-    revalidatePath("/");
-    return {
-      success: true,
-      issueNumber: result.issueNumber,
-      issueUrl: result.issueUrl,
-    };
-  } catch (err) {
-    console.error(
-      "[issuectl] assignDraftAction failed",
-      { draftId, repoId },
-      err,
+    const result = await withAuthRetry((octokit) =>
+      assignDraftToRepo(db, octokit, draftId, repoId),
     );
-    return { success: false, error: "Failed to assign draft to repo" };
+    issueNumber = result.issueNumber;
+    issueUrl = result.issueUrl;
+  } catch (err) {
+    if (err instanceof DraftPartialCommitError) {
+      // The GitHub issue exists — surface it as a success with a cleanup
+      // warning rather than a hard failure. The user needs the link to
+      // find their work.
+      console.warn(
+        "[issuectl] assignDraftAction partial commit",
+        { draftId, repoId, issueNumber: err.issueNumber },
+        err,
+      );
+      issueNumber = err.issueNumber;
+      issueUrl = err.issueUrl;
+      cleanupWarning = err.message;
+    } else {
+      console.error(
+        "[issuectl] assignDraftAction failed",
+        { draftId, repoId },
+        err,
+      );
+      return { success: false, error: formatErrorForUser(err) };
+    }
   }
+
+  const { stale } = revalidateSafely("/");
+  return {
+    success: true,
+    issueNumber,
+    issueUrl,
+    ...(cleanupWarning ? { cleanupWarning } : {}),
+    ...(stale ? { cacheStale: true as const } : {}),
+  };
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import {
   getDb,
-  getOctokit,
   getRepo,
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
@@ -11,7 +9,13 @@ import {
   addLabel as coreAddLabel,
   removeLabel as coreRemoveLabel,
   clearCacheKey,
+  withAuthRetry,
+  formatErrorForUser,
 } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
+
+const MAX_TITLE = 256;
+const MAX_BODY = 65536;
 
 export async function createIssue(data: {
   owner: string;
@@ -19,30 +23,49 @@ export async function createIssue(data: {
   title: string;
   body?: string;
   labels?: string[];
-}): Promise<{ success: boolean; issueNumber?: number; error?: string }> {
+}): Promise<{
+  success: boolean;
+  issueNumber?: number;
+  error?: string;
+  cacheStale?: true;
+}> {
   const { owner, repo, title, body, labels } = data;
   if (!owner || !repo || !title.trim()) {
     return { success: false, error: "Owner, repo, and title are required" };
   }
+  if (title.length > MAX_TITLE) {
+    return { success: false, error: `Title must be ${MAX_TITLE} characters or fewer` };
+  }
+  if (body !== undefined && body.length > MAX_BODY) {
+    return { success: false, error: `Body must be ${MAX_BODY} characters or fewer` };
+  }
 
+  let issueNumber: number;
   try {
     const db = getDb();
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
-    const issue = await coreCreateIssue(octokit, owner, repo, {
-      title: title.trim(),
-      body: body?.trim() || undefined,
-      labels,
-    });
+    const issue = await withAuthRetry((octokit) =>
+      coreCreateIssue(octokit, owner, repo, {
+        title: title.trim(),
+        body: body?.trim() || undefined,
+        labels,
+      }),
+    );
     clearCacheKey(db, `issues:${owner}/${repo}`);
-    revalidatePath(`/${owner}/${repo}`);
-    return { success: true, issueNumber: issue.number };
+    issueNumber = issue.number;
   } catch (err) {
     console.error("[issuectl] Failed to create issue:", err);
-    return { success: false, error: "Failed to create issue" };
+    return { success: false, error: formatErrorForUser(err) };
   }
+
+  const { stale } = revalidateSafely(`/${owner}/${repo}`);
+  return {
+    success: true,
+    issueNumber,
+    ...(stale ? { cacheStale: true as const } : {}),
+  };
 }
 
 export async function updateIssue(data: {
@@ -51,7 +74,7 @@ export async function updateIssue(data: {
   number: number;
   title?: string;
   body?: string;
-}): Promise<{ success: boolean; error?: string }> {
+}): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   const { owner, repo, number, title, body } = data;
   if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
     return { success: false, error: "Valid owner, repo, and issue number are required" };
@@ -59,32 +82,39 @@ export async function updateIssue(data: {
   if (title !== undefined && !title.trim()) {
     return { success: false, error: "Title cannot be empty" };
   }
+  if (title !== undefined && title.length > MAX_TITLE) {
+    return { success: false, error: `Title must be ${MAX_TITLE} characters or fewer` };
+  }
+  if (body !== undefined && body.length > MAX_BODY) {
+    return { success: false, error: `Body must be ${MAX_BODY} characters or fewer` };
+  }
 
   try {
     const db = getDb();
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
-    await coreUpdateIssue(octokit, owner, repo, number, {
-      title: title?.trim(),
-      body: body !== undefined ? body.trim() : undefined,
-    });
+    await withAuthRetry((octokit) =>
+      coreUpdateIssue(octokit, owner, repo, number, {
+        title: title?.trim(),
+        body: body !== undefined ? body.trim() : undefined,
+      }),
+    );
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
   } catch (err) {
     console.error("[issuectl] Failed to update issue:", err);
-    return { success: false, error: "Failed to update issue" };
+    return { success: false, error: formatErrorForUser(err) };
   }
-  revalidatePath(`/${owner}/${repo}/issues/${number}`);
-  return { success: true };
+  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
 export async function closeIssue(
   owner: string,
   repo: string,
   number: number,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
     return { success: false, error: "Valid owner, repo, and issue number are required" };
   }
@@ -94,16 +124,17 @@ export async function closeIssue(
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
-    await coreCloseIssue(octokit, owner, repo, number);
+    await withAuthRetry((octokit) =>
+      coreCloseIssue(octokit, owner, repo, number),
+    );
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
   } catch (err) {
     console.error("[issuectl] Failed to close issue:", err);
-    return { success: false, error: "Failed to close issue" };
+    return { success: false, error: formatErrorForUser(err) };
   }
-  revalidatePath(`/${owner}/${repo}/issues/${number}`);
-  return { success: true };
+  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
 export async function toggleLabel(data: {
@@ -112,7 +143,7 @@ export async function toggleLabel(data: {
   number: number;
   label: string;
   action: "add" | "remove";
-}): Promise<{ success: boolean; error?: string }> {
+}): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   const { owner, repo, number, label, action } = data;
   if (!owner || !repo || !Number.isFinite(number) || number <= 0 || !label) {
     return { success: false, error: "Valid owner, repo, issue number, and label are required" };
@@ -123,18 +154,21 @@ export async function toggleLabel(data: {
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
     if (action === "add") {
-      await coreAddLabel(octokit, owner, repo, number, label);
+      await withAuthRetry((octokit) =>
+        coreAddLabel(octokit, owner, repo, number, label),
+      );
     } else {
-      await coreRemoveLabel(octokit, owner, repo, number, label);
+      await withAuthRetry((octokit) =>
+        coreRemoveLabel(octokit, owner, repo, number, label),
+      );
     }
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
   } catch (err) {
     console.error(`[issuectl] Failed to ${action} label:`, err);
-    return { success: false, error: `Failed to ${action} label` };
+    return { success: false, error: formatErrorForUser(err) };
   }
-  revalidatePath(`/${owner}/${repo}/issues/${number}`);
-  return { success: true };
+  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -1,14 +1,15 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import {
   getDb,
-  getOctokit,
   getRepo,
   executeLaunch,
   endDeployment as coreEndDeployment,
+  withAuthRetry,
+  formatErrorForUser,
   type WorkspaceMode,
 } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 type LaunchFormData = {
   owner: string;
@@ -25,6 +26,14 @@ type LaunchResponse = {
   success: boolean;
   deploymentId?: number;
   error?: string;
+  cacheStale?: true;
+  /**
+   * Set when the `issuectl:deployed` label could not be applied after the
+   * retry budget. Launch still succeeded — the deployment row exists and
+   * the terminal opened — but the reconciler may not auto-advance this
+   * issue's lifecycle state.
+   */
+  labelWarning?: string;
 };
 
 const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
@@ -57,37 +66,42 @@ export async function launchIssue(
     return { success: false, error: "Invalid comment selection" };
   }
 
+  let deploymentId: number;
+  let labelWarning: string | undefined;
   try {
     const db = getDb();
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const octokit = await getOctokit();
 
-    const result = await executeLaunch(db, octokit, {
-      owner,
-      repo,
-      issueNumber,
-      branchName: trimmedBranch,
-      workspaceMode,
-      selectedComments: formData.selectedCommentIndices,
-      selectedFiles: formData.selectedFilePaths,
-      preamble: formData.preamble || undefined,
-    });
-
-    try {
-      revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
-    } catch (revalErr) {
-      console.warn("[issuectl] Cache revalidation failed (launch succeeded):", revalErr);
-    }
-
-    return { success: true, deploymentId: result.deploymentId };
+    const result = await withAuthRetry((octokit) =>
+      executeLaunch(db, octokit, {
+        owner,
+        repo,
+        issueNumber,
+        branchName: trimmedBranch,
+        workspaceMode,
+        selectedComments: formData.selectedCommentIndices,
+        selectedFiles: formData.selectedFilePaths,
+        preamble: formData.preamble || undefined,
+      }),
+    );
+    deploymentId = result.deploymentId;
+    labelWarning = result.labelWarning;
   } catch (err) {
     console.error("[issuectl] Launch failed:", err);
-    const message =
-      err instanceof Error ? err.message : "Launch failed unexpectedly";
-    return { success: false, error: message };
+    return { success: false, error: formatErrorForUser(err) };
   }
+
+  const { stale } = revalidateSafely(
+    `/${owner}/${repo}/issues/${issueNumber}`,
+  );
+  return {
+    success: true,
+    deploymentId,
+    ...(stale ? { cacheStale: true as const } : {}),
+    ...(labelWarning ? { labelWarning } : {}),
+  };
 }
 
 export async function endSession(
@@ -95,7 +109,7 @@ export async function endSession(
   owner: string,
   repo: string,
   issueNumber: number,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   try {
     const db = getDb();
     coreEndDeployment(db, deploymentId);
@@ -103,7 +117,9 @@ export async function endSession(
     console.error("[issuectl] Failed to end session:", err);
     return { success: false, error: err instanceof Error ? err.message : "Failed to end session" };
   }
-  revalidatePath(`/${owner}/${repo}/issues/${issueNumber}`);
-  revalidatePath(`/${owner}/${repo}/issues/${issueNumber}/launch`);
-  return { success: true };
+  const { stale } = revalidateSafely(
+    `/${owner}/${repo}/issues/${issueNumber}`,
+    `/${owner}/${repo}/issues/${issueNumber}/launch`,
+  );
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import {
   getDb,
   getOctokit,
@@ -10,12 +9,15 @@ import {
   clearCacheKey,
   parseIssues,
   formatRepoContext,
+  withAuthRetry,
+  formatErrorForUser,
 } from "@issuectl/core";
 import type {
   ParsedIssuesResponse,
   ReviewedIssue,
   BatchCreateResult,
 } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 type ParseActionResult =
   | { success: true; data: { parsed: ParsedIssuesResponse } }
@@ -65,8 +67,10 @@ export async function parseNaturalLanguage(
     return { success: true, data: { parsed: result.data } };
   } catch (err) {
     console.error("[issuectl] Failed to parse natural language:", err);
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return { success: false, error: `Failed to parse input: ${message}` };
+    return {
+      success: false,
+      error: `Failed to parse input: ${formatErrorForUser(err)}`,
+    };
   }
 }
 
@@ -81,7 +85,6 @@ export async function batchCreateIssues(
 
   try {
     const db = getDb();
-    const octokit = await getOctokit();
 
     const results = await Promise.all(
       accepted.map(async (issue) => {
@@ -96,11 +99,13 @@ export async function batchCreateIssues(
         }
 
         try {
-          const created = await coreCreateIssue(octokit, issue.owner, issue.repo, {
-            title: issue.title.trim(),
-            body: issue.body.trim() || undefined,
-            labels: issue.labels.length > 0 ? issue.labels : undefined,
-          });
+          const created = await withAuthRetry((octokit) =>
+            coreCreateIssue(octokit, issue.owner, issue.repo, {
+              title: issue.title.trim(),
+              body: issue.body.trim() || undefined,
+              labels: issue.labels.length > 0 ? issue.labels : undefined,
+            }),
+          );
 
           clearCacheKey(db, `issues:${issue.owner}/${issue.repo}`);
 
@@ -119,7 +124,7 @@ export async function batchCreateIssues(
           return {
             id: issue.id,
             success: false as const,
-            error: err instanceof Error ? err.message : "Unknown error",
+            error: formatErrorForUser(err),
             owner: issue.owner,
             repo: issue.repo,
           };
@@ -132,9 +137,7 @@ export async function batchCreateIssues(
         .filter((r) => r.success)
         .map((r) => `/${r.owner}/${r.repo}`),
     );
-    for (const repoPath of affectedRepos) {
-      revalidatePath(repoPath);
-    }
+    revalidateSafely(...affectedRepos);
 
     return {
       created: results.filter((r) => r.success).length,

--- a/packages/web/lib/actions/priority.ts
+++ b/packages/web/lib/actions/priority.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { getDb, setPriority, type Priority } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 const VALID_PRIORITIES: readonly Priority[] = ["low", "normal", "high"];
 
@@ -9,7 +9,7 @@ export async function setPriorityAction(
   repoId: number,
   issueNumber: number,
   priority: Priority,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (typeof repoId !== "number" || !Number.isInteger(repoId) || repoId <= 0) {
     return { success: false, error: "repoId must be a positive integer" };
   }
@@ -26,6 +26,6 @@ export async function setPriorityAction(
 
   const db = getDb();
   setPriority(db, repoId, issueNumber, priority);
-  revalidatePath("/");
-  return { success: true };
+  const { stale } = revalidateSafely("/");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -1,13 +1,19 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-import { getDb, getOctokit, getRepo, clearCacheKey } from "@issuectl/core";
+import {
+  getDb,
+  getRepo,
+  clearCacheKey,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 export async function mergePullAction(
   owner: string,
   repo: string,
   pullNumber: number,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (typeof owner !== "string" || owner.trim().length === 0) {
     return { success: false, error: "Invalid owner" };
   }
@@ -25,29 +31,30 @@ export async function mergePullAction(
   }
 
   try {
-    const octokit = await getOctokit();
-    await octokit.rest.pulls.merge({
-      owner,
-      repo,
-      pull_number: pullNumber,
-    });
+    await withAuthRetry((octokit) =>
+      octokit.rest.pulls.merge({
+        owner,
+        repo,
+        pull_number: pullNumber,
+      }),
+    );
     // Clear the PR detail cache so the re-rendered page shows merged state
     // instead of the pre-merge snapshot (otherwise the top StateChip stays
     // "open" until TTL expiry, contradicting the "merged successfully" banner).
     clearCacheKey(db, `pull-detail:${owner}/${repo}#${pullNumber}`);
     clearCacheKey(db, `pulls:${owner}/${repo}`);
-    revalidatePath(`/pulls/${owner}/${repo}/${pullNumber}`);
-    revalidatePath("/");
-    return { success: true };
   } catch (err) {
     console.error(
       "[issuectl] mergePullAction failed",
       { owner, repo, pullNumber },
       err,
     );
-    return {
-      success: false,
-      error: err instanceof Error ? err.message : "Merge failed",
-    };
+    return { success: false, error: formatErrorForUser(err) };
   }
+
+  const { stale } = revalidateSafely(
+    `/pulls/${owner}/${repo}/${pullNumber}`,
+    "/",
+  );
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -1,17 +1,27 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-import { getDb, getOctokit, getDashboardData } from "@issuectl/core";
+import {
+  getDb,
+  getDashboardData,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
-export async function refreshDashboard(): Promise<{ success: boolean; error?: string }> {
+export async function refreshDashboard(): Promise<{
+  success: boolean;
+  error?: string;
+  cacheStale?: true;
+}> {
   try {
     const db = getDb();
-    const octokit = await getOctokit();
-    await getDashboardData(db, octokit, { forceRefresh: true });
+    await withAuthRetry((octokit) =>
+      getDashboardData(db, octokit, { forceRefresh: true }),
+    );
   } catch (err) {
     console.error("[issuectl] Dashboard refresh failed:", err);
-    return { success: false, error: "Failed to refresh dashboard data" };
+    return { success: false, error: formatErrorForUser(err) };
   }
-  revalidatePath("/");
-  return { success: true };
+  const { stale } = revalidateSafely("/");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -1,15 +1,16 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import {
   getDb,
-  getOctokit,
   addRepo as coreAddRepo,
   removeRepo as coreRemoveRepo,
   updateRepo as coreUpdateRepo,
+  withAuthRetry,
+  formatErrorForUser,
 } from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 function expandHome(p: string): string {
   return p.startsWith("~") ? p.replace("~", homedir()) : p;
@@ -19,7 +20,12 @@ export async function addRepo(
   owner: string,
   name: string,
   localPath?: string,
-): Promise<{ success: boolean; warning?: string; error?: string }> {
+): Promise<{
+  success: boolean;
+  warning?: string;
+  error?: string;
+  cacheStale?: true;
+}> {
   if (!owner || !name) {
     return { success: false, error: "Owner and repo name are required" };
   }
@@ -28,10 +34,15 @@ export async function addRepo(
   }
 
   try {
-    const octokit = await getOctokit();
-    await octokit.rest.repos.get({ owner, repo: name });
-  } catch {
-    return { success: false, error: `Repository ${owner}/${name} not found on GitHub (or not accessible with your token)` };
+    await withAuthRetry((octokit) =>
+      octokit.rest.repos.get({ owner, repo: name }),
+    );
+  } catch (err) {
+    console.error("[issuectl] Failed to fetch repo from GitHub:", err);
+    return {
+      success: false,
+      error: `Repository ${owner}/${name} not found on GitHub: ${formatErrorForUser(err)}`,
+    };
   }
 
   try {
@@ -45,22 +56,25 @@ export async function addRepo(
         : "Failed to add repository";
     return { success: false, error: msg };
   }
-  revalidatePath("/settings");
-  revalidatePath("/");
+  const { stale } = revalidateSafely("/settings", "/");
 
   if (localPath) {
     const exists = await stat(expandHome(localPath)).catch(() => null);
     if (!exists) {
-      return { success: true, warning: "Local path does not exist — will prompt to clone on launch" };
+      return {
+        success: true,
+        warning: "Local path does not exist — will prompt to clone on launch",
+        ...(stale ? { cacheStale: true as const } : {}),
+      };
     }
   }
 
-  return { success: true };
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
 export async function removeRepo(
   id: number,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (!id || id <= 0) {
     return { success: false, error: "Invalid repo ID" };
   }
@@ -72,15 +86,14 @@ export async function removeRepo(
     console.error("[issuectl] Failed to remove repo:", err);
     return { success: false, error: "Failed to remove repository" };
   }
-  revalidatePath("/settings");
-  revalidatePath("/");
-  return { success: true };
+  const { stale } = revalidateSafely("/settings", "/");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
 export async function updateRepo(
   id: number,
   updates: { localPath?: string; branchPattern?: string },
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (!id || id <= 0) {
     return { success: false, error: "Invalid repo ID" };
   }
@@ -92,6 +105,6 @@ export async function updateRepo(
     console.error("[issuectl] Failed to update repo:", err);
     return { success: false, error: "Failed to update repository" };
   }
-  revalidatePath("/settings");
-  return { success: true };
+  const { stale } = revalidateSafely("/settings");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/worktrees.ts
+++ b/packages/web/lib/actions/worktrees.ts
@@ -1,12 +1,17 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { readdir, rm, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { getDb, getSetting, listRepos, getOctokit } from "@issuectl/core";
+import {
+  getDb,
+  getSetting,
+  listRepos,
+  withAuthRetry,
+} from "@issuectl/core";
+import { revalidateSafely } from "@/lib/revalidate";
 
 const execFileAsync = promisify(execFile);
 
@@ -82,31 +87,26 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
 
   const worktrees = results.filter((wt): wt is WorktreeInfo => wt !== null);
 
-  // Check staleness via GitHub API — a closed issue means the worktree is stale
-  let octokit;
-  try {
-    octokit = await getOctokit();
-  } catch (err) {
-    console.warn("[issuectl] Could not authenticate with GitHub — staleness checks skipped:", err);
-    return worktrees;
-  }
-
+  // Check staleness via GitHub API — a closed issue means the worktree is stale.
+  // Each issue lookup goes through withAuthRetry so a rotated token doesn't
+  // leave the entire staleness check in the dark.
   await Promise.all(
     worktrees.map(async (wt) => {
       if (!wt.owner || !wt.repo || !wt.issueNumber) return;
 
-      // Look up the canonical repo name from tracked repos
       const repoName = repos.find(
         (r) => r.name === wt.repo || `${r.owner}-${r.name}` === wt.repo,
       )?.name;
       if (!repoName) return;
 
       try {
-        const { data } = await octokit.rest.issues.get({
-          owner: wt.owner,
-          repo: repoName,
-          issue_number: wt.issueNumber,
-        });
+        const { data } = await withAuthRetry((octokit) =>
+          octokit.rest.issues.get({
+            owner: wt.owner!,
+            repo: repoName,
+            issue_number: wt.issueNumber!,
+          }),
+        );
         wt.stale = data.state === "closed";
       } catch (err) {
         if (err && typeof err === "object" && "status" in err) {
@@ -116,7 +116,10 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
             return;
           }
         }
-        console.warn(`[issuectl] Failed to check staleness for ${wt.owner}/${repoName}#${wt.issueNumber}:`, err);
+        console.warn(
+          `[issuectl] Failed to check staleness for ${wt.owner}/${repoName}#${wt.issueNumber}:`,
+          err,
+        );
       }
     }),
   );
@@ -127,7 +130,7 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
 export async function cleanupWorktree(
   path: string,
   parentRepoPath?: string,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   const worktreeDir = getWorktreeDir();
   // Prevent path traversal — only allow deletion within the configured worktree directory
   const resolved = resolve(path);
@@ -149,29 +152,55 @@ export async function cleanupWorktree(
     cwd = expandHome(parentRepoPath);
   }
 
+  // R9: two-phase cleanup. Git worktree removal is best-effort (the worktree
+  // entry may already be missing from .git/worktrees). rm, however, is the
+  // source of truth — if it fails with a permission error, the directory is
+  // orphaned and we MUST surface that to the user with the full path so they
+  // can clean it up manually.
+  let gitWarning: string | null = null;
   try {
-    // Two-phase cleanup: best-effort git worktree remove, then always rm the directory
-    await execFileAsync("git", ["worktree", "remove", resolved, "--force"], { cwd }).catch(
-      (err) => {
-        console.warn("[issuectl] git worktree remove failed, will still rm directory:", err.message);
-      },
-    );
-    if (cwd) {
-      await execFileAsync("git", ["worktree", "prune"], { cwd }).catch((err) => {
-        console.warn("[issuectl] git worktree prune failed:", err.message);
-      });
-    }
-    await rm(resolved, { recursive: true, force: true });
+    await execFileAsync("git", ["worktree", "remove", resolved, "--force"], { cwd });
   } catch (err) {
-    console.error("[issuectl] Failed to cleanup worktree:", err);
-    return { success: false, error: "Failed to remove worktree" };
+    gitWarning =
+      err instanceof Error ? err.message : "git worktree remove failed";
+    console.warn("[issuectl] git worktree remove failed, will still rm directory:", gitWarning);
+  }
+  if (cwd) {
+    try {
+      await execFileAsync("git", ["worktree", "prune"], { cwd });
+    } catch (err) {
+      console.warn(
+        "[issuectl] git worktree prune failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
-  revalidatePath("/settings");
-  return { success: true };
+  try {
+    await rm(resolved, { recursive: true, force: true });
+  } catch (err) {
+    console.error(
+      "[issuectl] Failed to rm worktree directory:",
+      { path: resolved, gitWarning },
+      err,
+    );
+    const rmMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = gitWarning
+      ? `Filesystem cleanup of ${resolved} failed (${rmMessage}); the git worktree entry also had a problem earlier (${gitWarning}). Remove the directory manually and run \`git worktree prune\` in the parent repo.`
+      : `Filesystem cleanup of ${resolved} failed (${rmMessage}). Remove the directory manually.`;
+    return { success: false, error: errorMessage };
+  }
+
+  const { stale } = revalidateSafely("/settings");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
-export async function cleanupStaleWorktrees(): Promise<{ success: boolean; removed: number; error?: string }> {
+export async function cleanupStaleWorktrees(): Promise<{
+  success: boolean;
+  removed: number;
+  error?: string;
+  cacheStale?: true;
+}> {
   let worktrees;
   try {
     worktrees = await listWorktrees();
@@ -200,13 +229,18 @@ export async function cleanupStaleWorktrees(): Promise<{ success: boolean; remov
     }
   }
 
-  revalidatePath("/settings");
+  const { stale: cacheStale } = revalidateSafely("/settings");
   if (failures.length > 0) {
     return {
       success: false,
       removed,
-      error: `Failed to remove ${failures.length} worktree(s)`,
+      error: `Failed to remove ${failures.length} worktree(s):\n${failures.join("\n")}`,
+      ...(cacheStale ? { cacheStale: true as const } : {}),
     };
   }
-  return { success: true, removed };
+  return {
+    success: true,
+    removed,
+    ...(cacheStale ? { cacheStale: true as const } : {}),
+  };
 }

--- a/packages/web/lib/revalidate.ts
+++ b/packages/web/lib/revalidate.ts
@@ -1,0 +1,35 @@
+import { revalidatePath } from "next/cache";
+
+/**
+ * Run `revalidatePath` for each path, retrying once on transient failure.
+ * Returns `{ stale: true }` if any path still couldn't be revalidated — the
+ * mutation itself has already succeeded, so we surface this as a soft warning
+ * rather than failing the action. Callers should propagate `cacheStale` on
+ * their success response so the UI can hint that a manual refresh may be
+ * needed.
+ *
+ * `revalidatePath` occasionally throws in edge cases (misconfigured route,
+ * runtime transition, internal Next.js errors), but the write has already
+ * happened and the user's data is safe on the server — failing the whole
+ * action would be worse than showing a stale view for one render.
+ */
+export function revalidateSafely(...paths: string[]): { stale: boolean } {
+  let stale = false;
+  for (const path of paths) {
+    try {
+      revalidatePath(path);
+    } catch {
+      try {
+        revalidatePath(path);
+      } catch (err) {
+        console.warn(
+          "[issuectl] Cache revalidation failed after retry",
+          { path },
+          err,
+        );
+        stale = true;
+      }
+    }
+  }
+  return { stale };
+}


### PR DESCRIPTION
**Stacked on #54** (base: \`fix/resilience-r1-r13\`). Do not merge until #54 lands; then rebase this onto main.

Phase 3 of the resilience-audit triage queue: R3, R4, R5, R6 wiring, R7, R8, R9, R12. Builds on Phase 1's R6 error classifier (#54) to route every server-action catch through a typed error surface, adds automatic recovery for stale GitHub tokens, caps subprocess runtime, enforces request-size limits, and surfaces soft warnings to the UI as a new \`warning\` toast type.

## Findings addressed

| # | Severity | Area | What landed |
|---|---|---|---|
| R3 | **High** | Auth | \`withAuthRetry\` wrapper in \`packages/core/src/github/client.ts\`. Detects 401, resets the cached Octokit, reads a fresh \`gh auth token\`, retries once. 7-test spec. |
| R4 | **High** | Data integrity | \`DraftPartialCommitError\` in \`packages/core/src/db/drafts.ts\`. Carries \`issueNumber\`/\`issueUrl\` when the DB commit fails after the GH issue was created. \`assignDraftAction\` catches explicitly and returns \`success: true\` with a \`cleanupWarning\` field so the user still gets redirected to their issue. |
| R5 | **High** | Subprocess | New \`timedExec()\` helper + \`SubprocessTimeoutError\`. Timeouts applied to every \`git fetch\`, \`git clone\`, \`git worktree add\`, \`git rev-parse\`, \`git checkout\`, \`which ghostty\`, and \`open -na Ghostty.app\`. No more unbounded hangs on slow networks. |
| R6 | **High** | Error surfacing | Every server action catch now routes through \`formatErrorForUser\` instead of a hardcoded \`\"Failed to …\"\` string. 429/401/403/404/422 are distinguishable in the UI. |
| R7 | **Medium** | Label drift | \`addLabel\` in \`executeLaunch\` now retries 3× with 500ms/1s/2s backoff. On final failure, records a \`labelWarning\` instead of swallowing the error; surfaced to LaunchModal as a warning toast. |
| R8 | **Medium** | Input limits | Server: title ≤256, body ≤65k, comment ≤65k, draft ≤256/65k (GitHub's documented limits). Client: \`maxLength\` attrs on every title/body/comment input. |
| R9 | **Medium** | Cleanup | Worktree two-phase cleanup (\`git worktree remove\` + \`rm\`) now tracks both phases separately and surfaces the full path in the error message when the rm phase fails. |
| R12 | **Low** | Cache | New \`revalidateSafely\` util retries once then returns \`cacheStale: true\` instead of failing the action. Every server action wired through it. Mutations no longer look failed because Next.js internal revalidation hiccuped. |

## Scope of diff

- **3 new files**: \`packages/core/src/github/client.test.ts\`, \`packages/core/src/launch/exec-timeout.ts\`, \`packages/web/lib/revalidate.ts\`
- **10 server actions** modified to use \`withAuthRetry\` + \`formatErrorForUser\` + \`revalidateSafely\` (issues, comments, pulls, drafts, launch, repos, refresh, parse, priority, worktrees)
- **7 components** modified for maxLength attrs + warning toast wiring (CreateIssueModal, EditIssueForm, CommentForm, DraftDetail, CreateDraftSheet, LaunchModal, AssignSheet)
- **2 ui primitives**: Toast / Toast.module.css — new \`warning\` variant

## What's left after this PR

- **R2** (deployment pending state) — next stacked PR
- **R1** (idempotency sentinel) — final stacked PR

## Test plan

- [x] \`pnpm turbo typecheck\` — 4/4 pass
- [x] \`pnpm turbo test\` — 269 core tests (7 new \`client.test.ts\`) + 17 web tests pass
- [x] \`pnpm turbo build\` — all packages build
- [x] \`pnpm turbo lint\` — no new errors (pre-existing warnings only)
- [ ] Manual: revoke gh auth mid-session, trigger an action, confirm it recovers on retry
- [ ] Manual: block git fetch (firewall), trigger launch, confirm "git fetch timed out after 30s" appears instead of a hang
- [ ] Manual: exceed length cap on issue title (paste a 500-char string), confirm client stops typing at 256