### PR TITLE
fix(core): unblock initSchema on upgrade DBs with duplicate live deployments

### DIFF
--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -467,3 +467,113 @@ describe("schema invariants — assumptions other code depends on", () => {
     expect(offenders).toEqual([]);
   });
 });
+
+describe("initSchema does not deadlock against pre-existing duplicate live deployments", () => {
+  it("v7 DB with duplicate live rows survives initSchema → runMigrations", () => {
+    // Regression test for the production bug where initSchema's
+    // CREATE UNIQUE INDEX in CREATE_TABLES failed against an existing
+    // v7 DB whose deployments table held duplicate live rows from the
+    // pre-R1-idempotency era. The fix moves the index out of
+    // CREATE_TABLES; the v9 migration's dedupe pass runs FIRST under
+    // runMigrations, then v9 creates the index cleanly.
+    //
+    // CRUCIAL: getDb's order is initSchema → runMigrations. This test
+    // mirrors that exact order. Reordering it would mask the bug.
+    const db = createRawTestDb();
+
+    // Build a v7-shaped DB: schema_version=7, action_nonces present
+    // (added in v7), CHECK on state column, NO live-unique index.
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (7);
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        name TEXT NOT NULL,
+        local_path TEXT,
+        branch_pattern TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(owner, name)
+      );
+      CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE deployments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id),
+        issue_number INTEGER NOT NULL,
+        branch_name TEXT NOT NULL,
+        workspace_mode TEXT NOT NULL,
+        workspace_path TEXT NOT NULL,
+        linked_pr_number INTEGER,
+        state TEXT NOT NULL DEFAULT 'active',
+        launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+        ended_at TEXT
+      );
+      CREATE TABLE cache (key TEXT PRIMARY KEY, data TEXT NOT NULL);
+      CREATE TABLE drafts (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL DEFAULT '',
+        priority TEXT NOT NULL DEFAULT 'normal',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE issue_metadata (
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        issue_number INTEGER NOT NULL,
+        priority TEXT NOT NULL DEFAULT 'normal',
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (repo_id, issue_number)
+      );
+      CREATE TABLE action_nonces (
+        nonce TEXT NOT NULL,
+        action_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        result_json TEXT,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (nonce, action_type)
+      );
+      INSERT INTO repos (owner, name) VALUES ('o', 'n');
+      -- Two duplicate live deployments for issue #42 — the exact
+      -- shape that broke the user's production DB.
+      INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
+        VALUES (1, 42, 'b1', 'existing', '/a');
+      INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path)
+        VALUES (1, 42, 'b2', 'existing', '/b');
+    `);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Mirror getDb's order exactly: initSchema first, then runMigrations.
+    expect(() => {
+      initSchema(db);
+      runMigrations(db);
+    }).not.toThrow();
+
+    expect(getSchemaVersion(db)).toBe(9);
+
+    // Verify the dedupe ran and the index now exists.
+    const live = db
+      .prepare("SELECT id FROM deployments WHERE ended_at IS NULL")
+      .all() as { id: number }[];
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe(2);
+
+    const indexes = db
+      .prepare(`SELECT name FROM pragma_index_list('deployments') WHERE "unique" = 1`)
+      .all() as { name: string }[];
+    expect(indexes.map((i) => i.name)).toContain("idx_deployments_live");
+
+    warnSpy.mockRestore();
+  });
+
+  it("fresh-install initSchema still creates the live-unique index", () => {
+    // The fix moves CREATE INDEX out of CREATE_TABLES into the
+    // fresh-install branch of initSchema, so this case must remain
+    // covered or new installs would be missing the index.
+    const db = createTestDb();
+    const indexes = db
+      .prepare(`SELECT name FROM pragma_index_list('deployments') WHERE "unique" = 1`)
+      .all() as { name: string }[];
+    expect(indexes.map((i) => i.name)).toContain("idx_deployments_live");
+  });
+});

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -70,16 +70,27 @@ const CREATE_TABLES = `
   CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
     ON action_nonces(created_at);
 
-  -- At most one live deployment per (repo, issue). Ended rows are
-  -- historical audit trail and are excluded from the predicate so
-  -- re-launching after a session closes is allowed.
-  CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_live
-    ON deployments(repo_id, issue_number)
-    WHERE ended_at IS NULL;
-
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL
   );
+`;
+
+// `idx_deployments_live` is intentionally NOT in CREATE_TABLES. On
+// upgrade DBs that pre-date R1 idempotency, the deployments table may
+// contain duplicate live rows from before the singleflight fix landed;
+// SQLite cannot create a unique index over a table that already
+// violates it, so a naive `CREATE UNIQUE INDEX IF NOT EXISTS` in
+// CREATE_TABLES would throw before the v9 migration's dedupe pass got
+// a chance to run (initSchema is called before runMigrations in
+// connection.ts). The fix:
+//   - Fresh installs: deployments is empty, so initSchema can create
+//     the index directly below after setting schema_version.
+//   - Upgrade installs: the v9 migration runs the dedupe and the
+//     CREATE INDEX in the correct order via runMigrations.
+const CREATE_LIVE_DEPLOYMENT_INDEX = `
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_live
+    ON deployments(repo_id, issue_number)
+    WHERE ended_at IS NULL;
 `;
 
 export function initSchema(db: Database.Database): void {
@@ -93,6 +104,10 @@ export function initSchema(db: Database.Database): void {
     db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(
       SCHEMA_VERSION,
     );
+    // Fresh install — deployments is empty, so the unique index
+    // creates cleanly. Upgrade DBs deliberately skip this branch and
+    // go through the v9 migration's dedupe-then-create-index path.
+    db.exec(CREATE_LIVE_DEPLOYMENT_INDEX);
   }
 }
 


### PR DESCRIPTION
## Production bug

Discovered while running the audit-verification e2e spec against the real `~/.issuectl/issuectl.db`. Every page load was failing server-side with:

\`\`\`
SqliteError: UNIQUE constraint failed: deployments.repo_id, deployments.issue_number
    at initSchema (../core/dist/index.js:94:6)
    at getDb (../core/dist/index.js:296:3)
    at MainListPage (app/page.tsx:27:19)
\`\`\`

## Root cause

Order-of-operations bug in PR #62. The v9 work added the partial unique index `idx_deployments_live` to **both** the v9 migration **and** the fresh-install `CREATE_TABLES` block in `schema.ts`. On fresh installs and CI in-memory DBs the deployments table is always empty, so the `CREATE UNIQUE INDEX` in `CREATE_TABLES` creates cleanly. On **upgrade** DBs that were running v7 with pre-R1-idempotency-era duplicate live deployments, the order in `connection.ts` is:

\`\`\`ts
initSchema(db);    // ← runs CREATE_TABLES, including CREATE UNIQUE INDEX
runMigrations(db); // ← would dedupe via v9 — never reached
\`\`\`

so the index creation tries to enforce uniqueness over already-duplicated rows **before** the v9 migration's dedupe pass gets a chance to run. SQLite throws `SQLITE_CONSTRAINT_UNIQUE` and `getDb` propagates the error to every caller.

The user's real DB had accumulated **7 duplicate live deployment rows** from before R1's idempotency-sentinel work and the launch.ts race-path catch landed; this hotfix surfaced them in the migration log.

## Fix

- Move the `CREATE UNIQUE INDEX idx_deployments_live` declaration **out** of `CREATE_TABLES` and into a separate `CREATE_LIVE_DEPLOYMENT_INDEX` constant.
- In `initSchema`, run the `CREATE INDEX` only inside the **fresh-install branch** (after `schema_version` is inserted), where deployments is guaranteed empty so the index creates trivially.
- **Upgrade installs** deliberately skip the fresh-install branch and let the v9 migration's existing dedupe-then-create-index path run via `runMigrations`.
- The v9 migration's `CREATE UNIQUE INDEX IF NOT EXISTS` already exists and is unchanged, so upgrade DBs follow the correct order: `runMigrations` → v8 (deployments rebuild) → v9 (dedupe + CREATE INDEX).

## Coverage

Two new tests in `schema.test.ts`:

1. **`v7 DB with duplicate live rows survives initSchema → runMigrations`** — builds a synthetic v7-shaped DB with two duplicate live rows for the same `(repo, issue)`, runs `initSchema` and `runMigrations` in the **exact order** `connection.ts` uses, and asserts the upgrade completes without throwing AND the dedupe ran AND the index was created. Reordering this test would mask the bug.
2. **`fresh-install initSchema still creates the live-unique index`** — asserts the fresh-install branch still creates the index, so the fix doesn't accidentally regress new installs.

## Verified end-to-end

Ran `next dev` against the real `~/.issuectl/issuectl.db` after the fix:

\`\`\`
ready in 2s
--- HTTP status ---
200
--- error trail in server log ---
[issuectl] Migration v9: ending 7 duplicate live deployment row(s) so the new unique index can be created. The most recent deployment per (repo, issue) is kept; older rows receive ended_at = now.
\`\`\`

The home page returns 200 and the migration's existing warn log records the dedupe of the 7 stale rows.

## Test plan

- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo test` — 321 core tests pass, including 2 new schema tests
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] Manual: `next dev` against the real `~/.issuectl/issuectl.db` returns 200 on `/` and logs the dedupe of 7 rows
- [ ] Manual after merge: confirm dashboard, settings, drafts, parse, issue detail, and pull detail all render without server errors

## Severity

This is a **release-blocking** bug for any user upgrading from v7 → v9 with duplicate live deployments. Recommend merging immediately — anyone who pulled `main` after PR #62 landed and has any pre-R1 duplicates is currently locked out of every page.