### PR TITLE
fix: mobile UX audit — touch targets, typography, and form attributes

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -150,6 +150,16 @@ textarea::placeholder {
   z-index: 1;
 }
 
+@media (pointer: coarse) {
+  /* Fallback floor for form elements not styled by CSS Modules.
+     Component-level min-height (set via class selectors) always wins. */
+  input,
+  textarea,
+  select {
+    min-height: 44px;
+  }
+}
+
 /* ── Standalone PWA adjustments ──────────────────────────────────
    When launched from the home screen (display: standalone), the
    browser address bar is gone. Add top padding to account for the

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -203,6 +203,7 @@
 .input {
   width: 100%;
   padding: 10px 12px;
+  min-height: 44px;
   background: var(--paper-bg-warm);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
@@ -266,7 +267,7 @@
   border: 1px solid var(--paper-line);
   white-space: nowrap;
   flex-shrink: 0;
-  min-height: 36px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   transition: background 0.15s, color 0.15s;

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -217,6 +217,7 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
             disabled={isPending}
             maxLength={65536}
             rows={4}
+            autoComplete="off"
             autoCapitalize="sentences"
             autoCorrect="on"
             spellCheck

--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -104,6 +104,10 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
         rows={3}
         disabled={sending}
         aria-label="Comment body"
+        autoComplete="off"
+        autoCapitalize="sentences"
+        spellCheck={true}
+        enterKeyHint="send"
       />
       {error && <div className={styles.error}>{error}</div>}
       <div className={styles.footer}>

--- a/packages/web/components/detail/CommentList.module.css
+++ b/packages/web/components/detail/CommentList.module.css
@@ -14,7 +14,7 @@
 
 .count {
   font-family: var(--paper-mono);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--paper-ink-faint);
   font-style: normal;
 }

--- a/packages/web/components/detail/DraftDetail.module.css
+++ b/packages/web/components/detail/DraftDetail.module.css
@@ -22,7 +22,8 @@
   border: none;
   border-bottom: 1px solid transparent;
   outline: none;
-  padding: 0;
+  padding: 6px 0;
+  min-height: 44px;
   transition: border-color 0.15s;
 }
 

--- a/packages/web/components/issue/LabelSelector.module.css
+++ b/packages/web/components/issue/LabelSelector.module.css
@@ -1,11 +1,14 @@
 .chips {
   display: flex;
-  gap: 6px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
 .chip {
-  padding: 4px 12px;
+  padding: 10px 12px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 600;
@@ -22,13 +25,8 @@
 }
 
 .chipSelected {
-  padding: 4px 12px;
-  border-radius: 12px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
+  composes: chip;
   border: 1px solid;
-  transition: background 0.15s, color 0.15s;
 }
 
 .chipSelected:hover:not(:disabled) {

--- a/packages/web/components/list/FilterEdgeSwipe.module.css
+++ b/packages/web/components/list/FilterEdgeSwipe.module.css
@@ -5,6 +5,7 @@
   transform: translateX(-50%);
   z-index: 40;
   width: 160px;
+  min-height: 44px;
   padding: 18px 20px calc(10px + env(safe-area-inset-bottom, 0px));
   background: linear-gradient(
     to top,
@@ -17,6 +18,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   /* Capture vertical pan gestures so upward swipes reach our handlers
      rather than scrolling the list behind. */
   touch-action: none;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -37,11 +37,13 @@
   vertical-align: 6px;
 }
 
+/* Hidden — primary nav is always visible inline. The hamburger button
+   and Drawer remain in the DOM but are not shown. */
 .menuBtn {
   background: transparent;
   border: none;
   color: var(--paper-ink-muted);
-  display: inline-flex;
+  display: none;
   align-items: center;
   justify-content: center;
   min-width: 44px;
@@ -63,12 +65,13 @@
   color: var(--paper-ink);
 }
 
-/* Desktop: inline nav links (hidden on mobile, where the drawer handles nav) */
+/* Inline nav links — visible on all viewports so primary navigation
+   is never hidden behind a hamburger. Compact on mobile, spaced on desktop. */
 .desktopNav {
-  display: none;
+  display: flex;
   align-items: baseline;
   margin-left: auto;
-  margin-right: 12px;
+  margin-right: 4px;
 }
 
 .desktopNavLink {
@@ -78,6 +81,9 @@
   color: var(--paper-ink-muted);
   cursor: pointer;
   padding: 4px 0;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .desktopNavLink:hover {
@@ -151,6 +157,7 @@
   color: var(--paper-ink-muted);
   padding: 12px 2px 14px;
   margin-right: 26px;
+  min-width: 44px;
   position: relative;
   cursor: default;
 }
@@ -231,12 +238,8 @@
     padding: 52px 24px 12px;
   }
 
-  .menuBtn {
-    display: none;
-  }
-
   .desktopNav {
-    display: flex;
+    margin-right: 12px;
   }
 
   .desktopDate {
@@ -308,8 +311,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 10px 14px;
-  min-height: 40px;
+  padding: 12px 14px;
+  min-height: 44px;
   font-family: var(--paper-serif);
   font-size: 13px;
   color: var(--paper-ink-muted);
@@ -318,14 +321,6 @@
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
   flex-shrink: 0;
-}
-
-/* Extend hit area to 44px (40 + 2 + 2) for WCAG 2.5.5 compliance. */
-.sectionTab::before,
-.sectionTabActive::before {
-  content: "";
-  position: absolute;
-  inset: -2px 0;
 }
 
 .sectionTab:hover,
@@ -354,7 +349,7 @@
 .sortToggle {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 8px;
   padding: 4px 16px 10px;
 }
 
@@ -369,20 +364,16 @@
 .sortOption,
 .sortOptionActive {
   position: relative;
-  padding: 4px 10px;
+  padding: 6px 10px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   border-radius: 999px;
   font-family: var(--paper-serif);
   font-size: 11px;
   color: var(--paper-ink-muted);
   text-decoration: none;
   white-space: nowrap;
-}
-
-.sortOption::before,
-.sortOptionActive::before {
-  content: "";
-  position: absolute;
-  inset: -4px 0;
 }
 
 .sortOption:hover {
@@ -521,6 +512,15 @@
 
 .tab {
   white-space: nowrap;
+}
+
+.pageStatus {
+  padding: 12px 24px;
+  text-align: center;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-faint);
 }
 
 .sentinel {

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -70,10 +70,17 @@ export function ListContent({
   }, [loadMore, activeSection]);
 
   if (activeTab === "issues") {
+    const total = data[activeSection].length;
+    const showing = Math.min(visibleCount, total);
     return (
       <>
         {renderIssueSection({ activeSection, data, visibleCount })}
-        {visibleCount < data[activeSection].length && (
+        {total > PAGE_SIZE && (
+          <div className={styles.pageStatus}>
+            Showing {showing} of {total}
+          </div>
+        )}
+        {visibleCount < total && (
           <div ref={sentinelRef} className={styles.sentinel} />
         )}
       </>

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -119,7 +119,7 @@
   font-family: var(--paper-serif);
   font-weight: 400;
   font-size: 17px;
-  line-height: 1.3;
+  line-height: 1.5;
   color: var(--paper-ink);
   margin-bottom: 6px;
   letter-spacing: -0.1px;
@@ -139,6 +139,7 @@
   flex-wrap: wrap;
   font-family: var(--paper-sans);
   font-size: 12px;
+  line-height: 1.5;
   color: var(--paper-ink-muted);
 }
 

--- a/packages/web/components/list/ListSection.module.css
+++ b/packages/web/components/list/ListSection.module.css
@@ -22,7 +22,7 @@
 
 .count {
   font-family: var(--paper-mono);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--paper-ink-faint);
   font-weight: 500;
 }

--- a/packages/web/components/list/PrListRow.module.css
+++ b/packages/web/components/list/PrListRow.module.css
@@ -54,7 +54,7 @@
   font-family: var(--paper-serif);
   font-weight: 400;
   font-size: 17px;
-  line-height: 1.3;
+  line-height: 1.5;
   color: var(--paper-ink);
   margin-bottom: 6px;
   letter-spacing: -0.1px;
@@ -66,7 +66,8 @@
   align-items: center;
   flex-wrap: wrap;
   font-family: var(--paper-sans);
-  font-size: 11px;
+  font-size: 12px;
+  line-height: 1.5;
   color: var(--paper-ink-muted);
 }
 

--- a/packages/web/components/parse/ParseInput.tsx
+++ b/packages/web/components/parse/ParseInput.tsx
@@ -83,6 +83,7 @@ export function ParseInput({ onParsed }: Props) {
         autoComplete="off"
         autoCapitalize="sentences"
         spellCheck={true}
+        enterKeyHint="done"
         aria-label="Issue description for Claude to parse"
         maxLength={8192}
       />

--- a/packages/web/e2e/mobile-ux-patterns.spec.ts
+++ b/packages/web/e2e/mobile-ux-patterns.spec.ts
@@ -217,13 +217,13 @@ async function expectTouchTarget(
 // ── Tests ───────────────────────────────────────────────────────────
 
 test.describe("Mobile UX regressions — touch targets (R3-R6)", () => {
-  test("dashboard nav overflow is 44x44", async ({ page }) => {
+  test("dashboard inline nav links are 44px tall", async ({ page }) => {
     if (skipReason) test.skip(true, skipReason);
     await page.goto(`${BASE_URL}/`);
     await expectTouchTarget(
       page,
-      'button[aria-label="Open navigation"]',
-      "dashboard nav overflow",
+      'nav a[href="/parse"]',
+      "inline nav Quick Create",
     );
   });
 


### PR DESCRIPTION
## Summary

Addresses all 20 findings from a mobile-ux-auditor QA run at 393×852 viewport (iPhone 15 Pro):

- **6 Critical**: Touch targets below 44px on section tabs, sort links, label chips, draft input, filter button; comment count font below iOS Caption 2 floor
- **4 Major**: Sort option tap spacing too tight, primary nav hidden behind hamburger, line-height below WCAG 1.4.12 on list rows
- **10 Minor**: PR meta font size, input heights, missing `enterKeyHint`/`autoCapitalize`/`spellCheck`, no `pointer:coarse` media queries, unbounded list indicator

### Changes across 14 files (all in `packages/web`):
- Enforce 44px min touch targets via `min-height` + `display: inline-flex` (replaced `::before` pseudo-element hit area hacks)
- Bump sub-11px fonts to 11px (iOS Caption 2 floor)
- Set `line-height: 1.5` on list row titles and meta (WCAG 1.4.12)
- Make primary nav always visible, hide hamburger menu
- Add mobile textarea attributes (`enterKeyHint`, `autoCapitalize`, `spellCheck`, `autoComplete`)
- Add "Showing X of Y" pagination indicator for infinite-scroll lists
- Add global `@media (pointer: coarse)` fallback floor for unstyled form elements
- Consolidate `LabelSelector .chipSelected` via `composes: chip`

### PR Review Toolkit results (4 agents, all passed):
- **Code reviewer**: 4 Important findings — all addressed
- **Comment analyzer**: 1 Critical (dead code removed), 4 improvements — addressed
- **Silent failure hunter**: 0 issues
- **Code simplifier**: 1 consolidation applied (LabelSelector)

## Test plan

- [x] `pnpm turbo typecheck` — all packages pass
- [x] Playwright verification at 393×852: zero interactive elements below 44px on dashboard and Create Issue pages
- [x] All font sizes ≥ 11px, all body line-heights at 1.5× ratio
- [ ] Visual regression check on desktop (768px+) — nav links should appear inline as before
- [ ] Verify label chips on Create Issue page render correctly with `composes` change