### PR TITLE
feat(web): display GitHub labels as colored chips

### DIFF
--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { GitHubIssue, Priority } from "@issuectl/core";
-import { Chip } from "@/components/paper";
+import { Chip, LabelChip } from "@/components/paper";
 import { timeAgo } from "@/lib/format";
 import { DetailTopBar } from "./DetailTopBar";
 import {
@@ -56,8 +56,8 @@ export function IssueDetail({
           {displayLabels.length > 0 && (
             <>
               <MetaSeparator />
-              {displayLabels.slice(0, 3).map((l) => (
-                <span key={l.name}>{l.name}</span>
+              {displayLabels.map((l) => (
+                <LabelChip key={l.name} name={l.name} color={l.color} />
               ))}
             </>
           )}

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -151,12 +151,3 @@
   color: var(--paper-ink-faint);
 }
 
-.lblBug {
-  color: var(--paper-brick);
-}
-
-.lblFeat {
-  /* Darker butter — var(--paper-butter) on cream fails WCAG AA (1.89:1).
-     #8a6914 restores >4.5:1 while keeping the warm-yellow feel. */
-  color: #8a6914;
-}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { UnifiedListItem } from "@issuectl/core";
-import { Checkbox, Chip } from "@/components/paper";
+import { Checkbox, Chip, LabelChip } from "@/components/paper";
 import styles from "./ListRow.module.css";
 
 type Props = {
@@ -22,17 +22,6 @@ function formatAge(updatedAt: string | number): string {
   if (diffDays < 1) return "today";
   if (diffDays === 1) return "1d";
   return `${diffDays}d`;
-}
-
-// Case-insensitive substring match. A label like "bug-report" will match
-// "bug" — that's intentional so common variants all paint brick red.
-function labelClass(labelName: string): string | undefined {
-  const lower = labelName.toLowerCase();
-  if (lower.includes("bug")) return styles.lblBug;
-  if (lower.includes("feat") || lower.includes("enhancement")) {
-    return styles.lblFeat;
-  }
-  return undefined;
 }
 
 export function ListRow({ item }: Props) {
@@ -62,7 +51,7 @@ export function ListRow({ item }: Props) {
   const titleClass =
     section === "shipped" ? `${styles.title} ${styles.done}` : styles.title;
 
-  const firstLabel = issue.labels.find(
+  const displayLabels = issue.labels.filter(
     (l) => !l.name.startsWith("issuectl:"),
   );
 
@@ -105,12 +94,12 @@ export function ListRow({ item }: Props) {
         <div className={styles.meta}>
           <Chip>{repo.name}</Chip>
           <span className={styles.num}>#{issue.number}</span>
-          {firstLabel && (
+          {displayLabels.length > 0 && (
             <>
               <span className={styles.sep}>·</span>
-              <span className={labelClass(firstLabel.name)}>
-                {firstLabel.name}
-              </span>
+              {displayLabels.map((l) => (
+                <LabelChip key={l.name} name={l.name} color={l.color} />
+              ))}
             </>
           )}
           <span className={styles.sep}>·</span>

--- a/packages/web/components/paper/LabelChip.module.css
+++ b/packages/web/components/paper/LabelChip.module.css
@@ -1,0 +1,12 @@
+.label {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  line-height: 1.5;
+}

--- a/packages/web/components/paper/LabelChip.tsx
+++ b/packages/web/components/paper/LabelChip.tsx
@@ -1,0 +1,44 @@
+import styles from "./LabelChip.module.css";
+
+type Props = {
+  name: string;
+  /** Hex color from GitHub (without leading #). */
+  color: string;
+};
+
+/**
+ * Determines whether to use dark or light text on a colored background
+ * using the W3C relative luminance formula. Returns true when the
+ * background is light enough to need dark text.
+ */
+function needsDarkText(hex: string): boolean {
+  const r = parseInt(hex.slice(0, 2), 16) / 255;
+  const g = parseInt(hex.slice(2, 4), 16) / 255;
+  const b = parseInt(hex.slice(4, 6), 16) / 255;
+
+  // sRGB → linear
+  const toLinear = (c: number) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+
+  const luminance =
+    0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+  // Threshold chosen so that e.g. GitHub's yellow (#fbca04) gets dark
+  // text while darker colors like #0e8a16 get white.
+  return luminance > 0.179;
+}
+
+export function LabelChip({ name, color }: Props) {
+  const hex = color.replace(/^#/, "");
+  const bg = `#${hex}`;
+  const textColor = needsDarkText(hex) ? "#1a1712" : "#fff";
+
+  return (
+    <span
+      className={styles.label}
+      style={{ backgroundColor: bg, color: textColor }}
+    >
+      {name}
+    </span>
+  );
+}

--- a/packages/web/components/paper/index.ts
+++ b/packages/web/components/paper/index.ts
@@ -4,3 +4,4 @@ export { Sheet } from "./Sheet";
 export { Drawer } from "./Drawer";
 export { Checkbox } from "./Checkbox";
 export { Fab } from "./Fab";
+export { LabelChip } from "./LabelChip";


### PR DESCRIPTION
## Summary
- Render all non-issuectl GitHub labels as colored chips on issue list rows and detail views (closes #116)
- New `LabelChip` Paper component uses W3C relative luminance to auto-pick dark/light text for readability
- Replaces the old substring-based color matching with actual GitHub hex colors
- Detail view: removed 3-label cap, all labels now display

## Test plan
- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` — 60 web tests pass
- [x] Labels render with GitHub colors on both list rows and issue detail
- [x] `issuectl:*` lifecycle labels correctly filtered out