### PR TITLE
fix: data freshness bugs (#128, #129, #131, #135)

### DIFF
--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -29,6 +29,9 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
       } else {
         setBody("");
         router.refresh();
+        if (result.cacheStale) {
+          setError("Comment posted — reload the page if it doesn't appear.");
+        }
       }
     } catch {
       setError("Failed to post comment");

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
+import { useToast } from "@/components/ui/ToastProvider";
 import { addComment } from "@/lib/actions/comments";
 import styles from "./CommentComposer.module.css";
 
@@ -14,6 +15,7 @@ type Props = {
 
 export function CommentComposer({ owner, repo, issueNumber }: Props) {
   const router = useRouter();
+  const { showToast } = useToast();
   const [body, setBody] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -30,7 +32,7 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
         setBody("");
         router.refresh();
         if (result.cacheStale) {
-          setError("Comment posted — reload the page if it doesn't appear.");
+          showToast("Comment posted — reload if it doesn't appear", "success");
         }
       }
     } catch {

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { addComment } from "@/lib/actions/comments";
 import styles from "./CommentComposer.module.css";
@@ -12,6 +13,7 @@ type Props = {
 };
 
 export function CommentComposer({ owner, repo, issueNumber }: Props) {
+  const router = useRouter();
   const [body, setBody] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -26,6 +28,7 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
         setError(result.error ?? "Failed to post comment");
       } else {
         setBody("");
+        router.refresh();
       }
     } catch {
       setError("Failed to post comment");

--- a/packages/web/components/detail/DetailTopBar.tsx
+++ b/packages/web/components/detail/DetailTopBar.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import type { ReactNode } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import styles from "./DetailTopBar.module.css";
 
 type Props = {
@@ -13,9 +16,25 @@ export function DetailTopBar({
   crumb,
   menu,
 }: Props) {
+  const router = useRouter();
+
+  function handleBack(e: React.MouseEvent) {
+    // Use browser history when available so filter state is preserved.
+    // Fall back to the hard link when there's no history (e.g. direct URL visit).
+    if (window.history.length > 1) {
+      e.preventDefault();
+      router.back();
+    }
+  }
+
   return (
     <div className={styles.bar}>
-      <Link href={backHref} className={styles.back} aria-label="Back">
+      <Link
+        href={backHref}
+        className={styles.back}
+        aria-label="Back"
+        onClick={handleBack}
+      >
         <svg
           width="12"
           height="20"

--- a/packages/web/components/detail/DetailTopBar.tsx
+++ b/packages/web/components/detail/DetailTopBar.tsx
@@ -19,9 +19,14 @@ export function DetailTopBar({
   const router = useRouter();
 
   function handleBack(e: React.MouseEvent) {
-    // Use browser history when available so filter state is preserved.
-    // Fall back to the hard link when there's no history (e.g. direct URL visit).
-    if (window.history.length > 1) {
+    // Use browser history when the referrer is our own app, so filter
+    // state in query params is preserved. When the user arrived from an
+    // external link (Slack, email, etc.), fall through to the hard
+    // <Link> href to avoid navigating them out of the app.
+    if (
+      window.history.length > 1 &&
+      document.referrer.startsWith(window.location.origin)
+    ) {
       e.preventDefault();
       router.back();
     }

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -192,3 +192,28 @@ test.describe("Data freshness — comment appears immediately (#135)", () => {
     await expect(page.getByText(commentText)).toBeVisible({ timeout: 10000 });
   });
 });
+
+// ── A2: New issue visible on dashboard after creation (#128) ────────
+
+test.describe("Data freshness — new issue visible on dashboard (#128)", () => {
+  test("issue appears on index page after creation without manual refresh", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/new`);
+    await expect(page.locator('input[type="text"]').first()).toBeVisible({ timeout: 15000 });
+
+    const issueTitle = `E2E freshness test ${Date.now()}`;
+    await page.locator('input[type="text"]').first().fill(issueTitle);
+    await page.click('button:has-text("Create")');
+
+    // After creation, the app navigates to the issue detail
+    await expect(page).toHaveURL(/\/issues\//, { timeout: 15000 });
+
+    // Navigate back to dashboard
+    await page.click('a[aria-label="Back"]');
+    await page.waitForLoadState("networkidle");
+
+    // The issue should be visible without pulling to refresh
+    await expect(page.getByText(issueTitle)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -114,6 +114,7 @@ let tmpDir: string;
 let dbPath: string;
 let server: ChildProcess;
 let skipReason: string | undefined;
+const createdIssueNumbers: number[] = [];
 
 test.beforeAll(async () => {
   const check = await canRun();
@@ -145,6 +146,22 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
+  for (const num of createdIssueNumbers) {
+    try {
+      await execFileAsync("gh", [
+        "issue",
+        "close",
+        String(num),
+        "--repo",
+        `${TEST_OWNER}/${TEST_REPO}`,
+        "--reason",
+        "not planned",
+      ]);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
   if (server) {
     const killTimeout = setTimeout(() => {
       try {
@@ -209,6 +226,10 @@ test.describe("Data freshness — new issue visible on dashboard (#128)", () => 
     // After creation, the app navigates to the issue detail
     await expect(page).toHaveURL(/\/issues\//, { timeout: 15000 });
 
+    // Track created issue for cleanup
+    const match = page.url().match(/\/issues\/(\d+)/);
+    if (match) createdIssueNumbers.push(Number(match[1]));
+
     // Navigate back to dashboard
     await page.click('a[aria-label="Back"]');
     await page.waitForLoadState("networkidle");
@@ -228,16 +249,21 @@ test.describe("Data freshness — filters persist on back-nav (#129)", () => {
     await page.waitForLoadState("networkidle");
 
     const issueLink = page.locator('a[href*="/issues/"]').first();
-    if (await issueLink.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await issueLink.click();
-      await page.waitForLoadState("networkidle");
-
-      // Click back
-      await page.click('a[aria-label="Back"]');
-      await page.waitForLoadState("networkidle");
-
-      // URL should still have the repo filter
-      expect(page.url()).toContain(`repo=${TEST_OWNER}/${TEST_REPO}`);
+    const isVisible = await issueLink.isVisible({ timeout: 5000 });
+    if (!isVisible) {
+      test.skip(true, "No issues visible for filter persistence test — check test data");
+      return;
     }
+
+    await issueLink.click();
+    await page.waitForLoadState("networkidle");
+
+    // Click back
+    await page.click('a[aria-label="Back"]');
+    await page.waitForLoadState("networkidle");
+
+    // URL should still have both query params
+    expect(page.url()).toContain(`repo=${TEST_OWNER}/${TEST_REPO}`);
+    expect(page.url()).toContain("section=in_focus");
   });
 });

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -89,23 +89,18 @@ function createTestDb(dbPath: string): void {
   db.close();
 }
 
-function waitForServer(url: string, timeoutMs: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + timeoutMs;
-    const check = () => {
-      fetch(url)
-        .then((res) => {
-          if (res.ok || res.status === 404) resolve();
-          else if (Date.now() > deadline) reject(new Error("Server timeout"));
-          else setTimeout(check, 500);
-        })
-        .catch(() => {
-          if (Date.now() > deadline) reject(new Error("Server timeout"));
-          else setTimeout(check, 500);
-        });
-    };
-    check();
-  });
+async function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok || res.status === 404) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error("Server timeout");
 }
 
 // ── Test suite ──────────────────────────────────────────────────────

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_PORT = 3856;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// ── Skip conditions ─────────────────────────────────────────────────
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+
+  return { ok: true };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS repos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      owner TEXT NOT NULL,
+      name TEXT NOT NULL,
+      local_path TEXT,
+      branch_pattern TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(owner, name)
+    );
+    CREATE TABLE IF NOT EXISTS deployments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_id INTEGER NOT NULL REFERENCES repos(id),
+      issue_number INTEGER NOT NULL,
+      branch_name TEXT NOT NULL,
+      workspace_mode TEXT NOT NULL,
+      workspace_path TEXT NOT NULL,
+      linked_pr_number INTEGER,
+      launched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS cache (
+      key TEXT PRIMARY KEY,
+      data TEXT NOT NULL,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  db.prepare("INSERT OR IGNORE INTO schema_version (version) VALUES (?)").run(4);
+
+  const defaults = [
+    ["branch_pattern", "issue-{number}-{slug}"],
+    ["terminal_app", "iterm2"],
+    ["terminal_window_title", "issuectl"],
+    ["terminal_tab_title_pattern", "#{number} — {title}"],
+    ["cache_ttl", "300"],
+    ["worktree_dir", "~/.issuectl/worktrees/"],
+  ];
+  const insertSetting = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+  );
+  for (const [key, value] of defaults) {
+    insertSetting.run(key, value);
+  }
+
+  db.prepare(
+    "INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)",
+  ).run(TEST_OWNER, TEST_REPO);
+
+  db.close();
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+// ── Test suite ──────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-df-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, ISSUECTL_DB_PATH: dbPath },
+    stdio: "pipe",
+  });
+
+  let serverStderr = "";
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderr += chunk.toString();
+  });
+
+  await waitForServer(BASE_URL, 30000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderr.slice(-500)}`,
+    );
+  });
+});
+
+test.afterAll(async () => {
+  if (server) {
+    const killTimeout = setTimeout(() => {
+      try {
+        server.kill("SIGKILL");
+      } catch {
+        /* already dead */
+      }
+    }, 5000);
+
+    server.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── A1: Comment appears immediately after posting (#135, #131) ──────
+
+test.describe("Data freshness — comment appears immediately (#135)", () => {
+  test("comment is visible after posting without manual refresh", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/`);
+    const issueLink = page.locator('a[href*="/issues/"]').first();
+    await expect(issueLink).toBeVisible({ timeout: 15000 });
+    await issueLink.click();
+
+    const textarea = page.locator('textarea[aria-label="Comment body"]');
+    await expect(textarea).toBeVisible({ timeout: 15000 });
+
+    const commentText = `E2E test comment ${Date.now()}`;
+    await textarea.fill(commentText);
+    await page.click('button:has-text("comment")');
+
+    // Comment should be visible WITHOUT a manual page refresh
+    await expect(page.getByText(commentText)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -217,3 +217,27 @@ test.describe("Data freshness — new issue visible on dashboard (#128)", () => 
     await expect(page.getByText(issueTitle)).toBeVisible({ timeout: 10000 });
   });
 });
+
+// ── A3: Filters persist on back-navigation (#129) ──────────────────
+
+test.describe("Data freshness — filters persist on back-nav (#129)", () => {
+  test("repo filter preserved when navigating back from issue detail", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/?repo=${TEST_OWNER}/${TEST_REPO}&section=in_focus`);
+    await page.waitForLoadState("networkidle");
+
+    const issueLink = page.locator('a[href*="/issues/"]').first();
+    if (await issueLink.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await issueLink.click();
+      await page.waitForLoadState("networkidle");
+
+      // Click back
+      await page.click('a[aria-label="Back"]');
+      await page.waitForLoadState("networkidle");
+
+      // URL should still have the repo filter
+      expect(page.url()).toContain(`repo=${TEST_OWNER}/${TEST_REPO}`);
+    }
+  });
+});

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -84,7 +84,7 @@ export async function createIssue(data: {
     return { success: false, error: formatErrorForUser(err) };
   }
 
-  const { stale } = revalidateSafely(`/${owner}/${repo}`);
+  const { stale } = revalidateSafely("/", `/${owner}/${repo}`);
   return {
     success: true,
     issueNumber,


### PR DESCRIPTION
## Summary
- **CommentComposer**: add `router.refresh()` after successful comment post so it appears immediately without manual page reload (#135, #131). Surface `cacheStale` hint via toast when server-side revalidation fails.
- **createIssue action**: revalidate `"/"` in addition to `"/${owner}/${repo}"` so newly created issues appear on the dashboard (#128)
- **DetailTopBar**: convert to client component with `router.back()` + `document.referrer` guard to preserve filter query params on back-navigation without navigating users out of the app (#129)
- **E2E**: new `data-freshness.spec.ts` covering all three fixes with proper cleanup and explicit skip behavior

## Test plan
- [ ] Post a comment on an issue detail page — it should appear immediately without refreshing
- [ ] Create a new issue — it should appear on the dashboard (`/`) after navigating back
- [ ] Apply repo + section filters on the dashboard, open an issue, click back — filters should be preserved in the URL
- [ ] Open an issue detail page directly from an external link — back button should navigate to `/`, not out of the app
- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo test` passes (347 core + 60 web)