### PR TITLE
fix: functionality gaps (#97, #96, #109, #103, #84)

### DIFF
--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -13,6 +13,7 @@ import { WorktreeSection } from "./WorktreeSection";
 import { AuthSection } from "./AuthSection";
 import type { Metadata } from "next";
 import styles from "./page.module.css";
+import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
 
 export const metadata: Metadata = { title: "Settings — issuectl" };
 export const dynamic = "force-dynamic";
@@ -47,7 +48,7 @@ export default async function SettingsPage() {
   const claudeExtraArgs = settingMap.claude_extra_args ?? "";
 
   return (
-    <>
+    <PullToRefreshWrapper>
       <PageHeader title="Settings" breadcrumb={<Link href="/">← dashboard</Link>} />
       <div className={styles.content}>
         <section className={styles.section}>
@@ -78,6 +79,6 @@ export default async function SettingsPage() {
           </Suspense>
         </section>
       </div>
-    </>
+    </PullToRefreshWrapper>
   );
 }

--- a/packages/web/components/list/AssignSheet.module.css
+++ b/packages/web/components/list/AssignSheet.module.css
@@ -40,6 +40,16 @@
   cursor: not-allowed;
 }
 
+.rowSelected {
+  composes: row;
+  background: var(--paper-accent-soft);
+  border-left: 3px solid var(--paper-accent);
+}
+
+.rowSelected:hover {
+  background: var(--paper-accent-soft);
+}
+
 .repoName {
   font-family: var(--paper-serif);
   font-weight: 500;
@@ -65,4 +75,5 @@
   padding: 16px 28px 0;
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
 }

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -22,26 +22,29 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
   const { showToast } = useToast();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
-  const [assigning, setAssigning] = useState<number | null>(null);
+  const [assigning, setAssigning] = useState(false);
+  const [selectedRepoId, setSelectedRepoId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
     setError(null);
     setLoading(true);
+    setSelectedRepoId(null);
     listReposAction()
       .then(setRepos)
       .catch(() => setError("Failed to load repos"))
       .finally(() => setLoading(false));
   }, [open]);
 
-  const handleAssign = async (repoId: number) => {
-    setAssigning(repoId);
+  const handleAssign = async () => {
+    if (selectedRepoId === null) return;
+    setAssigning(true);
     setError(null);
     const idempotencyKey = newIdempotencyKey();
-    const repo = repos.find((r) => r.id === repoId);
+    const repo = repos.find((r) => r.id === selectedRepoId);
     try {
-      const result = await assignDraftAction(draftId, repoId, idempotencyKey);
+      const result = await assignDraftAction(draftId, selectedRepoId, idempotencyKey);
       if (!result.success) {
         setError(result.error);
         return;
@@ -52,9 +55,6 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
         showToast(`Issue #${result.issueNumber} created`, "success");
       }
       onClose();
-      // The draft was deleted from the DB when it was promoted; sending
-      // the user back to / avoids a stale-detail-page 404 if navigation
-      // to the new issue fails.
       if (repo && result.issueNumber) {
         router.push(`/issues/${repo.owner}/${repo.name}/${result.issueNumber}`);
       } else {
@@ -64,9 +64,11 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
       console.error("[issuectl] assignDraft threw:", err);
       setError(err instanceof Error ? err.message : "Failed to assign draft");
     } finally {
-      setAssigning(null);
+      setAssigning(false);
     }
   };
+
+  const selectedRepo = repos.find((r) => r.id === selectedRepoId);
 
   return (
     <Sheet
@@ -86,21 +88,29 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
         {repos.map((repo) => (
           <button
             key={repo.id}
-            className={styles.row}
-            onClick={() => handleAssign(repo.id)}
-            disabled={assigning !== null}
+            className={
+              repo.id === selectedRepoId ? styles.rowSelected : styles.row
+            }
+            onClick={() => setSelectedRepoId(repo.id)}
+            disabled={assigning}
           >
             <div className={styles.repoName}>{repo.name}</div>
             <div className={styles.repoOwner}>{repo.owner}</div>
-            {assigning === repo.id && (
-              <div className={styles.spinner}>assigning…</div>
-            )}
           </button>
         ))}
         <div className={styles.footer}>
-          <Button variant="ghost" onClick={onClose} disabled={assigning !== null}>
+          <Button variant="ghost" onClick={onClose} disabled={assigning}>
             cancel
           </Button>
+          {selectedRepo && (
+            <Button
+              variant="primary"
+              onClick={handleAssign}
+              disabled={assigning}
+            >
+              {assigning ? "assigning…" : `assign to ${selectedRepo.name}`}
+            </Button>
+          )}
         </div>
       </div>
     </Sheet>

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button, Sheet } from "@/components/paper";
 import { createDraftAction } from "@/lib/actions/drafts";
 import styles from "./CreateDraftSheet.module.css";
@@ -11,6 +12,7 @@ type Props = {
 };
 
 export function CreateDraftSheet({ open, onClose }: Props) {
+  const router = useRouter();
   const [title, setTitle] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -34,6 +36,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
       }
       setTitle("");
       onClose();
+      router.push("/?section=unassigned");
     } catch {
       setError("Failed to save draft");
     } finally {

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -37,7 +37,8 @@ export function CreateDraftSheet({ open, onClose }: Props) {
       setTitle("");
       onClose();
       router.push("/?section=unassigned");
-    } catch {
+    } catch (err) {
+      console.error("[issuectl] createDraft threw:", err);
       setError("Failed to save draft");
     } finally {
       setSaving(false);

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -518,3 +518,8 @@
 .tab {
   white-space: nowrap;
 }
+
+.sentinel {
+  height: 1px;
+  width: 100%;
+}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -15,6 +15,7 @@ import { FiltersSheet } from "./FiltersSheet";
 import { FilterEdgeSwipe } from "./FilterEdgeSwipe";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
+import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
 
 type Repo = { owner: string; name: string };
 type PrEntry = { repo: Repo; pull: GitHubPull };
@@ -190,6 +191,7 @@ export function List({
   });
 
   return (
+    <PullToRefreshWrapper>
     <div className={styles.container}>
       <div className={styles.topBar}>
         <h1 className={styles.brand}>
@@ -420,6 +422,7 @@ export function List({
         <NavDrawerContent activeTab={activeTab} username={username} />
       </Drawer>
     </div>
+    </PullToRefreshWrapper>
   );
 }
 

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import type { GitHubPull, Section, SortMode, UnifiedList } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
@@ -119,6 +119,32 @@ export function List({
     activeRepoIndex >= 0
       ? REPO_COLORS[activeRepoIndex % REPO_COLORS.length]
       : undefined;
+
+  const PAGE_SIZE = 15;
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Reset visible count when section changes
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [activeSection]);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => prev + PAGE_SIZE);
+  }, []);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore, activeSection]);
 
   const issuesHref = buildHref({ repo: activeRepo, sort: activeSort });
   const prsHref = buildHref({
@@ -303,10 +329,26 @@ export function List({
       )}
 
       {activeTab === "issues" ? (
-        renderIssueSection({
-          activeSection,
-          data,
-        })
+        <>
+          {renderIssueSection({
+            activeSection,
+            data,
+            visibleCount,
+          })}
+          {(() => {
+            const totalItems =
+              activeSection === "unassigned"
+                ? data.unassigned.length
+                : activeSection === "in_focus"
+                  ? data.in_focus.length
+                  : activeSection === "in_flight"
+                    ? data.in_flight.length
+                    : data.shipped.length;
+            return visibleCount < totalItems ? (
+              <div ref={sentinelRef} className={styles.sentinel} />
+            ) : null;
+          })()}
+        </>
       ) : prCount === 0 ? (
         <div className={styles.empty}>
           <div className={styles.emptyMark}>❧</div>
@@ -384,11 +426,13 @@ export function List({
 function renderIssueSection({
   activeSection,
   data,
+  visibleCount,
 }: {
   activeSection: Section;
   data: UnifiedList;
+  visibleCount: number;
 }) {
-  const items =
+  const allItems =
     activeSection === "unassigned"
       ? data.unassigned
       : activeSection === "in_focus"
@@ -397,7 +441,7 @@ function renderIssueSection({
           ? data.in_flight
           : data.shipped;
 
-  if (items.length === 0) {
+  if (allItems.length === 0) {
     const empty = SECTION_EMPTY[activeSection];
     return (
       <div className={styles.empty}>
@@ -408,6 +452,7 @@ function renderIssueSection({
     );
   }
 
+  const items = allItems.slice(0, visibleCount);
   return <ListSection title={null} items={items} />;
 }
 

--- a/packages/web/components/settings/TrackedRepos.module.css
+++ b/packages/web/components/settings/TrackedRepos.module.css
@@ -2,3 +2,23 @@
   font-size: 12px;
   padding: 4px 10px;
 }
+
+.showAllBtn {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  margin-bottom: 8px;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-accent);
+  background: transparent;
+  border: 1px dashed var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  cursor: pointer;
+  text-align: center;
+}
+
+.showAllBtn:hover {
+  background: var(--paper-accent-soft);
+}

--- a/packages/web/components/settings/TrackedRepos.tsx
+++ b/packages/web/components/settings/TrackedRepos.tsx
@@ -13,22 +13,37 @@ type Props = {
   repos: Repo[];
 };
 
+const COLLAPSED_LIMIT = 5;
+
 export function TrackedRepos({ repos }: Props) {
   const [showAdd, setShowAdd] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const trackedSet = useMemo(
     () => new Set(repos.map(repoKey)),
     [repos],
   );
 
+  const visibleRepos = expanded ? repos : repos.slice(0, COLLAPSED_LIMIT);
+  const hasMore = repos.length > COLLAPSED_LIMIT;
+
   return (
     <>
-      {repos.map((repo, i) => (
+      {visibleRepos.map((repo, i) => (
         <RepoRow
           key={repo.id}
           repo={repo}
           color={REPO_COLORS[i % REPO_COLORS.length]}
         />
       ))}
+      {hasMore && !expanded && (
+        <button
+          type="button"
+          className={styles.showAllBtn}
+          onClick={() => setExpanded(true)}
+        >
+          show all {repos.length} repos
+        </button>
+      )}
       {showAdd ? (
         <AddRepoForm
           onClose={() => setShowAdd(false)}

--- a/packages/web/components/settings/WorktreeCleanup.module.css
+++ b/packages/web/components/settings/WorktreeCleanup.module.css
@@ -88,3 +88,23 @@
   color: var(--paper-accent);
   margin-top: 4px;
 }
+
+.showAllBtn {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  margin-bottom: 8px;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-accent);
+  background: transparent;
+  border: 1px dashed var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  cursor: pointer;
+  text-align: center;
+}
+
+.showAllBtn:hover {
+  background: var(--paper-accent-soft);
+}

--- a/packages/web/components/settings/WorktreeCleanup.tsx
+++ b/packages/web/components/settings/WorktreeCleanup.tsx
@@ -10,10 +10,13 @@ type Props = {
   worktrees: WorktreeInfo[];
 };
 
+const COLLAPSED_LIMIT = 5;
+
 export function WorktreeCleanup({ worktrees }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [expanded, setExpanded] = useState(false);
 
   if (worktrees.length === 0) {
     return <div className={styles.empty}>No worktrees found</div>;
@@ -46,6 +49,9 @@ export function WorktreeCleanup({ worktrees }: Props) {
     });
   }
 
+  const visibleWorktrees = expanded ? worktrees : worktrees.slice(0, COLLAPSED_LIMIT);
+  const hasMore = worktrees.length > COLLAPSED_LIMIT;
+
   return (
     <>
       {staleCount > 0 && (
@@ -63,7 +69,7 @@ export function WorktreeCleanup({ worktrees }: Props) {
           </Button>
         </div>
       )}
-      {worktrees.map((wt) => (
+      {visibleWorktrees.map((wt) => (
         <div key={wt.path} className={wt.stale ? styles.rowStale : styles.row}>
           <span className={styles.name}>{wt.name}</span>
           <span className={wt.stale ? styles.badgeStale : styles.badgeActive}>
@@ -82,6 +88,15 @@ export function WorktreeCleanup({ worktrees }: Props) {
           </Button>
         </div>
       ))}
+      {hasMore && !expanded && (
+        <button
+          type="button"
+          className={styles.showAllBtn}
+          onClick={() => setExpanded(true)}
+        >
+          show all {worktrees.length} worktrees
+        </button>
+      )}
       {error && <div className={styles.error} role="alert">{error}</div>}
       {success && <div className={styles.success} role="status">{success}</div>}
     </>

--- a/packages/web/components/ui/PullToRefreshWrapper.module.css
+++ b/packages/web/components/ui/PullToRefreshWrapper.module.css
@@ -1,0 +1,31 @@
+.container {
+  min-height: 100dvh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  overflow: hidden;
+  transition: height 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+.spinner {
+  font-size: 22px;
+  color: var(--paper-ink-faint);
+  transition: transform 0.2s ease-out;
+}
+
+.spinnerActive {
+  composes: spinner;
+  animation: spin 0.8s linear infinite;
+  color: var(--paper-accent);
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/packages/web/components/ui/PullToRefreshWrapper.module.css
+++ b/packages/web/components/ui/PullToRefreshWrapper.module.css
@@ -2,6 +2,7 @@
   min-height: 100dvh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
 }
 
 .indicator {

--- a/packages/web/components/ui/PullToRefreshWrapper.tsx
+++ b/packages/web/components/ui/PullToRefreshWrapper.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh";
+import { refreshAction } from "@/lib/actions/refresh";
+import styles from "./PullToRefreshWrapper.module.css";
+
+type Props = {
+  children: ReactNode;
+};
+
+export function PullToRefreshWrapper({ children }: Props) {
+  const router = useRouter();
+
+  const onRefresh = useCallback(async () => {
+    await refreshAction();
+    router.refresh();
+  }, [router]);
+
+  const { containerRef, pullDistance, refreshing } = usePullToRefresh({
+    onRefresh,
+  });
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      {(pullDistance > 0 || refreshing) && (
+        <div
+          className={styles.indicator}
+          style={
+            pullDistance > 0
+              ? { height: pullDistance, opacity: Math.min(pullDistance / 60, 1) }
+              : undefined
+          }
+        >
+          <div className={refreshing ? styles.spinnerActive : styles.spinner}>
+            ↻
+          </div>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/packages/web/components/ui/PullToRefreshWrapper.tsx
+++ b/packages/web/components/ui/PullToRefreshWrapper.tsx
@@ -15,7 +15,10 @@ export function PullToRefreshWrapper({ children }: Props) {
   const router = useRouter();
 
   const onRefresh = useCallback(async () => {
-    await refreshAction();
+    const result = await refreshAction();
+    if (!result.success) {
+      console.warn("[issuectl] Pull-to-refresh failed:", result.error);
+    }
     router.refresh();
   }, [router]);
 

--- a/packages/web/e2e/action-sheets.spec.ts
+++ b/packages/web/e2e/action-sheets.spec.ts
@@ -1,0 +1,503 @@
+import { test, expect } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { initSchema, runMigrations } from "@issuectl/core";
+
+const execFileAsync = promisify(execFile);
+
+// Distinct from other specs: quick-create (3848), audit-verification (3850),
+// mobile-ux-patterns (3851), launch-ui (3852), pwa-offline (3853).
+// launch-flow reuses the default :3847 and is macOS-only/never run in CI.
+const TEST_PORT = 3854;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// FilterEdgeSwipe is hidden when both min-width >= 768px AND the pointer
+// supports hover (CSS media: hover:hover). Use a mobile viewport with
+// isMobile:true so both conditions are unmet and the handle is visible.
+test.use({
+  viewport: { width: 393, height: 852 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+// Pins the navigation behavior after destructive actions performed via
+// action sheets (swipe-up → Sheet → ConfirmDialog). Specifically:
+//
+// - Draft delete navigates to /?section=unassigned
+// - Issue close navigates to /?section=shipped
+// - Cancelling either confirmation stays on the detail page
+//
+// These were broken in an earlier PR where router.refresh() was used
+// instead of router.push(), leaving the user stranded on a stale
+// detail page after a successful mutation.
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+}
+
+async function createTestIssue(title: string): Promise<number> {
+  const { stdout } = await execFileAsync("gh", [
+    "issue",
+    "create",
+    "--repo",
+    `${TEST_OWNER}/${TEST_REPO}`,
+    "--title",
+    title,
+    "--body",
+    "Auto-created by action-sheets.spec.ts — safe to delete.",
+  ]);
+  const match = stdout.trim().match(/\/issues\/(\d+)$/);
+  if (!match) {
+    throw new Error(`Could not parse issue number from gh output: ${stdout}`);
+  }
+  return Number(match[1]);
+}
+
+const STDERR_BUFFER_MAX_CHUNKS = 40;
+const serverStderrChunks: string[] = [];
+
+const DRAFT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const DRAFT_TITLE = "E2E test draft for deletion";
+const CANCEL_DRAFT_ID = "11111111-2222-3333-4444-555555555555";
+const CANCEL_DRAFT_TITLE = "Draft for cancel test";
+const ASSIGN_DRAFT_ID = "cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa";
+const ASSIGN_DRAFT_TITLE = "E2E test draft for assignment";
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  try {
+    initSchema(db);
+    runMigrations(db);
+
+    const defaults: Array<[string, string]> = [
+      ["branch_pattern", "issue-{number}-{slug}"],
+      ["terminal_app", "iterm2"],
+      ["terminal_window_title", "issuectl"],
+      ["terminal_tab_title_pattern", "#{number} — {title}"],
+      ["cache_ttl", "300"],
+      ["worktree_dir", "~/.issuectl/worktrees/"],
+    ];
+    const insertSetting = db.prepare(
+      "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+    );
+    for (const [key, value] of defaults) {
+      insertSetting.run(key, value);
+    }
+
+    db.prepare("INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)").run(
+      TEST_OWNER,
+      TEST_REPO,
+    );
+
+    // Seed drafts for the delete and cancel-delete tests
+    const now = Date.now();
+    const insertDraft = db.prepare(
+      `INSERT INTO drafts (id, title, body, priority, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    insertDraft.run(DRAFT_ID, DRAFT_TITLE, "Body for e2e test", "normal", now, now);
+    insertDraft.run(CANCEL_DRAFT_ID, CANCEL_DRAFT_TITLE, "", "normal", now, now);
+    insertDraft.run(ASSIGN_DRAFT_ID, ASSIGN_DRAFT_TITLE, "", "normal", now, now);
+
+    // Seed issues list cache so the index page renders from cache after
+    // navigation, without needing a live GitHub fetch for the issues list.
+    db.prepare(
+      "INSERT INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(`issues:${TEST_OWNER}/${TEST_REPO}`, JSON.stringify([]));
+  } finally {
+    db.close();
+  }
+}
+
+/** Seed the issue-header cache so the detail page renders without a GitHub fetch. */
+function seedIssueCache(dbPath: string, issueNumber: number, title: string): void {
+  const db = new Database(dbPath);
+  try {
+    const issue = {
+      number: issueNumber,
+      title,
+      body: "Created by e2e test",
+      state: "open",
+      labels: [],
+      user: { login: "test-bot", avatarUrl: "" },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      closedAt: null,
+      htmlUrl: `https://github.com/${TEST_OWNER}/${TEST_REPO}/issues/${issueNumber}`,
+    };
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(
+      `issue-header:${TEST_OWNER}/${TEST_REPO}#${issueNumber}`,
+      JSON.stringify(issue),
+    );
+
+    // Also seed the issue-content cache so the Suspense boundary resolves
+    // without a live fetch — avoids background API noise during the test.
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(
+      `issue-content:${TEST_OWNER}/${TEST_REPO}#${issueNumber}`,
+      JSON.stringify({ comments: [], linkedPRs: [] }),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+let closeIssueNumber: number;
+let cancelIssueNumber: number;
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    if (process.env.CI === "true") {
+      throw new Error(
+        `Action sheets suite cannot skip in CI: ${check.reason}. ` +
+          `This suite MUST run on PRs to pin post-mutation navigation.`,
+      );
+    }
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-action-sheets-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  // Create fresh GitHub issues for the close and cancel-close tests in
+  // parallel — each run gets its own issues so closing is idempotent.
+  const [closeNum, cancelNum] = await Promise.all([
+    createTestIssue("E2E action-sheets: close test"),
+    createTestIssue("E2E action-sheets: cancel close test"),
+  ]);
+  closeIssueNumber = closeNum;
+  cancelIssueNumber = cancelNum;
+
+  seedIssueCache(dbPath, closeIssueNumber, "E2E action-sheets: close test");
+  seedIssueCache(dbPath, cancelIssueNumber, "E2E action-sheets: cancel close test");
+
+  // Use an isolated .next output directory so the test dev server does
+  // not collide with the main dev server's .next/ cache (which would
+  // cause __webpack_modules__[moduleId] errors from pack-file races).
+  const distDir = join(tmpDir, ".next-test");
+
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: {
+      ...process.env,
+      ISSUECTL_DB_PATH: dbPath,
+      NEXT_DIST_DIR: distDir,
+      // Prevent `next dev` from writing the temp distDir's types path
+      // into the project's tsconfig.json include array.
+      NEXT_PRIVATE_SKIP_SETUP: "1",
+    },
+    stdio: "pipe",
+    detached: true,
+  });
+
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderrChunks.push(chunk.toString());
+    if (serverStderrChunks.length > STDERR_BUFFER_MAX_CHUNKS) {
+      serverStderrChunks.shift();
+    }
+  });
+
+  await waitForServer(BASE_URL, 60000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderrChunks.join("").slice(-800)}`,
+    );
+  });
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus && serverStderrChunks.length > 0) {
+    await testInfo.attach("server-stderr", {
+      body: serverStderrChunks.join("").slice(-2000),
+      contentType: "text/plain",
+    });
+  }
+});
+
+test.afterAll(async () => {
+  if (server && server.pid) {
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-server.pid!, signal);
+      } catch {
+        /* already dead or orphaned */
+      }
+    };
+
+    const killTimeout = setTimeout(() => killGroup("SIGKILL"), 5000);
+    killGroup("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  // `next dev` with a custom distDir writes the temp types path into
+  // tsconfig.json and next-env.d.ts. Restore both so the working tree
+  // stays clean after the test run.
+  await execFileAsync("git", [
+    "checkout", "--", "packages/web/tsconfig.json", "packages/web/next-env.d.ts",
+  ], { cwd: join(import.meta.dirname, "../../..") }).catch((err: unknown) => {
+    // git exits non-zero when there is nothing to revert — expected in CI.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("did not match any")) {
+      console.warn(`[action-sheets afterAll] git checkout failed (working tree may be dirty): ${msg}`);
+    }
+  });
+
+  // Close both test issues so they don't litter the test repo.
+  // closeIssueNumber may already be closed by the test — that's fine.
+  const issuesToClose = [closeIssueNumber, cancelIssueNumber].filter(Boolean);
+  await Promise.allSettled(
+    issuesToClose.map((num) =>
+      execFileAsync("gh", [
+        "issue", "close", String(num),
+        "--repo", `${TEST_OWNER}/${TEST_REPO}`,
+      ]).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[action-sheets afterAll] Could not close test issue #${num}: ${msg}`);
+      }),
+    ),
+  );
+});
+
+// ── Draft delete tests ────────────────────────────────────────────────
+
+test.describe("draft delete — action sheet flow", () => {
+  test("deleting a draft navigates to /?section=unassigned", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+    await page.goto(`${BASE_URL}/drafts/${DRAFT_ID}`);
+
+    // Verify the draft detail page rendered
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      DRAFT_TITLE,
+    );
+
+    // Open the action sheet via the bottom handle
+    await page.getByRole("button", { name: /Open Actions/ }).click();
+
+    // Sheet dialog opens — click the delete action
+    const sheet = page.getByRole("dialog", { name: "draft actions" });
+    await expect(sheet).toBeVisible();
+    await sheet.getByRole("button", { name: "Delete draft" }).click();
+
+    // ConfirmDialog replaces the sheet
+    const confirm = page.getByRole("dialog", { name: "Delete Draft" });
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText("cannot be recovered");
+
+    // Confirm the deletion
+    await confirm.getByRole("button", { name: "Delete Draft" }).click();
+
+    // Should navigate to the index page with unassigned section active
+    await page.waitForURL((url) => {
+      const u = new URL(url);
+      return u.pathname === "/" && u.searchParams.get("section") === "unassigned";
+    }, { timeout: 15000 });
+  });
+
+  test("cancelling draft delete stays on the detail page", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/drafts/${CANCEL_DRAFT_ID}`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      CANCEL_DRAFT_TITLE,
+    );
+
+    // Open action sheet → click delete → cancel
+    await page.getByRole("button", { name: /Open Actions/ }).click();
+    const sheet = page.getByRole("dialog", { name: "draft actions" });
+    await expect(sheet).toBeVisible();
+    await sheet.getByRole("button", { name: "Delete draft" }).click();
+
+    const confirm = page.getByRole("dialog", { name: "Delete Draft" });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole("button", { name: "Cancel" }).click();
+
+    // Dialog dismissed, still on the draft detail page
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+    expect(page.url()).toContain(`/drafts/${CANCEL_DRAFT_ID}`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      CANCEL_DRAFT_TITLE,
+    );
+  });
+});
+
+// ── Issue close tests ─────────────────────────────────────────────────
+
+test.describe("issue close — action sheet flow", () => {
+  test("closing an issue navigates to /?section=shipped", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+    const issueUrl = `${BASE_URL}/issues/${TEST_OWNER}/${TEST_REPO}/${closeIssueNumber}`;
+    await page.goto(issueUrl);
+
+    // Verify the issue detail page rendered with the action sheet handle
+    // (only shown for open issues)
+    const handle = page.getByRole("button", { name: /Open Actions/ });
+    await expect(handle).toBeVisible({ timeout: 15000 });
+
+    // Open the action sheet
+    await handle.click();
+    const sheet = page.getByRole("dialog", { name: "issue actions" });
+    await expect(sheet).toBeVisible();
+    await sheet.getByRole("button", { name: "Close issue" }).click();
+
+    // ConfirmDialog appears
+    const confirm = page.getByRole("dialog", { name: "Close Issue" });
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText("reopened later from GitHub");
+
+    // Confirm the close
+    await confirm.getByRole("button", { name: "Close Issue" }).click();
+
+    // Should navigate to the index page with shipped section active.
+    // The GitHub API call takes a moment, so allow a generous timeout.
+    await page.waitForURL((url) => {
+      const u = new URL(url);
+      return u.pathname === "/" && u.searchParams.get("section") === "shipped";
+    }, { timeout: 30000 });
+  });
+
+  test("cancelling issue close stays on the detail page", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    const issueUrl = `${BASE_URL}/issues/${TEST_OWNER}/${TEST_REPO}/${cancelIssueNumber}`;
+    await page.goto(issueUrl);
+
+    const handle = page.getByRole("button", { name: /Open Actions/ });
+    await expect(handle).toBeVisible({ timeout: 15000 });
+
+    // Open action sheet → click close → cancel
+    await handle.click();
+    const sheet = page.getByRole("dialog", { name: "issue actions" });
+    await expect(sheet).toBeVisible();
+    await sheet.getByRole("button", { name: "Close issue" }).click();
+
+    const confirm = page.getByRole("dialog", { name: "Close Issue" });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole("button", { name: "Cancel" }).click();
+
+    // Dialog dismissed, still on the issue detail page
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+    expect(page.url()).toContain(
+      `/issues/${TEST_OWNER}/${TEST_REPO}/${cancelIssueNumber}`,
+    );
+  });
+});
+
+// ── Draft assign tests ──────────────────────────────────────────────
+
+test.describe("draft assign — cache invalidation", () => {
+  test("assigning a draft to a repo shows the new issue on the index page", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/drafts/${ASSIGN_DRAFT_ID}`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      ASSIGN_DRAFT_TITLE,
+    );
+
+    // Open the action sheet via the bottom handle
+    await page.getByRole("button", { name: /Open Actions/ }).click();
+    const sheet = page.getByRole("dialog", { name: "draft actions" });
+    await expect(sheet).toBeVisible();
+
+    // Click "Assign to repo" to open the AssignSheet
+    await sheet.getByRole("button", { name: /Assign to repo/ }).click();
+
+    // The assign sheet should appear with the test repo listed
+    const assignSheet = page.getByRole("dialog", { name: /assign to repo/ });
+    await expect(assignSheet).toBeVisible();
+
+    // Select the test repo (click to select, not assign — the new two-step flow)
+    await assignSheet.getByText(TEST_REPO).click();
+
+    // Confirm the assignment
+    await assignSheet.getByRole("button", { name: /assign to/i }).click();
+
+    // Should navigate to the new issue's detail page
+    await page.waitForURL(
+      (url) => url.pathname.startsWith(`/issues/${TEST_OWNER}/${TEST_REPO}/`),
+      { timeout: 30000 },
+    );
+
+    // Extract the issue number from the URL for cleanup
+    const issueMatch = page.url().match(/\/issues\/[^/]+\/[^/]+\/(\d+)/);
+    const newIssueNumber = issueMatch ? Number(issueMatch[1]) : null;
+
+    // Navigate home and verify the issue appears in the "in focus" section
+    await page.goto(BASE_URL);
+    await expect(page.getByText(ASSIGN_DRAFT_TITLE)).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Clean up: close the created GitHub issue
+    if (newIssueNumber) {
+      await execFileAsync("gh", [
+        "issue", "close", String(newIssueNumber),
+        "--repo", `${TEST_OWNER}/${TEST_REPO}`,
+      ]).catch(() => {
+        console.warn(`Could not close test issue #${newIssueNumber}`);
+      });
+    }
+  });
+});

--- a/packages/web/hooks/usePullToRefresh.ts
+++ b/packages/web/hooks/usePullToRefresh.ts
@@ -18,6 +18,9 @@ export function usePullToRefresh({
   const containerRef = useRef<HTMLDivElement>(null);
   const startY = useRef<number | null>(null);
   const pulling = useRef(false);
+  // Store pullDistance in a ref so handleTouchEnd can read the latest
+  // value without being recreated on every pixel of movement.
+  const pullDistanceRef = useRef(0);
 
   const handleTouchStart = useCallback(
     (e: TouchEvent) => {
@@ -38,10 +41,12 @@ export function usePullToRefresh({
         pulling.current = true;
         const distance = Math.min(diff * 0.5, maxPull);
         setPullDistance(distance);
+        pullDistanceRef.current = distance;
         if (distance > 10) e.preventDefault();
       } else {
         pulling.current = false;
         setPullDistance(0);
+        pullDistanceRef.current = 0;
       }
     },
     [refreshing, maxPull],
@@ -55,9 +60,10 @@ export function usePullToRefresh({
     }
     startY.current = null;
     pulling.current = false;
-    if (pullDistance >= threshold) {
+    if (pullDistanceRef.current >= threshold) {
       setRefreshing(true);
       setPullDistance(0);
+      pullDistanceRef.current = 0;
       try {
         await onRefresh();
       } finally {
@@ -65,8 +71,9 @@ export function usePullToRefresh({
       }
     } else {
       setPullDistance(0);
+      pullDistanceRef.current = 0;
     }
-  }, [pullDistance, threshold, onRefresh, refreshing]);
+  }, [threshold, onRefresh, refreshing]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/packages/web/hooks/usePullToRefresh.ts
+++ b/packages/web/hooks/usePullToRefresh.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, useState, useCallback, useEffect } from "react";
+
+type Options = {
+  onRefresh: () => Promise<void>;
+  threshold?: number;
+  maxPull?: number;
+};
+
+export function usePullToRefresh({
+  onRefresh,
+  threshold = 60,
+  maxPull = 120,
+}: Options) {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const startY = useRef<number | null>(null);
+  const pulling = useRef(false);
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (refreshing) return;
+      const container = containerRef.current;
+      if (!container || container.scrollTop > 0) return;
+      startY.current = e.touches[0].clientY;
+    },
+    [refreshing],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (refreshing || startY.current === null) return;
+      const currentY = e.touches[0].clientY;
+      const diff = currentY - startY.current;
+      if (diff > 0) {
+        pulling.current = true;
+        const distance = Math.min(diff * 0.5, maxPull);
+        setPullDistance(distance);
+        if (distance > 10) e.preventDefault();
+      } else {
+        pulling.current = false;
+        setPullDistance(0);
+      }
+    },
+    [refreshing, maxPull],
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!pulling.current || refreshing) {
+      startY.current = null;
+      pulling.current = false;
+      return;
+    }
+    startY.current = null;
+    pulling.current = false;
+    if (pullDistance >= threshold) {
+      setRefreshing(true);
+      setPullDistance(0);
+      try {
+        await onRefresh();
+      } finally {
+        setRefreshing(false);
+      }
+    } else {
+      setPullDistance(0);
+    }
+  }, [pullDistance, threshold, onRefresh, refreshing]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    container.addEventListener("touchmove", handleTouchMove, {
+      passive: false,
+    });
+    container.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      container.removeEventListener("touchstart", handleTouchStart);
+      container.removeEventListener("touchmove", handleTouchMove);
+      container.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  return { containerRef, pullDistance, refreshing };
+}

--- a/packages/web/hooks/usePullToRefresh.ts
+++ b/packages/web/hooks/usePullToRefresh.ts
@@ -66,6 +66,8 @@ export function usePullToRefresh({
       pullDistanceRef.current = 0;
       try {
         await onRefresh();
+      } catch (err) {
+        console.error("[issuectl] Pull-to-refresh onRefresh threw:", err);
       } finally {
         setRefreshing(false);
       }

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -12,6 +12,8 @@ import {
   DuplicateInFlightError,
   formatErrorForUser,
   DraftPartialCommitError,
+  getRepoById,
+  clearCacheKey,
   type DraftInput,
   type DraftUpdate,
   type Priority,
@@ -266,6 +268,18 @@ export async function assignDraftAction(
       err,
     );
     return { success: false, error: formatErrorForUser(err) };
+  }
+
+  // Clear the SQLite issues cache for this repo so the next page render
+  // fetches fresh data from GitHub that includes the newly created issue.
+  try {
+    const db = getDb();
+    const repo = getRepoById(db, repoId);
+    if (repo) {
+      clearCacheKey(db, `issues:${repo.owner}/${repo.name}`);
+    }
+  } catch {
+    // Cache miss on next render is the fallback — don't fail the action.
   }
 
   const { stale } = revalidateSafely("/");

--- a/packages/web/lib/actions/drafts.ts
+++ b/packages/web/lib/actions/drafts.ts
@@ -278,8 +278,13 @@ export async function assignDraftAction(
     if (repo) {
       clearCacheKey(db, `issues:${repo.owner}/${repo.name}`);
     }
-  } catch {
+  } catch (err) {
     // Cache miss on next render is the fallback — don't fail the action.
+    console.warn(
+      "[issuectl] Failed to clear issues cache after draft assignment",
+      { repoId },
+      err,
+    );
   }
 
   const { stale } = revalidateSafely("/");

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -1,27 +1,24 @@
 "use server";
 
-import {
-  getDb,
-  getDashboardData,
-  withAuthRetry,
-  formatErrorForUser,
-} from "@issuectl/core";
+import { getDb, clearCache, dbExists } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
-export async function refreshDashboard(): Promise<{
+export async function refreshAction(): Promise<{
   success: boolean;
   error?: string;
-  cacheStale?: true;
 }> {
   try {
-    const db = getDb();
-    await withAuthRetry((octokit) =>
-      getDashboardData(db, octokit, { forceRefresh: true }),
-    );
+    if (dbExists()) {
+      const db = getDb();
+      clearCache(db);
+    }
   } catch (err) {
-    console.error("[issuectl] Dashboard refresh failed:", err);
-    return { success: false, error: formatErrorForUser(err) };
+    console.error("[issuectl] refreshAction failed to clear cache:", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to refresh",
+    };
   }
-  const { stale } = revalidateSafely("/");
-  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+  revalidateSafely("/", "/settings");
+  return { success: true };
 }

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -6,6 +6,7 @@ import { revalidateSafely } from "@/lib/revalidate";
 export async function refreshAction(): Promise<{
   success: boolean;
   error?: string;
+  cacheStale?: true;
 }> {
   try {
     if (dbExists()) {
@@ -19,6 +20,6 @@ export async function refreshAction(): Promise<{
       error: err instanceof Error ? err.message : "Failed to refresh",
     };
   }
-  revalidateSafely("/", "/settings");
-  return { success: true };
+  const { stale } = revalidateSafely("/", "/settings");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }


### PR DESCRIPTION
## Summary

Fixes five UX gaps in the web dashboard and adds pull-to-refresh:

- **#97** — Navigate to drafts section after creating a draft (was staying on current tab)
- **#96** — Add confirmation step to repo assignment (was one-tap-to-create, now select → confirm)
- **#109** — Fix assigned issues not showing on index (SQLite cache wasn't invalidated after assignment)
- **#103** — Add infinite scroll on mobile index page (IntersectionObserver, 15-item batches)
- **#84** — Add collapsible "show all N" sections on settings page (repos + worktrees)
- **Pull-to-refresh** — Touch-gesture refresh on index and settings pages with `overscroll-behavior-y: contain`

## Changes

- 16 files changed, ~900 insertions, ~50 deletions
- New `usePullToRefresh` hook + `PullToRefreshWrapper` component
- New `refreshAction` server action (clears all SQLite cache + revalidates)
- New e2e test for draft assignment → cache invalidation flow
- Review fixes: proper error logging across all catch blocks, stable touch handlers via ref pattern

## Test plan

- [ ] `pnpm turbo typecheck` passes (verified, 0 errors)
- [ ] `pnpm turbo build` passes (verified, all routes build)
- [ ] Create a draft → verify navigation lands on `/?section=unassigned`
- [ ] Open draft → action sheet → "Assign to repo" → verify two-step select/confirm flow
- [ ] After assigning draft to repo, verify new issue appears on index page
- [ ] On mobile viewport with >15 items in a section, verify infinite scroll loads more on scroll
- [ ] On settings page with >5 repos or worktrees, verify "show all N" collapse/expand
- [ ] On mobile, pull down on index page → verify refresh indicator + data refresh
- [ ] On mobile, pull down on settings page → verify same behavior
- [ ] Run `pnpm --filter @issuectl/web test:e2e` — all tests pass including new assign test

Closes #97, #96, #109, #103, #84