### PR TITLE
fix: use Node 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- semantic-release@25 requires Node >=22.14.0, but the release workflow used Node 20
- Bumps to Node 22 to match the requirement

## Context
The release workflow failed on first run after #162 merged:
> `[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.`