### PR TITLE
feat: show issue author in list rows (#130)

### DIFF
--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -151,3 +151,10 @@
   color: var(--paper-ink-faint);
 }
 
+.author {
+  color: var(--paper-ink-faint);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -104,6 +104,12 @@ export function ListRow({ item }: Props) {
           )}
           <span className={styles.sep}>·</span>
           <span>{formatAge(issue.updatedAt)}</span>
+          {issue.user && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.author}>{issue.user.login}</span>
+            </>
+          )}
         </div>
       </Link>
       <div className={styles.actions}>


### PR DESCRIPTION
## Summary
- Display `issue.user.login` in the meta row of `ListRow` for non-draft items, after the age span
- Add `.author` CSS class with ellipsis truncation at 120px max-width for long usernames (e.g. `dependabot[bot]`)
- Use `--paper-ink-faint` design token to match `.num` styling in the meta row

Closes #130

## Test plan
- [x] Typecheck passes (`pnpm turbo typecheck`)
- [x] Lint passes (pre-commit hook)
- [x] PR review toolkit: code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer, code-simplifier — all clean
- [ ] CI passes
- [ ] Visual check: author appears after age in list rows, truncates long names with ellipsis