### PR TITLE
fix: disable worktree mode when repo has no local path

### DIFF
--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -135,8 +135,11 @@ export async function executeLaunch(
     : null;
 
   if (!repoPath && options.workspaceMode !== "clone") {
+    const modeLabel =
+      options.workspaceMode === "worktree" ? "Worktree mode" : "Existing-repo mode";
     throw new Error(
-      `No local path configured for ${options.owner}/${options.repo}. Set a local path in settings or use clone mode.`,
+      `${modeLabel} requires a local path for ${options.owner}/${options.repo}. ` +
+      `Set a local path in Settings, or use "Fresh clone" mode instead.`,
     );
   }
 

--- a/packages/web/components/launch/WorkspaceModeSelector.tsx
+++ b/packages/web/components/launch/WorkspaceModeSelector.tsx
@@ -25,16 +25,19 @@ export function WorkspaceModeSelector({
   repo,
   issueNumber,
 }: Props) {
+  const noPathHint = "Requires a local path — set one in Settings";
   const options: Option[] = [
     {
       mode: "existing",
       label: "Existing repo",
-      detail: repoLocalPath ?? "No local path configured",
+      detail: repoLocalPath ?? noPathHint,
     },
     {
       mode: "worktree",
       label: "Git worktree",
-      detail: `~/.issuectl/worktrees/${repo}-issue-${issueNumber}/ · isolated, fast, shared history`,
+      detail: repoLocalPath
+        ? `~/.issuectl/worktrees/${repo}-issue-${issueNumber}/ · isolated, fast, shared history`
+        : noPathHint,
     },
     {
       mode: "clone",
@@ -49,7 +52,9 @@ export function WorkspaceModeSelector({
       <div className={styles.options}>
         {options.map((opt) => {
           const isSelected = value === opt.mode;
-          const isDisabled = opt.mode === "existing" && !repoLocalPath;
+          const isDisabled =
+            (opt.mode === "existing" || opt.mode === "worktree") &&
+            !repoLocalPath;
           return (
             <label
               key={opt.mode}


### PR DESCRIPTION
## Summary
- Disables "Git worktree" mode in the launch workspace selector when a repo has no local path, matching the existing behavior for "Existing repo" mode (closes #92)
- Improved error message in `executeLaunch` to name the specific mode that failed and suggest "Fresh clone" as an alternative
- Most of #92 was already implemented: `addRepo` accepts optional `localPath`, the UI labels it optional, `ClonePromptModal` handles clone-on-demand at launch

## Test plan
- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo test` — 407 tests pass
- [x] Worktree mode correctly disabled when no local path set