### PR TITLE
fix(web): native mobile UX — icons, overscroll, touch feedback

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -45,6 +45,10 @@
   color-scheme: light;
 }
 
+html {
+  overscroll-behavior: none;
+}
+
 *,
 *::before,
 *::after {
@@ -59,6 +63,8 @@ body {
   font-family: var(--paper-sans);
   min-height: 100dvh;
   -webkit-font-smoothing: antialiased;
+  overscroll-behavior: contain;
+  touch-action: manipulation;
 }
 
 a {

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -19,8 +19,6 @@
 }
 
 .back {
-  font-family: var(--paper-serif), sans-serif;
-  font-size: 22px;
   color: var(--paper-ink);
   text-decoration: none;
   display: inline-flex;
@@ -30,11 +28,16 @@
   min-height: 44px;
   margin-left: -10px;
   border-radius: var(--paper-radius-sm);
-  line-height: 1;
+  transition: background 0.1s;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .back:hover {
   background: var(--paper-bg-warm);
+}
+
+.back:active {
+  background: var(--paper-bg-warmer);
 }
 
 .pageTitle {

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -98,7 +98,21 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
     <div className={styles.container}>
       <div className={styles.topBar}>
         <Link href="/" className={styles.back} aria-label="Back to dashboard">
-          ←
+          <svg
+            width="12"
+            height="20"
+            viewBox="0 0 12 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M10 2L2 10L10 18"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
         </Link>
         <span className={styles.pageTitle}>New Issue</span>
         <button

--- a/packages/web/components/detail/CommentComposer.module.css
+++ b/packages/web/components/detail/CommentComposer.module.css
@@ -66,13 +66,7 @@
   }
 
   .composer {
-    position: sticky;
-    bottom: 0;
-    background: var(--paper-bg);
-    padding-top: 12px;
     padding-bottom: env(safe-area-inset-bottom, 12px);
     margin-top: 16px;
-    border-top: 1px solid var(--paper-line);
-    z-index: 10;
   }
 }

--- a/packages/web/components/detail/DetailTopBar.module.css
+++ b/packages/web/components/detail/DetailTopBar.module.css
@@ -7,8 +7,6 @@
 }
 
 .back {
-  font-family: var(--paper-serif);
-  font-size: 22px;
   color: var(--paper-ink);
   text-decoration: none;
   display: inline-flex;
@@ -18,11 +16,16 @@
   min-height: 44px;
   margin-left: -10px;
   border-radius: var(--paper-radius-sm);
-  line-height: 1;
+  transition: background 0.1s;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .back:hover {
   background: var(--paper-bg-warm);
+}
+
+.back:active {
+  background: var(--paper-bg-warmer);
 }
 
 .crumb {

--- a/packages/web/components/detail/DetailTopBar.tsx
+++ b/packages/web/components/detail/DetailTopBar.tsx
@@ -16,7 +16,21 @@ export function DetailTopBar({
   return (
     <div className={styles.bar}>
       <Link href={backHref} className={styles.back} aria-label="Back">
-        ‹
+        <svg
+          width="12"
+          height="20"
+          viewBox="0 0 12 20"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M10 2L2 10L10 18"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </Link>
       {crumb && <div className={styles.crumb}>{crumb}</div>}
       {menu && <div className={styles.menu}>{menu}</div>}

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -40,10 +40,7 @@
 .menuBtn {
   background: transparent;
   border: none;
-  font-family: var(--paper-mono);
-  font-size: 18px;
   color: var(--paper-ink-muted);
-  letter-spacing: 1px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -52,10 +49,17 @@
   padding: 0 12px;
   cursor: pointer;
   border-radius: var(--paper-radius-sm);
+  transition: background 0.1s;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .menuBtn:hover {
   background: var(--paper-bg-warm);
+  color: var(--paper-ink);
+}
+
+.menuBtn:active {
+  background: var(--paper-bg-warmer);
   color: var(--paper-ink);
 }
 

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -179,7 +179,20 @@ export function List({
           onClick={() => setDrawerOpen(true)}
           aria-label="Open navigation"
         >
-          ···
+          <svg
+            width="20"
+            height="16"
+            viewBox="0 0 20 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 2h16M2 8h16M2 14h16"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
         </button>
       </div>
 

--- a/packages/web/components/list/NavDrawerContent.module.css
+++ b/packages/web/components/list/NavDrawerContent.module.css
@@ -35,8 +35,11 @@
 
 .arrow {
   color: var(--paper-ink-faint);
-  font-size: 14px;
-  font-family: var(--paper-mono);
+  flex-shrink: 0;
+}
+
+.item:active {
+  background: var(--paper-bg-warmer);
 }
 
 .footer {

--- a/packages/web/components/list/NavDrawerContent.module.css
+++ b/packages/web/components/list/NavDrawerContent.module.css
@@ -22,6 +22,7 @@
   font-size: 15px;
   color: var(--paper-ink);
   text-decoration: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .item:hover {

--- a/packages/web/components/list/NavDrawerContent.tsx
+++ b/packages/web/components/list/NavDrawerContent.tsx
@@ -16,24 +16,24 @@ export function NavDrawerContent({ activeTab, username }: Props) {
         href="/"
         className={`${styles.item} ${activeTab === "issues" ? styles.on : ""}`}
       >
-        All issues<span className={styles.arrow}>›</span>
+        All issues<NavChevron />
       </Link>
       <Link
         href="/?tab=prs"
         className={`${styles.item} ${activeTab === "prs" ? styles.on : ""}`}
       >
-        Pull requests<span className={styles.arrow}>›</span>
+        Pull requests<NavChevron />
       </Link>
 
       <div className={styles.sectionLabel}>actions</div>
       <Link href="/new" className={styles.item}>
-        New Issue<span className={styles.arrow}>›</span>
+        New Issue<NavChevron />
       </Link>
       <Link href="/parse" className={styles.item}>
-        Quick Create<span className={styles.arrow}>›</span>
+        Quick Create<NavChevron />
       </Link>
       <Link href="/settings" className={styles.item}>
-        Settings<span className={styles.arrow}>›</span>
+        Settings<NavChevron />
       </Link>
 
       <div className={styles.footer}>
@@ -48,5 +48,26 @@ export function NavDrawerContent({ activeTab, username }: Props) {
         )}
       </div>
     </div>
+  );
+}
+
+function NavChevron() {
+  return (
+    <svg
+      className={styles.arrow}
+      width="8"
+      height="14"
+      viewBox="0 0 8 14"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M1 1l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary

- **#104** — Prevent canvas/page from dragging off-screen on mobile via `overscroll-behavior` on html/body and `touch-action: manipulation`
- **#110** — Replace Unicode text icons (‹, ←) with proper SVG back chevrons on DetailTopBar and NewIssuePage; add `:active` press states
- **#106** — Replace `···` text menu trigger with SVG hamburger icon; replace `›` text arrows with SVG forward chevrons in nav drawer
- **#95** — Remove `position: sticky` from CommentComposer on mobile so it flows at the end of content instead of always occupying viewport space

All interactive elements now have `-webkit-tap-highlight-color: transparent` and `:active` background feedback for native touch feel.

Closes #104, #110, #106, #95

## Test plan

- [ ] On iPhone Safari: verify page cannot be dragged/bounced off-screen (overscroll contained)
- [ ] Verify back chevrons render as clean SVG arrows on detail and new-issue pages
- [ ] Verify hamburger icon (☰) appears in top-right on mobile home page
- [ ] Verify nav drawer forward chevrons render as SVG arrows
- [ ] Verify all back buttons, menu button, and nav items show press feedback on touch
- [ ] Verify comment composer scrolls naturally at bottom of issue detail (not sticky)
- [ ] Verify no regressions on desktop (hover states, layout unchanged)