### PR TITLE
feat: show standard label tags in draft creation (#132)

### DIFF
--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -137,8 +137,8 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
       <div className={styles.form}>
         {initError && (
           <div className={styles.initError} role="alert">
-            Couldn't load labels from GitHub: {initError}. You can still create
-            the issue — label chips will be empty.
+            Couldn't load labels from GitHub: {initError}. Showing default
+            labels instead.
           </div>
         )}
 

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -18,6 +18,13 @@ type Props = {
   initError?: string;
 };
 
+const STANDARD_LABELS: GitHubLabel[] = [
+  { name: "bug", color: "d73a4a", description: null },
+  { name: "enhancement", color: "a2eeef", description: null },
+  { name: "documentation", color: "0075ca", description: null },
+  { name: "question", color: "d876e3", description: null },
+];
+
 function selectedChipStyle(label: GitHubLabel): React.CSSProperties {
   if (label.color) {
     return {
@@ -42,10 +49,12 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
   const [error, setError] = useState<string | null>(null);
 
   const repoKey = `${selectedRepo.owner}/${selectedRepo.repo}`;
-  const availableLabels = useMemo(
-    () => (labelsPerRepo[repoKey] ?? []).filter((l) => !isLifecycleLabel(l.name)),
-    [labelsPerRepo, repoKey],
-  );
+  const availableLabels = useMemo(() => {
+    const repoLabels = (labelsPerRepo[repoKey] ?? []).filter(
+      (l) => !isLifecycleLabel(l.name),
+    );
+    return repoLabels.length > 0 ? repoLabels : STANDARD_LABELS;
+  }, [labelsPerRepo, repoKey]);
 
   function handleSelectRepo(repo: RepoOption) {
     setSelectedRepo(repo);

--- a/packages/web/app/new/page.tsx
+++ b/packages/web/app/new/page.tsx
@@ -62,7 +62,7 @@ export default async function NewIssueRoute() {
           const labels = await listLabels(octokit, r.owner, r.name);
           return { key: `${r.owner}/${r.name}`, labels };
         } catch (err) {
-          // Non-fatal — repo still selectable, just renders with no label chips.
+          // Non-fatal — repo still selectable, falls back to standard labels.
           console.warn(
             `[issuectl] Failed to fetch labels for ${r.owner}/${r.name}:`,
             err instanceof Error ? err.message : err,

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -138,3 +138,13 @@
     flex: 0 0 auto;
   }
 }
+
+.labelLink {
+  display: block;
+  text-align: center;
+  padding: 8px 0;
+  font-family: var(--paper-serif);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-muted);
+  text-decoration: none;
+}

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button, Sheet } from "@/components/paper";
 import {
@@ -276,6 +277,9 @@ export function CreateDraftSheet({ open, onClose }: Props) {
             {buttonLabel(selectedRepoIds.size, saving)}
           </Button>
         </div>
+        <Link href="/new" className={styles.labelLink} onClick={onClose}>
+          or create with labels and repo →
+        </Link>
       </div>
     </Sheet>
   );


### PR DESCRIPTION
## Summary

- Add "or create with labels and repo →" link in CreateDraftSheet, linking to the full `/new` page
- Show standard fallback labels (bug, enhancement, documentation, question) in NewIssuePage when repo-specific labels are unavailable
- Fix stale comments and use correct design tokens (`--paper-ink-muted`, `--paper-serif`)

Closes #132

## Test plan

- [ ] Open the FAB quick-create sheet — verify "or create with labels and repo →" link appears below the save button
- [ ] Click the link — verify it closes the sheet and navigates to `/new`
- [ ] On `/new`, select a repo with no cached labels — verify the 4 standard labels (bug, enhancement, documentation, question) appear as chips
- [ ] Select a repo with cached labels — verify repo-specific labels appear instead of the fallback
- [ ] Trigger a label fetch error (e.g., disconnect network) — verify the initError banner says "Showing default labels instead"
- [ ] Typecheck passes: `pnpm turbo typecheck`