### PR TITLE
fix: desktop UX audit — accessibility, error handling, GFM

### DIFF
--- a/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getDb, getDeploymentById } from "@issuectl/core";
 import { DetailTopBar } from "@/components/detail/DetailTopBar";
 import { LaunchProgress } from "@/components/launch/LaunchProgress";
@@ -36,7 +36,7 @@ export default async function LaunchProgressPage({
 
   const deploymentId = idStr ? Number(idStr) : null;
   if (!deploymentId || !Number.isInteger(deploymentId) || deploymentId <= 0) {
-    notFound();
+    redirect(`/issues/${owner}/${repo}/${issueNumber}`);
   }
 
   const db = getDb();

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -107,6 +107,7 @@
 }
 
 .fieldLabel {
+  display: block;
   font-size: var(--paper-fs-sm);
   color: var(--paper-ink-muted);
   font-weight: 600;

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -187,8 +187,9 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
         </div>
 
         <div className={styles.field}>
-          <div className={styles.fieldLabel}>Title</div>
+          <label htmlFor="new-issue-title" className={styles.fieldLabel}>Title</label>
           <input
+            id="new-issue-title"
             type="text"
             className={styles.input}
             value={title}
@@ -206,10 +207,11 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
         </div>
 
         <div className={styles.field}>
-          <div className={styles.fieldLabel}>
+          <label htmlFor="new-issue-body" className={styles.fieldLabel}>
             Description <span className={styles.fieldHint}>(markdown)</span>
-          </div>
+          </label>
           <textarea
+            id="new-issue-body"
             className={styles.textarea}
             value={body}
             onChange={(e) => setBody(e.target.value)}

--- a/packages/web/components/detail/BodyText.module.css
+++ b/packages/web/components/detail/BodyText.module.css
@@ -58,6 +58,29 @@
   margin-bottom: 12px;
 }
 
+.body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+
+.body th,
+.body td {
+  border: 1px solid var(--paper-line);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.body th {
+  background: var(--paper-bg-warm);
+  font-weight: 600;
+}
+
+.body tr:nth-child(even) td {
+  background: var(--paper-bg-warm);
+}
+
 .body a {
   color: var(--paper-accent);
   text-decoration: underline;

--- a/packages/web/components/detail/BodyText.tsx
+++ b/packages/web/components/detail/BodyText.tsx
@@ -1,5 +1,8 @@
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import styles from "./BodyText.module.css";
+
+const REMARK_PLUGINS = [remarkGfm];
 
 type Props = {
   body: string | null | undefined;
@@ -15,7 +18,7 @@ export function BodyText({ body }: Props) {
   }
   return (
     <div className={styles.body}>
-      <ReactMarkdown>{body}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{body}</ReactMarkdown>
     </div>
   );
 }

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -328,10 +328,14 @@
   inset: -2px 0;
 }
 
-.sectionTab:hover,
+.sectionTab:hover {
+  color: var(--paper-ink-soft);
+}
+
 .sectionTab:focus-visible {
   color: var(--paper-ink-soft);
-  outline: none;
+  outline: 2px solid var(--paper-accent);
+  outline-offset: -2px;
 }
 
 .sectionTabActive {
@@ -413,10 +417,14 @@
   flex-shrink: 0;
 }
 
-.filterBtn:hover,
+.filterBtn:hover {
+  color: var(--paper-accent);
+}
+
 .filterBtn:focus-visible {
   color: var(--paper-accent);
-  outline: none;
+  outline: 2px solid var(--paper-accent);
+  outline-offset: -2px;
 }
 
 .filterBtnDot {
@@ -481,10 +489,12 @@
   inset: -6px;
 }
 
-.scopePillClear:hover,
+.scopePillClear:hover {
+  color: var(--paper-ink);
+}
+
 .scopePillClear:focus-visible {
   color: var(--paper-ink);
-  outline: none;
 }
 
 /* ── Responsive: desktop shows chip row + inline mine toggle, hides filter

--- a/packages/web/components/list/RepoFilterChips.module.css
+++ b/packages/web/components/list/RepoFilterChips.module.css
@@ -40,10 +40,12 @@
   inset: -6px 0;
 }
 
-.chip:hover,
+.chip:hover {
+  background: var(--paper-bg-warm);
+}
+
 .chip:focus-visible {
   background: var(--paper-bg-warm);
-  outline: none;
 }
 
 .chipActive {

--- a/packages/web/components/settings/WorktreeCleanup.module.css
+++ b/packages/web/components/settings/WorktreeCleanup.module.css
@@ -54,12 +54,6 @@
   color: var(--paper-ink-muted);
 }
 
-.deleteBtn {
-  font-size: 11px;
-  padding: 4px 8px;
-  color: var(--paper-brick);
-}
-
 .bulkBar {
   display: flex;
   align-items: center;
@@ -75,6 +69,25 @@
 .cleanAllBtn {
   font-size: 12px;
   padding: 4px 12px;
+}
+
+.confirmInline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.confirmText {
+  font-size: 12px;
+  color: var(--paper-ink-muted);
+  font-style: italic;
+}
+
+.dangerBtn {
+  font-size: 11px;
+  padding: 4px 8px;
+  color: var(--paper-brick);
 }
 
 .error {

--- a/packages/web/components/settings/WorktreeCleanup.tsx
+++ b/packages/web/components/settings/WorktreeCleanup.tsx
@@ -17,6 +17,8 @@ export function WorktreeCleanup({ worktrees }: Props) {
   const [success, setSuccess] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const [expanded, setExpanded] = useState(false);
+  // "all" = bulk stale cleanup, worktree path = single delete, null = no confirm
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
 
   if (worktrees.length === 0) {
     return <div className={styles.empty}>No worktrees found</div>;
@@ -27,10 +29,17 @@ export function WorktreeCleanup({ worktrees }: Props) {
   function handleDelete(wt: WorktreeInfo) {
     setError(null);
     setSuccess(null);
+    setConfirmTarget(null);
     startTransition(async () => {
-      const result = await cleanupWorktree(wt.path, wt.localPath ?? undefined);
-      if (!result.success) {
-        setError(result.error ?? "Failed to delete worktree");
+      try {
+        const result = await cleanupWorktree(wt.path, wt.localPath ?? undefined);
+        if (result.success) {
+          setSuccess(`Removed worktree "${wt.name}"`);
+        } else {
+          setError(result.error ?? "Failed to delete worktree");
+        }
+      } catch {
+        setError("Failed to delete worktree");
       }
     });
   }
@@ -38,13 +47,18 @@ export function WorktreeCleanup({ worktrees }: Props) {
   function handleCleanAll() {
     setError(null);
     setSuccess(null);
+    setConfirmTarget(null);
     startTransition(async () => {
-      const result = await cleanupStaleWorktrees();
-      if (result.removed > 0) {
-        setSuccess(`Removed ${result.removed} stale worktree${result.removed > 1 ? "s" : ""}`);
-      }
-      if (!result.success) {
-        setError(result.error ?? "Failed to clean stale worktrees");
+      try {
+        const result = await cleanupStaleWorktrees();
+        if (result.removed > 0) {
+          setSuccess(`Removed ${result.removed} stale worktree${result.removed > 1 ? "s" : ""}`);
+        }
+        if (!result.success) {
+          setError(result.error ?? "Failed to clean stale worktrees");
+        }
+      } catch {
+        setError("Failed to clean stale worktrees");
       }
     });
   }
@@ -59,14 +73,35 @@ export function WorktreeCleanup({ worktrees }: Props) {
           <span className={styles.staleCount}>
             {staleCount} stale worktree{staleCount > 1 ? "s" : ""}
           </span>
-          <Button
-            variant="ghost"
-            className={styles.cleanAllBtn}
-            onClick={handleCleanAll}
-            disabled={isPending}
-          >
-            {isPending ? "Cleaning..." : "Clean all stale"}
-          </Button>
+          {confirmTarget === "all" ? (
+            <span className={styles.confirmInline}>
+              <span className={styles.confirmText}>Remove all stale?</span>
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmTarget(null)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="ghost"
+                className={styles.dangerBtn}
+                onClick={handleCleanAll}
+                disabled={isPending}
+              >
+                {isPending ? "Cleaning..." : "Remove"}
+              </Button>
+            </span>
+          ) : (
+            <Button
+              variant="ghost"
+              className={styles.cleanAllBtn}
+              onClick={() => setConfirmTarget("all")}
+              disabled={isPending}
+            >
+              Clean all stale
+            </Button>
+          )}
         </div>
       )}
       {visibleWorktrees.map((wt) => (
@@ -78,14 +113,35 @@ export function WorktreeCleanup({ worktrees }: Props) {
           {wt.issueNumber && (
             <span className={styles.issue}>#{wt.issueNumber}</span>
           )}
-          <Button
-            variant="ghost"
-            className={styles.deleteBtn}
-            onClick={() => handleDelete(wt)}
-            disabled={isPending}
-          >
-            Delete
-          </Button>
+          {confirmTarget === wt.path ? (
+            <span className={styles.confirmInline}>
+              <span className={styles.confirmText}>Delete?</span>
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmTarget(null)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="ghost"
+                className={styles.dangerBtn}
+                onClick={() => handleDelete(wt)}
+                disabled={isPending}
+              >
+                {isPending ? "Deleting..." : "Delete"}
+              </Button>
+            </span>
+          ) : (
+            <Button
+              variant="ghost"
+              className={styles.dangerBtn}
+              onClick={() => setConfirmTarget(wt.path)}
+              disabled={isPending}
+            >
+              Delete
+            </Button>
+          )}
         </div>
       ))}
       {hasMore && !expanded && (

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "serwist": "^9.5.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       serwist:
         specifier: ^9.5.7
         version: 9.5.7(browserslist@4.28.1)(typescript@5.9.3)
@@ -1458,6 +1461,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1809,8 +1816,32 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1839,6 +1870,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -2134,11 +2186,17 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -3690,6 +3748,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -4019,6 +4079,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4033,6 +4102,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4127,6 +4253,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -4477,6 +4661,17 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4493,6 +4688,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Addresses findings from a desktop-focused UX audit (QA ux-auditor persona):

- **Accessibility:** Replace `<div>` field labels with proper `<label>` elements on new issue form; add explicit `focus-visible` outlines on section tabs, filter button, and scope pill clear link
- **Error handling:** Add try-catch wrappers around server action calls in WorktreeCleanup to prevent silent failures; add success feedback for individual worktree deletion
- **UX safety:** Add inline confirmation flow for destructive worktree delete/cleanup actions (replaces immediate action)
- **Content rendering:** Add `remark-gfm` for GitHub-flavored markdown tables, strikethrough, and autolinks in issue body
- **Navigation:** Redirect to issue detail instead of 404 when launch page is missing `deploymentId` param

## Changed files

| File | Change |
|------|--------|
| `NewIssuePage.tsx` / `.module.css` | `<label>` + `htmlFor` for Title and Description inputs |
| `BodyText.tsx` / `.module.css` | `remark-gfm` plugin + table styling |
| `List.module.css` | Split `:hover, :focus-visible` → separate rules with explicit outlines |
| `RepoFilterChips.module.css` | Remove redundant `outline: none` (global rule handles it) |
| `WorktreeCleanup.tsx` / `.module.css` | Inline confirm flow, try-catch, success feedback |
| `launch/.../page.tsx` | `redirect()` instead of `notFound()` for missing deploymentId |

## Test plan

- [x] `pnpm turbo typecheck` — all packages pass
- [x] `pnpm turbo lint` — no new errors (pre-existing warnings only)
- [x] `/simplify` — all findings addressed
- [x] `/pr-review-toolkit:review-pr all` — all Critical and Important issues fixed
- [ ] Manual: verify keyboard navigation shows focus rings on list tabs and filter controls
- [ ] Manual: verify worktree delete shows confirm → cancel/delete inline flow
- [ ] Manual: verify GFM tables render in issue body markdown