### PR TITLE
fix: mobile command sheet UX — safe-area, FAB, Claude icon

### DIFF
--- a/packages/web/components/list/FilterEdgeSwipe.module.css
+++ b/packages/web/components/list/FilterEdgeSwipe.module.css
@@ -1,12 +1,14 @@
 .zone {
   position: fixed;
   left: 50%;
-  bottom: 0;
+  /* Offset above Safari's bottom toolbar / home indicator so the
+     grab handle never overlaps the browser's back/forward buttons. */
+  bottom: env(safe-area-inset-bottom, 0px);
   transform: translateX(-50%);
   z-index: 40;
   width: 160px;
   min-height: 44px;
-  padding: 18px 20px calc(10px + env(safe-area-inset-bottom, 0px));
+  padding: 18px 20px 10px;
   background: linear-gradient(
     to top,
     var(--paper-bg) 30%,

--- a/packages/web/components/list/FilterEdgeSwipe.module.css
+++ b/packages/web/components/list/FilterEdgeSwipe.module.css
@@ -1,8 +1,8 @@
 .zone {
   position: fixed;
   left: 50%;
-  /* Offset above Safari's bottom toolbar / home indicator so the
-     grab handle never overlaps the browser's back/forward buttons. */
+  /* Offset above the home indicator and Safari's bottom toolbar so the
+     grab handle stays above system UI and remains easily tappable. */
   bottom: env(safe-area-inset-bottom, 0px);
   transform: translateX(-50%);
   z-index: 40;

--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -249,6 +249,12 @@
   margin-top: 2px;
 }
 
+/* Claude Code launch icon — distinct warm accent to make it feel app-specific */
+.claudeIcon {
+  background: var(--paper-bg-warmer, #e6dec4);
+  color: var(--paper-ink);
+}
+
 .version {
   display: block;
   text-align: center;

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -235,18 +235,18 @@ export function FiltersSheet({
           </span>
         </button>
 
-        <Link href="/?section=open&launch=next" className={styles.commandLink} onClick={onClose}>
+        <Link href="/?section=open" className={styles.commandLink} onClick={onClose}>
           <span className={`${styles.commandLinkIcon} ${styles.claudeIcon}`}>
-            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-              <path d="M3 14l2-2M5 12l4-8M9 4l4 8M13 12l2 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              <circle cx="9" cy="4" r="1.5" fill="currentColor" />
-              <circle cx="5" cy="12" r="1" fill="currentColor" />
-              <circle cx="13" cy="12" r="1" fill="currentColor" />
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M3 14l2-2M5 12l4-8M9 4l4 8M13 12l2 2" />
+              <circle cx="9" cy="4" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+              <circle cx="13" cy="12" r="1" fill="currentColor" stroke="none" />
             </svg>
           </span>
           <span className={styles.commandLinkText}>
             Launch Claude Code
-            <span className={styles.commandLinkDesc}>start a session on an open issue</span>
+            <span className={styles.commandLinkDesc}>swipe an open issue to launch</span>
           </span>
         </Link>
 

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -235,6 +235,21 @@ export function FiltersSheet({
           </span>
         </button>
 
+        <Link href="/?section=open&launch=next" className={styles.commandLink} onClick={onClose}>
+          <span className={`${styles.commandLinkIcon} ${styles.claudeIcon}`}>
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+              <path d="M3 14l2-2M5 12l4-8M9 4l4 8M13 12l2 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              <circle cx="9" cy="4" r="1.5" fill="currentColor" />
+              <circle cx="5" cy="12" r="1" fill="currentColor" />
+              <circle cx="13" cy="12" r="1" fill="currentColor" />
+            </svg>
+          </span>
+          <span className={styles.commandLinkText}>
+            Launch Claude Code
+            <span className={styles.commandLinkDesc}>start a session on an open issue</span>
+          </span>
+        </Link>
+
         <Link href="/parse" className={styles.commandLink} onClick={onClose}>
           <span className={styles.commandLinkIcon}>
             <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -26,10 +26,16 @@
   opacity: 0.92;
 }
 
-/* Command sheet replaces the FAB on mobile. */
+/* Mobile: compact FAB so it doesn't crowd the bottom sheet handle.
+   The "Create issue" action in the sheet is too far down on mobile,
+   so this provides a quick shortcut. */
 @media (max-width: 767px) {
   .fab {
-    display: none;
+    width: 48px;
+    height: 48px;
+    font-size: 28px;
+    right: 20px;
+    bottom: calc(52px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -26,16 +26,15 @@
   opacity: 0.92;
 }
 
-/* Mobile: compact FAB so it doesn't crowd the bottom sheet handle.
-   The "Create issue" action in the sheet is too far down on mobile,
-   so this provides a quick shortcut. */
+/* Mobile: compact FAB to avoid crowding the bottom sheet handle.
+   Keeps a visible quick-create shortcut above the command sheet. */
 @media (max-width: 767px) {
   .fab {
     width: 48px;
     height: 48px;
     font-size: 28px;
     right: 20px;
-    bottom: calc(52px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(64px + env(safe-area-inset-bottom, 0px));
   }
 }
 


### PR DESCRIPTION
## Summary

- **#167** — Fix sheet pull-up handle overlapping Safari's bottom toolbar by moving `env(safe-area-inset-bottom)` from padding to the `bottom` property, lifting the entire element above system UI
- **#168** — Re-show a compact 48px FAB on mobile for quick issue creation, positioned above the handle with sufficient clearance (64px + safe-area)
- **#177** — Add "Launch Claude Code" action with a custom branching-paths icon in the command sheet, styled with a distinct warm-accent background

## Test plan

- [ ] On iPhone Safari: verify the bottom grab handle no longer overlaps the toolbar/home indicator
- [ ] On mobile: verify the FAB (+) button is visible and doesn't overlap the swipe handle
- [ ] On mobile: open command sheet and verify "Launch Claude Code" action appears with distinct icon
- [ ] On mobile: tap "Launch Claude Code" navigates to open section
- [ ] On desktop (≥768px): verify FAB remains hidden, no visual regressions
- [ ] Run `pnpm turbo typecheck` — passes