### PR TITLE
fix: CI trigger, RepoPicker CSS, E2E stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - '**.html'
-      - '**.txt'
-      - 'docs/**'
-      - '.husky/**'
-      - 'LICENSE'
-      - '.github/**/*.md'
   pull_request:
     branches: [main]
     paths-ignore:

--- a/packages/web/components/settings/RepoPicker.module.css
+++ b/packages/web/components/settings/RepoPicker.module.css
@@ -139,9 +139,17 @@
 
 .name {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .name {
+    white-space: normal;
+    word-break: break-word;
+  }
 }
 
 .owner {
@@ -155,6 +163,10 @@
   border-radius: var(--paper-radius-sm);
   font-family: var(--paper-sans, system-ui, sans-serif);
   flex-shrink: 0;
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .badge {

--- a/packages/web/e2e/pwa-offline.spec.ts
+++ b/packages/web/e2e/pwa-offline.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
+import { existsSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -22,6 +23,13 @@ const TEST_REPO = "issuectl-test-repo";
 // in dev mode) and gh auth for the server to boot.
 
 async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  // next start requires a prior next build — without BUILD_ID the
+  // server crashes immediately with "Could not find a production build".
+  const buildId = join(import.meta.dirname, "..", ".next", "BUILD_ID");
+  if (!existsSync(buildId)) {
+    return { ok: false, reason: "no production build — run `pnpm turbo build` first" };
+  }
+
   try {
     await execFileAsync("gh", ["auth", "token"]);
     return { ok: true };

--- a/packages/web/e2e/quick-create.spec.ts
+++ b/packages/web/e2e/quick-create.spec.ts
@@ -235,32 +235,33 @@ test.describe("Quick Create flow", () => {
     await expect(parseButton).toBeEnabled();
     await parseButton.click();
 
-    // Wait for parsing to complete (Claude CLI can take up to 90s)
-    await expect(
-      page.getByRole("button", { name: "Parsing..." }),
-    ).toBeVisible({ timeout: 5000 });
-    await expect(
-      page.getByRole("button", { name: "Parsing..." }),
-    ).not.toBeVisible({ timeout: 90000 });
+    // Wait for parsing to complete (Claude CLI can take up to 90s).
+    // The "Parsing..." state may be too brief to catch if the CLI
+    // responds quickly, so we wait for the result directly rather
+    // than asserting the intermediate spinner.
+    await expect(page.getByText("parsed")).toBeVisible({ timeout: 90000 });
+    await expect(page.getByText(/\d+ included/)).toBeVisible();
 
-    // Step 2: Review — should show at least one issue card
-    await expect(page.getByText("parsed")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("included for creation")).toBeVisible();
-
-    // Verify a Create button exists with a count
-    const createButton = page.getByRole("button", { name: /Create \d+ Issue/ });
+    // Verify a Create button exists with a count — text varies based
+    // on whether issues matched repos or will be saved as drafts.
+    const createButton = page.getByRole("button", { name: /Create \d+|Save \d+ Draft/ });
     await expect(createButton).toBeVisible();
     await createButton.click();
 
-    // Step 3: Results
-    await expect(page.getByText("created")).toBeVisible({ timeout: 30000 });
+    // Step 3: Results — the summary says "created" or "saved" depending
+    // on whether the parser matched a repo or fell back to drafts.
+    await expect(page.getByText(/created|saved/)).toBeVisible({ timeout: 30000 });
 
-    // Extract created issue numbers from the links
+    // Extract created issue numbers from links. If Claude matched a
+    // repo, we get `#123` links; if it fell back to drafts, we get
+    // "view draft" links instead. Either is a valid success.
     const issueLinks = page.getByRole("link", { name: /^#\d+$/ });
-    const count = await issueLinks.count();
-    expect(count).toBeGreaterThanOrEqual(1);
+    const draftLinks = page.getByRole("link", { name: "view draft" });
+    const issueCount = await issueLinks.count();
+    const draftCount = await draftLinks.count();
+    expect(issueCount + draftCount).toBeGreaterThanOrEqual(1);
 
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < issueCount; i++) {
       const text = await issueLinks.nth(i).textContent();
       const num = Number(text?.replace("#", ""));
       if (num > 0) {

--- a/packages/web/e2e/quick-create.spec.ts
+++ b/packages/web/e2e/quick-create.spec.ts
@@ -251,6 +251,9 @@ test.describe("Quick Create flow", () => {
     // Step 3: Results — the summary says "created" or "saved" depending
     // on whether the parser matched a repo or fell back to drafts.
     await expect(page.getByText(/created|saved/)).toBeVisible({ timeout: 30000 });
+    // Ensure no partial failures slipped through — "failed" in the
+    // summary means the batch had errors we shouldn't silently accept.
+    await expect(page.getByText("failed")).not.toBeVisible();
 
     // Extract created issue numbers from links. If Claude matched a
     // repo, we get `#123` links; if it fell back to drafts, we get

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   testDir: "./e2e",
   timeout: 120000,
   retries: 0,
+  // Each spec spawns its own next dev server on a unique port. Running
+  // multiple in parallel causes CPU/cache contention that flakes timing-
+  // sensitive assertions. Serial execution adds ~30s but eliminates an
+  // entire class of false failures. Revisit if the suite exceeds 5min.
+  workers: 1,
   use: {
     baseURL: "http://localhost:3847",
     trace: "retain-on-failure",


### PR DESCRIPTION
## Summary
- Remove duplicate `push: [main]` CI trigger — every merged PR was running the full suite twice (closes #60)
- Fix RepoPicker text truncation on mobile — repo names now wrap instead of being hidden behind the "private" badge (closes #90)
- Fix flaky E2E tests: PWA spec now skips gracefully without a production build, quick-create spec removes brittle spinner assertion and updates stale UI text matchers
- Set Playwright `workers: 1` to eliminate resource contention between concurrent `next dev` servers

## Test plan
- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` — 398 unit tests pass
- [x] E2E: 27 pass, 4 PWA skip (no prod build) — all deterministic with `workers: 1`
- [x] Visual: RepoPicker verified on 393x852 mobile viewport — names wrap, badges constrained