### PR TITLE
feat(web): poll launch progress page while deployment is active

### DIFF
--- a/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@issuectl/core";
 import { DetailTopBar } from "@/components/detail/DetailTopBar";
 import { LaunchProgress } from "@/components/launch/LaunchProgress";
+import { LaunchProgressPoller } from "@/components/launch/LaunchProgressPoller";
 
 export const dynamic = "force-dynamic";
 
@@ -103,6 +104,7 @@ export default async function LaunchProgressPage({
           commentCount={commentCount}
           fileCount={fileCount}
         />
+        <LaunchProgressPoller active={deployment.endedAt === null} />
       </div>
     </div>
   );

--- a/packages/web/components/launch/LaunchProgressPoller.tsx
+++ b/packages/web/components/launch/LaunchProgressPoller.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const POLL_INTERVAL_MS = 5000;
+
+type Props = {
+  active: boolean;
+};
+
+// Drives a parent Server Component re-fetch via router.refresh() while the
+// deployment is active — the RSC equivalent of a polling fetch. Pauses on
+// visibilitychange so a backgrounded tab doesn't keep firing GitHub-backed
+// refreshes (battery, API quota). Browsers throttle hidden-tab timers, but
+// not aggressively enough to skip this.
+export function LaunchProgressPoller({ active }: Props) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!active) return;
+
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (timer) return;
+      timer = setInterval(() => {
+        router.refresh();
+      }, POLL_INTERVAL_MS);
+    };
+
+    const stop = () => {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) stop();
+      else start();
+    };
+
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [active, router]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Addresses R5 P1 #3 (deferred from PR #73). The launch progress page was a \`force-dynamic\` Server Component that rendered once at request time and froze — for a 10-minute Claude Code session the user previously saw zero updates until manually refreshing.

## Design

\`LaunchProgressPoller\` is a small (~50 line) no-render client component that calls \`router.refresh()\` on a 5-second interval while \`deployment.endedAt\` is null. The refresh re-runs the parent Server Component, which re-fetches via the existing \`getDeploymentById\` / \`getIssueDetail\` calls and re-renders. The pre-existing \`role=\"status\" aria-live=\"polite\"\` on \`.steps\` (added in PR #73) means VoiceOver gets the updates too.

Polling pauses on \`visibilitychange\` (battery + GitHub API quota when the tab is backgrounded) and stops automatically when the deployment ends — the SC re-renders with \`active=false\`, the effect re-runs, and cleanup tears down the interval.

**\"Server Components for reads\" rule still holds.** The poller fetches nothing itself; it just signals \"re-run the SC\". All data fetching stays server-side.

## Why \`router.refresh()\` not SSE/streaming
- One small client component vs a new route handler + streaming infrastructure
- Re-uses existing SC data path — no parallel fetch logic
- Confirmed via review: \`router.refresh()\` does partial RSC re-render, no full nav, no client-tree remount, no scroll jump
- 5 s cadence is responsive without being abusive (~120 RSC re-runs over a 10 min session, all hitting local SQLite + Octokit)

## Review trail
\`/pr-review-toolkit:review-pr all\` — 5 agents, 0 critical, 0 important, 3 actionable suggestions:
1. Comment shortening — applied (dropped filler, reframed visibility-pause justification)
2. Test coverage — see \"Testing\" below
3. Failure backoff on persistent server errors — **deferred**. Speculative without signal; per CLAUDE.md, don't design for hypothetical future requirements

## Testing
**No automated test added.** Project precedent is zero client-component unit tests in \`packages/web/components/\` — the only Vitest specs in the web package are Server Action integration tests. The natural alternative was extending \`packages/web/e2e/launch-flow.spec.ts\`, but that file is stale (references \`/mean-weasel/issuectl-test-repo/issues/1\` instead of the current \`/issues/[owner]/[repo]/[number]\` route structure, and is gated on macOS+Ghostty+gh auth). Adding to it would compound the brokenness; adding a new isolated spec to test a 30-line poller with its own dev-server fixture is heavier than the feature warrants.

Manual verification: typecheck clean, page renders 200, component bundle present.

## Test Plan
- [ ] Open a real launch session via \`Launch to Claude Code\` on an issue
- [ ] Watch the launch progress page — the bottom step should flip from \"Claude Code running\" to \"Session ended\" without manual refresh when the session terminates
- [ ] Tab away from the page, leave it backgrounded for 30 s, tab back — polling should resume (no missed refreshes piling up)
- [ ] Enable Reduce Motion in iOS Settings — spinner stays static; polling is unaffected
- [ ] VoiceOver: when the step transitions, the \`role=\"status\"\` live region should announce the new label

## Related
- R5 audit: \`qa-reports/mobile-ux-audit-r5.md\` (\"3. Launch progress\" → P1 #3)
- R6 verification: \`qa-reports/mobile-ux-audit-r6.md\` (deferred status confirmed)
- Prior fix bundle: PR #73