### PR TITLE
fix(web): tighten mobile top-bar padding + inset safe area

### DIFF
--- a/packages/web/app/drafts/[draftId]/loading.module.css
+++ b/packages/web/app/drafts/[draftId]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: 52px 16px 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: 52px 16px 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/launch/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: 52px 16px 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: 52px 16px 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/components/detail/DetailTopBar.module.css
+++ b/packages/web/components/detail/DetailTopBar.module.css
@@ -1,5 +1,5 @@
 .bar {
-  padding: 52px 16px 12px;
+  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -8,7 +8,7 @@
 }
 
 .topBar {
-  padding: 52px 24px 12px;
+  padding: calc(6px + env(safe-area-inset-top, 0px)) 24px 12px;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
@@ -220,6 +220,10 @@
 }
 
 @media (min-width: 768px) {
+  .topBar {
+    padding: 52px 24px 12px;
+  }
+
   .menuBtn {
     display: none;
   }

--- a/packages/web/components/paper/Drawer.module.css
+++ b/packages/web/components/paper/Drawer.module.css
@@ -22,7 +22,7 @@
 }
 
 .head {
-  padding: 52px 22px 18px;
+  padding: calc(18px + env(safe-area-inset-top, 0px)) 22px 18px;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- Hard-coded `padding-top: 52px` on mobile top bars was pure dead space — no `safe-area-inset-top` compensation and far larger than needed below the iOS status bar.
- Switch mobile top-bar padding to a small value plus `env(safe-area-inset-top, 0px)`; desktop (≥768px) values preserved via media-query overrides.
- Loading skeletons updated to match so pre-hydration heights line up with the real bars.

## Changes
- `components/list/List.module.css` — mobile `.topBar` → `calc(6px + safe-area-inset-top)`, desktop override restores `52px`
- `components/detail/DetailTopBar.module.css` — mobile `.bar` → `calc(14px + safe-area-inset-top)` (desktop override at `36px` was already in place)
- `components/paper/Drawer.module.css` — `.head` → `calc(18px + safe-area-inset-top)`
- `app/{issues,pulls,drafts,launch}/.../loading.module.css` — matched DetailTopBar on both breakpoints

## Test plan
- [x] Typecheck passes
- [x] Pre-push build passes
- [x] Index page on iPhone 13 viewport: brand \`h1\` moves from y=74 → y=28 (plus \`safe-area-inset-top\` on real device)
- [x] Desktop (1280×800): brand \`h1\` at y=64, unchanged
- [ ] Verify on real iPhone Safari at http://192.168.1.16:3847
- [ ] Detail page mobile spacing looks right
- [ ] Nav drawer header spacing looks right