### PR TITLE
fix(web): surface active deployment on issue detail + state-aware list action

### DIFF
--- a/packages/web/components/detail/LaunchCard.tsx
+++ b/packages/web/components/detail/LaunchCard.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@issuectl/core";
 import { Button } from "@/components/paper";
 import { LaunchModal } from "@/components/launch/LaunchModal";
+import { LaunchActiveBanner } from "@/components/launch/LaunchActiveBanner";
 import styles from "./LaunchCardPlaceholder.module.css";
 
 type Props = {
@@ -33,6 +34,24 @@ export function LaunchCard({
   initialWorkspaceMode,
 }: Props) {
   const [modalOpen, setModalOpen] = useState(false);
+
+  // Without this check the page renders "Ready to launch" for an
+  // issue already in flight — the unique-deployment DB constraint
+  // only rejects the duplicate after the user clicks Launch.
+  const liveDeployment = deployments.find((d) => d.endedAt === null);
+
+  if (liveDeployment) {
+    return (
+      <LaunchActiveBanner
+        deploymentId={liveDeployment.id}
+        branchName={liveDeployment.branchName}
+        endedAt={liveDeployment.endedAt}
+        owner={owner}
+        repo={repo}
+        issueNumber={issue.number}
+      />
+    );
+  }
 
   return (
     <>

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -44,20 +44,41 @@
 
 .actionBtn {
   font-family: var(--paper-serif);
-  font-style: italic;
-  font-size: 12px;
-  color: var(--paper-ink-muted);
-  background: transparent;
-  border: none;
+  font-style: normal;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--paper-accent);
+  background: var(--paper-accent-soft);
+  border: 1px solid transparent;
   cursor: pointer;
-  padding: 4px 8px;
+  padding: 7px 14px;
   text-decoration: none;
   border-radius: var(--paper-radius-sm);
+  white-space: nowrap;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .actionBtn:hover {
-  color: var(--paper-ink);
+  background: var(--paper-bg);
+  border-color: var(--paper-accent);
+  color: var(--paper-accent);
+}
+
+/* In-flight variant — visually distinct from the launch CTA so a row
+ * with an active session reads as "go to existing" rather than
+ * "start something new". */
+.actionBtnFlight {
+  color: var(--paper-ink-soft);
   background: var(--paper-bg-warmer);
+}
+
+.actionBtnFlight:hover {
+  color: var(--paper-ink);
+  background: var(--paper-bg);
+  border-color: var(--paper-line);
 }
 
 /* Mobile: keep assign in the meta row, hide desktop actions panel */

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -102,6 +102,32 @@ export function ListRow({ item, onAssign }: Props) {
     (l) => !l.name.startsWith("issuectl:"),
   );
 
+  // Label reflects what the click does: in-flight rows open an active
+  // session rather than launching, so "launch" would mislead.
+  // Exhaustive switch so a future addition to the Section union is a
+  // compile error here instead of silently rendering "launch →" on a
+  // section that should not launch.
+  let actionLabel: string;
+  let actionAria: string;
+  switch (section) {
+    case "in_focus":
+      actionLabel = "launch";
+      actionAria = "Launch issue";
+      break;
+    case "in_flight":
+      actionLabel = "open";
+      actionAria = "Open active session";
+      break;
+    case "shipped":
+      actionLabel = "view";
+      actionAria = "View issue";
+      break;
+    default: {
+      const _exhaustive: never = section;
+      throw new Error(`ListRow: unhandled section ${String(_exhaustive)}`);
+    }
+  }
+
   return (
     <div className={styles.item}>
       <Link
@@ -130,10 +156,10 @@ export function ListRow({ item, onAssign }: Props) {
       <div className={styles.actions}>
         <Link
           href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
-          className={styles.actionBtn}
-          aria-label="Open issue detail"
+          className={`${styles.actionBtn} ${section === "in_flight" ? styles.actionBtnFlight : ""}`}
+          aria-label={actionAria}
         >
-          launch
+          {actionLabel} →
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two related UX gaps surfaced during manual verification testing.

### LaunchCard ignored its deployments prop

`packages/web/components/detail/LaunchCard.tsx` received a `deployments: Deployment[]` prop but never read it. A user who launched an issue and navigated back to its detail page saw the **"Ready to launch"** card again with the Launch button, identical to a never-launched issue. Clicking would bounce off the partial unique deployment index with a friendly but post-hoc error — the user had no visible signal beforehand.

**Fix**: derive `liveDeployment = deployments.find(d => d.endedAt === null)`. When found, render the existing `LaunchActiveBanner` component (the same one already used by the post-launch `/launch/[...]` route), which shows the branch name, a session-active indicator, and an End Session button. Otherwise render the existing "Ready to launch" card. **No new component, no new action** — just consume the prop the Server Component was already passing in.

### ListRow action button said "launch" for already-launched issues

`packages/web/components/list/ListRow.tsx` hard-coded "launch" as the button label for every issue row regardless of section, and the styling was 12px italic muted text on a transparent background — reading more like hover-revealed body text than a primary action.

**Fix**:
- Derive label and aria-label from `item.section` via an **exhaustive `switch`** (per silent-failure-hunter review): `launch` for in_focus, `open` for in_flight (the click goes to the active-session banner above, not a launch), `view` for shipped. The `never` default makes a future addition to the `Section` union a compile error here instead of silently rendering "launch →" on a section that should not launch.
- Bump the visible affordance: 13px non-italic medium weight, accent color text on a faint accent background, more padding (7×14), border on hover.
- New `.actionBtnFlight` variant uses `--paper-ink-soft` on `--paper-bg-warmer` so an active-session row reads as "go to existing" rather than "start something new" — doesn't visually compete with launch CTAs in the same list.

## Pre-PR review (4 agents in parallel)

| Agent | Verdict |
|---|---|
| code-reviewer | "Tight, safe to ship. No critical or important issues." |
| silent-failure-hunter | Caught the section fallthrough hazard above (HIGH); fixed in the same diff via exhaustive switch + `never` assertion. |
| comment-analyzer | Asked to trim the `LaunchCard` and `ListRow` comments — rot-prone references to a specific schema version, a sibling component name, and the next line's JSX. Done. |
| pr-test-analyzer | Explicitly recommended **no new tests**. The underlying invariants (`endedAt === null` for live deployments, exhaustive `Section` union) are already pinned at the core layer by `deployments.test.ts`, `schema.test.ts` (v9 partial unique index), and `unified-list.test.ts`. |

## Verified manually

Against `~/.issuectl/issuectl.db` at `localhost:3847`:
- ✅ Issue with a live deployment now shows the active-session banner
- ✅ Same issue's row in the dashboard now shows `open →` in the muted variant instead of `launch →`
- ✅ Issue without a deployment renders the launch CTA as before
- ✅ Closed issues show `view →`

## Test plan

- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] Manual verification at `localhost:3847` against the real DB
- [ ] Manual after merge: confirm the ListRow visual affordance reads as a real button on a fresh browser session (no cached CSS)

## Out of scope (not introduced by this PR, deferred)

- **Cross-tab stale-banner state**: if Tab A ends a session, Tab B keeps showing `LaunchActiveBanner` until refresh. Clicking End Session in Tab B will then call `coreEndDeployment` on an already-ended row and surface a generic error. silent-failure-hunter flagged this as a known limitation, not introduced by this PR. Worth a follow-up: detect "already ended" in `coreEndDeployment` and return a stale-refresh hint.
- **`LaunchActiveBanner` `endedAt` prop is dead data** in this call site (the filter guarantees `endedAt === null`). Stylistic, no behavioral impact.
- **Pre-existing `:focus-visible` outline gap on `.actionBtn`** — out of scope for this PR.