### PR TITLE
fix(web): CSP hydration, UX P2 polish, and audit-verification e2e

### DIFF
--- a/packages/web/components/detail/DetailMeta.module.css
+++ b/packages/web/components/detail/DetailMeta.module.css
@@ -19,12 +19,20 @@
 }
 
 .state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-family: var(--paper-mono);
   font-size: 12px;
   padding: 2px 8px;
   border-radius: var(--paper-radius-sm);
   font-weight: 600;
   letter-spacing: 0.3px;
+}
+
+.stateGlyph {
+  font-size: 13px;
+  line-height: 1;
 }
 
 .state.open {

--- a/packages/web/components/detail/DetailMeta.tsx
+++ b/packages/web/components/detail/DetailMeta.tsx
@@ -13,8 +13,25 @@ type StateChipProps = {
   state: "open" | "closed" | "merged";
 };
 
+// Per-state icon glyph. Color alone is not enough to convey the
+// distinction between open / closed / merged for users with the kinds
+// of color blindness that confuse green and purple — the chip needs a
+// non-color signal too.
+const STATE_GLYPH = {
+  open: "○", // hollow circle — issue/PR is still active
+  closed: "✕", // x — closed without merging
+  merged: "⤥", // arrow into a target — merged into the base branch
+} as const;
+
 export function StateChip({ state }: StateChipProps) {
-  return <span className={`${styles.state} ${styles[state]}`}>{state}</span>;
+  return (
+    <span className={`${styles.state} ${styles[state]}`}>
+      <span aria-hidden="true" className={styles.stateGlyph}>
+        {STATE_GLYPH[state]}
+      </span>
+      {state}
+    </span>
+  );
 }
 
 export function MetaSeparator() {

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -2,6 +2,15 @@
   padding: 0 28px 28px;
 }
 
+.label {
+  display: block;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  margin-bottom: 4px;
+}
+
 .input {
   width: 100%;
   font-family: var(--paper-serif);
@@ -14,19 +23,12 @@
   background: transparent;
   padding: 4px 0 16px;
   outline: none;
+  margin-bottom: 18px;
 }
 
 .input::placeholder {
   color: var(--paper-ink-faint);
   font-style: italic;
-}
-
-.hint {
-  font-family: var(--paper-serif);
-  font-style: italic;
-  font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-faint);
-  margin-bottom: 18px;
 }
 
 .actions {

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -55,19 +55,19 @@ export function CreateDraftSheet({ open, onClose }: Props) {
       description={<em>a local draft without a repo — assign it later</em>}
     >
       <div className={styles.form}>
+        <label htmlFor="create-draft-title" className={styles.label}>
+          Title
+        </label>
         <input
+          id="create-draft-title"
           className={styles.input}
           placeholder="What needs to be done?"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           disabled={saving}
           autoFocus
-          aria-label="Draft title"
           maxLength={256}
         />
-        <div className={styles.hint}>
-          title only — add a body, labels, and a repo when you assign it
-        </div>
         {error && <div className={styles.error}>{error}</div>}
         <div className={styles.actions}>
           <Button variant="ghost" onClick={handleClose} disabled={saving}>

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -90,6 +90,32 @@
   align-self: center;
 }
 
+/* Desktop-only inline draft button. The mobile FAB is hidden at the
+ * same breakpoint by Fab.module.css so only one entry point is shown
+ * per viewport. */
+.desktopDraftBtn {
+  display: none;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-accent);
+  background: transparent;
+  border: 1px solid var(--paper-accent-soft);
+  border-radius: var(--paper-radius-sm);
+  padding: 6px 12px;
+  margin-left: 16px;
+  align-self: center;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.desktopDraftBtn:hover {
+  background: var(--paper-accent-soft);
+  border-color: var(--paper-accent);
+}
+
 .desktopDate b {
   color: var(--paper-ink-soft);
   font-style: normal;
@@ -199,5 +225,9 @@
 
   .desktopDate {
     display: block;
+  }
+
+  .desktopDraftBtn {
+    display: inline-block;
   }
 }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -92,6 +92,17 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
         <div className={styles.desktopDate}>
           {weekday} · <b>{short}</b>
         </div>
+        {/* Desktop-only inline create-draft button. The Fab below is */}
+        {/* the mobile entry point and is hidden on desktop. */}
+        {activeTab === "issues" && (
+          <button
+            type="button"
+            className={styles.desktopDraftBtn}
+            onClick={() => setCreateOpen(true)}
+          >
+            + draft
+          </button>
+        )}
       </div>
 
       {activeTab === "issues" ? (

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -26,9 +26,12 @@
   opacity: 0.92;
 }
 
+/* Mobile-only entry point. Desktop has the inline `+ draft` button in
+ * the tabs row (see List.module.css `.desktopDraftBtn`), so showing
+ * the FAB at the same breakpoint would create two redundant entry
+ * points for the same action. */
 @media (min-width: 768px) {
   .fab {
-    right: 40px;
-    bottom: 40px;
+    display: none;
   }
 }

--- a/packages/web/e2e/audit-verification.spec.ts
+++ b/packages/web/e2e/audit-verification.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+
+const execFileAsync = promisify(execFile);
+
+// Distinct from quick-create.spec.ts (3848) so the two specs can coexist.
+const TEST_PORT = 3850;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// ── Skip conditions ─────────────────────────────────────────────────
+//
+// This spec verifies UI/HTTP behavior that does NOT need Claude or
+// real GitHub round trips, but the dev server still requires `gh
+// auth token` to boot (RootLayout calls getAuthStatus). Skip the
+// suite if gh auth is not configured rather than failing the run.
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function createTestDb(dbPath: string): void {
+  // Mirror the schema setup from quick-create.spec.ts but on schema
+  // version 1 — runMigrations will bring it up to current. The test
+  // here cares about settings + repos seed only.
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS repos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      owner TEXT NOT NULL,
+      name TEXT NOT NULL,
+      local_path TEXT,
+      branch_pattern TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(owner, name)
+    );
+    CREATE TABLE IF NOT EXISTS deployments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_id INTEGER NOT NULL REFERENCES repos(id),
+      issue_number INTEGER NOT NULL,
+      branch_name TEXT NOT NULL,
+      workspace_mode TEXT NOT NULL,
+      workspace_path TEXT NOT NULL,
+      linked_pr_number INTEGER,
+      launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS cache (
+      key TEXT PRIMARY KEY,
+      data TEXT NOT NULL
+    );
+  `);
+
+  db.prepare("INSERT OR IGNORE INTO schema_version (version) VALUES (?)").run(4);
+
+  const defaults: Array<[string, string]> = [
+    ["branch_pattern", "issue-{number}-{slug}"],
+    ["terminal_app", "iterm2"],
+    ["terminal_window_title", "issuectl"],
+    ["terminal_tab_title_pattern", "#{number} — {title}"],
+    ["cache_ttl", "300"],
+    ["worktree_dir", "~/.issuectl/worktrees/"],
+  ];
+  const insertSetting = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+  );
+  for (const [key, value] of defaults) {
+    insertSetting.run(key, value);
+  }
+
+  db.prepare(
+    "INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)",
+  ).run(TEST_OWNER, TEST_REPO);
+
+  db.close();
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+// ── Test fixture ────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-audit-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, ISSUECTL_DB_PATH: dbPath },
+    stdio: "pipe",
+  });
+
+  let serverStderr = "";
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderr += chunk.toString();
+  });
+
+  await waitForServer(BASE_URL, 30000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderr.slice(-500)}`,
+    );
+  });
+});
+
+test.afterAll(async () => {
+  if (server) {
+    const killTimeout = setTimeout(() => {
+      try {
+        server.kill("SIGKILL");
+      } catch {
+        /* already dead */
+      }
+    }, 5000);
+
+    server.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+test.describe("Adv-R2 #4 — Content-Security-Policy header", () => {
+  // Defense-in-depth header added in commit 55b3030. Should be present
+  // on every route. The exact policy is allowed to evolve; the test
+  // just pins the load-bearing directives.
+  const REQUIRED_DIRECTIVES = [
+    "default-src 'self'",
+    "img-src 'self' data: https://avatars.githubusercontent.com",
+    "frame-ancestors 'none'",
+  ];
+
+  for (const route of ["/", "/settings", "/parse"]) {
+    test(`route ${route} sends CSP with the load-bearing directives`, async () => {
+      if (skipReason) test.skip(true, skipReason);
+      const res = await fetch(`${BASE_URL}${route}`);
+      const csp = res.headers.get("content-security-policy");
+      expect(csp, `no CSP header on ${route}`).toBeTruthy();
+      for (const directive of REQUIRED_DIRECTIVES) {
+        expect(csp, `${route} CSP missing "${directive}"`).toContain(directive);
+      }
+    });
+  }
+});
+
+// Two more findings from PRs #62 and #64 (B13 parse input cap, B9
+// updateDraft missing-row failure) are NOT verified in this e2e spec
+// because they live behind Client Component hydration paths that
+// fight Next.js dev-mode streaming — networkidle never fires in dev
+// (HMR socket), and the textarea/title editor live in components that
+// stream in after the initial HTML response. Both are already pinned
+// at the action layer:
+//
+//   - B13 (8K parse cap):  packages/core unit tests for
+//                          parseNaturalLanguage; the maxLength prop
+//                          on ParseInput.tsx is source-reviewable.
+//   - B9  (missing draft):  packages/web/lib/actions/drafts.test.ts
+//                          exercises updateDraftAction against a
+//                          real in-memory DB and asserts the
+//                          success:false path.
+//
+// CSP coverage above is the load-bearing e2e finding because it
+// requires the *running* server to attach the header on every route.

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,8 +1,18 @@
 import type { NextConfig } from "next";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Pin the workspace root to the monorepo root so Next.js does not
+// silently pick up a stray lockfile elsewhere on disk and emit the
+// "inferred your workspace root" warning on every dev startup. The
+// import.meta.url indirection keeps this resilient to where the
+// command is run from.
+const WORKSPACE_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   transpilePackages: ["@issuectl/core"],
+  outputFileTracingRoot: WORKSPACE_ROOT,
   images: {
     remotePatterns: [
       { hostname: "avatars.githubusercontent.com" },
@@ -14,16 +24,28 @@ const nextConfig: NextConfig = {
     // anywhere. The header limits the blast radius of any future DOM
     // manipulation or third-party script injection.
     //
-    // 'unsafe-inline' on style-src is required by next/font (which
-    // injects inline @font-face CSS) and React's runtime style hoisting.
+    // 'unsafe-inline' on script-src is required by Next.js (App Router
+    // emits inline hydration scripts on every SSR'd page; without
+    // 'unsafe-inline' the browser refuses every one of them and
+    // hydration silently fails — surfaced as ~30 CSP-violation entries
+    // in the dev error indicator). The strict alternative is per-page
+    // nonce-based CSP via middleware, which is significantly more
+    // invasive; this matches the recommended next/security-headers
+    // policy and the React docs' standard CSP example.
+    //
+    // 'unsafe-inline' on style-src is required by next/font (inline
+    // @font-face CSS) and React's runtime style hoisting.
+    //
     // 'unsafe-eval' on script-src is required by Next.js dev-mode HMR;
-    // it is harmless in production builds where eval is not used by the
-    // framework. img-src whitelists the GitHub avatar host already
-    // configured under `images.remotePatterns` above. data: covers
-    // inline SVG and base64 placeholders.
+    // it is harmless in production where eval is not used by the
+    // framework but kept for parity so dev/prod CSPs match.
+    //
+    // img-src whitelists the GitHub avatar host already configured
+    // under `images.remotePatterns` above. data: covers inline SVG and
+    // base64 placeholders.
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https://avatars.githubusercontent.com",
       "font-src 'self'",


### PR DESCRIPTION
## Summary

Mixed bag — one **critical** CSP hydration regression discovered while running the verification work, four UX P2 polish items from `qa-reports/ux-audit-r2.md`, and a new minimal e2e spec for the audit findings.

## CRITICAL — CSP was blocking React hydration

The CSP I added in PR #64 set `script-src 'self' 'unsafe-eval'`. That's missing `'unsafe-inline'`, which Next.js App Router needs for the inline hydration `<script>` tags it emits on every SSR'd page. The browser was refusing every one of them and hydration was silently failing — surfaced as **~30 CSP-violation entries** per page in the dev error indicator (which, in retrospect, is what the original UX P2 #12 audit finding was actually flagging).

Found by driving Playwright with `page.on('console', ...)` against `/`, `/parse`, and `/settings`. Every page logged dozens of:

\`\`\`
[error] Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'unsafe-eval''. Either the 'unsafe-inline' keyword, a hash, or a nonce is required to enable inline execution. The action has been blocked.
\`\`\`

**Fix**: add `'unsafe-inline'` to `script-src`, matching the standard Next.js + React CSP recipe. The strict alternative (per-page nonce-based CSP via middleware) is significantly more invasive; the relaxed policy still narrows the blast radius of cross-origin script injection. Verified via re-probe: zero CSP violations after the fix.

## Other fixes

- **Workspace lockfile warning** — `next.config.ts`: pin `outputFileTracingRoot` to the monorepo root via `import.meta.url`. Silences the "Next.js inferred your workspace root" warning that fires on every dev startup because of multiple lockfiles on disk.
- **UX P2 #11 — create-draft hint duplication** — the hint text duplicated the dialog description above it. Remove the hint and add a visible `<label htmlFor="...">` "Title" element above the input. Drops the placeholder-as-label antipattern.
- **UX P2 #13 — desktop draft entry point** — the mobile FAB was the only entry point for "create draft." Add an inline `+ draft` button in the desktop tabs row (issues tab only) styled as a subtle accent pill. Hide the FAB at the desktop breakpoint so there are not two entry points for the same action.
- **UX P2 #14 — merged chip color-only signal (a11y)** — `DetailMeta`'s `StateChip` used color alone to distinguish open / closed / merged. For users with green/purple color confusion the merged chip was unreadable. Add a per-state Unicode glyph (`○ open`, `✕ closed`, `⤥ merged`) inside the chip, marked `aria-hidden="true"` since the text label still carries the semantic meaning for screen readers.

## Audit verification e2e spec

`packages/web/e2e/audit-verification.spec.ts` — spawns a fresh `next dev` with an isolated test DB and asserts the **CSP header is present** on `/`, `/settings`, and `/parse` with the load-bearing directives (`default-src 'self'`, `img-src ... avatars...`, `frame-ancestors 'none'`). Skipped if `gh auth token` isn't configured, mirroring the `quick-create.spec.ts` skip pattern.

3 tests, runs in ~5s.

**B13 (parse 8K cap) and B9 (updateDraft missing-row failure) are intentionally NOT in this spec** because they live behind Client Component hydration paths that fight Next.js dev-mode streaming (HMR socket prevents `networkidle` from ever firing). Both are already pinned by the action-layer unit tests in `packages/web/lib/actions/drafts.test.ts` and the parse action unit tests.

## Verified-already-done (no fix needed)

- **UX P2 #15 settings save toast** — already wired in `SettingsForm.tsx:99-102` by the round-2 fix work.
- **UX P2 #16 monospace fallback leak** — `--font-mono-paper` → `--paper-mono` chain is correct in `globals.css` and `layout.tsx`; IBM Plex Mono is loading per the C-P1-6 perf work. The audit's concern was a stale runtime observation.

## Test plan

- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo test` — 321 core tests pass, 3 new web e2e CSP tests pass
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] **Critical**: Playwright console probe against `/`, `/parse`, `/settings` shows zero CSP violations after the `'unsafe-inline'` fix
- [ ] Manual: open the dashboard in a browser and visually verify (a) the new desktop "+ draft" button, (b) the FAB only on mobile widths, (c) the create-draft sheet has a visible "Title" label, (d) the merged-PR chip shows the ⤥ glyph, (e) the dev error indicator no longer shows CSP-violation count

## Severity

The CSP fix is **release-blocking** for anyone who has updated past PR #64 — every page on production is currently failing hydration. Recommend prioritizing this PR.