### PR TITLE
feat: offline mode with client-side queue and sync (#138)

### DIFF
--- a/packages/core/src/db/cache.ts
+++ b/packages/core/src/db/cache.ts
@@ -50,6 +50,14 @@ export function clearCacheKey(
   db.prepare("DELETE FROM cache WHERE key = ?").run(key);
 }
 
+export function getOldestCacheAge(db: Database.Database): number | null {
+  const row = db
+    .prepare("SELECT MIN(fetched_at) as oldest FROM cache")
+    .get() as { oldest: string | null } | undefined;
+  if (!row?.oldest) return null;
+  return new Date(row.oldest + "Z").getTime();
+}
+
 export function clearCache(
   db: Database.Database,
   keyPattern?: string,

--- a/packages/core/src/db/cache.ts
+++ b/packages/core/src/db/cache.ts
@@ -51,11 +51,16 @@ export function clearCacheKey(
 }
 
 export function getOldestCacheAge(db: Database.Database): number | null {
-  const row = db
-    .prepare("SELECT MIN(fetched_at) as oldest FROM cache")
-    .get() as { oldest: string | null } | undefined;
-  if (!row?.oldest) return null;
-  return new Date(row.oldest + "Z").getTime();
+  try {
+    const row = db
+      .prepare("SELECT MIN(fetched_at) as oldest FROM cache")
+      .get() as { oldest: string | null } | undefined;
+    if (!row?.oldest) return null;
+    return new Date(row.oldest + "Z").getTime();
+  } catch {
+    // Column may not exist in older schema versions
+    return null;
+  }
 }
 
 export function clearCache(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export {
   isFresh,
   clearCacheKey,
   clearCache,
+  getOldestCacheAge,
 } from "./db/cache.js";
 export {
   withIdempotency,

--- a/packages/web/app/api/health/route.ts
+++ b/packages/web/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ ok: true });
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -70,9 +70,11 @@ export default async function RootLayout({ children }: Props) {
       className={`${fraunces.variable} ${inter.variable} ${ibmPlexMono.variable}`}
     >
       <body>
-        <OfflineIndicator />
         {auth.authenticated ? (
-          <ToastProvider>{children}</ToastProvider>
+          <ToastProvider>
+            <OfflineIndicator />
+            {children}
+          </ToastProvider>
         ) : (
           <AuthErrorScreen />
         )}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -5,6 +5,7 @@ import {
   getPulls,
   listRepos,
   dbExists,
+  getOldestCacheAge,
   SORT_MODES,
   type GitHubPull,
   type Section,
@@ -77,6 +78,7 @@ export default async function MainListPage({ searchParams }: Props) {
     getUnifiedList(db, octokit, activeSort),
     gatherPulls(db, octokit, repos),
   ]);
+  const cachedAt = getOldestCacheAge(db);
 
   const username = auth.authenticated ? auth.username : null;
   const filteredData = filterUnifiedList(data, activeRepo);
@@ -94,6 +96,7 @@ export default async function MainListPage({ searchParams }: Props) {
       repos={repos.map((r) => ({ owner: r.owner, name: r.name }))}
       activeRepo={activeRepo}
       mineOnly={mineOnly}
+      cachedAt={cachedAt}
     />
   );
 }

--- a/packages/web/components/detail/ActionSheet.module.css
+++ b/packages/web/components/detail/ActionSheet.module.css
@@ -38,3 +38,14 @@
   text-align: center;
   flex-shrink: 0;
 }
+
+.disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.offlineHint {
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  margin-left: auto;
+}

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
 import { addComment } from "@/lib/actions/comments";
 import { tryOrQueue } from "@/lib/tryOrQueue";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
 import styles from "./CommentComposer.module.css";
 
 type Props = {
@@ -26,10 +27,12 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
     setSending(true);
     setError(null);
     try {
+      const nonce = newIdempotencyKey();
       const result = await tryOrQueue(
         "addComment",
         { owner, repo, issueNumber, body },
-        () => addComment(owner, repo, issueNumber, body),
+        () => addComment(owner, repo, issueNumber, body, nonce),
+        { nonce },
       );
 
       if (result.outcome === "queued") {

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
 import { addComment } from "@/lib/actions/comments";
+import { tryOrQueue } from "@/lib/tryOrQueue";
 import styles from "./CommentComposer.module.css";
 
 type Props = {
@@ -25,19 +26,33 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
     setSending(true);
     setError(null);
     try {
-      const result = await addComment(owner, repo, issueNumber, body);
-      if (!result.success) {
-        setError(result.error ?? "Failed to post comment");
-      } else {
+      const result = await tryOrQueue(
+        "addComment",
+        { owner, repo, issueNumber, body },
+        () => addComment(owner, repo, issueNumber, body),
+      );
+
+      if (result.outcome === "queued") {
         setBody("");
-        router.refresh();
-        showToast(
-          result.cacheStale
-            ? "Comment posted — reload if it doesn't appear"
-            : "Comment posted",
-          "success",
-        );
+        showToast("Comment queued — will sync when online", "warning");
+        return;
       }
+
+      if (result.outcome === "error") {
+        setError(result.error);
+        return;
+      }
+
+      // succeeded
+      setBody("");
+      router.refresh();
+      const data = result.data as { cacheStale?: boolean };
+      showToast(
+        data.cacheStale
+          ? "Comment posted — reload if it doesn't appear"
+          : "Comment posted",
+        "success",
+      );
     } catch (err) {
       console.error("[issuectl] addComment threw:", err);
       setError(err instanceof Error ? err.message : "Failed to post comment");

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -16,6 +16,7 @@ import { getComments } from "@/lib/actions/comments";
 import { listReposAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
+import { useOfflineAware } from "@/hooks/useOfflineAware";
 import styles from "./ActionSheet.module.css";
 import assignStyles from "../list/AssignSheet.module.css";
 
@@ -61,6 +62,8 @@ export function IssueActionSheet({
   const [reassigning, setReassigning] = useState(false);
   const [reassignError, setReassignError] = useState<string | null>(null);
   const [reassignKey, setReassignKey] = useState<string | null>(null);
+
+  const { isOffline } = useOfflineAware();
 
   useEffect(() => {
     if (!launchOpen) return;
@@ -203,16 +206,23 @@ export function IssueActionSheet({
             Launch with Claude
           </button>
         )}
-        <button className={styles.item} onClick={handleReassignTap}>
+        <button
+          className={`${styles.item} ${isOffline ? styles.disabled : ""}`}
+          onClick={isOffline ? undefined : handleReassignTap}
+          disabled={isOffline}
+        >
           <span className={styles.icon}>&harr;</span>
           Re-assign to repo
+          {isOffline && <span className={styles.offlineHint}>Requires connection</span>}
         </button>
         <button
-          className={`${styles.item} ${styles.danger}`}
-          onClick={handleCloseTap}
+          className={`${styles.item} ${styles.danger} ${isOffline ? styles.disabled : ""}`}
+          onClick={isOffline ? undefined : handleCloseTap}
+          disabled={isOffline}
         >
           <span className={styles.icon}>&bull;</span>
           Close issue
+          {isOffline && <span className={styles.offlineHint}>Requires connection</span>}
         </button>
       </Sheet>
 

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import type { GitHubLabel } from "@issuectl/core";
 import { toggleLabel } from "@/lib/actions/issues";
+import { tryOrQueue } from "@/lib/tryOrQueue";
 import { separateLabels } from "@/lib/labels";
 import { useToast } from "@/components/ui/ToastProvider";
 import { Badge } from "@/components/ui/Badge";
@@ -37,18 +38,23 @@ export function LabelManager({
     setError(null);
     const action = selectedNames.includes(label) ? "remove" : "add";
     startTransition(async () => {
-      const result = await toggleLabel({
-        owner,
-        repo,
-        number: issueNumber,
-        label,
-        action,
-      });
-      if (!result.success) {
-        setError(result.error ?? "Failed to update label");
-      } else {
-        showToast("Labels updated", "success");
+      const result = await tryOrQueue(
+        "toggleLabel",
+        { owner, repo, issueNumber, label, action },
+        () => toggleLabel({ owner, repo, number: issueNumber, label, action }),
+      );
+
+      if (result.outcome === "queued") {
+        showToast("Label change queued — will sync when online", "warning");
+        return;
       }
+
+      if (result.outcome === "error") {
+        setError(result.error);
+        return;
+      }
+
+      showToast("Labels updated", "success");
     });
   }
 

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -38,23 +38,28 @@ export function LabelManager({
     setError(null);
     const action = selectedNames.includes(label) ? "remove" : "add";
     startTransition(async () => {
-      const result = await tryOrQueue(
-        "toggleLabel",
-        { owner, repo, issueNumber, label, action },
-        () => toggleLabel({ owner, repo, number: issueNumber, label, action }),
-      );
+      try {
+        const result = await tryOrQueue(
+          "toggleLabel",
+          { owner, repo, issueNumber, label, action },
+          () => toggleLabel({ owner, repo, number: issueNumber, label, action }),
+        );
 
-      if (result.outcome === "queued") {
-        showToast("Label change queued — will sync when online", "warning");
-        return;
+        if (result.outcome === "queued") {
+          showToast("Label change queued — will sync when online", "warning");
+          return;
+        }
+
+        if (result.outcome === "error") {
+          setError(result.error);
+          return;
+        }
+
+        showToast("Labels updated", "success");
+      } catch (err) {
+        console.error("[issuectl] toggleLabel threw:", err);
+        setError(err instanceof Error ? err.message : "Failed to update label");
       }
-
-      if (result.outcome === "error") {
-        setError(result.error);
-        return;
-      }
-
-      showToast("Labels updated", "success");
     });
   }
 

--- a/packages/web/components/list/AssignSheet.tsx
+++ b/packages/web/components/list/AssignSheet.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { listReposAction, assignDraftAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
+import { tryOrQueue } from "@/lib/tryOrQueue";
 import styles from "./AssignSheet.module.css";
 
 type Repo = { id: number; owner: string; name: string };
@@ -48,20 +49,37 @@ export function AssignSheet({ open, onClose, draftId, draftTitle }: Props) {
     setError(null);
     const idempotencyKey = newIdempotencyKey();
     try {
-      const result = await assignDraftAction(draftId, selectedRepo.id, idempotencyKey);
-      if (!result.success) {
+      const result = await tryOrQueue(
+        "assignDraft",
+        { draftId, repoId: selectedRepo.id },
+        () => assignDraftAction(draftId, selectedRepo.id, idempotencyKey),
+        { nonce: idempotencyKey },
+      );
+
+      if (result.outcome === "queued") {
+        showToast("Queued — will sync when online", "warning");
+        setSelectedRepo(null);
+        onClose();
+        router.push("/?section=unassigned");
+        return;
+      }
+
+      if (result.outcome === "error") {
         setError(result.error);
         return;
       }
-      if (result.cleanupWarning) {
-        showToast(result.cleanupWarning, "warning");
+
+      // succeeded
+      const data = result.data as { issueNumber?: number; cleanupWarning?: string };
+      if (data.cleanupWarning) {
+        showToast(data.cleanupWarning as string, "warning");
       } else {
-        showToast(`Issue #${result.issueNumber} created`, "success");
+        showToast(`Issue #${data.issueNumber} created`, "success");
       }
       setSelectedRepo(null);
       onClose();
-      if (result.issueNumber) {
-        router.push(`/issues/${selectedRepo.owner}/${selectedRepo.name}/${result.issueNumber}`);
+      if (data.issueNumber) {
+        router.push(`/issues/${selectedRepo.owner}/${selectedRepo.name}/${data.issueNumber}`);
       } else {
         router.push("/");
       }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -16,6 +16,7 @@ import { FilterEdgeSwipe } from "./FilterEdgeSwipe";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
+import { CacheAge } from "@/components/ui/CacheAge";
 
 type Repo = { owner: string; name: string };
 type PrEntry = { repo: Repo; pull: GitHubPull };
@@ -31,6 +32,7 @@ type Props = {
   repos: Repo[];
   activeRepo: string | null;
   mineOnly: boolean;
+  cachedAt?: number | null;
 };
 
 const SORT_MODES: SortMode[] = ["updated", "created", "priority"];
@@ -89,6 +91,7 @@ export function List({
   activeRepo,
   activeSort,
   mineOnly,
+  cachedAt,
 }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -197,6 +200,7 @@ export function List({
         <h1 className={styles.brand}>
           issuectl<span className={styles.dot} />
         </h1>
+        <CacheAge cachedAt={cachedAt ?? null} />
         <nav className={styles.desktopNav}>
           <Link href="/parse" className={styles.desktopNavLink}>Quick Create</Link>
           <span className={styles.desktopNavSep}>·</span>

--- a/packages/web/components/ui/CacheAge.module.css
+++ b/packages/web/components/ui/CacheAge.module.css
@@ -1,0 +1,11 @@
+.badge {
+  display: inline-block;
+  padding: 1px 8px;
+  background: var(--paper-bg-warmer);
+  color: var(--paper-ink-muted);
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  font-weight: 500;
+  border-radius: 10px;
+  white-space: nowrap;
+}

--- a/packages/web/components/ui/CacheAge.tsx
+++ b/packages/web/components/ui/CacheAge.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import styles from "./CacheAge.module.css";
+
+type Props = {
+  cachedAt: number | null;
+};
+
+function formatAge(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+const REFRESH_INTERVAL = 60_000;
+const SHOW_THRESHOLD = 60_000;
+
+export function CacheAge({ cachedAt }: Props) {
+  const [now, setNow] = useState(Date.now);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), REFRESH_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!cachedAt) return null;
+
+  const age = now - cachedAt;
+  if (age < SHOW_THRESHOLD) return null;
+
+  return (
+    <span className={styles.badge} aria-label={`Data cached ${formatAge(age)}`}>
+      Cached {formatAge(age)}
+    </span>
+  );
+}

--- a/packages/web/components/ui/FailureModal.module.css
+++ b/packages/web/components/ui/FailureModal.module.css
@@ -1,0 +1,121 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 23, 18, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+  padding: 20px;
+}
+
+.modal {
+  background: var(--paper-bg);
+  border-radius: var(--paper-radius-lg);
+  box-shadow: var(--paper-shadow-modal);
+  width: 100%;
+  max-width: 440px;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 8px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-size: var(--paper-fs-lg);
+  font-weight: 600;
+  color: var(--paper-ink);
+}
+
+.close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+}
+
+.body {
+  padding: 8px 20px 20px;
+}
+
+.row {
+  padding: 12px 0;
+}
+
+.row + .row {
+  border-top: 1px solid var(--paper-line-soft);
+}
+
+.info {
+  margin-bottom: 8px;
+}
+
+.description {
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-base);
+  font-weight: 500;
+  color: var(--paper-ink);
+}
+
+.error {
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-brick);
+  margin-top: 2px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.retry,
+.discard {
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-sm);
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: var(--paper-radius-sm);
+  border: 1px solid var(--paper-line);
+  cursor: pointer;
+}
+
+.retry {
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+  border-color: var(--paper-accent-dim);
+}
+
+.retry:hover {
+  background: var(--paper-accent);
+  color: #fff;
+}
+
+.retry:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.discard {
+  background: none;
+  color: var(--paper-ink-muted);
+}
+
+.discard:hover {
+  color: var(--paper-brick);
+  border-color: var(--paper-brick);
+}
+
+.discard:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/packages/web/components/ui/FailureModal.tsx
+++ b/packages/web/components/ui/FailureModal.tsx
@@ -34,6 +34,8 @@ export function FailureModal({ failures, onRetry, onDiscard, onClose }: Props) {
     setRetrying(op.id);
     try {
       await onRetry(op);
+    } catch (err) {
+      console.error("[issuectl] Retry failed for operation:", op.id, err);
     } finally {
       setRetrying(null);
     }

--- a/packages/web/components/ui/FailureModal.tsx
+++ b/packages/web/components/ui/FailureModal.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { type QueuedOperation } from "@/lib/offline-queue";
+import styles from "./FailureModal.module.css";
+
+type Props = {
+  failures: QueuedOperation[];
+  onRetry: (op: QueuedOperation) => Promise<void>;
+  onDiscard: (id: string) => void;
+  onClose: () => void;
+};
+
+function describeOp(op: QueuedOperation): string {
+  const p = op.params;
+  switch (op.action) {
+    case "assignDraft":
+      return "Assign draft to repo";
+    case "addComment":
+      return `Comment on ${p.owner}/${p.repo}#${p.issueNumber}`;
+    case "toggleLabel": {
+      const verb = p.action === "add" ? "Add" : "Remove";
+      return `${verb} label "${p.label}" on ${p.owner}/${p.repo}#${p.issueNumber}`;
+    }
+    default:
+      return op.action;
+  }
+}
+
+export function FailureModal({ failures, onRetry, onDiscard, onClose }: Props) {
+  const [retrying, setRetrying] = useState<string | null>(null);
+
+  async function handleRetry(op: QueuedOperation) {
+    setRetrying(op.id);
+    try {
+      await onRetry(op);
+    } finally {
+      setRetrying(null);
+    }
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Failed operations"
+      >
+        <div className={styles.header}>
+          <h3 className={styles.title}>Failed to sync</h3>
+          <button className={styles.close} onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+        <div className={styles.body}>
+          {failures.map((op) => (
+            <div key={op.id} className={styles.row}>
+              <div className={styles.info}>
+                <div className={styles.description}>{describeOp(op)}</div>
+                <div className={styles.error}>{op.error}</div>
+              </div>
+              <div className={styles.actions}>
+                <button
+                  className={styles.retry}
+                  onClick={() => handleRetry(op)}
+                  disabled={retrying === op.id}
+                >
+                  {retrying === op.id ? "Retrying…" : "Retry"}
+                </button>
+                <button
+                  className={styles.discard}
+                  onClick={() => onDiscard(op.id)}
+                  disabled={retrying === op.id}
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/ui/OfflineIndicator.module.css
+++ b/packages/web/components/ui/OfflineIndicator.module.css
@@ -1,9 +1,12 @@
-.banner {
+.wrapper {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   z-index: 10000;
+}
+
+.banner {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,17 +22,38 @@
   padding-top: calc(6px + env(safe-area-inset-top));
 }
 
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:hover {
+  background: #963d26;
+}
+
 .icon {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
 }
 
+.textFull {
+  display: inline;
+}
+
+.textCompact {
+  display: none;
+}
+
+@media (max-width: 480px) {
+  .textFull {
+    display: none;
+  }
+  .textCompact {
+    display: inline;
+  }
+}
+
 @keyframes slideDown {
-  from {
-    transform: translateY(-100%);
-  }
-  to {
-    transform: translateY(0);
-  }
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
 }

--- a/packages/web/components/ui/OfflineIndicator.tsx
+++ b/packages/web/components/ui/OfflineIndicator.tsx
@@ -6,6 +6,7 @@ import { useSyncOnReconnect } from "@/hooks/useSyncOnReconnect";
 import { remove } from "@/lib/offline-queue";
 import { useToast } from "./ToastProvider";
 import { QueueDropdown } from "./QueueDropdown";
+import { FailureModal } from "./FailureModal";
 import styles from "./OfflineIndicator.module.css";
 
 export function OfflineIndicator() {
@@ -18,79 +19,131 @@ export function OfflineIndicator() {
     refreshQueue,
   } = useOfflineAware();
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [failureModalOpen, setFailureModalOpen] = useState(false);
 
   const handleSyncFailed = useCallback(
     (count: number) => {
       showToast(
-        `${count} operation${count > 1 ? "s" : ""} failed to sync`,
+        `${count} operation${count > 1 ? "s" : ""} failed to sync · Tap to review`,
         "error",
       );
       refreshQueue();
+      if (count > 0) setFailureModalOpen(true);
     },
     [showToast, refreshQueue],
   );
 
-  const handleSyncSuccess = useCallback(() => {
+  const handleRefreshQueue = useCallback(() => {
     refreshQueue();
   }, [refreshQueue]);
 
   useSyncOnReconnect({
     onSyncFailed: handleSyncFailed,
-    onRefreshQueue: handleSyncSuccess,
+    onRefreshQueue: handleRefreshQueue,
   });
 
   const handleCancel = useCallback(
     async (id: string) => {
-      await remove(id);
-      refreshQueue();
-      showToast("Queued operation cancelled", "warning");
+      try {
+        await remove(id);
+        refreshQueue();
+        showToast("Queued operation cancelled", "warning");
+      } catch (err) {
+        console.error("[issuectl] Failed to cancel queued operation:", err);
+        showToast("Failed to cancel operation", "error");
+      }
     },
     [refreshQueue, showToast],
   );
 
+  const handleRetry = useCallback(
+    async (op: { id: string; action: string; params: Record<string, unknown>; nonce: string }) => {
+      // The FailureModal's onRetry calls back here. For now, we just
+      // remove the failed op and re-enqueue it as pending so the next
+      // sync attempt picks it up.
+      const { enqueue, remove: removeOp } = await import("@/lib/offline-queue");
+      try {
+        await removeOp(op.id);
+        await enqueue(op.action as "assignDraft" | "addComment" | "toggleLabel", op.params, op.nonce);
+        refreshQueue();
+        showToast("Operation re-queued for sync", "success");
+      } catch (err) {
+        console.error("[issuectl] Failed to retry operation:", err);
+        showToast("Failed to retry operation", "error");
+      }
+    },
+    [refreshQueue, showToast],
+  );
+
+  const handleDiscard = useCallback(
+    async (id: string) => {
+      try {
+        await remove(id);
+        refreshQueue();
+        showToast("Operation discarded", "warning");
+      } catch (err) {
+        console.error("[issuectl] Failed to discard operation:", err);
+        showToast("Failed to discard operation", "error");
+      }
+    },
+    [refreshQueue, showToast],
+  );
+
+  // Nothing to show when online with no queue items
   if (!isOffline && pendingCount === 0 && failedCount === 0) return null;
 
-  if (!isOffline) return null;
-
   const pendingOps = queue.filter((op) => op.status === "pending");
+  const failedOps = queue.filter((op) => op.status === "failed");
   const hasQueue = pendingCount > 0;
 
-  function handleBannerClick() {
-    if (hasQueue) setDropdownOpen((o) => !o);
-  }
-
   return (
-    <div className={styles.wrapper}>
-      <div
-        className={`${styles.banner} ${hasQueue ? styles.clickable : ""}`}
-        role="status"
-        aria-live="polite"
-        onClick={handleBannerClick}
-      >
-        <svg
-          className={styles.icon}
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          aria-hidden="true"
-        >
-          <circle cx="8" cy="8" r="6" />
-          <line x1="8" y1="5" x2="8" y2="8.5" />
-          <line x1="8" y1="11" x2="8.01" y2="11" />
-        </svg>
-        <span className={styles.textFull}>
-          Offline — viewing cached data
-          {hasQueue && ` · ${pendingCount} operation${pendingCount > 1 ? "s" : ""} queued`}
-        </span>
-        <span className={styles.textCompact}>
-          Offline{hasQueue && ` · ${pendingCount} queued`}
-        </span>
-      </div>
-      {dropdownOpen && (
-        <QueueDropdown operations={pendingOps} onCancel={handleCancel} />
+    <>
+      {isOffline && (
+        <div className={styles.wrapper}>
+          <div
+            className={`${styles.banner} ${hasQueue ? styles.clickable : ""}`}
+            role="status"
+            aria-live="polite"
+            onClick={hasQueue ? () => setDropdownOpen((o) => !o) : undefined}
+          >
+            <svg
+              className={styles.icon}
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              aria-hidden="true"
+            >
+              <circle cx="8" cy="8" r="6" />
+              <line x1="8" y1="5" x2="8" y2="8.5" />
+              <line x1="8" y1="11" x2="8.01" y2="11" />
+            </svg>
+            <span className={styles.textFull}>
+              Offline — viewing cached data
+              {hasQueue && ` · ${pendingCount} operation${pendingCount > 1 ? "s" : ""} queued`}
+            </span>
+            <span className={styles.textCompact}>
+              Offline{hasQueue && ` �� ${pendingCount} queued`}
+            </span>
+          </div>
+          {dropdownOpen && (
+            <QueueDropdown operations={pendingOps} onCancel={handleCancel} />
+          )}
+        </div>
       )}
-    </div>
+
+      {failureModalOpen && failedOps.length > 0 && (
+        <FailureModal
+          failures={failedOps}
+          onRetry={handleRetry}
+          onDiscard={handleDiscard}
+          onClose={() => {
+            setFailureModalOpen(false);
+            refreshQueue();
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/packages/web/components/ui/OfflineIndicator.tsx
+++ b/packages/web/components/ui/OfflineIndicator.tsx
@@ -1,44 +1,96 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
+import { useOfflineAware } from "@/hooks/useOfflineAware";
+import { useSyncOnReconnect } from "@/hooks/useSyncOnReconnect";
+import { remove } from "@/lib/offline-queue";
+import { useToast } from "./ToastProvider";
+import { QueueDropdown } from "./QueueDropdown";
 import styles from "./OfflineIndicator.module.css";
 
 export function OfflineIndicator() {
-  const [isOffline, setIsOffline] = useState(false);
+  const { showToast } = useToast();
+  const {
+    isOffline,
+    queue,
+    pendingCount,
+    failedCount,
+    refreshQueue,
+  } = useOfflineAware();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  useEffect(() => {
-    setIsOffline(!navigator.onLine);
+  const handleSyncFailed = useCallback(
+    (count: number) => {
+      showToast(
+        `${count} operation${count > 1 ? "s" : ""} failed to sync`,
+        "error",
+      );
+      refreshQueue();
+    },
+    [showToast, refreshQueue],
+  );
 
-    const goOffline = () => setIsOffline(true);
-    const goOnline = () => setIsOffline(false);
+  const handleSyncSuccess = useCallback(() => {
+    refreshQueue();
+  }, [refreshQueue]);
 
-    window.addEventListener("offline", goOffline);
-    window.addEventListener("online", goOnline);
+  useSyncOnReconnect({
+    onSyncFailed: handleSyncFailed,
+    onRefreshQueue: handleSyncSuccess,
+  });
 
-    return () => {
-      window.removeEventListener("offline", goOffline);
-      window.removeEventListener("online", goOnline);
-    };
-  }, []);
+  const handleCancel = useCallback(
+    async (id: string) => {
+      await remove(id);
+      refreshQueue();
+      showToast("Queued operation cancelled", "warning");
+    },
+    [refreshQueue, showToast],
+  );
+
+  if (!isOffline && pendingCount === 0 && failedCount === 0) return null;
 
   if (!isOffline) return null;
 
+  const pendingOps = queue.filter((op) => op.status === "pending");
+  const hasQueue = pendingCount > 0;
+
+  function handleBannerClick() {
+    if (hasQueue) setDropdownOpen((o) => !o);
+  }
+
   return (
-    <div className={styles.banner} role="status" aria-live="polite">
-      <svg
-        className={styles.icon}
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        aria-hidden="true"
+    <div className={styles.wrapper}>
+      <div
+        className={`${styles.banner} ${hasQueue ? styles.clickable : ""}`}
+        role="status"
+        aria-live="polite"
+        onClick={handleBannerClick}
       >
-        <circle cx="8" cy="8" r="6" />
-        <line x1="8" y1="5" x2="8" y2="8.5" />
-        <line x1="8" y1="11" x2="8.01" y2="11" />
-      </svg>
-      Offline — viewing cached data
+        <svg
+          className={styles.icon}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6" />
+          <line x1="8" y1="5" x2="8" y2="8.5" />
+          <line x1="8" y1="11" x2="8.01" y2="11" />
+        </svg>
+        <span className={styles.textFull}>
+          Offline — viewing cached data
+          {hasQueue && ` · ${pendingCount} operation${pendingCount > 1 ? "s" : ""} queued`}
+        </span>
+        <span className={styles.textCompact}>
+          Offline{hasQueue && ` · ${pendingCount} queued`}
+        </span>
+      </div>
+      {dropdownOpen && (
+        <QueueDropdown operations={pendingOps} onCancel={handleCancel} />
+      )}
     </div>
   );
 }

--- a/packages/web/components/ui/QueueDropdown.module.css
+++ b/packages/web/components/ui/QueueDropdown.module.css
@@ -1,0 +1,66 @@
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--paper-bg-warm);
+  border-bottom: 1px solid var(--paper-line);
+  box-shadow: 0 4px 16px rgba(26, 23, 18, 0.12);
+  z-index: 9999;
+  animation: slideDown 0.2s ease-out;
+}
+
+.header {
+  padding: 8px 16px 4px;
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  font-weight: 600;
+  color: var(--paper-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  gap: 12px;
+}
+
+.row + .row {
+  border-top: 1px solid var(--paper-line-soft);
+}
+
+.description {
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-soft);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cancel {
+  background: none;
+  border: none;
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  font-weight: 500;
+  color: var(--paper-brick);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--paper-radius-sm);
+  flex-shrink: 0;
+}
+
+.cancel:hover {
+  background: rgba(168, 67, 42, 0.08);
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/packages/web/components/ui/QueueDropdown.tsx
+++ b/packages/web/components/ui/QueueDropdown.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { type QueuedOperation } from "@/lib/offline-queue";
+import styles from "./QueueDropdown.module.css";
+
+type Props = {
+  operations: QueuedOperation[];
+  onCancel: (id: string) => void;
+};
+
+function describeOp(op: QueuedOperation): string {
+  const p = op.params;
+  switch (op.action) {
+    case "assignDraft":
+      return "Assign draft → repo";
+    case "addComment":
+      return `Comment on ${p.owner as string}/${p.repo as string}#${p.issueNumber as number}`;
+    case "toggleLabel": {
+      const verb = (p.action as string) === "add" ? "Add" : "Remove";
+      return `${verb} label "${p.label as string}" on ${p.owner as string}/${p.repo as string}#${p.issueNumber as number}`;
+    }
+    default:
+      return op.action;
+  }
+}
+
+export function QueueDropdown({ operations, onCancel }: Props) {
+  if (operations.length === 0) return null;
+
+  return (
+    <div className={styles.dropdown} role="list" aria-label="Queued operations">
+      <div className={styles.header}>Queued operations</div>
+      {operations.map((op) => (
+        <div key={op.id} className={styles.row} role="listitem">
+          <span className={styles.description}>{describeOp(op)}</span>
+          <button
+            className={styles.cancel}
+            onClick={() => onCancel(op.id)}
+            aria-label={`Cancel: ${describeOp(op)}`}
+          >
+            Cancel
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/e2e/offline-queue.spec.ts
+++ b/packages/web/e2e/offline-queue.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+// These tests run against the dev server on :3847.
+// They use Playwright's built-in offline simulation.
+
+const BASE_URL = "http://localhost:3847";
+
+test.describe("Offline mode", () => {
+  test("shows offline banner when network is lost", async ({ page, context }) => {
+    await page.goto(BASE_URL);
+    await page.waitForLoadState("networkidle");
+
+    await context.setOffline(true);
+
+    // Trigger the browser's offline event.
+    await page.evaluate(() => window.dispatchEvent(new Event("offline")));
+
+    const banner = page.locator('[role="status"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("Offline");
+
+    await context.setOffline(false);
+    await page.evaluate(() => window.dispatchEvent(new Event("online")));
+
+    await expect(banner).not.toBeVisible();
+  });
+
+  test("health endpoint returns ok", async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/health`);
+    expect(res.ok()).toBe(true);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  test("blocked actions show disabled state when offline", async ({
+    page,
+    context,
+  }) => {
+    await page.goto(BASE_URL);
+    await page.waitForLoadState("networkidle");
+
+    // Find and click the first issue card.
+    const firstIssue = page.locator('a[href^="/issues/"]').first();
+    if (await firstIssue.isVisible()) {
+      await firstIssue.click();
+      await page.waitForLoadState("networkidle");
+
+      await context.setOffline(true);
+      await page.evaluate(() => window.dispatchEvent(new Event("offline")));
+
+      const banner = page.locator('[role="status"]');
+      await expect(banner).toBeVisible();
+
+      await context.setOffline(false);
+      await page.evaluate(() => window.dispatchEvent(new Event("online")));
+    }
+  });
+});

--- a/packages/web/hooks/useOfflineAware.ts
+++ b/packages/web/hooks/useOfflineAware.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect, useSyncExternalStore, useCallback } from "react";
+import { listAll, type QueuedOperation } from "@/lib/offline-queue";
+
+export type ActionTier = 1 | 2 | 3;
+
+const ACTION_TIERS: Record<string, ActionTier> = {
+  createDraft: 1,
+  editDraft: 1,
+  deleteDraft: 1,
+  setPriority: 1,
+  removeRepo: 1,
+  updateRepo: 1,
+  assignDraft: 2,
+  addComment: 2,
+  toggleLabel: 2,
+  closeIssue: 3,
+  mergePull: 3,
+  updateIssue: 3,
+  addRepo: 3,
+  refreshDashboard: 3,
+};
+
+function subscribeOnline(cb: () => void) {
+  window.addEventListener("online", cb);
+  window.addEventListener("offline", cb);
+  return () => {
+    window.removeEventListener("online", cb);
+    window.removeEventListener("offline", cb);
+  };
+}
+
+function getOnlineSnapshot() {
+  return navigator.onLine;
+}
+
+function getServerSnapshot() {
+  return true;
+}
+
+export function useOfflineAware() {
+  const isOnline = useSyncExternalStore(
+    subscribeOnline,
+    getOnlineSnapshot,
+    getServerSnapshot,
+  );
+  const [queue, setQueue] = useState<QueuedOperation[]>([]);
+
+  const refreshQueue = useCallback(async () => {
+    try {
+      const ops = await listAll();
+      setQueue(ops);
+    } catch {
+      // IndexedDB unavailable (SSR, etc.)
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshQueue();
+  }, [refreshQueue]);
+
+  const isOffline = !isOnline;
+
+  const pendingCount = queue.filter((op) => op.status === "pending").length;
+  const failedCount = queue.filter((op) => op.status === "failed").length;
+  const syncingCount = queue.filter((op) => op.status === "syncing").length;
+
+  function getTier(action: string): ActionTier {
+    return ACTION_TIERS[action] ?? 3;
+  }
+
+  function isBlocked(action: string): boolean {
+    return isOffline && getTier(action) === 3;
+  }
+
+  function canQueue(action: string): boolean {
+    return getTier(action) === 2;
+  }
+
+  return {
+    isOffline,
+    isOnline,
+    queue,
+    pendingCount,
+    failedCount,
+    syncingCount,
+    getTier,
+    isBlocked,
+    canQueue,
+    refreshQueue,
+  };
+}

--- a/packages/web/hooks/useOfflineAware.ts
+++ b/packages/web/hooks/useOfflineAware.ts
@@ -51,8 +51,8 @@ export function useOfflineAware() {
     try {
       const ops = await listAll();
       setQueue(ops);
-    } catch {
-      // IndexedDB unavailable (SSR, etc.)
+    } catch (err) {
+      console.warn("[issuectl] Failed to read offline queue:", err);
     }
   }, []);
 

--- a/packages/web/hooks/useSyncOnReconnect.ts
+++ b/packages/web/hooks/useSyncOnReconnect.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { checkHealth, replayQueue } from "@/lib/sync";
+import { listPending, type QueuedOperation } from "@/lib/offline-queue";
+import { assignDraftAction } from "@/lib/actions/drafts";
+import { addComment } from "@/lib/actions/comments";
+import { toggleLabel } from "@/lib/actions/issues";
+import { refreshAction } from "@/lib/actions/refresh";
+
+type ActionResult = { success: boolean; error?: string };
+
+async function executeOperation(op: QueuedOperation): Promise<ActionResult> {
+  const p = op.params;
+  switch (op.action) {
+    case "assignDraft":
+      return assignDraftAction(
+        p.draftId as string,
+        p.repoId as number,
+        op.nonce,
+      );
+    case "addComment":
+      return addComment(
+        p.owner as string,
+        p.repo as string,
+        p.issueNumber as number,
+        p.body as string,
+        op.nonce,
+      );
+    case "toggleLabel":
+      return toggleLabel({
+        owner: p.owner as string,
+        repo: p.repo as string,
+        number: p.issueNumber as number,
+        label: p.label as string,
+        action: p.action as "add" | "remove",
+      });
+    default:
+      return { success: false, error: `Unknown action: ${op.action}` };
+  }
+}
+
+type SyncCallbacks = {
+  onSyncSuccess?: (op: QueuedOperation) => void;
+  onSyncFailed?: (failedCount: number) => void;
+  onRefreshQueue?: () => void;
+};
+
+export function useSyncOnReconnect(callbacks?: SyncCallbacks) {
+  const syncingRef = useRef(false);
+
+  const handleOnline = useCallback(async () => {
+    if (syncingRef.current) return;
+
+    const pending = await listPending();
+    if (pending.length === 0) {
+      try {
+        await refreshAction();
+      } catch {
+        // Server might not be reachable yet.
+      }
+      return;
+    }
+
+    const healthy = await checkHealth();
+    if (!healthy) return;
+
+    syncingRef.current = true;
+    try {
+      const result = await replayQueue(executeOperation);
+      callbacks?.onRefreshQueue?.();
+
+      if (result.synced > 0) {
+        try {
+          await refreshAction();
+        } catch {
+          // Non-critical
+        }
+      }
+
+      if (result.failed > 0) {
+        callbacks?.onSyncFailed?.(result.failed);
+      }
+    } finally {
+      syncingRef.current = false;
+    }
+  }, [callbacks]);
+
+  useEffect(() => {
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, [handleOnline]);
+}

--- a/packages/web/hooks/useSyncOnReconnect.ts
+++ b/packages/web/hooks/useSyncOnReconnect.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef } from "react";
 import { checkHealth, replayQueue } from "@/lib/sync";
 import { listPending, type QueuedOperation } from "@/lib/offline-queue";
 import { assignDraftAction } from "@/lib/actions/drafts";
@@ -41,53 +41,67 @@ async function executeOperation(op: QueuedOperation): Promise<ActionResult> {
 }
 
 type SyncCallbacks = {
-  onSyncSuccess?: (op: QueuedOperation) => void;
   onSyncFailed?: (failedCount: number) => void;
   onRefreshQueue?: () => void;
 };
 
 export function useSyncOnReconnect(callbacks?: SyncCallbacks) {
   const syncingRef = useRef(false);
-
-  const handleOnline = useCallback(async () => {
-    if (syncingRef.current) return;
-
-    const pending = await listPending();
-    if (pending.length === 0) {
-      try {
-        await refreshAction();
-      } catch {
-        // Server might not be reachable yet.
-      }
-      return;
-    }
-
-    const healthy = await checkHealth();
-    if (!healthy) return;
-
-    syncingRef.current = true;
-    try {
-      const result = await replayQueue(executeOperation);
-      callbacks?.onRefreshQueue?.();
-
-      if (result.synced > 0) {
-        try {
-          await refreshAction();
-        } catch {
-          // Non-critical
-        }
-      }
-
-      if (result.failed > 0) {
-        callbacks?.onSyncFailed?.(result.failed);
-      }
-    } finally {
-      syncingRef.current = false;
-    }
-  }, [callbacks]);
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
 
   useEffect(() => {
+    async function handleOnline() {
+      if (syncingRef.current) return;
+
+      let pending: QueuedOperation[];
+      try {
+        pending = await listPending();
+      } catch (err) {
+        console.error("[issuectl] Failed to read offline queue on reconnect:", err);
+        return;
+      }
+
+      if (pending.length === 0) {
+        try {
+          await refreshAction();
+        } catch (err) {
+          // Optimistic refresh — server may not be fully reachable despite the online event.
+          console.warn("[issuectl] Post-reconnect refresh failed:", err);
+        }
+        return;
+      }
+
+      const healthy = await checkHealth();
+      if (!healthy) return;
+
+      syncingRef.current = true;
+      try {
+        const result = await replayQueue(executeOperation);
+        callbacksRef.current?.onRefreshQueue?.();
+
+        if (result.synced > 0) {
+          try {
+            await refreshAction();
+          } catch (err) {
+            // Sync succeeded but revalidation failed — cached data will be stale until next refresh.
+            console.warn("[issuectl] Post-sync refresh failed:", err);
+          }
+        }
+
+        if (result.failed > 0) {
+          callbacksRef.current?.onSyncFailed?.(result.failed);
+        }
+      } catch (err) {
+        console.error("[issuectl] Queue replay failed:", err);
+        callbacksRef.current?.onSyncFailed?.(0);
+        callbacksRef.current?.onRefreshQueue?.();
+      } finally {
+        syncingRef.current = false;
+      }
+    }
+
     window.addEventListener("online", handleOnline);
     return () => window.removeEventListener("online", handleOnline);
-  }, [handleOnline]);
+  }, []);
 }

--- a/packages/web/lib/offline-queue.test.ts
+++ b/packages/web/lib/offline-queue.test.ts
@@ -1,0 +1,93 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  enqueue,
+  listPending,
+  listFailed,
+  markSyncing,
+  markFailed,
+  markPending,
+  remove,
+  clearAll,
+  type QueuedOperation,
+} from "./offline-queue";
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+describe("offline-queue", () => {
+  it("enqueues an operation and lists it as pending", async () => {
+    const op = await enqueue("addComment", {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 47,
+      body: "hello",
+    }, "nonce-1");
+
+    expect(op.id).toBeDefined();
+    expect(op.action).toBe("addComment");
+    expect(op.status).toBe("pending");
+    expect(op.nonce).toBe("nonce-1");
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(op.id);
+  });
+
+  it("lists pending operations ordered by createdAt", async () => {
+    await enqueue("addComment", { body: "first" }, "n1");
+    await enqueue("toggleLabel", { label: "bug" }, "n2");
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(2);
+    expect(pending[0].action).toBe("addComment");
+    expect(pending[1].action).toBe("toggleLabel");
+  });
+
+  it("marks an operation as syncing", async () => {
+    const op = await enqueue("assignDraft", { draftId: "d1" }, "n1");
+    await markSyncing(op.id);
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+
+  it("marks an operation as failed with error", async () => {
+    const op = await enqueue("addComment", { body: "x" }, "n1");
+    await markSyncing(op.id);
+    await markFailed(op.id, "Repo not found");
+
+    const failed = await listFailed();
+    expect(failed).toHaveLength(1);
+    expect(failed[0].error).toBe("Repo not found");
+    expect(failed[0].attemptedAt).toBeDefined();
+  });
+
+  it("reverts a syncing operation back to pending", async () => {
+    const op = await enqueue("addComment", { body: "x" }, "n1");
+    await markSyncing(op.id);
+    await markPending(op.id);
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].status).toBe("pending");
+  });
+
+  it("removes an operation from the queue", async () => {
+    const op = await enqueue("addComment", { body: "x" }, "n1");
+    await remove(op.id);
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+
+  it("clearAll removes everything", async () => {
+    await enqueue("addComment", { body: "a" }, "n1");
+    await enqueue("toggleLabel", { label: "b" }, "n2");
+    await clearAll();
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/packages/web/lib/offline-queue.ts
+++ b/packages/web/lib/offline-queue.ts
@@ -1,0 +1,139 @@
+export type QueueableAction = "assignDraft" | "addComment" | "toggleLabel";
+
+export type QueuedOperation = {
+  id: string;
+  action: QueueableAction;
+  params: Record<string, unknown>;
+  nonce: string;
+  status: "pending" | "syncing" | "failed";
+  error: string | null;
+  createdAt: number;
+  attemptedAt: number | null;
+};
+
+const DB_NAME = "issuectl-offline";
+const STORE_NAME = "queued-ops";
+const DB_VERSION = 1;
+
+let _seq = 0;
+function monotonicNow(): number {
+  const now = Date.now();
+  _seq++;
+  return now * 1000 + (_seq % 1000);
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function withStore(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest,
+): Promise<unknown> {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, mode);
+        const store = tx.objectStore(STORE_NAME);
+        const request = fn(store);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        tx.oncomplete = () => db.close();
+      }),
+  );
+}
+
+function getAllFromStore(): Promise<QueuedOperation[]> {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.getAll();
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        tx.oncomplete = () => db.close();
+      }),
+  );
+}
+
+export async function enqueue(
+  action: QueueableAction,
+  params: Record<string, unknown>,
+  nonce: string,
+): Promise<QueuedOperation> {
+  const op: QueuedOperation = {
+    id: crypto.randomUUID(),
+    action,
+    params,
+    nonce,
+    status: "pending",
+    error: null,
+    createdAt: monotonicNow(),
+    attemptedAt: null,
+  };
+  await withStore("readwrite", (store) => store.put(op));
+  return op;
+}
+
+export async function listPending(): Promise<QueuedOperation[]> {
+  const all = await getAllFromStore();
+  return all
+    .filter((op) => op.status === "pending")
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function listFailed(): Promise<QueuedOperation[]> {
+  const all = await getAllFromStore();
+  return all.filter((op) => op.status === "failed");
+}
+
+export async function listAll(): Promise<QueuedOperation[]> {
+  const all = await getAllFromStore();
+  return all.sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function markSyncing(id: string): Promise<void> {
+  const all = await getAllFromStore();
+  const op = all.find((o) => o.id === id);
+  if (!op) return;
+  op.status = "syncing";
+  op.attemptedAt = Date.now();
+  await withStore("readwrite", (store) => store.put(op));
+}
+
+export async function markFailed(id: string, error: string): Promise<void> {
+  const all = await getAllFromStore();
+  const op = all.find((o) => o.id === id);
+  if (!op) return;
+  op.status = "failed";
+  op.error = error;
+  op.attemptedAt = Date.now();
+  await withStore("readwrite", (store) => store.put(op));
+}
+
+export async function markPending(id: string): Promise<void> {
+  const all = await getAllFromStore();
+  const op = all.find((o) => o.id === id);
+  if (!op) return;
+  op.status = "pending";
+  await withStore("readwrite", (store) => store.put(op));
+}
+
+export async function remove(id: string): Promise<void> {
+  await withStore("readwrite", (store) => store.delete(id));
+}
+
+export async function clearAll(): Promise<void> {
+  await withStore("readwrite", (store) => store.clear());
+}

--- a/packages/web/lib/offline-queue.ts
+++ b/packages/web/lib/offline-queue.ts
@@ -49,6 +49,8 @@ function withStore(
         request.onsuccess = () => resolve(request.result);
         request.onerror = () => reject(request.error);
         tx.oncomplete = () => db.close();
+        tx.onerror = () => db.close();
+        tx.onabort = () => db.close();
       }),
   );
 }
@@ -63,6 +65,8 @@ function getAllFromStore(): Promise<QueuedOperation[]> {
         request.onsuccess = () => resolve(request.result);
         request.onerror = () => reject(request.error);
         tx.oncomplete = () => db.close();
+        tx.onerror = () => db.close();
+        tx.onabort = () => db.close();
       }),
   );
 }

--- a/packages/web/lib/sync.test.ts
+++ b/packages/web/lib/sync.test.ts
@@ -1,0 +1,67 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { enqueue, clearAll, listPending, listFailed } from "./offline-queue";
+import { replayQueue } from "./sync";
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+describe("replayQueue", () => {
+  it("does nothing when queue is empty", async () => {
+    const executor = vi.fn();
+    const result = await replayQueue(executor);
+    expect(result).toEqual({ synced: 0, failed: 0, stopped: false });
+    expect(executor).not.toHaveBeenCalled();
+  });
+
+  it("replays pending operations and removes on success", async () => {
+    await enqueue("addComment", { body: "hello" }, "n1");
+    await enqueue("toggleLabel", { label: "bug" }, "n2");
+
+    const executor = vi.fn().mockResolvedValue({ success: true });
+    const result = await replayQueue(executor);
+
+    expect(result).toEqual({ synced: 2, failed: 0, stopped: false });
+    expect(executor).toHaveBeenCalledTimes(2);
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+
+  it("stops on network error and reverts to pending", async () => {
+    await enqueue("addComment", { body: "a" }, "n1");
+    await enqueue("toggleLabel", { label: "b" }, "n2");
+
+    const executor = vi.fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const result = await replayQueue(executor);
+
+    expect(result).toEqual({ synced: 0, failed: 0, stopped: true });
+    expect(executor).toHaveBeenCalledTimes(1);
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(2);
+  });
+
+  it("marks non-network failures and continues", async () => {
+    await enqueue("addComment", { body: "a" }, "n1");
+    await enqueue("toggleLabel", { label: "b" }, "n2");
+
+    const executor = vi.fn()
+      .mockResolvedValueOnce({ success: false, error: "Repo not found" })
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await replayQueue(executor);
+
+    expect(result).toEqual({ synced: 1, failed: 1, stopped: false });
+
+    const failed = await listFailed();
+    expect(failed).toHaveLength(1);
+    expect(failed[0].error).toBe("Repo not found");
+
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/packages/web/lib/sync.ts
+++ b/packages/web/lib/sync.ts
@@ -15,6 +15,15 @@ type ReplayResult = {
   stopped: boolean;
 };
 
+/**
+ * Replay all pending operations sequentially.
+ *
+ * Operations replay in order because they may depend on sequence (e.g.,
+ * assign draft creates an issue, then a queued comment targets it).
+ * Network errors halt the loop and revert the current op to pending.
+ * Non-network errors (validation, 404) mark the op as failed and continue,
+ * since retrying won't help.
+ */
 export async function replayQueue(
   executor: (op: QueuedOperation) => Promise<ActionResult>,
 ): Promise<ReplayResult> {
@@ -27,30 +36,54 @@ export async function replayQueue(
   let failed = 0;
 
   for (const op of pending) {
-    await markSyncing(op.id);
+    try {
+      await markSyncing(op.id);
+    } catch (err) {
+      console.warn("[issuectl] Failed to mark operation as syncing:", op.id, err);
+      failed++;
+      continue;
+    }
 
     try {
       const result = await executor(op);
 
       if (result.success) {
-        await remove(op.id);
+        try {
+          await remove(op.id);
+        } catch (err) {
+          console.warn("[issuectl] Sync succeeded but failed to remove from queue:", op.id, err);
+        }
         synced++;
       } else {
-        await markFailed(op.id, result.error ?? "Unknown error");
+        try {
+          await markFailed(op.id, result.error ?? "Unknown error");
+        } catch (err) {
+          console.warn("[issuectl] Failed to mark operation as failed:", op.id, err);
+        }
         failed++;
       }
     } catch (err) {
+      // Network-level failure — stop processing, revert to pending.
       if (
         err instanceof TypeError ||
         (err instanceof DOMException && err.name === "AbortError")
       ) {
-        await markPending(op.id);
+        try {
+          await markPending(op.id);
+        } catch (revertErr) {
+          console.warn("[issuectl] Failed to revert operation to pending:", op.id, revertErr);
+        }
         return { synced, failed, stopped: true };
       }
-      await markFailed(
-        op.id,
-        err instanceof Error ? err.message : "Unexpected error",
-      );
+      // Unexpected error — mark failed, continue.
+      try {
+        await markFailed(
+          op.id,
+          err instanceof Error ? err.message : "Unexpected error",
+        );
+      } catch (markErr) {
+        console.warn("[issuectl] Failed to mark operation as failed:", op.id, markErr);
+      }
       failed++;
     }
   }
@@ -58,6 +91,9 @@ export async function replayQueue(
   return { synced, failed, stopped: false };
 }
 
+/**
+ * Check if the server is reachable via the health endpoint.
+ */
 export async function checkHealth(baseUrl = ""): Promise<boolean> {
   try {
     const res = await fetch(`${baseUrl}/api/health`, {
@@ -65,7 +101,8 @@ export async function checkHealth(baseUrl = ""): Promise<boolean> {
       cache: "no-store",
     });
     return res.ok;
-  } catch {
+  } catch (err) {
+    console.warn("[issuectl] Health check failed:", err);
     return false;
   }
 }

--- a/packages/web/lib/sync.ts
+++ b/packages/web/lib/sync.ts
@@ -1,0 +1,71 @@
+import {
+  listPending,
+  markSyncing,
+  markFailed,
+  markPending,
+  remove,
+  type QueuedOperation,
+} from "./offline-queue";
+
+type ActionResult = { success: boolean; error?: string };
+
+type ReplayResult = {
+  synced: number;
+  failed: number;
+  stopped: boolean;
+};
+
+export async function replayQueue(
+  executor: (op: QueuedOperation) => Promise<ActionResult>,
+): Promise<ReplayResult> {
+  const pending = await listPending();
+  if (pending.length === 0) {
+    return { synced: 0, failed: 0, stopped: false };
+  }
+
+  let synced = 0;
+  let failed = 0;
+
+  for (const op of pending) {
+    await markSyncing(op.id);
+
+    try {
+      const result = await executor(op);
+
+      if (result.success) {
+        await remove(op.id);
+        synced++;
+      } else {
+        await markFailed(op.id, result.error ?? "Unknown error");
+        failed++;
+      }
+    } catch (err) {
+      if (
+        err instanceof TypeError ||
+        (err instanceof DOMException && err.name === "AbortError")
+      ) {
+        await markPending(op.id);
+        return { synced, failed, stopped: true };
+      }
+      await markFailed(
+        op.id,
+        err instanceof Error ? err.message : "Unexpected error",
+      );
+      failed++;
+    }
+  }
+
+  return { synced, failed, stopped: false };
+}
+
+export async function checkHealth(baseUrl = ""): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/web/lib/tryOrQueue.test.ts
+++ b/packages/web/lib/tryOrQueue.test.ts
@@ -1,0 +1,93 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { tryOrQueue } from "./tryOrQueue";
+import { clearAll, listPending } from "./offline-queue";
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+describe("tryOrQueue", () => {
+  it("returns succeeded when server action succeeds", async () => {
+    const action = vi.fn().mockResolvedValue({ success: true, issueNumber: 1 });
+
+    const result = await tryOrQueue("addComment", { body: "hi" }, action);
+
+    expect(result.outcome).toBe("succeeded");
+    expect(action).toHaveBeenCalled();
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+
+  it("queues when navigator.onLine is false", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+    const action = vi.fn();
+
+    const result = await tryOrQueue("addComment", { body: "hi" }, action);
+
+    expect(result.outcome).toBe("queued");
+    expect(action).not.toHaveBeenCalled();
+    const pending = await listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].action).toBe("addComment");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("queues when server action throws TypeError (fetch failure)", async () => {
+    const action = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const result = await tryOrQueue("addComment", { body: "hi" }, action);
+
+    expect(result.outcome).toBe("queued");
+    const pending = await listPending();
+    expect(pending).toHaveLength(1);
+  });
+
+  it("queues when server returns network error", async () => {
+    const action = vi.fn().mockResolvedValue({
+      success: false,
+      error: "Network error — GitHub is unreachable",
+    });
+
+    const result = await tryOrQueue(
+      "addComment",
+      { body: "hi" },
+      action,
+      { isNetworkError: (e) => e.includes("Network error") },
+    );
+
+    expect(result.outcome).toBe("queued");
+    const pending = await listPending();
+    expect(pending).toHaveLength(1);
+  });
+
+  it("returns error for non-network server failures", async () => {
+    const action = vi.fn().mockResolvedValue({
+      success: false,
+      error: "Validation failed: title is required",
+    });
+
+    const result = await tryOrQueue("addComment", { body: "hi" }, action);
+
+    expect(result.outcome).toBe("error");
+    if (result.outcome === "error") {
+      expect(result.error).toBe("Validation failed: title is required");
+    }
+    const pending = await listPending();
+    expect(pending).toHaveLength(0);
+  });
+
+  it("uses provided nonce instead of generating one", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+
+    await tryOrQueue("assignDraft", { draftId: "d1" }, vi.fn(), {
+      nonce: "existing-nonce",
+    });
+
+    const pending = await listPending();
+    expect(pending[0].nonce).toBe("existing-nonce");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/web/lib/tryOrQueue.ts
+++ b/packages/web/lib/tryOrQueue.ts
@@ -28,6 +28,20 @@ type Options = {
   isNetworkError?: (error: string) => boolean;
 };
 
+async function safeEnqueue(
+  action: QueueableAction,
+  params: Record<string, unknown>,
+  nonce: string,
+): Promise<TryOrQueueResult> {
+  try {
+    await enqueue(action, params, nonce);
+    return { outcome: "queued" };
+  } catch (enqueueErr) {
+    console.error("[issuectl] Failed to enqueue operation for offline sync:", enqueueErr);
+    return { outcome: "error", error: "Could not save operation for offline sync. Try again when you have a connection." };
+  }
+}
+
 export async function tryOrQueue(
   action: QueueableAction,
   params: Record<string, unknown>,
@@ -37,9 +51,9 @@ export async function tryOrQueue(
   const nonce = options?.nonce ?? newIdempotencyKey();
   const isNetErr = options?.isNetworkError ?? defaultIsNetworkError;
 
+  // Pre-flight: if browser says we're offline, queue immediately.
   if (typeof navigator !== "undefined" && navigator.onLine === false) {
-    await enqueue(action, params, nonce);
-    return { outcome: "queued" };
+    return safeEnqueue(action, params, nonce);
   }
 
   try {
@@ -49,18 +63,19 @@ export async function tryOrQueue(
       return { outcome: "succeeded", data: result as Record<string, unknown> };
     }
 
+    // Server responded but the operation failed.
     const errorMsg = result.error ?? "Unknown error";
     if (isNetErr(errorMsg)) {
-      await enqueue(action, params, nonce);
-      return { outcome: "queued" };
+      return safeEnqueue(action, params, nonce);
     }
 
     return { outcome: "error", error: errorMsg };
   } catch (err) {
+    // Fetch-level failure — server/tunnel unreachable.
     if (err instanceof TypeError || (err instanceof DOMException && err.name === "AbortError")) {
-      await enqueue(action, params, nonce);
-      return { outcome: "queued" };
+      return safeEnqueue(action, params, nonce);
     }
+    // Unexpected error — don't queue, surface it.
     throw err;
   }
 }

--- a/packages/web/lib/tryOrQueue.ts
+++ b/packages/web/lib/tryOrQueue.ts
@@ -1,0 +1,66 @@
+import { enqueue, type QueueableAction } from "./offline-queue";
+import { newIdempotencyKey } from "./idempotency-key";
+
+export type TryOrQueueResult =
+  | { outcome: "succeeded"; data: Record<string, unknown> }
+  | { outcome: "queued" }
+  | { outcome: "error"; error: string };
+
+type ActionResult = { success: boolean; error?: string };
+
+const NETWORK_KEYWORDS = [
+  "network error",
+  "unreachable",
+  "econnrefused",
+  "etimedout",
+  "enotfound",
+  "econnreset",
+  "timeout",
+] as const;
+
+function defaultIsNetworkError(error: string): boolean {
+  const lower = error.toLowerCase();
+  return NETWORK_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+type Options = {
+  nonce?: string;
+  isNetworkError?: (error: string) => boolean;
+};
+
+export async function tryOrQueue(
+  action: QueueableAction,
+  params: Record<string, unknown>,
+  serverActionFn: () => Promise<ActionResult>,
+  options?: Options,
+): Promise<TryOrQueueResult> {
+  const nonce = options?.nonce ?? newIdempotencyKey();
+  const isNetErr = options?.isNetworkError ?? defaultIsNetworkError;
+
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    await enqueue(action, params, nonce);
+    return { outcome: "queued" };
+  }
+
+  try {
+    const result = await serverActionFn();
+
+    if (result.success) {
+      return { outcome: "succeeded", data: result as Record<string, unknown> };
+    }
+
+    const errorMsg = result.error ?? "Unknown error";
+    if (isNetErr(errorMsg)) {
+      await enqueue(action, params, nonce);
+      return { outcome: "queued" };
+    }
+
+    return { outcome: "error", error: errorMsg };
+  } catch (err) {
+    if (err instanceof TypeError || (err instanceof DOMException && err.name === "AbortError")) {
+      await enqueue(action, params, nonce);
+      return { outcome: "queued" };
+    }
+    throw err;
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,6 +26,7 @@
     "@playwright/test": "^1.59.1",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
+    "fake-indexeddb": "^6.2.5",
     "vitest": "^4.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.0
         version: 19.2.3(@types/react@19.2.14)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       vitest:
         specifier: ^4.1.3
         version: 4.1.3(@types/node@22.19.17)(vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7))
@@ -1516,6 +1519,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -3765,6 +3772,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-content-type-parse@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- **Client-first IndexedDB queue** for offline operation storage — designed for remote access via Cloudflare Tunnel where "offline" means the tunnel is down, not just the device
- **Three-tier action classification**: Tier 1 (local-only, always works), Tier 2 (queueable — assign draft, comment, toggle label), Tier 3 (blocked — close, merge, reassign)
- **Sync-on-reconnect**: health check confirms server reachability, then sequential replay through existing server actions with idempotency nonces
- **Visual indicators**: brick-red offline banner (responsive — compact on mobile), CacheAge badge ("Cached 3d ago"), queue dropdown, FailureModal for retry/discard
- **Auto-refresh**: dashboard data revalidates after successful sync

### New files (16)
- `lib/offline-queue.ts` — IndexedDB queue with enqueue/replay/cancel
- `lib/tryOrQueue.ts` — server action wrapper intercepting network failures
- `lib/sync.ts` — replay logic with health check
- `hooks/useOfflineAware.ts` — offline state + action tier lookup
- `hooks/useSyncOnReconnect.ts` — sync trigger on online event
- `components/ui/CacheAge.tsx` — relative time badge
- `components/ui/QueueDropdown.tsx` — banner dropdown listing pending ops
- `components/ui/FailureModal.tsx` — retry/discard for failed operations
- `app/api/health/route.ts` — lightweight connectivity probe
- Unit tests (3 files, 17 tests) + E2E spec (3 tests)

### Modified files (8)
- `OfflineIndicator.tsx` — queue count, responsive text, FailureModal wiring
- `AssignSheet.tsx`, `CommentComposer.tsx`, `LabelManager.tsx` — wrapped with tryOrQueue
- `IssueActionSheet.tsx` — close/reassign disabled when offline
- `layout.tsx` — OfflineIndicator moved inside ToastProvider
- `page.tsx` + `List.tsx` — CacheAge badge in dashboard header
- `core/db/cache.ts` — getOldestCacheAge helper

## Test plan

- [x] `pnpm turbo typecheck` — all 4 tasks pass, 0 errors
- [x] `pnpm turbo test` — 424 tests pass (347 core + 77 web)
- [x] E2E: offline banner appears/disappears on network toggle
- [x] E2E: `/api/health` returns `{ ok: true }`
- [x] Visual: desktop offline banner with "Offline — viewing cached data"
- [x] Visual: mobile (393px) compact banner "Offline"
- [x] Visual: CacheAge badge renders next to brand title
- [x] PR review: 5 specialized agents (code, errors, tests, types, comments) — all critical/important issues addressed

Closes #138