### PR TITLE
fix: surface cacheStale hints across all mutation flows

### DIFF
--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -88,7 +88,12 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
           return;
         }
 
-        showToast("Issue created", "success");
+        showToast(
+          result.cacheStale
+            ? "Issue created — reload if it doesn't appear"
+            : "Issue created",
+          "success",
+        );
         router.push(
           `/issues/${selectedRepo.owner}/${selectedRepo.repo}/${result.issueNumber}`,
         );

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -31,13 +31,16 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
       } else {
         setBody("");
         router.refresh();
-        if (result.cacheStale) {
-          showToast("Comment posted — reload if it doesn't appear", "success");
-        }
+        showToast(
+          result.cacheStale
+            ? "Comment posted — reload if it doesn't appear"
+            : "Comment posted",
+          "success",
+        );
       }
     } catch (err) {
       console.error("[issuectl] addComment threw:", err);
-      setError("Failed to post comment");
+      setError(err instanceof Error ? err.message : "Failed to post comment");
     } finally {
       setSending(false);
     }

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -35,7 +35,8 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
           showToast("Comment posted — reload if it doesn't appear", "success");
         }
       }
-    } catch {
+    } catch (err) {
+      console.error("[issuectl] addComment threw:", err);
       setError("Failed to post comment");
     } finally {
       setSending(false);

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -117,7 +117,12 @@ export function IssueActionSheet({
           return;
         }
         setConfirmClose(false);
-        showToast("Issue closed", "success");
+        showToast(
+          result.cacheStale
+            ? "Issue closed — reload if the list looks stale"
+            : "Issue closed",
+          "success",
+        );
         router.push("/?section=shipped");
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
@@ -158,8 +163,9 @@ export function IssueActionSheet({
       if (result.cleanupWarning) {
         showToast(result.cleanupWarning, "warning");
       } else {
+        const msg = `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`;
         showToast(
-          `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`,
+          result.cacheStale ? `${msg} — reload if the list looks stale` : msg,
           "success",
         );
       }

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -161,7 +161,8 @@ export function IssueActionSheet({
       setSelectedRepo(null);
       setReassignSheetOpen(false);
       if (result.cleanupWarning) {
-        showToast(result.cleanupWarning, "warning");
+        const suffix = result.cacheStale ? " Reload if the list looks stale." : "";
+        showToast(`${result.cleanupWarning}${suffix}`, "warning");
       } else {
         const msg = `Issue moved to ${result.newOwner}/${result.newRepo}#${result.newIssueNumber}`;
         showToast(


### PR DESCRIPTION
## Summary
- **CommentComposer**: always show toast on comment success, log errors with console.error, extract err.message in catch block
- **NewIssuePage**: show degraded toast when createIssue cache revalidation fails
- **IssueActionSheet**: show degraded toast for closeIssue and reassignIssueAction; append stale hint to cleanupWarning when both present

Follow-up from PR #144 review.

## Test plan
- Post a comment — toast should say Comment posted
- Create an issue — toast should say Issue created
- Close an issue — toast should say Issue closed
- Re-assign an issue — toast should show the new location
- pnpm turbo typecheck passes