### PR TITLE
fix(resilience): R1 — idempotency sentinel for mutating actions

### DIFF
--- a/packages/core/src/db/idempotency.test.ts
+++ b/packages/core/src/db/idempotency.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import {
+  withIdempotency,
+  pruneExpiredNonces,
+  isValidNonce,
+  DuplicateInFlightError,
+} from "./idempotency.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createTestDb();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isValidNonce", () => {
+  it("accepts UUID v4 format", () => {
+    expect(isValidNonce("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+  });
+
+  it("accepts alphanumeric tokens with common separators", () => {
+    expect(isValidNonce("abc123def456")).toBe(true);
+    expect(isValidNonce("a.b-c_d.1234")).toBe(true);
+  });
+
+  it("rejects too-short tokens", () => {
+    expect(isValidNonce("abc")).toBe(false);
+    expect(isValidNonce("1234567")).toBe(false);
+  });
+
+  it("rejects too-long tokens", () => {
+    expect(isValidNonce("a".repeat(65))).toBe(false);
+  });
+
+  it("rejects tokens with dangerous characters", () => {
+    expect(isValidNonce("abc'; DROP TABLE")).toBe(false);
+    expect(isValidNonce("abc def")).toBe(false);
+    expect(isValidNonce("abc\x00def")).toBe(false);
+  });
+
+  it("rejects non-strings", () => {
+    expect(isValidNonce(null)).toBe(false);
+    expect(isValidNonce(undefined)).toBe(false);
+    expect(isValidNonce(42)).toBe(false);
+    expect(isValidNonce({ nonce: "abc" })).toBe(false);
+  });
+});
+
+describe("withIdempotency", () => {
+  it("runs fn on first call and returns its result", async () => {
+    const fn = vi.fn().mockResolvedValue({ id: 42 });
+    const result = await withIdempotency(db, "test-action", "abcd1234efgh", fn);
+    expect(result).toEqual({ id: 42 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays the stored result on a second call with the same nonce", async () => {
+    const fn = vi.fn().mockResolvedValue({ id: 42, url: "https://x" });
+    await withIdempotency(db, "create-issue", "nonce-111111", fn);
+    const replay = await withIdempotency(db, "create-issue", "nonce-111111", fn);
+    expect(replay).toEqual({ id: 42, url: "https://x" });
+    // fn should only run once, even though we called withIdempotency twice
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the same nonce across different action types", async () => {
+    const fn1 = vi.fn().mockResolvedValue("result-1");
+    const fn2 = vi.fn().mockResolvedValue("result-2");
+    const nonce = "sharednonce123";
+    const r1 = await withIdempotency(db, "action-a", nonce, fn1);
+    const r2 = await withIdempotency(db, "action-b", nonce, fn2);
+    expect(r1).toBe("result-1");
+    expect(r2).toBe("result-2");
+    expect(fn1).toHaveBeenCalledTimes(1);
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+
+  it("reruns fn after a failed attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockResolvedValueOnce("recovered");
+    const nonce = "retryable12345";
+    await expect(
+      withIdempotency(db, "retry-action", nonce, fn),
+    ).rejects.toThrow("first failed");
+    const result = await withIdempotency(db, "retry-action", nonce, fn);
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws DuplicateInFlightError when a pending row exists", () => {
+    // Manually seed a pending row — we can't actually test a concurrent
+    // in-flight call in a single-threaded test, but the sentinel check
+    // is the same code path.
+    db.prepare(
+      `INSERT INTO action_nonces (nonce, action_type, status, created_at) VALUES (?, ?, 'pending', ?)`,
+    ).run("inflight12345", "test", Date.now());
+
+    return expect(
+      withIdempotency(db, "test", "inflight12345", async () => "should-not-run"),
+    ).rejects.toBeInstanceOf(DuplicateInFlightError);
+  });
+
+  it("rejects invalid nonces before touching the DB", async () => {
+    const fn = vi.fn();
+    await expect(
+      withIdempotency(db, "test", "short", fn),
+    ).rejects.toThrow(/Invalid idempotency nonce/);
+    await expect(
+      withIdempotency(db, "test", "abc; DROP TABLE", fn),
+    ).rejects.toThrow(/Invalid idempotency nonce/);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("serializes null and undefined result values", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const nonce = "undefresult123";
+    const r1 = await withIdempotency(db, "void-action", nonce, fn);
+    const r2 = await withIdempotency(db, "void-action", nonce, fn);
+    expect(r1).toBeUndefined();
+    // Replay deserializes null — that's acceptable, the action has no meaningful return value
+    expect(r2 === null || r2 === undefined).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("pruneExpiredNonces", () => {
+  it("removes rows older than the TTL", () => {
+    const oneHourMs = 60 * 60 * 1000;
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO action_nonces (nonce, action_type, status, created_at) VALUES (?, ?, 'completed', ?)`,
+    ).run("oldnonce1234", "test", now - oneHourMs - 1000);
+    db.prepare(
+      `INSERT INTO action_nonces (nonce, action_type, status, created_at) VALUES (?, ?, 'completed', ?)`,
+    ).run("newnonce1234", "test", now);
+
+    const pruned = pruneExpiredNonces(db);
+    expect(pruned).toBe(1);
+
+    const remaining = db
+      .prepare(`SELECT nonce FROM action_nonces`)
+      .all() as { nonce: string }[];
+    expect(remaining.map((r) => r.nonce)).toEqual(["newnonce1234"]);
+  });
+});

--- a/packages/core/src/db/idempotency.ts
+++ b/packages/core/src/db/idempotency.ts
@@ -1,0 +1,156 @@
+import type Database from "better-sqlite3";
+
+/**
+ * Idempotency sentinel for server actions (R1 from the resilience audit).
+ *
+ * Problem: mutating server actions (create issue, add comment, launch, assign
+ * draft) have no built-in dedup. A slow request + user retry + React replay
+ * can produce duplicate GitHub issues, duplicate comments, or duplicate
+ * deployments. There is no natural idempotency key on the GitHub side for
+ * most of these operations.
+ *
+ * Solution: the client generates a UUID per intended submission. The server
+ * claims the (nonce, action_type) pair via `INSERT OR IGNORE` before running
+ * the action, stores the serialized result on completion, and on any future
+ * call with the same nonce either replays the stored result (completed) or
+ * refuses (pending / failed). This turns every mutating action into an
+ * at-most-once operation from the client's perspective — retries are safe.
+ *
+ * Scoping:
+ * - The same nonce can be used by different action types (draftId reused
+ *   across "create" and "assign" is fine).
+ * - Nonces older than 1 hour are pruned on each call; pruning is bounded by
+ *   a primary-key lookup so it can't dominate hot-path latency.
+ * - Failed actions are deleted, not marked — the user can retry with a
+ *   fresh nonce without being blocked by stale sentinels.
+ */
+
+/** Idempotency window — anything older is garbage-collected on next write. */
+const NONCE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Validate a nonce string. Accepts anything that looks like a random token:
+ * 8-64 chars of URL-safe characters. We don't enforce a specific UUID format
+ * so CLI callers can pass their own scheme, but we do bound the length to
+ * prevent unbounded-string inserts from an untrusted client.
+ */
+export function isValidNonce(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 8 &&
+    value.length <= 64 &&
+    /^[A-Za-z0-9._-]+$/.test(value)
+  );
+}
+
+type SentinelRow = {
+  status: string;
+  result_json: string | null;
+};
+
+export class DuplicateInFlightError extends Error {
+  readonly actionType: string;
+  readonly nonce: string;
+  constructor(actionType: string, nonce: string) {
+    super(`Action "${actionType}" is already in flight for this request`);
+    this.name = "DuplicateInFlightError";
+    this.actionType = actionType;
+    this.nonce = nonce;
+  }
+}
+
+/**
+ * Run `fn`, gated by an idempotency sentinel. On first call with a given
+ * (actionType, nonce) pair, runs the function, stores the result, and
+ * returns it. On a repeat call with the same pair:
+ *   - If the previous call completed successfully, returns the stored result
+ *     without re-running `fn` (the replay case).
+ *   - If the previous call is still in flight, throws `DuplicateInFlightError`
+ *     — the caller is expected to surface this as a "request already in
+ *     progress" message rather than re-invoking.
+ *   - If the previous call failed, deletes the sentinel and re-runs `fn`
+ *     (failures should not wedge the nonce forever).
+ *
+ * The result is serialized via `JSON.stringify`, so callers must only use
+ * this with JSON-serializable return values.
+ */
+export async function withIdempotency<T>(
+  db: Database.Database,
+  actionType: string,
+  nonce: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!isValidNonce(nonce)) {
+    throw new Error(`Invalid idempotency nonce: ${JSON.stringify(nonce)}`);
+  }
+
+  pruneExpiredNonces(db);
+
+  // Atomic claim: INSERT OR IGNORE either succeeds (we own the action) or
+  // does nothing (a row already exists with this key). No race window.
+  const claim = db
+    .prepare(
+      `INSERT OR IGNORE INTO action_nonces (nonce, action_type, status, created_at)
+       VALUES (?, ?, 'pending', ?)`,
+    )
+    .run(nonce, actionType, Date.now());
+
+  if (claim.changes === 0) {
+    // Existing row — check its state.
+    const existing = db
+      .prepare(
+        `SELECT status, result_json FROM action_nonces WHERE nonce = ? AND action_type = ?`,
+      )
+      .get(nonce, actionType) as SentinelRow | undefined;
+
+    if (!existing) {
+      // Row disappeared between INSERT OR IGNORE and SELECT — another
+      // caller deleted a failed row. Fall through to a fresh claim.
+      return withIdempotency(db, actionType, nonce, fn);
+    }
+
+    if (existing.status === "completed" && existing.result_json !== null) {
+      return JSON.parse(existing.result_json) as T;
+    }
+
+    if (existing.status === "pending") {
+      throw new DuplicateInFlightError(actionType, nonce);
+    }
+
+    // status === 'failed' — remove the sentinel so the retry gets a fresh
+    // run. We recurse once; a second-pass failure will hit this branch
+    // again only if another concurrent caller re-wrote it, which is fine.
+    db.prepare(
+      `DELETE FROM action_nonces WHERE nonce = ? AND action_type = ?`,
+    ).run(nonce, actionType);
+    return withIdempotency(db, actionType, nonce, fn);
+  }
+
+  try {
+    const result = await fn();
+    db.prepare(
+      `UPDATE action_nonces SET status = 'completed', result_json = ?
+       WHERE nonce = ? AND action_type = ?`,
+    ).run(JSON.stringify(result ?? null), nonce, actionType);
+    return result;
+  } catch (err) {
+    db.prepare(
+      `UPDATE action_nonces SET status = 'failed'
+       WHERE nonce = ? AND action_type = ?`,
+    ).run(nonce, actionType);
+    throw err;
+  }
+}
+
+/**
+ * Delete nonce rows older than the TTL. Cheap — the index on created_at
+ * makes this a bounded range scan. Called on every write so the table
+ * never grows unbounded, without needing a background cleanup job.
+ */
+export function pruneExpiredNonces(db: Database.Database): number {
+  const cutoff = Date.now() - NONCE_TTL_MS;
+  const info = db
+    .prepare(`DELETE FROM action_nonces WHERE created_at < ?`)
+    .run(cutoff);
+  return info.changes;
+}

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -98,6 +98,31 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE deployments ADD COLUMN state TEXT NOT NULL DEFAULT 'active';`);
     },
   },
+  {
+    version: 7,
+    up(db) {
+      // R1: action_nonces table backs the idempotency sentinel. A client
+      // generates a UUID per submission; the server claims the (nonce,
+      // action_type) pair via INSERT OR IGNORE before running the action
+      // and stores the serialized result on completion. A second call
+      // with the same nonce either replays the stored result (completed)
+      // or refuses (pending / failed). Cleanup runs opportunistically
+      // on writes — rows older than 1 hour are pruned.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS action_nonces (
+          nonce       TEXT NOT NULL,
+          action_type TEXT NOT NULL,
+          status      TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending', 'completed', 'failed')),
+          result_json TEXT,
+          created_at  INTEGER NOT NULL,
+          PRIMARY KEY (nonce, action_type)
+        );
+        CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
+          ON action_nonces(created_at);
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -22,6 +22,7 @@ describe("initSchema", () => {
 
     const names = tables.map((t) => t.name);
     expect(names).toEqual([
+      "action_nonces",
       "cache",
       "deployments",
       "drafts",
@@ -32,15 +33,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 6", () => {
+  it("sets schema_version to 7", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
   });
 });
 
@@ -57,10 +58,10 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
   });
 
-  it("migrates v1 schema through v6 and drops claude_aliases", () => {
+  it("migrates v1 schema through v7 and drops claude_aliases", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -73,14 +74,14 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v2 schema to v6 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state)", () => {
+  it("migrates v2 schema to v7 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE claude_aliases (id INTEGER PRIMARY KEY, command TEXT, description TEXT, is_default INTEGER, created_at TEXT);
@@ -91,7 +92,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -99,7 +100,7 @@ describe("runMigrations", () => {
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v3 schema to v6 and drops populated claude_aliases (data loss is intentional)", () => {
+  it("migrates v3 schema to v7 and drops populated claude_aliases (data loss is intentional)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -134,7 +135,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -150,10 +151,10 @@ describe("runMigrations", () => {
 });
 
 describe("schema v5 — drafts and issue_metadata", () => {
-  it("initSchema on a fresh DB produces schema version 6", () => {
+  it("initSchema on a fresh DB produces schema version 7", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -187,7 +188,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
     ).toThrow();
   });
 
-  it("migration from v4 → v6 adds drafts, issue_metadata, and deployments.state", () => {
+  it("migration from v4 → v7 adds drafts, issue_metadata, deployments.state, and action_nonces", () => {
     const db = createRawTestDb();
     // Simulate a v4 DB: run the v4-era schema manually. The deployments
     // table is included here because v6's migration does ALTER TABLE on it.
@@ -219,7 +220,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -56,6 +56,19 @@ const CREATE_TABLES = `
     updated_at   INTEGER NOT NULL,
     PRIMARY KEY (repo_id, issue_number)
   );
+
+  CREATE TABLE IF NOT EXISTS action_nonces (
+    nonce       TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'completed', 'failed')),
+    result_json TEXT,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (nonce, action_type)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
+    ON action_nonces(created_at);
 
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,12 @@ export {
   clearCacheKey,
   clearCache,
 } from "./db/cache.js";
+export {
+  withIdempotency,
+  pruneExpiredNonces,
+  isValidNonce,
+  DuplicateInFlightError,
+} from "./db/idempotency.js";
 // GitHub client
 export type {
   GitHubUser,

--- a/packages/web/components/issue/CommentForm.tsx
+++ b/packages/web/components/issue/CommentForm.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { addComment } from "@/lib/actions/comments";
 import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import styles from "./CommentForm.module.css";
 
 type Props = {
@@ -21,10 +22,11 @@ export function CommentForm({ owner, repo, issueNumber }: Props) {
   function handleSubmit() {
     if (!body.trim()) return;
     const text = body;
+    const idempotencyKey = newIdempotencyKey();
     setBody("");
     setError(null);
     startTransition(async () => {
-      const result = await addComment(owner, repo, issueNumber, text);
+      const result = await addComment(owner, repo, issueNumber, text, idempotencyKey);
       if (!result.success) {
         setBody(text);
         setError(result.error ?? "Failed to post comment. Please try again.");

--- a/packages/web/components/issue/CreateIssueModal.tsx
+++ b/packages/web/components/issue/CreateIssueModal.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/ui/Modal";
 import { useToast } from "@/components/ui/ToastProvider";
 import { Button } from "@/components/paper";
 import type { RepoOption } from "@/lib/types";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import { LabelSelector } from "./LabelSelector";
 import styles from "./CreateIssueModal.module.css";
 
@@ -45,6 +46,11 @@ export function CreateIssueModal({
 
   function handleSubmit() {
     setError(null);
+    // A fresh nonce per click — a replay at the server layer (proxy,
+    // React internal retry, etc.) sees the same nonce and returns the
+    // stored result; a genuine retry after a failure also gets a fresh
+    // nonce because this function runs again.
+    const idempotencyKey = newIdempotencyKey();
     startTransition(async () => {
       const result = await createIssue({
         owner: selectedRepo.owner,
@@ -52,6 +58,7 @@ export function CreateIssueModal({
         title,
         body: body || undefined,
         labels: selectedLabels.length > 0 ? selectedLabels : undefined,
+        idempotencyKey,
       });
 
       if (!result.success) {

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -13,6 +13,7 @@ import { launchIssue } from "@/lib/actions/launch";
 import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
 import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import { BranchInput } from "./BranchInput";
 import { WorkspaceModeSelector } from "./WorkspaceModeSelector";
 import { ContextToggles } from "./ContextToggles";
@@ -82,6 +83,7 @@ export function LaunchModal({
 
   function handleLaunch() {
     setError(null);
+    const idempotencyKey = newIdempotencyKey();
     startTransition(async () => {
       const result = await launchIssue({
         owner,
@@ -92,6 +94,7 @@ export function LaunchModal({
         selectedCommentIndices: selectedComments,
         selectedFilePaths: selectedFiles,
         preamble: preamble.trim() || undefined,
+        idempotencyKey,
       });
 
       if (!result.success) {

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Sheet, Button } from "@/components/paper";
 import { listReposAction, assignDraftAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import styles from "./AssignSheet.module.css";
 
 type Repo = { id: number; owner: string; name: string };
@@ -35,8 +36,9 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
   const handleAssign = async (repoId: number) => {
     setAssigning(repoId);
     setError(null);
+    const idempotencyKey = newIdempotencyKey();
     try {
-      const result = await assignDraftAction(draftId, repoId);
+      const result = await assignDraftAction(draftId, repoId, idempotencyKey);
       if (!result.success) {
         setError(result.error);
         return;

--- a/packages/web/lib/actions/comments.ts
+++ b/packages/web/lib/actions/comments.ts
@@ -5,6 +5,8 @@ import {
   getRepo,
   addComment as coreAddComment,
   withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
   formatErrorForUser,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
@@ -16,6 +18,7 @@ export async function addComment(
   repo: string,
   issueNumber: number,
   body: string,
+  idempotencyKey?: string,
 ): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (!owner || !repo || issueNumber <= 0 || !body.trim()) {
     return { success: false, error: "Invalid input" };
@@ -32,10 +35,24 @@ export async function addComment(
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    await withAuthRetry((octokit) =>
-      coreAddComment(db, octokit, owner, repo, issueNumber, body),
-    );
+    const runAddComment = async () => {
+      await withAuthRetry((octokit) =>
+        coreAddComment(db, octokit, owner, repo, issueNumber, body),
+      );
+      return null;
+    };
+    if (idempotencyKey) {
+      await withIdempotency(db, "add-comment", idempotencyKey, runAddComment);
+    } else {
+      await runAddComment();
+    }
   } catch (err) {
+    if (err instanceof DuplicateInFlightError) {
+      return {
+        success: false,
+        error: "This comment is already being posted — please wait.",
+      };
+    }
     console.error("[issuectl] Failed to add comment:", err);
     return { success: false, error: formatErrorForUser(err) };
   }

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -7,6 +7,8 @@ import {
   listRepos,
   updateDraft,
   withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
   formatErrorForUser,
   DraftPartialCommitError,
   type DraftInput,
@@ -130,6 +132,7 @@ export async function updateDraftAction(
 export async function assignDraftAction(
   draftId: string,
   repoId: number,
+  idempotencyKey?: string,
 ): Promise<
   | {
       success: true;
@@ -160,32 +163,54 @@ export async function assignDraftAction(
   let cleanupWarning: string | undefined;
   try {
     const db = getDb();
-    const result = await withAuthRetry((octokit) =>
-      assignDraftToRepo(db, octokit, draftId, repoId),
-    );
+    const runAssign = async () => {
+      try {
+        const result = await withAuthRetry((octokit) =>
+          assignDraftToRepo(db, octokit, draftId, repoId),
+        );
+        return {
+          issueNumber: result.issueNumber,
+          issueUrl: result.issueUrl,
+          cleanupWarning: null as string | null,
+        };
+      } catch (err) {
+        if (err instanceof DraftPartialCommitError) {
+          // The GitHub issue exists — return it as a "success with warning"
+          // so the idempotency sentinel stores it as completed and a retry
+          // replays the same issueNumber rather than creating a duplicate.
+          console.warn(
+            "[issuectl] assignDraftAction partial commit",
+            { draftId, repoId, issueNumber: err.issueNumber },
+            err,
+          );
+          return {
+            issueNumber: err.issueNumber,
+            issueUrl: err.issueUrl,
+            cleanupWarning: err.message,
+          };
+        }
+        throw err;
+      }
+    };
+    const result = idempotencyKey
+      ? await withIdempotency(db, "assign-draft", idempotencyKey, runAssign)
+      : await runAssign();
     issueNumber = result.issueNumber;
     issueUrl = result.issueUrl;
+    cleanupWarning = result.cleanupWarning ?? undefined;
   } catch (err) {
-    if (err instanceof DraftPartialCommitError) {
-      // The GitHub issue exists — surface it as a success with a cleanup
-      // warning rather than a hard failure. The user needs the link to
-      // find their work.
-      console.warn(
-        "[issuectl] assignDraftAction partial commit",
-        { draftId, repoId, issueNumber: err.issueNumber },
-        err,
-      );
-      issueNumber = err.issueNumber;
-      issueUrl = err.issueUrl;
-      cleanupWarning = err.message;
-    } else {
-      console.error(
-        "[issuectl] assignDraftAction failed",
-        { draftId, repoId },
-        err,
-      );
-      return { success: false, error: formatErrorForUser(err) };
+    if (err instanceof DuplicateInFlightError) {
+      return {
+        success: false,
+        error: "This draft is already being assigned — please wait.",
+      };
     }
+    console.error(
+      "[issuectl] assignDraftAction failed",
+      { draftId, repoId },
+      err,
+    );
+    return { success: false, error: formatErrorForUser(err) };
   }
 
   const { stale } = revalidateSafely("/");

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -10,6 +10,8 @@ import {
   removeLabel as coreRemoveLabel,
   clearCacheKey,
   withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
   formatErrorForUser,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
@@ -23,13 +25,20 @@ export async function createIssue(data: {
   title: string;
   body?: string;
   labels?: string[];
+  /**
+   * Idempotency nonce — optional but strongly recommended for any
+   * client-originated call. If present, a second call with the same nonce
+   * replays the stored result rather than creating a duplicate issue on
+   * GitHub. Generated client-side via `crypto.randomUUID()` per submission.
+   */
+  idempotencyKey?: string;
 }): Promise<{
   success: boolean;
   issueNumber?: number;
   error?: string;
   cacheStale?: true;
 }> {
-  const { owner, repo, title, body, labels } = data;
+  const { owner, repo, title, body, labels, idempotencyKey } = data;
   if (!owner || !repo || !title.trim()) {
     return { success: false, error: "Owner, repo, and title are required" };
   }
@@ -46,16 +55,28 @@ export async function createIssue(data: {
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
-    const issue = await withAuthRetry((octokit) =>
-      coreCreateIssue(octokit, owner, repo, {
-        title: title.trim(),
-        body: body?.trim() || undefined,
-        labels,
-      }),
-    );
-    clearCacheKey(db, `issues:${owner}/${repo}`);
-    issueNumber = issue.number;
+    const runCreate = async () => {
+      const issue = await withAuthRetry((octokit) =>
+        coreCreateIssue(octokit, owner, repo, {
+          title: title.trim(),
+          body: body?.trim() || undefined,
+          labels,
+        }),
+      );
+      clearCacheKey(db, `issues:${owner}/${repo}`);
+      return { number: issue.number };
+    };
+    const result = idempotencyKey
+      ? await withIdempotency(db, "create-issue", idempotencyKey, runCreate)
+      : await runCreate();
+    issueNumber = result.number;
   } catch (err) {
+    if (err instanceof DuplicateInFlightError) {
+      return {
+        success: false,
+        error: "This issue is already being created — please wait.",
+      };
+    }
     console.error("[issuectl] Failed to create issue:", err);
     return { success: false, error: formatErrorForUser(err) };
   }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -6,6 +6,8 @@ import {
   executeLaunch,
   endDeployment as coreEndDeployment,
   withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
   formatErrorForUser,
   type WorkspaceMode,
 } from "@issuectl/core";
@@ -20,6 +22,7 @@ type LaunchFormData = {
   selectedCommentIndices: number[];
   selectedFilePaths: string[];
   preamble?: string;
+  idempotencyKey?: string;
 };
 
 type LaunchResponse = {
@@ -74,21 +77,36 @@ export async function launchIssue(
       return { success: false, error: "Repository is not tracked" };
     }
 
-    const result = await withAuthRetry((octokit) =>
-      executeLaunch(db, octokit, {
-        owner,
-        repo,
-        issueNumber,
-        branchName: trimmedBranch,
-        workspaceMode,
-        selectedComments: formData.selectedCommentIndices,
-        selectedFiles: formData.selectedFilePaths,
-        preamble: formData.preamble || undefined,
-      }),
-    );
+    const runLaunch = async () => {
+      const r = await withAuthRetry((octokit) =>
+        executeLaunch(db, octokit, {
+          owner,
+          repo,
+          issueNumber,
+          branchName: trimmedBranch,
+          workspaceMode,
+          selectedComments: formData.selectedCommentIndices,
+          selectedFiles: formData.selectedFilePaths,
+          preamble: formData.preamble || undefined,
+        }),
+      );
+      return {
+        deploymentId: r.deploymentId,
+        labelWarning: r.labelWarning ?? null,
+      };
+    };
+    const result = formData.idempotencyKey
+      ? await withIdempotency(db, "launch-issue", formData.idempotencyKey, runLaunch)
+      : await runLaunch();
     deploymentId = result.deploymentId;
-    labelWarning = result.labelWarning;
+    labelWarning = result.labelWarning ?? undefined;
   } catch (err) {
+    if (err instanceof DuplicateInFlightError) {
+      return {
+        success: false,
+        error: "This launch is already in progress — please wait.",
+      };
+    }
     console.error("[issuectl] Launch failed:", err);
     return { success: false, error: formatErrorForUser(err) };
   }

--- a/packages/web/lib/idempotency-key.ts
+++ b/packages/web/lib/idempotency-key.ts
@@ -1,0 +1,17 @@
+/**
+ * Generate a short random token for action idempotency. The server-side
+ * `withIdempotency` helper accepts 8–64-char URL-safe strings; `randomUUID`
+ * returns 36 chars matching that constraint.
+ *
+ * Falls back to a timestamp-derived token on platforms without the Web
+ * Crypto API (none in practice — Next.js runs on Node 20+ where
+ * `crypto.randomUUID` is always available — but the fallback avoids
+ * runtime crashes during SSR warm-up or tests).
+ */
+export function newIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const rand = Math.random().toString(36).slice(2, 14);
+  return `${Date.now().toString(36)}-${rand}`;
+}


### PR DESCRIPTION
**Stacked on #56** (base: \`fix/resilience-phase4\`). Do not merge until #54, #55, and #56 land; then rebase this onto main. **This is the final PR of the resilience-audit triage queue.**

Closes R1, the original Critical finding from qa-reports/resilience-audit.md: mutating server actions had no deduplication, so a slow request + user retry + React replay could produce duplicate GitHub issues, duplicate comments, duplicate deployments, and duplicate draft assignments.

## How it works

Client generates a UUID per submission via \`crypto.randomUUID()\` and passes it to the action as \`idempotencyKey\`. The action wraps its core work in \`withIdempotency(db, actionType, nonce, fn)\`:

- **\`INSERT OR IGNORE\`** claims the \`(nonce, action_type)\` pair atomically. If the claim wins, \`fn\` runs and the JSON-serialized result is stored. If the claim loses and the existing row is \`'completed'\`, the stored result is replayed without re-running \`fn\` — the duplicate call returns the exact same issueNumber/deploymentId the first call returned.
- If the existing row is \`'pending'\`, \`DuplicateInFlightError\` is thrown and the action surfaces *"This action is already in progress."*
- If the existing row is \`'failed'\`, the sentinel is deleted and \`fn\` reruns — failed attempts should not wedge the nonce forever.

## Storage

- New \`action_nonces\` table (schema v7), PK \`(nonce, action_type)\`, index on \`created_at\`.
- Rows older than 1 hour pruned on every write via \`pruneExpiredNonces\` — bounded range scan, no background job.
- Nonces are 8–64 chars of \`[A-Za-z0-9._-]\`. Server rejects anything else before touching the DB.

## Wired into

| Action | Action type key | Client component |
|---|---|---|
| \`createIssue\` | \`create-issue\` | CreateIssueModal |
| \`addComment\` | \`add-comment\` | CommentForm |
| \`launchIssue\` | \`launch-issue\` | LaunchModal |
| \`assignDraftAction\` | \`assign-draft\` | AssignSheet |

For \`assign-draft\`, the DraftPartialCommitError recovery path from R4 now runs *inside* the sentinel — a replay after a partial commit returns the same issueNumber + cleanupWarning instead of attempting re-creation.

All four actions are backward-compatible — the \`idempotencyKey\` parameter is optional, so legacy callers (CLI, tests, internal tooling) keep working without it.

## Client helper

\`packages/web/lib/idempotency-key.ts\` — \`newIdempotencyKey()\` uses \`crypto.randomUUID()\` with a timestamp-derived fallback for environments without Web Crypto. A new click = a new nonce (intentional fresh attempt); a React internal retry or proxy replay of the same click uses the same nonce (idempotent).

## Tests

- **14 new tests** in \`idempotency.test.ts\`: nonce validation, run-on-first-call, replay-on-second-call, scoping across action types, rerun-after-failure, DuplicateInFlightError on pending, invalid-nonce rejection, null/undefined result serialization, TTL pruning.
- Updated \`schema.test.ts\` for version 7 (5 assertions) and the new \`action_nonces\` table in the \`creates all expected tables\` check.
- **307 core tests pass** (up from 293).

## Test plan

- [x] \`pnpm turbo typecheck\` — 4/4 pass
- [x] \`pnpm turbo test\` — 307 core + 17 web, all green
- [ ] Manual: click "Create Issue" twice rapidly in CreateIssueModal, confirm only one issue is created on GitHub
- [ ] Manual: simulate an action replay (e.g., reload the page mid-submit via devtools "block request" toggle), confirm the second attempt returns the same issue rather than creating a duplicate
- [ ] Manual: create a draft, assign to repo, confirm the \`action_nonces\` row appears and is pruned after 1 hour

## Resilience audit queue status

With this PR, all 13 findings from \`qa-reports/resilience-audit.md\` are addressed:

| # | Severity | Landed in |
|---|---|---|
| R1 | Critical | **This PR** |
| R2 | Critical | #56 |
| R3 | High | #55 |
| R4 | High | #55 |
| R5 | High | #55 |
| R6 | High | #54 (module) + #55 (wiring) |
| R7 | Medium | #55 |
| R8 | Medium | #55 |
| R9 | Medium | #55 |
| R10 | Medium | #54 |
| R11 | Low | #54 |
| R12 | Low | #55 |
| R13 | Low | #54 |