### PR TITLE
feat(web): repo picker, URL filters, section sub-tabs, mobile filter sheet

### DIFF
--- a/docs/mockups/add-repo-picker.html
+++ b/docs/mockups/add-repo-picker.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Add Repo Picker — mockup</title>
+<style>
+  :root {
+    --paper-bg:           #f3ecd9;
+    --paper-bg-warm:      #ede5cf;
+    --paper-bg-warmer:    #e6dec4;
+    --paper-ink:          #1a1712;
+    --paper-ink-soft:     #3a342a;
+    --paper-ink-muted:    #746a50;
+    --paper-line:         #e0d6bc;
+    --paper-line-soft:    #e9dfc6;
+    --paper-accent:       #2d5f3f;
+    --paper-accent-dim:   #4a7a5c;
+    --paper-accent-soft:  #dce8de;
+    --paper-brick:        #a8432a;
+    --paper-butter:       #d9a54d;
+    --paper-radius-sm:    3px;
+    --paper-radius-md:    6px;
+    --paper-radius-lg:    10px;
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #2a2a28;
+    color: #e8e3d3;
+    font-family: Georgia, "Times New Roman", serif;
+    padding: 24px;
+    min-height: 100dvh;
+  }
+  h1 { font-size: 22px; margin-bottom: 6px; }
+  h2 { font-size: 14px; color: #b8b09a; margin-bottom: 10px; font-weight: normal; font-style: italic; }
+  .gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(393px, 1fr));
+    gap: 32px;
+    margin-top: 24px;
+  }
+  .frame {
+    background: var(--paper-bg);
+    color: var(--paper-ink);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 8px 30px rgba(0,0,0,0.4);
+  }
+  .frame-label { font-size: 12px; color: #b8b09a; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; font-family: system-ui, sans-serif; }
+  .mobile { width: 393px; }
+  .desktop { width: 640px; }
+
+  /* ── Shared form styles ── */
+  .page { padding: 20px 16px 32px; }
+  .section-title { font-size: 12px; color: var(--paper-ink-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
+
+  .form {
+    background: var(--paper-bg);
+    border: 1px solid var(--paper-accent);
+    border-radius: var(--paper-radius-md);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .field-label { font-size: 12px; color: var(--paper-ink-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
+
+  /* ── Picker trigger (closed state) ── */
+  .picker-trigger {
+    width: 100%;
+    min-height: 44px;
+    padding: 10px 12px;
+    background: var(--paper-bg-warm);
+    border: 1px solid var(--paper-line);
+    border-radius: var(--paper-radius-md);
+    color: var(--paper-ink-muted);
+    font-size: 16px;
+    font-family: Georgia, serif;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+  }
+  .picker-trigger.selected { color: var(--paper-ink); }
+  .picker-trigger .caret { color: var(--paper-ink-muted); font-size: 12px; }
+
+  /* ── Picker open ── */
+  .picker-open {
+    background: var(--paper-bg-warm);
+    border: 1px solid var(--paper-accent);
+    border-radius: var(--paper-radius-md);
+    overflow: hidden;
+  }
+  .picker-search {
+    width: 100%;
+    padding: 12px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--paper-line);
+    font-size: 16px;
+    font-family: Georgia, serif;
+    color: var(--paper-ink);
+    outline: none;
+  }
+  .picker-search::placeholder { color: var(--paper-ink-muted); font-style: italic; }
+  .picker-list {
+    max-height: 280px;
+    overflow-y: auto;
+    list-style: none;
+  }
+  .picker-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    min-height: 44px;
+    border-bottom: 1px solid var(--paper-line-soft);
+    cursor: pointer;
+    font-size: 15px;
+  }
+  .picker-item:last-child { border-bottom: none; }
+  .picker-item:hover { background: var(--paper-accent-soft); }
+  .picker-item.tracked { opacity: 0.5; cursor: default; }
+  .picker-item.tracked:hover { background: transparent; }
+  .picker-item .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--paper-accent); flex-shrink: 0; }
+  .picker-item .name { flex: 1; }
+  .picker-item .name .owner { color: var(--paper-ink-muted); }
+  .picker-item .badge {
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--paper-bg-warmer);
+    color: var(--paper-ink-muted);
+    font-family: system-ui, sans-serif;
+  }
+  .picker-item .badge.private { background: var(--paper-butter); color: var(--paper-ink); }
+
+  .picker-footer {
+    padding: 8px 12px;
+    background: var(--paper-bg);
+    border-top: 1px solid var(--paper-line);
+  }
+  .picker-footer button {
+    background: none;
+    border: none;
+    color: var(--paper-accent);
+    font-size: 13px;
+    font-family: Georgia, serif;
+    font-style: italic;
+    cursor: pointer;
+    padding: 6px 0;
+    min-height: 32px;
+  }
+
+  /* ── Manual entry fallback ── */
+  .manual-entry input {
+    width: 100%;
+    padding: 10px 12px;
+    min-height: 44px;
+    background: var(--paper-bg-warm);
+    border: 1px solid var(--paper-line);
+    border-radius: var(--paper-radius-md);
+    color: var(--paper-ink);
+    font-size: 16px;
+    font-family: Georgia, serif;
+    outline: none;
+  }
+  .manual-entry input:focus { border-color: var(--paper-accent); }
+  .manual-entry .back-to-picker {
+    background: none;
+    border: none;
+    color: var(--paper-accent);
+    font-size: 12px;
+    font-family: Georgia, serif;
+    font-style: italic;
+    cursor: pointer;
+    padding: 6px 0;
+    margin-top: 4px;
+  }
+
+  /* ── Local path field ── */
+  .path-input {
+    width: 100%;
+    padding: 10px 12px;
+    min-height: 44px;
+    background: var(--paper-bg-warm);
+    border: 1px solid var(--paper-line);
+    border-radius: var(--paper-radius-md);
+    color: var(--paper-ink);
+    font-size: 16px;
+    font-family: Georgia, serif;
+    outline: none;
+  }
+  .path-hint { font-size: 12px; color: var(--paper-ink-muted); margin-top: 6px; }
+
+  /* ── Actions ── */
+  .actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  .mobile .actions { flex-direction: column-reverse; }
+  .desktop .actions { justify-content: flex-end; }
+  .btn {
+    min-height: 44px;
+    padding: 10px 18px;
+    border-radius: var(--paper-radius-md);
+    font-family: Georgia, serif;
+    font-size: 15px;
+    cursor: pointer;
+    border: 1px solid transparent;
+  }
+  .mobile .btn { width: 100%; }
+  .btn-primary {
+    background: var(--paper-accent);
+    color: #fff;
+  }
+  .btn-ghost {
+    background: transparent;
+    color: var(--paper-ink);
+    border-color: var(--paper-line);
+  }
+
+  /* ── Desktop two-column ── */
+  .row-desktop {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+  }
+
+  /* Tracked repos above form */
+  .tracked-list { margin-bottom: 12px; }
+  .tracked-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--paper-bg);
+    border: 1px solid var(--paper-line);
+    border-radius: var(--paper-radius-md);
+    margin-bottom: 6px;
+    font-size: 14px;
+    flex-wrap: wrap;
+  }
+  .tracked-item .dot-tracked { width: 8px; height: 8px; border-radius: 50%; background: var(--paper-accent); }
+  .tracked-item .name-tracked { flex: 1; font-weight: 500; }
+  .tracked-item .path-tracked { font-family: ui-monospace, monospace; font-size: 11px; color: var(--paper-ink-muted); width: 100%; margin-left: 18px; }
+</style>
+</head>
+<body>
+  <h1>Add Repo — picker redesign</h1>
+  <h2>Mobile-first, fed by GitHub API, with manual fallback</h2>
+
+  <div class="gallery">
+
+    <!-- 1. Mobile: closed / empty state -->
+    <div>
+      <div class="frame-label">1. Mobile — closed state (initial)</div>
+      <div class="frame mobile">
+        <div class="page">
+          <div class="section-title">Tracked Repositories</div>
+          <div class="tracked-list">
+            <div class="tracked-item">
+              <span class="dot-tracked"></span>
+              <span class="name-tracked">mean-weasel/issuectl</span>
+              <span class="path-tracked">~/Desktop/issuectl</span>
+            </div>
+          </div>
+          <div class="form">
+            <div>
+              <div class="field-label">Repository</div>
+              <button class="picker-trigger">
+                <span>Select a repository…</span>
+                <span class="caret">▾</span>
+              </button>
+            </div>
+            <div>
+              <div class="field-label">Local Path (optional)</div>
+              <input class="path-input" placeholder="~/Desktop/my-repo">
+              <div class="path-hint">Leave blank to prompt on launch</div>
+            </div>
+            <div class="actions">
+              <button class="btn btn-ghost">Cancel</button>
+              <button class="btn btn-primary">Add Repo</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 2. Mobile: picker open with search + list -->
+    <div>
+      <div class="frame-label">2. Mobile — picker open, filtered</div>
+      <div class="frame mobile">
+        <div class="page">
+          <div class="form">
+            <div>
+              <div class="field-label">Repository</div>
+              <div class="picker-open">
+                <input class="picker-search" value="sea" placeholder="search your repos…" autofocus>
+                <ul class="picker-list">
+                  <li class="picker-item">
+                    <span class="dot"></span>
+                    <span class="name"><span class="owner">mean-weasel/</span><strong>sea</strong>tify</span>
+                    <span class="badge">public</span>
+                  </li>
+                  <li class="picker-item">
+                    <span class="dot"></span>
+                    <span class="name"><span class="owner">mean-weasel/</span><strong>sea</strong>tify-web</span>
+                    <span class="badge private">private</span>
+                  </li>
+                  <li class="picker-item tracked">
+                    <span class="dot"></span>
+                    <span class="name"><span class="owner">acme-co/</span>ocean-<strong>sea</strong>rch</span>
+                    <span class="badge">already tracked</span>
+                  </li>
+                </ul>
+                <div class="picker-footer">
+                  <button>Can't find it? Enter manually →</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 3. Mobile: manual entry fallback -->
+    <div>
+      <div class="frame-label">3. Mobile — manual entry fallback</div>
+      <div class="frame mobile">
+        <div class="page">
+          <div class="form">
+            <div class="manual-entry">
+              <div class="field-label">Repository</div>
+              <input placeholder="owner/repo (e.g., mean-weasel/seatify)">
+              <button class="back-to-picker">← back to picker</button>
+            </div>
+            <div>
+              <div class="field-label">Local Path (optional)</div>
+              <input class="path-input" value="~/Desktop/other-repo">
+              <div class="path-hint">Leave blank to prompt on launch</div>
+            </div>
+            <div class="actions">
+              <button class="btn btn-ghost">Cancel</button>
+              <button class="btn btn-primary">Add Repo</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 4. Desktop: picker open -->
+    <div>
+      <div class="frame-label">4. Desktop — ≥768px, two-column</div>
+      <div class="frame desktop">
+        <div class="page">
+          <div class="form">
+            <div class="row-desktop">
+              <div>
+                <div class="field-label">Repository</div>
+                <div class="picker-open">
+                  <input class="picker-search" value="" placeholder="search your repos…">
+                  <ul class="picker-list">
+                    <li class="picker-item">
+                      <span class="dot"></span>
+                      <span class="name"><span class="owner">mean-weasel/</span>seatify</span>
+                      <span class="badge">public</span>
+                    </li>
+                    <li class="picker-item">
+                      <span class="dot"></span>
+                      <span class="name"><span class="owner">mean-weasel/</span>blog</span>
+                      <span class="badge">public</span>
+                    </li>
+                    <li class="picker-item tracked">
+                      <span class="dot"></span>
+                      <span class="name"><span class="owner">mean-weasel/</span>issuectl</span>
+                      <span class="badge">already tracked</span>
+                    </li>
+                    <li class="picker-item">
+                      <span class="dot"></span>
+                      <span class="name"><span class="owner">acme-co/</span>billing-api</span>
+                      <span class="badge private">private</span>
+                    </li>
+                  </ul>
+                  <div class="picker-footer">
+                    <button>Can't find it? Enter manually →</button>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div class="field-label">Local Path (optional)</div>
+                <input class="path-input" placeholder="~/Desktop/my-repo">
+                <div class="path-hint">Leave blank to prompt on launch</div>
+              </div>
+            </div>
+            <div class="actions">
+              <button class="btn btn-ghost">Cancel</button>
+              <button class="btn btn-primary">Add Repo</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/docs/mockups/mobile-filter-sheet.html
+++ b/docs/mockups/mobile-filter-sheet.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Mobile filter sheet — mockup</title>
+<style>
+  :root {
+    --paper-bg:           #f3ecd9;
+    --paper-bg-warm:      #ede5cf;
+    --paper-bg-warmer:    #e6dec4;
+    --paper-ink:          #1a1712;
+    --paper-ink-soft:     #3a342a;
+    --paper-ink-muted:    #746a50;
+    --paper-line:         #e0d6bc;
+    --paper-line-soft:    #e9dfc6;
+    --paper-accent:       #2d5f3f;
+    --paper-accent-soft:  #dce8de;
+    --paper-brick:        #a8432a;
+    --paper-butter:       #d9a54d;
+    --paper-radius-sm:    3px;
+    --paper-radius-md:    6px;
+    --paper-radius-lg:    10px;
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #2a2a28;
+    color: #e8e3d3;
+    font-family: Georgia, "Times New Roman", serif;
+    padding: 24px;
+    min-height: 100dvh;
+  }
+  h1 { font-size: 22px; margin-bottom: 4px; }
+  h2 { font-size: 14px; color: #b8b09a; font-weight: normal; font-style: italic; margin-bottom: 24px; }
+  .gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(393px, max-content));
+    gap: 32px;
+    justify-content: start;
+  }
+  .frame-label { font-size: 12px; color: #b8b09a; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; font-family: system-ui, sans-serif; }
+  .frame {
+    width: 393px;
+    height: 760px;
+    background: var(--paper-bg);
+    color: var(--paper-ink);
+    border-radius: 32px;
+    overflow: hidden;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.4);
+    position: relative;
+  }
+
+  /* ── Header ── */
+  .top-bar {
+    padding: 18px 20px 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+  .brand {
+    font-family: Georgia, serif;
+    font-style: italic;
+    font-size: 22px;
+    font-weight: 700;
+  }
+  .brand-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--paper-accent);
+    margin-left: 2px;
+  }
+  .menu {
+    font-size: 22px;
+    color: var(--paper-ink-muted);
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* ── Tabs row ── */
+  .tabs-row {
+    display: flex;
+    align-items: center;
+    padding: 0 20px;
+    gap: 24px;
+    border-bottom: 1px solid var(--paper-line);
+  }
+  .tabs {
+    display: flex;
+    gap: 18px;
+    flex: 1;
+  }
+  .tab, .tab-on {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 14px 0;
+    font-size: 14px;
+    color: var(--paper-ink-muted);
+    text-decoration: none;
+    font-family: Georgia, serif;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+  }
+  .tab-on {
+    color: var(--paper-ink);
+    font-weight: 700;
+    font-style: italic;
+    border-bottom-color: var(--paper-ink);
+  }
+  .tab .count, .tab-on .count {
+    font-size: 12px;
+    color: var(--paper-ink-muted);
+    font-weight: 400;
+    font-style: normal;
+  }
+  .filter-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    background: transparent;
+    border: none;
+    color: var(--paper-ink);
+    font-size: 18px;
+    cursor: pointer;
+    position: relative;
+  }
+  .filter-btn .badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--paper-accent);
+  }
+
+  /* ── Section sub-tabs ── */
+  .sub-tabs {
+    display: flex;
+    gap: 0;
+    padding: 0 20px;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--paper-line);
+  }
+  .sub-tabs::-webkit-scrollbar { display: none; }
+  .sub, .sub-on {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 14px;
+    font-size: 13px;
+    color: var(--paper-ink-muted);
+    text-decoration: none;
+    font-family: Georgia, serif;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .sub-on {
+    color: var(--paper-ink);
+    font-weight: 500;
+    border-bottom-color: var(--paper-ink);
+  }
+  .sub-count { font-size: 11px; color: var(--paper-ink-muted); }
+
+  /* ── Active scope pill (optional indicator variant) ── */
+  .scope-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 6px;
+    padding: 2px 8px;
+    background: var(--paper-accent-soft);
+    border-radius: 999px;
+    font-size: 12px;
+    font-style: italic;
+    color: var(--paper-ink-soft);
+    font-weight: 500;
+  }
+  .scope-pill .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .scope-pill .close { color: var(--paper-ink-muted); font-size: 14px; line-height: 1; }
+
+  /* ── List area (illustrative) ── */
+  .list { padding: 14px 0 0; }
+  .row {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--paper-line-soft);
+  }
+  .row-title {
+    font-size: 15px;
+    color: var(--paper-ink);
+    margin-bottom: 6px;
+    line-height: 1.3;
+  }
+  .row-meta {
+    font-size: 12px;
+    color: var(--paper-ink-muted);
+  }
+  .row-chip {
+    display: inline-block;
+    font-family: ui-monospace, monospace;
+    font-size: 11px;
+    background: var(--paper-bg-warmer);
+    padding: 2px 6px;
+    border-radius: var(--paper-radius-sm);
+    margin-right: 6px;
+  }
+  .fab {
+    position: absolute;
+    bottom: 30px;
+    right: 24px;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: var(--paper-ink);
+    color: var(--paper-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
+  }
+
+  /* ── Sheet (bottom sheet overlay) ── */
+  .sheet-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.45);
+  }
+  .sheet {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--paper-bg);
+    border-radius: 20px 20px 0 0;
+    padding: 10px 0 28px;
+    box-shadow: 0 -8px 30px rgba(0,0,0,0.2);
+  }
+  .sheet-grabber {
+    width: 44px;
+    height: 5px;
+    border-radius: 999px;
+    background: var(--paper-line);
+    margin: 0 auto 12px;
+  }
+  .sheet-header {
+    padding: 6px 20px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .sheet-title { font-family: Georgia, serif; font-size: 18px; font-weight: 700; font-style: italic; }
+  .sheet-clear {
+    color: var(--paper-accent);
+    font-size: 13px;
+    font-style: italic;
+    font-family: Georgia, serif;
+    background: none;
+    border: none;
+    min-height: 32px;
+    padding: 4px 0;
+    cursor: pointer;
+  }
+  .sheet-group-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-weight: 600;
+    color: var(--paper-ink-muted);
+    padding: 10px 20px 6px;
+  }
+  .sheet-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+    min-height: 56px;
+    border-bottom: 1px solid var(--paper-line-soft);
+    cursor: pointer;
+  }
+  .sheet-row:last-of-type { border-bottom: none; }
+  .sheet-row:hover { background: var(--paper-bg-warm); }
+  .sheet-row.selected { background: var(--paper-accent-soft); }
+  .sheet-row .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .sheet-row .label { flex: 1; font-size: 16px; color: var(--paper-ink); }
+  .sheet-row .sublabel { font-size: 12px; color: var(--paper-ink-muted); }
+  .sheet-row .check {
+    width: 20px;
+    height: 20px;
+    color: var(--paper-accent);
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+  .sheet-done {
+    margin: 18px 20px 0;
+    padding: 14px;
+    min-height: 44px;
+    width: calc(100% - 40px);
+    background: var(--paper-ink);
+    color: var(--paper-bg);
+    border: none;
+    border-radius: 12px;
+    font-family: Georgia, serif;
+    font-style: italic;
+    font-weight: 700;
+    font-size: 15px;
+    cursor: pointer;
+  }
+</style>
+</head>
+<body>
+  <h1>Mobile filter redesign</h1>
+  <h2>Chip rows collapsed into a single filter button + bottom sheet</h2>
+
+  <div class="gallery">
+
+    <!-- 1. Current layout for reference -->
+    <div>
+      <div class="frame-label">1. Current (3 filter rows)</div>
+      <div class="frame">
+        <div class="top-bar">
+          <span class="brand">issuectl<span class="brand-dot"></span></span>
+          <span class="menu">···</span>
+        </div>
+        <div class="tabs-row">
+          <div class="tabs">
+            <span class="tab-on">Issues<span class="count">107</span></span>
+            <span class="tab">Pull requests<span class="count">4</span></span>
+          </div>
+        </div>
+        <div style="padding: 12px 20px 12px; display: flex; gap: 8px; border-bottom: 1px solid var(--paper-line);">
+          <span style="padding: 6px 12px; border: 1px solid var(--paper-line); border-radius: 999px; background: var(--paper-bg-warm); font-size: 13px;">all</span>
+          <span style="padding: 6px 12px; border: 1px solid var(--paper-line); border-radius: 999px; font-size: 13px; display: inline-flex; align-items: center; gap: 6px;"><span style="width: 8px; height: 8px; border-radius: 50%; background: #f85149;"></span>issuectl</span>
+          <span style="padding: 6px 12px; border: 1px solid var(--paper-line); border-radius: 999px; font-size: 13px; display: inline-flex; align-items: center; gap: 6px;"><span style="width: 8px; height: 8px; border-radius: 50%; background: #58a6ff;"></span>seatify</span>
+        </div>
+        <div class="sub-tabs">
+          <span class="sub">drafts<span class="sub-count">3</span></span>
+          <span class="sub-on">in focus<span class="sub-count">50</span></span>
+          <span class="sub">in flight<span class="sub-count">0</span></span>
+          <span class="sub">shipped<span class="sub-count">54</span></span>
+        </div>
+        <div class="list">
+          <div class="row">
+            <div class="row-title">test(e2e): upload wizard — specs fail consistently post-fix</div>
+            <div class="row-meta"><span class="row-chip">seatify</span>#678 · today</div>
+          </div>
+          <div class="row">
+            <div class="row-title">ci: nightly-stability workflow has failed on main</div>
+            <div class="row-meta"><span class="row-chip">seatify</span>#677 · today</div>
+          </div>
+          <div class="row">
+            <div class="row-title">bug: Add Manually toggle doesn't render</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#612 · 1d</div>
+          </div>
+        </div>
+        <div class="fab">+</div>
+      </div>
+    </div>
+
+    <!-- 2. Proposed: filter icon in tab row, no active filters -->
+    <div>
+      <div class="frame-label">2. Proposed — 2 rows, filter icon in tab row</div>
+      <div class="frame">
+        <div class="top-bar">
+          <span class="brand">issuectl<span class="brand-dot"></span></span>
+          <span class="menu">···</span>
+        </div>
+        <div class="tabs-row">
+          <div class="tabs">
+            <span class="tab-on">Issues<span class="count">107</span></span>
+            <span class="tab">Pull requests<span class="count">4</span></span>
+          </div>
+          <button class="filter-btn" aria-label="Filters">
+            ⚲
+          </button>
+        </div>
+        <div class="sub-tabs">
+          <span class="sub">drafts<span class="sub-count">3</span></span>
+          <span class="sub-on">in focus<span class="sub-count">50</span></span>
+          <span class="sub">in flight<span class="sub-count">0</span></span>
+          <span class="sub">shipped<span class="sub-count">54</span></span>
+        </div>
+        <div class="list">
+          <div class="row">
+            <div class="row-title">test(e2e): upload wizard — specs fail consistently post-fix</div>
+            <div class="row-meta"><span class="row-chip">seatify</span>#678 · today</div>
+          </div>
+          <div class="row">
+            <div class="row-title">ci: nightly-stability workflow has failed on main</div>
+            <div class="row-meta"><span class="row-chip">seatify</span>#677 · today</div>
+          </div>
+          <div class="row">
+            <div class="row-title">bug: Add Manually toggle doesn't render</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#612 · 1d</div>
+          </div>
+          <div class="row">
+            <div class="row-title">bug(setup-import): validation error on empty field</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#611 · 1d</div>
+          </div>
+          <div class="row">
+            <div class="row-title">feat: add draft-to-issue assign flow from detail page</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#608 · 2d</div>
+          </div>
+        </div>
+        <div class="fab">+</div>
+      </div>
+    </div>
+
+    <!-- 3. Proposed: with active filter (dot indicator + scope pill) -->
+    <div>
+      <div class="frame-label">3. Proposed — repo filter active (dot + pill)</div>
+      <div class="frame">
+        <div class="top-bar">
+          <span class="brand">issuectl<span class="brand-dot"></span></span>
+          <span class="menu">···</span>
+        </div>
+        <div class="tabs-row">
+          <div class="tabs">
+            <span class="tab-on">
+              Issues<span class="count">8</span>
+              <span class="scope-pill"><span class="dot" style="background: #f85149"></span>issuectl<span class="close">×</span></span>
+            </span>
+            <span class="tab">PRs<span class="count">0</span></span>
+          </div>
+          <button class="filter-btn" aria-label="Filters">
+            ⚲
+            <span class="badge"></span>
+          </button>
+        </div>
+        <div class="sub-tabs">
+          <span class="sub-on">in focus<span class="sub-count">2</span></span>
+          <span class="sub">in flight<span class="sub-count">0</span></span>
+          <span class="sub">shipped<span class="sub-count">6</span></span>
+        </div>
+        <div class="list">
+          <div class="row">
+            <div class="row-title">CI: push re-runs the full test suite after merge</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#60 · 3d</div>
+          </div>
+          <div class="row">
+            <div class="row-title">Ghostty launcher: -e flag not working correctly via open -na</div>
+            <div class="row-meta"><span class="row-chip">issuectl</span>#29 · 7d</div>
+          </div>
+        </div>
+        <div class="fab">+</div>
+      </div>
+    </div>
+
+    <!-- 4. Filter sheet open — Issues tab (just repo) -->
+    <div>
+      <div class="frame-label">4. Sheet open — Issues tab</div>
+      <div class="frame">
+        <div class="top-bar">
+          <span class="brand">issuectl<span class="brand-dot"></span></span>
+          <span class="menu">···</span>
+        </div>
+        <div class="tabs-row">
+          <div class="tabs">
+            <span class="tab-on">Issues<span class="count">107</span></span>
+            <span class="tab">PRs<span class="count">4</span></span>
+          </div>
+          <button class="filter-btn">⚲</button>
+        </div>
+        <div class="sub-tabs">
+          <span class="sub">drafts<span class="sub-count">3</span></span>
+          <span class="sub-on">in focus<span class="sub-count">50</span></span>
+          <span class="sub">in flight<span class="sub-count">0</span></span>
+          <span class="sub">shipped<span class="sub-count">54</span></span>
+        </div>
+        <div class="list" style="opacity: 0.3;">
+          <div class="row"><div class="row-title">test(e2e)…</div></div>
+          <div class="row"><div class="row-title">ci: nightly-stability…</div></div>
+        </div>
+        <div class="sheet-backdrop"></div>
+        <div class="sheet">
+          <div class="sheet-grabber"></div>
+          <div class="sheet-header">
+            <span class="sheet-title">Filters</span>
+            <button class="sheet-clear" disabled style="opacity: 0.4">Clear</button>
+          </div>
+          <div class="sheet-group-label">Repository</div>
+          <div class="sheet-row selected">
+            <span class="label">All repos</span>
+            <span class="check">✓</span>
+          </div>
+          <div class="sheet-row">
+            <span class="dot" style="background: #f85149;"></span>
+            <span class="label">mean-weasel/issuectl</span>
+          </div>
+          <div class="sheet-row">
+            <span class="dot" style="background: #58a6ff;"></span>
+            <span class="label">mean-weasel/seatify</span>
+          </div>
+          <button class="sheet-done">Done</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 5. Filter sheet open — PRs tab (repo + author) -->
+    <div>
+      <div class="frame-label">5. Sheet open — PRs tab (repo + author)</div>
+      <div class="frame">
+        <div class="top-bar">
+          <span class="brand">issuectl<span class="brand-dot"></span></span>
+          <span class="menu">···</span>
+        </div>
+        <div class="tabs-row">
+          <div class="tabs">
+            <span class="tab">Issues<span class="count">107</span></span>
+            <span class="tab-on">PRs<span class="count">4</span></span>
+          </div>
+          <button class="filter-btn">⚲<span class="badge"></span></button>
+        </div>
+        <div class="list" style="opacity: 0.3;">
+          <div class="row"><div class="row-title">chore(deps)…</div></div>
+        </div>
+        <div class="sheet-backdrop"></div>
+        <div class="sheet">
+          <div class="sheet-grabber"></div>
+          <div class="sheet-header">
+            <span class="sheet-title">Filters</span>
+            <button class="sheet-clear">Clear</button>
+          </div>
+          <div class="sheet-group-label">Repository</div>
+          <div class="sheet-row">
+            <span class="label">All repos</span>
+          </div>
+          <div class="sheet-row selected">
+            <span class="dot" style="background: #f85149;"></span>
+            <span class="label">mean-weasel/issuectl</span>
+            <span class="check">✓</span>
+          </div>
+          <div class="sheet-row">
+            <span class="dot" style="background: #58a6ff;"></span>
+            <span class="label">mean-weasel/seatify</span>
+          </div>
+          <div class="sheet-group-label" style="margin-top: 8px;">Author</div>
+          <div class="sheet-row selected">
+            <span class="label">Everyone</span>
+            <span class="check">✓</span>
+          </div>
+          <div class="sheet-row">
+            <span class="label">Just me <span class="sublabel">(@neonwatty)</span></span>
+          </div>
+          <button class="sheet-done">Done</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/packages/core/src/data/github-repos.test.ts
+++ b/packages/core/src/data/github-repos.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { createTestDb } from "../db/test-helpers.js";
+import { replaceAccessibleRepos } from "../db/github-repos.js";
+import {
+  ACCESSIBLE_REPOS_TTL_SECONDS,
+  readCachedAccessibleRepos,
+} from "./github-repos.js";
+import type { GitHubAccessibleRepo } from "../github/types.js";
+
+const alpha: GitHubAccessibleRepo = {
+  owner: "acme",
+  name: "alpha",
+  private: false,
+  pushedAt: "2026-04-10T12:00:00Z",
+};
+
+describe("readCachedAccessibleRepos", () => {
+  it("empty cache is always stale", () => {
+    const db = createTestDb();
+    const snapshot = readCachedAccessibleRepos(db, 1_000_000);
+    expect(snapshot).toEqual({ repos: [], syncedAt: null, isStale: true });
+  });
+
+  it("fresh cache (just synced) is not stale", () => {
+    const db = createTestDb();
+    const syncedAt = replaceAccessibleRepos(db, [alpha]);
+    const snapshot = readCachedAccessibleRepos(db, syncedAt);
+    expect(snapshot.isStale).toBe(false);
+    expect(snapshot.syncedAt).toBe(syncedAt);
+    expect(snapshot.repos).toHaveLength(1);
+  });
+
+  it("exactly at TTL boundary is not stale", () => {
+    const db = createTestDb();
+    const syncedAt = replaceAccessibleRepos(db, [alpha]);
+    const now = syncedAt + ACCESSIBLE_REPOS_TTL_SECONDS;
+    expect(readCachedAccessibleRepos(db, now).isStale).toBe(false);
+  });
+
+  it("one second past TTL is stale", () => {
+    const db = createTestDb();
+    const syncedAt = replaceAccessibleRepos(db, [alpha]);
+    const now = syncedAt + ACCESSIBLE_REPOS_TTL_SECONDS + 1;
+    expect(readCachedAccessibleRepos(db, now).isStale).toBe(true);
+  });
+});

--- a/packages/core/src/data/github-repos.ts
+++ b/packages/core/src/data/github-repos.ts
@@ -1,0 +1,40 @@
+import type Database from "better-sqlite3";
+import type { Octokit } from "@octokit/rest";
+import type { GitHubAccessibleRepo } from "../github/types.js";
+import { listAccessibleRepos } from "../github/repos.js";
+import {
+  listCachedAccessibleRepos,
+  replaceAccessibleRepos,
+} from "../db/github-repos.js";
+
+export const ACCESSIBLE_REPOS_TTL_SECONDS = 24 * 60 * 60;
+
+export type AccessibleReposSnapshot = {
+  repos: GitHubAccessibleRepo[];
+  /**
+   * Unix timestamp in **seconds** (NOT milliseconds) of the most recent
+   * successful sync, or null if the cache is empty. Consumers that compare
+   * against `Date.now()` must divide by 1000.
+   */
+  syncedAt: number | null;
+  isStale: boolean;
+};
+
+export function readCachedAccessibleRepos(
+  db: Database.Database,
+  now: number = Math.floor(Date.now() / 1000),
+): AccessibleReposSnapshot {
+  const { repos, syncedAt } = listCachedAccessibleRepos(db);
+  const isStale =
+    syncedAt === null || now - syncedAt > ACCESSIBLE_REPOS_TTL_SECONDS;
+  return { repos, syncedAt, isStale };
+}
+
+export async function refreshAccessibleRepos(
+  db: Database.Database,
+  octokit: Octokit,
+): Promise<AccessibleReposSnapshot> {
+  const fresh = await listAccessibleRepos(octokit);
+  const syncedAt = replaceAccessibleRepos(db, fresh);
+  return { repos: fresh, syncedAt, isStale: false };
+}

--- a/packages/core/src/data/pulls.ts
+++ b/packages/core/src/data/pulls.ts
@@ -24,14 +24,17 @@ export async function getPulls(
   fromCache: boolean;
   cachedAt: Date | null;
 }> {
-  const cacheKey = `pulls:${owner}/${repo}`;
+  // Prefix is `pulls-open:` (not `pulls:`) so the switch from state="all" to
+  // state="open" on upgrade doesn't briefly render stale merged/closed PRs
+  // from the old cache until TTL expires.
+  const cacheKey = `pulls-open:${owner}/${repo}`;
   const ttl = getCacheTtl(db);
 
   if (!options?.forceRefresh) {
     const cached = getCached<GitHubPull[]>(db, cacheKey);
     if (cached) {
       if (!isFresh(cached.fetchedAt, ttl)) {
-        listPulls(octokit, owner, repo, "all").then((data) => {
+        listPulls(octokit, owner, repo, "open").then((data) => {
           setCached(db, cacheKey, data);
         }).catch((err) => {
           console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
@@ -41,7 +44,7 @@ export async function getPulls(
     }
   }
 
-  const pulls = await listPulls(octokit, owner, repo, "all");
+  const pulls = await listPulls(octokit, owner, repo, "open");
   setCached(db, cacheKey, pulls);
   return { pulls, fromCache: false, cachedAt: new Date() };
 }

--- a/packages/core/src/db/github-repos.test.ts
+++ b/packages/core/src/db/github-repos.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "./test-helpers.js";
+import {
+  listCachedAccessibleRepos,
+  getAccessibleReposSyncedAt,
+  replaceAccessibleRepos,
+} from "./github-repos.js";
+import type { GitHubAccessibleRepo } from "../github/types.js";
+
+const alpha: GitHubAccessibleRepo = {
+  owner: "acme",
+  name: "alpha",
+  private: false,
+  pushedAt: "2026-04-10T12:00:00Z",
+};
+const beta: GitHubAccessibleRepo = {
+  owner: "acme",
+  name: "beta",
+  private: true,
+  pushedAt: "2026-04-12T09:00:00Z",
+};
+const gamma: GitHubAccessibleRepo = {
+  owner: "acme",
+  name: "gamma",
+  private: false,
+  pushedAt: null,
+};
+
+describe("github-repos DB helpers", () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  describe("listCachedAccessibleRepos", () => {
+    it("returns empty snapshot on fresh DB", () => {
+      expect(listCachedAccessibleRepos(db)).toEqual({
+        repos: [],
+        syncedAt: null,
+      });
+    });
+
+    it("orders by pushed_at DESC then owner/name ASC, nulls last", () => {
+      replaceAccessibleRepos(db, [alpha, beta, gamma]);
+      const { repos } = listCachedAccessibleRepos(db);
+      expect(repos.map((r) => r.name)).toEqual(["beta", "alpha", "gamma"]);
+    });
+
+    it("round-trips private flag and pushed_at", () => {
+      replaceAccessibleRepos(db, [alpha, beta, gamma]);
+      const { repos } = listCachedAccessibleRepos(db);
+      const byName = Object.fromEntries(repos.map((r) => [r.name, r]));
+      expect(byName.alpha.private).toBe(false);
+      expect(byName.beta.private).toBe(true);
+      expect(byName.gamma.pushedAt).toBeNull();
+    });
+  });
+
+  describe("replaceAccessibleRepos", () => {
+    it("sets uniform synced_at for the whole batch", () => {
+      const now = replaceAccessibleRepos(db, [alpha, beta]);
+      expect(listCachedAccessibleRepos(db).syncedAt).toBe(now);
+      expect(getAccessibleReposSyncedAt(db)).toBe(now);
+    });
+
+    it("fully replaces previous rows (no leftover from prior sync)", () => {
+      replaceAccessibleRepos(db, [alpha, beta]);
+      replaceAccessibleRepos(db, [gamma]);
+      const { repos } = listCachedAccessibleRepos(db);
+      expect(repos.map((r) => r.name)).toEqual(["gamma"]);
+    });
+
+    it("empty replace clears the table but still updates synced_at", () => {
+      replaceAccessibleRepos(db, [alpha]);
+      const secondSync = replaceAccessibleRepos(db, []);
+      expect(listCachedAccessibleRepos(db).repos).toEqual([]);
+      // An empty replace leaves MAX(synced_at) = null since no rows, but
+      // the function still returns the intended timestamp so callers can
+      // report it.
+      expect(getAccessibleReposSyncedAt(db)).toBeNull();
+      expect(typeof secondSync).toBe("number");
+    });
+
+    it("atomic: a duplicate-key INSERT rolls back the DELETE", () => {
+      replaceAccessibleRepos(db, [alpha, beta]);
+      // Simulate pathological input: GitHub response contains the same
+      // (owner, name) twice. PRIMARY KEY violation should roll back the
+      // DELETE so the prior state is preserved.
+      expect(() =>
+        replaceAccessibleRepos(db, [gamma, gamma]),
+      ).toThrow();
+      const { repos } = listCachedAccessibleRepos(db);
+      expect(repos.map((r) => r.name).sort()).toEqual(["alpha", "beta"]);
+    });
+  });
+
+  describe("getAccessibleReposSyncedAt", () => {
+    it("returns null when the table is empty", () => {
+      expect(getAccessibleReposSyncedAt(db)).toBeNull();
+    });
+
+    it("returns MAX(synced_at) after a populated replace", () => {
+      const t = replaceAccessibleRepos(db, [alpha, beta]);
+      expect(getAccessibleReposSyncedAt(db)).toBe(t);
+    });
+  });
+});

--- a/packages/core/src/db/github-repos.ts
+++ b/packages/core/src/db/github-repos.ts
@@ -1,0 +1,59 @@
+import type Database from "better-sqlite3";
+import type { GitHubAccessibleRepo } from "../github/types.js";
+
+type Row = {
+  owner: string;
+  name: string;
+  is_private: 0 | 1;
+  pushed_at: string | null;
+  synced_at: number;
+};
+
+export function listCachedAccessibleRepos(
+  db: Database.Database,
+): { repos: GitHubAccessibleRepo[]; syncedAt: number | null } {
+  const rows = db
+    .prepare(
+      "SELECT owner, name, is_private, pushed_at, synced_at FROM github_accessible_repos ORDER BY pushed_at DESC NULLS LAST, owner ASC, name ASC",
+    )
+    .all() as Row[];
+
+  if (rows.length === 0) return { repos: [], syncedAt: null };
+
+  return {
+    repos: rows.map((r) => ({
+      owner: r.owner,
+      name: r.name,
+      private: r.is_private === 1,
+      pushedAt: r.pushed_at,
+    })),
+    syncedAt: rows[0].synced_at,
+  };
+}
+
+export function getAccessibleReposSyncedAt(
+  db: Database.Database,
+): number | null {
+  const row = db
+    .prepare("SELECT MAX(synced_at) as synced_at FROM github_accessible_repos")
+    .get() as { synced_at: number | null } | undefined;
+  return row?.synced_at ?? null;
+}
+
+export function replaceAccessibleRepos(
+  db: Database.Database,
+  repos: GitHubAccessibleRepo[],
+): number {
+  const now = Math.floor(Date.now() / 1000);
+  const replaceAll = db.transaction((items: GitHubAccessibleRepo[]) => {
+    db.prepare("DELETE FROM github_accessible_repos").run();
+    const insert = db.prepare(
+      "INSERT INTO github_accessible_repos (owner, name, is_private, pushed_at, synced_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    for (const r of items) {
+      insert.run(r.owner, r.name, r.private ? 1 : 0, r.pushedAt, now);
+    }
+  });
+  replaceAll(repos);
+  return now;
+}

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -209,6 +209,26 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 10,
+    up(db) {
+      // Local cache of the authenticated user's accessible GitHub repos.
+      // Populated by the RepoPicker in settings so adding a new repo shows
+      // a searchable list without a network round-trip on every open.
+      // Refreshed on-demand via the picker's refresh button or when
+      // synced_at is older than the app-level staleness threshold (24h).
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS github_accessible_repos (
+          owner      TEXT NOT NULL,
+          name       TEXT NOT NULL,
+          is_private INTEGER NOT NULL DEFAULT 0 CHECK (is_private IN (0, 1)),
+          pushed_at  TEXT,
+          synced_at  INTEGER NOT NULL,
+          PRIMARY KEY (owner, name)
+        );
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -26,6 +26,7 @@ describe("initSchema", () => {
       "cache",
       "deployments",
       "drafts",
+      "github_accessible_repos",
       "issue_metadata",
       "repos",
       "schema_version",
@@ -33,15 +34,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 9", () => {
+  it("sets schema_version to 10", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
   });
 });
 
@@ -58,7 +59,7 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
   });
 
   it("migrates v1 schema through v9 and drops claude_aliases", () => {
@@ -74,7 +75,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -98,7 +99,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -141,7 +142,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -160,7 +161,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
   it("initSchema on a fresh DB produces schema version 9", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -226,7 +227,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -314,7 +315,7 @@ describe("schema v8 — deployments FK cascade", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
 
     // Pre-existing row should have been copied over with its state intact
     const row = db
@@ -397,7 +398,7 @@ describe("schema v9 — live deployment unique index", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
     // Row id=1 (older duplicate) → ended. id=2 (most recent live) → live.
     // id=3 (historic ended) → still ended, untouched.
     const live = db
@@ -549,7 +550,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
       runMigrations(db);
     }).not.toThrow();
 
-    expect(getSchemaVersion(db)).toBe(9);
+    expect(getSchemaVersion(db)).toBe(10);
 
     // Verify the dedupe ran and the index now exists.
     const live = db
@@ -575,5 +576,22 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
       .prepare(`SELECT name FROM pragma_index_list('deployments') WHERE "unique" = 1`)
       .all() as { name: string }[];
     expect(indexes.map((i) => i.name)).toContain("idx_deployments_live");
+  });
+
+  it("v10 migration creates github_accessible_repos with expected columns", () => {
+    const db = createTestDb();
+    expect(getSchemaVersion(db)).toBe(10);
+
+    const cols = db
+      .prepare("PRAGMA table_info(github_accessible_repos)")
+      .all() as { name: string; type: string; pk: number }[];
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual(["is_private", "name", "owner", "pushed_at", "synced_at"]);
+
+    const pkCols = cols
+      .filter((c) => c.pk > 0)
+      .map((c) => c.name)
+      .sort();
+    expect(pkCols).toEqual(["name", "owner"]);
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 9;
+const SCHEMA_VERSION = 10;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -69,6 +69,15 @@ const CREATE_TABLES = `
 
   CREATE INDEX IF NOT EXISTS idx_action_nonces_created_at
     ON action_nonces(created_at);
+
+  CREATE TABLE IF NOT EXISTS github_accessible_repos (
+    owner      TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    is_private INTEGER NOT NULL DEFAULT 0 CHECK (is_private IN (0, 1)),
+    pushed_at  TEXT,
+    synced_at  INTEGER NOT NULL,
+    PRIMARY KEY (owner, name)
+  );
 
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/packages/core/src/github/repos.test.ts
+++ b/packages/core/src/github/repos.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Octokit } from "@octokit/rest";
+import { listAccessibleRepos } from "./repos.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockFn = ReturnType<typeof vi.fn<(...args: any[]) => any>>;
+
+function makeOctokit() {
+  const listForAuthenticatedUser = vi.fn() as MockFn;
+  const octokit = {
+    rest: {
+      repos: { listForAuthenticatedUser },
+    },
+  } as unknown as Octokit;
+  return { octokit, listForAuthenticatedUser };
+}
+
+describe("listAccessibleRepos", () => {
+  it("maps Octokit response to GitHubAccessibleRepo shape", async () => {
+    const { octokit, listForAuthenticatedUser } = makeOctokit();
+    listForAuthenticatedUser.mockResolvedValue({
+      data: [
+        {
+          owner: { login: "mean-weasel" },
+          name: "seatify",
+          private: false,
+          pushed_at: "2026-04-10T12:00:00Z",
+        },
+        {
+          owner: { login: "acme-co" },
+          name: "billing-api",
+          private: true,
+          pushed_at: null,
+        },
+      ],
+    });
+
+    const repos = await listAccessibleRepos(octokit);
+    expect(repos).toEqual([
+      {
+        owner: "mean-weasel",
+        name: "seatify",
+        private: false,
+        pushedAt: "2026-04-10T12:00:00Z",
+      },
+      {
+        owner: "acme-co",
+        name: "billing-api",
+        private: true,
+        pushedAt: null,
+      },
+    ]);
+  });
+
+  it("requests one page of 100, sorted by pushed, all affiliations", async () => {
+    const { octokit, listForAuthenticatedUser } = makeOctokit();
+    listForAuthenticatedUser.mockResolvedValue({ data: [] });
+    await listAccessibleRepos(octokit);
+    expect(listForAuthenticatedUser).toHaveBeenCalledWith({
+      per_page: 100,
+      sort: "pushed",
+      affiliation: "owner,collaborator,organization_member",
+    });
+  });
+});

--- a/packages/core/src/github/repos.ts
+++ b/packages/core/src/github/repos.ts
@@ -1,0 +1,32 @@
+import type { Octokit } from "@octokit/rest";
+import type { GitHubAccessibleRepo } from "./types.js";
+
+const PAGE_SIZE = 100;
+
+export async function listAccessibleRepos(
+  octokit: Octokit,
+): Promise<GitHubAccessibleRepo[]> {
+  // Single page cap. 100 most recently pushed repos covers almost all real
+  // use cases; the picker has a manual-entry fallback for the long tail.
+  const { data } = await octokit.rest.repos.listForAuthenticatedUser({
+    per_page: PAGE_SIZE,
+    sort: "pushed",
+    affiliation: "owner,collaborator,organization_member",
+  });
+  if (data.length === PAGE_SIZE) {
+    // Possible truncation: the user has 100+ accessible repos. Without
+    // surfacing this, older repos silently disappear from the picker each
+    // refresh. Log so operators see the signal and the picker can route it
+    // to a subtle UI hint later if needed.
+    console.warn(
+      `[issuectl] listAccessibleRepos returned ${PAGE_SIZE} repos — result may be truncated. ` +
+        "The picker's manual-entry fallback covers repos beyond the first page.",
+    );
+  }
+  return data.map((item) => ({
+    owner: item.owner.login,
+    name: item.name,
+    private: item.private,
+    pushedAt: item.pushed_at ?? null,
+  }));
+}

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -72,3 +72,17 @@ export type GitHubPullFile = {
   additions: number;
   deletions: number;
 };
+
+export type GitHubAccessibleRepo = {
+  owner: string;
+  name: string;
+  private: boolean;
+  pushedAt: string | null;
+};
+
+// Canonical `owner/name` key shared across UI + cache lookups. Callers
+// previously computed this inline in at least four places; drift here
+// silently breaks Set<string> membership checks, URL param compares, etc.
+export function repoKey(r: { owner: string; name: string }): string {
+  return `${r.owner}/${r.name}`;
+}

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -79,10 +79,3 @@ export type GitHubAccessibleRepo = {
   private: boolean;
   pushedAt: string | null;
 };
-
-// Canonical `owner/name` key shared across UI + cache lookups. Callers
-// previously computed this inline in at least four places; drift here
-// silently breaks Set<string> membership checks, URL param compares, etc.
-export function repoKey(r: { owner: string; name: string }): string {
-  return `${r.owner}/${r.name}`;
-}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,7 +91,6 @@ export type {
   GitHubPullFile,
   GitHubAccessibleRepo,
 } from "./github/types.js";
-export { repoKey } from "./github/types.js";
 export { getGhToken, checkGhAuth } from "./github/auth.js";
 export { getOctokit, resetOctokit, withAuthRetry } from "./github/client.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,11 @@ export {
   updateRepo,
 } from "./db/repos.js";
 export {
+  listCachedAccessibleRepos,
+  getAccessibleReposSyncedAt,
+  replaceAccessibleRepos,
+} from "./db/github-repos.js";
+export {
   getSetting,
   setSetting,
   getSettings,
@@ -84,7 +89,9 @@ export type {
   GitHubLabel,
   GitHubCheck,
   GitHubPullFile,
+  GitHubAccessibleRepo,
 } from "./github/types.js";
+export { repoKey } from "./github/types.js";
 export { getGhToken, checkGhAuth } from "./github/auth.js";
 export { getOctokit, resetOctokit, withAuthRetry } from "./github/client.js";
 export {
@@ -105,6 +112,7 @@ export {
   addLabel,
   removeLabel,
 } from "./github/labels.js";
+export { listAccessibleRepos } from "./github/repos.js";
 
 // Cached data layer (SWR)
 export {
@@ -118,6 +126,12 @@ export {
   getPullDetail,
 } from "./data/pulls.js";
 export { getDashboardData } from "./data/repos.js";
+export {
+  readCachedAccessibleRepos,
+  refreshAccessibleRepos,
+  ACCESSIBLE_REPOS_TTL_SECONDS,
+  type AccessibleReposSnapshot,
+} from "./data/github-repos.js";
 export {
   getComments,
   addComment,

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -6,18 +6,35 @@ import {
   listRepos,
   dbExists,
   type GitHubPull,
+  type Section,
 } from "@issuectl/core";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 import { List } from "@/components/list/List";
 import { getAuthStatus } from "@/lib/auth";
+import {
+  filterPrs,
+  filterUnifiedList,
+  resolveActiveRepo,
+  type PrEntry,
+} from "@/lib/page-filters";
 
 export const dynamic = "force-dynamic";
 
 type Props = {
-  searchParams: Promise<{ tab?: string }>;
+  searchParams: Promise<{
+    tab?: string;
+    repo?: string;
+    mine?: string;
+    section?: string;
+  }>;
 };
 
-type PrEntry = { repo: { owner: string; name: string }; pull: GitHubPull };
+const SECTIONS: readonly Section[] = [
+  "unassigned",
+  "in_focus",
+  "in_flight",
+  "shipped",
+];
 
 export default async function MainListPage({ searchParams }: Props) {
   if (!dbExists()) {
@@ -30,11 +47,21 @@ export default async function MainListPage({ searchParams }: Props) {
     return <WelcomeScreen />;
   }
 
-  const { tab } = await searchParams;
+  const {
+    tab,
+    repo: repoParam,
+    mine: mineParam,
+    section: sectionParam,
+  } = await searchParams;
   const activeTab = tab === "prs" ? "prs" : "issues";
+  const activeRepo = resolveActiveRepo(repoParam, repos);
+  const mineOnly = mineParam === "1";
+  const activeSection: Section = (SECTIONS as readonly string[]).includes(
+    sectionParam ?? "",
+  )
+    ? (sectionParam as Section)
+    : "in_focus";
 
-  // Auth check doesn't depend on octokit, so start it in parallel with the
-  // octokit handshake. Then fan out data fetches in parallel once octokit is ready.
   const [octokit, auth] = await Promise.all([getOctokit(), getAuthStatus()]);
 
   const [data, allPrs] = await Promise.all([
@@ -43,14 +70,20 @@ export default async function MainListPage({ searchParams }: Props) {
   ]);
 
   const username = auth.authenticated ? auth.username : null;
+  const filteredData = filterUnifiedList(data, activeRepo);
+  const filteredPrs = filterPrs(allPrs, activeRepo, mineOnly ? username : null);
 
   return (
     <List
-      data={data}
+      data={filteredData}
       activeTab={activeTab}
-      prs={allPrs}
-      prCount={allPrs.length}
+      activeSection={activeSection}
+      prs={filteredPrs}
+      prCount={filteredPrs.length}
       username={username}
+      repos={repos.map((r) => ({ owner: r.owner, name: r.name }))}
+      activeRepo={activeRepo}
+      mineOnly={mineOnly}
     />
   );
 }

--- a/packages/web/components/list/FilterEdgeSwipe.module.css
+++ b/packages/web/components/list/FilterEdgeSwipe.module.css
@@ -1,0 +1,37 @@
+.zone {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  z-index: 40;
+  width: 160px;
+  padding: 18px 20px calc(10px + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(
+    to top,
+    var(--paper-bg) 30%,
+    rgba(243, 236, 217, 0.85) 70%,
+    rgba(243, 236, 217, 0) 100%
+  );
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* Capture vertical pan gestures so upward swipes reach our handlers
+     rather than scrolling the list behind. */
+  touch-action: none;
+}
+
+.handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--paper-ink-faint);
+  opacity: 0.55;
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .zone {
+    display: none;
+  }
+}

--- a/packages/web/components/list/FilterEdgeSwipe.tsx
+++ b/packages/web/components/list/FilterEdgeSwipe.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRef } from "react";
+import styles from "./FilterEdgeSwipe.module.css";
+
+type Props = {
+  onTrigger: () => void;
+  label?: string;
+};
+
+const OPEN_THRESHOLD_PX = 40;
+
+export function FilterEdgeSwipe({ onTrigger, label = "Filters" }: Props) {
+  const startY = useRef<number | null>(null);
+  const firedRef = useRef(false);
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
+    if (e.touches.length === 0) return;
+    startY.current = e.touches[0].clientY;
+    firedRef.current = false;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLButtonElement>) => {
+    if (startY.current === null || firedRef.current) return;
+    if (e.touches.length === 0) return;
+    const delta = startY.current - e.touches[0].clientY;
+    if (delta > OPEN_THRESHOLD_PX) {
+      firedRef.current = true;
+      onTrigger();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    // Reset both refs for symmetry — guards against any state held across
+    // a gesture that was interrupted between touchstart and touchend.
+    startY.current = null;
+    firedRef.current = false;
+  };
+
+  return (
+    <button
+      type="button"
+      className={styles.zone}
+      onClick={onTrigger}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+      aria-label={`Open ${label} — swipe up or tap`}
+    >
+      <span className={styles.handle} aria-hidden />
+    </button>
+  );
+}

--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -1,0 +1,95 @@
+.clearBar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 4px 4px;
+  min-height: 32px;
+}
+
+.clearBtn {
+  color: var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  font-style: italic;
+  text-decoration: none;
+  padding: 6px 10px;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.clearBtn:hover,
+.clearBtn:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.clearPlaceholder {
+  height: 32px;
+}
+
+.groupLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: var(--paper-ink-muted);
+  padding: 12px 4px 6px;
+}
+
+.row,
+.rowActive {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 8px;
+  min-height: 56px;
+  border-bottom: 1px solid var(--paper-line-soft);
+  text-decoration: none;
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-size: 16px;
+  border-radius: var(--paper-radius-md);
+  margin: 0 -8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.row:hover,
+.row:focus-visible {
+  background: var(--paper-bg-warm);
+  outline: none;
+}
+
+.rowActive {
+  background: var(--paper-accent-soft);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.labelOwner {
+  color: var(--paper-ink-muted);
+}
+
+.labelSub {
+  color: var(--paper-ink-muted);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.check {
+  color: var(--paper-accent);
+  font-size: 18px;
+  flex-shrink: 0;
+}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { repoKey } from "@issuectl/core";
+import { Sheet } from "@/components/paper";
+import { REPO_COLORS } from "@/lib/constants";
+import styles from "./FiltersSheet.module.css";
+
+type Repo = { owner: string; name: string };
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  repos: Repo[];
+  activeRepo: string | null;
+  showAuthor: boolean;
+  mineOnly: boolean;
+  username: string | null;
+  repoHref: (repoKey: string | null) => string;
+  mineHref: (mine: boolean | null) => string;
+  clearHref: string | null;
+};
+
+export function FiltersSheet({
+  open,
+  onClose,
+  repos,
+  activeRepo,
+  showAuthor,
+  mineOnly,
+  username,
+  repoHref,
+  mineHref,
+  clearHref,
+}: Props) {
+  return (
+    <Sheet open={open} onClose={onClose} title="Filters">
+      <div className={styles.clearBar}>
+        {clearHref ? (
+          <Link
+            href={clearHref}
+            className={styles.clearBtn}
+            onClick={onClose}
+          >
+            clear all
+          </Link>
+        ) : (
+          <span className={styles.clearPlaceholder} />
+        )}
+      </div>
+
+      <div className={styles.groupLabel}>Repository</div>
+      <Link
+        href={repoHref(null)}
+        className={activeRepo === null ? styles.rowActive : styles.row}
+        onClick={onClose}
+      >
+        <span className={styles.label}>All repos</span>
+        {activeRepo === null && <span className={styles.check}>✓</span>}
+      </Link>
+      {repos.map((repo, i) => {
+        const key = repoKey(repo);
+        const isActive = key === activeRepo;
+        const color = REPO_COLORS[i % REPO_COLORS.length];
+        return (
+          <Link
+            key={key}
+            href={repoHref(key)}
+            className={isActive ? styles.rowActive : styles.row}
+            onClick={onClose}
+          >
+            <span
+              className={styles.dot}
+              style={{ background: color }}
+              aria-hidden
+            />
+            <span className={styles.label}>
+              <span className={styles.labelOwner}>{repo.owner}/</span>
+              {repo.name}
+            </span>
+            {isActive && <span className={styles.check}>✓</span>}
+          </Link>
+        );
+      })}
+
+      {showAuthor && (
+        <>
+          <div className={styles.groupLabel}>Author</div>
+          <Link
+            href={mineHref(null)}
+            className={!mineOnly ? styles.rowActive : styles.row}
+            onClick={onClose}
+          >
+            <span className={styles.label}>Everyone</span>
+            {!mineOnly && <span className={styles.check}>✓</span>}
+          </Link>
+          <Link
+            href={mineHref(true)}
+            className={mineOnly ? styles.rowActive : styles.row}
+            onClick={onClose}
+          >
+            <span className={styles.label}>
+              Just me
+              {username && (
+                <span className={styles.labelSub}> (@{username})</span>
+              )}
+            </span>
+            {mineOnly && <span className={styles.check}>✓</span>}
+          </Link>
+        </>
+      )}
+    </Sheet>
+  );
+}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { repoKey } from "@issuectl/core";
 import { Sheet } from "@/components/paper";
 import { REPO_COLORS } from "@/lib/constants";
+import { repoKey } from "@/lib/repo-key";
 import styles from "./FiltersSheet.module.css";
 
 type Repo = { owner: string; name: string };

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -1,9 +1,10 @@
 .container {
   max-width: 900px;
   margin: 0 auto;
-  /* Bottom padding clears the FAB (60px + 30px inset + 14px breathing room)
-     so the last row never sits under the floating action button. */
-  padding: 12px 0 calc(104px + env(safe-area-inset-bottom, 0px));
+  /* Bottom padding clears the FAB (60px + 30px inset + 54px breathing room)
+     so the last row's trailing action button clears the floating action
+     button even when a user scrolls to the end of a dense row. */
+  padding: 12px 0 calc(144px + env(safe-area-inset-bottom, 0px));
   background: var(--paper-bg);
   min-height: 100dvh;
   position: relative;
@@ -241,4 +242,233 @@
   .desktopDraftBtn {
     display: inline-block;
   }
+}
+
+.mineToggle {
+  display: inline-flex;
+  margin: 0 16px 12px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  padding: 2px;
+  align-self: flex-start;
+}
+
+.mineOption,
+.mineOptionActive {
+  position: relative;
+  padding: 6px 14px;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-ink-muted);
+  text-decoration: none;
+}
+
+/* Extend hit area to 44px without visually growing the segmented toggle. */
+.mineOption::before,
+.mineOptionActive::before {
+  content: "";
+  position: absolute;
+  inset: -6px 0;
+}
+
+.mineOptionActive {
+  background: var(--paper-bg);
+  color: var(--paper-ink);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  font-weight: 500;
+}
+
+.sectionTabs {
+  display: flex;
+  gap: 0;
+  padding: 0 16px;
+  margin-bottom: 8px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.sectionTabs::-webkit-scrollbar {
+  display: none;
+}
+
+.sectionTab,
+.sectionTabActive {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  min-height: 40px;
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-ink-muted);
+  text-decoration: none;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  flex-shrink: 0;
+}
+
+/* Extend hit area to 44px (40 + 2 + 2) for WCAG 2.5.5 compliance. */
+.sectionTab::before,
+.sectionTabActive::before {
+  content: "";
+  position: absolute;
+  inset: -2px 0;
+}
+
+.sectionTab:hover,
+.sectionTab:focus-visible {
+  color: var(--paper-ink-soft);
+  outline: none;
+}
+
+.sectionTabActive {
+  color: var(--paper-ink);
+  font-weight: 500;
+  border-bottom-color: var(--paper-ink);
+}
+
+.sectionTabCount {
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  font-weight: 400;
+}
+
+.sectionTabActive .sectionTabCount {
+  color: var(--paper-ink-soft);
+}
+
+/* ── Filter button (mobile only) ── */
+.filterBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  margin-left: auto;
+  align-self: center;
+  background: transparent;
+  border: none;
+  color: var(--paper-ink);
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.filterBtn:hover,
+.filterBtn:focus-visible {
+  color: var(--paper-accent);
+  outline: none;
+}
+
+.filterBtnDot {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--paper-accent);
+  border: 1.5px solid var(--paper-bg);
+}
+
+/* ── Scope pill (mobile only) ── */
+.scopePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 2px 4px 2px 8px;
+  background: var(--paper-accent-soft);
+  border-radius: 999px;
+  font-size: 11px;
+  font-style: italic;
+  font-weight: 500;
+  color: var(--paper-ink-soft);
+  font-family: var(--paper-serif);
+  max-width: 160px;
+}
+
+.scopePillDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.scopePillLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scopePillClear {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  color: var(--paper-ink-muted);
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 1;
+  font-style: normal;
+}
+
+/* Extend hit area on the × link to ~30px without visually growing the pill. */
+.scopePillClear::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+}
+
+.scopePillClear:hover,
+.scopePillClear:focus-visible {
+  color: var(--paper-ink);
+  outline: none;
+}
+
+/* ── Responsive: desktop shows chip row + inline mine toggle, hides filter
+     button + scope pill. Mobile inverts. ── */
+@media (max-width: 767px) {
+  .desktopChipRow {
+    display: none;
+  }
+  .mineToggle {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .filterBtn {
+    display: none;
+  }
+  .scopePill {
+    display: none;
+  }
+}
+
+/* Swap tab labels at narrow widths so the scope pill + filter icon
+   don't force "Pull requests" to wrap. */
+.tabLabelShort { display: none; }
+
+@media (max-width: 479px) {
+  .tabLabelFull { display: none; }
+  .tabLabelShort { display: inline; }
+  .tab {
+    margin-right: 18px;
+  }
+}
+
+.tab {
+  white-space: nowrap;
 }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -2,33 +2,62 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { GitHubPull, Section, UnifiedList } from "@issuectl/core";
+import { repoKey, type GitHubPull, type Section, type UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
+import { REPO_COLORS } from "@/lib/constants";
 import { ListSection } from "./ListSection";
 import { PrListRow } from "./PrListRow";
 import { CreateDraftSheet } from "./CreateDraftSheet";
 import { AssignSheet } from "./AssignSheet";
 import { NavDrawerContent } from "./NavDrawerContent";
+import { RepoFilterChips } from "./RepoFilterChips";
+import { FiltersSheet } from "./FiltersSheet";
+import { FilterEdgeSwipe } from "./FilterEdgeSwipe";
+import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 
-type PrEntry = { repo: { owner: string; name: string }; pull: GitHubPull };
+type Repo = { owner: string; name: string };
+type PrEntry = { repo: Repo; pull: GitHubPull };
 
 type Props = {
   data: UnifiedList;
   activeTab: "issues" | "prs";
+  activeSection: Section;
   prCount: number;
   prs: PrEntry[];
   username: string | null;
+  repos: Repo[];
+  activeRepo: string | null;
+  mineOnly: boolean;
 };
 
+// Lowercase is intentional — matches the Paper mockup typography.
 const SECTION_LABEL: Record<Section, string> = {
-  unassigned: "unassigned",
+  unassigned: "drafts",
   in_focus: "in focus",
   in_flight: "in flight",
   shipped: "shipped",
 };
 
-// Lowercase is intentional — matches the Paper mockup typography.
+const SECTION_EMPTY: Record<Section, { title: string; body: string }> = {
+  unassigned: {
+    title: "no drafts",
+    body: "start a draft with the + button — it'll live here until you assign it to a repo.",
+  },
+  in_focus: {
+    title: "all clear",
+    body: "nothing on your plate. breathe, or draft the next one.",
+  },
+  in_flight: {
+    title: "nothing in flight",
+    body: "when you launch an issue, it lands here while you work on it.",
+  },
+  shipped: {
+    title: "nothing shipped yet",
+    body: "closed issues show up here once PRs merge and reconcile.",
+  },
+};
+
 function formatDate(d: Date): { weekday: string; short: string } {
   const weekday = d
     .toLocaleDateString("en-US", { weekday: "long" })
@@ -39,21 +68,89 @@ function formatDate(d: Date): { weekday: string; short: string } {
   return { weekday, short };
 }
 
-export function List({ data, activeTab, prCount, prs, username }: Props) {
+export function List({
+  data,
+  activeTab,
+  activeSection,
+  prCount,
+  prs,
+  username,
+  repos,
+  activeRepo,
+  mineOnly,
+}: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [assignTarget, setAssignTarget] = useState<{
     id: string;
     title: string;
   } | null>(null);
 
-  const issueCount =
-    data.unassigned.length +
-    data.in_focus.length +
-    data.in_flight.length +
-    data.shipped.length;
+  const sectionCounts: Record<Section, number> = {
+    unassigned: data.unassigned.length,
+    in_focus: data.in_focus.length,
+    in_flight: data.in_flight.length,
+    shipped: data.shipped.length,
+  };
+  const totalIssueCount =
+    sectionCounts.unassigned +
+    sectionCounts.in_focus +
+    sectionCounts.in_flight +
+    sectionCounts.shipped;
+
   const { weekday, short } = formatDate(new Date());
-  const isEmpty = activeTab === "issues" ? issueCount === 0 : prCount === 0;
+
+  const visibleSections: Section[] = activeRepo
+    ? ["in_focus", "in_flight", "shipped"]
+    : ["unassigned", "in_focus", "in_flight", "shipped"];
+
+  const isPrTab = activeTab === "prs";
+  const hasActiveFilter = activeRepo !== null || (isPrTab && mineOnly);
+  const activeRepoIndex = activeRepo
+    ? repos.findIndex((r) => repoKey(r) === activeRepo)
+    : -1;
+  const activeRepoColor =
+    activeRepoIndex >= 0
+      ? REPO_COLORS[activeRepoIndex % REPO_COLORS.length]
+      : undefined;
+
+  const issuesHref = buildHref({ repo: activeRepo });
+  const prsHref = buildHref({
+    tab: "prs",
+    repo: activeRepo,
+    mine: mineOnly ? true : null,
+  });
+
+  const chipHref = (repoKey: string | null) =>
+    buildHref({
+      tab: activeTab,
+      repo: repoKey,
+      mine: isPrTab && mineOnly ? true : null,
+      section: activeTab === "issues" ? activeSection : null,
+    });
+
+  const sectionHref = (section: Section) =>
+    buildHref({ repo: activeRepo, section });
+
+  const mineHref = (mine: boolean | null) =>
+    buildHref({ tab: "prs", repo: activeRepo, mine });
+
+  const clearFiltersHref = hasActiveFilter
+    ? buildHref({
+        tab: isPrTab ? "prs" : undefined,
+        section: activeTab === "issues" ? activeSection : null,
+      })
+    : null;
+
+  // On mobile the scope pill replaces the repo chip row as the visible
+  // "you're filtered to X" indicator. Clearing the repo from the pill keeps
+  // any author filter intact (since they're orthogonal).
+  const clearRepoHref = buildHref({
+    tab: isPrTab ? "prs" : undefined,
+    mine: isPrTab && mineOnly ? true : null,
+    section: activeTab === "issues" ? activeSection : null,
+  });
 
   return (
     <div className={styles.container}>
@@ -75,25 +172,38 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
         </button>
       </div>
 
-      {/* Desktop: date + tabs inline. Mobile: tabs only, date in drawer. */}
       <div className={styles.tabs}>
         <Link
-          href="/"
+          href={issuesHref}
           className={`${styles.tab} ${activeTab === "issues" ? styles.on : ""}`}
         >
-          Issues<span className={styles.count}>{issueCount}</span>
+          Issues<span className={styles.count}>{totalIssueCount}</span>
+          {activeTab === "issues" && activeRepo && (
+            <ScopePill
+              label={activeRepo.split("/").pop() ?? activeRepo}
+              color={activeRepoColor}
+              clearHref={clearRepoHref}
+            />
+          )}
         </Link>
         <Link
-          href="/?tab=prs"
+          href={prsHref}
           className={`${styles.tab} ${activeTab === "prs" ? styles.on : ""}`}
         >
-          Pull requests<span className={styles.count}>{prCount}</span>
+          <span className={styles.tabLabelFull}>Pull requests</span>
+          <span className={styles.tabLabelShort}>PRs</span>
+          <span className={styles.count}>{prCount}</span>
+          {activeTab === "prs" && activeRepo && (
+            <ScopePill
+              label={activeRepo.split("/").pop() ?? activeRepo}
+              color={activeRepoColor}
+              clearHref={clearRepoHref}
+            />
+          )}
         </Link>
         <div className={styles.desktopDate}>
           {weekday} · <b>{short}</b>
         </div>
-        {/* Desktop-only inline create-draft button. The Fab below is */}
-        {/* the mobile entry point and is hidden on desktop. */}
         {activeTab === "issues" && (
           <button
             type="button"
@@ -103,48 +213,89 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
             + draft
           </button>
         )}
+        <button
+          type="button"
+          className={styles.filterBtn}
+          onClick={() => setFiltersOpen(true)}
+          aria-label="Open filters"
+          aria-haspopup="dialog"
+        >
+          <FilterIcon />
+          {hasActiveFilter && <span className={styles.filterBtnDot} aria-hidden />}
+        </button>
       </div>
 
+      <div className={styles.desktopChipRow}>
+        <RepoFilterChips
+          repos={repos}
+          activeRepo={activeRepo}
+          buildHref={chipHref}
+        />
+      </div>
+
+      {activeTab === "issues" && (
+        <nav className={styles.sectionTabs} aria-label="Filter by section">
+          {visibleSections.map((section) => {
+            const isActive = section === activeSection;
+            const count = sectionCounts[section];
+            return (
+              <Link
+                key={section}
+                href={sectionHref(section)}
+                className={isActive ? styles.sectionTabActive : styles.sectionTab}
+                aria-current={isActive ? "page" : undefined}
+              >
+                {SECTION_LABEL[section]}
+                <span className={styles.sectionTabCount}>{count}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+
+      {activeTab === "prs" && repos.length > 0 && (
+        <div
+          className={styles.mineToggle}
+          role="tablist"
+          aria-label="Author filter"
+        >
+          <Link
+            href={mineHref(null)}
+            className={!mineOnly ? styles.mineOptionActive : styles.mineOption}
+            aria-current={!mineOnly ? "page" : undefined}
+          >
+            everyone
+          </Link>
+          <Link
+            href={mineHref(true)}
+            className={mineOnly ? styles.mineOptionActive : styles.mineOption}
+            aria-current={mineOnly ? "page" : undefined}
+          >
+            mine
+          </Link>
+        </div>
+      )}
+
       {activeTab === "issues" ? (
-        isEmpty ? (
-          <div className={styles.empty}>
-            <div className={styles.emptyMark}>❧</div>
-            <h3>all clear</h3>
-            <p>
-              nothing on your plate today.{" "}
-              <em>breathe, or draft the next one.</em>
-            </p>
-          </div>
-        ) : (
-          <div>
-            <ListSection
-              title={SECTION_LABEL.unassigned}
-              items={data.unassigned}
-              onAssign={(id, title) => setAssignTarget({ id, title })}
-            />
-            <ListSection
-              title={SECTION_LABEL.in_focus}
-              items={data.in_focus}
-              onAssign={(id, title) => setAssignTarget({ id, title })}
-            />
-            <ListSection
-              title={SECTION_LABEL.in_flight}
-              items={data.in_flight}
-              onAssign={(id, title) => setAssignTarget({ id, title })}
-            />
-            <ListSection
-              title={SECTION_LABEL.shipped}
-              items={data.shipped}
-              onAssign={(id, title) => setAssignTarget({ id, title })}
-            />
-          </div>
-        )
-      ) : isEmpty ? (
+        renderIssueSection({
+          activeSection,
+          data,
+          onAssign: (id, title) => setAssignTarget({ id, title }),
+        })
+      ) : prCount === 0 ? (
         <div className={styles.empty}>
           <div className={styles.emptyMark}>❧</div>
           <h3>no pull requests</h3>
           <p>
-            <em>no open pull requests across your repos.</em>
+            <em>
+              {activeRepo && mineOnly
+                ? `no open PRs from you in ${activeRepo}.`
+                : activeRepo
+                  ? `no open PRs in ${activeRepo}.`
+                  : mineOnly
+                    ? "no open PRs from you across your repos."
+                    : "no open PRs across your repos."}
+            </em>
           </p>
         </div>
       ) : (
@@ -179,6 +330,23 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
         </>
       )}
 
+      <FiltersSheet
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        repos={repos}
+        activeRepo={activeRepo}
+        showAuthor={isPrTab}
+        mineOnly={mineOnly}
+        username={username}
+        repoHref={chipHref}
+        mineHref={mineHref}
+        clearHref={clearFiltersHref}
+      />
+
+      {!filtersOpen && (
+        <FilterEdgeSwipe onTrigger={() => setFiltersOpen(true)} />
+      )}
+
       <Drawer
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
@@ -191,5 +359,87 @@ export function List({ data, activeTab, prCount, prs, username }: Props) {
         <NavDrawerContent activeTab={activeTab} username={username} />
       </Drawer>
     </div>
+  );
+}
+
+function renderIssueSection({
+  activeSection,
+  data,
+  onAssign,
+}: {
+  activeSection: Section;
+  data: UnifiedList;
+  onAssign: (id: string, title: string) => void;
+}) {
+  const items =
+    activeSection === "unassigned"
+      ? data.unassigned
+      : activeSection === "in_focus"
+        ? data.in_focus
+        : activeSection === "in_flight"
+          ? data.in_flight
+          : data.shipped;
+
+  if (items.length === 0) {
+    const empty = SECTION_EMPTY[activeSection];
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyMark}>❧</div>
+        <h3>{empty.title}</h3>
+        <p><em>{empty.body}</em></p>
+      </div>
+    );
+  }
+
+  return <ListSection title={null} items={items} onAssign={onAssign} />;
+}
+
+function FilterIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M2 4h14M4 9h10M7 14h4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function ScopePill({
+  label,
+  color,
+  clearHref,
+}: {
+  label: string;
+  color: string | undefined;
+  clearHref: string;
+}) {
+  return (
+    <span className={styles.scopePill}>
+      {color && (
+        <span
+          className={styles.scopePillDot}
+          style={{ background: color }}
+          aria-hidden
+        />
+      )}
+      <span className={styles.scopePillLabel}>{label}</span>
+      <Link
+        href={clearHref}
+        className={styles.scopePillClear}
+        aria-label={`Clear ${label} filter`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        ×
+      </Link>
+    </span>
   );
 }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { repoKey, type GitHubPull, type Section, type UnifiedList } from "@issuectl/core";
+import type { GitHubPull, Section, UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
 import { REPO_COLORS } from "@/lib/constants";
+import { repoKey } from "@/lib/repo-key";
 import { ListSection } from "./ListSection";
 import { PrListRow } from "./PrListRow";
 import { CreateDraftSheet } from "./CreateDraftSheet";

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -203,5 +203,7 @@
 }
 
 .lblFeat {
-  color: var(--paper-butter);
+  /* Darker butter — var(--paper-butter) on cream fails WCAG AA (1.89:1).
+     #8a6914 restores >4.5:1 while keeping the warm-yellow feel. */
+  color: #8a6914;
 }

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -4,7 +4,7 @@ import { ListRow } from "./ListRow";
 import styles from "./ListSection.module.css";
 
 type Props = {
-  title: ReactNode;
+  title: ReactNode | null;
   items: UnifiedListItem[];
   onAssign?: (draftId: string, draftTitle: string) => void;
 };
@@ -14,11 +14,13 @@ export function ListSection({ title, items, onAssign }: Props) {
 
   return (
     <>
-      <div className={styles.section}>
-        <h3>{title}</h3>
-        <div className={styles.rule} />
-        <span className={styles.count}>{items.length}</span>
-      </div>
+      {title ? (
+        <div className={styles.section}>
+          <h3>{title}</h3>
+          <div className={styles.rule} />
+          <span className={styles.count}>{items.length}</span>
+        </div>
+      ) : null}
       {items.map((item) => (
         <ListRow
           key={

--- a/packages/web/components/list/RepoFilterChips.module.css
+++ b/packages/web/components/list/RepoFilterChips.module.css
@@ -1,0 +1,67 @@
+.row {
+  display: flex;
+  gap: 8px;
+  padding: 8px 16px 12px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.row::-webkit-scrollbar {
+  display: none;
+}
+
+.chip,
+.chipActive {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  min-height: 32px;
+  border-radius: 999px;
+  border: 1px solid var(--paper-line);
+  background: var(--paper-bg);
+  color: var(--paper-ink-soft);
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Extend hit area to 44x44 without visually growing the chip (WCAG 2.5.5).
+   Horizontal extension stays at 0 so hit zones don't collide with adjacent
+   chips in the horizontal scroll row. */
+.chip::before,
+.chipActive::before {
+  content: "";
+  position: absolute;
+  inset: -6px 0;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: var(--paper-bg-warm);
+  outline: none;
+}
+
+.chipActive {
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
+  border-width: 1.5px;
+  font-weight: 500;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .row {
+    padding: 8px 16px 16px;
+  }
+}

--- a/packages/web/components/list/RepoFilterChips.tsx
+++ b/packages/web/components/list/RepoFilterChips.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { repoKey } from "@issuectl/core";
+import { REPO_COLORS } from "@/lib/constants";
+import styles from "./RepoFilterChips.module.css";
+
+type Repo = { owner: string; name: string };
+
+type Props = {
+  repos: Repo[];
+  activeRepo: string | null;
+  buildHref: (repoKey: string | null) => string;
+};
+
+export function RepoFilterChips({ repos, activeRepo, buildHref }: Props) {
+  if (repos.length <= 1) return null;
+
+  return (
+    <nav className={styles.row} aria-label="Filter by repository">
+      <Link
+        href={buildHref(null)}
+        className={activeRepo === null ? styles.chipActive : styles.chip}
+        aria-current={activeRepo === null ? "page" : undefined}
+      >
+        all
+      </Link>
+      {repos.map((repo, i) => {
+        const key = repoKey(repo);
+        const isActive = key === activeRepo;
+        const color = REPO_COLORS[i % REPO_COLORS.length];
+        return (
+          <Link
+            key={key}
+            href={buildHref(key)}
+            className={isActive ? styles.chipActive : styles.chip}
+            aria-current={isActive ? "page" : undefined}
+            style={isActive ? { borderColor: color } : undefined}
+          >
+            <span className={styles.dot} style={{ background: color }} />
+            {repo.name}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/packages/web/components/list/RepoFilterChips.tsx
+++ b/packages/web/components/list/RepoFilterChips.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { repoKey } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
+import { repoKey } from "@/lib/repo-key";
 import styles from "./RepoFilterChips.module.css";
 
 type Repo = { owner: string; name: string };

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -40,12 +40,26 @@
   }
 }
 
+/* Generous invisible hit area around the visible grabber so a user can
+   initiate the drag-to-dismiss gesture with a thumb without having to
+   land on the 4px bar. Only this zone is touch-enabled for dismissal;
+   the body is left scrollable. */
+.grabArea {
+  padding: 6px 0 10px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.grabArea:active {
+  cursor: grabbing;
+}
+
 .grab {
   width: 44px;
   height: 4px;
   background: var(--paper-ink-faint);
   border-radius: 3px;
-  margin: 0 auto 10px;
+  margin: 0 auto;
 }
 
 .head {

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { ReactNode } from "react";
-import { useEffect, useId, useRef } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import styles from "./Sheet.module.css";
 
 type Props = {
@@ -12,8 +12,6 @@ type Props = {
   children: ReactNode;
 };
 
-// Tabbable elements inside a dialog container. Excludes disabled and
-// explicit -1 tabindex. Keeps focus cycling predictable for the trap.
 function getFocusable(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(
@@ -22,15 +20,34 @@ function getFocusable(container: HTMLElement): HTMLElement[] {
   );
 }
 
+// Dismiss thresholds, matching iOS-native bottom-sheet feel:
+//   - A slow drag past DISMISS_DRAG_PX dismisses.
+//   - A fast flick (velocity > FLICK_VELOCITY_PX_PER_MS) dismisses after
+//     only FLICK_MIN_DRAG_PX — so a quick swipe closes without needing the
+//     full slow-drag distance.
+const DISMISS_DRAG_PX = 100;
+const FLICK_VELOCITY_PX_PER_MS = 0.5;
+const FLICK_MIN_DRAG_PX = 40;
+
 export function Sheet({ open, onClose, title, description, children }: Props) {
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [dragY, setDragY] = useState(0);
+  const dragStart = useRef<{ y: number; t: number } | null>(null);
+  const isDesktopRef = useRef(false);
 
-  // Focus management: on open, move focus into the dialog and capture the
-  // previously-focused element so we can restore it on close. This effect
-  // is intentionally scoped to `[open]` — rerunning it on `onClose` identity
-  // change would re-capture mid-session and land focus back inside the
-  // dialog instead of on the trigger that opened it.
+  // Track viewport size across the sheet's open lifetime so a
+  // portrait→landscape rotation mid-drag doesn't compose the wrong transform.
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 768px)");
+    const update = () => {
+      isDesktopRef.current = mql.matches;
+    };
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
   useEffect(() => {
     if (!open) return;
     const toRestore = document.activeElement as HTMLElement | null;
@@ -44,9 +61,6 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     };
   }, [open]);
 
-  // Body scroll lock while the sheet is open. Prevents the page behind the
-  // scrim from scrolling when the user drags on the scrim or tries to swipe
-  // the sheet — a real mobile Safari confusion source otherwise.
   useEffect(() => {
     if (!open) return;
     const prev = document.body.style.overflow;
@@ -56,7 +70,6 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     };
   }, [open]);
 
-  // Keyboard handling: Escape closes, Tab/Shift+Tab cycle within the dialog.
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
@@ -86,7 +99,61 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
+  // Reset drag state when the sheet closes so a stale dragY doesn't leak
+  // into the next open.
+  useEffect(() => {
+    if (!open) {
+      dragStart.current = null;
+      setDragY(0);
+    }
+  }, [open]);
+
   if (!open) return null;
+
+  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (e.touches.length === 0) return;
+    dragStart.current = { y: e.touches[0].clientY, t: Date.now() };
+  };
+
+  const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    // iOS can fire touchmove with an empty touches list during gesture
+    // interruption (system UI preempt, multi-touch release race). Guard
+    // both conditions so a stale dragStart can't crash us.
+    if (!dragStart.current || e.touches.length === 0) return;
+    const delta = e.touches[0].clientY - dragStart.current.y;
+    setDragY(Math.max(0, delta));
+  };
+
+  const onTouchEnd = () => {
+    if (!dragStart.current) return;
+    const elapsed = Math.max(1, Date.now() - dragStart.current.t);
+    const velocity = dragY / elapsed;
+    const shouldDismiss =
+      dragY > DISMISS_DRAG_PX ||
+      (dragY > FLICK_MIN_DRAG_PX && velocity > FLICK_VELOCITY_PX_PER_MS);
+    dragStart.current = null;
+    if (shouldDismiss) {
+      onClose();
+    } else {
+      setDragY(0);
+    }
+  };
+
+  // Preserve the existing desktop centered transform by composing the two.
+  // On mobile the sheet is edge-aligned so only translateY matters.
+  const sheetTransform =
+    dragY > 0
+      ? isDesktopRef.current
+        ? `translate(-50%, ${dragY}px)`
+        : `translate3d(0, ${dragY}px, 0)`
+      : undefined;
+  const sheetStyle: CSSProperties | undefined = sheetTransform
+    ? { transform: sheetTransform, transition: "none" }
+    : undefined;
+  const scrimStyle: CSSProperties | undefined =
+    dragY > 0
+      ? { opacity: Math.max(0.1, 1 - dragY / 400), transition: "none" }
+      : undefined;
 
   return (
     <>
@@ -94,6 +161,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
         className={styles.scrim}
         onClick={onClose}
         aria-hidden="true"
+        style={scrimStyle}
       />
       <div
         ref={dialogRef}
@@ -102,8 +170,18 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
+        style={sheetStyle}
       >
-        <div className={styles.grab} />
+        <div
+          className={styles.grabArea}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchEnd}
+          aria-hidden="true"
+        >
+          <div className={styles.grab} />
+        </div>
         <div className={styles.head}>
           <h2 id={titleId} className={styles.title}>
             {title}

--- a/packages/web/components/settings/AddRepoForm.module.css
+++ b/packages/web/components/settings/AddRepoForm.module.css
@@ -1,8 +1,8 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 16px;
+  gap: 14px;
+  padding: 16px;
   background: var(--paper-bg);
   border: 1px solid var(--paper-accent);
   border-radius: var(--paper-radius-md);
@@ -11,17 +11,19 @@
 
 .row {
   display: flex;
-  gap: 12px;
+  flex-direction: column;
+  gap: 14px;
 }
 
 .field {
   flex: 1;
+  min-width: 0;
 }
 
 .label {
   font-size: 12px;
   color: var(--paper-ink-muted);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -29,12 +31,13 @@
 
 .input {
   width: 100%;
-  padding: 8px 12px;
+  padding: 10px 12px;
+  min-height: 44px;
   background: var(--paper-bg-warm);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   color: var(--paper-ink);
-  font-size: 13px;
+  font-size: 16px;
   font-family: var(--paper-serif);
   outline: none;
 }
@@ -43,19 +46,116 @@
   border-color: var(--paper-accent);
 }
 
+.manual {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.backLink {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-size: 12px;
+  font-style: italic;
+  cursor: pointer;
+  padding: 6px 0;
+  min-height: 32px;
+}
+
+.backLink:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.selected {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  min-height: 44px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-md);
+}
+
+.selectedDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--paper-accent);
+  flex-shrink: 0;
+}
+
+.selectedName {
+  flex: 1;
+  font-weight: 500;
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedChange {
+  background: none;
+  border: none;
+  color: var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  font-style: italic;
+  cursor: pointer;
+  padding: 6px 8px;
+  min-height: 32px;
+}
+
+.selectedChange:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .actions {
   display: flex;
+  flex-direction: column-reverse;
   gap: 8px;
-  justify-content: flex-end;
+}
+
+.actions > * {
+  width: 100%;
+  min-height: 44px;
 }
 
 .error {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--paper-brick);
 }
 
 .pathHint {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--paper-ink-muted);
-  margin-top: 2px;
+  margin-top: 4px;
+}
+
+/* Darker warm yellow (#d9a54d on cream fails WCAG AA at 1.89:1). */
+.warning {
+  font-size: 13px;
+  color: #8a6914;
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .row {
+    flex-direction: row;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+
+  .actions > * {
+    width: auto;
+  }
 }

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -1,18 +1,38 @@
 "use client";
 
 import { useState, useTransition, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { addRepo } from "@/lib/actions/repos";
 import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
+import { RepoPicker } from "./RepoPicker";
 import styles from "./AddRepoForm.module.css";
 
 type Props = {
   onClose: () => void;
+  trackedSet: Set<string>;
 };
 
-export function AddRepoForm({ onClose }: Props) {
+type RepoIdentity = { owner: string; name: string };
+
+// Discriminated state instead of `mode` + `selected` nullable pair.
+// `mode: "selected" && selected === null` was representable before; now it
+// isn't — the "selected" variant carries its repo inline.
+type FormMode =
+  | { kind: "picker" }
+  | { kind: "selected"; repo: RepoIdentity }
+  | { kind: "manual"; input: string };
+
+function parseManual(input: string): RepoIdentity | null {
+  const parts = input.trim().split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  return { owner: parts[0], name: parts[1] };
+}
+
+export function AddRepoForm({ onClose, trackedSet }: Props) {
+  const router = useRouter();
   const { showToast } = useToast();
-  const [ownerRepo, setOwnerRepo] = useState("");
+  const [formMode, setFormMode] = useState<FormMode>({ kind: "picker" });
   const [localPath, setLocalPath] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
@@ -28,64 +48,141 @@ export function AddRepoForm({ onClose }: Props) {
   function handleSubmit() {
     setError(null);
     setWarning(null);
-    const parts = ownerRepo.trim().split("/");
-    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+
+    const target =
+      formMode.kind === "manual"
+        ? parseManual(formMode.input)
+        : formMode.kind === "selected"
+          ? formMode.repo
+          : null;
+    if (!target) {
       setError("Format: owner/repo (e.g., mean-weasel/seatify)");
       return;
     }
 
     startTransition(async () => {
       const result = await addRepo(
-        parts[0],
-        parts[1],
+        target.owner,
+        target.name,
         localPath.trim() || undefined,
       );
-      if (result.success) {
-        if (result.warning) {
-          setWarning(result.warning);
-          timerRef.current = setTimeout(() => onClose(), 2000);
-        } else {
-          showToast("Repository added", "success");
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      const { addedRepo } = result;
+      const repoHref = `/?repo=${encodeURIComponent(`${addedRepo.owner}/${addedRepo.name}`)}`;
+      if (result.warning) {
+        setWarning(result.warning);
+        timerRef.current = setTimeout(() => {
           onClose();
-        }
+          router.push(repoHref);
+        }, 2000);
       } else {
-        setError(result.error ?? "Failed to add repo");
+        showToast("Repository added", "success");
+        onClose();
+        router.push(repoHref);
       }
     });
   }
+
+  const canSubmit =
+    !isPending &&
+    (formMode.kind === "manual"
+      ? formMode.input.trim().length > 0
+      : formMode.kind === "selected");
 
   return (
     <div className={styles.form}>
       <div className={styles.row}>
         <div className={styles.field}>
           <div className={styles.label}>Repository</div>
-          <input
-            className={styles.input}
-            value={ownerRepo}
-            onChange={(e) => setOwnerRepo(e.target.value)}
-            placeholder="owner/repo (e.g., mean-weasel/seatify)"
-            disabled={isPending}
-            autoFocus
-          />
+
+          {formMode.kind === "picker" && (
+            <RepoPicker
+              trackedSet={trackedSet}
+              disabled={isPending}
+              onSelect={(owner, name) =>
+                setFormMode({ kind: "selected", repo: { owner, name } })
+              }
+              onManualEntry={() => setFormMode({ kind: "manual", input: "" })}
+            />
+          )}
+
+          {formMode.kind === "selected" && (
+            <div className={styles.selected}>
+              <span className={styles.selectedDot} />
+              <span className={styles.selectedName}>
+                {formMode.repo.owner}/{formMode.repo.name}
+              </span>
+              <button
+                type="button"
+                className={styles.selectedChange}
+                onClick={() => setFormMode({ kind: "picker" })}
+                disabled={isPending}
+              >
+                change
+              </button>
+            </div>
+          )}
+
+          {formMode.kind === "manual" && (
+            <div className={styles.manual}>
+              <input
+                className={styles.input}
+                value={formMode.input}
+                onChange={(e) =>
+                  setFormMode({ kind: "manual", input: e.target.value })
+                }
+                placeholder="owner/repo (e.g., mean-weasel/seatify)"
+                disabled={isPending}
+                autoFocus
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                enterKeyHint="done"
+              />
+              <button
+                type="button"
+                className={styles.backLink}
+                onClick={() => setFormMode({ kind: "picker" })}
+                disabled={isPending}
+              >
+                &larr; back to picker
+              </button>
+            </div>
+          )}
         </div>
+
         <div className={styles.field}>
           <div className={styles.label}>Local Path (optional)</div>
           <input
             className={styles.input}
             value={localPath}
             onChange={(e) => setLocalPath(e.target.value)}
-            placeholder="~/Desktop/seatify"
+            placeholder="~/Desktop/my-repo"
             disabled={isPending}
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <div className={styles.pathHint}>Leave blank to prompt on launch</div>
         </div>
       </div>
+
       {error && (
-        <span className={styles.error} role="alert">{error}</span>
+        <span className={styles.error} role="alert">
+          {error}
+        </span>
       )}
       {warning && (
-        <span className={styles.pathHint} style={{ color: "var(--yellow)" }} role="status">{warning}</span>
+        <span className={styles.warning} role="status">
+          {warning}
+        </span>
       )}
+
       <div className={styles.actions}>
         <Button variant="ghost" onClick={onClose} disabled={isPending}>
           Cancel
@@ -93,7 +190,7 @@ export function AddRepoForm({ onClose }: Props) {
         <Button
           variant="primary"
           onClick={handleSubmit}
-          disabled={isPending || !ownerRepo.trim()}
+          disabled={!canSubmit}
         >
           {isPending ? "Adding..." : "Add Repo"}
         </Button>

--- a/packages/web/components/settings/RepoPicker.module.css
+++ b/packages/web/components/settings/RepoPicker.module.css
@@ -1,0 +1,205 @@
+.picker {
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-md);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--paper-bg);
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.headerLabel {
+  font-size: 12px;
+  color: var(--paper-ink-muted);
+  font-style: italic;
+}
+
+.refreshBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.refreshBtn:hover:not(:disabled),
+.refreshBtn:focus-visible {
+  background: var(--paper-accent-soft);
+  border-color: var(--paper-accent);
+  outline: none;
+}
+
+.refreshBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.refreshIcon {
+  display: inline-block;
+}
+
+.refreshIconSpin {
+  display: inline-block;
+  animation: repoPickerSpin 0.9s linear infinite;
+}
+
+@keyframes repoPickerSpin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.inlineError {
+  padding: 8px 12px;
+  background: rgba(168, 67, 42, 0.08);
+  color: var(--paper-brick);
+  font-size: 12px;
+  border-top: 1px solid var(--paper-line-soft);
+}
+
+.search {
+  width: 100%;
+  padding: 12px;
+  min-height: 44px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--paper-line);
+  font-size: 16px;
+  font-family: var(--paper-serif);
+  color: var(--paper-ink);
+  outline: none;
+}
+
+.search::placeholder {
+  color: var(--paper-ink-muted);
+  font-style: italic;
+}
+
+.list {
+  max-height: 280px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.item,
+.itemTracked {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  min-height: 44px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--paper-line-soft);
+  font-family: var(--paper-serif);
+  font-size: 15px;
+  color: var(--paper-ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.item:last-child,
+.itemTracked:last-child {
+  border-bottom: none;
+}
+
+.item:hover,
+.item:focus-visible {
+  background: var(--paper-accent-soft);
+  outline: none;
+}
+
+.itemTracked {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--paper-accent);
+  flex-shrink: 0;
+}
+
+.name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.owner {
+  color: var(--paper-ink-muted);
+}
+
+.badge,
+.badgePrivate {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-sans, system-ui, sans-serif);
+  flex-shrink: 0;
+}
+
+.badge {
+  background: var(--paper-bg-warmer);
+  color: var(--paper-ink-muted);
+}
+
+.badgePrivate {
+  background: var(--paper-butter);
+  color: var(--paper-ink);
+}
+
+.status {
+  padding: 16px 12px;
+  font-size: 13px;
+  color: var(--paper-ink-muted);
+  font-style: italic;
+  text-align: center;
+}
+
+.error {
+  padding: 12px;
+  font-size: 13px;
+  color: var(--paper-brick);
+}
+
+.footer {
+  padding: 6px 12px;
+  background: var(--paper-bg);
+  border-top: 1px solid var(--paper-line);
+}
+
+.manualLink {
+  background: none;
+  border: none;
+  color: var(--paper-accent);
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  font-style: italic;
+  cursor: pointer;
+  padding: 6px 0;
+  min-height: 32px;
+}
+
+.manualLink:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/web/components/settings/RepoPicker.tsx
+++ b/packages/web/components/settings/RepoPicker.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { repoKey, type GitHubAccessibleRepo } from "@issuectl/core";
+import {
+  getGithubReposAction,
+  refreshGithubReposAction,
+} from "@/lib/actions/repos";
+import styles from "./RepoPicker.module.css";
+
+type Props = {
+  trackedSet: Set<string>;
+  disabled?: boolean;
+  onSelect: (owner: string, name: string) => void;
+  onManualEntry: () => void;
+};
+
+function formatAgo(syncedAt: number | null): string {
+  if (syncedAt === null) return "never synced";
+  const diff = Math.floor(Date.now() / 1000) - syncedAt;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export function RepoPicker({ trackedSet, disabled, onSelect, onManualEntry }: Props) {
+  const [repos, setRepos] = useState<GitHubAccessibleRepo[]>([]);
+  const [syncedAt, setSyncedAt] = useState<number | null>(null);
+  // Decomposed the previous 4-ary `phase` union into two orthogonal
+  // booleans + a latest-error string. `ready && error` (stale data + recent
+  // refresh failure) is now expressed naturally instead of via a workaround.
+  const [isRefreshing, setIsRefreshing] = useState(true);
+  const [initialLoadDone, setInitialLoadDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    (async () => {
+      const read = await getGithubReposAction();
+      if (cancelledRef.current) return;
+
+      if (!read.success) {
+        setError(read.error);
+        setIsRefreshing(false);
+        setInitialLoadDone(true);
+        return;
+      }
+
+      setRepos(read.snapshot.repos);
+      setSyncedAt(read.snapshot.syncedAt);
+      setInitialLoadDone(true);
+
+      const needsFetch =
+        read.snapshot.repos.length === 0 || read.snapshot.isStale;
+      if (!needsFetch) {
+        setIsRefreshing(false);
+        return;
+      }
+
+      const fresh = await refreshGithubReposAction();
+      if (cancelledRef.current) return;
+      if (fresh.success) {
+        setRepos(fresh.snapshot.repos);
+        setSyncedAt(fresh.snapshot.syncedAt);
+        setError(null);
+      } else {
+        setError(fresh.error);
+      }
+      setIsRefreshing(false);
+    })();
+
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    // Don't auto-focus on touch devices — doing so pops the on-screen
+    // keyboard the moment the picker opens, which competes with the user's
+    // intent to scroll the list first. Desktop still gets autofocus.
+    if (!initialLoadDone) return;
+    const isPointer = window.matchMedia("(hover: hover)").matches;
+    if (isPointer) searchRef.current?.focus();
+  }, [initialLoadDone]);
+
+  async function handleRefresh() {
+    setIsRefreshing(true);
+    setError(null);
+    const fresh = await refreshGithubReposAction();
+    if (cancelledRef.current) return;
+    if (fresh.success) {
+      setRepos(fresh.snapshot.repos);
+      setSyncedAt(fresh.snapshot.syncedAt);
+    } else {
+      setError(fresh.error);
+    }
+    setIsRefreshing(false);
+  }
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.owner.toLowerCase().includes(q) ||
+        repoKey(r).toLowerCase().includes(q),
+    );
+  }, [repos, query]);
+
+  const isBusy = isRefreshing || disabled;
+  const showInitialLoading = !initialLoadDone && isRefreshing;
+  const showHardError = error !== null && repos.length === 0;
+
+  return (
+    <div className={styles.picker}>
+      <div className={styles.header}>
+        <span className={styles.headerLabel}>
+          {isRefreshing ? "refreshing…" : `updated ${formatAgo(syncedAt)}`}
+        </span>
+        <button
+          type="button"
+          className={styles.refreshBtn}
+          onClick={handleRefresh}
+          disabled={isBusy}
+          aria-label="Refresh repository list"
+          title="Refresh repository list"
+        >
+          <span className={isRefreshing ? styles.refreshIconSpin : styles.refreshIcon}>
+            ↻
+          </span>
+        </button>
+      </div>
+
+      <input
+        ref={searchRef}
+        className={styles.search}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="search your repos…"
+        disabled={disabled || showInitialLoading}
+        autoComplete="off"
+        autoCapitalize="off"
+        autoCorrect="off"
+        spellCheck={false}
+        enterKeyHint="search"
+        aria-label="Search repositories"
+      />
+
+      <div className={styles.list} role="listbox">
+        {showInitialLoading && <div className={styles.status}>loading repos…</div>}
+        {showHardError && error && (
+          <div className={styles.error} role="alert">
+            {error}
+          </div>
+        )}
+        {!showInitialLoading && !showHardError && filtered.length === 0 && (
+          <div className={styles.status}>
+            {query ? "no matches — try manual entry below" : "no repos found"}
+          </div>
+        )}
+        {!showInitialLoading &&
+          filtered.map((repo) => {
+            const key = repoKey(repo);
+            const tracked = trackedSet.has(key);
+            return (
+              <button
+                key={key}
+                type="button"
+                role="option"
+                aria-selected={false}
+                className={tracked ? styles.itemTracked : styles.item}
+                onClick={() => !tracked && onSelect(repo.owner, repo.name)}
+                disabled={tracked || disabled}
+              >
+                <span className={styles.dot} />
+                <span className={styles.name}>
+                  <span className={styles.owner}>{repo.owner}/</span>
+                  {repo.name}
+                </span>
+                {tracked ? (
+                  <span className={styles.badge}>already tracked</span>
+                ) : repo.private ? (
+                  <span className={styles.badgePrivate}>private</span>
+                ) : null}
+              </button>
+            );
+          })}
+      </div>
+
+      {!showHardError && error && (
+        <div className={styles.inlineError} role="alert">
+          refresh failed: {error}
+        </div>
+      )}
+
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={styles.manualLink}
+          onClick={onManualEntry}
+          disabled={disabled}
+        >
+          Can&rsquo;t find it? Enter manually &rarr;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/settings/RepoPicker.tsx
+++ b/packages/web/components/settings/RepoPicker.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { repoKey, type GitHubAccessibleRepo } from "@issuectl/core";
+import type { GitHubAccessibleRepo } from "@issuectl/core";
 import {
   getGithubReposAction,
   refreshGithubReposAction,
 } from "@/lib/actions/repos";
+import { repoKey } from "@/lib/repo-key";
 import styles from "./RepoPicker.module.css";
 
 type Props = {

--- a/packages/web/components/settings/RepoRow.module.css
+++ b/packages/web/components/settings/RepoRow.module.css
@@ -77,11 +77,19 @@
 
 .editRow {
   display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 
 .editField {
   flex: 1;
+  min-width: 0;
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .editRow {
+    flex-direction: row;
+  }
 }
 
 .editLabel {
@@ -95,7 +103,8 @@
 
 .editInput {
   width: 100%;
-  padding: 8px 12px;
+  padding: 10px 12px;
+  min-height: 44px;
   background: var(--paper-bg-warm);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);

--- a/packages/web/components/settings/TrackedRepos.tsx
+++ b/packages/web/components/settings/TrackedRepos.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import type { Repo } from "@issuectl/core";
+import { useMemo, useState } from "react";
+import { repoKey, type Repo } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
 import { Button } from "@/components/paper";
 import { RepoRow } from "./RepoRow";
@@ -14,6 +14,10 @@ type Props = {
 
 export function TrackedRepos({ repos }: Props) {
   const [showAdd, setShowAdd] = useState(false);
+  const trackedSet = useMemo(
+    () => new Set(repos.map(repoKey)),
+    [repos],
+  );
 
   return (
     <>
@@ -25,7 +29,10 @@ export function TrackedRepos({ repos }: Props) {
         />
       ))}
       {showAdd ? (
-        <AddRepoForm onClose={() => setShowAdd(false)} />
+        <AddRepoForm
+          onClose={() => setShowAdd(false)}
+          trackedSet={trackedSet}
+        />
       ) : (
         <Button
           variant="ghost"

--- a/packages/web/components/settings/TrackedRepos.tsx
+++ b/packages/web/components/settings/TrackedRepos.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { repoKey, type Repo } from "@issuectl/core";
+import type { Repo } from "@issuectl/core";
 import { REPO_COLORS } from "@/lib/constants";
+import { repoKey } from "@/lib/repo-key";
 import { Button } from "@/components/paper";
 import { RepoRow } from "./RepoRow";
 import { AddRepoForm } from "./AddRepoForm";

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -7,8 +7,14 @@ import {
   addRepo as coreAddRepo,
   removeRepo as coreRemoveRepo,
   updateRepo as coreUpdateRepo,
+  readCachedAccessibleRepos,
+  refreshAccessibleRepos,
+  getIssues,
+  getPulls,
+  listLabels,
   withAuthRetry,
   formatErrorForUser,
+  type AccessibleReposSnapshot,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
@@ -16,16 +22,24 @@ function expandHome(p: string): string {
   return p.startsWith("~") ? p.replace("~", homedir()) : p;
 }
 
+function errMessage(err: unknown): unknown {
+  return err instanceof Error ? err.message : err;
+}
+
+export type AddRepoResult =
+  | {
+      success: true;
+      addedRepo: { owner: string; name: string };
+      warning?: string;
+      cacheStale?: true;
+    }
+  | { success: false; error: string };
+
 export async function addRepo(
   owner: string,
   name: string,
   localPath?: string,
-): Promise<{
-  success: boolean;
-  warning?: string;
-  error?: string;
-  cacheStale?: true;
-}> {
+): Promise<AddRepoResult> {
   if (!owner || !name) {
     return { success: false, error: "Owner and repo name are required" };
   }
@@ -38,7 +52,7 @@ export async function addRepo(
       octokit.rest.repos.get({ owner, repo: name }),
     );
   } catch (err) {
-    console.error("[issuectl] Failed to fetch repo from GitHub:", err);
+    console.error("[issuectl] Failed to fetch repo from GitHub:", errMessage(err));
     return {
       success: false,
       error: `Repository ${owner}/${name} not found on GitHub: ${formatErrorForUser(err)}`,
@@ -49,27 +63,69 @@ export async function addRepo(
     const db = getDb();
     coreAddRepo(db, { owner, name, localPath });
   } catch (err) {
-    console.error("[issuectl] Failed to add repo:", err);
+    console.error("[issuectl] Failed to add repo:", errMessage(err));
     const msg =
       err instanceof Error && err.message.includes("UNIQUE")
         ? "Repository already tracked"
         : "Failed to add repository";
     return { success: false, error: msg };
   }
+
+  // Warm the caches for the new repo so the user lands on / with a populated
+  // dashboard rather than waiting for first-visit SSR fetches. Individual
+  // failures are logged but do not fail the add — the index page's SWR path
+  // will retry on next render.
+  try {
+    const db = getDb();
+    await withAuthRetry(async (octokit) => {
+      await Promise.all([
+        getIssues(db, octokit, owner, name).catch((err) => {
+          console.warn(
+            `[issuectl] Warm getIssues failed for ${owner}/${name}:`,
+            errMessage(err),
+          );
+        }),
+        getPulls(db, octokit, owner, name).catch((err) => {
+          console.warn(
+            `[issuectl] Warm getPulls failed for ${owner}/${name}:`,
+            errMessage(err),
+          );
+        }),
+        listLabels(octokit, owner, name).catch((err) => {
+          console.warn(
+            `[issuectl] Warm listLabels failed for ${owner}/${name}:`,
+            errMessage(err),
+          );
+        }),
+      ]);
+    });
+  } catch (err) {
+    console.error(
+      `[issuectl] Warm sync failed for ${owner}/${name}:`,
+      errMessage(err),
+    );
+  }
+
   const { stale } = revalidateSafely("/settings", "/");
+  const addedRepo = { owner, name };
 
   if (localPath) {
     const exists = await stat(expandHome(localPath)).catch(() => null);
     if (!exists) {
       return {
         success: true,
+        addedRepo,
         warning: "Local path does not exist — will prompt to clone on launch",
         ...(stale ? { cacheStale: true as const } : {}),
       };
     }
   }
 
-  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+  return {
+    success: true,
+    addedRepo,
+    ...(stale ? { cacheStale: true as const } : {}),
+  };
 }
 
 export async function removeRepo(
@@ -83,11 +139,43 @@ export async function removeRepo(
     const db = getDb();
     coreRemoveRepo(db, id);
   } catch (err) {
-    console.error("[issuectl] Failed to remove repo:", err);
+    console.error("[issuectl] Failed to remove repo:", errMessage(err));
     return { success: false, error: "Failed to remove repository" };
   }
   const { stale } = revalidateSafely("/settings", "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+export async function getGithubReposAction(): Promise<
+  | { success: true; snapshot: AccessibleReposSnapshot }
+  | { success: false; error: string }
+> {
+  try {
+    const db = getDb();
+    return { success: true, snapshot: readCachedAccessibleRepos(db) };
+  } catch (err) {
+    console.error("[issuectl] readCachedAccessibleRepos failed:", errMessage(err));
+    return { success: false, error: formatErrorForUser(err) };
+  }
+}
+
+export async function refreshGithubReposAction(): Promise<
+  | { success: true; snapshot: AccessibleReposSnapshot }
+  | { success: false; error: string }
+> {
+  try {
+    const db = getDb();
+    const snapshot = await withAuthRetry((octokit) =>
+      refreshAccessibleRepos(db, octokit),
+    );
+    return { success: true, snapshot };
+  } catch (err) {
+    console.error(
+      "[issuectl] refreshAccessibleRepos failed:",
+      errMessage(err),
+    );
+    return { success: false, error: formatErrorForUser(err) };
+  }
 }
 
 export async function updateRepo(
@@ -102,7 +190,7 @@ export async function updateRepo(
     const db = getDb();
     coreUpdateRepo(db, id, updates);
   } catch (err) {
-    console.error("[issuectl] Failed to update repo:", err);
+    console.error("[issuectl] Failed to update repo:", errMessage(err));
     return { success: false, error: "Failed to update repository" };
   }
   const { stale } = revalidateSafely("/settings");

--- a/packages/web/lib/list-href.test.ts
+++ b/packages/web/lib/list-href.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { buildHref } from "./list-href";
+
+describe("buildHref", () => {
+  it("no params → /", () => {
+    expect(buildHref({})).toBe("/");
+  });
+
+  it("tab=issues is the default and is omitted", () => {
+    expect(buildHref({ tab: "issues" })).toBe("/");
+  });
+
+  it("tab=prs is serialized", () => {
+    expect(buildHref({ tab: "prs" })).toBe("/?tab=prs");
+  });
+
+  it("section=in_focus is the default and is omitted", () => {
+    expect(buildHref({ section: "in_focus" })).toBe("/");
+  });
+
+  it("non-default sections are serialized", () => {
+    expect(buildHref({ section: "shipped" })).toBe("/?section=shipped");
+    expect(buildHref({ section: "in_flight" })).toBe("/?section=in_flight");
+    expect(buildHref({ section: "unassigned" })).toBe("/?section=unassigned");
+  });
+
+  it("mine=true → mine=1; mine=null and false are omitted", () => {
+    expect(buildHref({ tab: "prs", mine: true })).toBe("/?tab=prs&mine=1");
+    expect(buildHref({ tab: "prs", mine: null })).toBe("/?tab=prs");
+    expect(buildHref({ tab: "prs", mine: false })).toBe("/?tab=prs");
+  });
+
+  it("repo is passed through verbatim when non-empty", () => {
+    expect(buildHref({ repo: "acme/alpha" })).toBe("/?repo=acme%2Falpha");
+  });
+
+  it("repo=null is omitted", () => {
+    expect(buildHref({ repo: null })).toBe("/");
+  });
+
+  it("composes all four params correctly", () => {
+    // `buildHref` is a dumb URL serializer — callers are responsible for
+    // gating `section` off on the PR tab. When they do pass a non-default
+    // section alongside other params, it gets serialized.
+    expect(
+      buildHref({
+        tab: "prs",
+        repo: "acme/alpha",
+        mine: true,
+        section: "shipped",
+      }),
+    ).toBe("/?tab=prs&repo=acme%2Falpha&mine=1&section=shipped");
+  });
+});

--- a/packages/web/lib/list-href.ts
+++ b/packages/web/lib/list-href.ts
@@ -1,0 +1,30 @@
+import type { Section } from "@issuectl/core";
+
+export type HrefParams = {
+  tab?: "issues" | "prs";
+  repo?: string | null;
+  mine?: boolean | null;
+  section?: Section | null;
+};
+
+/**
+ * Builds the dashboard URL from filter/tab/section state. Conventions:
+ *   - `tab === "issues"` is default → omitted from the URL.
+ *   - `mine === true` → `mine=1`; null/false → omitted (default is "everyone").
+ *   - `section === "in_focus"` is default → omitted.
+ *   - `repo` is passed through verbatim when non-empty.
+ *
+ * Keeping defaults out of the URL keeps `/` canonical and makes back-button
+ * deduplication sane — every "home" link is literally `/`, not `/?tab=issues`.
+ */
+export function buildHref(params: HrefParams): string {
+  const search = new URLSearchParams();
+  if (params.tab === "prs") search.set("tab", "prs");
+  if (params.repo) search.set("repo", params.repo);
+  if (params.mine === true) search.set("mine", "1");
+  if (params.section && params.section !== "in_focus") {
+    search.set("section", params.section);
+  }
+  const qs = search.toString();
+  return qs ? `/?${qs}` : "/";
+}

--- a/packages/web/lib/page-filters.test.ts
+++ b/packages/web/lib/page-filters.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import type { GitHubPull, UnifiedList } from "@issuectl/core";
+import {
+  resolveActiveRepo,
+  filterUnifiedList,
+  filterPrs,
+  type PrEntry,
+} from "./page-filters";
+
+const trackedRepos = [
+  { owner: "acme", name: "alpha" },
+  { owner: "acme", name: "beta" },
+];
+
+describe("resolveActiveRepo", () => {
+  it("returns null when no param", () => {
+    expect(resolveActiveRepo(undefined, trackedRepos)).toBeNull();
+  });
+
+  it("returns null when param matches no tracked repo", () => {
+    expect(resolveActiveRepo("other/repo", trackedRepos)).toBeNull();
+  });
+
+  it("returns the param when it matches a tracked repo", () => {
+    expect(resolveActiveRepo("acme/alpha", trackedRepos)).toBe("acme/alpha");
+  });
+});
+
+function makeUnifiedList(): UnifiedList {
+  const alpha = {
+    id: 1,
+    owner: "acme",
+    name: "alpha",
+    localPath: null,
+    branchPattern: null,
+    createdAt: "2026-01-01",
+  };
+  const beta = {
+    id: 2,
+    owner: "acme",
+    name: "beta",
+    localPath: null,
+    branchPattern: null,
+    createdAt: "2026-01-01",
+  };
+  const issueItem = (repo: typeof alpha, number: number) => ({
+    kind: "issue" as const,
+    repo,
+    issue: {
+      number,
+      title: `Issue ${number}`,
+      body: null,
+      state: "open" as const,
+      labels: [],
+      user: null,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      closedAt: null,
+      htmlUrl: "",
+    },
+    priority: "normal" as const,
+    section: "in_focus" as const,
+  });
+  return {
+    unassigned: [
+      {
+        kind: "draft",
+        draft: {
+          id: "d1",
+          title: "draft 1",
+          body: "",
+          priority: "normal",
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      },
+    ],
+    in_focus: [issueItem(alpha, 1), issueItem(beta, 2)],
+    in_flight: [],
+    shipped: [],
+  };
+}
+
+describe("filterUnifiedList", () => {
+  it("returns input unchanged when no repo filter", () => {
+    const list = makeUnifiedList();
+    expect(filterUnifiedList(list, null)).toBe(list);
+  });
+
+  it("drops drafts when a repo filter is active", () => {
+    const list = makeUnifiedList();
+    const filtered = filterUnifiedList(list, "acme/alpha");
+    expect(filtered.unassigned).toEqual([]);
+  });
+
+  it("keeps only items matching the active repo", () => {
+    const list = makeUnifiedList();
+    const filtered = filterUnifiedList(list, "acme/alpha");
+    expect(filtered.in_focus).toHaveLength(1);
+    expect(filtered.in_focus[0].repo.name).toBe("alpha");
+  });
+});
+
+function makePull(overrides: Partial<GitHubPull> = {}): GitHubPull {
+  return {
+    number: 1,
+    title: "PR",
+    body: null,
+    state: "open",
+    merged: false,
+    user: { login: "me", avatarUrl: "" },
+    headRef: "f",
+    baseRef: "main",
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    createdAt: "",
+    updatedAt: "",
+    mergedAt: null,
+    closedAt: null,
+    htmlUrl: "",
+    ...overrides,
+  };
+}
+
+describe("filterPrs", () => {
+  const entries: PrEntry[] = [
+    { repo: { owner: "acme", name: "alpha" }, pull: makePull({ number: 1, user: { login: "me", avatarUrl: "" } }) },
+    { repo: { owner: "acme", name: "beta" }, pull: makePull({ number: 2, user: { login: "other", avatarUrl: "" } }) },
+    { repo: { owner: "acme", name: "alpha" }, pull: makePull({ number: 3, user: null }) },
+  ];
+
+  it("no filters returns all", () => {
+    expect(filterPrs(entries, null, null)).toHaveLength(3);
+  });
+
+  it("filters by repo", () => {
+    const result = filterPrs(entries, "acme/alpha", null);
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.repo.name === "alpha")).toBe(true);
+  });
+
+  it("filters by author (mine)", () => {
+    const result = filterPrs(entries, null, "me");
+    expect(result.map((e) => e.pull.number)).toEqual([1]);
+  });
+
+  it("composes repo + author as AND (not OR)", () => {
+    const result = filterPrs(entries, "acme/beta", "me");
+    // alpha#1 is mine but wrong repo; beta#2 is right repo but not mine.
+    expect(result).toEqual([]);
+  });
+
+  it("hides null-user PRs when author filter is active", () => {
+    const result = filterPrs(entries, null, "me");
+    expect(result.find((e) => e.pull.user === null)).toBeUndefined();
+  });
+});

--- a/packages/web/lib/page-filters.ts
+++ b/packages/web/lib/page-filters.ts
@@ -1,4 +1,5 @@
-import { repoKey, type GitHubPull, type UnifiedList } from "@issuectl/core";
+import type { GitHubPull, UnifiedList } from "@issuectl/core";
+import { repoKey } from "./repo-key";
 
 export type PrEntry = {
   repo: { owner: string; name: string };

--- a/packages/web/lib/page-filters.ts
+++ b/packages/web/lib/page-filters.ts
@@ -1,0 +1,57 @@
+import { repoKey, type GitHubPull, type UnifiedList } from "@issuectl/core";
+
+export type PrEntry = {
+  repo: { owner: string; name: string };
+  pull: GitHubPull;
+};
+
+/**
+ * Validate a raw `?repo=` URL parameter against the user's tracked repos.
+ * Returns the param verbatim if it matches a real repo, null otherwise —
+ * this prevents stray or outdated repo keys in the URL from producing an
+ * empty filtered view with no indication that the filter was rejected.
+ */
+export function resolveActiveRepo(
+  param: string | undefined,
+  repos: readonly { owner: string; name: string }[],
+): string | null {
+  if (!param) return null;
+  const exists = repos.some((r) => repoKey(r) === param);
+  return exists ? param : null;
+}
+
+/**
+ * Filter a unified list to a single repo. Drafts (`unassigned`) are dropped
+ * entirely when a repo filter is active because drafts have no repo.
+ */
+export function filterUnifiedList(
+  data: UnifiedList,
+  activeRepo: string | null,
+): UnifiedList {
+  if (!activeRepo) return data;
+  const match = (item: { repo: { owner: string; name: string } }) =>
+    repoKey(item.repo) === activeRepo;
+  return {
+    unassigned: [],
+    in_focus: data.in_focus.filter(match),
+    in_flight: data.in_flight.filter(match),
+    shipped: data.shipped.filter(match),
+  };
+}
+
+/**
+ * Filter PRs by repo AND by author. Passing `username === null` skips the
+ * author filter (used when the user isn't signed in OR when "everyone" is
+ * selected).
+ */
+export function filterPrs(
+  prs: readonly PrEntry[],
+  activeRepo: string | null,
+  username: string | null,
+): PrEntry[] {
+  return prs.filter(({ repo, pull }) => {
+    if (activeRepo && repoKey(repo) !== activeRepo) return false;
+    if (username && pull.user?.login !== username) return false;
+    return true;
+  });
+}

--- a/packages/web/lib/repo-key.ts
+++ b/packages/web/lib/repo-key.ts
@@ -1,0 +1,9 @@
+/**
+ * Canonical `owner/name` key shared across UI + cache lookups. Lives in the
+ * web package (not core) because every consumer is either a client component
+ * or a web-local util — pulling core as a runtime dep from a client file
+ * drags better-sqlite3 into the client bundle.
+ */
+export function repoKey(r: { owner: string; name: string }): string {
+  return `${r.owner}/${r.name}`;
+}


### PR DESCRIPTION
## Summary

Reshapes the settings add-repo flow and the dashboard around how users actually find and scope work.

- **Settings → searchable repo picker** fed by the authenticated user's GitHub repos. Cached in a new SQLite table (`github_accessible_repos`) with 24h SWR + manual refresh button. "Enter manually" fallback preserves the old text-input path. Add-repo eagerly warms issues/pulls/labels so the dashboard lands populated, then redirects to `/?repo=<new>`.
- **Dashboard gets URL-driven filters**: `?repo=owner/name`, `?mine=1`, `?section=unassigned|in_focus|in_flight|shipped` — all server-side filtered. Chip row + section sub-tabs on desktop.
- **PR tab cleanup**: fetch narrowed to `state: "open"` (fewer rows, faster SSR, cleaner empty-state copy). Default switched to "everyone", `mine` is opt-in.
- **Mobile filter UX**: three filter rows collapse into a single bottom-sheet behind a filter icon (top tab row) and a swipe-up handle at the screen bottom. `Sheet` primitive now supports drag-to-dismiss (iOS-native feel, fast-flick threshold). Responsive CSS hides chip row + segmented toggle below 768px.
- **Mobile a11y**: touch targets extended to 44x44 via `::before` pseudo-elements on new chrome; `.lblFeat` darkened from butter (1.89:1) to `#8a6914` (>4.5:1); list bottom-padding bumped 104→144px for FAB clearance.

## Design notes

- Schema bumped to **v10** (`github_accessible_repos`): `(owner, name, is_private, pushed_at, synced_at)` PK `(owner, name)`. `replaceAccessibleRepos` is atomic DELETE+INSERT in a transaction so a mid-loop failure doesn't leave the cache empty.
- Server action return shapes are **discriminated unions** (`AddRepoResult`, `getGithubReposAction`, `refreshGithubReposAction`) — no more bag-of-optionals or `??` fallbacks at callsites.
- `buildHref`, `filterUnifiedList`, `filterPrs`, `resolveActiveRepo` extracted to pure util modules so the URL contract + server-side filter predicates are directly unit-tested.
- `repoKey()` lives in `packages/web/lib/` (not core) so client components don't drag `better-sqlite3` into the client bundle via transitive imports.
- Mockups in `docs/mockups/add-repo-picker.html` and `docs/mockups/mobile-filter-sheet.html` preserved for reference.

## Test plan

- [ ] \`pnpm turbo typecheck\` clean
- [ ] \`pnpm turbo test\` all green (adds 33+ new tests: github/repos, db/github-repos, data/github-repos, lib/page-filters, lib/list-href, schema v10 migration)
- [ ] \`pnpm --filter @issuectl/web build\` succeeds (client bundle boundary preserved)
- [ ] Settings → add a repo via the picker; verify list loads, filters on type, dims already-tracked, lands on \`/?repo=...\` with issues populated
- [ ] Manual-entry fallback works for repos outside the top 100
- [ ] Refresh button on picker swaps label to "refreshing…" and back to "updated Xm ago"
- [ ] Dashboard: \`[all] [repo1] [repo2]\` chips filter the issue list; drafts sub-tab hidden when a repo is active
- [ ] Section sub-tabs switch between drafts / in focus / in flight / shipped; URL-synced
- [ ] PR tab defaults to "everyone"; \`mine\` toggle filters to \`@username\`
- [ ] Mobile (viewport <768): chip row + mine toggle replaced by filter icon + scope pill; filter sheet opens via tap or swipe-up from bottom handle
- [ ] Filter sheet dismissible via drag-down on grabber, backdrop tap, or Escape

## Review coverage

Ran \`/pr-review-toolkit:review-pr all\` (5 agents: code, comments, errors, types, tests). All 3 Critical and 4 Important findings addressed in this branch; 11+ suggestions also fixed. Focused re-review after the repoKey relocation confirmed no regressions.