### PR TITLE
fix: address remaining adversarial-r2 lows + sanitize endSession err

### DIFF
--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -133,7 +133,7 @@ export async function endSession(
     coreEndDeployment(db, deploymentId);
   } catch (err) {
     console.error("[issuectl] Failed to end session:", err);
-    return { success: false, error: err instanceof Error ? err.message : "Failed to end session" };
+    return { success: false, error: formatErrorForUser(err) };
   }
   const { stale } = revalidateSafely(
     `/${owner}/${repo}/issues/${issueNumber}`,

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -9,10 +9,35 @@ const nextConfig: NextConfig = {
     ],
   },
   async headers() {
+    // CSP is defense-in-depth — React's JSX escaping prevents the XSS
+    // vectors that exist today, and there is no `dangerouslySetInnerHTML`
+    // anywhere. The header limits the blast radius of any future DOM
+    // manipulation or third-party script injection.
+    //
+    // 'unsafe-inline' on style-src is required by next/font (which
+    // injects inline @font-face CSS) and React's runtime style hoisting.
+    // 'unsafe-eval' on script-src is required by Next.js dev-mode HMR;
+    // it is harmless in production builds where eval is not used by the
+    // framework. img-src whitelists the GitHub avatar host already
+    // configured under `images.remotePatterns` above. data: covers
+    // inline SVG and base64 placeholders.
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https://avatars.githubusercontent.com",
+      "font-src 'self'",
+      "connect-src 'self'",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; ");
+
     return [
       {
         source: "/(.*)",
         headers: [
+          { key: "Content-Security-Policy", value: csp },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary

Stacked on top of #62. Closes the remaining actionable findings from `qa-reports/adversarial-audit-r2.md` and `qa-reports/ux-audit-r2.md` after the previous round of fixes (8a09d61) and the type-scale polish (2154132) overtook most of the originally-flagged items.

**Re-audit caveat**: 25 findings across the two R2 reports → 4 actionable, 5 P2 polish deferred. Most P0/P1 items had already landed in commit `8a09d61`. The full triage matrix is in the commit message.

## Commits (1)

- **bb263ac** — `fix: address remaining adversarial-r2 lows + sanitize endSession err`
  - **Adv-R2 #7** (Octokit error leak): `endSession` in `lib/actions/launch.ts:136` was the only action returning raw `err.message` instead of `formatErrorForUser(err)`. One-line fix.
  - **Adv-R2 #4** (CSP header): `next.config.ts` already set `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` but no `Content-Security-Policy`. Added a sane default policy with the necessary `'unsafe-inline'` for `next/font` and `'unsafe-eval'` for Next.js dev HMR. `img-src` whitelists the GitHub avatar host already in `images.remotePatterns`. `frame-ancestors 'none'` supersedes the `X-Frame-Options DENY`.
  - Verified the production build serves the header on `/`, `/settings`, and `/parse` (all 200).

## Findings already on main (no work needed)

### Adversarial R2

| # | Sev | Status |
|---|---|---|
| 1 | M | tracked-repo authz on actions | ✅ `getRepo(db,…)` in 5 mutation actions (8a09d61) |
| 2 | M | updateDraftAction missing validation | ✅ `validateTitle/Body/Priority` called (8a09d61) |
| 3 | M | createDraft/assignDraft raw throw | ✅ both use structured returns (8a09d61) |

### UX R2

| # | Sev | Status |
|---|---|---|
| 1 | P0 | hover-only row actions | ✅ `:focus-within` + inverted `@media (hover: none)` block — verified all three input modes (mouse hover, keyboard, touch) work |
| 2 | P0 | merged chip contrast 1.93:1 | ✅ 8a09d61 |
| 3 | P0 | settings warning contrast 1.89:1 | ✅ 8a09d61 |
| 4 | P0 | no h1 on home/draft detail | ✅ 8a09d61 |
| 5 | P0 | `--paper-ink-faint` 3.6:1 | ✅ darkened to `#6e644a` in `globals.css:9` |
| 6 | P1 | 3 unlabeled inputs | ✅ 8a09d61 |
| 7 | P1 | WCAG target-size links | ✅ 8a09d61 |
| 8 | P1 | Button default type | ✅ `Button.tsx:33` `type={rest.type ?? "button"}` |
| 9 | P1 | half-pixel font sizes (spacing grid) | ✅ grep finds zero `*.5px` declarations |
| 10 | P1 | 8 font sizes / no type scale | ✅ `--paper-fs-*` tokens in 22 files (2154132 type-scale polish) |

## Out of scope (deferred)

- **Adv-R2 #5** (empty draft title CHECK constraint): app layer already prevents empty titles via `validateTitle` in both `createDraftAction` and `updateDraftAction`. The audit's defense-in-depth schema CHECK would require a v10 table rebuild migration (SQLite cannot ALTER constraints) which is more invasive than the LOW severity warrants. The only bypass is direct DB write access, which is outside the threat model for a single-user local app.
- **Adv-R2 #6** (dev-mode error templates leak file paths): standard Next.js dev behavior, not present in production builds.
- **UX P2 polish (5 items)**: create-draft hint copy duplication, Next.js dev error indicator investigation, desktop FAB → inline button (UX call), `.state.merged` chip needs an icon (color-only a11y), settings save success toast, settings monospace fallback verification. All "would be nicer" not "actually broken" — defer until they bubble up.

## Stacking

This PR is **stacked on `fix/audit-mediums-and-perf-polish` (#62)**. Merge order:
1. Merge #62 first
2. Retarget this PR to `main` with `gh pr edit <this-pr> --base main`
3. Merge

CI will not run on this PR until it's retargeted to main (the workflow only triggers on `pull_request` against `main`). Same pattern as the prior resilience stacked PRs.

## Test plan

- [x] `pnpm turbo typecheck` — clean across core/cli/web
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] `pnpm --filter @issuectl/web build` — production build green
- [x] Smoke test: `pnpm exec next start --port 3849`, CSP header present on `/`, `/settings`, `/parse`, all return 200
- [ ] Manual: open the dashboard in a browser with CSP active, watch the dev console for any CSP violation warnings (especially around next/font, hydration scripts, server actions)
- [ ] Manual: end a launch session with a deployment id that doesn't exist — should get a sanitized error message instead of raw SQLite text