### PR TITLE
fix: resolve scroll lock leak and reduce mobile top padding

### DIFF
--- a/packages/web/app/drafts/[draftId]/loading.module.css
+++ b/packages/web/app/drafts/[draftId]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -161,7 +161,8 @@ textarea::placeholder {
 }
 
 /* ── Standalone PWA safe-area ───────────────────────────────────
-   Individual page top bars (List topBar, DetailTopBar, PageHeader,
-   NewIssuePage) include env(safe-area-inset-top) in their own
-   padding, so the body does NOT add it globally — that caused
-   double safe-area spacing on notched / Dynamic Island devices. */
+   Each page/section handles env(safe-area-inset-top) in its own
+   top bar or header padding, so the body does NOT add it globally
+   — that caused double safe-area spacing on notched / Dynamic
+   Island devices. See List topBar, DetailTopBar, PageHeader,
+   NewIssuePage, Drawer head, and route loading skeletons. */

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -160,16 +160,8 @@ textarea::placeholder {
   }
 }
 
-/* ── Standalone PWA adjustments ──────────────────────────────────
-   When launched from the home screen (display: standalone), the
-   browser address bar is gone. Add top padding to account for the
-   status bar area on notched/Dynamic Island devices. */
-@media (display-mode: standalone) {
-  body {
-    /* In standalone mode the browser chrome is absent. This padding
-       prevents page content from sitting under the device status bar
-       or Dynamic Island. The offline indicator banner is position:
-       fixed and handles its own safe-area inset independently. */
-    padding-top: env(safe-area-inset-top);
-  }
-}
+/* ── Standalone PWA safe-area ───────────────────────────────────
+   Individual page top bars (List topBar, DetailTopBar, PageHeader,
+   NewIssuePage) include env(safe-area-inset-top) in their own
+   padding, so the body does NOT add it globally — that caused
+   double safe-area spacing on notched / Dynamic Island devices. */

--- a/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/launch/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -11,7 +11,7 @@
   top: 0;
   z-index: 20;
   background: var(--paper-bg);
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/packages/web/app/new/loading.module.css
+++ b/packages/web/app/new/loading.module.css
@@ -5,7 +5,7 @@
 }
 
 .topBar {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/loading.module.css
@@ -9,7 +9,7 @@
 }
 
 .header {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   border-bottom: 1px solid var(--paper-line);
 }
 

--- a/packages/web/components/detail/DetailTopBar.module.css
+++ b/packages/web/components/detail/DetailTopBar.module.css
@@ -1,5 +1,5 @@
 .bar {
-  padding: calc(14px + env(safe-area-inset-top, 0px)) 16px 12px;
+  padding: calc(8px + env(safe-area-inset-top, 0px)) 16px 10px;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -3,7 +3,7 @@
   margin: 0 auto;
   /* Bottom padding provides scroll-end breathing room so the last row
      clears the filter handle and safe-area inset. */
-  padding: 12px 0 calc(80px + env(safe-area-inset-bottom, 0px));
+  padding: 4px 0 calc(80px + env(safe-area-inset-bottom, 0px));
   background: var(--paper-bg);
   min-height: 100dvh;
   position: relative;

--- a/packages/web/components/paper/Drawer.tsx
+++ b/packages/web/components/paper/Drawer.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useId, useRef } from "react";
+import { useScrollLock } from "@/hooks/useScrollLock";
 import styles from "./Drawer.module.css";
 
 type Props = {
@@ -40,14 +41,7 @@ export function Drawer({ open, onClose, title, children }: Props) {
   }, [open]);
 
   // Body scroll lock while the drawer is open.
-  useEffect(() => {
-    if (!open) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [open]);
+  useScrollLock(open);
 
   // Escape + Tab trap.
   useEffect(() => {

--- a/packages/web/components/paper/Drawer.tsx
+++ b/packages/web/components/paper/Drawer.tsx
@@ -40,7 +40,7 @@ export function Drawer({ open, onClose, title, children }: Props) {
     };
   }, [open]);
 
-  // Body scroll lock while the drawer is open.
+  // Body scroll lock while the drawer is open (no exit animation, so `open` suffices).
   useScrollLock(open);
 
   // Escape + Tab trap.

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties, ReactNode } from "react";
 import { useEffect, useId, useRef, useState } from "react";
+import { useScrollLock } from "@/hooks/useScrollLock";
 import styles from "./Sheet.module.css";
 
 type Props = {
@@ -84,14 +85,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
   }, [open]);
 
   // Lock body scroll for the full mounted lifetime (including exit animation).
-  useEffect(() => {
-    if (!visible) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [visible]);
+  useScrollLock(visible);
 
   useEffect(() => {
     if (!open) return;

--- a/packages/web/components/ui/PageHeader.module.css
+++ b/packages/web/components/ui/PageHeader.module.css
@@ -1,8 +1,15 @@
 .header {
-  padding: 24px 32px 0;
+  padding: calc(10px + env(safe-area-inset-top, 0px)) 20px 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
+}
+
+@media (min-width: 768px) {
+  .header {
+    padding: 24px 32px 0;
+    gap: 16px;
+  }
 }
 
 .titleRow {

--- a/packages/web/hooks/useScrollLock.ts
+++ b/packages/web/hooks/useScrollLock.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Ref-counted body scroll lock.
+ *
+ * Multiple Sheet/Drawer instances can request a lock simultaneously.
+ * The body overflow is only restored when every lock has been released,
+ * avoiding the stale-restore bug where a closing modal restores
+ * "hidden" because it captured that value from an overlapping modal.
+ */
+let lockCount = 0;
+
+function lock() {
+  lockCount++;
+  if (lockCount === 1) {
+    document.body.style.overflow = "hidden";
+  }
+}
+
+function unlock() {
+  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount === 0) {
+    document.body.style.overflow = "";
+  }
+}
+
+export function useScrollLock(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    lock();
+    return unlock;
+  }, [active]);
+}

--- a/packages/web/hooks/useScrollLock.ts
+++ b/packages/web/hooks/useScrollLock.ts
@@ -5,10 +5,13 @@ import { useEffect } from "react";
 /**
  * Ref-counted body scroll lock.
  *
- * Multiple Sheet/Drawer instances can request a lock simultaneously.
- * The body overflow is only restored when every lock has been released,
- * avoiding the stale-restore bug where a closing modal restores
- * "hidden" because it captured that value from an overlapping modal.
+ * Multiple Sheet/Drawer instances can request a lock simultaneously —
+ * the most common overlap is a Sheet's exit animation (which keeps
+ * `visible` true) coinciding with another modal opening. The body
+ * overflow is only restored when every lock has been released, avoiding
+ * the stale-restore bug where a closing modal restores the overflow
+ * value it captured at open time, prematurely unlocking scroll while
+ * another modal is still visible.
  */
 let lockCount = 0;
 
@@ -20,7 +23,14 @@ function lock() {
 }
 
 function unlock() {
-  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount <= 0) {
+    console.warn(
+      "[useScrollLock] unlock() called when lockCount is already 0. " +
+        "This indicates a mismatched lock/unlock — check component lifecycle.",
+    );
+    return;
+  }
+  lockCount--;
   if (lockCount === 0) {
     document.body.style.overflow = "";
   }


### PR DESCRIPTION
## Summary

- **#171 — Vertical scrolling broken:** Replace the fragile save/restore body scroll lock in Sheet and Drawer with a ref-counted `useScrollLock` hook. The old pattern captured `document.body.style.overflow` per-instance; when modals overlapped (e.g., FiltersSheet exit animation + CreateDraftSheet open), the saved value could corrupt, permanently locking the viewport. The counter approach only restores overflow when all locks release.
- **#176 — Too much white space at top on mobile:** Remove the standalone PWA `body { padding-top: env(safe-area-inset-top) }` that double-counted the safe-area inset (each page top bar already includes it). Reduce top padding across all pages on mobile: List container 12→4px, DetailTopBar 14→8px, PageHeader 24→10px, NewIssuePage 14→8px, and all matching loading skeletons.

## Test plan

- [ ] Typecheck passes (`pnpm turbo typecheck`)
- [ ] Open and close FiltersSheet, then CreateDraftSheet in quick succession — page remains scrollable
- [ ] Open a Sheet, navigate away via back button — page remains scrollable on the new route
- [ ] Verify top padding is reduced on mobile across dashboard, detail, settings, and new-issue pages
- [ ] Verify standalone PWA mode no longer has double safe-area spacing at top
- [ ] Run E2E suite (`pnpm --filter @issuectl/web test:e2e`)

Closes #171, closes #176