### PR TITLE
fix: filter data by active repo at source, add pull-to-refresh on issue detail

### DIFF
--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -160,9 +160,15 @@ export async function getUnifiedList(
   db: Database.Database,
   octokit: Octokit,
   sortMode: SortMode = "updated",
+  repoFilter?: { owner: string; name: string } | null,
 ): Promise<UnifiedList> {
-  const drafts = listDrafts(db);
-  const repos = listRepos(db);
+  const drafts = repoFilter ? [] : listDrafts(db);
+  const allRepos = listRepos(db);
+  const repos = repoFilter
+    ? allRepos.filter(
+        (r) => r.owner === repoFilter.owner && r.name === repoFilter.name,
+      )
+    : allRepos;
 
   // Per-repo failures are caught and logged so one bad repo doesn't
   // kill the whole feed — we render the remaining repos' data and

--- a/packages/web/app/DashboardContent.tsx
+++ b/packages/web/app/DashboardContent.tsx
@@ -13,11 +13,16 @@ import { ListContent } from "@/components/list/ListContent";
 import { DashboardError } from "@/components/ui/DashboardError";
 import {
   filterPrs,
-  filterUnifiedList,
   type PrEntry,
 } from "@/lib/page-filters";
 
 type Repo = { owner: string; name: string };
+
+function parseRepoKey(key: string): { owner: string; name: string } | null {
+  const idx = key.indexOf("/");
+  if (idx < 1) return null;
+  return { owner: key.slice(0, idx), name: key.slice(idx + 1) };
+}
 
 type Props = {
   repos: Repo[];
@@ -47,19 +52,25 @@ export async function DashboardContent({
     const db = getDb();
     const octokit = await getOctokit();
 
+    const repoFilter = activeRepo ? parseRepoKey(activeRepo) : null;
+    const targetRepos = repoFilter
+      ? repos.filter(
+          (r) => r.owner === repoFilter.owner && r.name === repoFilter.name,
+        )
+      : repos;
+
     const [data, allPrs] = await Promise.all([
-      getUnifiedList(db, octokit, activeSort),
-      gatherPulls(db, octokit, repos),
+      getUnifiedList(db, octokit, activeSort, repoFilter),
+      gatherPulls(db, octokit, targetRepos),
     ]);
 
-    const filteredData = filterUnifiedList(data, activeRepo);
-    const filteredPrs = filterPrs(allPrs, activeRepo, mineOnly ? username : null);
+    const filteredPrs = filterPrs(allPrs, null, mineOnly ? username : null);
 
     const sectionCounts: Record<Section, number> = {
-      unassigned: filteredData.unassigned.length,
-      open: filteredData.open.length,
-      running: filteredData.running.length,
-      closed: filteredData.closed.length,
+      unassigned: data.unassigned.length,
+      open: data.open.length,
+      running: data.running.length,
+      closed: data.closed.length,
     };
 
     const totalIssueCount =
@@ -77,7 +88,7 @@ export async function DashboardContent({
         <ListContent
           activeTab={activeTab}
           activeSection={activeSection}
-          data={filteredData}
+          data={data}
           prs={filteredPrs}
           activeRepo={activeRepo}
           mineOnly={mineOnly}

--- a/packages/web/app/DashboardContent.tsx
+++ b/packages/web/app/DashboardContent.tsx
@@ -15,14 +15,9 @@ import {
   filterPrs,
   type PrEntry,
 } from "@/lib/page-filters";
+import { parseRepoKey } from "@/lib/repo-key";
 
 type Repo = { owner: string; name: string };
-
-function parseRepoKey(key: string): { owner: string; name: string } | null {
-  const idx = key.indexOf("/");
-  if (idx < 1) return null;
-  return { owner: key.slice(0, idx), name: key.slice(idx + 1) };
-}
 
 type Props = {
   repos: Repo[];

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "@issuectl/core";
 import { IssueDetail } from "@/components/detail/IssueDetail";
 import { IssueDetailContent } from "@/components/detail/IssueDetailContent";
+import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
+import { refreshIssueAction } from "@/lib/actions/refresh";
 import styles from "./loading.module.css";
 
 export const dynamic = "force-dynamic";
@@ -67,26 +69,35 @@ export default async function IssueDetailPage({
       ? getPriority(db, repoId, issueNumber)
       : "normal";
 
+    const boundRefresh = refreshIssueAction.bind(
+      null,
+      owner,
+      repo,
+      issueNumber,
+    );
+
     return (
-      <IssueDetail
-        owner={owner}
-        repoName={repo}
-        repoId={repoId}
-        currentPriority={currentPriority}
-        issue={issue}
-        repoLocalPath={repoRecord?.localPath ?? null}
-        deployments={deployments}
-        referencedFiles={referencedFiles}
-      >
-        <Suspense fallback={<ContentSkeleton />}>
-          <IssueDetailContent
-            owner={owner}
-            repoName={repo}
-            issue={issue}
-            deployments={deployments}
-          />
-        </Suspense>
-      </IssueDetail>
+      <PullToRefreshWrapper action={boundRefresh}>
+        <IssueDetail
+          owner={owner}
+          repoName={repo}
+          repoId={repoId}
+          currentPriority={currentPriority}
+          issue={issue}
+          repoLocalPath={repoRecord?.localPath ?? null}
+          deployments={deployments}
+          referencedFiles={referencedFiles}
+        >
+          <Suspense fallback={<ContentSkeleton />}>
+            <IssueDetailContent
+              owner={owner}
+              repoName={repo}
+              issue={issue}
+              deployments={deployments}
+            />
+          </Suspense>
+        </IssueDetail>
+      </PullToRefreshWrapper>
     );
   } catch (err) {
     const status = err !== null && err !== undefined && typeof err === "object" && "status" in err

--- a/packages/web/components/ui/PullToRefreshWrapper.tsx
+++ b/packages/web/components/ui/PullToRefreshWrapper.tsx
@@ -9,18 +9,20 @@ import styles from "./PullToRefreshWrapper.module.css";
 
 type Props = {
   children: ReactNode;
+  /** Override the default global cache-clear with a targeted action. */
+  action?: () => Promise<{ success: boolean; error?: string }>;
 };
 
-export function PullToRefreshWrapper({ children }: Props) {
+export function PullToRefreshWrapper({ children, action }: Props) {
   const router = useRouter();
 
   const onRefresh = useCallback(async () => {
-    const result = await refreshAction();
+    const result = await (action ?? refreshAction)();
     if (!result.success) {
       console.warn("[issuectl] Pull-to-refresh failed:", result.error);
     }
     router.refresh();
-  }, [router]);
+  }, [router, action]);
 
   const { containerRef, pullDistance, refreshing } = usePullToRefresh({
     onRefresh,

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -35,23 +35,46 @@ export async function refreshAction(): Promise<{
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
+const ISSUE_REFRESH_COOLDOWN_MS = 5_000;
+let lastIssueRefreshAt = 0;
+
 /**
- * Targeted refresh for a single issue detail page — clears only the
- * cache keys relevant to this issue so the next render fetches fresh
- * comments, labels, and status from GitHub.
+ * Targeted refresh for a single issue detail page — clears the cache
+ * keys that the detail page actually reads (issue-header, issue-content)
+ * plus the repo-wide issue list, so the next render fetches fresh data
+ * from GitHub.
  */
 export async function refreshIssueAction(
   owner: string,
   repo: string,
   number: number,
 ): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
+  if (
+    typeof owner !== "string" || !/^[\w.-]+$/.test(owner) ||
+    typeof repo !== "string" || !/^[\w.-]+$/.test(repo) ||
+    !Number.isInteger(number) || number <= 0
+  ) {
+    return { success: false, error: "Invalid issue reference" };
+  }
+
+  const now = Date.now();
+  if (now - lastIssueRefreshAt < ISSUE_REFRESH_COOLDOWN_MS) {
+    return {
+      success: false,
+      error: "Please wait a few seconds before refreshing again",
+    };
+  }
+
   try {
     if (dbExists()) {
       const db = getDb();
-      clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+      clearCacheKey(db, `issue-header:${owner}/${repo}#${number}`);
+      clearCacheKey(db, `issue-content:${owner}/${repo}#${number}`);
       clearCacheKey(db, `issues:${owner}/${repo}`);
-      clearCacheKey(db, `comments:${owner}/${repo}#${number}`);
     }
+    lastIssueRefreshAt = now;
+    const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`);
+    return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
   } catch (err) {
     console.error("[issuectl] refreshIssueAction failed:", err);
     return {
@@ -59,6 +82,4 @@ export async function refreshIssueAction(
       error: err instanceof Error ? err.message : "Failed to refresh",
     };
   }
-  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`);
-  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getDb, clearCache, dbExists } from "@issuectl/core";
+import { getDb, clearCache, clearCacheKey, dbExists } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
 const REFRESH_COOLDOWN_MS = 10_000;
@@ -32,5 +32,33 @@ export async function refreshAction(): Promise<{
   }
   lastRefreshAt = now;
   const { stale } = revalidateSafely("/", "/settings");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+/**
+ * Targeted refresh for a single issue detail page — clears only the
+ * cache keys relevant to this issue so the next render fetches fresh
+ * comments, labels, and status from GitHub.
+ */
+export async function refreshIssueAction(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
+  try {
+    if (dbExists()) {
+      const db = getDb();
+      clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+      clearCacheKey(db, `issues:${owner}/${repo}`);
+      clearCacheKey(db, `comments:${owner}/${repo}#${number}`);
+    }
+  } catch (err) {
+    console.error("[issuectl] refreshIssueAction failed:", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to refresh",
+    };
+  }
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`);
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/page-filters.test.ts
+++ b/packages/web/lib/page-filters.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { GitHubPull, UnifiedList } from "@issuectl/core";
+import type { GitHubPull } from "@issuectl/core";
 import {
   resolveActiveRepo,
-  filterUnifiedList,
   filterPrs,
   type PrEntry,
 } from "./page-filters";
@@ -23,81 +22,6 @@ describe("resolveActiveRepo", () => {
 
   it("returns the param when it matches a tracked repo", () => {
     expect(resolveActiveRepo("acme/alpha", trackedRepos)).toBe("acme/alpha");
-  });
-});
-
-function makeUnifiedList(): UnifiedList {
-  const alpha = {
-    id: 1,
-    owner: "acme",
-    name: "alpha",
-    localPath: null,
-    branchPattern: null,
-    createdAt: "2026-01-01",
-  };
-  const beta = {
-    id: 2,
-    owner: "acme",
-    name: "beta",
-    localPath: null,
-    branchPattern: null,
-    createdAt: "2026-01-01",
-  };
-  const issueItem = (repo: typeof alpha, number: number) => ({
-    kind: "issue" as const,
-    repo,
-    issue: {
-      number,
-      title: `Issue ${number}`,
-      body: null,
-      state: "open" as const,
-      labels: [],
-      user: null,
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-      closedAt: null,
-      htmlUrl: "",
-    },
-    priority: "normal" as const,
-    section: "open" as const,
-  });
-  return {
-    unassigned: [
-      {
-        kind: "draft",
-        draft: {
-          id: "d1",
-          title: "draft 1",
-          body: "",
-          priority: "normal",
-          createdAt: 0,
-          updatedAt: 0,
-        },
-      },
-    ],
-    open: [issueItem(alpha, 1), issueItem(beta, 2)],
-    running: [],
-    closed: [],
-  };
-}
-
-describe("filterUnifiedList", () => {
-  it("returns input unchanged when no repo filter", () => {
-    const list = makeUnifiedList();
-    expect(filterUnifiedList(list, null)).toBe(list);
-  });
-
-  it("drops drafts when a repo filter is active", () => {
-    const list = makeUnifiedList();
-    const filtered = filterUnifiedList(list, "acme/alpha");
-    expect(filtered.unassigned).toEqual([]);
-  });
-
-  it("keeps only items matching the active repo", () => {
-    const list = makeUnifiedList();
-    const filtered = filterUnifiedList(list, "acme/alpha");
-    expect(filtered.open).toHaveLength(1);
-    expect(filtered.open[0].repo.name).toBe("alpha");
   });
 });
 

--- a/packages/web/lib/page-filters.ts
+++ b/packages/web/lib/page-filters.ts
@@ -1,4 +1,4 @@
-import type { GitHubPull, UnifiedList } from "@issuectl/core";
+import type { GitHubPull } from "@issuectl/core";
 import { repoKey } from "./repo-key";
 
 export type PrEntry = {
@@ -19,25 +19,6 @@ export function resolveActiveRepo(
   if (!param) return null;
   const exists = repos.some((r) => repoKey(r) === param);
   return exists ? param : null;
-}
-
-/**
- * Filter a unified list to a single repo. Drafts (`unassigned`) are dropped
- * entirely when a repo filter is active because drafts have no repo.
- */
-export function filterUnifiedList(
-  data: UnifiedList,
-  activeRepo: string | null,
-): UnifiedList {
-  if (!activeRepo) return data;
-  const match = (item: { repo: { owner: string; name: string } }) =>
-    repoKey(item.repo) === activeRepo;
-  return {
-    unassigned: [],
-    open: data.open.filter(match),
-    running: data.running.filter(match),
-    closed: data.closed.filter(match),
-  };
 }
 
 /**

--- a/packages/web/lib/repo-key.ts
+++ b/packages/web/lib/repo-key.ts
@@ -7,3 +7,15 @@
 export function repoKey(r: { owner: string; name: string }): string {
   return `${r.owner}/${r.name}`;
 }
+
+/**
+ * Inverse of `repoKey` — parse `"owner/name"` back into its parts.
+ * Returns `null` for malformed input (missing slash, empty owner or name).
+ */
+export function parseRepoKey(
+  key: string,
+): { owner: string; name: string } | null {
+  const idx = key.indexOf("/");
+  if (idx < 1 || idx >= key.length - 1) return null;
+  return { owner: key.slice(0, idx), name: key.slice(idx + 1) };
+}


### PR DESCRIPTION
## Summary

- **#169** — Push repo filtering into the core `getUnifiedList` data layer so only the selected repo's issues, deployments, and priorities are fetched. Eliminates the previous fetch-all-then-filter-client-side approach that allowed unselected repo issues to leak into views. PRs are also scoped to the target repos in `gatherPulls`.
- **#175** — Add pull-to-refresh on the issue detail page via `PullToRefreshWrapper` with a targeted `refreshIssueAction` that clears only the relevant cache keys (`issue-header`, `issue-content`, repo issue list) instead of nuking the global cache.
- Ran full PR review toolkit (6 agents). Fixed all critical and important findings: corrected cache keys, added server action input validation + cooldown, guarded empty repo names in `parseRepoKey`, removed dead `filterUnifiedList` code.

## Changed files

| File | Change |
|---|---|
| `packages/core/src/data/unified-list.ts` | Added optional `repoFilter` param to `getUnifiedList` |
| `packages/web/app/DashboardContent.tsx` | Parse `activeRepo`, pass filter to core + `gatherPulls` |
| `packages/web/app/issues/[owner]/[repo]/[number]/page.tsx` | Wrap in `PullToRefreshWrapper` with bound `refreshIssueAction` |
| `packages/web/components/ui/PullToRefreshWrapper.tsx` | Added optional `action` prop for targeted refresh |
| `packages/web/lib/actions/refresh.ts` | Added `refreshIssueAction` with validation, cooldown, correct cache keys |
| `packages/web/lib/repo-key.ts` | Added `parseRepoKey` (inverse of `repoKey`) |
| `packages/web/lib/page-filters.ts` | Removed dead `filterUnifiedList` |
| `packages/web/lib/page-filters.test.ts` | Removed `filterUnifiedList` tests |

## Test plan

- [x] `pnpm turbo typecheck` passes (all 3 packages)
- [x] `pnpm --filter @issuectl/web test` passes (79 tests)
- [x] Lint passes (0 errors)
- [ ] Manual: select a repo filter on dashboard — only that repo's issues/PRs show
- [ ] Manual: with no repo filter — all repos' issues + drafts show
- [ ] Manual: on issue detail page, pull-to-refresh updates comments/labels/status
- [ ] Manual: rapid pull-to-refresh on detail page is rate-limited (5s cooldown)

Closes #169, closes #175