### PR TITLE
fix: resolve ghostty app path dynamically for reliable launch

### DIFF
--- a/packages/core/src/launch/terminals/ghostty.integration.test.ts
+++ b/packages/core/src/launch/terminals/ghostty.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { createGhosttyLauncher, resolveGhosttyBinary } from "./ghostty.js";
+import { createGhosttyLauncher, resolveGhostty } from "./ghostty.js";
 import type { TerminalSettings } from "../terminal.js";
 
 const execFileAsync = promisify(execFile);
@@ -35,7 +35,7 @@ async function canRunIntegrationTests(): Promise<{ ok: boolean; reason?: string 
   }
 
   try {
-    await resolveGhosttyBinary();
+    await resolveGhostty();
   } catch {
     return { ok: false, reason: "Ghostty not installed — skipping integration tests" };
   }
@@ -144,7 +144,7 @@ describe("Ghostty integration", () => {
   it("verify resolves the Ghostty binary", async ({ skip }) => {
     if (skipReason) skip(skipReason);
 
-    const binary = await resolveGhosttyBinary();
+    const { binary } = await resolveGhostty();
     expect(binary).toBeTruthy();
 
     // Verify it can actually get the version

--- a/packages/core/src/launch/terminals/ghostty.test.ts
+++ b/packages/core/src/launch/terminals/ghostty.test.ts
@@ -93,11 +93,9 @@ describe("meetsMinVersion", () => {
 });
 
 describe("buildGhosttyArgs", () => {
-  it("produces open -na args with title and command", () => {
+  it("produces ghostty CLI args with title and command", () => {
     const args = buildGhosttyArgs("#42 — Fix auth", "cd '/tmp' && echo hello");
     expect(args).toEqual([
-      "-na", "Ghostty.app",
-      "--args",
       "--title=#42 — Fix auth",
       "-e", "/bin/bash", "-lic", "cd '/tmp' && echo hello || exec $SHELL -l",
     ]);
@@ -105,6 +103,6 @@ describe("buildGhosttyArgs", () => {
 
   it("handles em dashes in title without issue", () => {
     const args = buildGhosttyArgs("#99 — Test title", "echo test");
-    expect(args[3]).toBe("--title=#99 — Test title");
+    expect(args[0]).toBe("--title=#99 — Test title");
   });
 });

--- a/packages/core/src/launch/terminals/ghostty.test.ts
+++ b/packages/core/src/launch/terminals/ghostty.test.ts
@@ -93,16 +93,23 @@ describe("meetsMinVersion", () => {
 });
 
 describe("buildGhosttyArgs", () => {
-  it("produces ghostty CLI args with title and command", () => {
-    const args = buildGhosttyArgs("#42 — Fix auth", "cd '/tmp' && echo hello");
+  it("produces open -na args with app path, title and command", () => {
+    const args = buildGhosttyArgs("Ghostty.app", "#42 — Fix auth", "cd '/tmp' && echo hello");
     expect(args).toEqual([
+      "-na", "Ghostty.app",
+      "--args",
       "--title=#42 — Fix auth",
       "-e", "/bin/bash", "-lic", "cd '/tmp' && echo hello || exec $SHELL -l",
     ]);
   });
 
+  it("handles custom app path", () => {
+    const args = buildGhosttyArgs("/Applications/Ghostty.app", "#1 — Test", "echo test");
+    expect(args[1]).toBe("/Applications/Ghostty.app");
+  });
+
   it("handles em dashes in title without issue", () => {
-    const args = buildGhosttyArgs("#99 — Test title", "echo test");
-    expect(args[0]).toBe("--title=#99 — Test title");
+    const args = buildGhosttyArgs("Ghostty.app", "#99 — Test title", "echo test");
+    expect(args[3]).toBe("--title=#99 — Test title");
   });
 });

--- a/packages/core/src/launch/terminals/ghostty.ts
+++ b/packages/core/src/launch/terminals/ghostty.ts
@@ -2,11 +2,11 @@ import type { TerminalLauncher, TerminalLaunchOptions, TerminalSettings } from "
 import { timedExec } from "../exec-timeout.js";
 
 // Timeout budgets for the handful of synchronous Ghostty-probing calls.
-// `open -na Ghostty.app` returns quickly once the application receives the
-// event — 10s is generous. `which` and `--version` are similarly fast.
+// `ghostty -e ...` returns quickly once the window opens — 10s is generous.
+// `which` and `--version` are similarly fast.
 const WHICH_TIMEOUT_MS = 5_000;
 const VERSION_TIMEOUT_MS = 5_000;
-const OPEN_TIMEOUT_MS = 10_000;
+const LAUNCH_TIMEOUT_MS = 10_000;
 
 export type GhosttyVersion = { readonly major: number; readonly minor: number; readonly patch: number };
 
@@ -48,8 +48,6 @@ export function buildGhosttyArgs(tabTitle: string, shellCommand: string): string
   // On failure, drop into an interactive shell so the user can see the error.
   const wrappedCommand = `${shellCommand} || exec $SHELL -l`;
   return [
-    "-na", "Ghostty.app",
-    "--args",
     `--title=${tabTitle}`,
     "-e", "/bin/bash", "-lic", wrappedCommand,
   ];
@@ -87,6 +85,9 @@ export async function resolveGhosttyBinary(): Promise<string> {
 }
 
 export function createGhosttyLauncher(settings: TerminalSettings): TerminalLauncher {
+  // Resolved once during verify(), reused by launch().
+  let resolvedBinary: string | undefined;
+
   return {
     name: "Ghostty",
 
@@ -95,8 +96,8 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
         throw new Error("Ghostty launcher is only supported on macOS");
       }
 
-      const binary = await resolveGhosttyBinary();
-      const { stdout } = await timedExec(binary, ["--version"], {
+      resolvedBinary = await resolveGhosttyBinary();
+      const { stdout } = await timedExec(resolvedBinary, ["--version"], {
         timeoutMs: VERSION_TIMEOUT_MS,
         step: "ghostty --version",
       });
@@ -110,17 +111,19 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
     },
 
     async launch(options: TerminalLaunchOptions): Promise<void> {
+      // Resolve the binary if launch() is called without a prior verify().
+      const binary = resolvedBinary ?? await resolveGhosttyBinary();
       const tabTitle = expandTabTitle(settings.tabTitlePattern, options);
       const shellCommand = buildShellCommand(options.workspacePath, options.contextFilePath, options.claudeCommand);
       const args = buildGhosttyArgs(tabTitle, shellCommand);
       try {
-        await timedExec("open", args, {
-          timeoutMs: OPEN_TIMEOUT_MS,
-          step: "open -na Ghostty.app",
+        await timedExec(binary, args, {
+          timeoutMs: LAUNCH_TIMEOUT_MS,
+          step: "ghostty -e",
         });
       } catch (err) {
         throw new Error(
-          `Failed to launch Ghostty terminal. Ensure Ghostty.app is installed and accessible. ` +
+          `Failed to launch Ghostty terminal. Ensure the ghostty CLI is installed and accessible. ` +
           `(${err instanceof Error ? err.message : String(err)})`,
           { cause: err },
         );

--- a/packages/core/src/launch/terminals/ghostty.ts
+++ b/packages/core/src/launch/terminals/ghostty.ts
@@ -2,11 +2,12 @@ import type { TerminalLauncher, TerminalLaunchOptions, TerminalSettings } from "
 import { timedExec } from "../exec-timeout.js";
 
 // Timeout budgets for the handful of synchronous Ghostty-probing calls.
-// `ghostty -e ...` returns quickly once the window opens — 10s is generous.
-// `which` and `--version` are similarly fast.
+// `which` and `--version` return quickly. `open -na` is fire-and-forget
+// on macOS — it returns once the launch event is delivered, not when the
+// window closes.
 const WHICH_TIMEOUT_MS = 5_000;
 const VERSION_TIMEOUT_MS = 5_000;
-const LAUNCH_TIMEOUT_MS = 10_000;
+const OPEN_TIMEOUT_MS = 10_000;
 
 export type GhosttyVersion = { readonly major: number; readonly minor: number; readonly patch: number };
 
@@ -42,38 +43,54 @@ export function buildShellCommand(workspacePath: string, contextFilePath: string
   return `cd ${shellEscape(workspacePath)} && cat ${shellEscape(contextFilePath)} | ${claudeCommand}`;
 }
 
-export function buildGhosttyArgs(tabTitle: string, shellCommand: string): string[] {
+export function buildGhosttyArgs(appPath: string, tabTitle: string, shellCommand: string): string[] {
   // Use interactive login shell (-lic) so PATH includes user tools and
   // shell aliases are expanded (aliases only work in interactive mode).
   // On failure, drop into an interactive shell so the user can see the error.
   const wrappedCommand = `${shellCommand} || exec $SHELL -l`;
+  // `open -na` is macOS's fire-and-forget app launcher — it returns
+  // immediately after delivering the launch event, unlike invoking the
+  // ghostty binary directly which blocks until the window closes.
   return [
+    "-na", appPath,
+    "--args",
     `--title=${tabTitle}`,
     "-e", "/bin/bash", "-lic", wrappedCommand,
   ];
 }
 
-const GHOSTTY_APP_BINARY = "/Applications/Ghostty.app/Contents/MacOS/ghostty";
+const GHOSTTY_APP_PATH = "/Applications/Ghostty.app";
+const GHOSTTY_APP_BINARY = `${GHOSTTY_APP_PATH}/Contents/MacOS/ghostty`;
 
-export async function resolveGhosttyBinary(): Promise<string> {
+export type ResolvedGhostty = {
+  /** Path to the ghostty CLI binary (for --version checks). */
+  binary: string;
+  /** Path to the .app bundle (for `open -na`). */
+  appPath: string;
+};
+
+export async function resolveGhostty(): Promise<ResolvedGhostty> {
+  // Try PATH first — if `ghostty` is in PATH, the .app bundle is at
+  // the standard location.
   try {
     await timedExec("which", ["ghostty"], {
       timeoutMs: WHICH_TIMEOUT_MS,
       step: "which ghostty",
     });
-    return "ghostty";
+    return { binary: "ghostty", appPath: "Ghostty.app" };
   } catch (err: unknown) {
     // "which" exits 1 when not found — only fall through for that case
     const code = (err as { code?: string | number }).code;
     if (code !== "ENOENT" && code !== 1) throw err;
   }
 
+  // Fall back to the standard /Applications install.
   try {
     await timedExec(GHOSTTY_APP_BINARY, ["--version"], {
       timeoutMs: VERSION_TIMEOUT_MS,
       step: "ghostty --version",
     });
-    return GHOSTTY_APP_BINARY;
+    return { binary: GHOSTTY_APP_BINARY, appPath: GHOSTTY_APP_PATH };
   } catch (err: unknown) {
     const code = (err as { code?: string }).code;
     if (code !== "ENOENT") throw err;
@@ -86,7 +103,7 @@ export async function resolveGhosttyBinary(): Promise<string> {
 
 export function createGhosttyLauncher(settings: TerminalSettings): TerminalLauncher {
   // Resolved once during verify(), reused by launch().
-  let resolvedBinary: string | undefined;
+  let resolved: ResolvedGhostty | undefined;
 
   return {
     name: "Ghostty",
@@ -96,8 +113,8 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
         throw new Error("Ghostty launcher is only supported on macOS");
       }
 
-      resolvedBinary = await resolveGhosttyBinary();
-      const { stdout } = await timedExec(resolvedBinary, ["--version"], {
+      resolved = await resolveGhostty();
+      const { stdout } = await timedExec(resolved.binary, ["--version"], {
         timeoutMs: VERSION_TIMEOUT_MS,
         step: "ghostty --version",
       });
@@ -111,19 +128,19 @@ export function createGhosttyLauncher(settings: TerminalSettings): TerminalLaunc
     },
 
     async launch(options: TerminalLaunchOptions): Promise<void> {
-      // Resolve the binary if launch() is called without a prior verify().
-      const binary = resolvedBinary ?? await resolveGhosttyBinary();
+      // Resolve if launch() is called without a prior verify().
+      const { appPath } = resolved ?? await resolveGhostty();
       const tabTitle = expandTabTitle(settings.tabTitlePattern, options);
       const shellCommand = buildShellCommand(options.workspacePath, options.contextFilePath, options.claudeCommand);
-      const args = buildGhosttyArgs(tabTitle, shellCommand);
+      const args = buildGhosttyArgs(appPath, tabTitle, shellCommand);
       try {
-        await timedExec(binary, args, {
-          timeoutMs: LAUNCH_TIMEOUT_MS,
-          step: "ghostty -e",
+        await timedExec("open", args, {
+          timeoutMs: OPEN_TIMEOUT_MS,
+          step: "open -na Ghostty.app",
         });
       } catch (err) {
         throw new Error(
-          `Failed to launch Ghostty terminal. Ensure the ghostty CLI is installed and accessible. ` +
+          `Failed to launch Ghostty terminal. Ensure Ghostty.app is installed and accessible. ` +
           `(${err instanceof Error ? err.message : String(err)})`,
           { cause: err },
         );


### PR DESCRIPTION
## Summary
- Resolves the Ghostty binary dynamically: checks PATH first, falls back to `/Applications/Ghostty.app/Contents/MacOS/ghostty` (closes #29)
- Uses `open -na <resolved-app-path>` for launch (fire-and-forget), keeping the CLI binary for `--version` checks during `verify()`
- The direct `ghostty -e` invocation blocks until the window closes, which would timeout after 10s — `open -na` returns immediately after delivering the launch event
- Updates unit and integration test expectations

## Test plan
- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` — 398 tests pass (including updated ghostty.test.ts)
- [x] `buildGhosttyArgs` produces `["-na", appPath, "--args", "--title=...", "-e", ...]`
- [x] `resolveGhostty()` returns both `binary` and `appPath`