### PR TITLE
feat(web): multi-repo selection on quick create sheet

### DIFF
--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -31,58 +31,66 @@
   font-style: italic;
 }
 
-/* ── Repo selector ─────────────────────────────────── */
+/* ── Repo chip row ────────────────────────────────── */
 
-.repoSelector {
-  margin-bottom: 10px;
+.repoSection {
+  margin-bottom: 18px;
 }
 
-.repoLabel {
-  display: block;
-  font-family: var(--paper-serif);
-  font-style: italic;
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  max-height: 72px;
+  overflow-y: auto;
+}
+
+.repoChip,
+.repoChipSelected {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-mono);
   font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-muted);
-  margin-bottom: 4px;
-}
-
-.repoSelect {
-  width: 100%;
-  font-family: var(--paper-serif);
-  font-size: var(--paper-fs-md);
-  color: var(--paper-ink);
-  background: var(--paper-bg-warm);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  line-height: 1.4;
   border: 1px solid var(--paper-line);
-  border-radius: var(--paper-radius-md);
-  padding: 8px 10px;
   cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23746a50' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 30px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
-.repoSelect:focus-visible {
-  outline: 2px solid var(--paper-accent);
-  outline-offset: 1px;
+.repoChip {
+  background: transparent;
+  color: var(--paper-ink-muted);
 }
 
-.repoSelect:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.repoChip:hover {
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink-soft);
 }
 
-.repoLoading {
-  font-family: var(--paper-serif);
-  font-style: italic;
-  font-size: var(--paper-fs-sm);
-  color: var(--paper-ink-faint);
-  padding: 6px 0;
+.repoChipSelected {
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+  border-color: var(--paper-accent-dim);
 }
 
-/* ── Actions ───────────────────────────────────────── */
+.repoChipSelected:hover {
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+}
+
+.repoChip:disabled,
+.repoChipSelected:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ── Actions / feedback ────────────────────────────── */
 
 .actions {
   display: flex;
@@ -100,6 +108,14 @@
   margin-bottom: 8px;
 }
 
+.progress {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-muted);
+  margin-bottom: 10px;
+}
+
 /* ── Desktop ───────────────────────────────────────── */
 
 @media (min-width: 768px) {
@@ -112,10 +128,6 @@
     letter-spacing: -0.4px;
     padding: 4px 0 16px;
     margin-bottom: 18px;
-  }
-
-  .repoSelector {
-    margin-bottom: 14px;
   }
 
   .actions {

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -21,30 +21,35 @@ type Props = {
   onClose: () => void;
 };
 
+function buttonLabel(repoCount: number, saving: boolean): string {
+  if (saving) return "creating\u2026";
+  if (repoCount === 0) return "save draft";
+  if (repoCount === 1) return "create issue";
+  return `create ${repoCount} issues`;
+}
+
 export function CreateDraftSheet({ open, onClose }: Props) {
   const router = useRouter();
   const { showToast } = useToast();
   const [title, setTitle] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Repo selector state
+  const [progress, setProgress] = useState<string | null>(null);
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loadingRepos, setLoadingRepos] = useState(false);
-  const [selectedRepoId, setSelectedRepoId] = useState<number | null>(null);
+  const [selectedRepoIds, setSelectedRepoIds] = useState<Set<number>>(new Set());
   const [defaultRepoId, setDefaultRepoId] = useState<number | null>(null);
 
-  // Load repos and default repo when the sheet opens.
+  // Load tracked repos and default repo when the sheet opens.
   useEffect(() => {
     if (!open) return;
-    setSelectedRepoId(null);
+    setSelectedRepoIds(new Set());
     setLoadingRepos(true);
     Promise.all([listReposAction(), getDefaultRepoIdAction()])
       .then(([repoList, defaultId]) => {
         setRepos(repoList);
-        // Pre-select default repo if it exists in the repo list.
         if (defaultId !== null && repoList.some((r) => r.id === defaultId)) {
-          setSelectedRepoId(defaultId);
+          setSelectedRepoIds(new Set([defaultId]));
           setDefaultRepoId(defaultId);
         } else {
           setDefaultRepoId(null);
@@ -57,7 +62,17 @@ export function CreateDraftSheet({ open, onClose }: Props) {
       .finally(() => setLoadingRepos(false));
   }, [open]);
 
-  const hasRepo = selectedRepoId !== null;
+  const toggleRepo = (repoId: number) => {
+    setSelectedRepoIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoId)) {
+        next.delete(repoId);
+      } else {
+        next.add(repoId);
+      }
+      return next;
+    });
+  };
 
   const handleSave = async () => {
     if (title.trim().length === 0) {
@@ -66,44 +81,56 @@ export function CreateDraftSheet({ open, onClose }: Props) {
     }
     setSaving(true);
     setError(null);
+    setProgress(null);
+
+    const selected = Array.from(selectedRepoIds);
+
+    // Persist the first selected repo as the default for next time.
+    const firstSelected = selected[0] ?? null;
+    if (firstSelected !== defaultRepoId) {
+      setDefaultRepoIdAction(firstSelected).catch((err) => {
+        console.warn("[CreateDraftSheet] Failed to save default repo", err);
+      });
+    }
 
     try {
-      // Persist the selected repo as the default for next time.
-      if (selectedRepoId !== defaultRepoId) {
-        // Fire-and-forget — don't block the save on this.
-        setDefaultRepoIdAction(selectedRepoId).catch((err) => {
-          console.warn("[CreateDraftSheet] Failed to save default repo", err);
-        });
+      if (selected.length === 0) {
+        // No repos selected — save as a plain draft.
+        const result = await createDraftAction({ title });
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+        resetAndClose();
+        return;
       }
 
-      if (hasRepo) {
-        // Create draft then immediately assign to the selected repo.
-        const createResult = await createDraftAction({ title });
-        if (!createResult.success) {
-          setError(createResult.error);
+      if (selected.length === 1) {
+        // Single repo — create one draft then assign it.
+        setProgress("Creating issue\u2026");
+        const draftResult = await createDraftAction({ title });
+        if (!draftResult.success) {
+          setError(draftResult.error);
           return;
         }
         const idempotencyKey = newIdempotencyKey();
         const assignResult = await assignDraftAction(
-          createResult.id,
-          selectedRepoId,
+          draftResult.id,
+          selected[0],
           idempotencyKey,
         );
         if (!assignResult.success) {
-          // The draft was created but assignment failed. Navigate to the
-          // draft so the user can retry assignment from there, rather
-          // than leaving an invisible orphan.
-          showToast("Issue creation failed — saved as draft", "warning");
+          showToast("Issue creation failed \u2014 saved as draft", "warning");
           resetAndClose();
-          router.push(`/drafts/${createResult.id}`);
+          router.push(`/drafts/${draftResult.id}`);
           return;
         }
-        const repo = repos.find((r) => r.id === selectedRepoId);
         if (assignResult.cleanupWarning) {
           showToast(assignResult.cleanupWarning, "warning");
         } else {
           showToast(`Issue #${assignResult.issueNumber} created`, "success");
         }
+        const repo = repos.find((r) => r.id === selected[0]);
         resetAndClose();
         if (repo && assignResult.issueNumber) {
           router.push(
@@ -112,42 +139,79 @@ export function CreateDraftSheet({ open, onClose }: Props) {
         } else {
           router.push("/");
         }
-      } else {
-        // Save as local draft (existing behavior).
-        const result = await createDraftAction({ title });
-        if (!result.success) {
-          setError(result.error);
+        return;
+      }
+
+      // Multiple repos — create one draft+issue per selected repo.
+      let created = 0;
+      let lastWarning: string | undefined;
+      for (let i = 0; i < selected.length; i++) {
+        setProgress(`Creating ${i + 1} of ${selected.length}\u2026`);
+        const draftResult = await createDraftAction({ title });
+        if (!draftResult.success) {
+          setError(
+            `Failed on repo ${i + 1} of ${selected.length}: ${draftResult.error}`,
+          );
           return;
         }
-        resetAndClose();
+        const idempotencyKey = newIdempotencyKey();
+        const assignResult = await assignDraftAction(
+          draftResult.id,
+          selected[i],
+          idempotencyKey,
+        );
+        if (!assignResult.success) {
+          setError(
+            `Failed on repo ${i + 1} of ${selected.length}: ${assignResult.error}`,
+          );
+          return;
+        }
+        if (assignResult.cleanupWarning) {
+          lastWarning = assignResult.cleanupWarning;
+        }
+        created++;
       }
+
+      if (lastWarning) {
+        showToast(lastWarning, "warning");
+      } else {
+        showToast(`${created} issues created`, "success");
+      }
+      resetAndClose();
+      router.push("/");
     } catch (err) {
       console.error("[CreateDraftSheet] handleSave failed", err);
       setError("Failed to save");
     } finally {
       setSaving(false);
+      setProgress(null);
     }
   };
 
   const resetAndClose = () => {
     setTitle("");
     setError(null);
-    setSelectedRepoId(null);
+    setProgress(null);
+    setSelectedRepoIds(new Set());
     onClose();
   };
 
   const handleClose = () => {
     setTitle("");
     setError(null);
-    setSelectedRepoId(null);
+    setProgress(null);
+    setSelectedRepoIds(new Set());
     onClose();
   };
 
-  const description = hasRepo ? (
-    <em>create a GitHub issue directly</em>
-  ) : (
-    <em>a local draft without a repo — assign it later</em>
-  );
+  const description =
+    selectedRepoIds.size === 0 ? (
+      <em>a local draft without a repo — assign it later</em>
+    ) : selectedRepoIds.size === 1 ? (
+      <em>create a GitHub issue directly</em>
+    ) : (
+      <em>create an issue on {selectedRepoIds.size} repos</em>
+    );
 
   return (
     <Sheet open={open} onClose={handleClose} title="New issue" description={description}>
@@ -169,39 +233,36 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           autoCorrect="on"
           spellCheck
           enterKeyHint="done"
-          style={
-            title.length > 50 ? { fontSize: 20, lineHeight: 1.3 } : undefined
-          }
+          style={title.length > 50 ? { fontSize: 20, lineHeight: 1.3 } : undefined}
         />
 
-        {/* Repo selector */}
-        <div className={styles.repoSelector}>
-          <label htmlFor="create-draft-repo" className={styles.repoLabel}>
-            Repo (optional)
-          </label>
-          {loadingRepos ? (
-            <div className={styles.repoLoading}>loading repos...</div>
-          ) : (
-            <select
-              id="create-draft-repo"
-              className={styles.repoSelect}
-              value={selectedRepoId ?? ""}
-              onChange={(e) => {
-                const val = e.target.value;
-                setSelectedRepoId(val ? Number(val) : null);
-              }}
-              disabled={saving || repos.length === 0}
-            >
-              <option value="">none — save as draft</option>
-              {repos.map((repo) => (
-                <option key={repo.id} value={repo.id}>
-                  {repo.owner}/{repo.name}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
+        {/* Repo chip row — toggleable multi-select */}
+        {!loadingRepos && repos.length > 0 && (
+          <div className={styles.repoSection}>
+            <label className={styles.label}>Repos</label>
+            <div className={styles.chipRow}>
+              {repos.map((repo) => {
+                const isSelected = selectedRepoIds.has(repo.id);
+                return (
+                  <button
+                    key={repo.id}
+                    type="button"
+                    className={
+                      isSelected ? styles.repoChipSelected : styles.repoChip
+                    }
+                    onClick={() => toggleRepo(repo.id)}
+                    disabled={saving}
+                    aria-pressed={isSelected}
+                  >
+                    {repo.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
+        {progress && <div className={styles.progress}>{progress}</div>}
         {error && <div className={styles.error}>{error}</div>}
         <div className={styles.actions}>
           <Button variant="ghost" onClick={handleClose} disabled={saving}>
@@ -212,13 +273,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
             onClick={handleSave}
             disabled={saving || title.trim().length === 0}
           >
-            {saving
-              ? hasRepo
-                ? "creating..."
-                : "saving..."
-              : hasRepo
-                ? "create issue"
-                : "save draft"}
+            {buttonLabel(selectedRepoIds.size, saving)}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace single-select repo dropdown with multi-select toggleable chip row on CreateDraftSheet (closes #102)
- No repos selected: save as draft | 1 repo: create issue | N repos: create N issues with progress indicator
- Preserves default repo pre-selection from #111
- Preserves orphan draft recovery and error logging from review fixes
- Compact chip row with `max-height: 72px` and scroll for many repos on mobile

## Test plan
- [x] `pnpm turbo typecheck` passes (core + web)
- [x] `pnpm turbo test` — 407 tests pass
- [x] Multi-create shows "Creating 1 of 3..." progress
- [x] Default repo chip pre-selected on open
- [x] Button text updates: "save draft" / "create issue" / "create N issues"