### PR TITLE
fix(adversarial): address Critical + High findings from audit

### DIFF
--- a/packages/core/src/data/map-limit.test.ts
+++ b/packages/core/src/data/map-limit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { mapLimit } from "./map-limit.js";
+
+describe("mapLimit", () => {
+  it("returns [] for an empty input", async () => {
+    const result = await mapLimit([], 3, async (x) => x);
+    expect(result).toEqual([]);
+  });
+
+  it("preserves input order in the result array", async () => {
+    const items = [1, 2, 3, 4, 5];
+    // Intentionally stagger so completion order is reversed relative
+    // to input order; the result array must still match input order.
+    const result = await mapLimit(items, 2, async (x) => {
+      await new Promise((r) => setTimeout(r, (6 - x) * 5));
+      return x * 10;
+    });
+    expect(result).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it("caps in-flight work at `limit` at any point in time", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+
+    await mapLimit(items, 4, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+    });
+
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1); // actually parallel, not serialized
+  });
+
+  it("clamps limit to item count when limit > items.length", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapLimit([1, 2, 3], 100, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+    });
+    expect(peak).toBe(3);
+  });
+
+  it("clamps limit to 1 when passed 0 or negative", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapLimit([1, 2, 3], 0, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it("rejects the overall promise when any worker throws", async () => {
+    const items = [1, 2, 3, 4, 5];
+    await expect(
+      mapLimit(items, 2, async (x) => {
+        if (x === 3) throw new Error("boom");
+        return x;
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("passes the item index to the callback", async () => {
+    const items = ["a", "b", "c"];
+    const result = await mapLimit(items, 2, async (item, index) => ({
+      item,
+      index,
+    }));
+    expect(result).toEqual([
+      { item: "a", index: 0 },
+      { item: "b", index: 1 },
+      { item: "c", index: 2 },
+    ]);
+  });
+});

--- a/packages/core/src/data/map-limit.ts
+++ b/packages/core/src/data/map-limit.ts
@@ -1,0 +1,47 @@
+/**
+ * Run `fn` over each item with bounded concurrency and return results in
+ * input order.
+ *
+ * A4: the dashboard and unified-list queries fan out over every tracked
+ * repo via `Promise.all(repos.map(…))`. With ~50 tracked repos × (issues
+ * + pulls) per load, that hits ~100 concurrent Octokit requests — right
+ * at GitHub's secondary rate limit. A hand-rolled worker pool caps
+ * concurrency with no new dependency.
+ *
+ * Semantics match `Promise.all` on the happy path (ordered results,
+ * short-circuit reject on any failure). Callers that want per-item
+ * failure isolation should wrap `fn` in a try/catch inside the closure,
+ * as the existing getDashboardData / getUnifiedList callers already do.
+ */
+export async function mapLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const effectiveLimit = Math.max(1, Math.min(limit, items.length));
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: effectiveLimit }, () => worker()),
+  );
+  return results;
+}
+
+/**
+ * Default concurrency for repo-level GitHub fan-out. Each worker may
+ * issue multiple inner requests (e.g. getDashboardData does issues +
+ * pulls per repo) so steady-state concurrency is `DEFAULT_REPO_FANOUT *
+ * inner`. Keep this conservative to stay well under GitHub's secondary
+ * rate limit (~80-100 req/window).
+ */
+export const DEFAULT_REPO_FANOUT = 6;

--- a/packages/core/src/data/map-limit.ts
+++ b/packages/core/src/data/map-limit.ts
@@ -1,17 +1,8 @@
 /**
- * Run `fn` over each item with bounded concurrency and return results in
- * input order.
- *
- * A4: the dashboard and unified-list queries fan out over every tracked
- * repo via `Promise.all(repos.map(…))`. With ~50 tracked repos × (issues
- * + pulls) per load, that hits ~100 concurrent Octokit requests — right
- * at GitHub's secondary rate limit. A hand-rolled worker pool caps
- * concurrency with no new dependency.
- *
- * Semantics match `Promise.all` on the happy path (ordered results,
- * short-circuit reject on any failure). Callers that want per-item
- * failure isolation should wrap `fn` in a try/catch inside the closure,
- * as the existing getDashboardData / getUnifiedList callers already do.
+ * Run `fn` over each item with bounded concurrency and return results
+ * in input order. Semantics match `Promise.all`: any reject short-
+ * circuits the overall promise. Callers that want per-item failure
+ * isolation should wrap `fn` in a try/catch inside the closure.
  */
 export async function mapLimit<T, R>(
   items: readonly T[],
@@ -21,6 +12,9 @@ export async function mapLimit<T, R>(
   if (items.length === 0) return [];
   const effectiveLimit = Math.max(1, Math.min(limit, items.length));
   const results = new Array<R>(items.length);
+  // Workers race on a shared counter rather than receiving pre-sliced
+  // ranges so a slow worker cannot delay items its neighbors could pick
+  // up. Safe under JS's single-threaded increment.
   let nextIndex = 0;
 
   async function worker() {
@@ -38,10 +32,8 @@ export async function mapLimit<T, R>(
 }
 
 /**
- * Default concurrency for repo-level GitHub fan-out. Each worker may
- * issue multiple inner requests (e.g. getDashboardData does issues +
- * pulls per repo) so steady-state concurrency is `DEFAULT_REPO_FANOUT *
- * inner`. Keep this conservative to stay well under GitHub's secondary
- * rate limit (~80-100 req/window).
+ * Default concurrency for repo-level GitHub fan-out. Kept conservative
+ * to stay well under GitHub's secondary rate limit (~80-100 req/window)
+ * given each worker may issue several inner requests per repo.
  */
 export const DEFAULT_REPO_FANOUT = 6;

--- a/packages/core/src/data/repos.ts
+++ b/packages/core/src/data/repos.ts
@@ -50,10 +50,6 @@ export async function getDashboardData(
   const repos = listRepos(db);
   let oldestCachedAt: Date | null = null;
 
-  // A4: cap per-repo fan-out so loading a dashboard with many tracked
-  // repos does not burst past GitHub's secondary rate limit. Each worker
-  // still issues issues + pulls in parallel, so steady-state concurrency
-  // is roughly DEFAULT_REPO_FANOUT * 2 outbound Octokit requests.
   const enrichedRepos = await mapLimit(
     repos,
     DEFAULT_REPO_FANOUT,

--- a/packages/core/src/data/repos.ts
+++ b/packages/core/src/data/repos.ts
@@ -7,6 +7,7 @@ import { getIssues } from "./issues.js";
 import { getPulls } from "./pulls.js";
 import { getDeploymentsByRepo } from "../db/deployments.js";
 import { reconcileRepoLifecycle } from "../lifecycle/reconcile.js";
+import { mapLimit, DEFAULT_REPO_FANOUT } from "./map-limit.js";
 
 function countLabelOccurrences(
   labels: GitHubLabel[][],
@@ -49,8 +50,14 @@ export async function getDashboardData(
   const repos = listRepos(db);
   let oldestCachedAt: Date | null = null;
 
-  const enrichedRepos = await Promise.all(
-    repos.map(async (repo) => {
+  // A4: cap per-repo fan-out so loading a dashboard with many tracked
+  // repos does not burst past GitHub's secondary rate limit. Each worker
+  // still issues issues + pulls in parallel, so steady-state concurrency
+  // is roughly DEFAULT_REPO_FANOUT * 2 outbound Octokit requests.
+  const enrichedRepos = await mapLimit(
+    repos,
+    DEFAULT_REPO_FANOUT,
+    async (repo) => {
       const [issueResult, pullResult] = await Promise.all([
         getIssues(db, octokit, repo.owner, repo.name, options),
         getPulls(db, octokit, repo.owner, repo.name, options),
@@ -94,7 +101,7 @@ export async function getDashboardData(
           ? Math.max(...openIssues.map((i) => daysSince(i.createdAt)))
           : 0,
       };
-    }),
+    },
   );
 
   const totalIssues = enrichedRepos.reduce((sum, r) => sum + r.issueCount, 0);

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -140,12 +140,10 @@ export async function getUnifiedList(
   const drafts = listDrafts(db);
   const repos = listRepos(db);
 
-  // Fetch each tracked repo's data with bounded concurrency. Per-repo
-  // failures (network error, 404, rate limit, revoked token) are caught
-  // and logged so one bad repo doesn't kill the whole page — we render
-  // the remaining repos' data and drafts. A4: mapLimit caps fan-out so
-  // loading the feed with many tracked repos does not burst past
-  // GitHub's secondary rate limit.
+  // Per-repo failures are caught and logged so one bad repo doesn't
+  // kill the whole feed — we render the remaining repos' data and
+  // drafts. Phase 4/5 can surface a "couldn't load N repos" banner if
+  // the degraded experience becomes noticeable.
   const results = await mapLimit(
     repos,
     DEFAULT_REPO_FANOUT,

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -16,6 +16,7 @@ import { listRepos } from "../db/repos.js";
 import { getDeploymentsByRepo } from "../db/deployments.js";
 import { listPrioritiesForRepo } from "../db/priority.js";
 import { getIssues } from "./issues.js";
+import { mapLimit, DEFAULT_REPO_FANOUT } from "./map-limit.js";
 
 export type PerRepoData = {
   repo: Repo;
@@ -139,13 +140,16 @@ export async function getUnifiedList(
   const drafts = listDrafts(db);
   const repos = listRepos(db);
 
-  // Fetch each tracked repo's data in parallel. Per-repo failures (network
-  // error, 404, rate limit, revoked token) are caught and logged so one bad
-  // repo doesn't kill the whole page — we render the remaining repos' data
-  // and drafts. Phase 4/5 can surface a "couldn't load N repos" banner if
-  // the degraded experience becomes noticeable.
-  const results = await Promise.all(
-    repos.map(async (repo): Promise<PerRepoData | null> => {
+  // Fetch each tracked repo's data with bounded concurrency. Per-repo
+  // failures (network error, 404, rate limit, revoked token) are caught
+  // and logged so one bad repo doesn't kill the whole page — we render
+  // the remaining repos' data and drafts. A4: mapLimit caps fan-out so
+  // loading the feed with many tracked repos does not burst past
+  // GitHub's secondary rate limit.
+  const results = await mapLimit(
+    repos,
+    DEFAULT_REPO_FANOUT,
+    async (repo): Promise<PerRepoData | null> => {
       try {
         const { issues } = await getIssues(db, octokit, repo.owner, repo.name);
         const deployments = getDeploymentsByRepo(db, repo.id);
@@ -158,7 +162,7 @@ export async function getUnifiedList(
         );
         return null;
       }
-    }),
+    },
   );
 
   const perRepo: PerRepoData[] = results.filter(

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -7,6 +7,7 @@ import {
   getDeploymentById,
   getDeploymentsForIssue,
   getDeploymentsByRepo,
+  hasLiveDeploymentForIssue,
   updateLinkedPR,
   endDeployment,
   activateDeployment,
@@ -46,7 +47,10 @@ describe("recordDeployment", () => {
     expect(dep.launchedAt).toBeTruthy();
   });
 
-  it("allows multiple deployments for the same issue", () => {
+  it("allows re-deploying an issue after the prior deployment has ended", () => {
+    // A3: the partial unique index idx_deployments_live forbids two live
+    // rows for the same (repo, issue), but historical (ended) rows do not
+    // count — ending d1 frees up the (repo, issue) slot for d2.
     const d1 = recordDeployment(db, {
       repoId,
       issueNumber: 1,
@@ -54,6 +58,8 @@ describe("recordDeployment", () => {
       workspaceMode: "existing",
       workspacePath: "/a",
     });
+    endDeployment(db, d1.id);
+
     const d2 = recordDeployment(db, {
       repoId,
       issueNumber: 1,
@@ -63,6 +69,25 @@ describe("recordDeployment", () => {
     });
 
     expect(d1.id).not.toBe(d2.id);
+  });
+
+  it("blocks a second live deployment for the same (repo, issue)", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 1,
+      branchName: "issue-1-a",
+      workspaceMode: "existing",
+      workspacePath: "/a",
+    });
+    expect(() =>
+      recordDeployment(db, {
+        repoId,
+        issueNumber: 1,
+        branchName: "issue-1-b",
+        workspaceMode: "worktree",
+        workspacePath: "/b",
+      }),
+    ).toThrow(/UNIQUE/);
   });
 
   it("rejects non-existent repoId (FK constraint)", () => {
@@ -114,13 +139,18 @@ describe("getDeploymentsForIssue", () => {
   it("returns only deployments matching repo and issue number", () => {
     const repo = seedRepo(db);
 
-    recordDeployment(db, {
+    // The v9 live-unique index forbids two live rows for the same
+    // (repo, issue), so end the first before launching a second. Ended
+    // rows stay visible to getDeploymentsForIssue (state='active' filter
+    // does not exclude ended_at).
+    const first = recordDeployment(db, {
       repoId: repo.id,
       issueNumber: 1,
       branchName: "a",
       workspaceMode: "existing",
       workspacePath: "/a",
     });
+    endDeployment(db, first.id);
     recordDeployment(db, {
       repoId: repo.id,
       issueNumber: 1,
@@ -144,11 +174,22 @@ describe("getDeploymentsForIssue", () => {
   it("returns results ordered by launched_at DESC", () => {
     const repo = seedRepo(db);
 
-    // Explicit timestamps so ordering is deterministic (datetime('now') has second-level precision)
+    // Explicit timestamps so ordering is deterministic (datetime('now')
+    // has second-level precision). The older row is also marked ended to
+    // satisfy the v9 live-unique index; getDeploymentsForIssue still
+    // surfaces ended rows for history.
     db.prepare(
-      `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(repo.id, 1, "first", "existing", "/first", "2025-01-01T00:00:00");
+      `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      repo.id,
+      1,
+      "first",
+      "existing",
+      "/first",
+      "2025-01-01T00:00:00",
+      "2025-01-01T12:00:00",
+    );
     db.prepare(
       `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -394,5 +435,65 @@ describe("deployment state (R2: pending/active lifecycle)", () => {
     );
     // Active row should still be there
     expect(getDeploymentById(db, dep.id)).toBeDefined();
+  });
+});
+
+describe("hasLiveDeploymentForIssue", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repoId = seedRepo(db).id;
+  });
+
+  it("returns false when no deployment exists for the issue", () => {
+    expect(hasLiveDeploymentForIssue(db, repoId, 42)).toBe(false);
+  });
+
+  it("returns true when a pending deployment exists", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 42,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      state: "pending",
+    });
+    expect(hasLiveDeploymentForIssue(db, repoId, 42)).toBe(true);
+  });
+
+  it("returns true when an active deployment exists", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 42,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    expect(hasLiveDeploymentForIssue(db, repoId, 42)).toBe(true);
+  });
+
+  it("returns false when only an ended deployment exists", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 42,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    endDeployment(db, dep.id);
+    expect(hasLiveDeploymentForIssue(db, repoId, 42)).toBe(false);
+  });
+
+  it("scopes by (repo, issue) — other issues do not count", () => {
+    recordDeployment(db, {
+      repoId,
+      issueNumber: 42,
+      branchName: "b",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    expect(hasLiveDeploymentForIssue(db, repoId, 99)).toBe(false);
   });
 });

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -48,9 +48,9 @@ describe("recordDeployment", () => {
   });
 
   it("allows re-deploying an issue after the prior deployment has ended", () => {
-    // A3: the partial unique index idx_deployments_live forbids two live
-    // rows for the same (repo, issue), but historical (ended) rows do not
-    // count — ending d1 frees up the (repo, issue) slot for d2.
+    // The live-unique index forbids two live rows for the same
+    // (repo, issue), but ended rows do not count — ending d1 frees up
+    // the slot for d2.
     const d1 = recordDeployment(db, {
       repoId,
       issueNumber: 1,
@@ -87,7 +87,7 @@ describe("recordDeployment", () => {
         workspaceMode: "worktree",
         workspacePath: "/b",
       }),
-    ).toThrow(/UNIQUE/);
+    ).toThrow(/UNIQUE constraint failed: deployments\.repo_id, deployments\.issue_number/);
   });
 
   it("rejects non-existent repoId (FK constraint)", () => {
@@ -139,10 +139,10 @@ describe("getDeploymentsForIssue", () => {
   it("returns only deployments matching repo and issue number", () => {
     const repo = seedRepo(db);
 
-    // The v9 live-unique index forbids two live rows for the same
+    // The live-unique index forbids two live rows for the same
     // (repo, issue), so end the first before launching a second. Ended
-    // rows stay visible to getDeploymentsForIssue (state='active' filter
-    // does not exclude ended_at).
+    // rows stay visible to getDeploymentsForIssue (the `state='active'`
+    // filter does not exclude ended_at).
     const first = recordDeployment(db, {
       repoId: repo.id,
       issueNumber: 1,
@@ -175,8 +175,8 @@ describe("getDeploymentsForIssue", () => {
     const repo = seedRepo(db);
 
     // Explicit timestamps so ordering is deterministic (datetime('now')
-    // has second-level precision). The older row is also marked ended to
-    // satisfy the v9 live-unique index; getDeploymentsForIssue still
+    // has second-level precision). The older row is also marked ended
+    // to satisfy the live-unique index; getDeploymentsForIssue still
     // surfaces ended rows for history.
     db.prepare(
       `INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at)

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -109,6 +109,27 @@ export function getDeploymentsByRepo(
   return rows.map(rowToDeployment);
 }
 
+/**
+ * Returns true if a live (not-ended) deployment already exists for the
+ * given (repo, issue). "Live" covers both "pending" and "active" — i.e.
+ * anything that will conflict with the partial unique index
+ * `idx_deployments_live`. Used by the launch flow as a pre-check so the
+ * user sees a friendly error instead of the workspace prep burning git
+ * cycles only to then trip the UNIQUE constraint at insert time.
+ */
+export function hasLiveDeploymentForIssue(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): boolean {
+  const row = db
+    .prepare(
+      "SELECT 1 FROM deployments WHERE repo_id = ? AND issue_number = ? AND ended_at IS NULL LIMIT 1",
+    )
+    .get(repoId, issueNumber);
+  return row !== undefined;
+}
+
 export function updateLinkedPR(
   db: Database.Database,
   deploymentId: number,

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -110,12 +110,8 @@ export function getDeploymentsByRepo(
 }
 
 /**
- * Returns true if a live (not-ended) deployment already exists for the
- * given (repo, issue). "Live" covers both "pending" and "active" — i.e.
- * anything that will conflict with the partial unique index
- * `idx_deployments_live`. Used by the launch flow as a pre-check so the
- * user sees a friendly error instead of the workspace prep burning git
- * cycles only to then trip the UNIQUE constraint at insert time.
+ * "Live" means pending or active (ended rows are excluded) — matches
+ * the `idx_deployments_live` partial unique index predicate.
  */
 export function hasLiveDeploymentForIssue(
   db: Database.Database,

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -164,6 +164,33 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 9,
+    up(db) {
+      // A3: enforce at most one live (not-ended) deployment per (repo, issue).
+      // The adversarial audit showed that nothing prevents duplicate active
+      // rows for the same issue — rapid Launch clicks or multi-tab relaunches
+      // create phantom deployments pointing at the same worktree.
+      //
+      // Existing DBs may already have duplicates (that's the bug). Dedupe
+      // first by ending the older rows — the most recent (highest id) per
+      // (repo, issue) wins — then create the partial unique index.
+      db.exec(`
+        UPDATE deployments
+        SET ended_at = datetime('now')
+        WHERE ended_at IS NULL
+          AND id NOT IN (
+            SELECT MAX(id) FROM deployments
+            WHERE ended_at IS NULL
+            GROUP BY repo_id, issue_number
+          );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_live
+          ON deployments(repo_id, issue_number)
+          WHERE ended_at IS NULL;
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -126,15 +126,13 @@ const migrations: Migration[] = [
   {
     version: 8,
     up(db) {
-      // A2: deployments.repo_id had no ON DELETE clause, so the default
-      // NO ACTION blocked removeRepo on any repo with launch history.
-      // SQLite cannot ALTER a foreign key; rebuild the table with CASCADE.
-      // Nothing else references deployments, so the rebuild needs no
-      // deferred-FK gymnastics.
-      //
-      // This rebuild also folds in the CHECK (state IN ('pending','active'))
-      // constraint that the v6 ALTER-based migration could not add —
-      // migrated DBs now match fresh installs.
+      // Rebuild `deployments` so `repo_id` uses ON DELETE CASCADE — the
+      // v1 schema omitted the clause, and SQLite cannot ALTER an FK.
+      // Nothing else references `deployments`, so the rebuild needs no
+      // deferred-FK gymnastics. The rebuild also folds in the
+      // CHECK (state IN ('pending','active')) constraint that the v6
+      // ALTER-based migration could not add, so migrated DBs now match
+      // fresh installs.
       db.exec(`
         CREATE TABLE deployments_new (
           id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -167,14 +165,34 @@ const migrations: Migration[] = [
   {
     version: 9,
     up(db) {
-      // A3: enforce at most one live (not-ended) deployment per (repo, issue).
-      // The adversarial audit showed that nothing prevents duplicate active
-      // rows for the same issue — rapid Launch clicks or multi-tab relaunches
-      // create phantom deployments pointing at the same worktree.
+      // Enforce at most one live (not-ended) deployment per
+      // (repo, issue). DBs that ran under earlier versions may already
+      // have duplicates — end the older rows first (most recent id per
+      // pair wins) so the index creation cannot fail. The subquery's
+      // inner `ended_at IS NULL` filter is load-bearing: a mixed
+      // live+ended pair must keep its live row, even if the live row
+      // is not the highest id overall.
       //
-      // Existing DBs may already have duplicates (that's the bug). Dedupe
-      // first by ending the older rows — the most recent (highest id) per
-      // (repo, issue) wins — then create the partial unique index.
+      // Count duplicates first and log the row count so operators have
+      // a paper trail for state that quietly disappears from the UI
+      // (matches the v4 claude_aliases precedent).
+      const { n } = db
+        .prepare(
+          `SELECT COUNT(*) as n FROM deployments
+           WHERE ended_at IS NULL
+             AND id NOT IN (
+               SELECT MAX(id) FROM deployments
+               WHERE ended_at IS NULL
+               GROUP BY repo_id, issue_number
+             )`,
+        )
+        .get() as { n: number };
+      if (n > 0) {
+        console.warn(
+          `[issuectl] Migration v9: ending ${n} duplicate live deployment row(s) so the new unique index can be created. The most recent deployment per (repo, issue) is kept; older rows receive ended_at = now.`,
+        );
+      }
+
       db.exec(`
         UPDATE deployments
         SET ended_at = datetime('now')

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -123,6 +123,47 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 8,
+    up(db) {
+      // A2: deployments.repo_id had no ON DELETE clause, so the default
+      // NO ACTION blocked removeRepo on any repo with launch history.
+      // SQLite cannot ALTER a foreign key; rebuild the table with CASCADE.
+      // Nothing else references deployments, so the rebuild needs no
+      // deferred-FK gymnastics.
+      //
+      // This rebuild also folds in the CHECK (state IN ('pending','active'))
+      // constraint that the v6 ALTER-based migration could not add —
+      // migrated DBs now match fresh installs.
+      db.exec(`
+        CREATE TABLE deployments_new (
+          id               INTEGER PRIMARY KEY AUTOINCREMENT,
+          repo_id          INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+          issue_number     INTEGER NOT NULL,
+          branch_name      TEXT NOT NULL,
+          workspace_mode   TEXT NOT NULL,
+          workspace_path   TEXT NOT NULL,
+          linked_pr_number INTEGER,
+          state            TEXT NOT NULL DEFAULT 'active'
+                           CHECK (state IN ('pending', 'active')),
+          launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          ended_at         TEXT
+        );
+
+        INSERT INTO deployments_new (
+          id, repo_id, issue_number, branch_name, workspace_mode,
+          workspace_path, linked_pr_number, state, launched_at, ended_at
+        )
+        SELECT
+          id, repo_id, issue_number, branch_name, workspace_mode,
+          workspace_path, linked_pr_number, state, launched_at, ended_at
+        FROM deployments;
+
+        DROP TABLE deployments;
+        ALTER TABLE deployments_new RENAME TO deployments;
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/repos.test.ts
+++ b/packages/core/src/db/repos.test.ts
@@ -9,7 +9,7 @@ import {
   listRepos,
   updateRepo,
 } from "./repos.js";
-import { recordDeployment } from "./deployments.js";
+import { recordDeployment, getDeploymentsByRepo } from "./deployments.js";
 
 describe("addRepo", () => {
   let db: Database.Database;
@@ -134,7 +134,9 @@ describe("removeRepo", () => {
     );
   });
 
-  it("rejects deletion when repo has deployments (FK constraint)", () => {
+  it("cascades to deployment rows (no FK block)", () => {
+    // A2 fix: deployments.repo_id now has ON DELETE CASCADE, so removing
+    // a repo with launch history is allowed and drops the orphaned rows.
     const repo = addRepo(db, { owner: "acme", name: "fk-test" });
     recordDeployment(db, {
       repoId: repo.id,
@@ -143,7 +145,12 @@ describe("removeRepo", () => {
       workspaceMode: "existing",
       workspacePath: "/x",
     });
-    expect(() => removeRepo(db, repo.id)).toThrow();
+    expect(getDeploymentsByRepo(db, repo.id)).toHaveLength(1);
+
+    removeRepo(db, repo.id);
+
+    expect(getRepoById(db, repo.id)).toBeUndefined();
+    expect(getDeploymentsByRepo(db, repo.id)).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -83,6 +83,10 @@ describe("runMigrations", () => {
 
   it("migrates v2 schema to v9 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces, rebuilds deployments with CASCADE+live index)", () => {
     const db = createRawTestDb();
+    // The v2 fixture originally covered only claude_aliases; a repos
+    // table + row is now included because the v8 deployments rebuild
+    // declares a FK against repos and SQLite validates the reference
+    // table during the INSERT SELECT.
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, name TEXT NOT NULL, UNIQUE(owner, name));
       INSERT INTO repos (owner, name) VALUES ('acme', 'api');
@@ -246,16 +250,6 @@ describe("schema v5 — drafts and issue_metadata", () => {
 });
 
 describe("schema v8 — deployments FK cascade", () => {
-  it("fresh schema declares ON DELETE CASCADE on deployments.repo_id", () => {
-    const db = createTestDb();
-    const fks = db
-      .prepare("PRAGMA foreign_key_list(deployments)")
-      .all() as { table: string; from: string; on_delete: string }[];
-    const repoFk = fks.find((f) => f.from === "repo_id" && f.table === "repos");
-    expect(repoFk).toBeDefined();
-    expect(repoFk?.on_delete).toBe("CASCADE");
-  });
-
   it("deleting a repo cascades to its deployment rows", () => {
     const db = createTestDb();
     db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run(
@@ -312,26 +306,25 @@ describe("schema v8 — deployments FK cascade", () => {
       );
     `);
     db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
+    // Seed `state='pending'` explicitly so the preservation assertion
+    // below cannot be satisfied by the fresh schema's DEFAULT 'active'.
     db.prepare(
-      "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 1, 'b', 'existing', '/x')",
+      "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, state) VALUES (1, 1, 'b', 'existing', '/x', 'pending')",
     ).run();
 
     runMigrations(db);
 
     expect(getSchemaVersion(db)).toBe(9);
-    const fks = db
-      .prepare("PRAGMA foreign_key_list(deployments)")
-      .all() as { table: string; from: string; on_delete: string }[];
-    expect(fks.find((f) => f.from === "repo_id")?.on_delete).toBe("CASCADE");
 
-    // Pre-existing row should have been copied over
+    // Pre-existing row should have been copied over with its state intact
     const row = db
       .prepare("SELECT issue_number, state FROM deployments WHERE id = 1")
       .get() as { issue_number: number; state: string };
     expect(row.issue_number).toBe(1);
-    expect(row.state).toBe("active");
+    expect(row.state).toBe("pending");
 
-    // Cascade works on the upgraded table
+    // Cascade works on the upgraded table — the behavioral check that
+    // proves the rebuilt FK is in place.
     db.prepare("DELETE FROM repos WHERE id = 1").run();
     const { c } = db
       .prepare("SELECT COUNT(*) as c FROM deployments")
@@ -341,30 +334,10 @@ describe("schema v8 — deployments FK cascade", () => {
 });
 
 describe("schema v9 — live deployment unique index", () => {
-  it("fresh schema creates idx_deployments_live as a partial unique index", () => {
-    const db = createTestDb();
-    const idx = db
-      .prepare(
-        "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_deployments_live'",
-      )
-      .get() as { name: string; sql: string } | undefined;
-    expect(idx).toBeDefined();
-    expect(idx?.sql).toContain("UNIQUE");
-    expect(idx?.sql).toContain("ended_at IS NULL");
-  });
-
-  it("blocks a second live deployment for the same (repo, issue)", () => {
-    const db = createTestDb();
-    db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
-    const insertRow = () =>
-      db
-        .prepare(
-          "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 42, 'b', 'existing', '/x')",
-        )
-        .run();
-    insertRow();
-    expect(insertRow).toThrow(/UNIQUE/);
-  });
+  // The "blocks a second live deployment" case lives in deployments.test.ts
+  // where it exercises the recordDeployment helper rather than raw SQL.
+  // Here we keep only the cases that are specific to the schema layer:
+  // the allowed-after-end behavior and the v8→v9 migration dedup.
 
   it("allows a new live deployment after the previous one is ended", () => {
     const db = createTestDb();
@@ -411,16 +384,36 @@ describe("schema v9 — live deployment unique index", () => {
         VALUES (1, 42, 'b1', 'existing', '/a');
       INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
         VALUES (1, 42, 'b2', 'existing', '/b');
+      -- A third row for the same (repo, issue) that is already ended.
+      -- The dedup subquery's inner "ended_at IS NULL" filter must exclude
+      -- this row from the MAX(id) computation so the most recent *live*
+      -- row (id=2) wins, even though this ended row has the highest id.
+      INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, ended_at)
+        VALUES (1, 42, 'historic', 'existing', '/h', '2025-01-01T00:00:00');
     `);
+
+    // Silence the migration's warn() log so test output stays clean.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     runMigrations(db);
 
     expect(getSchemaVersion(db)).toBe(9);
-    // The older duplicate (id=1) should have been ended; id=2 remains live.
+    // Row id=1 (older duplicate) → ended. id=2 (most recent live) → live.
+    // id=3 (historic ended) → still ended, untouched.
     const live = db
       .prepare("SELECT id FROM deployments WHERE ended_at IS NULL")
       .all() as { id: number }[];
     expect(live).toHaveLength(1);
     expect(live[0].id).toBe(2);
+
+    const ended = db
+      .prepare("SELECT id FROM deployments WHERE ended_at IS NOT NULL ORDER BY id")
+      .all() as { id: number }[];
+    expect(ended.map((r) => r.id)).toEqual([1, 3]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ending 1 duplicate"),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -417,3 +417,53 @@ describe("schema v9 — live deployment unique index", () => {
     warnSpy.mockRestore();
   });
 });
+
+describe("schema invariants — assumptions other code depends on", () => {
+  it("deployments has exactly one unique index, named idx_deployments_live", () => {
+    // The race-path catch in launch.ts (executeLaunch step 8) translates
+    // any SQLITE_CONSTRAINT_UNIQUE thrown by recordDeployment into the
+    // friendly duplicate-launch error. That predicate is only correct
+    // because `idx_deployments_live` is the *sole* unique constraint on
+    // `deployments` — if a future migration adds another, the catch
+    // would misfire and translate the wrong constraint. This test fails
+    // loudly so the developer is forced to update the catch in lockstep.
+    const db = createTestDb();
+    const indexes = db
+      .prepare(
+        `SELECT name, "unique" FROM pragma_index_list('deployments') WHERE "unique" = 1`,
+      )
+      .all() as { name: string; unique: number }[];
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0]?.name).toBe("idx_deployments_live");
+  });
+
+  it("no other table has a foreign key referencing deployments", () => {
+    // The v8 migration rebuilds `deployments` via CREATE/INSERT/DROP/
+    // RENAME without disabling foreign keys. That works only because
+    // nothing FK-references `deployments` — if some future table does,
+    // the v8 migration is frozen history and won't be updated, so the
+    // new migration would need to run with deferred FK enforcement.
+    // This test fails loudly so the developer notices when adding such
+    // a reference.
+    const db = createTestDb();
+    const tables = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != 'deployments'`,
+      )
+      .all() as { name: string }[];
+
+    const offenders: Array<{ table: string; from: string }> = [];
+    for (const { name } of tables) {
+      const fks = db
+        .prepare(`SELECT "table" as ref, "from" FROM pragma_foreign_key_list(?)`)
+        .all(name) as { ref: string; from: string }[];
+      for (const fk of fks) {
+        if (fk.ref === "deployments") {
+          offenders.push({ table: name, from: fk.from });
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -33,15 +33,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 7", () => {
+  it("sets schema_version to 8", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
   });
 });
 
@@ -58,15 +58,15 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
   });
 
-  it("migrates v1 schema through v7 and drops claude_aliases", () => {
+  it("migrates v1 schema through v8 and drops claude_aliases", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
       CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-      CREATE TABLE deployments (id INTEGER PRIMARY KEY, repo_id INTEGER, issue_number INTEGER, branch_name TEXT, workspace_mode TEXT, workspace_path TEXT);
+      CREATE TABLE deployments (id INTEGER PRIMARY KEY, repo_id INTEGER, issue_number INTEGER, branch_name TEXT, workspace_mode TEXT, workspace_path TEXT, linked_pr_number INTEGER, launched_at TEXT);
       CREATE TABLE cache (key TEXT PRIMARY KEY, data TEXT NOT NULL);
       CREATE TABLE schema_version (version INTEGER NOT NULL);
       INSERT INTO schema_version (version) VALUES (1);
@@ -74,16 +74,18 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v2 schema to v7 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces)", () => {
+  it("migrates v2 schema to v8 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces, rebuilds deployments with CASCADE)", () => {
     const db = createRawTestDb();
     db.exec(`
+      CREATE TABLE repos (id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, name TEXT NOT NULL, UNIQUE(owner, name));
+      INSERT INTO repos (owner, name) VALUES ('acme', 'api');
       CREATE TABLE claude_aliases (id INTEGER PRIMARY KEY, command TEXT, description TEXT, is_default INTEGER, created_at TEXT);
       CREATE TABLE deployments (id INTEGER PRIMARY KEY, repo_id INTEGER, issue_number INTEGER, branch_name TEXT, workspace_mode TEXT, workspace_path TEXT, linked_pr_number INTEGER, launched_at TEXT);
       CREATE TABLE schema_version (version INTEGER NOT NULL);
@@ -92,7 +94,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -100,7 +102,7 @@ describe("runMigrations", () => {
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v3 schema to v7 and drops populated claude_aliases (data loss is intentional)", () => {
+  it("migrates v3 schema to v8 and drops populated claude_aliases (data loss is intentional)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -135,7 +137,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -151,10 +153,10 @@ describe("runMigrations", () => {
 });
 
 describe("schema v5 — drafts and issue_metadata", () => {
-  it("initSchema on a fresh DB produces schema version 7", () => {
+  it("initSchema on a fresh DB produces schema version 8", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -188,7 +190,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
     ).toThrow();
   });
 
-  it("migration from v4 → v7 adds drafts, issue_metadata, deployments.state, and action_nonces", () => {
+  it("migration from v4 → v8 adds drafts, issue_metadata, deployments.state+CHECK+CASCADE, and action_nonces", () => {
     const db = createRawTestDb();
     // Simulate a v4 DB: run the v4-era schema manually. The deployments
     // table is included here because v6's migration does ALTER TABLE on it.
@@ -220,7 +222,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(8);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -240,5 +242,100 @@ describe("schema v5 — drafts and issue_metadata", () => {
     const stateCol = cols.find((c) => c.name === "state");
     expect(stateCol).toBeDefined();
     expect(stateCol?.dflt_value).toContain("active");
+  });
+});
+
+describe("schema v8 — deployments FK cascade", () => {
+  it("fresh schema declares ON DELETE CASCADE on deployments.repo_id", () => {
+    const db = createTestDb();
+    const fks = db
+      .prepare("PRAGMA foreign_key_list(deployments)")
+      .all() as { table: string; from: string; on_delete: string }[];
+    const repoFk = fks.find((f) => f.from === "repo_id" && f.table === "repos");
+    expect(repoFk).toBeDefined();
+    expect(repoFk?.on_delete).toBe("CASCADE");
+  });
+
+  it("deleting a repo cascades to its deployment rows", () => {
+    const db = createTestDb();
+    db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run(
+      "acme",
+      "api",
+    );
+    const repoId = Number(
+      (db.prepare("SELECT id FROM repos WHERE owner='acme'").get() as { id: number }).id,
+    );
+    db.prepare(
+      "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (?, ?, ?, ?, ?)",
+    ).run(repoId, 1, "b", "existing", "/x");
+
+    const before = db
+      .prepare("SELECT COUNT(*) as c FROM deployments WHERE repo_id = ?")
+      .get(repoId) as { c: number };
+    expect(before.c).toBe(1);
+
+    db.prepare("DELETE FROM repos WHERE id = ?").run(repoId);
+
+    const after = db
+      .prepare("SELECT COUNT(*) as c FROM deployments WHERE repo_id = ?")
+      .get(repoId) as { c: number };
+    expect(after.c).toBe(0);
+  });
+
+  it("migrated DB matches fresh schema's FK cascade", () => {
+    // A v7 DB upgraded to v8 should have the same CASCADE FK as a fresh
+    // install — the migration rebuilds the deployments table.
+    const db = createRawTestDb();
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (7);
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        local_path TEXT,
+        branch_pattern TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(owner, name)
+      );
+      CREATE TABLE deployments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id),
+        issue_number INTEGER NOT NULL,
+        branch_name TEXT NOT NULL,
+        workspace_mode TEXT NOT NULL,
+        workspace_path TEXT NOT NULL,
+        linked_pr_number INTEGER,
+        state TEXT NOT NULL DEFAULT 'active',
+        launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+        ended_at TEXT
+      );
+    `);
+    db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
+    db.prepare(
+      "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 1, 'b', 'existing', '/x')",
+    ).run();
+
+    runMigrations(db);
+
+    expect(getSchemaVersion(db)).toBe(8);
+    const fks = db
+      .prepare("PRAGMA foreign_key_list(deployments)")
+      .all() as { table: string; from: string; on_delete: string }[];
+    expect(fks.find((f) => f.from === "repo_id")?.on_delete).toBe("CASCADE");
+
+    // Pre-existing row should have been copied over
+    const row = db
+      .prepare("SELECT issue_number, state FROM deployments WHERE id = 1")
+      .get() as { issue_number: number; state: string };
+    expect(row.issue_number).toBe(1);
+    expect(row.state).toBe("active");
+
+    // Cascade works on the upgraded table
+    db.prepare("DELETE FROM repos WHERE id = 1").run();
+    const { c } = db
+      .prepare("SELECT COUNT(*) as c FROM deployments")
+      .get() as { c: number };
+    expect(c).toBe(0);
   });
 });

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -33,15 +33,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 8", () => {
+  it("sets schema_version to 9", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
   });
 });
 
@@ -58,10 +58,10 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
   });
 
-  it("migrates v1 schema through v8 and drops claude_aliases", () => {
+  it("migrates v1 schema through v9 and drops claude_aliases", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -74,14 +74,14 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v2 schema to v8 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces, rebuilds deployments with CASCADE)", () => {
+  it("migrates v2 schema to v9 (adds ended_at, drops claude_aliases, adds drafts+issue_metadata+state+action_nonces, rebuilds deployments with CASCADE+live index)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, name TEXT NOT NULL, UNIQUE(owner, name));
@@ -94,7 +94,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -102,7 +102,7 @@ describe("runMigrations", () => {
     expect(tables).toHaveLength(0);
   });
 
-  it("migrates v3 schema to v8 and drops populated claude_aliases (data loss is intentional)", () => {
+  it("migrates v3 schema to v9 and drops populated claude_aliases (data loss is intentional)", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE repos (id INTEGER PRIMARY KEY, owner TEXT, name TEXT);
@@ -137,7 +137,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -153,10 +153,10 @@ describe("runMigrations", () => {
 });
 
 describe("schema v5 — drafts and issue_metadata", () => {
-  it("initSchema on a fresh DB produces schema version 8", () => {
+  it("initSchema on a fresh DB produces schema version 9", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -190,7 +190,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
     ).toThrow();
   });
 
-  it("migration from v4 → v8 adds drafts, issue_metadata, deployments.state+CHECK+CASCADE, and action_nonces", () => {
+  it("migration from v4 → v9 adds drafts, issue_metadata, deployments.state+CHECK+CASCADE+live index, and action_nonces", () => {
     const db = createRawTestDb();
     // Simulate a v4 DB: run the v4-era schema manually. The deployments
     // table is included here because v6's migration does ALTER TABLE on it.
@@ -222,7 +222,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -318,7 +318,7 @@ describe("schema v8 — deployments FK cascade", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(8);
+    expect(getSchemaVersion(db)).toBe(9);
     const fks = db
       .prepare("PRAGMA foreign_key_list(deployments)")
       .all() as { table: string; from: string; on_delete: string }[];
@@ -337,5 +337,90 @@ describe("schema v8 — deployments FK cascade", () => {
       .prepare("SELECT COUNT(*) as c FROM deployments")
       .get() as { c: number };
     expect(c).toBe(0);
+  });
+});
+
+describe("schema v9 — live deployment unique index", () => {
+  it("fresh schema creates idx_deployments_live as a partial unique index", () => {
+    const db = createTestDb();
+    const idx = db
+      .prepare(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_deployments_live'",
+      )
+      .get() as { name: string; sql: string } | undefined;
+    expect(idx).toBeDefined();
+    expect(idx?.sql).toContain("UNIQUE");
+    expect(idx?.sql).toContain("ended_at IS NULL");
+  });
+
+  it("blocks a second live deployment for the same (repo, issue)", () => {
+    const db = createTestDb();
+    db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
+    const insertRow = () =>
+      db
+        .prepare(
+          "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 42, 'b', 'existing', '/x')",
+        )
+        .run();
+    insertRow();
+    expect(insertRow).toThrow(/UNIQUE/);
+  });
+
+  it("allows a new live deployment after the previous one is ended", () => {
+    const db = createTestDb();
+    db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
+    db.prepare(
+      "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 42, 'b1', 'existing', '/x')",
+    ).run();
+    db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = 1").run();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path) VALUES (1, 42, 'b2', 'existing', '/y')",
+        )
+        .run(),
+    ).not.toThrow();
+  });
+
+  it("v8 → v9 migration dedupes existing live rows before creating the index", () => {
+    const db = createRawTestDb();
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (8);
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        UNIQUE(owner, name)
+      );
+      CREATE TABLE deployments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        issue_number INTEGER NOT NULL,
+        branch_name TEXT NOT NULL,
+        workspace_mode TEXT NOT NULL,
+        workspace_path TEXT NOT NULL,
+        linked_pr_number INTEGER,
+        state TEXT NOT NULL DEFAULT 'active'
+          CHECK (state IN ('pending', 'active')),
+        launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+        ended_at TEXT
+      );
+      INSERT INTO repos (owner, name) VALUES ('o', 'n');
+      INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
+        VALUES (1, 42, 'b1', 'existing', '/a');
+      INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
+        VALUES (1, 42, 'b2', 'existing', '/b');
+    `);
+
+    runMigrations(db);
+
+    expect(getSchemaVersion(db)).toBe(9);
+    // The older duplicate (id=1) should have been ended; id=2 remains live.
+    const live = db
+      .prepare("SELECT id FROM deployments WHERE ended_at IS NULL")
+      .all() as { id: number }[];
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe(2);
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 8;
+const SCHEMA_VERSION = 9;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -69,6 +69,13 @@ const CREATE_TABLES = `
 
   CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
     ON action_nonces(created_at);
+
+  -- A3: at most one live deployment per (repo, issue). "Live" = not ended.
+  -- Covers both pending and active states; ended rows (historical audit
+  -- trail) are excluded so re-launching after a session ends is allowed.
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_live
+    ON deployments(repo_id, issue_number)
+    WHERE ended_at IS NULL;
 
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -70,9 +70,9 @@ const CREATE_TABLES = `
   CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
     ON action_nonces(created_at);
 
-  -- A3: at most one live deployment per (repo, issue). "Live" = not ended.
-  -- Covers both pending and active states; ended rows (historical audit
-  -- trail) are excluded so re-launching after a session ends is allowed.
+  -- At most one live deployment per (repo, issue). Ended rows are
+  -- historical audit trail and are excluded from the predicate so
+  -- re-launching after a session closes is allowed.
   CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_live
     ON deployments(repo_id, issue_number)
     WHERE ended_at IS NULL;

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -20,7 +20,7 @@ const CREATE_TABLES = `
 
   CREATE TABLE IF NOT EXISTS deployments (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
-    repo_id          INTEGER NOT NULL REFERENCES repos(id),
+    repo_id          INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
     issue_number     INTEGER NOT NULL,
     branch_name      TEXT NOT NULL,
     workspace_mode   TEXT NOT NULL,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export {
   getDeploymentById,
   getDeploymentsForIssue,
   getDeploymentsByRepo,
+  hasLiveDeploymentForIssue,
   updateLinkedPR,
   endDeployment,
   activateDeployment,

--- a/packages/core/src/launch/launch.test.ts
+++ b/packages/core/src/launch/launch.test.ts
@@ -1,5 +1,70 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildClaudeCommand } from "./launch.js";
+import type Database from "better-sqlite3";
+import type { Octokit } from "@octokit/rest";
+import { buildClaudeCommand, executeLaunch } from "./launch.js";
+import { createTestDb } from "../db/test-helpers.js";
+import { addRepo } from "../db/repos.js";
+import { recordDeployment } from "../db/deployments.js";
+import * as deploymentsModule from "../db/deployments.js";
+
+// Stub every module side-effect outside the pre-check's reach so the
+// test only measures ordering: did `prepareWorkspace` run even though
+// a live deployment already existed? `vi.hoisted` declares the spy at
+// the same time vi.mock is hoisted so the factory can reference it.
+const { prepareWorkspaceSpy } = vi.hoisted(() => ({
+  prepareWorkspaceSpy: vi.fn(async () => ({
+    path: "/tmp/fake-workspace",
+    branchName: "fake-branch",
+  })),
+}));
+
+vi.mock("./workspace.js", () => ({
+  prepareWorkspace: prepareWorkspaceSpy,
+}));
+
+vi.mock("./terminal.js", () => ({
+  getTerminalLauncher: () => ({
+    verify: async () => {},
+    launch: async () => {},
+  }),
+}));
+
+vi.mock("../data/issues.js", () => ({
+  getIssueDetail: async () => ({
+    issue: {
+      number: 42,
+      title: "test issue",
+      body: "",
+      state: "open",
+      labels: [],
+      user: null,
+      createdAt: "2026-04-12T00:00:00Z",
+      updatedAt: "2026-04-12T00:00:00Z",
+      closedAt: null,
+      htmlUrl: "https://example.invalid",
+    },
+    comments: [],
+    referencedFiles: [],
+  }),
+}));
+
+vi.mock("./context.js", () => ({
+  assembleContext: () => "fake context",
+  writeContextFile: async () => "/tmp/fake-context.md",
+}));
+
+vi.mock("../github/labels.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../github/labels.js")>(
+      "../github/labels.js",
+    );
+  return {
+    ...actual,
+    ensureLifecycleLabels: async () => {},
+    addLabel: async () => {},
+    removeLabel: async () => {},
+  };
+});
 
 describe("buildClaudeCommand", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -82,5 +147,120 @@ describe("buildClaudeCommand", () => {
   it("falls back on parentheses", () => {
     expect(buildClaudeCommand("(echo hi)")).toBe("claude");
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("executeLaunch duplicate-deployment pre-check", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    prepareWorkspaceSpy.mockClear();
+    db = createTestDb();
+  });
+
+  it("refuses to launch and skips workspace prep when a live deployment already exists", async () => {
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 42,
+      branchName: "prior-branch",
+      workspaceMode: "existing",
+      workspacePath: "/tmp/prior-workspace",
+    });
+
+    await expect(
+      executeLaunch(db, {} as Octokit, {
+        owner: "acme",
+        repo: "api",
+        issueNumber: 42,
+        branchName: "new-branch",
+        workspaceMode: "existing",
+        selectedComments: [],
+        selectedFiles: [],
+      }),
+    ).rejects.toThrow(/already has an active deployment/);
+
+    expect(prepareWorkspaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("translates a race-path UNIQUE violation into the friendly duplicate-launch error", async () => {
+    // Simulate the race: the pre-check returns false (the concurrent
+    // live row was inserted between the SELECT and the INSERT), but
+    // the real live row already exists in the DB, so recordDeployment
+    // trips idx_deployments_live. The catch at launch.ts step 8 must
+    // translate the raw SqliteError into the same friendly message
+    // the pre-check throws.
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 42,
+      branchName: "winner-branch",
+      workspaceMode: "existing",
+      workspacePath: "/tmp/winner",
+    });
+
+    const preCheckSpy = vi
+      .spyOn(deploymentsModule, "hasLiveDeploymentForIssue")
+      .mockReturnValue(false);
+
+    try {
+      await expect(
+        executeLaunch(db, {} as Octokit, {
+          owner: "acme",
+          repo: "api",
+          issueNumber: 42,
+          branchName: "loser-branch",
+          workspaceMode: "existing",
+          selectedComments: [],
+          selectedFiles: [],
+        }),
+      ).rejects.toThrow(/already has an active deployment/);
+
+      // prepareWorkspace *should* have run — this is the race path,
+      // not the pre-check path. We're asserting the catch works once
+      // we've gotten past the optimistic check.
+      expect(prepareWorkspaceSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      preCheckSpy.mockRestore();
+    }
+  });
+
+  it("allows launch when the prior deployment has ended", async () => {
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    const prior = recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 42,
+      branchName: "prior-branch",
+      workspaceMode: "existing",
+      workspacePath: "/tmp/prior-workspace",
+    });
+    // End the prior session so the live-unique index releases the slot
+    db.prepare(
+      "UPDATE deployments SET ended_at = datetime('now') WHERE id = ?",
+    ).run(prior.id);
+
+    await executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 42,
+      branchName: "new-branch",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+    });
+
+    expect(prepareWorkspaceSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -52,6 +52,12 @@ function expandHome(p: string): string {
   return p;
 }
 
+function duplicateLaunchError(issueNumber: number): Error {
+  return new Error(
+    `Issue #${issueNumber} already has an active deployment. End the existing session before launching again.`,
+  );
+}
+
 export async function executeLaunch(
   db: Database.Database,
   octokit: Octokit,
@@ -116,16 +122,12 @@ export async function executeLaunch(
     );
   }
 
-  // A3: refuse to launch when a live deployment already exists for this
-  // issue. The partial unique index idx_deployments_live would catch this
-  // at INSERT time, but by then prepareWorkspace has already run — doing
-  // the check up front saves the git cycles and surfaces a clean error.
-  // A race that slips past this pre-check will still be caught by the
-  // index when recordDeployment runs.
+  // Cheap pre-check before the expensive git work in step 6. The partial
+  // unique index `idx_deployments_live` is the source of truth at insert
+  // time (step 8); this lookup just avoids burning workspace prep on a
+  // request that will be rejected anyway.
   if (hasLiveDeploymentForIssue(db, repoRecord.id, options.issueNumber)) {
-    throw new Error(
-      `Issue #${options.issueNumber} already has an active deployment. End the existing session before launching again.`,
-    );
+    throw duplicateLaunchError(options.issueNumber);
   }
 
   const repoPath = repoRecord.localPath
@@ -181,14 +183,35 @@ export async function executeLaunch(
   // 8. Record deployment in DB as pending. This row is INVISIBLE to the
   // UI and reconciler until step 9 succeeds — if the terminal launch
   // fails, we delete the row in the catch and no one ever saw it.
-  const deployment = recordDeployment(db, {
-    repoId: repoRecord.id,
-    issueNumber: options.issueNumber,
-    branchName: options.branchName,
-    workspaceMode: options.workspaceMode,
-    workspacePath: workspace.path,
-    state: "pending",
-  });
+  //
+  // The pre-check is an optimization, not a lock: concurrent launches
+  // can both pass it, and the loser trips `idx_deployments_live` here.
+  // Translate that one constraint into the friendly duplicate-launch
+  // message so both sides of the race see the same story.
+  let deployment;
+  try {
+    deployment = recordDeployment(db, {
+      repoId: repoRecord.id,
+      issueNumber: options.issueNumber,
+      branchName: options.branchName,
+      workspaceMode: options.workspaceMode,
+      workspacePath: workspace.path,
+      state: "pending",
+    });
+  } catch (err) {
+    // `idx_deployments_live` is the only unique constraint on
+    // `deployments`, so any SQLITE_CONSTRAINT_UNIQUE thrown here came
+    // from that index. better-sqlite3 formats the message as
+    // "UNIQUE constraint failed: deployments.repo_id, deployments.issue_number"
+    // — the column list, not the index name — so match on `code`.
+    if (
+      err instanceof Error &&
+      (err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE"
+    ) {
+      throw duplicateLaunchError(options.issueNumber);
+    }
+    throw err;
+  }
 
   // 9. Open terminal
   //

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -6,6 +6,7 @@ import {
   recordDeployment,
   activateDeployment,
   deletePendingDeployment,
+  hasLiveDeploymentForIssue,
 } from "../db/deployments.js";
 import { getIssueDetail } from "../data/issues.js";
 import { ensureLifecycleLabels, addLabel } from "../github/labels.js";
@@ -112,6 +113,18 @@ export async function executeLaunch(
   if (!repoRecord) {
     throw new Error(
       `Repository ${options.owner}/${options.repo} not found in database`,
+    );
+  }
+
+  // A3: refuse to launch when a live deployment already exists for this
+  // issue. The partial unique index idx_deployments_live would catch this
+  // at INSERT time, but by then prepareWorkspace has already run — doing
+  // the check up front saves the git cycles and surfaces a clean error.
+  // A race that slips past this pre-check will still be caught by the
+  // index when recordDeployment runs.
+  if (hasLiveDeploymentForIssue(db, repoRecord.id, options.issueNumber)) {
+    throw new Error(
+      `Issue #${options.issueNumber} already has an active deployment. End the existing session before launching again.`,
     );
   }
 

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -3,6 +3,7 @@
 import {
   getDb,
   getOctokit,
+  getRepo,
   listRepos,
   listLabels,
   createIssue as coreCreateIssue,
@@ -93,6 +94,16 @@ export async function batchCreateIssues(
             id: issue.id,
             success: false as const,
             error: "Owner, repo, and title are required",
+            owner: issue.owner,
+            repo: issue.repo,
+          };
+        }
+
+        if (!getRepo(db, issue.owner, issue.repo)) {
+          return {
+            id: issue.id,
+            success: false as const,
+            error: `Repository not tracked: ${issue.owner}/${issue.repo}`,
             owner: issue.owner,
             repo: issue.repo,
           };


### PR DESCRIPTION
## Summary

Addresses the 4 actionable Critical + High findings from `qa-reports/adversarial-audit.md` (the other 3 Highs were already closed by the resilience PRs #54–57). 6 commits on this branch:

- **A1** `5358dcd` — `batchCreateIssues` now gates each accepted row through `getRepo(db, owner, repo)`, matching the trust-boundary pattern every other Server Action uses. LLM-hallucinated owner/repo no longer lands issues in untracked repos.
- **A2** `a94e3ca` — Schema v8 rebuilds `deployments` with `REFERENCES repos(id) ON DELETE CASCADE`. SQLite can't ALTER an FK, so it's a CREATE/INSERT/DROP/RENAME rebuild. Also folds in the v6 `CHECK (state IN ('pending','active'))` constraint that the ALTER-based migration couldn't add. Unblocks `removeRepo` after launch history exists.
- **A3** `1f87ef0` — Schema v9 adds partial unique index `idx_deployments_live ON deployments(repo_id, issue_number) WHERE ended_at IS NULL`. Pre-existing duplicates are deduped first (most recent id per pair wins; older rows get `ended_at`). New `hasLiveDeploymentForIssue` helper + pre-check in `executeLaunch` before `prepareWorkspace` so the user sees a friendly error instead of burning git cycles.
- **A4** `3fb0497` — New `mapLimit` worker-pool utility (`packages/core/src/data/map-limit.ts`) caps `getDashboardData` and `getUnifiedList` at `DEFAULT_REPO_FANOUT = 6` to stay well under GitHub's secondary rate limit. No new dependency.
- **PR review pass** `17c6bd1` — Addresses pre-PR review feedback from code-reviewer / pr-test-analyzer / silent-failure-hunter / comment-analyzer:
  - **Race path catch** in `launch.ts` step 8: two concurrent launches could both pass the cheap pre-check, the loser tripped `idx_deployments_live` at insert time, and the raw `SqliteError` bubbled through `formatErrorForUser`. Now caught and translated to the same friendly duplicate-launch message via a shared `duplicateLaunchError` helper. **The review caught a real bug here** — my initial predicate matched on `err.message.includes("idx_deployments_live")`, but better-sqlite3 formats the message as the column tuple, not the index name. The new test exercising the race path failed immediately and forced the fix to match on `code === "SQLITE_CONSTRAINT_UNIQUE"`.
  - **Three new behavioral tests** in `launch.test.ts` (with `vi.hoisted` + `vi.mock` stubs for workspace, terminal, context, label, and issue-detail modules): pre-check fires before `prepareWorkspace`; happy path after end; race path translation.
  - **v9 dedup logging** matches the v4 `claude_aliases` precedent — `console.warn` with row count before destructive operation.
  - **Test cleanup**: extended v8→v9 fixture with a mixed live+ended row to pin the subquery's inner `ended_at IS NULL` filter; seeded `state='pending'` explicitly in the v7→v8 preservation test (was passing on `DEFAULT 'active'`); dropped two PRAGMA SQL-scraping tests in favor of the behavioral assertions next to them; dropped a duplicate UNIQUE test in schema.test.ts in favor of the helper version in deployments.test.ts; tightened `toThrow(/UNIQUE/)` to the column-tuple format.
  - **Comment cleanup**: stripped `A#:` prefixes and audit-finding narrative from live code per CLAUDE.md ("avoid narrative comments tied to the current task"). Migration block comments kept (frozen history). Trimmed `hasLiveDeploymentForIssue` docstring to one sentence keyed to the index predicate. Fixed a factually wrong sentence in `mapLimit`'s docstring claiming both callers wrap `fn` in try/catch (only `getUnifiedList` does).
- **Invariant guards** `a5a1ec8` — Two new schema tests lock load-bearing assumptions:
  - `deployments` has exactly one unique index (`idx_deployments_live`) — if a future migration adds another, the launch.ts race-catch predicate would silently misfire. Test fails loudly.
  - No other table has an inbound FK to `deployments` — the v8 rebuild migration is frozen history and assumes this. Test scans `pragma_foreign_key_list` of every other table.

## Findings already closed by resilience PRs (not in this branch)

- **#5 Silent token staleness** → R3 `withAuthRetry` resets the cached Octokit on 401 and retries.
- **#6 Draft body unbounded** → R8 server-action `MAX_BODY = 65536` cap.
- **#7 Label silent failure** → R2 pending state + R7 retry with `labelWarning` surfaced to the UI.

## Out of scope

- Silent-failure-hunter flagged that v8 INSERT SELECT failures during web first-boot surface as Next.js 500s instead of an actionable "disk full / re-run issuectl init" message. **Pre-existing for all migrations**, not an A2 regression. Warrants its own follow-up.
- Audit finding #1's LLM-hallucination concern uses strict case-sensitive `getRepo` — matches the project-wide convention in 7 other action files. Changing parse.ts unilaterally would create divergence; convention-wide change is a separate discussion.

## Test plan

- [x] `pnpm turbo typecheck` — clean across core/cli/web
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] `pnpm --filter @issuectl/core test` — 315/315 pass
- [x] All 4 adversarial fixes have behavioral test coverage at the layer they live (helper, schema, action)
- [ ] Manual: track a repo, launch an issue, navigate back, click Launch again — should see "Issue #N already has an active deployment" instead of duplicate worktree
- [ ] Manual: track a repo, launch an issue, end the session, click Launch again — should succeed
- [ ] Manual: track a repo, launch an issue against it, try to remove the repo from settings — should succeed (cascades the deployment row)
- [ ] Manual: trigger `/parse` with text referencing a non-tracked repo, accept the row in the review sheet, click Create — that one row should fail with "Repository not tracked: …", others in the batch should still create
- [ ] Manual: load `/` with 10+ tracked repos and rapid-refresh — should not 403 with secondary rate limit
- [ ] Manual: upgrade an existing DB with duplicate live deployments — `console.warn` should log the row count being deduped at v9 migration time

## Note on schema migration

This PR bumps schema 7 → 9. Existing v7 DBs auto-migrate on next `getDb()` call. The v9 dedup is destructive (older duplicate rows get `ended_at` set) and is logged with a row count.