### PR TITLE
feat: launch enhancements — default permissions, in-progress label, comment count

### DIFF
--- a/packages/core/src/data/issues.test.ts
+++ b/packages/core/src/data/issues.test.ts
@@ -54,6 +54,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     state: "open",
     labels: [],
     user: null,
+    commentCount: 0,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
     closedAt: null,

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -25,6 +25,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     state: "open",
     labels: [],
     user: null,
+    commentCount: 0,
     createdAt: "2026-04-01T00:00:00Z",
     updatedAt: "2026-04-01T00:00:00Z",
     closedAt: null,

--- a/packages/core/src/db/settings.test.ts
+++ b/packages/core/src/db/settings.test.ts
@@ -71,9 +71,9 @@ describe("seedDefaults", () => {
     expect(keys).toContain("claude_extra_args");
   });
 
-  it("seedDefaults sets claude_extra_args to empty string by default", () => {
+  it("seedDefaults sets claude_extra_args to --dangerously-skip-permissions by default", () => {
     seedDefaults(db);
-    expect(getSetting(db, "claude_extra_args")).toBe("");
+    expect(getSetting(db, "claude_extra_args")).toBe("--dangerously-skip-permissions");
   });
 
   it("uses INSERT OR IGNORE — does not overwrite existing values", () => {

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -5,7 +5,7 @@ const DEFAULT_SETTINGS: Setting[] = [
   { key: "branch_pattern", value: "issue-{number}-{slug}" },
   { key: "cache_ttl", value: "300" },
   { key: "worktree_dir", value: "~/.issuectl/worktrees/" },
-  { key: "claude_extra_args", value: "" },
+  { key: "claude_extra_args", value: "--dangerously-skip-permissions" },
 ];
 
 export function getSetting(

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -14,6 +14,7 @@ function mapIssue(raw: unknown): GitHubIssue {
     state: string;
     labels: Array<{ name?: string; color?: string; description?: string | null } | string>;
     user: RawGitHubUser;
+    comments: number;
     created_at: string;
     updated_at: string;
     closed_at: string | null;
@@ -32,6 +33,7 @@ function mapIssue(raw: unknown): GitHubIssue {
         description: l.description ?? null,
       })),
     user: mapUser(r.user),
+    commentCount: r.comments ?? 0,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     closedAt: r.closed_at,

--- a/packages/core/src/github/labels.test.ts
+++ b/packages/core/src/github/labels.test.ts
@@ -119,12 +119,13 @@ describe("ensureLifecycleLabels", () => {
     createLabel.mockResolvedValue({});
 
     await ensureLifecycleLabels(octokit, "owner", "repo");
-    expect(createLabel).toHaveBeenCalledTimes(3);
+    expect(createLabel).toHaveBeenCalledTimes(4);
 
     const names = createLabel.mock.calls.map(
       (call: Array<Record<string, unknown>>) => call[0].name,
     );
     expect(names).toContain(LIFECYCLE_LABEL.deployed);
+    expect(names).toContain(LIFECYCLE_LABEL.inProgress);
     expect(names).toContain(LIFECYCLE_LABEL.prOpen);
     expect(names).toContain(LIFECYCLE_LABEL.done);
   });

--- a/packages/core/src/github/labels.ts
+++ b/packages/core/src/github/labels.ts
@@ -90,6 +90,21 @@ export async function addLabel(
   });
 }
 
+export async function addLabels(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  labels: string[],
+): Promise<void> {
+  await octokit.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels,
+  });
+}
+
 export async function removeLabel(
   octokit: Octokit,
   owner: string,

--- a/packages/core/src/github/labels.ts
+++ b/packages/core/src/github/labels.ts
@@ -3,6 +3,7 @@ import type { GitHubLabel } from "./types.js";
 
 export const LIFECYCLE_LABEL = {
   deployed: "issuectl:deployed",
+  inProgress: "issuectl:in-progress",
   prOpen: "issuectl:pr-open",
   done: "issuectl:done",
 } as const;
@@ -12,6 +13,11 @@ const LIFECYCLE_LABELS = [
     name: LIFECYCLE_LABEL.deployed,
     color: "d29922",
     description: "Launched to Claude Code via issuectl",
+  },
+  {
+    name: LIFECYCLE_LABEL.inProgress,
+    color: "fbca04",
+    description: "Issue is actively being worked on",
   },
   {
     name: LIFECYCLE_LABEL.prOpen,

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -16,6 +16,7 @@ export type GitHubIssue = {
   state: "open" | "closed";
   labels: GitHubLabel[];
   user: GitHubUser | null;
+  commentCount: number;
   createdAt: string;
   updatedAt: string;
   closedAt: string | null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   listLabels,
   ensureLifecycleLabels,
   addLabel,
+  addLabels,
   removeLabel,
 } from "./github/labels.js";
 export { listAccessibleRepos } from "./github/repos.js";

--- a/packages/core/src/launch/launch.test.ts
+++ b/packages/core/src/launch/launch.test.ts
@@ -58,6 +58,7 @@ vi.mock("../data/issues.js", () => ({
       state: "open",
       labels: [],
       user: null,
+      commentCount: 0,
       createdAt: "2026-04-12T00:00:00Z",
       updatedAt: "2026-04-12T00:00:00Z",
       closedAt: null,

--- a/packages/core/src/launch/launch.test.ts
+++ b/packages/core/src/launch/launch.test.ts
@@ -83,6 +83,7 @@ vi.mock("../github/labels.js", async () => {
     ...actual,
     ensureLifecycleLabels: async () => {},
     addLabel: async () => {},
+    addLabels: async () => {},
     removeLabel: async () => {},
   };
 });

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -157,7 +157,7 @@ export async function executeLaunch(
   // Workspace cleanup is not attempted since the branch/files may be valuable.
   let labelWarning: string | undefined;
   try {
-    // 7. Apply issuectl:deployed label. Retry up to 3 times because label
+    // 7. Apply lifecycle labels. Retry up to 3 times because label
     // failures are usually transient (rate limit, network blip) and a
     // dropped label leaves the reconciler unable to advance this issue.
     await ensureLifecycleLabels(octokit, options.owner, options.repo);
@@ -168,6 +168,15 @@ export async function executeLaunch(
         options.repo,
         options.issueNumber,
         LIFECYCLE_LABEL.deployed,
+      ),
+    );
+    await retryLabel(() =>
+      addLabel(
+        octokit,
+        options.owner,
+        options.repo,
+        options.issueNumber,
+        LIFECYCLE_LABEL.inProgress,
       ),
     );
   } catch (err) {

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -10,7 +10,7 @@ import {
   updateTtydInfo,
 } from "../db/deployments.js";
 import { getIssueDetail } from "../data/issues.js";
-import { ensureLifecycleLabels, addLabel, LIFECYCLE_LABEL } from "../github/labels.js";
+import { ensureLifecycleLabels, addLabels, LIFECYCLE_LABEL } from "../github/labels.js";
 import {
   assembleContext,
   writeContextFile,
@@ -37,11 +37,12 @@ export interface LaunchResult {
   contextFilePath: string;
   ttydPort: number;
   /**
-   * Set when the `issuectl:deployed` label could not be applied after the
-   * retry budget was exhausted. Launch continues in that case — the workspace
-   * and deployment row are valid — but the lifecycle reconciler won't pick
-   * up this issue until the label is added by some other path. Surface this
-   * to the UI so the user knows the state has drifted.
+   * Set when lifecycle labels (`issuectl:deployed`, `issuectl:in-progress`)
+   * could not be applied after the retry budget was exhausted. Launch
+   * continues — the workspace and deployment row are valid — but the
+   * lifecycle reconciler won't pick up this issue until the labels are
+   * added by some other path. Surface this to the UI so the user knows
+   * the state has drifted.
    */
   labelWarning?: string;
 }
@@ -157,34 +158,26 @@ export async function executeLaunch(
   // Workspace cleanup is not attempted since the branch/files may be valuable.
   let labelWarning: string | undefined;
   try {
-    // 7. Apply lifecycle labels. Retry up to 3 times because label
-    // failures are usually transient (rate limit, network blip) and a
-    // dropped label leaves the reconciler unable to advance this issue.
+    // 7. Apply lifecycle labels in a single API call. Retry up to 3
+    // times because label failures are usually transient (rate limit,
+    // network blip) and dropped labels leave the reconciler unable to
+    // advance this issue.
     await ensureLifecycleLabels(octokit, options.owner, options.repo);
     await retryLabel(() =>
-      addLabel(
+      addLabels(
         octokit,
         options.owner,
         options.repo,
         options.issueNumber,
-        LIFECYCLE_LABEL.deployed,
-      ),
-    );
-    await retryLabel(() =>
-      addLabel(
-        octokit,
-        options.owner,
-        options.repo,
-        options.issueNumber,
-        LIFECYCLE_LABEL.inProgress,
+        [LIFECYCLE_LABEL.deployed, LIFECYCLE_LABEL.inProgress],
       ),
     );
   } catch (err) {
     // Final failure is non-fatal — the workspace is ready, proceed anyway
     // but record a warning so the caller can tell the user.
     const msg = err instanceof Error ? err.message : String(err);
-    labelWarning = `Could not apply the \`${LIFECYCLE_LABEL.deployed}\` label after 3 attempts (${msg}). Launch continued, but lifecycle status may not update automatically — you may need to add the label manually.`;
-    console.warn("[issuectl] Failed to apply deployed label after retries:", err);
+    labelWarning = `Could not apply lifecycle labels after 3 attempts (${msg}). Launch continued, but lifecycle status may not update automatically — you may need to add labels manually.`;
+    console.warn("[issuectl] Failed to apply lifecycle labels after retries:", err);
   }
 
   // 8. Record deployment in DB as pending. This row is INVISIBLE to the

--- a/packages/core/src/lifecycle/reconcile.test.ts
+++ b/packages/core/src/lifecycle/reconcile.test.ts
@@ -166,6 +166,37 @@ describe("reconcileIssueLifecycle", () => {
     expect(rows[0].linked_pr_number).toBe(42);
   });
 
+  it("removes inProgress label when PR is open", async () => {
+    const octokit = fakeOctokit();
+    const issue = makeIssue({
+      labels: [
+        { name: LIFECYCLE_LABEL.deployed, color: "", description: null },
+        { name: LIFECYCLE_LABEL.inProgress, color: "", description: null },
+      ],
+    });
+    const linkedPRs = [makePR({ state: "open", merged: false })];
+    const result = await reconcileIssueLifecycle(db, octokit, "owner", "repo", issue, linkedPRs);
+    expect(result.labelsAdded).toContain(LIFECYCLE_LABEL.prOpen);
+    expect(result.labelsRemoved).toContain(LIFECYCLE_LABEL.inProgress);
+  });
+
+  it("removes inProgress label when PR is merged", async () => {
+    const octokit = fakeOctokit();
+    const issue = makeIssue({
+      state: "closed",
+      labels: [
+        { name: LIFECYCLE_LABEL.deployed, color: "", description: null },
+        { name: LIFECYCLE_LABEL.inProgress, color: "", description: null },
+        { name: LIFECYCLE_LABEL.prOpen, color: "", description: null },
+      ],
+    });
+    const linkedPRs = [makePR({ state: "closed", merged: true, mergedAt: "2026-01-02T00:00:00Z" })];
+    const result = await reconcileIssueLifecycle(db, octokit, "owner", "repo", issue, linkedPRs);
+    expect(result.labelsAdded).toContain(LIFECYCLE_LABEL.done);
+    expect(result.labelsRemoved).toContain(LIFECYCLE_LABEL.prOpen);
+    expect(result.labelsRemoved).toContain(LIFECYCLE_LABEL.inProgress);
+  });
+
   it("returns correct ReconcileResult shape", async () => {
     const octokit = fakeOctokit();
     const issue = makeIssue({

--- a/packages/core/src/lifecycle/reconcile.test.ts
+++ b/packages/core/src/lifecycle/reconcile.test.ts
@@ -17,6 +17,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     state: "open",
     labels: [],
     user: null,
+    commentCount: 0,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
     closedAt: null,

--- a/packages/core/src/lifecycle/reconcile.ts
+++ b/packages/core/src/lifecycle/reconcile.ts
@@ -77,9 +77,6 @@ export async function reconcileIssueLifecycle(
     if (hasLabel(LIFECYCLE_LABEL.prOpen)) {
       toRemove.push(LIFECYCLE_LABEL.prOpen);
     }
-    if (hasLabel(LIFECYCLE_LABEL.inProgress)) {
-      toRemove.push(LIFECYCLE_LABEL.inProgress);
-    }
     if (issue.state === "closed" && !hasLabel(LIFECYCLE_LABEL.done)) {
       toAdd.push(LIFECYCLE_LABEL.done);
     }
@@ -87,9 +84,11 @@ export async function reconcileIssueLifecycle(
     if (!hasLabel(LIFECYCLE_LABEL.prOpen)) {
       toAdd.push(LIFECYCLE_LABEL.prOpen);
     }
-    if (hasLabel(LIFECYCLE_LABEL.inProgress)) {
-      toRemove.push(LIFECYCLE_LABEL.inProgress);
-    }
+  }
+
+  // Both transitions (merged, pr-open) move past the in-progress phase.
+  if (hasLabel(LIFECYCLE_LABEL.inProgress)) {
+    toRemove.push(LIFECYCLE_LABEL.inProgress);
   }
 
   if (toAdd.length > 0 || toRemove.length > 0) {

--- a/packages/core/src/lifecycle/reconcile.ts
+++ b/packages/core/src/lifecycle/reconcile.ts
@@ -77,12 +77,18 @@ export async function reconcileIssueLifecycle(
     if (hasLabel(LIFECYCLE_LABEL.prOpen)) {
       toRemove.push(LIFECYCLE_LABEL.prOpen);
     }
+    if (hasLabel(LIFECYCLE_LABEL.inProgress)) {
+      toRemove.push(LIFECYCLE_LABEL.inProgress);
+    }
     if (issue.state === "closed" && !hasLabel(LIFECYCLE_LABEL.done)) {
       toAdd.push(LIFECYCLE_LABEL.done);
     }
   } else if (linkedPR.state === "open") {
     if (!hasLabel(LIFECYCLE_LABEL.prOpen)) {
       toAdd.push(LIFECYCLE_LABEL.prOpen);
+    }
+    if (hasLabel(LIFECYCLE_LABEL.inProgress)) {
+      toRemove.push(LIFECYCLE_LABEL.inProgress);
     }
   }
 

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -55,7 +55,7 @@ export function LaunchModal({
 
   const [branchName, setBranchName] = useState(defaultBranch);
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>(
-    initialWorkspaceMode ?? (repoLocalPath ? "existing" : "clone"),
+    initialWorkspaceMode ?? (repoLocalPath ? "worktree" : "clone"),
   );
   const [selectedComments, setSelectedComments] = useState<number[]>(
     comments.map((_, i) => i),
@@ -67,7 +67,7 @@ export function LaunchModal({
 
   const [initialBranch] = useState(defaultBranch);
   const [initialMode] = useState<WorkspaceMode>(
-    initialWorkspaceMode ?? (repoLocalPath ? "existing" : "clone"),
+    initialWorkspaceMode ?? (repoLocalPath ? "worktree" : "clone"),
   );
 
   // Auto-select all comments when they arrive via lazy-fetch (initially empty).

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -173,6 +173,18 @@
   white-space: nowrap;
 }
 
+.comments {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--paper-ink-faint);
+}
+
+.commentIcon {
+  width: 12px;
+  height: 12px;
+}
+
 .activeLabel {
   color: var(--paper-accent);
   font-weight: 600;

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -105,7 +105,7 @@ export function ListRow({ item, onLaunch }: Props) {
               ))}
             </>
           )}
-          {issue.commentCount > 0 && (
+          {(issue.commentCount ?? 0) > 0 && (
             <>
               <span className={styles.sep}>·</span>
               <span className={styles.comments}>

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -105,6 +105,22 @@ export function ListRow({ item, onLaunch }: Props) {
               ))}
             </>
           )}
+          {issue.commentCount > 0 && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.comments}>
+                <svg
+                  className={styles.commentIcon}
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2v2.19l2.72-2.72.53-.22h4.25a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+                </svg>
+                {issue.commentCount}
+              </span>
+            </>
+          )}
           <span className={styles.sep}>·</span>
           <span>{formatAge(issue.updatedAt)}</span>
           {issue.user && (

--- a/packages/web/e2e/action-sheets.spec.ts
+++ b/packages/web/e2e/action-sheets.spec.ts
@@ -131,6 +131,7 @@ function seedIssueCache(dbPath: string, issueNumber: number, title: string): voi
       state: "open",
       labels: [],
       user: { login: "test-bot", avatarUrl: "" },
+      commentCount: 0,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       closedAt: null,

--- a/packages/web/lib/page-filters.test.ts
+++ b/packages/web/lib/page-filters.test.ts
@@ -53,6 +53,7 @@ function makeUnifiedList(): UnifiedList {
       state: "open" as const,
       labels: [],
       user: null,
+      commentCount: 0,
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-01-01T00:00:00Z",
       closedAt: null,


### PR DESCRIPTION
## Summary

- **#174**: Default `claude_extra_args` to `--dangerously-skip-permissions` and default workspace mode to `worktree` for safer isolated launches
- **#178**: Apply `issuectl:in-progress` label on launch; reconciler removes it when a PR opens or merges
- **#173**: Add `commentCount` to `GitHubIssue` type (extracted from GitHub API response) and render a subtle comment icon + count in the issue list view

## Details

**Launch defaults (#174):** New installs get `--dangerously-skip-permissions` as the default Claude extra arg, and `worktree` as the default workspace mode (instead of `existing`). Existing users keep their current settings via `INSERT OR IGNORE`.

**In-progress label (#178):** New `issuectl:in-progress` lifecycle label (yellow, `#fbca04`) applied alongside `issuectl:deployed` in a single API call. The reconciler removes it when a PR opens or merges. Both labels are applied via the new `addLabels()` function (one network round-trip instead of two).

**Comment count (#173):** The GitHub REST API already returns a `comments` integer on every issue — we just weren't mapping it. Now `mapIssue()` extracts it into `commentCount`, and `ListRow` renders a speech-bubble SVG + count when > 0. Stale cached issues without the field degrade gracefully (`?? 0`).

## Test plan

- [x] `pnpm turbo typecheck` — all 3 packages pass
- [x] `pnpm turbo test` — 438 tests pass, 0 failures
- [x] `labels.test.ts` — updated to expect 4 lifecycle labels (was 3)
- [x] `reconcile.test.ts` — new tests for `inProgress` removal on PR open and PR merge
- [x] `settings.test.ts` — updated assertion for new default
- [x] All mock `GitHubIssue` objects updated with `commentCount: 0`
- [x] Full 6-agent PR review toolkit run; all critical and important findings addressed