### PR TITLE
feat: confirm before assign + re-assign issue to different repo

### DIFF
--- a/packages/core/src/github/issues.test.ts
+++ b/packages/core/src/github/issues.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
 import {
   listIssues,
   getIssue,
@@ -8,7 +9,12 @@ import {
   closeIssue,
   getComments,
   addComment,
+  reassignIssue,
 } from "./issues.js";
+import { createTestDb } from "../db/test-helpers.js";
+import { addRepo } from "../db/repos.js";
+import { setPriority, getPriority } from "../db/priority.js";
+import { setCached, getCached } from "../db/cache.js";
 
 /* ---------- helpers ---------- */
 
@@ -241,5 +247,173 @@ describe("addComment", () => {
       issue_number: 1,
       body: "A comment",
     });
+  });
+});
+
+/* ---------- reassignIssue ---------- */
+
+describe("reassignIssue", () => {
+  let db: Database.Database;
+  let oldRepoId: number;
+  let newRepoId: number;
+
+  const RAW_NEW_ISSUE = {
+    ...RAW_ISSUE,
+    number: 42,
+    html_url: "https://github.com/other-owner/other-repo/issues/42",
+  };
+
+  function makeReassignOctokit() {
+    const kit = makeOctokit();
+    // getIssue — fetch old issue
+    kit.get.mockResolvedValue({ data: RAW_ISSUE });
+    // createIssue — create on new repo
+    kit.create.mockResolvedValue({ data: RAW_NEW_ISSUE });
+    // addComment — cross-reference
+    kit.createComment.mockResolvedValue({ data: RAW_COMMENT });
+    // closeIssue — close old
+    kit.update.mockResolvedValue({ data: { ...RAW_ISSUE, state: "closed" } });
+    return kit;
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    const oldRepo = addRepo(db, { owner: "owner", name: "repo" });
+    const newRepo = addRepo(db, { owner: "other-owner", name: "other-repo" });
+    oldRepoId = oldRepo.id;
+    newRepoId = newRepo.id;
+  });
+
+  it("happy path: creates new issue, comments, closes old, returns result without cleanupWarning", async () => {
+    const { octokit, create, createComment, update } = makeReassignOctokit();
+
+    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+
+    // Verify new issue created on target repo with correct title/body
+    expect(create).toHaveBeenCalledWith({
+      owner: "other-owner",
+      repo: "other-repo",
+      title: "Bug report",
+      body: "Something is broken",
+      labels: undefined,
+    });
+
+    // Verify cross-reference comment added to old issue
+    expect(createComment).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 1,
+      body: "Moved to other-owner/other-repo#42",
+    });
+
+    // Verify old issue closed
+    expect(update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 1,
+      state: "closed",
+    });
+
+    // Verify return value
+    expect(result).toEqual({
+      newIssueNumber: 42,
+      newIssueUrl: "https://github.com/other-owner/other-repo/issues/42",
+      newOwner: "other-owner",
+      newRepo: "other-repo",
+    });
+    expect(result.cleanupWarning).toBeUndefined();
+  });
+
+  it("throws when old and new repo IDs are the same", async () => {
+    const { octokit } = makeReassignOctokit();
+
+    await expect(
+      reassignIssue(db, octokit, oldRepoId, 1, oldRepoId),
+    ).rejects.toThrow("Cannot re-assign an issue to the same repo");
+  });
+
+  it("throws when old repo ID does not exist in DB", async () => {
+    const { octokit } = makeReassignOctokit();
+
+    await expect(
+      reassignIssue(db, octokit, 9999, 1, newRepoId),
+    ).rejects.toThrow("Old repo (id 9999) not found");
+  });
+
+  it("throws when new repo ID does not exist in DB", async () => {
+    const { octokit } = makeReassignOctokit();
+
+    await expect(
+      reassignIssue(db, octokit, oldRepoId, 1, 9999),
+    ).rejects.toThrow("New repo (id 9999) not found");
+  });
+
+  it("returns result with cleanupWarning when closeIssue fails after create succeeds", async () => {
+    const { octokit, update } = makeReassignOctokit();
+
+    // addComment succeeds (uses createComment), but closeIssue (uses update) fails.
+    update.mockRejectedValue(new Error("API rate limit exceeded"));
+
+    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+
+    // Should NOT throw
+    expect(result.newIssueNumber).toBe(42);
+    expect(result.newIssueUrl).toBe("https://github.com/other-owner/other-repo/issues/42");
+    expect(result.cleanupWarning).toContain("could not be closed");
+    expect(result.cleanupWarning).toContain("API rate limit exceeded");
+  });
+
+  it("returns result with cleanupWarning when addComment fails after create succeeds", async () => {
+    const { octokit, createComment } = makeReassignOctokit();
+
+    createComment.mockRejectedValue(new Error("Forbidden"));
+
+    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+
+    expect(result.newIssueNumber).toBe(42);
+    expect(result.cleanupWarning).toContain("could not be closed");
+    expect(result.cleanupWarning).toContain("Forbidden");
+  });
+
+  it("migrates priority from old repo/issue to new repo/issue", async () => {
+    const { octokit } = makeReassignOctokit();
+
+    // Seed a priority on the old repo/issue
+    setPriority(db, oldRepoId, 1, "high");
+
+    await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+
+    // New repo/issue should have the priority
+    expect(getPriority(db, newRepoId, 42)).toBe("high");
+    // Old repo/issue priority should be deleted (returns default "normal")
+    expect(getPriority(db, oldRepoId, 1)).toBe("normal");
+  });
+
+  it("clears all 5 cache keys after reassignment", async () => {
+    const { octokit } = makeReassignOctokit();
+
+    // Seed cache entries for all 5 keys that reassignIssue should clear
+    const cacheKeys = [
+      "issues:owner/repo",
+      "issue-detail:owner/repo#1",
+      "issue-header:owner/repo#1",
+      "issue-content:owner/repo#1",
+      "issues:other-owner/other-repo",
+    ];
+    for (const key of cacheKeys) {
+      setCached(db, key, { placeholder: true });
+    }
+
+    // Verify they exist before
+    for (const key of cacheKeys) {
+      expect(getCached(db, key)).not.toBeNull();
+    }
+
+    await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+
+    // All 5 cache keys should be cleared
+    for (const key of cacheKeys) {
+      expect(getCached(db, key)).toBeNull();
+    }
   });
 });

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -1,6 +1,10 @@
 import type { Octokit } from "@octokit/rest";
+import type Database from "better-sqlite3";
 import type { GitHubIssue, GitHubComment, RawGitHubUser } from "./types.js";
 import { mapUser } from "./types.js";
+import { getRepoById } from "../db/repos.js";
+import { clearCacheKey } from "../db/cache.js";
+import { deletePriority, getPriority, setPriority } from "../db/priority.js";
 
 function mapIssue(raw: unknown): GitHubIssue {
   const r = raw as {
@@ -159,4 +163,70 @@ export async function addComment(
     body,
   });
   return mapComment(data);
+}
+
+export type ReassignResult = {
+  newIssueNumber: number;
+  newIssueUrl: string;
+  newOwner: string;
+  newRepo: string;
+};
+
+/**
+ * Re-assigns an issue from one repo to another by:
+ * 1. Fetching the issue from the old repo
+ * 2. Creating it on the new repo (preserving title and body)
+ * 3. Closing the old issue with a cross-reference comment
+ * 4. Migrating the local priority to the new repo/issue
+ * 5. Invalidating relevant caches
+ */
+export async function reassignIssue(
+  db: Database.Database,
+  octokit: Octokit,
+  oldRepoId: number,
+  issueNumber: number,
+  newRepoId: number,
+): Promise<ReassignResult> {
+  if (oldRepoId === newRepoId) {
+    throw new Error("Cannot re-assign an issue to the same repo");
+  }
+
+  const oldRepo = getRepoById(db, oldRepoId);
+  if (!oldRepo) throw new Error(`Old repo (id ${oldRepoId}) not found`);
+
+  const newRepo = getRepoById(db, newRepoId);
+  if (!newRepo) throw new Error(`New repo (id ${newRepoId}) not found`);
+
+  // 1. Fetch the existing issue
+  const oldIssue = await getIssue(octokit, oldRepo.owner, oldRepo.name, issueNumber);
+
+  // 2. Create the issue on the new repo
+  const newIssue = await createIssue(octokit, newRepo.owner, newRepo.name, {
+    title: oldIssue.title,
+    body: oldIssue.body ?? undefined,
+  });
+
+  // 3. Close the old issue with a cross-reference comment
+  const crossRef = `Moved to ${newRepo.owner}/${newRepo.name}#${newIssue.number}`;
+  await addComment(octokit, oldRepo.owner, oldRepo.name, issueNumber, crossRef);
+  await closeIssue(octokit, oldRepo.owner, oldRepo.name, issueNumber);
+
+  // 4. Migrate local priority
+  const oldPriority = getPriority(db, oldRepoId, issueNumber);
+  setPriority(db, newRepoId, newIssue.number, oldPriority);
+  deletePriority(db, oldRepoId, issueNumber);
+
+  // 5. Invalidate caches
+  clearCacheKey(db, `issues:${oldRepo.owner}/${oldRepo.name}`);
+  clearCacheKey(db, `issue-detail:${oldRepo.owner}/${oldRepo.name}#${issueNumber}`);
+  clearCacheKey(db, `issue-header:${oldRepo.owner}/${oldRepo.name}#${issueNumber}`);
+  clearCacheKey(db, `issue-content:${oldRepo.owner}/${oldRepo.name}#${issueNumber}`);
+  clearCacheKey(db, `issues:${newRepo.owner}/${newRepo.name}`);
+
+  return {
+    newIssueNumber: newIssue.number,
+    newIssueUrl: newIssue.htmlUrl,
+    newOwner: newRepo.owner,
+    newRepo: newRepo.name,
+  };
 }

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -170,6 +170,8 @@ export type ReassignResult = {
   newIssueUrl: string;
   newOwner: string;
   newRepo: string;
+  /** Set when the new issue was created but old-issue cleanup failed. */
+  cleanupWarning?: string;
 };
 
 /**
@@ -206,12 +208,25 @@ export async function reassignIssue(
     body: oldIssue.body ?? undefined,
   });
 
-  // 3. Close the old issue with a cross-reference comment
-  const crossRef = `Moved to ${newRepo.owner}/${newRepo.name}#${newIssue.number}`;
-  await addComment(octokit, oldRepo.owner, oldRepo.name, issueNumber, crossRef);
-  await closeIssue(octokit, oldRepo.owner, oldRepo.name, issueNumber);
+  // 3. Close the old issue with a cross-reference comment.
+  // After the new issue exists, cleanup of the old issue is best-effort:
+  // if it fails, we still return the result so the caller (and the
+  // idempotency layer) record the new issue — preventing duplicates on
+  // retry.
+  let cleanupWarning: string | undefined;
+  try {
+    const crossRef = `Moved to ${newRepo.owner}/${newRepo.name}#${newIssue.number}`;
+    await addComment(octokit, oldRepo.owner, oldRepo.name, issueNumber, crossRef);
+    await closeIssue(octokit, oldRepo.owner, oldRepo.name, issueNumber);
+  } catch (cleanupErr) {
+    console.warn(
+      `[issuectl] reassignIssue: new issue created (${newRepo.owner}/${newRepo.name}#${newIssue.number}) but old issue cleanup failed`,
+      cleanupErr,
+    );
+    cleanupWarning = `Issue moved but #${issueNumber} could not be closed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`;
+  }
 
-  // 4. Migrate local priority
+  // 4. Migrate local priority (local-only, safe to do even on cleanup failure)
   const oldPriority = getPriority(db, oldRepoId, issueNumber);
   setPriority(db, newRepoId, newIssue.number, oldPriority);
   deletePriority(db, oldRepoId, issueNumber);
@@ -228,5 +243,6 @@ export async function reassignIssue(
     newIssueUrl: newIssue.htmlUrl,
     newOwner: newRepo.owner,
     newRepo: newRepo.name,
+    cleanupWarning,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,8 @@ export {
   createIssue,
   updateIssue,
   closeIssue,
+  reassignIssue,
+  type ReassignResult,
 } from "./github/issues.js";
 export {
   LIFECYCLE_LABEL,

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -8,6 +8,7 @@ import { FilterEdgeSwipe } from "@/components/list/FilterEdgeSwipe";
 import { closeIssue, reassignIssueAction } from "@/lib/actions/issues";
 import { listReposAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import styles from "./ActionSheet.module.css";
 import assignStyles from "../list/AssignSheet.module.css";
 
@@ -87,6 +88,7 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
         repoId,
         number,
         selectedRepo.id,
+        newIdempotencyKey(),
       );
       if (!result.success) {
         setReassignError(result.error);

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -36,6 +36,7 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
   const [reassigning, setReassigning] = useState(false);
   const [reassignError, setReassignError] = useState<string | null>(null);
+  const [reassignKey, setReassignKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!reassignSheetOpen) return;
@@ -43,7 +44,10 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
     setLoadingRepos(true);
     listReposAction()
       .then(setRepos)
-      .catch(() => setReassignError("Failed to load repos"))
+      .catch((err) => {
+        console.error("[issuectl] Failed to load repos for reassign:", err);
+        setReassignError("Failed to load repos");
+      })
       .finally(() => setLoadingRepos(false));
   }, [reassignSheetOpen]);
 
@@ -64,7 +68,8 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
         setConfirmClose(false);
         showToast("Issue closed", "success");
         router.push("/?section=shipped");
-      } catch {
+      } catch (err) {
+        console.error("[issuectl] Close issue failed:", err);
         setError("Unable to reach the server. Check your connection and try again.");
       }
     });
@@ -77,10 +82,13 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
 
   function handleRepoSelect(targetRepo: Repo) {
     setSelectedRepo(targetRepo);
+    // Generate idempotency key once per intent so retries reuse
+    // the same key and don't create duplicate issues.
+    setReassignKey(newIdempotencyKey());
   }
 
   async function handleReassignConfirm() {
-    if (!selectedRepo) return;
+    if (!selectedRepo || !reassignKey) return;
     setReassigning(true);
     setReassignError(null);
     try {
@@ -88,7 +96,7 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
         repoId,
         number,
         selectedRepo.id,
-        newIdempotencyKey(),
+        reassignKey,
       );
       if (!result.success) {
         setReassignError(result.error);
@@ -96,14 +104,19 @@ export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
       }
       setSelectedRepo(null);
       setReassignSheetOpen(false);
-      showToast(
-        `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`,
-        "success",
-      );
+      if (result.cleanupWarning) {
+        showToast(result.cleanupWarning, "warning");
+      } else {
+        showToast(
+          `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`,
+          "success",
+        );
+      }
       router.push(
         `/issues/${result.newOwner}/${result.newRepo}/${result.newIssueNumber}`,
       );
-    } catch {
+    } catch (err) {
+      console.error("[issuectl] Reassign issue failed:", err);
       setReassignError(
         "Unable to reach the server. Check your connection and try again.",
       );

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -1,27 +1,50 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Sheet } from "@/components/paper";
+import { Sheet, Button } from "@/components/paper";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { FilterEdgeSwipe } from "@/components/list/FilterEdgeSwipe";
-import { closeIssue } from "@/lib/actions/issues";
+import { closeIssue, reassignIssueAction } from "@/lib/actions/issues";
+import { listReposAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
 import styles from "./ActionSheet.module.css";
+import assignStyles from "../list/AssignSheet.module.css";
+
+type Repo = { id: number; owner: string; name: string };
 
 type Props = {
   owner: string;
   repo: string;
+  repoId: number;
   number: number;
 };
 
-export function IssueActionSheet({ owner, repo, number }: Props) {
+export function IssueActionSheet({ owner, repo, repoId, number }: Props) {
   const router = useRouter();
   const { showToast } = useToast();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [confirmClose, setConfirmClose] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+
+  // Re-assign state
+  const [reassignSheetOpen, setReassignSheetOpen] = useState(false);
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [loadingRepos, setLoadingRepos] = useState(false);
+  const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
+  const [reassigning, setReassigning] = useState(false);
+  const [reassignError, setReassignError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!reassignSheetOpen) return;
+    setReassignError(null);
+    setLoadingRepos(true);
+    listReposAction()
+      .then(setRepos)
+      .catch(() => setReassignError("Failed to load repos"))
+      .finally(() => setLoadingRepos(false));
+  }, [reassignSheetOpen]);
 
   function handleCloseTap() {
     setSheetOpen(false);
@@ -46,6 +69,49 @@ export function IssueActionSheet({ owner, repo, number }: Props) {
     });
   }
 
+  function handleReassignTap() {
+    setSheetOpen(false);
+    setReassignSheetOpen(true);
+  }
+
+  function handleRepoSelect(targetRepo: Repo) {
+    setSelectedRepo(targetRepo);
+  }
+
+  async function handleReassignConfirm() {
+    if (!selectedRepo) return;
+    setReassigning(true);
+    setReassignError(null);
+    try {
+      const result = await reassignIssueAction(
+        repoId,
+        number,
+        selectedRepo.id,
+      );
+      if (!result.success) {
+        setReassignError(result.error);
+        return;
+      }
+      setSelectedRepo(null);
+      setReassignSheetOpen(false);
+      showToast(
+        `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`,
+        "success",
+      );
+      router.push(
+        `/issues/${result.newOwner}/${result.newRepo}/${result.newIssueNumber}`,
+      );
+    } catch {
+      setReassignError(
+        "Unable to reach the server. Check your connection and try again.",
+      );
+    } finally {
+      setReassigning(false);
+    }
+  }
+
+  const otherRepos = repos.filter((r) => r.id !== repoId);
+
   return (
     <>
       <FilterEdgeSwipe
@@ -58,6 +124,10 @@ export function IssueActionSheet({ owner, repo, number }: Props) {
         onClose={() => setSheetOpen(false)}
         title="issue actions"
       >
+        <button className={styles.item} onClick={handleReassignTap}>
+          <span className={styles.icon}>&harr;</span>
+          Re-assign to repo
+        </button>
         <button
           className={`${styles.item} ${styles.danger}`}
           onClick={handleCloseTap}
@@ -76,6 +146,67 @@ export function IssueActionSheet({ owner, repo, number }: Props) {
           onCancel={() => setConfirmClose(false)}
           isPending={isPending}
           error={error ?? undefined}
+        />
+      )}
+
+      <Sheet
+        open={reassignSheetOpen}
+        onClose={() => setReassignSheetOpen(false)}
+        title="re-assign to repo"
+        description={
+          <em>
+            #{number} &mdash; currently on {owner}/{repo}
+          </em>
+        }
+      >
+        <div className={assignStyles.body}>
+          {loadingRepos && (
+            <div className={assignStyles.loading}>loading repos…</div>
+          )}
+          {reassignError && !selectedRepo && (
+            <div className={assignStyles.error}>{reassignError}</div>
+          )}
+          {!loadingRepos && otherRepos.length === 0 && !reassignError && (
+            <div className={assignStyles.empty}>
+              <em>no other repos available</em>
+            </div>
+          )}
+          {otherRepos.map((r) => (
+            <button
+              key={r.id}
+              className={assignStyles.row}
+              onClick={() => handleRepoSelect(r)}
+              disabled={reassigning}
+            >
+              <div className={assignStyles.repoName}>{r.name}</div>
+              <div className={assignStyles.repoOwner}>{r.owner}</div>
+            </button>
+          ))}
+          <div className={assignStyles.footer}>
+            <Button
+              variant="ghost"
+              onClick={() => setReassignSheetOpen(false)}
+              disabled={reassigning}
+            >
+              cancel
+            </Button>
+          </div>
+        </div>
+      </Sheet>
+
+      {selectedRepo && (
+        <ConfirmDialog
+          title="Re-assign Issue"
+          message={`Move issue #${number} from ${owner}/${repo} to ${selectedRepo.owner}/${selectedRepo.name}? The old issue will be closed with a cross-reference.`}
+          confirmLabel="Re-assign"
+          confirmVariant="default"
+          onConfirm={handleReassignConfirm}
+          onCancel={() => {
+            setSelectedRepo(null);
+            setReassignError(null);
+          }}
+          isPending={reassigning}
+          error={reassignError ?? undefined}
         />
       )}
     </>

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -78,6 +78,7 @@ export function IssueDetail({
         <IssueActionSheet
           owner={owner}
           repo={repoName}
+          repoId={repoId}
           number={issue.number}
         />
       )}

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Sheet, Button } from "@/components/paper";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { listReposAction, assignDraftAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
@@ -22,29 +23,32 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
   const { showToast } = useToast();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
-  const [assigning, setAssigning] = useState(false);
-  const [selectedRepoId, setSelectedRepoId] = useState<number | null>(null);
+  const [assigning, setAssigning] = useState<number | null>(null);
+  const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
     setError(null);
+    setSelectedRepo(null);
     setLoading(true);
-    setSelectedRepoId(null);
     listReposAction()
       .then(setRepos)
       .catch(() => setError("Failed to load repos"))
       .finally(() => setLoading(false));
   }, [open]);
 
-  const handleAssign = async () => {
-    if (selectedRepoId === null) return;
-    setAssigning(true);
+  const handleRepoTap = (repo: Repo) => {
+    setSelectedRepo(repo);
+  };
+
+  const handleConfirmAssign = async () => {
+    if (!selectedRepo) return;
+    setAssigning(selectedRepo.id);
     setError(null);
     const idempotencyKey = newIdempotencyKey();
-    const repo = repos.find((r) => r.id === selectedRepoId);
     try {
-      const result = await assignDraftAction(draftId, selectedRepoId, idempotencyKey);
+      const result = await assignDraftAction(draftId, selectedRepo.id, idempotencyKey);
       if (!result.success) {
         setError(result.error);
         return;
@@ -54,9 +58,10 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
       } else {
         showToast(`Issue #${result.issueNumber} created`, "success");
       }
+      setSelectedRepo(null);
       onClose();
-      if (repo && result.issueNumber) {
-        router.push(`/issues/${repo.owner}/${repo.name}/${result.issueNumber}`);
+      if (result.issueNumber) {
+        router.push(`/issues/${selectedRepo.owner}/${selectedRepo.name}/${result.issueNumber}`);
       } else {
         router.push("/");
       }
@@ -64,55 +69,63 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
       console.error("[issuectl] assignDraft threw:", err);
       setError(err instanceof Error ? err.message : "Failed to assign draft");
     } finally {
-      setAssigning(false);
+      setAssigning(null);
     }
   };
 
-  const selectedRepo = repos.find((r) => r.id === selectedRepoId);
-
   return (
-    <Sheet
-      open={open}
-      onClose={onClose}
-      title="assign to repo"
-      description={<em>{draftTitle}</em>}
-    >
-      <div className={styles.body}>
-        {loading && <div className={styles.loading}>loading repos…</div>}
-        {error && <div className={styles.error}>{error}</div>}
-        {!loading && repos.length === 0 && !error && (
-          <div className={styles.empty}>
-            <em>no repos tracked yet — add one in settings</em>
-          </div>
-        )}
-        {repos.map((repo) => (
-          <button
-            key={repo.id}
-            className={
-              repo.id === selectedRepoId ? styles.rowSelected : styles.row
-            }
-            onClick={() => setSelectedRepoId(repo.id)}
-            disabled={assigning}
-          >
-            <div className={styles.repoName}>{repo.name}</div>
-            <div className={styles.repoOwner}>{repo.owner}</div>
-          </button>
-        ))}
-        <div className={styles.footer}>
-          <Button variant="ghost" onClick={onClose} disabled={assigning}>
-            cancel
-          </Button>
-          {selectedRepo && (
-            <Button
-              variant="primary"
-              onClick={handleAssign}
-              disabled={assigning}
-            >
-              {assigning ? "assigning…" : `assign to ${selectedRepo.name}`}
-            </Button>
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title="assign to repo"
+        description={<em>{draftTitle}</em>}
+      >
+        <div className={styles.body}>
+          {loading && <div className={styles.loading}>loading repos…</div>}
+          {error && !selectedRepo && <div className={styles.error}>{error}</div>}
+          {!loading && repos.length === 0 && !error && (
+            <div className={styles.empty}>
+              <em>no repos tracked yet — add one in settings</em>
+            </div>
           )}
+          {repos.map((repo) => (
+            <button
+              key={repo.id}
+              className={styles.row}
+              onClick={() => handleRepoTap(repo)}
+              disabled={assigning !== null}
+            >
+              <div className={styles.repoName}>{repo.name}</div>
+              <div className={styles.repoOwner}>{repo.owner}</div>
+              {assigning === repo.id && (
+                <div className={styles.spinner}>assigning…</div>
+              )}
+            </button>
+          ))}
+          <div className={styles.footer}>
+            <Button variant="ghost" onClick={onClose} disabled={assigning !== null}>
+              cancel
+            </Button>
+          </div>
         </div>
-      </div>
-    </Sheet>
+      </Sheet>
+
+      {selectedRepo && (
+        <ConfirmDialog
+          title="Assign to Repo"
+          message={`Assign "${draftTitle}" to ${selectedRepo.owner}/${selectedRepo.name}?`}
+          confirmLabel="Assign"
+          confirmVariant="default"
+          onConfirm={handleConfirmAssign}
+          onCancel={() => {
+            setSelectedRepo(null);
+            setError(null);
+          }}
+          isPending={assigning !== null}
+          error={error ?? undefined}
+        />
+      )}
+    </>
   );
 }

--- a/packages/web/components/ui/ConfirmDialog.tsx
+++ b/packages/web/components/ui/ConfirmDialog.tsx
@@ -8,6 +8,8 @@ type Props = {
   title: string;
   message: string;
   confirmLabel?: string;
+  /** Use "danger" (default) for destructive actions, "default" for neutral. */
+  confirmVariant?: "danger" | "default";
   onConfirm: () => void;
   onCancel: () => void;
   isPending?: boolean;
@@ -18,6 +20,7 @@ export function ConfirmDialog({
   title,
   message,
   confirmLabel = "Confirm",
+  confirmVariant = "danger",
   onConfirm,
   onCancel,
   isPending,
@@ -38,7 +41,7 @@ export function ConfirmDialog({
             variant="primary"
             onClick={onConfirm}
             disabled={isPending}
-            className={styles.danger}
+            className={confirmVariant === "danger" ? styles.danger : undefined}
           >
             {isPending ? `${confirmLabel}...` : confirmLabel}
           </Button>

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -208,6 +208,7 @@ export async function reassignIssueAction(
       newIssueNumber: number;
       newOwner: string;
       newRepo: string;
+      cleanupWarning?: string;
       cacheStale?: true;
     }
   | { success: false; error: string }
@@ -257,6 +258,12 @@ export async function reassignIssueAction(
       ? await withIdempotency(db, "reassign-issue", idempotencyKey, runReassign)
       : await runReassign();
   } catch (err) {
+    if (err instanceof DuplicateInFlightError) {
+      return {
+        success: false,
+        error: "This issue is already being re-assigned — please wait.",
+      };
+    }
     console.error("[issuectl] Failed to re-assign issue:", err);
     return { success: false, error: formatErrorForUser(err) };
   }
@@ -267,6 +274,7 @@ export async function reassignIssueAction(
     newIssueNumber: result.newIssueNumber,
     newOwner: result.newOwner,
     newRepo: result.newRepo,
+    ...(result.cleanupWarning ? { cleanupWarning: result.cleanupWarning } : {}),
     ...(stale ? { cacheStale: true as const } : {}),
   };
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -3,9 +3,11 @@
 import {
   getDb,
   getRepo,
+  getRepoById,
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,
+  reassignIssue as coreReassignIssue,
   addLabel as coreAddLabel,
   removeLabel as coreRemoveLabel,
   clearCacheKey,
@@ -13,6 +15,7 @@ import {
   withIdempotency,
   DuplicateInFlightError,
   formatErrorForUser,
+  type ReassignResult,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
@@ -192,4 +195,76 @@ export async function toggleLabel(data: {
   }
   const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+export async function reassignIssueAction(
+  oldRepoId: number,
+  issueNumber: number,
+  newRepoId: number,
+): Promise<
+  | {
+      success: true;
+      newIssueNumber: number;
+      newOwner: string;
+      newRepo: string;
+      cacheStale?: true;
+    }
+  | { success: false; error: string }
+> {
+  if (
+    typeof oldRepoId !== "number" ||
+    !Number.isInteger(oldRepoId) ||
+    oldRepoId <= 0
+  ) {
+    return { success: false, error: "oldRepoId must be a positive integer" };
+  }
+  if (
+    typeof newRepoId !== "number" ||
+    !Number.isInteger(newRepoId) ||
+    newRepoId <= 0
+  ) {
+    return { success: false, error: "newRepoId must be a positive integer" };
+  }
+  if (
+    typeof issueNumber !== "number" ||
+    !Number.isFinite(issueNumber) ||
+    issueNumber <= 0
+  ) {
+    return {
+      success: false,
+      error: "issueNumber must be a positive integer",
+    };
+  }
+  if (oldRepoId === newRepoId) {
+    return { success: false, error: "Cannot re-assign to the same repo" };
+  }
+
+  let result: ReassignResult;
+  try {
+    const db = getDb();
+    const oldRepo = getRepoById(db, oldRepoId);
+    if (!oldRepo) {
+      return { success: false, error: "Old repository is not tracked" };
+    }
+    const newRepo = getRepoById(db, newRepoId);
+    if (!newRepo) {
+      return { success: false, error: "New repository is not tracked" };
+    }
+
+    result = await withAuthRetry((octokit) =>
+      coreReassignIssue(db, octokit, oldRepoId, issueNumber, newRepoId),
+    );
+  } catch (err) {
+    console.error("[issuectl] Failed to re-assign issue:", err);
+    return { success: false, error: formatErrorForUser(err) };
+  }
+
+  const { stale } = revalidateSafely("/");
+  return {
+    success: true,
+    newIssueNumber: result.newIssueNumber,
+    newOwner: result.newOwner,
+    newRepo: result.newRepo,
+    ...(stale ? { cacheStale: true as const } : {}),
+  };
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -201,6 +201,7 @@ export async function reassignIssueAction(
   oldRepoId: number,
   issueNumber: number,
   newRepoId: number,
+  idempotencyKey?: string,
 ): Promise<
   | {
       success: true;
@@ -242,18 +243,19 @@ export async function reassignIssueAction(
   let result: ReassignResult;
   try {
     const db = getDb();
-    const oldRepo = getRepoById(db, oldRepoId);
-    if (!oldRepo) {
-      return { success: false, error: "Old repository is not tracked" };
-    }
-    const newRepo = getRepoById(db, newRepoId);
-    if (!newRepo) {
-      return { success: false, error: "New repository is not tracked" };
-    }
 
-    result = await withAuthRetry((octokit) =>
-      coreReassignIssue(db, octokit, oldRepoId, issueNumber, newRepoId),
-    );
+    const runReassign = async () => {
+      return withAuthRetry((octokit) =>
+        coreReassignIssue(db, octokit, oldRepoId, issueNumber, newRepoId),
+      );
+    };
+
+    // Idempotency guard: a retry after partial failure (new issue
+    // created but old not yet closed) replays the stored result
+    // rather than creating a duplicate issue on the target repo.
+    result = idempotencyKey
+      ? await withIdempotency(db, "reassign-issue", idempotencyKey, runReassign)
+      : await runReassign();
   } catch (err) {
     console.error("[issuectl] Failed to re-assign issue:", err);
     return { success: false, error: formatErrorForUser(err) };


### PR DESCRIPTION
## Summary
- Add confirmation step before assigning a draft to a repo — prevents accidental mis-clicks (closes #112)
- Add "Re-assign to repo" option in issue action sheet — closes the old issue, creates on the new repo, adds cross-reference comment (closes #94)
- Added `confirmVariant` prop to ConfirmDialog for non-destructive actions
- Idempotency guard on `reassignIssueAction` prevents duplicate issues on retry after partial failure

## Test plan
- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` — 398 tests pass
- [x] Assign flow: tap repo → confirm dialog → assign (cancel returns to list)
- [x] Re-assign: tap "Re-assign" → repo picker (excludes current) → confirm → creates new issue + closes old
- [x] Cross-reference comment added to old issue linking to new
- [x] Idempotency key prevents duplicate issues on retry