### PR TITLE
Sort toggle: updated/created/priority for issue list

### DIFF
--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -206,7 +206,7 @@ describe("groupIntoSections", () => {
           priorities,
         },
       ],
-    });
+    }, "priority");
     const focus = result.in_focus;
     expect(focus).toHaveLength(3);
     if (focus[0].kind !== "issue") throw new Error("expected issue");
@@ -225,7 +225,7 @@ describe("groupIntoSections", () => {
     const result = groupIntoSections({
       drafts: [lowest, normalOlder, normalNewer, high],
       perRepo: [],
-    });
+    }, "priority");
     const titles = result.unassigned.map((item) => {
       if (item.kind !== "draft") throw new Error("expected draft");
       return item.draft.title;

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -6,6 +6,7 @@ import type {
   IssuePriority,
   Deployment,
   Priority,
+  SortMode,
   UnifiedList,
   DraftListItem,
   IssueListItem,
@@ -55,17 +56,28 @@ function compareByPriorityThenUpdatedAt(
 
 export function groupIntoSections(
   input: GroupIntoSectionsInput,
+  sortMode: SortMode = "updated",
 ): UnifiedList {
-  const unassigned: DraftListItem[] = input.drafts
-    .slice()
-    .sort((a, b) =>
-      compareByPriorityThenUpdatedAt(
-        a.priority,
-        a.updatedAt,
-        b.priority,
-        b.updatedAt,
-      ),
-    )
+  const sortDrafts = (drafts: Draft[]): Draft[] => {
+    const copy = drafts.slice();
+    switch (sortMode) {
+      case "priority":
+        return copy.sort((a, b) =>
+          compareByPriorityThenUpdatedAt(a.priority, a.updatedAt, b.priority, b.updatedAt),
+        );
+      case "created":
+      case "updated": {
+        const field = sortMode === "created" ? "createdAt" : "updatedAt";
+        return copy.sort((a, b) => {
+          const aSafe = Number.isFinite(a[field]) ? a[field] : 0;
+          const bSafe = Number.isFinite(b[field]) ? b[field] : 0;
+          return bSafe - aSafe;
+        });
+      }
+    }
+  };
+
+  const unassigned: DraftListItem[] = sortDrafts(input.drafts)
     .map((draft) => ({ kind: "draft" as const, draft }));
 
   const in_focus: IssueListItem[] = [];
@@ -113,17 +125,28 @@ export function groupIntoSections(
     }
   }
 
-  const sortIssues = (items: IssueListItem[]): IssueListItem[] =>
-    items.slice().sort((a, b) => {
-      const aUpdated = new Date(a.issue.updatedAt).getTime();
-      const bUpdated = new Date(b.issue.updatedAt).getTime();
-      return compareByPriorityThenUpdatedAt(
-        a.priority,
-        aUpdated,
-        b.priority,
-        bUpdated,
-      );
-    });
+  const sortIssues = (items: IssueListItem[]): IssueListItem[] => {
+    const copy = items.slice();
+    switch (sortMode) {
+      case "priority":
+        return copy.sort((a, b) => {
+          const aUpdated = new Date(a.issue.updatedAt).getTime();
+          const bUpdated = new Date(b.issue.updatedAt).getTime();
+          return compareByPriorityThenUpdatedAt(a.priority, aUpdated, b.priority, bUpdated);
+        });
+      case "created":
+      case "updated": {
+        const field = sortMode === "created" ? "createdAt" : "updatedAt";
+        return copy.sort((a, b) => {
+          const aTime = new Date(a.issue[field]).getTime();
+          const bTime = new Date(b.issue[field]).getTime();
+          const aSafe = Number.isFinite(aTime) ? aTime : 0;
+          const bSafe = Number.isFinite(bTime) ? bTime : 0;
+          return bSafe - aSafe;
+        });
+      }
+    }
+  };
 
   return {
     unassigned,
@@ -136,6 +159,7 @@ export function groupIntoSections(
 export async function getUnifiedList(
   db: Database.Database,
   octokit: Octokit,
+  sortMode: SortMode = "updated",
 ): Promise<UnifiedList> {
   const drafts = listDrafts(db);
   const repos = listRepos(db);
@@ -167,5 +191,5 @@ export async function getUnifiedList(
     (r): r is PerRepoData => r !== null,
   );
 
-  return groupIntoSections({ drafts, perRepo });
+  return groupIntoSections({ drafts, perRepo }, sortMode);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,11 +10,13 @@ export type {
   Priority,
   IssuePriority,
   Section,
+  SortMode,
   UnifiedListItem,
   DraftListItem,
   IssueListItem,
   UnifiedList,
 } from "./types.js";
+export { SORT_MODES } from "./types.js";
 
 export { getDb, getDbPath, dbExists, closeDb } from "./db/connection.js";
 export { initSchema, getSchemaVersion } from "./db/schema.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,10 @@ export type IssuePriority = {
 
 export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
 
+export type SortMode = "updated" | "created" | "priority";
+
+export const SORT_MODES: readonly SortMode[] = ["updated", "created", "priority"];
+
 // A UnifiedListItem is a discriminated union with two variants: a local
 // Draft (the caller will place it in the unassigned section) or a
 // GitHub-backed issue already assigned to one of the three issue sections.

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -5,8 +5,10 @@ import {
   getPulls,
   listRepos,
   dbExists,
+  SORT_MODES,
   type GitHubPull,
   type Section,
+  type SortMode,
 } from "@issuectl/core";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 import { List } from "@/components/list/List";
@@ -26,6 +28,7 @@ type Props = {
     repo?: string;
     mine?: string;
     section?: string;
+    sort?: string;
   }>;
 };
 
@@ -52,6 +55,7 @@ export default async function MainListPage({ searchParams }: Props) {
     repo: repoParam,
     mine: mineParam,
     section: sectionParam,
+    sort: sortParam,
   } = await searchParams;
   const activeTab = tab === "prs" ? "prs" : "issues";
   const activeRepo = resolveActiveRepo(repoParam, repos);
@@ -61,11 +65,16 @@ export default async function MainListPage({ searchParams }: Props) {
   )
     ? (sectionParam as Section)
     : "in_focus";
+  const activeSort: SortMode = (SORT_MODES as readonly string[]).includes(
+    sortParam ?? "",
+  )
+    ? (sortParam as SortMode)
+    : "updated";
 
   const [octokit, auth] = await Promise.all([getOctokit(), getAuthStatus()]);
 
   const [data, allPrs] = await Promise.all([
-    getUnifiedList(db, octokit),
+    getUnifiedList(db, octokit, activeSort),
     gatherPulls(db, octokit, repos),
   ]);
 
@@ -78,6 +87,7 @@ export default async function MainListPage({ searchParams }: Props) {
       data={filteredData}
       activeTab={activeTab}
       activeSection={activeSection}
+      activeSort={activeSort}
       prs={filteredPrs}
       prCount={filteredPrs.length}
       username={username}

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -346,6 +346,52 @@
   color: var(--paper-ink-soft);
 }
 
+/* ── Sort toggle ── */
+.sortToggle {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 16px 10px;
+}
+
+.sortLabel {
+  font-family: var(--paper-serif);
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  margin-right: 4px;
+  font-style: italic;
+}
+
+.sortOption,
+.sortOptionActive {
+  position: relative;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-family: var(--paper-serif);
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.sortOption::before,
+.sortOptionActive::before {
+  content: "";
+  position: absolute;
+  inset: -4px 0;
+}
+
+.sortOption:hover {
+  color: var(--paper-ink-soft);
+}
+
+.sortOptionActive {
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink);
+  font-weight: 500;
+  border: 1px solid var(--paper-line);
+}
+
 /* ── Filter button (mobile only) ── */
 .filterBtn {
   display: inline-flex;

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { GitHubPull, Section, UnifiedList } from "@issuectl/core";
+import type { GitHubPull, Section, SortMode, UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
 import { REPO_COLORS } from "@/lib/constants";
 import { repoKey } from "@/lib/repo-key";
@@ -24,12 +24,21 @@ type Props = {
   data: UnifiedList;
   activeTab: "issues" | "prs";
   activeSection: Section;
+  activeSort: SortMode;
   prCount: number;
   prs: PrEntry[];
   username: string | null;
   repos: Repo[];
   activeRepo: string | null;
   mineOnly: boolean;
+};
+
+const SORT_MODES: SortMode[] = ["updated", "created", "priority"];
+
+const SORT_LABEL: Record<SortMode, string> = {
+  updated: "updated",
+  created: "created",
+  priority: "priority",
 };
 
 // Lowercase is intentional — matches the Paper mockup typography.
@@ -78,6 +87,7 @@ export function List({
   username,
   repos,
   activeRepo,
+  activeSort,
   mineOnly,
 }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
@@ -116,7 +126,7 @@ export function List({
       ? REPO_COLORS[activeRepoIndex % REPO_COLORS.length]
       : undefined;
 
-  const issuesHref = buildHref({ repo: activeRepo });
+  const issuesHref = buildHref({ repo: activeRepo, sort: activeSort });
   const prsHref = buildHref({
     tab: "prs",
     repo: activeRepo,
@@ -129,10 +139,14 @@ export function List({
       repo: repoKey,
       mine: isPrTab && mineOnly ? true : null,
       section: activeTab === "issues" ? activeSection : null,
+      sort: activeTab === "issues" ? activeSort : null,
     });
 
   const sectionHref = (section: Section) =>
-    buildHref({ repo: activeRepo, section });
+    buildHref({ repo: activeRepo, section, sort: activeSort });
+
+  const sortHref = (sort: SortMode) =>
+    buildHref({ repo: activeRepo, section: activeSection, sort });
 
   const mineHref = (mine: boolean | null) =>
     buildHref({ tab: "prs", repo: activeRepo, mine });
@@ -141,6 +155,7 @@ export function List({
     ? buildHref({
         tab: isPrTab ? "prs" : undefined,
         section: activeTab === "issues" ? activeSection : null,
+        sort: activeTab === "issues" ? activeSort : null,
       })
     : null;
 
@@ -151,6 +166,7 @@ export function List({
     tab: isPrTab ? "prs" : undefined,
     mine: isPrTab && mineOnly ? true : null,
     section: activeTab === "issues" ? activeSection : null,
+    sort: activeTab === "issues" ? activeSort : null,
   });
 
   return (
@@ -235,23 +251,38 @@ export function List({
       </div>
 
       {activeTab === "issues" && (
-        <nav className={styles.sectionTabs} aria-label="Filter by section">
-          {visibleSections.map((section) => {
-            const isActive = section === activeSection;
-            const count = sectionCounts[section];
-            return (
+        <>
+          <nav className={styles.sectionTabs} aria-label="Filter by section">
+            {visibleSections.map((section) => {
+              const isActive = section === activeSection;
+              const count = sectionCounts[section];
+              return (
+                <Link
+                  key={section}
+                  href={sectionHref(section)}
+                  className={isActive ? styles.sectionTabActive : styles.sectionTab}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {SECTION_LABEL[section]}
+                  <span className={styles.sectionTabCount}>{count}</span>
+                </Link>
+              );
+            })}
+          </nav>
+          <div className={styles.sortToggle} role="group" aria-label="Sort order">
+            <span className={styles.sortLabel}>sort:</span>
+            {SORT_MODES.map((mode) => (
               <Link
-                key={section}
-                href={sectionHref(section)}
-                className={isActive ? styles.sectionTabActive : styles.sectionTab}
-                aria-current={isActive ? "page" : undefined}
+                key={mode}
+                href={sortHref(mode)}
+                className={mode === activeSort ? styles.sortOptionActive : styles.sortOption}
+                aria-current={mode === activeSort ? "true" : undefined}
               >
-                {SECTION_LABEL[section]}
-                <span className={styles.sectionTabCount}>{count}</span>
+                {SORT_LABEL[mode]}
               </Link>
-            );
-          })}
-        </nav>
+            ))}
+          </div>
+        </>
       )}
 
       {activeTab === "prs" && repos.length > 0 && (

--- a/packages/web/lib/list-href.ts
+++ b/packages/web/lib/list-href.ts
@@ -1,10 +1,11 @@
-import type { Section } from "@issuectl/core";
+import type { Section, SortMode } from "@issuectl/core";
 
 export type HrefParams = {
   tab?: "issues" | "prs";
   repo?: string | null;
   mine?: boolean | null;
   section?: Section | null;
+  sort?: SortMode | null;
 };
 
 /**
@@ -24,6 +25,9 @@ export function buildHref(params: HrefParams): string {
   if (params.mine === true) search.set("mine", "1");
   if (params.section && params.section !== "in_focus") {
     search.set("section", params.section);
+  }
+  if (params.sort && params.sort !== "updated") {
+    search.set("sort", params.sort);
   }
   const qs = search.toString();
   return qs ? `/?${qs}` : "/";


### PR DESCRIPTION
## Summary

- **Sort toggle** below section tabs with three modes: `updated` (new default), `created`, `priority`
- Sort preference persists via `?sort=` URL param across tab switches, section changes, and repo filters
- Default `updated` is omitted from URL to keep `/` canonical
- `SortMode` type and `SORT_MODES` constant defined in core, shared across packages
- Exhaustive `switch` statements in sort logic — adding a new variant triggers compile errors
- Aligned NaN guards across draft and issue sort paths
- Existing priority-sort tests updated to pass `sortMode: "priority"` explicitly

## Test plan

- [ ] Default view (`/`) shows issues sorted by most recently updated
- [ ] Click "created" — URL becomes `/?sort=created`, list re-sorts by creation date
- [ ] Click "priority" — URL becomes `/?sort=priority`, high-priority issues sort first
- [ ] Click "updated" — URL returns to `/`, sort resets to default
- [ ] Switch sections (in focus → shipped → back) — sort preference preserved
- [ ] Switch tabs (Issues → PRs → Issues) — sort preference preserved
- [ ] Filter by repo — sort preference preserved in URL
- [ ] Mobile viewport — sort toggle fits below section tabs, touch targets adequate
- [ ] `pnpm --filter @issuectl/core test` — all 338 tests pass