### PR TITLE
chore(web): allow LAN dev origins for cross-device testing

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -13,6 +13,13 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   transpilePackages: ["@issuectl/core"],
   outputFileTracingRoot: WORKSPACE_ROOT,
+  // Next.js 15 warns on cross-origin requests to /_next/* in dev mode
+  // and threatens to refuse them in a future major. issuectl is a local
+  // single-user tool that's commonly accessed from a phone or tablet on
+  // the same LAN as the host machine, so the private RFC1918 ranges
+  // are explicitly allowed. localhost is implicit and does not need
+  // listing here.
+  allowedDevOrigins: ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"],
   images: {
     remotePatterns: [
       { hostname: "avatars.githubusercontent.com" },


### PR DESCRIPTION
## Summary

Next.js 15 warns on cross-origin requests to `/_next/*` in dev mode and threatens to refuse them in a future major version, surfaced as a "Cross origin request detected from <ip> to /_next/* resource" message in the dev error indicator on every page load when accessing the dev server from anywhere other than localhost (e.g. a phone, tablet, or second laptop on the same Wi-Fi).

issuectl is a local single-user tool that's commonly accessed from multiple devices on the same LAN as the host machine — verifying the mobile UX, sharing the dashboard with another monitor, etc. Allow the three RFC1918 private ranges explicitly. Localhost is implicit and does not need listing.

## Verified

- Before: dev log shows the cross-origin warning on every request from `192.168.1.x`
- After: clean dev log, zero warnings, `/_next/*` responses succeed, page renders cleanly

## Test plan

- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] Manual: hit dev server from LAN IP, no cross-origin warning in server log