### PR TITLE
fix: stale UI after mutations — cache keys + revalidation paths

### DIFF
--- a/packages/core/src/data/comments.test.ts
+++ b/packages/core/src/data/comments.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "../db/test-helpers.js";
+import { setCached, getCached } from "../db/cache.js";
+import { addComment } from "./comments.js";
+
+vi.mock("../github/issues.js", () => ({
+  addComment: vi.fn().mockResolvedValue({
+    id: 200,
+    body: "test comment",
+    user: { login: "alice", avatarUrl: "https://avatar.test/alice" },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    htmlUrl: "https://github.com/owner/repo/issues/1#issuecomment-200",
+  }),
+  getComments: vi.fn(),
+}));
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createTestDb();
+});
+
+const OWNER = "owner";
+const REPO = "repo";
+const ISSUE = 7;
+
+const CACHE_KEYS = [
+  `comments:${OWNER}/${REPO}#${ISSUE}`,
+  `issue-content:${OWNER}/${REPO}#${ISSUE}`,
+  `issue-detail:${OWNER}/${REPO}#${ISSUE}`,
+  `pull-detail:${OWNER}/${REPO}#${ISSUE}`,
+];
+
+// Minimal stub — the real Octokit is never hit because the github layer is mocked.
+const octokit = {} as Parameters<typeof addComment>[1];
+
+describe("addComment (data layer)", () => {
+  it("clears all 4 cache keys after posting", async () => {
+    for (const key of CACHE_KEYS) {
+      setCached(db, key, { placeholder: true });
+    }
+    for (const key of CACHE_KEYS) {
+      expect(getCached(db, key)).not.toBeNull();
+    }
+
+    await addComment(db, octokit, OWNER, REPO, ISSUE, "hello");
+
+    for (const key of CACHE_KEYS) {
+      expect(getCached(db, key)).toBeNull();
+    }
+  });
+});

--- a/packages/core/src/data/comments.ts
+++ b/packages/core/src/data/comments.ts
@@ -51,6 +51,7 @@ export async function addComment(
 ): Promise<GitHubComment> {
   const comment = await postComment(octokit, owner, repo, issueNumber, body);
   clearCacheKey(db, `comments:${owner}/${repo}#${issueNumber}`);
+  clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
   clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
   clearCacheKey(db, `pull-detail:${owner}/${repo}#${issueNumber}`);
   return comment;

--- a/packages/web/lib/actions/comments.ts
+++ b/packages/web/lib/actions/comments.ts
@@ -79,8 +79,8 @@ export async function addComment(
     return { success: false, error: formatErrorForUser(err) };
   }
   const { stale } = revalidateSafely(
-    `/${owner}/${repo}/issues/${issueNumber}`,
-    `/${owner}/${repo}/pulls/${issueNumber}`,
+    `/issues/${owner}/${repo}/${issueNumber}`,
+    `/pulls/${owner}/${repo}/${issueNumber}`,
   );
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -84,7 +84,7 @@ export async function createIssue(data: {
     return { success: false, error: formatErrorForUser(err) };
   }
 
-  const { stale } = revalidateSafely("/", `/${owner}/${repo}`);
+  const { stale } = revalidateSafely("/");
   return {
     success: true,
     issueNumber,
@@ -130,7 +130,7 @@ export async function updateIssue(data: {
     console.error("[issuectl] Failed to update issue:", err);
     return { success: false, error: formatErrorForUser(err) };
   }
-  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
@@ -157,7 +157,7 @@ export async function closeIssue(
     console.error("[issuectl] Failed to close issue:", err);
     return { success: false, error: formatErrorForUser(err) };
   }
-  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
@@ -193,7 +193,7 @@ export async function toggleLabel(data: {
     console.error(`[issuectl] Failed to ${action} label:`, err);
     return { success: false, error: formatErrorForUser(err) };
   }
-  const { stale } = revalidateSafely(`/${owner}/${repo}/issues/${number}`);
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -136,7 +136,8 @@ export async function launchIssue(
   }
 
   const { stale } = revalidateSafely(
-    `/${owner}/${repo}/issues/${issueNumber}`,
+    `/issues/${owner}/${repo}/${issueNumber}`,
+    "/",
   );
   return {
     success: true,
@@ -198,8 +199,9 @@ export async function endSession(
     return { success: false, error: formatErrorForUser(err) };
   }
   const { stale } = revalidateSafely(
-    `/${owner}/${repo}/issues/${issueNumber}`,
-    `/${owner}/${repo}/issues/${issueNumber}/launch`,
+    `/issues/${owner}/${repo}/${issueNumber}`,
+    `/launch/${owner}/${repo}/${issueNumber}`,
+    "/",
   );
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -203,15 +203,7 @@ export async function batchCreateIssues(
       }
     });
 
-    const affectedRepos = new Set(
-      results
-        .filter((r) => r.success && r.owner)
-        .map((r) => `/${r.owner}/${r.repo}`),
-    );
-    if (results.some((r) => r.draftId)) {
-      affectedRepos.add("/");
-    }
-    revalidateSafely(...affectedRepos);
+    revalidateSafely("/");
 
     return {
       created: results.filter((r) => r.success && r.issueNumber).length,


### PR DESCRIPTION
## Summary

- **#170** — New issues didn't appear on the index page until switching tabs
- **#172** — New comments didn't appear on the detail page until a full reload

Root causes:
- Core `addComment` never cleared the `issue-content:` cache key used by `IssueDetailContent`, so `router.refresh()` re-rendered with stale SQLite data
- Every `revalidatePath` call in server actions had swapped path segments (`/${owner}/${repo}/issues/${n}` instead of `/issues/${owner}/${repo}/${n}`), making all revalidation a silent no-op
- `updateIssue`, `closeIssue`, `toggleLabel`, and launch actions never revalidated `"/"`, so the index page Router Cache was never invalidated
- `batchCreateIssues` in `parse.ts` had the same dead revalidation path pattern

## Test plan

- [x] `pnpm turbo typecheck` — all packages pass
- [x] New test: `packages/core/src/data/comments.test.ts` verifies `addComment` clears all 4 cache keys (`comments:`, `issue-content:`, `issue-detail:`, `pull-detail:`)
- [x] PR review toolkit run (code-reviewer, silent-failure-hunter, test-analyzer, comment-analyzer, code-simplifier) — all critical/important findings addressed
- [ ] Manual: create an issue → verify it appears on index without tab switch
- [ ] Manual: post a comment → verify it appears without full reload