### PR TITLE
fix(resilience): R2 — deployment pending state with rollback

### DIFF
--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -54,6 +54,7 @@ function makeDeployment(issueNumber: number, ended = false): Deployment {
     workspaceMode: "worktree",
     workspacePath: `/tmp/${issueNumber}`,
     linkedPrNumber: null,
+    state: "active",
     launchedAt: "2026-04-01T00:00:00Z",
     endedAt: ended ? "2026-04-02T00:00:00Z" : null,
   };

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -9,6 +9,8 @@ import {
   getDeploymentsByRepo,
   updateLinkedPR,
   endDeployment,
+  activateDeployment,
+  deletePendingDeployment,
 } from "./deployments.js";
 
 function seedRepo(db: Database.Database) {
@@ -248,5 +250,149 @@ describe("endDeployment", () => {
     expect(() => endDeployment(db, 999)).toThrow(
       "No deployment found with id 999",
     );
+  });
+});
+
+describe("deployment state (R2: pending/active lifecycle)", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repoId = seedRepo(db).id;
+  });
+
+  it("defaults new rows to state='active' for backward compatibility", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 1,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    expect(dep.state).toBe("active");
+  });
+
+  it("records a pending deployment when state='pending' is passed", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 2,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    expect(dep.state).toBe("pending");
+  });
+
+  it("getDeploymentsForIssue hides pending rows from callers", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 3,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    const rows = getDeploymentsForIssue(db, repoId, 3);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("getDeploymentsByRepo hides pending rows from callers", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 4,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    const rows = getDeploymentsByRepo(db, repoId);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("getDeploymentById returns pending rows so rollback can find them", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 5,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    const row = getDeploymentById(db, dep.id);
+    expect(row).toBeDefined();
+    expect(row?.state).toBe("pending");
+  });
+
+  it("activateDeployment flips pending → active", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 6,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    activateDeployment(db, dep.id);
+    const row = getDeploymentById(db, dep.id);
+    expect(row?.state).toBe("active");
+  });
+
+  it("activateDeployment makes the row visible to list queries", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 7,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    expect(getDeploymentsForIssue(db, repoId, 7)).toHaveLength(0);
+    activateDeployment(db, dep.id);
+    expect(getDeploymentsForIssue(db, repoId, 7)).toHaveLength(1);
+  });
+
+  it("activateDeployment throws when no pending row exists", () => {
+    // Active rows cannot be re-activated
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 8,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    expect(() => activateDeployment(db, dep.id)).toThrow(
+      /No pending deployment/,
+    );
+    expect(() => activateDeployment(db, 99999)).toThrow(/No pending deployment/);
+  });
+
+  it("deletePendingDeployment removes a pending row as a rollback", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 9,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    deletePendingDeployment(db, dep.id);
+    expect(getDeploymentById(db, dep.id)).toBeUndefined();
+  });
+
+  it("deletePendingDeployment refuses to delete an active row", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 10,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    expect(() => deletePendingDeployment(db, dep.id)).toThrow(
+      /No pending deployment/,
+    );
+    // Active row should still be there
+    expect(getDeploymentById(db, dep.id)).toBeDefined();
   });
 });

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import type { Deployment } from "../types.js";
+import type { Deployment, DeploymentState } from "../types.js";
 
 type DeploymentRow = {
   id: number;
@@ -9,6 +9,7 @@ type DeploymentRow = {
   workspace_mode: string;
   workspace_path: string;
   linked_pr_number: number | null;
+  state: string;
   launched_at: string;
   ended_at: string | null;
 };
@@ -22,6 +23,7 @@ function rowToDeployment(row: DeploymentRow): Deployment {
     workspaceMode: row.workspace_mode as Deployment["workspaceMode"],
     workspacePath: row.workspace_path,
     linkedPrNumber: row.linked_pr_number,
+    state: (row.state as DeploymentState) ?? "active",
     launchedAt: row.launched_at,
     endedAt: row.ended_at,
   };
@@ -35,12 +37,21 @@ export function recordDeployment(
     branchName: string;
     workspaceMode: Deployment["workspaceMode"];
     workspacePath: string;
+    /**
+     * Optional initial state. Defaults to "active" for callers that want
+     * the legacy one-shot write. The launch flow passes "pending" so the
+     * row stays invisible to the UI and reconciler until `activateDeployment`
+     * flips it after the terminal opens — or `deleteDeployment` unwinds
+     * it after a launch failure.
+     */
+    state?: DeploymentState;
   },
 ): Deployment {
+  const state: DeploymentState = deployment.state ?? "active";
   const result = db
     .prepare(
-      `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, state)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     )
     .run(
       deployment.repoId,
@@ -48,6 +59,7 @@ export function recordDeployment(
       deployment.branchName,
       deployment.workspaceMode,
       deployment.workspacePath,
+      state,
     );
 
   const inserted = getDeploymentById(db, Number(result.lastInsertRowid));
@@ -70,9 +82,14 @@ export function getDeploymentsForIssue(
   repoId: number,
   issueNumber: number,
 ): Deployment[] {
+  // Filter out "pending" rows — they represent in-flight launches whose
+  // terminal hasn't opened yet. UI components, the lifecycle reconciler,
+  // and the unified list all call this and should never see a pending
+  // deployment. The rollback path in executeLaunch holds the ID directly
+  // and uses getDeploymentById, which bypasses this filter.
   const rows = db
     .prepare(
-      "SELECT * FROM deployments WHERE repo_id = ? AND issue_number = ? ORDER BY launched_at DESC",
+      "SELECT * FROM deployments WHERE repo_id = ? AND issue_number = ? AND state = 'active' ORDER BY launched_at DESC",
     )
     .all(repoId, issueNumber) as DeploymentRow[];
   return rows.map(rowToDeployment);
@@ -82,9 +99,11 @@ export function getDeploymentsByRepo(
   db: Database.Database,
   repoId: number,
 ): Deployment[] {
+  // See getDeploymentsForIssue — pending rows are excluded from all
+  // callers except the launch rollback path.
   const rows = db
     .prepare(
-      "SELECT * FROM deployments WHERE repo_id = ? ORDER BY launched_at DESC",
+      "SELECT * FROM deployments WHERE repo_id = ? AND state = 'active' ORDER BY launched_at DESC",
     )
     .all(repoId) as DeploymentRow[];
   return rows.map(rowToDeployment);
@@ -114,5 +133,48 @@ export function endDeployment(
     .run(deploymentId);
   if (result.changes === 0) {
     throw new Error(`No deployment found with id ${deploymentId}`);
+  }
+}
+
+/**
+ * Flip a "pending" deployment to "active". Called by executeLaunch once
+ * the terminal has successfully opened. Throws if the row doesn't exist
+ * or isn't pending — both indicate a programming error in the launch
+ * flow, not a runtime condition to recover from.
+ */
+export function activateDeployment(
+  db: Database.Database,
+  deploymentId: number,
+): void {
+  const result = db
+    .prepare(
+      "UPDATE deployments SET state = 'active' WHERE id = ? AND state = 'pending'",
+    )
+    .run(deploymentId);
+  if (result.changes === 0) {
+    throw new Error(
+      `No pending deployment found with id ${deploymentId} to activate`,
+    );
+  }
+}
+
+/**
+ * Delete a "pending" deployment row. Called by executeLaunch's rollback
+ * path when the terminal launch fails after the row was written. This is
+ * safe because pending rows are never visible to the UI or reconciler —
+ * removing one cannot leave dangling references. Throws if the row is
+ * not pending (active or ended rows must go through endDeployment).
+ */
+export function deletePendingDeployment(
+  db: Database.Database,
+  deploymentId: number,
+): void {
+  const result = db
+    .prepare("DELETE FROM deployments WHERE id = ? AND state = 'pending'")
+    .run(deploymentId);
+  if (result.changes === 0) {
+    throw new Error(
+      `No pending deployment found with id ${deploymentId} to delete`,
+    );
   }
 }

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -81,6 +81,23 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 6,
+    up(db) {
+      // R2: deployments now have an explicit lifecycle state. "pending"
+      // covers the narrow window during executeLaunch between writing the
+      // DB row and the terminal actually opening — if the terminal launch
+      // fails, the launch flow deletes the pending row as a clean rollback.
+      // Existing rows migrate to "active" (they pre-date the state column
+      // and are already live).
+      //
+      // SQLite can't ADD COLUMN with a CHECK constraint, so we add the
+      // column with a DEFAULT and rely on the application layer to insert
+      // only valid values going forward. The CREATE TABLE for fresh
+      // installs in schema.ts does include the CHECK constraint.
+      db.exec(`ALTER TABLE deployments ADD COLUMN state TEXT NOT NULL DEFAULT 'active';`);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -32,15 +32,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 5", () => {
+  it("sets schema_version to 6", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
   });
 });
 
@@ -57,10 +57,10 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
   });
 
-  it("migrates v1 schema through v5 and drops claude_aliases", () => {
+  it("migrates v1 schema through v6 and drops claude_aliases", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -73,14 +73,14 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v2 schema to v5 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata)", () => {
+  it("migrates v2 schema to v6 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE claude_aliases (id INTEGER PRIMARY KEY, command TEXT, description TEXT, is_default INTEGER, created_at TEXT);
@@ -91,7 +91,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -99,7 +99,7 @@ describe("runMigrations", () => {
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v3 schema to v5 and drops populated claude_aliases (data loss is intentional)", () => {
+  it("migrates v3 schema to v6 and drops populated claude_aliases (data loss is intentional)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -134,7 +134,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -150,10 +150,10 @@ describe("runMigrations", () => {
 });
 
 describe("schema v5 — drafts and issue_metadata", () => {
-  it("initSchema on a fresh DB produces schema version 5", () => {
+  it("initSchema on a fresh DB produces schema version 6", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -187,9 +187,10 @@ describe("schema v5 — drafts and issue_metadata", () => {
     ).toThrow();
   });
 
-  it("migration from v4 → v5 adds drafts and issue_metadata to an existing DB", () => {
+  it("migration from v4 → v6 adds drafts, issue_metadata, and deployments.state", () => {
     const db = createRawTestDb();
-    // Simulate a v4 DB: run the v4-era schema manually
+    // Simulate a v4 DB: run the v4-era schema manually. The deployments
+    // table is included here because v6's migration does ALTER TABLE on it.
     db.exec(`
       CREATE TABLE schema_version (version INTEGER NOT NULL);
       INSERT INTO schema_version (version) VALUES (4);
@@ -202,12 +203,23 @@ describe("schema v5 — drafts and issue_metadata", () => {
         created_at TEXT NOT NULL DEFAULT (datetime('now')),
         UNIQUE(owner, name)
       );
+      CREATE TABLE deployments (
+        id INTEGER PRIMARY KEY,
+        repo_id INTEGER,
+        issue_number INTEGER,
+        branch_name TEXT,
+        workspace_mode TEXT,
+        workspace_path TEXT,
+        linked_pr_number INTEGER,
+        launched_at TEXT,
+        ended_at TEXT
+      );
     `);
     expect(getSchemaVersion(db)).toBe(4);
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(5);
+    expect(getSchemaVersion(db)).toBe(6);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -220,5 +232,12 @@ describe("schema v5 — drafts and issue_metadata", () => {
       )
       .get();
     expect(meta).toBeDefined();
+    // v6 ALTER should have added the state column with default 'active'
+    const cols = db
+      .prepare("PRAGMA table_info(deployments)")
+      .all() as { name: string; dflt_value: string | null }[];
+    const stateCol = cols.find((c) => c.name === "state");
+    expect(stateCol).toBeDefined();
+    expect(stateCol?.dflt_value).toContain("active");
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 5;
+const SCHEMA_VERSION = 6;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -26,6 +26,8 @@ const CREATE_TABLES = `
     workspace_mode   TEXT NOT NULL,
     workspace_path   TEXT NOT NULL,
     linked_pr_number INTEGER,
+    state            TEXT NOT NULL DEFAULT 'active'
+                     CHECK (state IN ('pending', 'active')),
     launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
     ended_at         TEXT
   );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type {
   Setting,
   SettingKey,
   Deployment,
+  DeploymentState,
   CacheEntry,
   Draft,
   DraftInput,
@@ -56,6 +57,8 @@ export {
   getDeploymentsByRepo,
   updateLinkedPR,
   endDeployment,
+  activateDeployment,
+  deletePendingDeployment,
 } from "./db/deployments.js";
 export {
   getCacheTtl,

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -2,7 +2,11 @@ import type Database from "better-sqlite3";
 import type { Octokit } from "@octokit/rest";
 import { getRepo } from "../db/repos.js";
 import { getSetting } from "../db/settings.js";
-import { recordDeployment } from "../db/deployments.js";
+import {
+  recordDeployment,
+  activateDeployment,
+  deletePendingDeployment,
+} from "../db/deployments.js";
 import { getIssueDetail } from "../data/issues.js";
 import { ensureLifecycleLabels, addLabel } from "../github/labels.js";
 import { LIFECYCLE_LABEL } from "../github/labels.js";
@@ -161,13 +165,16 @@ export async function executeLaunch(
     console.warn("[issuectl] Failed to apply deployed label after retries:", err);
   }
 
-  // 8. Record deployment in DB
+  // 8. Record deployment in DB as pending. This row is INVISIBLE to the
+  // UI and reconciler until step 9 succeeds — if the terminal launch
+  // fails, we delete the row in the catch and no one ever saw it.
   const deployment = recordDeployment(db, {
     repoId: repoRecord.id,
     issueNumber: options.issueNumber,
     branchName: options.branchName,
     workspaceMode: options.workspaceMode,
     workspacePath: workspace.path,
+    state: "pending",
   });
 
   // 9. Open terminal
@@ -178,15 +185,36 @@ export async function executeLaunch(
   // value looks dangerous, we fall back to plain "claude" and log a warning.
   const claudeCommand = buildClaudeCommand(getSetting(db, "claude_extra_args"));
   console.warn(`[issuectl] launching: ${claudeCommand}`);
-  await launcher.launch({
-    workspacePath: workspace.path,
-    contextFilePath,
-    issueNumber: options.issueNumber,
-    issueTitle: detail.issue.title,
-    owner: options.owner,
-    repo: options.repo,
-    claudeCommand,
-  });
+  try {
+    await launcher.launch({
+      workspacePath: workspace.path,
+      contextFilePath,
+      issueNumber: options.issueNumber,
+      issueTitle: detail.issue.title,
+      owner: options.owner,
+      repo: options.repo,
+      claudeCommand,
+    });
+  } catch (err) {
+    // Terminal launch failed — unwind the pending deployment row so the
+    // UI doesn't show a phantom active session. The workspace artifacts
+    // (branch, worktree/clone directory) stay put since they may be
+    // valuable; only the DB state is rolled back.
+    try {
+      deletePendingDeployment(db, deployment.id);
+    } catch (rollbackErr) {
+      console.error(
+        "[issuectl] Failed to roll back pending deployment after launch failure",
+        { deploymentId: deployment.id },
+        rollbackErr,
+      );
+    }
+    throw err;
+  }
+
+  // 9b. Flip pending → active. The deployment is now visible to the UI
+  // and reconciler.
+  activateDeployment(db, deployment.id);
 
   // 10. Return result
   return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,8 @@ export type Setting = {
 import type { WorkspaceMode } from "./launch/workspace.js";
 import type { GitHubIssue } from "./github/types.js";
 
+export type DeploymentState = "pending" | "active";
+
 export type Deployment = {
   id: number;
   repoId: number;
@@ -32,6 +34,14 @@ export type Deployment = {
   workspaceMode: WorkspaceMode;
   workspacePath: string;
   linkedPrNumber: number | null;
+  /**
+   * Lifecycle state of the deployment row. "pending" is a transient
+   * staging state used only by the launch flow — written before the
+   * terminal is opened and flipped to "active" on success (or deleted
+   * on failure). UI and reconciler queries filter out pending rows;
+   * only the rollback path in executeLaunch sees them.
+   */
+  state: DeploymentState;
   launchedAt: string;
   endedAt: string | null;
 };


### PR DESCRIPTION
**Stacked on #55** (base: \`fix/resilience-phase3\`). Do not merge until #54 and #55 land; then rebase this onto main.

Phase 4 of the resilience-audit triage queue. Closes **R2**, the second Critical finding from the audit: \`executeLaunch\` wrote the deployment row unconditionally, so a failure in the terminal-launch step left a phantom "active" deployment in the UI that the reconciler could not clean up.

## What changed

- **Schema version 6** — migration adds a \`state\` column to \`deployments\` with values \`'pending' | 'active'\`. Existing rows migrate to \`'active'\` (already live by definition). Fresh installs get the \`CHECK\` constraint; migrated DBs rely on the application layer since SQLite's ALTER TABLE can't carry a CHECK constraint.

- **Deployment lifecycle** (\`packages/core/src/db/deployments.ts\`).
  - \`recordDeployment\` takes an optional \`state\` field, defaulting to \`'active'\`.
  - \`getDeploymentsForIssue\` and \`getDeploymentsByRepo\` filter out pending rows — UI, reconciler, and unified-list never see a half-launched deployment.
  - \`getDeploymentById\` returns pending rows unchanged so the rollback path can find them by id.
  - New \`activateDeployment(id)\` — flips pending → active after a successful launch.
  - New \`deletePendingDeployment(id)\` — rollback helper that refuses to delete non-pending rows.

- **\`executeLaunch\` rollback** (\`packages/core/src/launch/launch.ts\`). Steps 8–9 are now a two-phase commit:
  1. \`recordDeployment(…, state: 'pending')\` writes a hidden row
  2. \`launcher.launch(…)\` opens the terminal
  3. On success: \`activateDeployment\` makes it visible
  4. On failure: \`deletePendingDeployment\` unwinds, then rethrows the original error
  
  Workspace artifacts (branch, worktree directory) are preserved on failure — the existing file comment already said "the branch/files may be valuable." A failed rollback is caught + logged separately so it can never mask the real launch error.

## Tests

- **9 new tests** in \`deployments.test.ts\`: default state, pending insert, list-query filtering (×2), getById bypass, activate transition, activate visibility, activate-non-pending error, delete rollback, delete refusal on active rows.
- Updated \`schema.test.ts\` to assert version 6 and extended the v4→v6 migration test to include a deployments table.
- Updated the \`unified-list.test.ts\` fixture with the new \`state\` field.
- **278 core tests pass** (up from 269).

## Test plan

- [x] \`pnpm turbo typecheck\` — 4/4 pass
- [x] \`pnpm turbo test\` — 278 core + 17 web, all green
- [x] \`pnpm turbo lint\` — no new errors; 3 pre-existing + new file-length warnings (deployments.test.ts is 345 lines, 45 over threshold — acceptable for a test file)
- [ ] Manual: trigger launch with Ghostty quit, confirm UI shows "Launch failed" toast AND DB has no row for that deployment afterwards
- [ ] Manual: trigger launch with Ghostty running, confirm normal flow — row appears as active, reconciler picks it up

## What's left

- **R1** (idempotency sentinel) — final stacked PR.