### PR TITLE
feat: list UX redesign — section rename, wider layout, swipe-to-launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ issuectl web                    # Start dashboard (localhost:3847)
    - Common situations where you should ask:
      - The spec/plan doesn't cover a specific UI behavior or edge case
      - You're choosing between two reasonable implementation approaches
-     - A technical risk from the plan (Ghostty CLI, better-sqlite3 bindings, etc.) materializes and needs a decision
+     - A technical risk from the plan (ttyd, better-sqlite3 bindings, etc.) materializes and needs a decision
      - You're about to deviate from the plan (different file structure, different API shape, etc.)
      - A dependency has an unexpected API or limitation
    - **Do not ask** about things you can verify yourself (does a function exist, does a type match, does a build pass).

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -72,12 +72,12 @@ describe("groupIntoSections", () => {
     });
     expect(result.unassigned).toHaveLength(2);
     expect(result.unassigned.every((item) => item.kind === "draft")).toBe(true);
-    expect(result.in_focus).toEqual([]);
-    expect(result.in_flight).toEqual([]);
-    expect(result.shipped).toEqual([]);
+    expect(result.open).toEqual([]);
+    expect(result.running).toEqual([]);
+    expect(result.closed).toEqual([]);
   });
 
-  it("puts closed issues in shipped", () => {
+  it("puts closed issues in closed", () => {
     const closed = makeIssue({ number: 1, state: "closed" });
     const result = groupIntoSections({
       drafts: [],
@@ -90,11 +90,11 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    expect(result.shipped).toHaveLength(1);
-    expect(result.in_focus).toEqual([]);
+    expect(result.closed).toHaveLength(1);
+    expect(result.open).toEqual([]);
   });
 
-  it("puts open issues with an active deployment in in_flight", () => {
+  it("puts open issues with an active deployment in running", () => {
     const issue = makeIssue({ number: 2 });
     const result = groupIntoSections({
       drafts: [],
@@ -107,11 +107,11 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    expect(result.in_flight).toHaveLength(1);
-    expect(result.in_focus).toEqual([]);
+    expect(result.running).toHaveLength(1);
+    expect(result.open).toEqual([]);
   });
 
-  it("treats an issue with only ended deployments as in_focus", () => {
+  it("treats an issue with only ended deployments as open", () => {
     const issue = makeIssue({ number: 3 });
     const result = groupIntoSections({
       drafts: [],
@@ -124,11 +124,11 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    expect(result.in_focus).toHaveLength(1);
-    expect(result.in_flight).toEqual([]);
+    expect(result.open).toHaveLength(1);
+    expect(result.running).toEqual([]);
   });
 
-  it("puts open issues with no deployment in in_focus", () => {
+  it("puts open issues with no deployment in open", () => {
     const issue = makeIssue({ number: 4 });
     const result = groupIntoSections({
       drafts: [],
@@ -141,7 +141,7 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    expect(result.in_focus).toHaveLength(1);
+    expect(result.open).toHaveLength(1);
   });
 
   it("enriches issues with their priority from the repo's priority map", () => {
@@ -165,7 +165,7 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    const item = result.in_focus[0];
+    const item = result.open[0];
     if (item.kind !== "issue") throw new Error("expected issue");
     expect(item.priority).toBe("high");
   });
@@ -183,7 +183,7 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    const item = result.in_focus[0];
+    const item = result.open[0];
     if (item.kind !== "issue") throw new Error("expected issue");
     expect(item.priority).toBe("normal");
   });
@@ -209,7 +209,7 @@ describe("groupIntoSections", () => {
         },
       ],
     }, "priority");
-    const focus = result.in_focus;
+    const focus = result.open;
     expect(focus).toHaveLength(3);
     if (focus[0].kind !== "issue") throw new Error("expected issue");
     if (focus[1].kind !== "issue") throw new Error("expected issue");
@@ -238,31 +238,31 @@ describe("groupIntoSections", () => {
 
   it("item.section matches the bucket an issue lands in", () => {
     const openIssue = makeIssue({ number: 1, state: "open" });
-    const shippedIssue = makeIssue({ number: 2, state: "closed" });
-    const flightIssue = makeIssue({ number: 3, state: "open" });
+    const closedIssue = makeIssue({ number: 2, state: "closed" });
+    const runningIssue = makeIssue({ number: 3, state: "open" });
     const result = groupIntoSections({
       drafts: [],
       perRepo: [
         {
           repo,
-          issues: [openIssue, shippedIssue, flightIssue],
+          issues: [openIssue, closedIssue, runningIssue],
           deployments: [makeDeployment(3, false)],
           priorities: [],
         },
       ],
     });
 
-    for (const item of result.in_focus) {
+    for (const item of result.open) {
       if (item.kind !== "issue") throw new Error("expected issue");
-      expect(item.section).toBe("in_focus");
+      expect(item.section).toBe("open");
     }
-    for (const item of result.in_flight) {
+    for (const item of result.running) {
       if (item.kind !== "issue") throw new Error("expected issue");
-      expect(item.section).toBe("in_flight");
+      expect(item.section).toBe("running");
     }
-    for (const item of result.shipped) {
+    for (const item of result.closed) {
       if (item.kind !== "issue") throw new Error("expected issue");
-      expect(item.section).toBe("shipped");
+      expect(item.section).toBe("closed");
     }
   });
 
@@ -292,9 +292,9 @@ describe("groupIntoSections", () => {
       ],
     });
 
-    expect(result.in_focus).toHaveLength(3);
+    expect(result.open).toHaveLength(3);
     // Verify both repos are represented by looking at the item.repo.name
-    const repoNames = result.in_focus.map((item) => {
+    const repoNames = result.open.map((item) => {
       if (item.kind !== "issue") throw new Error("expected issue");
       return item.repo.name;
     });
@@ -332,7 +332,7 @@ describe("groupIntoSections", () => {
       ],
     });
 
-    for (const item of result.in_focus) {
+    for (const item of result.open) {
       if (item.kind !== "issue") throw new Error("expected issue");
       if (item.repo.name === "api") {
         expect(item.priority).toBe("normal");
@@ -342,10 +342,10 @@ describe("groupIntoSections", () => {
     }
   });
 
-  it("a closed issue with an active deployment still lands in shipped", () => {
-    // Precedence test: closed → shipped wins over active deployment → in_flight.
+  it("a closed issue with an active deployment still lands in closed", () => {
+    // Precedence test: closed → closed wins over active deployment → running.
     // Pins the branch order in groupIntoSections so a future refactor can't
-    // silently move closed-with-deployment issues into in_flight.
+    // silently move closed-with-deployment issues into running.
     const issue = makeIssue({ number: 7, state: "closed" });
     const result = groupIntoSections({
       drafts: [],
@@ -358,15 +358,15 @@ describe("groupIntoSections", () => {
         },
       ],
     });
-    expect(result.shipped).toHaveLength(1);
-    expect(result.in_flight).toHaveLength(0);
+    expect(result.closed).toHaveLength(1);
+    expect(result.running).toHaveLength(0);
   });
 
   it("handles empty input cleanly", () => {
     const result = groupIntoSections({ drafts: [], perRepo: [] });
     expect(result.unassigned).toEqual([]);
-    expect(result.in_focus).toEqual([]);
-    expect(result.in_flight).toEqual([]);
-    expect(result.shipped).toEqual([]);
+    expect(result.open).toEqual([]);
+    expect(result.running).toEqual([]);
+    expect(result.closed).toEqual([]);
   });
 });

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -80,9 +80,9 @@ export function groupIntoSections(
   const unassigned: DraftListItem[] = sortDrafts(input.drafts)
     .map((draft) => ({ kind: "draft" as const, draft }));
 
-  const in_focus: IssueListItem[] = [];
-  const in_flight: IssueListItem[] = [];
-  const shipped: IssueListItem[] = [];
+  const open: IssueListItem[] = [];
+  const running: IssueListItem[] = [];
+  const closed: IssueListItem[] = [];
 
   for (const { repo, issues, deployments, priorities } of input.perRepo) {
     // A deployment row with ended_at IS NULL means there's a live
@@ -101,14 +101,14 @@ export function groupIntoSections(
       const priority = priorityMap.get(issue.number) ?? "normal";
 
       // Closed wins over an active deployment (a stale deployment shouldn't
-      // keep a closed issue out of shipped). See the dedicated test.
-      let section: "in_focus" | "in_flight" | "shipped";
+      // keep a closed issue out of closed). See the dedicated test.
+      let section: "open" | "running" | "closed";
       if (issue.state === "closed") {
-        section = "shipped";
+        section = "closed";
       } else if (activeLaunchSet.has(issue.number)) {
-        section = "in_flight";
+        section = "running";
       } else {
-        section = "in_focus";
+        section = "open";
       }
 
       const item: IssueListItem = {
@@ -119,9 +119,9 @@ export function groupIntoSections(
         section,
       };
 
-      if (section === "in_focus") in_focus.push(item);
-      else if (section === "in_flight") in_flight.push(item);
-      else shipped.push(item);
+      if (section === "open") open.push(item);
+      else if (section === "running") running.push(item);
+      else closed.push(item);
     }
   }
 
@@ -150,9 +150,9 @@ export function groupIntoSections(
 
   return {
     unassigned,
-    in_focus: sortIssues(in_focus),
-    in_flight: sortIssues(in_flight),
-    shipped: sortIssues(shipped),
+    open: sortIssues(open),
+    running: sortIssues(running),
+    closed: sortIssues(closed),
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,7 +75,7 @@ export type IssuePriority = {
   updatedAt: number; // unix seconds
 };
 
-export type Section = "unassigned" | "in_focus" | "in_flight" | "shipped";
+export type Section = "unassigned" | "open" | "running" | "closed";
 
 export type SortMode = "updated" | "created" | "priority";
 
@@ -109,7 +109,7 @@ export type IssueListItem = Extract<UnifiedListItem, { kind: "issue" }>;
 // future caller) from silently pushing an issue into unassigned.
 export type UnifiedList = {
   unassigned: DraftListItem[];
-  in_focus: IssueListItem[];
-  in_flight: IssueListItem[];
-  shipped: IssueListItem[];
+  open: IssueListItem[];
+  running: IssueListItem[];
+  closed: IssueListItem[];
 };

--- a/packages/web/app/DashboardContent.tsx
+++ b/packages/web/app/DashboardContent.tsx
@@ -54,16 +54,16 @@ export async function DashboardContent({
 
     const sectionCounts: Record<Section, number> = {
       unassigned: filteredData.unassigned.length,
-      in_focus: filteredData.in_focus.length,
-      in_flight: filteredData.in_flight.length,
-      shipped: filteredData.shipped.length,
+      open: filteredData.open.length,
+      running: filteredData.running.length,
+      closed: filteredData.closed.length,
     };
 
     const totalIssueCount =
       sectionCounts.unassigned +
-      sectionCounts.in_focus +
-      sectionCounts.in_flight +
-      sectionCounts.shipped;
+      sectionCounts.open +
+      sectionCounts.running +
+      sectionCounts.closed;
 
     return (
       <ListCountUpdater

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -30,10 +30,17 @@ type Props = {
 
 const SECTIONS: readonly Section[] = [
   "unassigned",
-  "in_focus",
-  "in_flight",
-  "shipped",
+  "open",
+  "running",
+  "closed",
 ];
+
+// Map legacy URL params so old bookmarks still work.
+const SECTION_MIGRATION: Record<string, string> = {
+  in_focus: "open",
+  in_flight: "running",
+  shipped: "closed",
+};
 
 export default async function MainListPage({ searchParams }: Props) {
   if (!dbExists()) {
@@ -56,11 +63,12 @@ export default async function MainListPage({ searchParams }: Props) {
   const activeTab = tab === "prs" ? "prs" : "issues";
   const activeRepo = resolveActiveRepo(repoParam, repos);
   const mineOnly = mineParam === "1";
+  const resolvedSection = SECTION_MIGRATION[sectionParam ?? ""] ?? sectionParam;
   const activeSection: Section = (SECTIONS as readonly string[]).includes(
-    sectionParam ?? "",
+    resolvedSection ?? "",
   )
-    ? (sectionParam as Section)
-    : "in_focus";
+    ? (resolvedSection as Section)
+    : "open";
   const activeSort: SortMode = (SORT_MODES as readonly string[]).includes(
     sortParam ?? "",
   )

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -68,8 +68,11 @@ export function IssueActionSheet({
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (searchParams.get("launch") === "true") {
+    if (searchParams.get("launch") === "true" && !hasLiveDeployment) {
       handleLaunchTap();
+      const url = new URL(window.location.href);
+      url.searchParams.delete("launch");
+      window.history.replaceState({}, "", url.toString());
     }
   }, []); // only run on mount
 

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -142,7 +142,7 @@ export function IssueActionSheet({
             : "Issue closed",
           "success",
         );
-        router.push("/?section=shipped");
+        router.push("/?section=closed");
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
         setError("Unable to reach the server. Check your connection and try again.");

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -71,8 +71,7 @@ export function IssueActionSheet({
     if (searchParams.get("launch") === "true") {
       handleLaunchTap();
     }
-  // eslint-disable-next-line -- only run on mount
-  }, []);
+  }, []); // only run on mount
 
   useEffect(() => {
     if (!launchOpen) return;

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type {
   GitHubIssue,
   GitHubComment,
@@ -65,6 +65,14 @@ export function IssueActionSheet({
   const [reassignKey, setReassignKey] = useState<string | null>(null);
 
   const { isOffline } = useOfflineAware();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("launch") === "true") {
+      handleLaunchTap();
+    }
+  // eslint-disable-next-line -- only run on mount
+  }, []);
 
   useEffect(() => {
     if (!launchOpen) return;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -1,5 +1,5 @@
 .container {
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   /* Bottom padding clears the FAB (60px + 30px inset + 54px breathing room)
      so the last row's trailing action button clears the floating action
@@ -338,6 +338,18 @@
   color: var(--paper-ink);
   font-weight: 500;
   border-bottom-color: var(--paper-ink);
+}
+
+.sectionTabRunning {
+  composes: sectionTabActive;
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+  border-radius: var(--paper-radius-sm) var(--paper-radius-sm) 0 0;
+}
+
+.sectionTabRunning .sectionTabCount {
+  color: var(--paper-bg);
+  opacity: 0.8;
 }
 
 .sectionTabCount {

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -139,7 +139,6 @@
 .tabs {
   padding: 18px 24px 0;
   display: flex;
-  gap: 0;
   border-bottom: 1px solid var(--paper-line);
 }
 
@@ -289,7 +288,6 @@
 
 .sectionTabs {
   display: flex;
-  gap: 0;
   padding: 0 16px;
   margin-bottom: 8px;
   overflow-x: auto;

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -42,9 +42,9 @@ const SORT_LABEL: Record<SortMode, string> = {
 // Lowercase is intentional — matches the Paper mockup typography.
 const SECTION_LABEL: Record<Section, string> = {
   unassigned: "drafts",
-  in_focus: "in focus",
-  in_flight: "in flight",
-  shipped: "shipped",
+  open: "open",
+  running: "running",
+  closed: "closed",
 };
 
 function formatDate(d: Date): { weekday: string; short: string } {
@@ -80,8 +80,8 @@ export function List({
   const { weekday, short } = formatDate(new Date());
 
   const visibleSections: Section[] = activeRepo
-    ? ["in_focus", "in_flight", "shipped"]
-    : ["unassigned", "in_focus", "in_flight", "shipped"];
+    ? ["open", "running", "closed"]
+    : ["unassigned", "open", "running", "closed"];
 
   const isPrTab = activeTab === "prs";
   const hasActiveFilter = activeRepo !== null || (isPrTab && mineOnly);
@@ -243,11 +243,16 @@ export function List({
             {visibleSections.map((section) => {
               const isActive = section === activeSection;
               const count = sectionCounts?.[section] ?? null;
+              const tabClass = isActive
+                ? section === "running"
+                  ? styles.sectionTabRunning
+                  : styles.sectionTabActive
+                : styles.sectionTab;
               return (
                 <Link
                   key={section}
                   href={sectionHref(section)}
-                  className={isActive ? styles.sectionTabActive : styles.sectionTab}
+                  className={tabClass}
                   aria-current={isActive ? "page" : undefined}
                 >
                   {SECTION_LABEL[section]}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -243,11 +243,14 @@ export function List({
             {visibleSections.map((section) => {
               const isActive = section === activeSection;
               const count = sectionCounts?.[section] ?? null;
-              const tabClass = isActive
-                ? section === "running"
-                  ? styles.sectionTabRunning
-                  : styles.sectionTabActive
-                : styles.sectionTab;
+              let tabClass: string;
+              if (!isActive) {
+                tabClass = styles.sectionTab;
+              } else if (section === "running") {
+                tabClass = styles.sectionTabRunning;
+              } else {
+                tabClass = styles.sectionTabActive;
+              }
               return (
                 <Link
                   key={section}

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import type { Section, UnifiedList } from "@issuectl/core";
 import type { PrEntry } from "@/lib/page-filters";
 import { ListSection } from "./ListSection";
@@ -45,6 +46,7 @@ export function ListContent({
   activeRepo,
   mineOnly,
 }: Props) {
+  const router = useRouter();
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -55,6 +57,13 @@ export function ListContent({
   const loadMore = useCallback(() => {
     setVisibleCount((prev) => prev + PAGE_SIZE);
   }, []);
+
+  const handleLaunch = useCallback(
+    (owner: string, repo: string, issueNumber: number) => {
+      router.push(`/issues/${owner}/${repo}/${issueNumber}?launch=true`);
+    },
+    [router],
+  );
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -72,7 +81,7 @@ export function ListContent({
   if (activeTab === "issues") {
     return (
       <>
-        {renderIssueSection({ activeSection, data, visibleCount })}
+        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch })}
         {visibleCount < data[activeSection].length && (
           <div ref={sentinelRef} className={styles.sentinel} />
         )}
@@ -120,10 +129,12 @@ function renderIssueSection({
   activeSection,
   data,
   visibleCount,
+  onLaunch,
 }: {
   activeSection: Section;
   data: UnifiedList;
   visibleCount: number;
+  onLaunch: (owner: string, repo: string, issueNumber: number) => void;
 }) {
   const allItems = data[activeSection];
 
@@ -141,5 +152,5 @@ function renderIssueSection({
   }
 
   const items = allItems.slice(0, visibleCount);
-  return <ListSection title={null} items={items} />;
+  return <ListSection title={null} items={items} onLaunch={onLaunch} />;
 }

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -65,6 +65,13 @@ export function ListContent({
     [router],
   );
 
+  const handleNavigate = useCallback(
+    (owner: string, repo: string, issueNumber: number) => {
+      router.push(`/issues/${owner}/${repo}/${issueNumber}`);
+    },
+    [router],
+  );
+
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
@@ -81,7 +88,7 @@ export function ListContent({
   if (activeTab === "issues") {
     return (
       <>
-        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch })}
+        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch, onNavigate: handleNavigate })}
         {visibleCount < data[activeSection].length && (
           <div ref={sentinelRef} className={styles.sentinel} />
         )}
@@ -89,23 +96,24 @@ export function ListContent({
     );
   }
 
-  const prCount = prs.length;
+  if (prs.length === 0) {
+    let emptyMessage: string;
+    if (activeRepo && mineOnly) {
+      emptyMessage = `no open PRs from you in ${activeRepo}.`;
+    } else if (activeRepo) {
+      emptyMessage = `no open PRs in ${activeRepo}.`;
+    } else if (mineOnly) {
+      emptyMessage = "no open PRs from you across your repos.";
+    } else {
+      emptyMessage = "no open PRs across your repos.";
+    }
 
-  if (prCount === 0) {
     return (
       <div className={styles.empty}>
         <div className={styles.emptyMark}>❧</div>
         <h3>no pull requests</h3>
         <p>
-          <em>
-            {activeRepo && mineOnly
-              ? `no open PRs from you in ${activeRepo}.`
-              : activeRepo
-                ? `no open PRs in ${activeRepo}.`
-                : mineOnly
-                  ? "no open PRs from you across your repos."
-                  : "no open PRs across your repos."}
-          </em>
+          <em>{emptyMessage}</em>
         </p>
       </div>
     );
@@ -130,11 +138,13 @@ function renderIssueSection({
   data,
   visibleCount,
   onLaunch,
+  onNavigate,
 }: {
   activeSection: Section;
   data: UnifiedList;
   visibleCount: number;
   onLaunch: (owner: string, repo: string, issueNumber: number) => void;
+  onNavigate: (owner: string, repo: string, issueNumber: number) => void;
 }) {
   const allItems = data[activeSection];
 
@@ -152,5 +162,5 @@ function renderIssueSection({
   }
 
   const items = allItems.slice(0, visibleCount);
-  return <ListSection title={null} items={items} onLaunch={onLaunch} />;
+  return <ListSection title={null} items={items} onLaunch={onLaunch} onNavigate={onNavigate} />;
 }

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -23,16 +23,16 @@ const SECTION_EMPTY: Record<Section, { title: string; body: string }> = {
     title: "no drafts",
     body: "start a draft with the + button — it'll live here until you assign it to a repo.",
   },
-  in_focus: {
+  open: {
     title: "all clear",
     body: "nothing on your plate. breathe, or draft the next one.",
   },
-  in_flight: {
-    title: "nothing in flight",
-    body: "when you launch an issue, it lands here while you work on it.",
+  running: {
+    title: "no running sessions",
+    body: "when you launch an issue with Claude Code, it lands here while the session is active.",
   },
-  shipped: {
-    title: "nothing shipped yet",
+  closed: {
+    title: "nothing closed yet",
     body: "closed issues show up here once PRs merge and reconcile.",
   },
 };

--- a/packages/web/components/list/ListCountContext.tsx
+++ b/packages/web/components/list/ListCountContext.tsx
@@ -44,13 +44,13 @@ export function ListCountUpdater({
 }: Counts & { children: ReactNode }) {
   const ctx = useContext(ListCountContext);
   const setCounts = ctx?.setCounts;
-  const { unassigned, in_focus, in_flight, shipped } = sectionCounts;
+  const { unassigned, open, running, closed } = sectionCounts;
   useEffect(() => {
     setCounts?.({
-      sectionCounts: { unassigned, in_focus, in_flight, shipped },
+      sectionCounts: { unassigned, open, running, closed },
       totalIssueCount,
       prCount,
     });
-  }, [setCounts, unassigned, in_focus, in_flight, shipped, totalIssueCount, prCount]);
+  }, [setCounts, unassigned, open, running, closed, totalIssueCount, prCount]);
   return <>{children}</>;
 }

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -76,12 +76,12 @@
 /* In-flight variant — visually distinct from the launch CTA so a row
  * with an active session reads as "go to existing" rather than
  * "start something new". */
-.actionBtnFlight {
+.actionBtnRunning {
   color: var(--paper-ink-soft);
   background: var(--paper-bg-warmer);
 }
 
-.actionBtnFlight:hover {
+.actionBtnRunning:hover {
   color: var(--paper-ink);
   background: var(--paper-bg);
   border-color: var(--paper-line);
@@ -157,4 +157,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.activeLabel {
+  color: var(--paper-accent);
+  font-weight: 600;
 }

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -73,7 +73,7 @@
   color: var(--paper-accent);
 }
 
-/* In-flight variant — visually distinct from the launch CTA so a row
+/* Running variant — visually distinct from the launch CTA so a row
  * with an active session reads as "go to existing" rather than
  * "start something new". */
 .actionBtnRunning {
@@ -105,6 +105,10 @@
 
   .item:hover .actions,
   .item:focus-within .actions {
+    display: flex;
+  }
+
+  .item[data-section="running"] .actions {
     display: flex;
   }
 

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -2,10 +2,12 @@ import Link from "next/link";
 import type { UnifiedListItem } from "@issuectl/core";
 import { Checkbox, Chip, LabelChip } from "@/components/paper";
 import { SyncDot } from "@/components/ui/SyncDot";
+import { SwipeRow } from "./SwipeRow";
 import styles from "./ListRow.module.css";
 
 type Props = {
   item: UnifiedListItem;
+  onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
 // Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
@@ -25,7 +27,7 @@ function formatAge(updatedAt: string | number): string {
   return `${diffDays}d`;
 }
 
-export function ListRow({ item }: Props) {
+export function ListRow({ item, onLaunch }: Props) {
   if (item.kind === "draft") {
     return (
       <div className={styles.item}>
@@ -82,7 +84,7 @@ export function ListRow({ item }: Props) {
     }
   }
 
-  return (
+  const rowContent = (
     <div className={styles.item}>
       <Link
         href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
@@ -130,4 +132,16 @@ export function ListRow({ item }: Props) {
       </div>
     </div>
   );
+
+  if (section === "open" && onLaunch) {
+    return (
+      <SwipeRow
+        onLaunch={() => onLaunch(repo.owner, repo.name, issue.number)}
+      >
+        {rowContent}
+      </SwipeRow>
+    );
+  }
+
+  return rowContent;
 }

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -8,6 +8,7 @@ import styles from "./ListRow.module.css";
 type Props = {
   item: UnifiedListItem;
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onNavigate?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
 // Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
@@ -27,7 +28,7 @@ function formatAge(updatedAt: string | number): string {
   return `${diffDays}d`;
 }
 
-export function ListRow({ item, onLaunch }: Props) {
+export function ListRow({ item, onLaunch, onNavigate }: Props) {
   if (item.kind === "draft") {
     return (
       <div className={styles.item}>
@@ -58,7 +59,7 @@ export function ListRow({ item, onLaunch }: Props) {
     (l) => !l.name.startsWith("issuectl:"),
   );
 
-  // Label reflects what the click does: in-flight rows open an active
+  // Label reflects what the click does: running rows open an active
   // session rather than launching, so "launch" would mislead.
   // Exhaustive switch so a future addition to the Section union is a
   // compile error here instead of silently rendering "launch →" on a
@@ -85,7 +86,7 @@ export function ListRow({ item, onLaunch }: Props) {
   }
 
   const rowContent = (
-    <div className={styles.item}>
+    <div className={styles.item} data-section={section}>
       <Link
         href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
         className={styles.rowLink}
@@ -122,13 +123,23 @@ export function ListRow({ item, onLaunch }: Props) {
         </div>
       </Link>
       <div className={styles.actions}>
-        <Link
-          href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
-          className={`${styles.actionBtn} ${section === "running" ? styles.actionBtnRunning : ""}`}
-          aria-label={actionAria}
-        >
-          {actionLabel} →
-        </Link>
+        {section === "open" && onLaunch ? (
+          <button
+            className={styles.actionBtn}
+            onClick={() => onLaunch(repo.owner, repo.name, issue.number)}
+            aria-label={actionAria}
+          >
+            {actionLabel} →
+          </button>
+        ) : (
+          <Link
+            href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
+            className={`${styles.actionBtn} ${section === "running" ? styles.actionBtnRunning : ""}`}
+            aria-label={actionAria}
+          >
+            {actionLabel} →
+          </Link>
+        )}
       </div>
     </div>
   );
@@ -137,6 +148,11 @@ export function ListRow({ item, onLaunch }: Props) {
     return (
       <SwipeRow
         onLaunch={() => onLaunch(repo.owner, repo.name, issue.number)}
+        onReassign={
+          onNavigate
+            ? () => onNavigate(repo.owner, repo.name, issue.number)
+            : undefined
+        }
       >
         {rowContent}
       </SwipeRow>

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -48,9 +48,9 @@ export function ListRow({ item }: Props) {
 
   const { issue, repo, section } = item;
   const checkState =
-    section === "shipped" ? "done" : section === "in_flight" ? "flight" : "open";
+    section === "closed" ? "done" : section === "running" ? "flight" : "open";
   const titleClass =
-    section === "shipped" ? `${styles.title} ${styles.done}` : styles.title;
+    section === "closed" ? `${styles.title} ${styles.done}` : styles.title;
 
   const displayLabels = issue.labels.filter(
     (l) => !l.name.startsWith("issuectl:"),
@@ -64,15 +64,15 @@ export function ListRow({ item }: Props) {
   let actionLabel: string;
   let actionAria: string;
   switch (section) {
-    case "in_focus":
+    case "open":
       actionLabel = "launch";
       actionAria = "Launch issue";
       break;
-    case "in_flight":
+    case "running":
       actionLabel = "open";
       actionAria = "Open active session";
       break;
-    case "shipped":
+    case "closed":
       actionLabel = "view";
       actionAria = "View issue";
       break;
@@ -111,12 +111,18 @@ export function ListRow({ item }: Props) {
               <span className={styles.author}>{issue.user.login}</span>
             </>
           )}
+          {section === "running" && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.activeLabel}>active</span>
+            </>
+          )}
         </div>
       </Link>
       <div className={styles.actions}>
         <Link
           href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
-          className={`${styles.actionBtn} ${section === "in_flight" ? styles.actionBtnFlight : ""}`}
+          className={`${styles.actionBtn} ${section === "running" ? styles.actionBtnRunning : ""}`}
           aria-label={actionAria}
         >
           {actionLabel} →

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -6,9 +6,10 @@ import styles from "./ListSection.module.css";
 type Props = {
   title: ReactNode | null;
   items: UnifiedListItem[];
+  onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
-export function ListSection({ title, items }: Props) {
+export function ListSection({ title, items, onLaunch }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -28,6 +29,7 @@ export function ListSection({ title, items }: Props) {
               : `issue-${item.repo.id}-${item.issue.number}`
           }
           item={item}
+          onLaunch={onLaunch}
         />
       ))}
     </>

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -7,9 +7,10 @@ type Props = {
   title: ReactNode | null;
   items: UnifiedListItem[];
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onNavigate?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
-export function ListSection({ title, items, onLaunch }: Props) {
+export function ListSection({ title, items, onLaunch, onNavigate }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -30,6 +31,7 @@ export function ListSection({ title, items, onLaunch }: Props) {
           }
           item={item}
           onLaunch={onLaunch}
+          onNavigate={onNavigate}
         />
       ))}
     </>

--- a/packages/web/components/list/SwipeRow.module.css
+++ b/packages/web/components/list/SwipeRow.module.css
@@ -1,0 +1,62 @@
+.wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.actions {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  transform: translateX(100%);
+  transition: transform 0.2s ease;
+}
+
+.wrapper[data-swiped="true"] .actions {
+  transform: translateX(0);
+}
+
+.content {
+  transition: transform 0.2s ease;
+  background: var(--paper-bg);
+}
+
+.wrapper[data-swiped="true"] .content {
+  transform: translateX(-160px);
+}
+
+.actionBtn {
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  font-family: var(--paper-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--paper-bg);
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.launchBtn {
+  background: var(--paper-accent);
+}
+
+.reassignBtn {
+  background: var(--paper-ink-muted);
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .wrapper {
+    overflow: visible;
+  }
+
+  .actions {
+    display: none;
+  }
+
+  .content {
+    transform: none !important;
+  }
+}

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useRef, useState, useCallback, type ReactNode } from "react";
+import styles from "./SwipeRow.module.css";
+
+const SWIPE_THRESHOLD = 60;
+
+type Props = {
+  children: ReactNode;
+  onLaunch?: () => void;
+  onReassign?: () => void;
+  disabled?: boolean;
+};
+
+export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
+  const [swiped, setSwiped] = useState(false);
+  const startX = useRef<number | null>(null);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled) return;
+      startX.current = e.touches[0].clientX;
+    },
+    [disabled],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (startX.current === null) return;
+      const delta = startX.current - e.changedTouches[0].clientX;
+      if (delta > SWIPE_THRESHOLD) {
+        setSwiped(true);
+      } else if (delta < -SWIPE_THRESHOLD) {
+        setSwiped(false);
+      }
+      startX.current = null;
+    },
+    [],
+  );
+
+  const close = useCallback(() => setSwiped(false), []);
+
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className={styles.wrapper}
+      data-swiped={swiped}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className={styles.actions}>
+        {onLaunch && (
+          <button
+            className={`${styles.actionBtn} ${styles.launchBtn}`}
+            onClick={() => {
+              close();
+              onLaunch();
+            }}
+          >
+            Launch
+          </button>
+        )}
+        {onReassign && (
+          <button
+            className={`${styles.actionBtn} ${styles.reassignBtn}`}
+            onClick={() => {
+              close();
+              onReassign();
+            }}
+          >
+            Re-assign
+          </button>
+        )}
+      </div>
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -27,7 +27,12 @@ export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
   const handleTouchEnd = useCallback(
     (e: React.TouchEvent) => {
       if (startX.current === null) return;
-      const delta = startX.current - e.changedTouches[0].clientX;
+      const touch = e.changedTouches[0];
+      if (!touch) {
+        startX.current = null;
+        return;
+      }
+      const delta = startX.current - touch.clientX;
       if (delta > SWIPE_THRESHOLD) {
         setSwiped(true);
       } else if (delta < -SWIPE_THRESHOLD) {
@@ -37,6 +42,10 @@ export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
     },
     [],
   );
+
+  const handleTouchCancel = useCallback(() => {
+    startX.current = null;
+  }, []);
 
   const close = useCallback(() => setSwiped(false), []);
 
@@ -50,6 +59,7 @@ export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
       data-swiped={swiped}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
     >
       <div className={styles.actions}>
         {onLaunch && (

--- a/packages/web/e2e/action-sheets.spec.ts
+++ b/packages/web/e2e/action-sheets.spec.ts
@@ -30,7 +30,7 @@ test.use({
 // action sheets (swipe-up → Sheet → ConfirmDialog). Specifically:
 //
 // - Draft delete navigates to /?section=unassigned
-// - Issue close navigates to /?section=shipped
+// - Issue close navigates to /?section=closed
 // - Cancelling either confirmation stays on the detail page
 //
 // These were broken in an earlier PR where router.refresh() was used
@@ -377,7 +377,7 @@ test.describe("draft delete — action sheet flow", () => {
 // ── Issue close tests ─────────────────────────────────────────────────
 
 test.describe("issue close — action sheet flow", () => {
-  test("closing an issue navigates to /?section=shipped", async ({
+  test("closing an issue navigates to /?section=closed", async ({
     page,
   }) => {
     if (skipReason) test.skip(true, skipReason);
@@ -403,11 +403,11 @@ test.describe("issue close — action sheet flow", () => {
     // Confirm the close
     await confirm.getByRole("button", { name: "Close Issue" }).click();
 
-    // Should navigate to the index page with shipped section active.
+    // Should navigate to the index page with closed section active.
     // The GitHub API call takes a moment, so allow a generous timeout.
     await page.waitForURL((url) => {
       const u = new URL(url);
-      return u.pathname === "/" && u.searchParams.get("section") === "shipped";
+      return u.pathname === "/" && u.searchParams.get("section") === "closed";
     }, { timeout: 30000 });
   });
 
@@ -483,7 +483,7 @@ test.describe("draft assign — cache invalidation", () => {
     const issueMatch = page.url().match(/\/issues\/[^/]+\/[^/]+\/(\d+)/);
     const newIssueNumber = issueMatch ? Number(issueMatch[1]) : null;
 
-    // Navigate home and verify the issue appears in the "in focus" section.
+    // Navigate home and verify the issue appears in the "open" section.
     // Wait for networkidle so the Suspense streaming completes — the
     // dashboard fetches from GitHub via an async Server Component.
     await page.goto(BASE_URL);

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -272,7 +272,7 @@ test.describe("Data freshness — filters persist on back-nav (#129)", () => {
   test("repo filter preserved when navigating back from issue detail", async ({ page }) => {
     if (skipReason) test.skip(true, skipReason);
 
-    await page.goto(`${BASE_URL}/?repo=${TEST_OWNER}/${TEST_REPO}&section=in_focus`);
+    await page.goto(`${BASE_URL}/?repo=${TEST_OWNER}/${TEST_REPO}&section=open`);
     await page.waitForLoadState("networkidle");
 
     const issueLink = page.locator('a[href*="/issues/"]').first();
@@ -297,6 +297,6 @@ test.describe("Data freshness — filters persist on back-nav (#129)", () => {
 
     // URL should still have both query params
     expect(page.url()).toContain(`repo=${TEST_OWNER}/${TEST_REPO}`);
-    expect(page.url()).toContain("section=in_focus");
+    expect(page.url()).toContain("section=open");
   });
 });

--- a/packages/web/lib/list-href.test.ts
+++ b/packages/web/lib/list-href.test.ts
@@ -14,13 +14,13 @@ describe("buildHref", () => {
     expect(buildHref({ tab: "prs" })).toBe("/?tab=prs");
   });
 
-  it("section=in_focus is the default and is omitted", () => {
-    expect(buildHref({ section: "in_focus" })).toBe("/");
+  it("section=open is the default and is omitted", () => {
+    expect(buildHref({ section: "open" })).toBe("/");
   });
 
   it("non-default sections are serialized", () => {
-    expect(buildHref({ section: "shipped" })).toBe("/?section=shipped");
-    expect(buildHref({ section: "in_flight" })).toBe("/?section=in_flight");
+    expect(buildHref({ section: "closed" })).toBe("/?section=closed");
+    expect(buildHref({ section: "running" })).toBe("/?section=running");
     expect(buildHref({ section: "unassigned" })).toBe("/?section=unassigned");
   });
 
@@ -47,8 +47,8 @@ describe("buildHref", () => {
         tab: "prs",
         repo: "acme/alpha",
         mine: true,
-        section: "shipped",
+        section: "closed",
       }),
-    ).toBe("/?tab=prs&repo=acme%2Falpha&mine=1&section=shipped");
+    ).toBe("/?tab=prs&repo=acme%2Falpha&mine=1&section=closed");
   });
 });

--- a/packages/web/lib/list-href.ts
+++ b/packages/web/lib/list-href.ts
@@ -12,7 +12,7 @@ export type HrefParams = {
  * Builds the dashboard URL from filter/tab/section state. Conventions:
  *   - `tab === "issues"` is default → omitted from the URL.
  *   - `mine === true` → `mine=1`; null/false → omitted (default is "everyone").
- *   - `section === "in_focus"` is default → omitted.
+ *   - `section === "open"` is default → omitted.
  *   - `repo` is passed through verbatim when non-empty.
  *
  * Keeping defaults out of the URL keeps `/` canonical and makes back-button
@@ -23,7 +23,7 @@ export function buildHref(params: HrefParams): string {
   if (params.tab === "prs") search.set("tab", "prs");
   if (params.repo) search.set("repo", params.repo);
   if (params.mine === true) search.set("mine", "1");
-  if (params.section && params.section !== "in_focus") {
+  if (params.section && params.section !== "open") {
     search.set("section", params.section);
   }
   if (params.sort && params.sort !== "updated") {

--- a/packages/web/lib/page-filters.test.ts
+++ b/packages/web/lib/page-filters.test.ts
@@ -59,7 +59,7 @@ function makeUnifiedList(): UnifiedList {
       htmlUrl: "",
     },
     priority: "normal" as const,
-    section: "in_focus" as const,
+    section: "open" as const,
   });
   return {
     unassigned: [
@@ -75,9 +75,9 @@ function makeUnifiedList(): UnifiedList {
         },
       },
     ],
-    in_focus: [issueItem(alpha, 1), issueItem(beta, 2)],
-    in_flight: [],
-    shipped: [],
+    open: [issueItem(alpha, 1), issueItem(beta, 2)],
+    running: [],
+    closed: [],
   };
 }
 
@@ -96,8 +96,8 @@ describe("filterUnifiedList", () => {
   it("keeps only items matching the active repo", () => {
     const list = makeUnifiedList();
     const filtered = filterUnifiedList(list, "acme/alpha");
-    expect(filtered.in_focus).toHaveLength(1);
-    expect(filtered.in_focus[0].repo.name).toBe("alpha");
+    expect(filtered.open).toHaveLength(1);
+    expect(filtered.open[0].repo.name).toBe("alpha");
   });
 });
 

--- a/packages/web/lib/page-filters.ts
+++ b/packages/web/lib/page-filters.ts
@@ -34,9 +34,9 @@ export function filterUnifiedList(
     repoKey(item.repo) === activeRepo;
   return {
     unassigned: [],
-    in_focus: data.in_focus.filter(match),
-    in_flight: data.in_flight.filter(match),
-    shipped: data.shipped.filter(match),
+    open: data.open.filter(match),
+    running: data.running.filter(match),
+    closed: data.closed.filter(match),
   };
 }
 


### PR DESCRIPTION
## Summary

- Rename list sections: In Focus → **Open**, In Flight → **Running**, Shipped → **Closed**
- Reorder: Drafts → Open → Running → Closed
- Widen desktop container from 900px to 1200px
- Add **SwipeRow** for mobile swipe-left-to-reveal Launch + Re-assign actions
- Desktop: hover-to-reveal Launch button on open issue rows
- Running rows: "Open Terminal" always visible (not hover-gated), green "active" label
- Running tab gets green accent background
- Launch from list navigates to issue page with `?launch=true` to auto-open the launch modal
- URL param migration for old bookmarks (`?section=in_focus` → `?section=open`)

## What changed

**Core:**
- `Section` type: `"unassigned" | "open" | "running" | "closed"`
- `UnifiedList` fields renamed to match
- `groupIntoSections` logic updated with new string values

**Web:**
- `SwipeRow` component — touch gesture wrapper for mobile swipe-to-reveal
- `ListRow` — conditional SwipeRow wrapping, hover Launch button, running indicator
- `List` — section tabs with new labels, running tab green accent
- `ListContent` — launch/navigate handlers, updated empty messages
- `IssueActionSheet` — auto-open launch modal from `?launch=true`, guard against live deployments, URL cleanup
- All consumers updated (DashboardContent, ListCountContext, list-href, page-filters, E2E tests)

## Test plan

- [x] `pnpm turbo typecheck` — 0 errors
- [x] `pnpm --filter @issuectl/core test` — 354 tests passing
- [x] PR review toolkit (6 agents) — all findings addressed
- [ ] Manual: verify section tabs show "drafts", "open", "running" (green), "closed"
- [ ] Manual: desktop hover Launch button on open rows
- [ ] Manual: mobile swipe-left reveals Launch + Re-assign
- [ ] Manual: launch from list navigates and auto-opens modal