### PR TITLE
chore: ignore PNG screenshots in repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 .worktrees/
 .superpowers/
 
+# Screenshots (local QA/mockup references, not tracked)
+*.png
+
 # QA tool caches and run artifacts
 .playwright-cli/
 .playwright-mcp/


### PR DESCRIPTION
## Summary
- Adds `*.png` to `.gitignore` so local QA/mockup screenshots don't get tracked

## Test plan
- [x] No code changes — gitignore only