### PR TITLE
fix: skip pre-push build when dev server is running

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,5 +2,13 @@
 changed_files=$(git diff --name-only HEAD @{push} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
 
 if echo "$changed_files" | grep -qvE '\.(md|html|txt|json|yaml|yml)$|^docs/|^\.husky/|^\.github/|CLAUDE\.md|LICENSE'; then
-  pnpm turbo build
+  # If the Next.js dev server is running, a prod build would overwrite .next/
+  # and corrupt the live server's CSS module references. Run typecheck only
+  # (which is safe) and let CI handle the full build.
+  if lsof -nP -iTCP:3847 -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "⚠ Dev server detected on :3847 — skipping build (would corrupt .next/). Running typecheck only."
+    pnpm turbo typecheck
+  else
+    pnpm turbo build
+  fi
 fi


### PR DESCRIPTION
## Summary

- The pre-push hook runs `pnpm turbo build`, which overwrites `.next/` — the same directory the dev server serves from. This corrupts CSS module references and produces an unstyled page that requires `rm -rf .next/` + dev restart to recover.
- This has happened multiple times during normal development workflow (push while dev is running).
- Fix: detect a running dev server on `:3847` via `lsof` and fall back to `typecheck` only. CI runs the full build on every PR, so there's no coverage gap.

## Test plan

- [ ] With dev server running: `git push` → verify hook prints warning and runs typecheck (not build)
- [ ] With dev server stopped: `git push` → verify hook runs full build as before
- [ ] After push with dev running: verify styles still render correctly in browser