### PR TITLE
fix(web): inline saved flash + bolder global toast for save feedback

### DIFF
--- a/packages/web/components/settings/SettingsForm.module.css
+++ b/packages/web/components/settings/SettingsForm.module.css
@@ -85,6 +85,25 @@
   color: var(--paper-brick);
 }
 
+.savedFlash {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-accent);
+  animation: savedFlashIn 0.18s ease-out;
+}
+
+@keyframes savedFlashIn {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 .fieldError {
   font-size: 12px;
   color: var(--paper-brick);

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { updateSettings } from "@/lib/actions/settings";
 import { useToast } from "@/components/ui/ToastProvider";
 import { Button } from "@/components/paper";
 import { validateClaudeArgs } from "@issuectl/core/validation";
 import type { SettingKey } from "@issuectl/core";
 import styles from "./SettingsForm.module.css";
+
+// Save button gets an inline flash in addition to the toast: the
+// toast is the global + screen-reader path, but after clicking the
+// user's eyes are on the button, not the toast region.
+const SAVED_FLASH_MS = 2500;
 
 type Props = {
   branchPattern: string;
@@ -41,8 +46,16 @@ export function SettingsForm({
     claude_extra_args: claudeExtraArgs,
   });
   const [error, setError] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isPending, startTransition] = useTransition();
   const { showToast } = useToast();
+
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
 
   const originals: FormValues = {
     branch_pattern: branchPattern,
@@ -78,11 +91,21 @@ export function SettingsForm({
 
   function handleSave() {
     setError(null);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
     startTransition(async () => {
       const changed = (Object.keys(originals) as (keyof FormValues)[]).filter(
         (k) => values[k] !== originals[k],
       );
-      if (changed.length === 0) return;
+      if (changed.length === 0) {
+        // Unreachable: the Save button is `disabled={!isDirty}` so a
+        // click without any dirty fields means the disabled-button
+        // invariant has drifted. Log loudly rather than silently no-op
+        // (which would also wipe a stale ✓ Saved flash on screen).
+        console.warn(
+          "[issuectl] SettingsForm.handleSave: clicked with no dirty fields — disabled-button invariant broken",
+        );
+        return;
+      }
 
       const updates: Partial<Record<SettingKey, string>> = {};
       for (const key of changed) {
@@ -100,6 +123,11 @@ export function SettingsForm({
       } else {
         showToast("Settings saved", "success");
       }
+      setSavedFlash(true);
+      flashTimerRef.current = setTimeout(
+        () => setSavedFlash(false),
+        SAVED_FLASH_MS,
+      );
     });
   }
 
@@ -218,6 +246,11 @@ export function SettingsForm({
               ? "Save with warnings"
               : "Save Settings"}
         </Button>
+        {savedFlash && !isPending && (
+          <span className={styles.savedFlash} aria-hidden="true">
+            ✓ Saved
+          </span>
+        )}
         {error && <span className={styles.error} role="alert">{error}</span>}
       </div>
     </>

--- a/packages/web/components/ui/Toast.module.css
+++ b/packages/web/components/ui/Toast.module.css
@@ -1,36 +1,46 @@
 .toast {
   position: fixed;
-  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
-  right: calc(24px + env(safe-area-inset-right, 0px));
+  bottom: calc(28px + env(safe-area-inset-bottom, 0px));
+  right: calc(28px + env(safe-area-inset-right, 0px));
   z-index: 10000;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
+  gap: 14px;
+  padding: 16px 22px;
   background: var(--paper-bg);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
-  font-size: 13px;
+  font-family: var(--paper-serif);
+  font-size: 15px;
+  font-weight: 500;
   color: var(--paper-ink);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  animation: slideIn 0.2s ease-out;
-  max-width: 360px;
+  box-shadow: 0 12px 32px rgba(26, 23, 18, 0.28),
+    0 2px 6px rgba(26, 23, 18, 0.12);
+  animation: slideIn 0.22s ease-out;
+  min-width: 260px;
+  max-width: 420px;
 }
 
 .toast[data-exiting="true"] {
-  animation: slideOut 0.15s ease-in forwards;
+  animation: slideOut 0.18s ease-in forwards;
 }
 
 .success {
-  border-left: 3px solid var(--paper-accent);
+  border-left: 5px solid var(--paper-accent);
+  background: var(--paper-accent-soft);
+  color: var(--paper-ink);
 }
 
 .error {
-  border-left: 3px solid var(--paper-brick);
+  border-left: 5px solid var(--paper-brick);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
 }
 
 .warning {
-  border-left: 3px solid var(--paper-amber, var(--paper-brick));
+  border-left: 5px solid var(--paper-butter);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
 }
 
 .message {
@@ -42,13 +52,16 @@
   border: none;
   color: var(--paper-ink-muted);
   cursor: pointer;
-  font-size: 16px;
-  padding: 0;
+  font-size: 20px;
+  padding: 4px 4px 6px;
   line-height: 1;
+  border-radius: var(--paper-radius-sm);
+  transition: color 0.15s, background 0.15s;
 }
 
 .dismiss:hover {
-  color: var(--paper-ink-soft);
+  color: var(--paper-ink);
+  background: rgba(26, 23, 18, 0.06);
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Summary

User reported they didn't see any toast or success indicator after saving settings. Playwright screenshot probe confirmed the toast WAS firing in the bottom-right corner — but the Save button sits bottom-left and the toast was small (13px, plain background, 4s auto-dismiss), so it slid in and out at a spot the user wasn't watching.

Two-part fix.

### Inline `✓ Saved` affordance next to the Save button

- New `savedFlash` state in `SettingsForm.tsx` with a 2.5s timer ref cleared on unmount. `handleSave` clears any pending timer at the top, and on a successful `updateSettings` flips `savedFlash=true` and starts a fresh timer.
- New `<span aria-hidden="true">✓ Saved</span>` rendered in the existing `.saveRow` between the Button and the error span, conditional on `savedFlash && !isPending`. `aria-hidden` because the toast already carries the screen-reader announcement.
- New `.savedFlash` class (paper-serif italic 13px accent color) plus a `savedFlashIn` keyframe (opacity + 4px translateX slide-in).
- The toast still fires alongside; this is **additive** feedback at the user's actual point of attention, not a replacement.

### Bolder global Toast chrome

- font-size 13 → 15, weight regular → 500, paper-serif family
- padding 12/16 → 16/22, gap 10 → 14
- border-left 3px → 5px
- success/error/warning now pick up tinted backgrounds (`--paper-accent-soft` / `--paper-bg-warm`) instead of plain bg, so the state is visible at a glance instead of relying on the thin left border alone
- shadow strengthened: `0 8px 24px` → `0 12px 32px` + a second `0 2px 6px` layer for closer-range presence
- min-width 260, max-width 360 → 420 so longer messages get more room
- dismiss button bumped to 20px with a hover background pill so it looks like a real affordance

## Pre-PR review (4 agents in parallel)

| Agent | Verdict |
|---|---|
| code-reviewer | **Important**: `--paper-amber` is not defined in globals.css, so warning toasts had been falling through to brick-red — visually identical to `.error` after the bolder treatment. **Fixed**: use the existing `--paper-butter` (#d9a54d) which is the design system's actual amber. |
| silent-failure-hunter | **HIGH**: `handleSave` had a `setSavedFlash(false)` *outside* `startTransition` causing (a) a one-frame flicker and (b) silently erasing the visible flash on the `changed.length === 0` early return path. **Fixed**: dropped the redundant reset, converted the early return to a `console.warn` naming the broken disabled-button invariant. |
| comment-analyzer | Asked to drop the standard React useEffect cleanup boilerplate and trim the SAVED_FLASH_MS docstring. **Fixed**. |
| pr-test-analyzer | Explicitly recommended **no new tests** — the underlying `updateSettings` action is already pinned by `settings.test.ts` (success, validation failure, batch rollback, cacheStale, SQLITE_BUSY) and the new code is presentational with a failure mode visible to the naked eye. |

## Verified manually

Playwright screenshot probe (running dev server, real DB):
- ✅ Inline `✓ Saved` slides in next to the Save button after a successful save
- ✅ Bolder bottom-right toast renders simultaneously (accent-tinted background, 5px border, 15px text)
- ✅ Both signals fire for the same save event

## Test plan

- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo lint` — clean (only pre-existing warnings)
- [x] Manual verification at `localhost:3847/settings`
- [ ] Manual after merge: confirm warning toasts (e.g. cleanupWarning from `assignDraftAction`) now render with butter-amber border, not brick-red