### PR TITLE
test(web): pin R3-R6 mobile UX wins with Playwright regression spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,37 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo build
+
+  e2e-mobile-ux:
+    name: E2E Mobile UX
+    runs-on: ubuntu-latest
+    needs: [typecheck, lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Verify gh CLI auth
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # GH_TOKEN env var satisfies both `gh auth status` here and the
+        # canRun() probe inside the spec (which calls `gh auth token`).
+        # The spec hard-fails in CI if canRun() returns false, so a
+        # misconfigured token causes a loud failure, not a silent skip.
+        run: gh auth status
+      - name: Install Playwright chromium
+        run: pnpm --filter @issuectl/web exec playwright install --with-deps chromium
+      - name: Run mobile UX regression tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-chromium
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-mobile-ux
+          path: packages/web/playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build core package
+        # next dev resolves @issuectl/core via its package.json exports
+        # (dist/index.js), so the workspace package must be built before
+        # the web dev server can boot. Other jobs use TS path resolution
+        # and don't need this.
+        run: pnpm turbo build --filter=@issuectl/core
       - name: Verify gh CLI auth
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/e2e/mobile-ux-patterns.spec.ts
+++ b/packages/web/e2e/mobile-ux-patterns.spec.ts
@@ -1,0 +1,422 @@
+import { test, expect, type Page } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+
+const execFileAsync = promisify(execFile);
+
+// Distinct from audit-verification.spec.ts (3850) and quick-create.spec.ts
+// (3848) so specs can run in parallel.
+const TEST_PORT = 3851;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// Pins regressions from audit rounds R3-R6. Every assertion here is
+// something that was broken in one of those audits and has been fixed
+// in a shipped PR (#70, #73, #75). If any assertion fails, a previously
+// closed finding has regressed.
+
+const IOS_MIN_TOUCH = 44;
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+}
+
+// Keep the last N chunks of dev-server stderr so test failures can attach
+// server context. Without this, a 500 during navigation shows up as
+// "element not found" with no hint of what the server actually did.
+const STDERR_BUFFER_MAX_CHUNKS = 40;
+const serverStderrChunks: string[] = [];
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS repos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      owner TEXT NOT NULL,
+      name TEXT NOT NULL,
+      local_path TEXT,
+      branch_pattern TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(owner, name)
+    );
+    CREATE TABLE IF NOT EXISTS deployments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_id INTEGER NOT NULL REFERENCES repos(id),
+      issue_number INTEGER NOT NULL,
+      branch_name TEXT NOT NULL,
+      workspace_mode TEXT NOT NULL,
+      workspace_path TEXT NOT NULL,
+      linked_pr_number INTEGER,
+      launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS cache (
+      key TEXT PRIMARY KEY,
+      data TEXT NOT NULL
+    );
+  `);
+
+  db.prepare("INSERT OR IGNORE INTO schema_version (version) VALUES (?)").run(4);
+
+  const defaults: Array<[string, string]> = [
+    ["branch_pattern", "issue-{number}-{slug}"],
+    ["terminal_app", "iterm2"],
+    ["terminal_window_title", "issuectl"],
+    ["terminal_tab_title_pattern", "#{number} — {title}"],
+    ["cache_ttl", "300"],
+    ["worktree_dir", "~/.issuectl/worktrees/"],
+  ];
+  const insertSetting = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+  );
+  for (const [key, value] of defaults) {
+    insertSetting.run(key, value);
+  }
+
+  db.prepare("INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)").run(
+    TEST_OWNER,
+    TEST_REPO,
+  );
+
+  db.close();
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    // A silent skip would send CI green with zero assertions, defeating the
+    // whole point of this regression spec. Hard-fail in CI; skip locally.
+    if (process.env.CI === "true") {
+      throw new Error(
+        `Mobile UX regression suite cannot skip in CI: ${check.reason}. ` +
+          `This suite MUST run on PRs to pin the R3-R6 audit fixes.`,
+      );
+    }
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-mobile-ux-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  // detached: true so server.kill("SIGTERM") targets the process group and
+  // reaches the real `next dev` child — without it, `npx` swallows the
+  // signal and `next dev` lingers on TEST_PORT across local re-runs.
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, ISSUECTL_DB_PATH: dbPath },
+    stdio: "pipe",
+    detached: true,
+  });
+
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderrChunks.push(chunk.toString());
+    if (serverStderrChunks.length > STDERR_BUFFER_MAX_CHUNKS) {
+      serverStderrChunks.shift();
+    }
+  });
+
+  // 60s tolerates a cold `next dev` compile on a CI runner that's also
+  // cold on the pnpm store. Local runs still resolve in ~2s.
+  await waitForServer(BASE_URL, 60000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderrChunks.join("").slice(-800)}`,
+    );
+  });
+});
+
+test.afterAll(async () => {
+  if (server && server.pid) {
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-server.pid!, signal);
+      } catch {
+        /* already dead or orphaned */
+      }
+    };
+
+    const killTimeout = setTimeout(() => killGroup("SIGKILL"), 5000);
+
+    killGroup("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+async function expectTouchTarget(
+  page: Page,
+  selector: string,
+  label: string,
+): Promise<void> {
+  const locator = page.locator(selector).first();
+  await expect(locator, `${label} not visible`).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label} has no bounding box`).not.toBeNull();
+  expect(
+    box!.height,
+    `${label} height ${box!.height}px < ${IOS_MIN_TOUCH}px (iOS HIG)`,
+  ).toBeGreaterThanOrEqual(IOS_MIN_TOUCH);
+  expect(
+    box!.width,
+    `${label} width ${box!.width}px < ${IOS_MIN_TOUCH}px (iOS HIG)`,
+  ).toBeGreaterThanOrEqual(IOS_MIN_TOUCH);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+test.describe("Mobile UX regressions — touch targets (R3-R6)", () => {
+  test("dashboard nav overflow is 44x44", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/`);
+    await expectTouchTarget(
+      page,
+      'button[aria-label="Open navigation"]',
+      "dashboard nav overflow",
+    );
+  });
+
+  test("dashboard FAB is 44x44 and reachable", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/`);
+    // FAB is intentional on this app — we pin its presence + size.
+    await expectTouchTarget(
+      page,
+      'button[aria-label="Create a new draft"]',
+      "create-draft FAB",
+    );
+  });
+
+  test("settings breadcrumb back link is 44 tall", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/settings`);
+    const link = page.locator('a:has-text("← dashboard")').first();
+    await expect(link).toBeVisible();
+    const box = await link.boundingBox();
+    expect(box).not.toBeNull();
+    expect(
+      box!.height,
+      `settings breadcrumb ${box!.height}px < ${IOS_MIN_TOUCH}`,
+    ).toBeGreaterThanOrEqual(IOS_MIN_TOUCH);
+  });
+
+  test("parse breadcrumb back link is 44 tall", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/parse`);
+    const link = page.locator('a:has-text("← dashboard")').first();
+    await expect(link).toBeVisible();
+    const box = await link.boundingBox();
+    expect(box).not.toBeNull();
+    expect(
+      box!.height,
+      `parse breadcrumb ${box!.height}px < ${IOS_MIN_TOUCH}`,
+    ).toBeGreaterThanOrEqual(IOS_MIN_TOUCH);
+  });
+
+  test("not-found page CTA is 44 tall", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/this-route-does-not-exist-xyz`);
+    const link = page.locator('a:has-text("Back to Dashboard")').first();
+    await expect(link).toBeVisible();
+    const box = await link.boundingBox();
+    expect(box).not.toBeNull();
+    expect(
+      box!.height,
+      `404 CTA ${box!.height}px < ${IOS_MIN_TOUCH}`,
+    ).toBeGreaterThanOrEqual(IOS_MIN_TOUCH);
+  });
+});
+
+test.describe("Mobile UX regressions — iOS Safari viewport (R3)", () => {
+  test("body uses 100dvh not 100vh", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/`);
+    // When 100dvh is in use, body.clientHeight matches window.innerHeight
+    // within 1px even when the test harness doesn't have a dynamic toolbar.
+    // 100vh on mobile Safari can produce a body that overflows the viewport
+    // because of the way Safari reports 100vh. We can't directly test the
+    // Safari behavior from Chromium, so instead we check the computed
+    // min-height resolves to the dvh equivalent.
+    const minHeight = await page.evaluate(
+      () => getComputedStyle(document.body).minHeight,
+    );
+    const innerHeight = await page.evaluate(() => window.innerHeight);
+    // dvh resolves to innerHeight at steady state.
+    expect(parseFloat(minHeight)).toBeCloseTo(innerHeight, 0);
+  });
+
+  test("no horizontal overflow on dashboard", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/`);
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+    const clientWidth = await page.evaluate(
+      () => document.documentElement.clientWidth,
+    );
+    expect(
+      scrollWidth,
+      `body scrollWidth ${scrollWidth} > clientWidth ${clientWidth}`,
+    ).toBeLessThanOrEqual(clientWidth);
+  });
+});
+
+test.describe("Mobile UX regressions — iOS form attrs (R3, R5)", () => {
+  test("settings text inputs have iOS form attrs", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/settings`);
+
+    // Every non-read-only text input should carry the R3 attr set.
+    const writableInputs = [
+      "sf-branch-pattern",
+      "sf-cache-ttl",
+      "sf-window-title",
+      "sf-tab-title",
+      "sf-claude-args",
+    ];
+
+    for (const id of writableInputs) {
+      const input = page.locator(`#${id}`);
+      await expect(input, `${id} not found`).toBeVisible();
+      const autoComplete = await input.getAttribute("autocomplete");
+      const enterKeyHint = await input.getAttribute("enterkeyhint");
+      expect(autoComplete, `${id} missing autocomplete`).toBe("off");
+      expect(enterKeyHint, `${id} missing enterkeyhint`).toBe("done");
+    }
+  });
+
+  test("settings cache TTL has numeric inputmode", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/settings`);
+    const inputMode = await page
+      .locator("#sf-cache-ttl")
+      .getAttribute("inputmode");
+    expect(inputMode).toBe("numeric");
+  });
+
+  // Note: no parse textarea assertion. ParseFlow gates the textarea behind
+  // Claude CLI availability + repos + no init error, making it environment-
+  // dependent and unreliable for CI pinning. The same iOS form-attr concern
+  // is covered by the settings-form tests above, which render deterministically.
+
+  test("text inputs are >= 16px to prevent iOS Safari zoom-on-focus", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/settings`);
+    const inputs = await page
+      .locator('input[type="text"]:visible, input:not([type]):visible')
+      .all();
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      const fontSize = await input.evaluate(
+        (el) => parseFloat(getComputedStyle(el).fontSize),
+      );
+      expect(
+        fontSize,
+        `input font-size ${fontSize}px < 16px (triggers iOS Safari zoom)`,
+      ).toBeGreaterThanOrEqual(16);
+    }
+  });
+});
+
+test.describe("Mobile UX regressions — motion and a11y (R3, R5)", () => {
+  test("FAB opens sheet with a real animation", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/`);
+
+    await page.click('button[aria-label="Create a new draft"]');
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+
+    const animation = await dialog.evaluate(
+      (el) => getComputedStyle(el).animationName,
+    );
+    // If keyframes regress, animationName will be "none".
+    expect(
+      animation,
+      `sheet animationName "${animation}" — R3 fix has regressed`,
+    ).not.toBe("none");
+  });
+
+  test("prefers-reduced-motion disables sheet animation", async ({
+    browser,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+    const context = await browser.newContext({
+      viewport: { width: 393, height: 852 },
+      isMobile: true,
+      hasTouch: true,
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(`${BASE_URL}/`);
+      await page.click('button[aria-label="Create a new draft"]');
+      const dialog = page.locator('[role="dialog"]');
+      await expect(dialog).toBeVisible();
+      const animation = await dialog.evaluate(
+        (el) => getComputedStyle(el).animationName,
+      );
+      expect(
+        animation,
+        `sheet animation not disabled under prefers-reduced-motion — R3 gate has regressed`,
+      ).toBe("none");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -8,4 +8,22 @@ export default defineConfig({
     baseURL: "http://localhost:3847",
     trace: "retain-on-failure",
   },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: { ...devices["Desktop Chrome"] },
+      testIgnore: /mobile-ux-patterns\.spec\.ts/,
+    },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 5"],
+        viewport: { width: 393, height: 852 },
+        deviceScaleFactor: 3,
+        isMobile: true,
+        hasTouch: true,
+      },
+      testMatch: /mobile-ux-patterns\.spec\.ts/,
+    },
+  ],
 });


### PR DESCRIPTION
## Summary
Closes the feedback loop on the R3-R6 audit cycle. Without regression coverage, the 10+ mobile UX fixes from PRs #69-75 are protected only by future audit rounds (R7, R8...). This PR pins them at the CI layer so a dev accidentally removing \`min-height: 44px\`, reintroducing \`100vh\`, or dropping an \`enterKeyHint\` will fail CI on their next push.

## What gets pinned

**Touch targets (R3-R5)**
- Dashboard nav overflow \`···\` — 44×44
- Dashboard create-draft FAB — 44×44 (pinning presence + size of an intentional pattern)
- Settings breadcrumb \`← dashboard\` — 44 tall
- Parse breadcrumb \`← dashboard\` — 44 tall
- not-found \"Back to Dashboard\" CTA — 44 tall

**iOS Safari viewport (R3)**
- Body \`min-height\` resolves to \`innerHeight\` (100dvh behavior, not 100vh)
- No horizontal overflow at 393 px on dashboard

**iOS form attrs (R3, R5)**
- All writable settings inputs carry \`autocomplete=\"off\"\` + \`enterkeyhint=\"done\"\`
- Cache TTL specifically has \`inputmode=\"numeric\"\`
- All text inputs on settings >= 16 px (prevents iOS Safari focus-zoom)

**Motion & a11y (R3, R5)**
- Create-draft sheet has a non-\"none\" \`animationName\` (catches keyframes regression)
- Under \`reducedMotion: \"reduce\"\`, sheet \`animationName === \"none\"\` (catches gate regression)

## What's NOT pinned (and why)

- **Parse textarea iOS attrs** — ParseFlow gates the textarea behind Claude CLI availability + repos + no init error, making it environment-dependent and unreliable for CI pinning. Settings inputs cover the same concern deterministically.
- **h1 line-height, meta-chip sizes** — deferred editorial Paper choices across R3-R6, not regressions to pin.
- **Launch progress page** — needs a deployment fixture; deferred to when the audit pulls in live fixtures.
- **Standard anti-pattern sweep** (hamburger, FAB, drawer, breadcrumb as blanket fails) — this app uses those patterns intentionally. The \`mobile-ux-ci\` skill's default anti-pattern set would fail this app for correct design choices. I pinned specific regression targets instead.

## How the spec runs

Follows the \`audit-verification.spec.ts\` pattern: spawns its own dev server on port 3851 (distinct from 3847/3848/3850) with a seeded SQLite DB. Uses \`canRun()\` to skip locally if \`gh auth\` isn't configured, but **hard-fails in CI** (throws if \`CI === \"true\"\` and \`canRun()\` returned false) so a misconfigured \`GITHUB_TOKEN\` causes a loud failure, not a silent green.

Server spawned with \`detached: true\` so \`SIGTERM\` reaches the child \`next dev\` process group (prevents port 3851 orphans on local re-runs). Server stderr is kept in a 40-chunk rolling buffer and surfaced on startup-timeout failures.

## playwright.config.ts

Added \`projects\` array:
- \`desktop-chromium\` — existing specs (testIgnore mobile-ux)
- \`mobile-chromium\` — Pixel 5 device, 393×852 viewport, \`isMobile: true\`, \`hasTouch: true\`, testMatch restricted to the new spec

## CI integration

New \`e2e-mobile-ux\` job in \`.github/workflows/ci.yml\`:
- Runs after \`typecheck, lint, test\` (parallel with \`build\`)
- Installs chromium via \`playwright install --with-deps\`
- Sets \`GH_TOKEN: secrets.GITHUB_TOKEN\` so \`canRun()\` and the dev server's \`getAuthStatus\` both succeed
- Uploads \`playwright-report/\` as an artifact on failure (7 day retention)

## Review trail
\`/pr-review-toolkit:review-pr\` — code-reviewer + silent-failure-hunter.

**Addressed:**
- Silent skip → green CI (HIGH) — added CI hard-fail branch in beforeAll
- Parse textarea skip masking regressions — dropped the test entirely
- Server stderr discarded — rolling buffer, surfaced on timeout
- npx kill doesn't reach \`next dev\` child — \`detached: true\` + process group kill
- 30s waitForServer timeout flaky on CI cold start — bumped to 60s
- GH_TOKEN intent in CI step — documented in a comment

**Deferred (low):**
- \`spawn\` error event handler (low probability, low blast radius)
- Shared e2e fixture extraction (3 specs now duplicate the server-spawn boilerplate; worth a follow-up PR)

## Test Plan
- [ ] Local run: \`cd packages/web && npx playwright test mobile-ux-patterns.spec.ts --project=mobile-chromium\` — 12 passing in ~12s
- [ ] CI run: all 5 jobs green (typecheck, lint, test, build, e2e-mobile-ux)
- [ ] Intentional regression test: temporarily revert a 44×44 touch target fix locally, verify the spec fails with a clear message