### PR TITLE
feat: mobile command sheet UX redesign

### DIFF
--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -93,3 +93,158 @@
   font-size: 18px;
   flex-shrink: 0;
 }
+
+/* ── Mobile-only command sections ── */
+.mobileOnly {
+  display: block;
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .mobileOnly {
+    display: none;
+  }
+}
+
+.commandSection {
+  margin-bottom: 20px;
+}
+
+.commandLabel {
+  display: block;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  color: var(--paper-ink-muted);
+  margin-bottom: 10px;
+}
+
+/* View toggle (Issues / PRs) */
+.viewToggle {
+  display: flex;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.viewOption {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 6px;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--paper-ink-muted);
+  text-align: center;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: all 0.15s ease;
+}
+
+.viewOptionActive {
+  background: var(--paper-bg);
+  color: var(--paper-ink);
+  font-weight: 500;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+/* Section chips */
+.sectionChips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.sectionChip {
+  padding: 9px 14px;
+  border-radius: 6px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--paper-ink-soft);
+  text-decoration: none;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sectionChipActive {
+  background: var(--paper-ink);
+  border-color: var(--paper-ink);
+  color: var(--paper-bg);
+  font-weight: 500;
+}
+
+.sectionChipCount {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+.sectionChipActive .sectionChipCount {
+  color: var(--paper-bg);
+  opacity: 0.7;
+}
+
+/* Divider */
+.commandDivider {
+  height: 1px;
+  background: var(--paper-line);
+  margin: 8px 0 16px;
+}
+
+/* Action links */
+.commandLink {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 0;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+  border-bottom: 1px solid var(--paper-line-soft);
+  text-decoration: none;
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.commandLink:last-child {
+  border-bottom: none;
+}
+
+.commandLinkIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--paper-accent-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--paper-accent);
+}
+
+.commandLinkText {
+  display: flex;
+  flex-direction: column;
+}
+
+.commandLinkDesc {
+  font-family: var(--paper-sans);
+  font-style: normal;
+  font-size: 12px;
+  color: var(--paper-ink-muted);
+  margin-top: 2px;
+}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { SortMode } from "@issuectl/core";
+import type { Section, SortMode } from "@issuectl/core";
 import { Sheet } from "@/components/paper";
 import { REPO_COLORS } from "@/lib/constants";
 import { repoKey } from "@/lib/repo-key";
@@ -29,6 +29,13 @@ type Props = {
   showSort: boolean;
   activeSort: SortMode;
   sortHref: (sort: SortMode) => string;
+  // New: command sheet sections (mobile only)
+  activeTab: "issues" | "prs";
+  tabHref: (tab: "issues" | "prs") => string;
+  activeSection: Section;
+  sectionHref: (section: Section) => string;
+  sectionCounts: Record<Section, number | null> | null;
+  onCreateDraft: () => void;
 };
 
 export function FiltersSheet({
@@ -45,9 +52,65 @@ export function FiltersSheet({
   showSort,
   activeSort,
   sortHref,
+  activeTab,
+  tabHref,
+  activeSection,
+  sectionHref,
+  sectionCounts,
+  onCreateDraft,
 }: Props) {
   return (
     <Sheet open={open} onClose={onClose} title="Filters">
+      {/* ── Mobile command sections ── */}
+      <div className={styles.mobileOnly}>
+        {/* View toggle: Issues / PRs */}
+        <div className={styles.commandSection}>
+          <span className={styles.commandLabel}>view</span>
+          <div className={styles.viewToggle}>
+            <Link
+              href={tabHref("issues")}
+              className={`${styles.viewOption} ${activeTab === "issues" ? styles.viewOptionActive : ""}`}
+              onClick={onClose}
+            >
+              Issues
+            </Link>
+            <Link
+              href={tabHref("prs")}
+              className={`${styles.viewOption} ${activeTab === "prs" ? styles.viewOptionActive : ""}`}
+              onClick={onClose}
+            >
+              PRs
+            </Link>
+          </div>
+        </div>
+
+        {/* Section chips: drafts / open / running / closed (issues only) */}
+        {activeTab === "issues" && (
+          <div className={styles.commandSection}>
+            <span className={styles.commandLabel}>section</span>
+            <div className={styles.sectionChips}>
+              {(["unassigned", "open", "running", "closed"] as Section[]).map(
+                (section) => (
+                  <Link
+                    key={section}
+                    href={sectionHref(section)}
+                    className={`${styles.sectionChip} ${section === activeSection ? styles.sectionChipActive : ""}`}
+                    onClick={onClose}
+                  >
+                    {section === "unassigned" ? "drafts" : section}
+                    {sectionCounts !== null && sectionCounts[section] !== null && (
+                      <span className={styles.sectionChipCount}>
+                        {sectionCounts[section]}
+                      </span>
+                    )}
+                  </Link>
+                ),
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
       <div className={styles.clearBar}>
         {clearHref ? (
           <Link
@@ -142,6 +205,54 @@ export function FiltersSheet({
           })}
         </>
       )}
+
+      {/* ── Mobile action links ── */}
+      <div className={styles.mobileOnly}>
+        <div className={styles.commandDivider} />
+
+        <button
+          className={styles.commandLink}
+          onClick={() => {
+            onClose();
+            onCreateDraft();
+          }}
+        >
+          <span className={styles.commandLinkIcon}>
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 3v12M3 9h12" />
+            </svg>
+          </span>
+          <span className={styles.commandLinkText}>
+            Create Draft
+            <span className={styles.commandLinkDesc}>start a new issue draft</span>
+          </span>
+        </button>
+
+        <Link href="/parse" className={styles.commandLink} onClick={onClose}>
+          <span className={styles.commandLinkIcon}>
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M13 3l2 2-8 8H5v-2l8-8z" />
+            </svg>
+          </span>
+          <span className={styles.commandLinkText}>
+            Quick Create
+            <span className={styles.commandLinkDesc}>paste a GitHub URL to create an issue</span>
+          </span>
+        </Link>
+
+        <Link href="/settings" className={styles.commandLink} onClick={onClose}>
+          <span className={styles.commandLinkIcon}>
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="9" cy="9" r="3" />
+              <path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.3 3.3l1.4 1.4M13.3 13.3l1.4 1.4M3.3 14.7l1.4-1.4M13.3 4.7l1.4-1.4" />
+            </svg>
+          </span>
+          <span className={styles.commandLinkText}>
+            Settings
+            <span className={styles.commandLinkDesc}>repos, tokens, preferences</span>
+          </span>
+        </Link>
+      </div>
     </Sheet>
   );
 }

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -9,6 +9,13 @@ import styles from "./FiltersSheet.module.css";
 
 type Repo = { owner: string; name: string };
 
+const SECTIONS = [
+  "unassigned",
+  "open",
+  "running",
+  "closed",
+] as const satisfies readonly Section[];
+
 const SORT_OPTIONS: { mode: SortMode; label: string }[] = [
   { mode: "updated", label: "Last updated" },
   { mode: "created", label: "Date created" },
@@ -29,7 +36,7 @@ type Props = {
   showSort: boolean;
   activeSort: SortMode;
   sortHref: (sort: SortMode) => string;
-  // New: command sheet sections (mobile only)
+  // Command sheet sections (mobile only)
   activeTab: "issues" | "prs";
   tabHref: (tab: "issues" | "prs") => string;
   activeSection: Section;
@@ -89,7 +96,7 @@ export function FiltersSheet({
           <div className={styles.commandSection}>
             <span className={styles.commandLabel}>section</span>
             <div className={styles.sectionChips}>
-              {(["unassigned", "open", "running", "closed"] as Section[]).map(
+              {SECTIONS.map(
                 (section) => (
                   <Link
                     key={section}

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -301,6 +301,7 @@
 @media (min-width: 768px) {
   .topBar {
     padding: 52px 24px 12px;
+    border-bottom: none;
   }
 
   .desktopNav {
@@ -589,6 +590,19 @@
   }
   .mineToggle {
     display: none;
+  }
+  /* Command sheet handles these on mobile */
+  .tabs {
+    display: none;
+  }
+  .sectionTabs {
+    display: none;
+  }
+  .sortToggle {
+    display: none;
+  }
+  .topBar {
+    border-bottom: 1px solid var(--paper-line);
   }
 }
 

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -1,10 +1,9 @@
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  /* Bottom padding clears the FAB (60px + 30px inset + 54px breathing room)
-     so the last row's trailing action button clears the floating action
-     button even when a user scrolls to the end of a dense row. */
-  padding: 12px 0 calc(144px + env(safe-area-inset-bottom, 0px));
+  /* Bottom padding provides scroll-end breathing room so the last row
+     clears the filter handle and safe-area inset. */
+  padding: 12px 0 calc(80px + env(safe-area-inset-bottom, 0px));
   background: var(--paper-bg);
   min-height: 100dvh;
   position: relative;
@@ -103,8 +102,8 @@
   background: var(--paper-bg-warmer);
 }
 
-/* Hidden — primary nav is always visible inline. The hamburger button
-   and Drawer remain in the DOM but are not shown. */
+/* Hidden — the command sheet (mobile) and inline nav (desktop) handle
+   navigation. The hamburger and Drawer remain in the DOM but are unused. */
 .menuBtn {
   background: transparent;
   border: none;
@@ -131,8 +130,8 @@
   color: var(--paper-ink);
 }
 
-/* Inline nav links — visible on all viewports so primary navigation
-   is never hidden behind a hamburger. Compact on mobile, spaced on desktop. */
+/* Desktop nav links. Hidden on mobile where the command sheet provides
+   equivalent navigation (Settings, Quick Create). */
 .desktopNav {
   display: flex;
   align-items: baseline;
@@ -174,9 +173,8 @@
   align-self: center;
 }
 
-/* Desktop-only inline draft button. The mobile FAB is hidden at the
- * same breakpoint by Fab.module.css so only one entry point is shown
- * per viewport. */
+/* Desktop-only inline draft button. On mobile, the command sheet's
+ * "Create Draft" action provides this functionality instead. */
 .desktopDraftBtn {
   display: none;
   font-family: var(--paper-serif);

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -601,6 +601,9 @@
   .sortToggle {
     display: none;
   }
+  .desktopNav {
+    display: none;
+  }
   .topBar {
     border-bottom: 1px solid var(--paper-line);
   }

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -37,6 +37,72 @@
   vertical-align: 6px;
 }
 
+/* Mobile monogram: show "ic", hide "issuectl" */
+.brandCompact {
+  display: inline;
+}
+
+.brandFull {
+  display: none;
+}
+
+/* Mobile: context breadcrumb */
+.contextLabel {
+  margin-left: auto;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  min-height: 44px;
+}
+
+.contextSep {
+  color: var(--paper-ink-faint);
+  margin: 0 2px;
+}
+
+.contextSection {
+  color: var(--paper-accent);
+  font-weight: 500;
+}
+
+.contextCount {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+  margin-left: 2px;
+}
+
+/* Mobile: sheet menu button (filter icon) */
+.sheetMenuBtn {
+  margin-left: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  background: transparent;
+  border: none;
+  color: var(--paper-ink);
+  cursor: pointer;
+  border-radius: var(--paper-radius-sm);
+  transition: background 0.1s;
+  -webkit-tap-highlight-color: transparent;
+  flex-shrink: 0;
+}
+
+.sheetMenuBtn:active {
+  background: var(--paper-bg-warmer);
+}
+
 /* Hidden — primary nav is always visible inline. The hamburger button
    and Drawer remain in the DOM but are not shown. */
 .menuBtn {
@@ -247,6 +313,22 @@
 
   .desktopDraftBtn {
     display: inline-block;
+  }
+
+  .brandCompact {
+    display: none;
+  }
+
+  .brandFull {
+    display: inline;
+  }
+
+  .contextLabel {
+    display: none;
+  }
+
+  .sheetMenuBtn {
+    display: none;
   }
 }
 

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -140,15 +140,68 @@ export function List({
     <PullToRefreshWrapper>
     <div className={styles.container}>
       <div className={styles.topBar}>
+        {/* Brand: full on desktop, compact on mobile */}
         <h1 className={styles.brand}>
-          issuectl<span className={styles.dot} />
+          <span className={styles.brandFull}>issuectl</span>
+          <span className={styles.brandCompact}>ic</span>
+          <span className={styles.dot} />
         </h1>
+
+        {/* Mobile: context breadcrumb — tappable to open sheet */}
+        <button
+          className={styles.contextLabel}
+          onClick={() => setFiltersOpen(true)}
+          aria-label="Open command sheet"
+        >
+          {activeTab === "issues" ? "issues" : "PRs"}
+          <span className={styles.contextSep}>›</span>
+          <span className={styles.contextSection}>
+            {activeTab === "issues"
+              ? SECTION_LABEL[activeSection]
+              : mineOnly
+                ? "mine"
+                : "everyone"}
+          </span>
+          {sectionCounts && activeTab === "issues" && (
+            <span className={styles.contextCount}>
+              {sectionCounts[activeSection] ?? ""}
+            </span>
+          )}
+          {activeTab === "prs" && prCount !== null && (
+            <span className={styles.contextCount}>{prCount}</span>
+          )}
+        </button>
+
         <CacheAge cachedAt={cachedAt ?? null} />
         <nav className={styles.desktopNav}>
           <Link href="/parse" className={styles.desktopNavLink}>Quick Create</Link>
           <span className={styles.desktopNavSep}>·</span>
           <Link href="/settings" className={styles.desktopNavLink}>Settings</Link>
         </nav>
+
+        {/* Mobile: single menu button to open command sheet */}
+        <button
+          className={styles.sheetMenuBtn}
+          onClick={() => setFiltersOpen(true)}
+          aria-label="Open command sheet"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 4h14M4 9h10M7 14h4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+
+        {/* Desktop: hamburger for drawer (currently hidden via display:none) */}
         <button
           className={styles.menuBtn}
           onClick={() => setDrawerOpen(true)}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -100,6 +100,15 @@ export function List({
     mine: mineOnly ? true : null,
   });
 
+  const tabHref = (tab: "issues" | "prs") =>
+    buildHref({
+      tab: tab === "prs" ? "prs" : undefined,
+      repo: activeRepo,
+      section: tab === "issues" ? activeSection : null,
+      sort: tab === "issues" ? activeSort : null,
+      mine: tab === "prs" && mineOnly ? true : null,
+    });
+
   const chipHref = (rk: string | null) =>
     buildHref({
       tab: activeTab,
@@ -387,6 +396,15 @@ export function List({
         showSort={!isPrTab}
         activeSort={activeSort}
         sortHref={sortHref}
+        activeTab={activeTab}
+        tabHref={tabHref}
+        activeSection={activeSection}
+        sectionHref={sectionHref}
+        sectionCounts={sectionCounts}
+        onCreateDraft={() => {
+          setFiltersOpen(false);
+          setCreateOpen(true);
+        }}
       />
 
       {!filtersOpen && (

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -145,6 +145,11 @@ export function List({
     sort: activeTab === "issues" ? activeSort : null,
   });
 
+  const contextSectionLabel =
+    activeTab === "issues"
+      ? SECTION_LABEL[activeSection]
+      : mineOnly ? "mine" : "everyone";
+
   return (
     <PullToRefreshWrapper>
     <div className={styles.container}>
@@ -165,11 +170,7 @@ export function List({
           {activeTab === "issues" ? "issues" : "PRs"}
           <span className={styles.contextSep}>›</span>
           <span className={styles.contextSection}>
-            {activeTab === "issues"
-              ? SECTION_LABEL[activeSection]
-              : mineOnly
-                ? "mine"
-                : "everyone"}
+            {contextSectionLabel}
           </span>
           {sectionCounts && activeTab === "issues" && (
             <span className={styles.contextCount}>
@@ -192,7 +193,7 @@ export function List({
         <button
           className={styles.sheetMenuBtn}
           onClick={() => setFiltersOpen(true)}
-          aria-label="Open command sheet"
+          aria-label="Filters and navigation"
         >
           <svg
             width="18"
@@ -403,7 +404,9 @@ export function List({
         sectionCounts={sectionCounts}
         onCreateDraft={() => {
           setFiltersOpen(false);
-          setCreateOpen(true);
+          // Delay opening CreateDraftSheet until the FiltersSheet exit
+          // animation finishes (220ms) to avoid overlapping modals.
+          setTimeout(() => setCreateOpen(true), 220);
         }}
       />
 

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -65,13 +65,6 @@ export function ListContent({
     [router],
   );
 
-  const handleNavigate = useCallback(
-    (owner: string, repo: string, issueNumber: number) => {
-      router.push(`/issues/${owner}/${repo}/${issueNumber}`);
-    },
-    [router],
-  );
-
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
@@ -90,7 +83,7 @@ export function ListContent({
     const showing = Math.min(visibleCount, total);
     return (
       <>
-        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch, onNavigate: handleNavigate })}
+        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch })}
         {total > PAGE_SIZE && (
           <div className={styles.pageStatus}>
             Showing {showing} of {total}
@@ -145,13 +138,11 @@ function renderIssueSection({
   data,
   visibleCount,
   onLaunch,
-  onNavigate,
 }: {
   activeSection: Section;
   data: UnifiedList;
   visibleCount: number;
   onLaunch: (owner: string, repo: string, issueNumber: number) => void;
-  onNavigate: (owner: string, repo: string, issueNumber: number) => void;
 }) {
   const allItems = data[activeSection];
 
@@ -169,5 +160,5 @@ function renderIssueSection({
   }
 
   const items = allItems.slice(0, visibleCount);
-  return <ListSection title={null} items={items} onLaunch={onLaunch} onNavigate={onNavigate} />;
+  return <ListSection title={null} items={items} onLaunch={onLaunch} />;
 }

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -35,7 +35,9 @@
 }
 
 /* Row actions (launch / open / view). Inline below the link on mobile;
- * right-aligned floating on desktop hover. */
+ * right-aligned floating on desktop hover. For open-section rows the
+ * SwipeRow component provides the actions via swipe-to-reveal, so inline
+ * actions are hidden on mobile touch devices. */
 .actions {
   display: flex;
   align-items: center;
@@ -43,6 +45,13 @@
   gap: 8px;
   justify-content: flex-end;
   flex-shrink: 0;
+}
+
+/* Hide inline actions on mobile for open rows — SwipeRow reveals them */
+@media (max-width: 767px), (hover: none) {
+  .item[data-section="open"] .actions {
+    display: none;
+  }
 }
 
 .actionBtn {

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -148,11 +148,6 @@ export function ListRow({ item, onLaunch, onNavigate }: Props) {
     return (
       <SwipeRow
         onLaunch={() => onLaunch(repo.owner, repo.name, issue.number)}
-        onReassign={
-          onNavigate
-            ? () => onNavigate(repo.owner, repo.name, issue.number)
-            : undefined
-        }
       >
         {rowContent}
       </SwipeRow>

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -8,7 +8,6 @@ import styles from "./ListRow.module.css";
 type Props = {
   item: UnifiedListItem;
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
-  onNavigate?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
 // Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
@@ -28,7 +27,7 @@ function formatAge(updatedAt: string | number): string {
   return `${diffDays}d`;
 }
 
-export function ListRow({ item, onLaunch, onNavigate }: Props) {
+export function ListRow({ item, onLaunch }: Props) {
   if (item.kind === "draft") {
     return (
       <div className={styles.item}>

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -7,10 +7,9 @@ type Props = {
   title: ReactNode | null;
   items: UnifiedListItem[];
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
-  onNavigate?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
-export function ListSection({ title, items, onLaunch, onNavigate }: Props) {
+export function ListSection({ title, items, onLaunch }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -31,7 +30,6 @@ export function ListSection({ title, items, onLaunch, onNavigate }: Props) {
           }
           item={item}
           onLaunch={onLaunch}
-          onNavigate={onNavigate}
         />
       ))}
     </>

--- a/packages/web/components/list/SwipeRow.module.css
+++ b/packages/web/components/list/SwipeRow.module.css
@@ -10,7 +10,7 @@
   bottom: 0;
   display: flex;
   transform: translateX(100%);
-  transition: transform 0.2s ease;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .wrapper[data-swiped="true"] .actions {
@@ -18,18 +18,18 @@
 }
 
 .content {
-  transition: transform 0.2s ease;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
   background: var(--paper-bg);
 }
 
 .wrapper[data-swiped="true"] .content {
-  transform: translateX(-160px);
+  transform: translateX(-80px);
 }
 
 .actionBtn {
   display: flex;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 24px;
   font-family: var(--paper-sans);
   font-size: 14px;
   font-weight: 600;
@@ -41,10 +41,6 @@
 
 .launchBtn {
   background: var(--paper-accent);
-}
-
-.reassignBtn {
-  background: var(--paper-ink-muted);
 }
 
 @media (min-width: 768px) and (hover: hover) {

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -8,11 +8,10 @@ const SWIPE_THRESHOLD = 60;
 type Props = {
   children: ReactNode;
   onLaunch?: () => void;
-  onReassign?: () => void;
   disabled?: boolean;
 };
 
-export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
+export function SwipeRow({ children, onLaunch, disabled }: Props) {
   const [swiped, setSwiped] = useState(false);
   const startX = useRef<number | null>(null);
 
@@ -71,17 +70,6 @@ export function SwipeRow({ children, onLaunch, onReassign, disabled }: Props) {
             }}
           >
             Launch
-          </button>
-        )}
-        {onReassign && (
-          <button
-            className={`${styles.actionBtn} ${styles.reassignBtn}`}
-            onClick={() => {
-              close();
-              onReassign();
-            }}
-          >
-            Re-assign
           </button>
         )}
       </div>

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -26,10 +26,16 @@
   opacity: 0.92;
 }
 
-/* Mobile-only entry point. Desktop has the inline `+ draft` button in
- * the tabs row (see List.module.css `.desktopDraftBtn`), so showing
- * the FAB at the same breakpoint would create two redundant entry
- * points for the same action. */
+/* Command sheet replaces the FAB on mobile. */
+@media (max-width: 767px) {
+  .fab {
+    display: none;
+  }
+}
+
+/* Desktop has the inline `+ draft` button in the tabs row
+ * (see List.module.css `.desktopDraftBtn`), so the FAB is
+ * hidden there too. */
 @media (min-width: 768px) {
   .fab {
     display: none;

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -33,6 +33,25 @@
   to { transform: translateY(0); }
 }
 
+/* Exit animations */
+.scrim[data-closing] {
+  animation: scrimOut 220ms ease-in forwards;
+}
+
+.sheet[data-closing] {
+  animation: sheetOut 220ms cubic-bezier(0.36, 0, 0.66, -0.56) forwards;
+}
+
+@keyframes scrimOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes sheetOut {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .scrim,
   .sheet {
@@ -112,6 +131,21 @@
     to {
       opacity: 1;
       transform: translate(-50%, 0);
+    }
+  }
+
+  .sheet[data-closing] {
+    animation: sheetOutDesktop 220ms ease-in forwards;
+  }
+
+  @keyframes sheetOutDesktop {
+    from {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    to {
+      opacity: 0;
+      transform: translate(-50%, 12px);
     }
   }
 }

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -33,13 +33,16 @@
   to { transform: translateY(0); }
 }
 
-/* Exit animations */
+/* Exit animations — pointer-events disabled so taps pass through to
+   content beneath during the slide-out. */
 .scrim[data-closing] {
   animation: scrimOut 220ms ease-in forwards;
+  pointer-events: none;
 }
 
 .sheet[data-closing] {
   animation: sheetOut 220ms cubic-bezier(0.36, 0, 0.66, -0.56) forwards;
+  pointer-events: none;
 }
 
 @keyframes scrimOut {
@@ -54,7 +57,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .scrim,
-  .sheet {
+  .sheet,
+  .scrim[data-closing],
+  .sheet[data-closing] {
     animation: none;
   }
 }

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -50,7 +50,11 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
 
   useEffect(() => {
     if (!closing) return;
-    const timer = setTimeout(() => setVisible(false), EXIT_DURATION_MS);
+    const prefersReduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const duration = prefersReduced ? 0 : EXIT_DURATION_MS;
+    const timer = setTimeout(() => setVisible(false), duration);
     return () => clearTimeout(timer);
   }, [closing]);
 
@@ -79,14 +83,15 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     };
   }, [open]);
 
+  // Lock body scroll for the full mounted lifetime (including exit animation).
   useEffect(() => {
-    if (!open) return;
+    if (!visible) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = prev;
     };
-  }, [open]);
+  }, [visible]);
 
   useEffect(() => {
     if (!open) return;

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -29,12 +29,30 @@ const DISMISS_DRAG_PX = 100;
 const FLICK_VELOCITY_PX_PER_MS = 0.5;
 const FLICK_MIN_DRAG_PX = 40;
 
+const EXIT_DURATION_MS = 220;
+
 export function Sheet({ open, onClose, title, description, children }: Props) {
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
   const [dragY, setDragY] = useState(0);
   const dragStart = useRef<{ y: number; t: number } | null>(null);
   const isDesktopRef = useRef(false);
+
+  // Stay mounted during exit animation so the slide-down is visible.
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+    }
+  }, [open]);
+
+  const closing = !open && visible;
+
+  useEffect(() => {
+    if (!closing) return;
+    const timer = setTimeout(() => setVisible(false), EXIT_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [closing]);
 
   // Track viewport size across the sheet's open lifetime so a
   // portrait→landscape rotation mid-drag doesn't compose the wrong transform.
@@ -108,7 +126,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     }
   }, [open]);
 
-  if (!open) return null;
+  if (!visible) return null;
 
   const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
     if (e.touches.length === 0) return;
@@ -159,6 +177,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
     <>
       <div
         className={styles.scrim}
+        data-closing={closing || undefined}
         onClick={onClose}
         aria-hidden="true"
         style={scrimStyle}
@@ -166,6 +185,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
       <div
         ref={dialogRef}
         className={styles.sheet}
+        data-closing={closing || undefined}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/packages/web/components/ui/CacheAge.module.css
+++ b/packages/web/components/ui/CacheAge.module.css
@@ -9,3 +9,9 @@
   border-radius: 10px;
   white-space: nowrap;
 }
+
+@media (max-width: 767px) {
+  .badge {
+    display: none;
+  }
+}

--- a/packages/web/e2e/mobile-ux-patterns.spec.ts
+++ b/packages/web/e2e/mobile-ux-patterns.spec.ts
@@ -217,24 +217,24 @@ async function expectTouchTarget(
 // ── Tests ───────────────────────────────────────────────────────────
 
 test.describe("Mobile UX regressions — touch targets (R3-R6)", () => {
-  test("dashboard inline nav links are 44px tall", async ({ page }) => {
+  test("command sheet button meets 44px touch target", async ({ page }) => {
     if (skipReason) test.skip(true, skipReason);
     await page.goto(`${BASE_URL}/`);
     await expectTouchTarget(
       page,
-      'nav a[href="/parse"]',
-      "inline nav Quick Create",
+      'button[aria-label="Open command sheet"]',
+      "command sheet menu button",
     );
   });
 
-  test("dashboard FAB is 44x44 and reachable", async ({ page }) => {
+  test("command sheet button is 44x44 and reachable", async ({ page }) => {
     if (skipReason) test.skip(true, skipReason);
     await page.goto(`${BASE_URL}/`);
-    // FAB is intentional on this app — we pin its presence + size.
+    // Command sheet button replaces the FAB on mobile viewports.
     await expectTouchTarget(
       page,
-      'button[aria-label="Create a new draft"]',
-      "create-draft FAB",
+      'button[aria-label="Open command sheet"]',
+      "command sheet button",
     );
   });
 
@@ -372,11 +372,11 @@ test.describe("Mobile UX regressions — iOS form attrs (R3, R5)", () => {
 });
 
 test.describe("Mobile UX regressions — motion and a11y (R3, R5)", () => {
-  test("FAB opens sheet with a real animation", async ({ page }) => {
+  test("command sheet opens with a real animation", async ({ page }) => {
     if (skipReason) test.skip(true, skipReason);
     await page.goto(`${BASE_URL}/`);
 
-    await page.click('button[aria-label="Create a new draft"]');
+    await page.click('button[aria-label="Open command sheet"]');
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -404,7 +404,7 @@ test.describe("Mobile UX regressions — motion and a11y (R3, R5)", () => {
     const page = await context.newPage();
     try {
       await page.goto(`${BASE_URL}/`);
-      await page.click('button[aria-label="Create a new draft"]');
+      await page.click('button[aria-label="Open command sheet"]');
       const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible();
       const animation = await dialog.evaluate(


### PR DESCRIPTION
## Summary

- Redesigns the mobile list view to maximize content area by consolidating all navigation, filtering, sorting, and actions into a single bottom "command sheet"
- On mobile: top bar shows only "ic·" monogram + context breadcrumb + menu icon. All tabs, sections, sort, create draft, quick create, and settings live in the command sheet
- On desktop: completely unchanged — inline nav, tabs, sections, sort, and "+ draft" button remain as-is
- SwipeRow simplified: removed reassign button, added spring animation (cubic-bezier overshoot)
- Sheet component gains smooth close animation (220ms slide-down with pointer-events disabled during exit)

**Reference mockups:**
- Issues view: `docs/mockups/mobile-command-sheet-issues.html`
- PRs view: `docs/mockups/mobile-command-sheet-prs.html`

## Test plan

- [ ] Verify mobile main canvas: "ic·" + breadcrumb + menu icon, issue rows start immediately
- [ ] Verify command sheet opens via menu icon, breadcrumb tap, or bottom handle swipe
- [ ] Verify sheet contains: view toggle, section chips, repo filter, sort, Create Draft, Quick Create, Settings
- [ ] Verify sheet close animation is smooth (not instant)
- [ ] Verify Create Draft from sheet opens the draft form after sheet closes
- [ ] Verify swipe-to-launch on open rows reveals single "Launch" button with spring animation
- [ ] Verify desktop is completely unchanged (full brand, inline nav, tabs, sections, sort)
- [ ] Verify E2E tests pass (`pnpm --filter @issuectl/web test:e2e`)