### PR TITLE
Quick Create: mobile polish, progress indicator, draft support

### DIFF
--- a/packages/core/src/parse/types.ts
+++ b/packages/core/src/parse/types.ts
@@ -32,11 +32,13 @@ export type ReviewedIssue = {
 
 export type BatchCreateResult = {
   created: number;
+  drafted: number;
   failed: number;
   results: Array<{
     id: string;
     success: boolean;
     issueNumber?: number;
+    draftId?: string;
     error?: string;
     owner: string;
     repo: string;

--- a/packages/web/app/parse/page.module.css
+++ b/packages/web/app/parse/page.module.css
@@ -1,4 +1,10 @@
 .content {
-  padding: 20px 32px 32px;
+  padding: 20px 16px calc(32px + env(safe-area-inset-bottom, 0px));
   max-width: 800px;
+}
+
+@media (min-width: 768px) {
+  .content {
+    padding: 20px 32px 32px;
+  }
 }

--- a/packages/web/components/parse/ParseInput.module.css
+++ b/packages/web/components/parse/ParseInput.module.css
@@ -18,11 +18,14 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   color: var(--paper-ink);
-  font-size: 16px;
+  font-size: var(--paper-fs-lg);
   font-family: var(--paper-serif), sans-serif;
   outline: none;
   resize: vertical;
   line-height: 1.5;
+  /* Chrome 123+ / Safari 17.4+ — grows with content, falls back to
+     resize: vertical elsewhere. */
+  field-sizing: content;
 }
 
 .textarea:focus {
@@ -39,24 +42,59 @@
   gap: 12px;
 }
 
-.spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--paper-line);
-  border-top-color: var(--paper-accent);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+/* ── Progress indicator ── */
+
+.progressBar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
+.progressTrack {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--paper-line);
+  overflow: hidden;
+}
+
+.progressPulse {
+  height: 100%;
+  width: 40%;
+  border-radius: 2px;
+  background: var(--paper-accent);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: translateX(-100%);
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(300%);
+    opacity: 0.6;
   }
 }
 
-.parsingText {
-  font-size: 12px;
+.progressLabel {
+  font-size: var(--paper-fs-sm);
   color: var(--paper-ink-muted);
+  font-style: italic;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .error {
@@ -65,5 +103,11 @@
   border: 1px solid rgba(248, 81, 73, 0.2);
   border-radius: var(--paper-radius-md);
   color: var(--paper-brick);
-  font-size: 12px;
+  font-size: var(--paper-fs-sm);
+}
+
+@media (min-width: 768px) {
+  .textarea {
+    font-size: var(--paper-fs-base);
+  }
 }

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import type { ParsedIssuesResponse } from "@issuectl/core";
 import { parseNaturalLanguage } from "@/lib/actions/parse";
 import { Button } from "@/components/paper";
@@ -10,10 +10,38 @@ type Props = {
   onParsed: (data: ParsedIssuesResponse) => void;
 };
 
+const PROGRESS_STAGES = [
+  { label: "Reading your input...", delayMs: 0 },
+  { label: "Identifying repos and labels...", delayMs: 4000 },
+  { label: "Structuring issues...", delayMs: 12000 },
+  { label: "Finalizing...", delayMs: 30000 },
+] as const;
+
+function useProgressStage(active: boolean): string {
+  const [stageIndex, setStageIndex] = useState(0);
+
+  useEffect(() => {
+    if (!active) {
+      setStageIndex(0);
+      return;
+    }
+
+    setStageIndex(0);
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (let i = 1; i < PROGRESS_STAGES.length; i++) {
+      timers.push(setTimeout(() => setStageIndex(i), PROGRESS_STAGES[i].delayMs));
+    }
+    return () => timers.forEach(clearTimeout);
+  }, [active]);
+
+  return PROGRESS_STAGES[stageIndex].label;
+}
+
 export function ParseInput({ onParsed }: Props) {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const stageLabel = useProgressStage(isPending);
 
   function handleParse() {
     setError(null);
@@ -58,23 +86,24 @@ export function ParseInput({ onParsed }: Props) {
         aria-label="Issue description for Claude to parse"
         maxLength={8192}
       />
-      <div className={styles.footer}>
-        <Button
-          variant="primary"
-          onClick={handleParse}
-          disabled={isPending || !input.trim()}
-        >
-          {isPending ? "Parsing..." : "Parse with Claude"}
-        </Button>
-        {isPending && (
-          <>
-            <div className={styles.spinner} />
-            <span className={styles.parsingText}>
-              Claude is analyzing your input...
-            </span>
-          </>
-        )}
-      </div>
+      {isPending ? (
+        <div className={styles.progressBar} role="status" aria-live="polite">
+          <div className={styles.progressTrack}>
+            <div className={styles.progressPulse} />
+          </div>
+          <span className={styles.progressLabel}>{stageLabel}</span>
+        </div>
+      ) : (
+        <div className={styles.footer}>
+          <Button
+            variant="primary"
+            onClick={handleParse}
+            disabled={!input.trim()}
+          >
+            Parse with Claude
+          </Button>
+        </div>
+      )}
       {error && (
         <div className={styles.error} role="alert">
           {error}

--- a/packages/web/components/parse/ParseIssueCard.module.css
+++ b/packages/web/components/parse/ParseIssueCard.module.css
@@ -22,6 +22,7 @@
   padding: 12px 16px;
   border-bottom: 1px solid var(--paper-line);
   background: var(--paper-bg);
+  flex-wrap: wrap;
 }
 
 .typeBadge {
@@ -66,6 +67,11 @@
   background: var(--paper-bg-warm);
   color: var(--paper-ink-soft);
   cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .toggleButton:hover {
@@ -107,7 +113,7 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   color: var(--paper-ink);
-  font-size: 13px;
+  font-size: var(--paper-fs-lg);
   font-family: var(--paper-serif), sans-serif;
   outline: none;
 }
@@ -124,11 +130,14 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   color: var(--paper-ink);
-  font-size: 12px;
+  font-size: var(--paper-fs-lg);
   font-family: var(--paper-mono), monospace;
   outline: none;
   resize: vertical;
   line-height: 1.5;
+  /* Chrome 123+ / Safari 17.4+ — grows with content, falls back to
+     resize: vertical elsewhere. */
+  field-sizing: content;
 }
 
 .textarea:focus {
@@ -142,10 +151,11 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   color: var(--paper-ink);
-  font-size: 13px;
+  font-size: var(--paper-fs-lg);
   font-family: var(--paper-serif), sans-serif;
   outline: none;
   cursor: pointer;
+  min-height: 44px;
 }
 
 .select:focus {
@@ -172,4 +182,19 @@
   background: var(--paper-bg);
   border-radius: var(--paper-radius-sm);
   border-left: 2px solid var(--paper-line);
+}
+
+/* ── Desktop ── */
+@media (min-width: 768px) {
+  .input,
+  .textarea,
+  .select,
+  .selectUnmatched {
+    font-size: var(--paper-fs-base);
+  }
+
+  .toggleButton {
+    min-height: unset;
+    min-width: unset;
+  }
 }

--- a/packages/web/components/parse/ParseResults.module.css
+++ b/packages/web/components/parse/ParseResults.module.css
@@ -61,6 +61,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
+  min-height: 44px;
   background: var(--paper-bg-warm);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
@@ -90,6 +91,9 @@
   color: var(--paper-accent);
   text-decoration: none;
   font-weight: 500;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .resultLink:hover {

--- a/packages/web/components/parse/ParseResults.tsx
+++ b/packages/web/components/parse/ParseResults.tsx
@@ -10,6 +10,20 @@ type Props = {
   onReset: () => void;
 };
 
+function summaryText(results: BatchCreateResult): string {
+  const parts: string[] = [];
+  if (results.created > 0) {
+    parts.push(`${results.created} issue${results.created !== 1 ? "s" : ""} created`);
+  }
+  if (results.drafted > 0) {
+    parts.push(`${results.drafted} draft${results.drafted !== 1 ? "s" : ""} saved`);
+  }
+  if (results.failed > 0) {
+    parts.push(`${results.failed} failed`);
+  }
+  return parts.length > 0 ? parts.join(", ") : "No issues processed";
+}
+
 export function ParseResults({ results, onReset }: Props) {
   const allSuccess = results.failed === 0;
 
@@ -20,9 +34,7 @@ export function ParseResults({ results, onReset }: Props) {
           {allSuccess ? "\u2713" : "!"}
         </span>
         <span className={styles.summaryText}>
-          {results.created} issue{results.created !== 1 ? "s" : ""} created
-          {results.failed > 0 &&
-            `, ${results.failed} failed`}
+          {summaryText(results)}
         </span>
       </div>
 
@@ -33,7 +45,7 @@ export function ParseResults({ results, onReset }: Props) {
               {r.success ? "\u2713" : "\u2717"}
             </span>
             <span className={styles.resultRepo}>
-              {r.owner}/{r.repo}
+              {r.draftId ? "draft" : `${r.owner}/${r.repo}`}
             </span>
             <div className={styles.resultSpacer} />
             {r.success && r.issueNumber !== undefined ? (
@@ -42,6 +54,13 @@ export function ParseResults({ results, onReset }: Props) {
                 className={styles.resultLink}
               >
                 #{r.issueNumber}
+              </Link>
+            ) : r.success && r.draftId ? (
+              <Link
+                href={`/drafts/${r.draftId}`}
+                className={styles.resultLink}
+              >
+                view draft
               </Link>
             ) : (
               <span className={styles.resultError}>

--- a/packages/web/components/parse/ParseReview.module.css
+++ b/packages/web/components/parse/ParseReview.module.css
@@ -22,6 +22,50 @@
   padding-top: 8px;
 }
 
+/* ── Progress indicator ── */
+
+.progressBar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 8px;
+}
+
+.progressTrack {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--paper-line);
+  overflow: hidden;
+}
+
+.progressPulse {
+  height: 100%;
+  width: 40%;
+  border-radius: 2px;
+  background: var(--paper-accent);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: translateX(-100%);
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(300%);
+    opacity: 0.6;
+  }
+}
+
+.progressLabel {
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-muted);
+  font-style: italic;
+}
+
 .error {
   padding: 8px 12px;
   background: rgba(184, 74, 46, 0.08);

--- a/packages/web/components/parse/ParseReview.tsx
+++ b/packages/web/components/parse/ParseReview.tsx
@@ -46,20 +46,16 @@ export function ParseReview({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const acceptedCount = cards.filter((c) => c.accepted).length;
-  const unmatchedAccepted = cards.filter(
-    (c) => c.accepted && (!c.owner || !c.repo),
-  );
+  const accepted = cards.filter((c) => c.accepted);
+  const acceptedCount = accepted.length;
+  const matchedCount = accepted.filter((c) => c.owner && c.repo).length;
+  const draftCount = accepted.filter((c) => !c.owner || !c.repo).length;
 
   function handleCardChange(updated: IssueCardState) {
     setCards((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
   }
 
   function handleCreate() {
-    if (unmatchedAccepted.length > 0) {
-      setError("All included issues must have a repository selected.");
-      return;
-    }
     setError(null);
     startTransition(async () => {
       try {
@@ -90,7 +86,8 @@ export function ParseReview({
     <div className={styles.wrapper}>
       <div className={styles.summary}>
         {parsed.issues.length} issue{parsed.issues.length !== 1 ? "s" : ""}{" "}
-        parsed &mdash; {acceptedCount} included for creation
+        parsed &mdash; {acceptedCount} included
+        {draftCount > 0 && ` (${draftCount} without repo \u2192 saved as draft${draftCount !== 1 ? "s" : ""})`}
       </div>
 
       <div className={styles.cards}>
@@ -111,20 +108,39 @@ export function ParseReview({
         </div>
       )}
 
-      <div className={styles.footer}>
-        <Button variant="ghost" onClick={onBack} disabled={isPending}>
-          Back
-        </Button>
-        <Button
-          variant="primary"
-          onClick={handleCreate}
-          disabled={isPending || acceptedCount === 0}
-        >
-          {isPending
-            ? "Creating..."
-            : `Create ${acceptedCount} Issue${acceptedCount !== 1 ? "s" : ""}`}
-        </Button>
-      </div>
+      {isPending ? (
+        <div className={styles.progressBar} role="status" aria-live="polite">
+          <div className={styles.progressTrack}>
+            <div className={styles.progressPulse} />
+          </div>
+          <span className={styles.progressLabel}>
+            {matchedCount > 0 && draftCount > 0
+              ? `Creating ${matchedCount} issue${matchedCount !== 1 ? "s" : ""} and saving ${draftCount} draft${draftCount !== 1 ? "s" : ""}...`
+              : draftCount > 0
+                ? `Saving ${draftCount} draft${draftCount !== 1 ? "s" : ""}...`
+                : `Creating ${matchedCount} issue${matchedCount !== 1 ? "s" : ""} on GitHub...`}
+          </span>
+        </div>
+      ) : (
+        <div className={styles.footer}>
+          <Button variant="ghost" onClick={onBack}>
+            Back
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleCreate}
+            disabled={acceptedCount === 0}
+          >
+            {acceptedCount === 0
+              ? "Select issues to create"
+              : matchedCount > 0 && draftCount > 0
+                ? `Create ${matchedCount} + Draft ${draftCount}`
+                : draftCount > 0
+                  ? `Save ${draftCount} Draft${draftCount !== 1 ? "s" : ""}`
+                  : `Create ${matchedCount} Issue${matchedCount !== 1 ? "s" : ""}`}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -7,6 +7,7 @@ import {
   listRepos,
   listLabels,
   createIssue as coreCreateIssue,
+  createDraft,
   clearCacheKey,
   parseIssues,
   formatRepoContext,
@@ -97,7 +98,7 @@ export async function batchCreateIssues(
   const accepted = issues.filter((i) => i.accepted);
 
   if (accepted.length === 0) {
-    return { created: 0, failed: 0, results: [] };
+    return { created: 0, drafted: 0, failed: 0, results: [] };
   }
 
   try {
@@ -105,14 +106,43 @@ export async function batchCreateIssues(
 
     const results = await Promise.all(
       accepted.map(async (issue) => {
-        if (!issue.owner || !issue.repo || !issue.title.trim()) {
+        if (!issue.title.trim()) {
           return {
             id: issue.id,
             success: false as const,
-            error: "Owner, repo, and title are required",
+            error: "Title is required",
             owner: issue.owner,
             repo: issue.repo,
           };
+        }
+
+        // No repo selected — save as a local draft instead
+        if (!issue.owner || !issue.repo) {
+          try {
+            const draft = createDraft(db, {
+              title: issue.title.trim(),
+              body: issue.body.trim() || undefined,
+            });
+            return {
+              id: issue.id,
+              success: true as const,
+              draftId: draft.id,
+              owner: "",
+              repo: "",
+            };
+          } catch (err) {
+            console.error(
+              `[issuectl] Failed to save draft "${issue.title}":`,
+              err,
+            );
+            return {
+              id: issue.id,
+              success: false as const,
+              error: "Failed to save draft locally. Please try again.",
+              owner: "",
+              repo: "",
+            };
+          }
         }
 
         if (!getRepo(db, issue.owner, issue.repo)) {
@@ -161,18 +191,34 @@ export async function batchCreateIssues(
 
     const affectedRepos = new Set(
       results
-        .filter((r) => r.success)
+        .filter((r) => r.success && r.owner)
         .map((r) => `/${r.owner}/${r.repo}`),
     );
+    if (results.some((r) => r.draftId)) {
+      affectedRepos.add("/");
+    }
     revalidateSafely(...affectedRepos);
 
     return {
-      created: results.filter((r) => r.success).length,
+      created: results.filter((r) => r.success && r.issueNumber).length,
+      drafted: results.filter((r) => r.success && r.draftId).length,
       failed: results.filter((r) => !r.success).length,
       results,
     };
   } catch (err) {
     console.error("[issuectl] Failed to batch create issues:", err);
-    return { created: 0, failed: accepted.length, results: [] };
+    const errorMsg = formatErrorForUser(err);
+    return {
+      created: 0,
+      drafted: 0,
+      failed: accepted.length,
+      results: accepted.map((issue) => ({
+        id: issue.id,
+        success: false as const,
+        error: errorMsg,
+        owner: issue.owner,
+        repo: issue.repo,
+      })),
+    };
   }
 }


### PR DESCRIPTION
## Summary

- **Mobile CSS polish** — safe-area insets, 44px touch targets, 16px fonts (prevent iOS zoom), responsive breakpoints across all parse components
- **Staged progress indicator** — replaces static spinner with a pulsing progress bar and rotating stage labels ("Reading your input..." → "Identifying repos..." → "Structuring issues..." → "Finalizing...") during Claude CLI parsing, plus a matching indicator during batch issue creation
- **Draft support** — issues without a repo assigned are saved as local drafts instead of blocking; button adapts to show "Create N + Draft M" for mixed batches; results screen links to draft detail pages

## Test plan

- [ ] Navigate to /parse on mobile (393x852) — textarea should be 16px, no iOS zoom on focus
- [ ] Parse a multi-issue prompt — progress bar should pulse with rotating stage labels
- [ ] On review screen, deselect repo on one issue — button should show "Create 1 + Draft 1"
- [ ] Submit with mixed repos/no-repos — GitHub issues created, drafts saved, results show both
- [ ] Deselect all issues — button should read "Select issues to create" and be disabled
- [ ] Verify /parse on desktop (1280+) — textarea font scales down, layout stays constrained