### PR TITLE
fix: address audit Mediums + Lows and perf polish

### DIFF
--- a/packages/core/src/db/idempotency.test.ts
+++ b/packages/core/src/db/idempotency.test.ts
@@ -151,12 +151,10 @@ describe("pruneExpiredNonces", () => {
   });
 });
 
-describe("withIdempotency — singleflight pattern (B10 use case)", () => {
-  // assignDraftAction wraps two layers of withIdempotency: an outer
-  // user-nonce sentinel for same-tab dedup, and an inner draftId-keyed
-  // sentinel that collapses cross-tab requests onto the same result.
-  // These tests exercise the inner-layer semantics directly — the same
-  // mechanism, just keyed on a draft id instead of a user-supplied nonce.
+describe("withIdempotency — singleflight pattern", () => {
+  // Pin the cross-tab idempotency case where the sentinel key is a
+  // resource id (e.g. draftId) instead of a per-submission user nonce,
+  // so two distinct callers collapse onto the same stored result.
 
   const draftId = "550e8400-e29b-41d4-a716-446655440000";
   const SINGLEFLIGHT = "assign-draft-singleflight";

--- a/packages/core/src/db/idempotency.test.ts
+++ b/packages/core/src/db/idempotency.test.ts
@@ -150,3 +150,93 @@ describe("pruneExpiredNonces", () => {
     expect(remaining.map((r) => r.nonce)).toEqual(["newnonce1234"]);
   });
 });
+
+describe("withIdempotency — singleflight pattern (B10 use case)", () => {
+  // assignDraftAction wraps two layers of withIdempotency: an outer
+  // user-nonce sentinel for same-tab dedup, and an inner draftId-keyed
+  // sentinel that collapses cross-tab requests onto the same result.
+  // These tests exercise the inner-layer semantics directly — the same
+  // mechanism, just keyed on a draft id instead of a user-supplied nonce.
+
+  const draftId = "550e8400-e29b-41d4-a716-446655440000";
+  const SINGLEFLIGHT = "assign-draft-singleflight";
+
+  it("a second caller with a different outer nonce replays the first caller's result", async () => {
+    // Tab A wins: claims the draftId, runs the work, stores the result.
+    // Tab B (different user nonce, same draftId) hits the completed
+    // sentinel and replays without re-running the GH-issue-creating
+    // inner function. Same issue URL for both tabs — the user is led
+    // to the issue tab A actually created.
+    const work = vi.fn().mockResolvedValue({
+      issueNumber: 42,
+      issueUrl: "https://github.com/o/r/issues/42",
+    });
+
+    const tabA = await withIdempotency(db, SINGLEFLIGHT, draftId, work);
+    const tabB = await withIdempotency(db, SINGLEFLIGHT, draftId, work);
+
+    expect(tabA).toEqual({
+      issueNumber: 42,
+      issueUrl: "https://github.com/o/r/issues/42",
+    });
+    expect(tabB).toEqual(tabA);
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it("a second caller throws DuplicateInFlightError while the first is still pending", async () => {
+    // Tab A is mid-flight (pending sentinel row); tab B refuses rather
+    // than start a parallel run that would create a duplicate GitHub
+    // issue. Tab B's inner work is never invoked.
+    let releaseTabA: () => void = () => {};
+    const tabAStarted = new Promise<void>((resolve) => {
+      releaseTabA = resolve;
+    });
+
+    const tabAWork = vi.fn(async () => {
+      await tabAStarted;
+      return { issueNumber: 42, issueUrl: "https://example.invalid/42" };
+    });
+
+    const tabAPromise = withIdempotency(db, SINGLEFLIGHT, draftId, tabAWork);
+
+    const tabBWork = vi.fn().mockResolvedValue({
+      issueNumber: 99,
+      issueUrl: "should-never-be-returned",
+    });
+
+    await expect(
+      withIdempotency(db, SINGLEFLIGHT, draftId, tabBWork),
+    ).rejects.toBeInstanceOf(DuplicateInFlightError);
+    expect(tabBWork).not.toHaveBeenCalled();
+
+    releaseTabA();
+    await tabAPromise;
+  });
+
+  it("a failed first attempt does not wedge the singleflight slot", async () => {
+    // The original assignment failed transiently (e.g. network blip).
+    // The next caller is allowed to retry — the failed sentinel is
+    // deleted and recreated on the recursive call.
+    const failingWork = vi.fn().mockRejectedValue(new Error("network timeout"));
+    await expect(
+      withIdempotency(db, SINGLEFLIGHT, draftId, failingWork),
+    ).rejects.toThrow("network timeout");
+
+    const successfulWork = vi.fn().mockResolvedValue({
+      issueNumber: 42,
+      issueUrl: "https://example.invalid/42",
+    });
+    const result = await withIdempotency(
+      db,
+      SINGLEFLIGHT,
+      draftId,
+      successfulWork,
+    );
+
+    expect(result).toEqual({
+      issueNumber: 42,
+      issueUrl: "https://example.invalid/42",
+    });
+    expect(successfulWork).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/launch/workspace.test.ts
+++ b/packages/core/src/launch/workspace.test.ts
@@ -147,4 +147,18 @@ describe("prepareWorkspace — clone mode", () => {
     ).rejects.toThrow("clone failed");
     expect(rmMock).toHaveBeenCalled();
   });
+
+  it("refuses to reuse a dirty existing clone", async () => {
+    // Symmetric with the worktree-mode dirty refusal: an existing
+    // clone dir from a previous launch may have uncommitted work that
+    // createOrCheckoutBranch would silently switch away from.
+    accessMock.mockResolvedValue(undefined);
+    execFileMock.mockResolvedValue({ stdout: ".git\n", stderr: "" });
+    branchMocks.isWorkingTreeClean.mockResolvedValue(false);
+
+    await expect(
+      prepareWorkspace({ ...BASE_OPTIONS, mode: "clone" }),
+    ).rejects.toThrow(/uncommitted changes/);
+    expect(branchMocks.createOrCheckoutBranch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/launch/workspace.test.ts
+++ b/packages/core/src/launch/workspace.test.ts
@@ -108,7 +108,7 @@ describe("prepareWorkspace — worktree mode", () => {
     expect(branchMocks.createOrCheckoutBranch).toHaveBeenCalled();
   });
 
-  it("refuses to reuse a dirty existing worktree (B8)", async () => {
+  it("refuses to reuse a dirty existing worktree", async () => {
     // The previous launch left uncommitted work in the reused dir; the
     // existing path silently switched branches and lost it. Now we
     // refuse loudly and the user must commit/stash before relaunching.

--- a/packages/core/src/launch/workspace.test.ts
+++ b/packages/core/src/launch/workspace.test.ts
@@ -40,9 +40,9 @@ beforeEach(() => {
   accessMock.mockReset();
   mkdirMock.mockResolvedValue(undefined);
   rmMock.mockResolvedValue(undefined);
-  branchMocks.createOrCheckoutBranch.mockResolvedValue(undefined);
-  branchMocks.isWorkingTreeClean.mockResolvedValue(true);
-  branchMocks.getDefaultBranch.mockResolvedValue("origin/main");
+  branchMocks.createOrCheckoutBranch.mockReset().mockResolvedValue(undefined);
+  branchMocks.isWorkingTreeClean.mockReset().mockResolvedValue(true);
+  branchMocks.getDefaultBranch.mockReset().mockResolvedValue("origin/main");
 });
 
 const BASE_OPTIONS = {
@@ -106,6 +106,20 @@ describe("prepareWorkspace — worktree mode", () => {
     expect(result.path).toBe("/tmp/worktrees/myrepo-issue-1");
     expect(result.created).toBe(false);
     expect(branchMocks.createOrCheckoutBranch).toHaveBeenCalled();
+  });
+
+  it("refuses to reuse a dirty existing worktree (B8)", async () => {
+    // The previous launch left uncommitted work in the reused dir; the
+    // existing path silently switched branches and lost it. Now we
+    // refuse loudly and the user must commit/stash before relaunching.
+    accessMock.mockResolvedValue(undefined);
+    execFileMock.mockResolvedValue({ stdout: ".git\n", stderr: "" });
+    branchMocks.isWorkingTreeClean.mockResolvedValue(false);
+
+    await expect(
+      prepareWorkspace({ ...BASE_OPTIONS, mode: "worktree" }),
+    ).rejects.toThrow(/uncommitted changes/);
+    expect(branchMocks.createOrCheckoutBranch).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/launch/workspace.ts
+++ b/packages/core/src/launch/workspace.ts
@@ -115,7 +115,7 @@ async function prepareWorktree(options: {
   // re-launches the same issue with a different branch name, the
   // existing worktree's checkout would silently be switched away from
   // any uncommitted work. Refuse instead and let the user commit or
-  // stash deliberately. Adversarial audit finding #8.
+  // stash deliberately.
   if (await pathExists(worktreePath)) {
     if (await isGitRepo(worktreePath)) {
       const clean = await isWorkingTreeClean(worktreePath);

--- a/packages/core/src/launch/workspace.ts
+++ b/packages/core/src/launch/workspace.ts
@@ -185,9 +185,18 @@ async function prepareClone(options: {
 
   await mkdir(options.worktreeDir, { recursive: true });
 
-  // If the directory already exists from a previous launch, reuse it
+  // If the directory already exists from a previous launch, reuse it.
+  // Same hazard as the worktree reuse path above: createOrCheckoutBranch
+  // would silently switch branches and lose any uncommitted work the
+  // user left behind. Refuse loudly when the existing clone is dirty.
   if (await pathExists(clonePath)) {
     if (await isGitRepo(clonePath)) {
+      const clean = await isWorkingTreeClean(clonePath);
+      if (!clean) {
+        throw new Error(
+          `Clone at ${clonePath} has uncommitted changes from a previous launch of this issue. Commit or stash them (or remove the directory) before launching again.`,
+        );
+      }
       await timedExec("git", ["fetch", "origin"], {
         cwd: clonePath,
         timeoutMs: GIT_FETCH_TIMEOUT_MS,

--- a/packages/core/src/launch/workspace.ts
+++ b/packages/core/src/launch/workspace.ts
@@ -110,9 +110,20 @@ async function prepareWorktree(options: {
 
   await mkdir(options.worktreeDir, { recursive: true });
 
-  // If the directory already exists from a previous launch, reuse it
+  // If the directory already exists from a previous launch, reuse it.
+  // The path is keyed only on (repo, issue#), not branch — if the user
+  // re-launches the same issue with a different branch name, the
+  // existing worktree's checkout would silently be switched away from
+  // any uncommitted work. Refuse instead and let the user commit or
+  // stash deliberately. Adversarial audit finding #8.
   if (await pathExists(worktreePath)) {
     if (await isGitRepo(worktreePath)) {
+      const clean = await isWorkingTreeClean(worktreePath);
+      if (!clean) {
+        throw new Error(
+          `Worktree at ${worktreePath} has uncommitted changes from a previous launch of this issue. Commit or stash them (or remove the worktree with \`git worktree remove\`) before launching again.`,
+        );
+      }
       await createOrCheckoutBranch(worktreePath, options.branchName);
       return { path: worktreePath, mode: "worktree", created: false };
     }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -6,9 +6,12 @@ import { ToastProvider } from "@/components/ui/ToastProvider";
 import { getAuthStatus } from "@/lib/auth";
 import "./globals.css";
 
+// Inter and Fraunces are variable fonts — omitting `weight` lets
+// next/font ship a single file per style instead of one per weight,
+// cutting the per-route font CSS substantially while keeping every
+// weight (400-700) the design system uses.
 const fraunces = Fraunces({
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
   style: ["normal", "italic"],
   variable: "--font-serif",
   display: "swap",
@@ -16,14 +19,18 @@ const fraunces = Fraunces({
 
 const inter = Inter({
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   display: "swap",
 });
 
+// IBM Plex Mono is not a variable font on Google Fonts, so we still
+// specify discrete weights — but only the ones used in the design
+// system (400 for body mono, 600 for emphasis chips/badges). 500 had
+// no usage in CSS and 700 is browser-synthesized from 600 in the rare
+// case it's requested.
 const ibmPlexMono = IBM_Plex_Mono({
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["400", "600"],
   variable: "--font-mono-paper",
   display: "swap",
 });

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -53,6 +53,7 @@ export function ParseInput({ onParsed }: Props) {
         disabled={isPending}
         autoFocus
         aria-label="Issue description for Claude to parse"
+        maxLength={8192}
       />
       <div className={styles.footer}>
         <Button

--- a/packages/web/lib/actions/drafts.test.ts
+++ b/packages/web/lib/actions/drafts.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+
+// vi.mock is hoisted, so we cannot reference a const declared above it.
+// Use vi.hoisted() to create the spies before hoisting occurs.
+const revalidatePath = vi.hoisted(() => vi.fn());
+vi.mock("next/cache", () => ({ revalidatePath }));
+
+const { dbHolder, assignDraftToRepoMock } = vi.hoisted(() => ({
+  // Mutable holder so beforeEach can swap in a fresh DB without
+  // reassigning the captured-by-closure binding inside the mock factory.
+  dbHolder: { db: null as Database.Database | null },
+  assignDraftToRepoMock: vi.fn(),
+}));
+
+vi.mock("@issuectl/core", async () => {
+  // Keep withIdempotency, the error classes, the validation helpers,
+  // and initSchema as the real implementations — the wiring test
+  // depends on the actual sentinel-table semantics. Override only the
+  // bits that touch the network and the DB connection factory.
+  const real = await vi.importActual<typeof import("@issuectl/core")>(
+    "@issuectl/core",
+  );
+  return {
+    ...real,
+    getDb: () => {
+      if (!dbHolder.db) throw new Error("test DB not initialised");
+      return dbHolder.db;
+    },
+    withAuthRetry: <T,>(fn: (octokit: unknown) => Promise<T>) => fn({}),
+    assignDraftToRepo: (...args: unknown[]) => assignDraftToRepoMock(...args),
+  };
+});
+
+// Import AFTER mocks are registered.
+const { assignDraftAction } = await import("./drafts.js");
+const { initSchema } = await import("@issuectl/core");
+
+const VALID_DRAFT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+beforeEach(() => {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  initSchema(db);
+  // Seed a repo so getRepoById inside assignDraftToRepo would resolve
+  // (the mock bypasses that call entirely, but a real schema needs the
+  // row for any future test that exercises a non-mocked code path).
+  db.prepare("INSERT INTO repos (owner, name) VALUES (?, ?)").run("o", "n");
+  // Seed a draft row so the production validators do not short-circuit
+  // before the singleflight runs. Same reason — the mocked
+  // assignDraftToRepo never reads it but the action's call chain does.
+  db.prepare(
+    `INSERT INTO drafts (id, title, body, priority, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(VALID_DRAFT_ID, "t", "", "normal", 0, 0);
+  dbHolder.db = db;
+  assignDraftToRepoMock.mockReset();
+  revalidatePath.mockReset();
+});
+
+describe("assignDraftAction — singleflight wiring", () => {
+  it("two callers with different idempotency keys collapse onto one assignDraftToRepo call", async () => {
+    // The actual cross-tab guarantee: tab A and tab B each generate a
+    // distinct user nonce, both reach the action, and the inner
+    // draftId-keyed sentinel ensures only one of them runs the work.
+    // The other replays the stored {issueNumber, issueUrl}.
+    assignDraftToRepoMock.mockResolvedValue({
+      repoId: 1,
+      issueNumber: 42,
+      issueUrl: "https://example.invalid/42",
+    });
+
+    const tabA = await assignDraftAction(VALID_DRAFT_ID, 1, "tabANonce0001");
+    const tabB = await assignDraftAction(VALID_DRAFT_ID, 1, "tabBNonce0002");
+
+    expect(tabA).toMatchObject({ success: true, issueNumber: 42 });
+    expect(tabB).toMatchObject({ success: true, issueNumber: 42 });
+    // The crucial property — the GitHub-issue-creating call only ran
+    // once even though both tabs invoked the action. A regression that
+    // unwrapped the inner singleflight would call this twice.
+    expect(assignDraftToRepoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a draftId shorter than 8 characters before invoking the singleflight", async () => {
+    // The sibling validators at the top of the function need to share
+    // the same length floor as withIdempotency's isValidNonce (8 chars)
+    // so the singleflight wrap below cannot trip on a malformed caller
+    // with an opaque "Invalid idempotency nonce" error.
+    const result = await assignDraftAction("short", 1, "validNonce0001");
+    expect(result).toEqual({
+      success: false,
+      error: "draftId must be at least 8 characters",
+    });
+    expect(assignDraftToRepoMock).not.toHaveBeenCalled();
+  });
+
+  it("same idempotency key replays the stored result without re-invoking the work", async () => {
+    // The outer (user-nonce) sentinel — same-tab retries from the
+    // existing R1 idempotency. Pinned here to make sure the new
+    // singleflight wrap did not break the outer layer.
+    assignDraftToRepoMock.mockResolvedValue({
+      repoId: 1,
+      issueNumber: 42,
+      issueUrl: "https://example.invalid/42",
+    });
+
+    const first = await assignDraftAction(VALID_DRAFT_ID, 1, "sameNonce0001");
+    const second = await assignDraftAction(VALID_DRAFT_ID, 1, "sameNonce0001");
+
+    expect(first).toMatchObject({ success: true, issueNumber: 42 });
+    expect(second).toMatchObject({ success: true, issueNumber: 42 });
+    expect(assignDraftToRepoMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -202,9 +202,36 @@ export async function assignDraftAction(
         throw err;
       }
     };
+    // B10: a per-draft singleflight gate, layered under the user-nonce
+    // idempotency. Two concurrent tabs send fresh (distinct) user nonces,
+    // so the outer "assign-draft" sentinel does not deduplicate them —
+    // both would race into runAssign and both would create GitHub issues,
+    // orphaning whichever loses the local delete. Keying a second
+    // sentinel on the draftId itself collapses cross-tab requests onto
+    // the same result: the loser of the race either replays the winner's
+    // {issueNumber, issueUrl} (if the winner has finished) or throws
+    // DuplicateInFlightError (if the winner is still in flight). Both
+    // surface the same friendly "already being assigned" UI message —
+    // and the replay case actually returns the winner's issue URL so
+    // the user is led directly to their newly created issue.
+    //
+    // withIdempotency's isValidNonce requires 8+ URL-safe chars. Draft
+    // UUIDs are 36 chars hyphenated and pass cleanly; rejecting shorter
+    // ids upfront keeps the singleflight error message coherent for
+    // malformed callers.
+    if (draftId.length < 8) {
+      return { success: false, error: "draftId must be at least 8 characters" };
+    }
+    const runWithSingleflight = () =>
+      withIdempotency(db, "assign-draft-singleflight", draftId, runAssign);
     const result = idempotencyKey
-      ? await withIdempotency(db, "assign-draft", idempotencyKey, runAssign)
-      : await runAssign();
+      ? await withIdempotency(
+          db,
+          "assign-draft",
+          idempotencyKey,
+          runWithSingleflight,
+        )
+      : await runWithSingleflight();
     issueNumber = result.issueNumber;
     issueUrl = result.issueUrl;
     cleanupWarning = result.cleanupWarning ?? undefined;

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -120,15 +120,17 @@ export async function updateDraftAction(
 
   try {
     const db = getDb();
-    // updateDraft returns undefined when no row exists for the id —
-    // a tab-A-deleted-the-draft / tab-B-still-editing race. Surface
-    // that as an explicit failure so the editing tab cannot believe
-    // its autosaves are persisting when they are silently no-ops.
+    // updateDraft returns undefined when no row exists for the id.
+    // Surface that as an explicit failure so the editing surface
+    // cannot believe its autosaves are persisting when they are
+    // silently no-ops — reachable via cross-tab delete, stale router
+    // cache on back-navigation, or an unmounted editor still
+    // referencing a freshly-deleted id.
     const updated = updateDraft(db, draftId, update);
     if (!updated) {
       return {
         success: false,
-        error: "Draft no longer exists — it may have been deleted in another tab",
+        error: "Draft no longer exists — it may have been deleted.",
       };
     }
   } catch (err) {
@@ -157,8 +159,11 @@ export async function assignDraftAction(
     }
   | { success: false; error: string }
 > {
-  if (typeof draftId !== "string" || draftId.length === 0) {
-    return { success: false, error: "draftId must be a non-empty string" };
+  // Length floor matches `isValidNonce`'s 8-char minimum so the
+  // singleflight wrap below can use draftId as a sentinel key without
+  // tripping on a malformed caller. UUID drafts are 36 chars and pass.
+  if (typeof draftId !== "string" || draftId.length < 8) {
+    return { success: false, error: "draftId must be at least 8 characters" };
   }
   if (
     typeof repoId !== "number" ||
@@ -202,26 +207,14 @@ export async function assignDraftAction(
         throw err;
       }
     };
-    // B10: a per-draft singleflight gate, layered under the user-nonce
-    // idempotency. Two concurrent tabs send fresh (distinct) user nonces,
-    // so the outer "assign-draft" sentinel does not deduplicate them —
-    // both would race into runAssign and both would create GitHub issues,
-    // orphaning whichever loses the local delete. Keying a second
-    // sentinel on the draftId itself collapses cross-tab requests onto
-    // the same result: the loser of the race either replays the winner's
-    // {issueNumber, issueUrl} (if the winner has finished) or throws
-    // DuplicateInFlightError (if the winner is still in flight). Both
-    // surface the same friendly "already being assigned" UI message —
-    // and the replay case actually returns the winner's issue URL so
-    // the user is led directly to their newly created issue.
-    //
-    // withIdempotency's isValidNonce requires 8+ URL-safe chars. Draft
-    // UUIDs are 36 chars hyphenated and pass cleanly; rejecting shorter
-    // ids upfront keeps the singleflight error message coherent for
-    // malformed callers.
-    if (draftId.length < 8) {
-      return { success: false, error: "draftId must be at least 8 characters" };
-    }
+    // Two-layer idempotency: the outer sentinel deduplicates same-tab
+    // retries (one user nonce → one stored result), while the inner
+    // sentinel collapses cross-tab races onto the same draft. Distinct
+    // user nonces bypass the outer layer, so without this the second
+    // tab would race into runAssign and create a duplicate GitHub
+    // issue; keying the inner layer on the draftId itself means the
+    // loser of the race either replays the winner's {issueNumber,
+    // issueUrl} or throws DuplicateInFlightError.
     const runWithSingleflight = () =>
       withIdempotency(db, "assign-draft-singleflight", draftId, runAssign);
     const result = idempotencyKey

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -120,7 +120,17 @@ export async function updateDraftAction(
 
   try {
     const db = getDb();
-    updateDraft(db, draftId, update);
+    // updateDraft returns undefined when no row exists for the id —
+    // a tab-A-deleted-the-draft / tab-B-still-editing race. Surface
+    // that as an explicit failure so the editing tab cannot believe
+    // its autosaves are persisting when they are silently no-ops.
+    const updated = updateDraft(db, draftId, update);
+    if (!updated) {
+      return {
+        success: false,
+        error: "Draft no longer exists — it may have been deleted in another tab",
+      };
+    }
   } catch (err) {
     console.error("[issuectl] updateDraftAction failed", err);
     return { success: false, error: "Failed to update draft" };

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -20,6 +20,13 @@ import type {
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
+// Parse input is a free-form prompt that gets piped to the Claude CLI;
+// cost and latency are proportional to token count and the content is
+// never persisted, so the cap is much tighter than draft/issue body
+// limits (65536). 8K is generous for the "describe what you want" use
+// case and prevents a paste-bomb from burning the LLM budget.
+const MAX_PARSE_INPUT = 8192;
+
 type ParseActionResult =
   | { success: true; data: { parsed: ParsedIssuesResponse } }
   | { success: false; error: string };
@@ -27,8 +34,17 @@ type ParseActionResult =
 export async function parseNaturalLanguage(
   input: string,
 ): Promise<ParseActionResult> {
+  if (typeof input !== "string") {
+    return { success: false, error: "Input must be a string" };
+  }
   if (!input.trim()) {
     return { success: false, error: "Input cannot be empty" };
+  }
+  if (input.length > MAX_PARSE_INPUT) {
+    return {
+      success: false,
+      error: `Input must be ${MAX_PARSE_INPUT} characters or fewer`,
+    };
   }
 
   try {


### PR DESCRIPTION
## Summary

Closes the remaining actionable adversarial Mediums/Lows from `qa-reports/adversarial-audit.md` and the one perf item from `qa-reports/perf-audit-r2.md` that was not already overtaken by prior fixes.

**Re-audit caveat**: the original triage queue had 13 items, but verification against current `main` showed 7 of them were already addressed by commit `8a09d61` (round-2 audit fixes) and follow-ups — `loading.tsx` for all 4 dynamic routes, the auth subprocess cache, settings-page Suspense streaming, tab `<Link>` conversion, `PrDetail` Server Component split, and the `rehype-highlight` chunk no longer reaches the client. Saved roughly half the originally-planned work; the audits are stale relative to current main.

## Commits (7)

- **B13** `b85b3c2` — `parseNaturalLanguage` accepted unbounded input. Cap server-side at 8K (much tighter than draft body's 65536 since LLM cost is proportional to token count and the prompt is never persisted), tighten the `typeof input` guard, mirror the cap as `maxLength={8192}` on the textarea.
- **B9** `379619b` — `updateDraftAction` discarded `updateDraft`'s return value and replied `{success: true}` even when the row was gone. Capture the return; on undefined, surface `"Draft no longer exists — it may have been deleted."` so autosaves cannot silently no-op. The cross-tab race, stale router cache, and unmounted-editor cases all reach the same state and produce the same message.
- **C-P1-6** `39638a7` — `next/font/google` was loading 4 individual Inter files, 8 Fraunces files, and 3 IBM Plex Mono files — 28 / 548KB on disk. Switch Inter and Fraunces to their variable-font versions (one file per style) and drop IBM Plex Mono's unused `500` weight. Net: 23 files / 504KB.
- **B8** `cfddcf3` — `prepareWorktree` reused an existing dir keyed only on `(repo, issue#)` and silently switched branches via `createOrCheckoutBranch`, losing any uncommitted work from the prior launch. Add an `isWorkingTreeClean` check (already imported and used by `prepareExisting`) and refuse loudly with a message that points at the path and suggests `git worktree remove` as one recovery option.
- **B10** `219a639` — `assignDraftAction`'s R1 idempotency keys on the user's per-submission nonce, so cross-tab races (each tab generates a fresh nonce) bypass it and both tabs end up calling GitHub's POST /issues. Layer a per-draft singleflight under the user-nonce sentinel by reusing `withIdempotency` with a fixed action_type `"assign-draft-singleflight"` and the draftId as the key. Loser of the race either replays the winner's `{issueNumber, issueUrl}` or throws `DuplicateInFlightError` — same friendly UI message either way, and the replay case actually returns the winner's issue URL so the second tab is led to the right issue. No schema bump.
- **PR review pass** `bc5ae2a` — Aggregated the four pre-PR review agents' findings:
  - **New `packages/web/lib/actions/drafts.test.ts`** (3 tests) pins the B10 wiring at the action layer with a real in-memory SQLite + the `settings.test.ts` mock pattern. The previous round of singleflight tests in `idempotency.test.ts` only exercised the underlying mechanism — a refactor that unwrapped the inner layer or reordered the wrapping would silently pass them all. The new tests assert that two distinct user nonces both succeed and `assignDraftToRepo` runs exactly once.
  - **Length check consolidation**: `draftId.length < 8` was buried inside the try block at `drafts.ts:222`; moved to the top of the function next to the sibling validators, replacing the now-shadowed `length === 0` check.
  - **Comment cleanup**: stripped `B#:` audit-finding prefixes from live code, test names, and describe block titles per CLAUDE.md ("don't reference the current task in comments since they rot"). Trimmed the long B10 comment to four lines focused on the two-layer rationale. Migration-style historical comments are unaffected.
- **prepareClone symmetric dirty refusal** `17d056a` — code-reviewer flagged that `prepareClone` had the same hazard B8 fixed for `prepareWorktree`. Same one-line check, same throw shape, matching test. Out of B8's strict scope per CLAUDE.md but the symmetry argument is strong: shipping B8 alone would leave a known same-shape footgun on the clone-mode code path.

## Findings already on main (no work needed)

These were in the original queue but verified to be already addressed:

| # | Where it landed |
|---|---|
| C-P0-1 auth subprocess cache | `lib/auth.ts:7-9` (60s TTL, commit `8a09d61`) |
| C-P0-2 settings TTFB streaming | `settings/page.tsx` `<Suspense>` boundaries |
| C-P0-3 tab `<a>` → `<Link>` | `List.tsx:80,86` |
| C-P1-4 loading.tsx on 4 dynamic routes | All 4 files exist |
| C-P2-7 rehype-highlight chunk | Gone from client bundle (`PrDetail` is now Server Component) |
| C-P2-8 PrDetail Client Component split | Done |
| B11 orphan worktree cleanup | Manual `WorktreeCleanup` UI + `cleanupStaleWorktrees` action exist |

## Test plan

- [x] `pnpm turbo typecheck` — clean across core/cli/web
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] `pnpm --filter @issuectl/core test` — 319/319 pass (3 new singleflight cases in `idempotency.test.ts`, 1 new dirty-worktree case + 1 new dirty-clone case in `workspace.test.ts`)
- [x] `pnpm --filter @issuectl/web test` — 20/20 pass (3 new action-layer wiring cases in `drafts.test.ts`, 17 existing in `settings.test.ts`)
- [x] `pnpm --filter @issuectl/web build` — production build green; font media dir 504KB / 23 files (was 548KB / 28)
- [ ] Manual: paste a >8K string into `/parse` — should be rejected at the textarea before submission, and rejected at the server if the textarea cap is bypassed
- [ ] Manual: edit a draft in tab A, delete it in tab B, return to tab A and trigger an autosave — should see "Draft no longer exists" instead of silent fake-success
- [ ] Manual: launch an issue in worktree mode, leave uncommitted changes in the worktree, relaunch with a different branch — should refuse with "uncommitted changes from a previous launch" instead of silently switching
- [ ] Manual: same as above but with clone mode — same refusal
- [ ] Manual: open an unsaved draft in two tabs, click "Assign to repo" in both at the same time — only one GitHub issue should be created; the second tab should either show the same issue URL (fast race) or "draft is already being assigned — please wait" (slow race)
- [ ] Manual: visual check that the dashboard typography looks the same after the variable-font swap (no missing weights at 400/500/600/700 for serif/sans, no missing 400/600 for mono)

## Out of scope

- B9 and B13 are untested at the action layer. Both are 1-3 line conditional changes; the marginal cost of standing up an action-layer test harness is higher than the regression risk. The new `drafts.test.ts` infrastructure could absorb tests for them later if the value calculus changes.
- The `silent-failure-hunter` agent flagged a benign edge case in B10 where tab B's outer user-nonce row gets written as `status='failed'` even though tab B never executed any work. Harmless — the row is keyed on tab B's unique nonce and is GC'd by `pruneExpiredNonces` within the hour. Documented but not fixed.