### PR TITLE
fix: lock sheet horizontal scroll, add version to command sheet

### DIFF
--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -248,3 +248,12 @@
   color: var(--paper-ink-muted);
   margin-top: 2px;
 }
+
+.version {
+  display: block;
+  text-align: center;
+  font-family: var(--paper-mono);
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+  padding: 16px 0 4px;
+}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -259,6 +259,10 @@ export function FiltersSheet({
             <span className={styles.commandLinkDesc}>repos, tokens, preferences</span>
           </span>
         </Link>
+
+        <span className={styles.version}>
+          v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+        </span>
       </div>
     </Sheet>
   );

--- a/packages/web/components/paper/Sheet.module.css
+++ b/packages/web/components/paper/Sheet.module.css
@@ -19,7 +19,10 @@
   padding: 12px 0 calc(28px + env(safe-area-inset-bottom, 0px));
   z-index: 1001;
   max-height: 85dvh;
+  overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   animation: sheetIn 260ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 


### PR DESCRIPTION
## Summary

- Prevent horizontal scroll/drag on the bottom sheet (`overflow-x: hidden`, `overscroll-behavior: contain`) so it feels native on mobile
- Show app version at the bottom of the mobile command sheet for quick iteration feedback

## Test plan

- [ ] Open command sheet on mobile — verify no horizontal scroll/drag
- [ ] Scroll vertically in the sheet — verify it stays contained (no page scroll bleed)
- [ ] Verify version number visible at bottom of command sheet