### PR TITLE
feat: add HomeHub manifest for Cloudflare Tunnel

### DIFF
--- a/.homehub.yml
+++ b/.homehub.yml
@@ -1,0 +1,3 @@
+port: 3847
+start: pnpm --filter @issuectl/web start
+install: pnpm install && pnpm turbo build

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build",
+    "start": "next start --port 3847",
     "typecheck": "tsc --noEmit",
     "lint": "eslint app/ components/ lib/",
     "dev": "next dev --port 3847",


### PR DESCRIPTION
## Summary
- Adds `.homehub.yml` manifest declaring port (3847), start command, and install+build chain
- Adds `start` script to web package (`next start --port 3847`)
- Enables `make add name=issuectl port=3847 path=... ` from the HomeHub gateway

## Test plan
- [ ] `pnpm --filter @issuectl/web start` serves the production build on :3847
- [ ] HomeHub `make add` reads the manifest correctly