### PR TITLE
fix: log first-attempt revalidation failure before retry

### DIFF
--- a/packages/web/lib/revalidate.ts
+++ b/packages/web/lib/revalidate.ts
@@ -18,7 +18,8 @@ export function revalidateSafely(...paths: string[]): { stale: boolean } {
   for (const path of paths) {
     try {
       revalidatePath(path);
-    } catch {
+    } catch (firstErr) {
+      console.debug("[issuectl] Cache revalidation failed, retrying", { path }, firstErr);
       try {
         revalidatePath(path);
       } catch (err) {

--- a/packages/web/lib/revalidate.ts
+++ b/packages/web/lib/revalidate.ts
@@ -19,7 +19,7 @@ export function revalidateSafely(...paths: string[]): { stale: boolean } {
     try {
       revalidatePath(path);
     } catch (firstErr) {
-      console.debug("[issuectl] Cache revalidation failed, retrying", { path }, firstErr);
+      console.warn("[issuectl] Cache revalidation failed, retrying", { path }, firstErr);
       try {
         revalidatePath(path);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Log the first-attempt revalidatePath failure with console.warn before retrying
- Previously the outer catch discarded the error silently — transient failures were invisible unless both attempts failed
- Enables operators to spot intermittent revalidation issues before they escalate

## Context
Identified during PR #144 review by the silent-failure-hunter agent. The revalidateSafely helper retries once on failure, but only logged when the retry also failed — making transient issues completely invisible.

## Test plan
- pnpm turbo typecheck passes
- pnpm turbo test passes
- No functional behavior change — only adds logging