### PR TITLE
feat: swipe-to-close issues, close with comment, FAB sizing

### DIFF
--- a/docs/superpowers/plans/2026-04-20-issue-close-ux.md
+++ b/docs/superpowers/plans/2026-04-20-issue-close-ux.md
@@ -1,0 +1,1369 @@
+# Issue Close UX & FAB Sizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add swipe-to-close on the issue list, replace bare close confirmation with a comment-enabled modal, remove decorative checkboxes from rows, and bump the mobile FAB size.
+
+**Architecture:** The changes span three layers: (1) server action update to accept an optional closing comment, (2) a new `CloseIssueModal` client component that replaces the bare `ConfirmDialog` for closing, and (3) `SwipeRow`/`ListRow` modifications for bidirectional swipe and checkbox removal. Each task produces working, testable code independently.
+
+**Tech Stack:** Next.js Server Actions, React client components, CSS Modules, Octokit (`addComment` + `closeIssue` in core).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/web/components/paper/Fab.module.css` | Modify | Increase mobile FAB from 48→52px |
+| `packages/web/lib/actions/issues.ts` | Modify | Add optional `comment` param to `closeIssue` server action |
+| `packages/web/components/ui/CloseIssueModal.tsx` | Create | Modal with optional comment textarea + close confirmation |
+| `packages/web/components/ui/CloseIssueModal.module.css` | Create | Styles for the new modal |
+| `packages/web/components/list/SwipeRow.tsx` | Modify | Add right-swipe (onClose) support |
+| `packages/web/components/list/SwipeRow.module.css` | Modify | Add left-side close button styles |
+| `packages/web/components/list/ListRow.tsx` | Modify | Remove Checkbox, add onClose prop, wire SwipeRow for close |
+| `packages/web/components/list/ListRow.module.css` | Modify | Remove .check styles, reduce left padding |
+| `packages/web/components/list/ListSection.tsx` | Modify | Thread onClose prop |
+| `packages/web/components/list/ListContent.tsx` | Modify | Add CloseIssueModal state + onClose handler |
+| `packages/web/components/detail/IssueActionSheet.tsx` | Modify | Use CloseIssueModal instead of ConfirmDialog for close |
+
+---
+
+### Task 1: FAB Size Increase
+
+**Files:**
+- Modify: `packages/web/components/paper/Fab.module.css:31-38`
+
+- [ ] **Step 1: Update FAB dimensions**
+
+In `packages/web/components/paper/Fab.module.css`, change the mobile media query:
+
+```css
+@media (max-width: 767px) {
+  .fab {
+    width: 52px;
+    height: 52px;
+    font-size: 30px;
+    right: 20px;
+    bottom: calc(64px + env(safe-area-inset-bottom, 0px));
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS (CSS-only change, no type impact)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/components/paper/Fab.module.css
+git commit -m "fix: increase mobile FAB from 48px to 52px for better tap target"
+```
+
+---
+
+### Task 2: Update `closeIssue` Server Action to Accept Optional Comment
+
+**Files:**
+- Modify: `packages/web/lib/actions/issues.ts:137-162`
+
+- [ ] **Step 1: Add `comment` parameter and comment-first logic**
+
+Replace the existing `closeIssue` function in `packages/web/lib/actions/issues.ts`:
+
+```typescript
+export async function closeIssue(
+  owner: string,
+  repo: string,
+  number: number,
+  comment?: string,
+): Promise<{ success: true; cacheStale?: true } | { success: false; error: string }> {
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
+    return { success: false, error: "Valid owner, repo, and issue number are required" };
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
+
+    // Post closing comment first — abort if this fails so the issue
+    // isn't closed without the user's intended comment.
+    if (comment && comment.trim()) {
+      await withAuthRetry((octokit) =>
+        coreAddComment(octokit, owner, repo, number, comment.trim()),
+      );
+    }
+
+    await withAuthRetry((octokit) =>
+      coreCloseIssue(octokit, owner, repo, number),
+    );
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+  } catch (err) {
+    console.error("[issuectl] Failed to close issue:", err);
+    return { success: false, error: formatErrorForUser(err) };
+  }
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+```
+
+- [ ] **Step 2: Add import for `addComment`**
+
+At the top of `packages/web/lib/actions/issues.ts`, add `addComment` to the core import:
+
+```typescript
+import {
+  getDb,
+  getRepo,
+  getRepoById,
+  createIssue as coreCreateIssue,
+  updateIssue as coreUpdateIssue,
+  closeIssue as coreCloseIssue,
+  addComment as coreAddComment,
+  reassignIssue as coreReassignIssue,
+  addLabel as coreAddLabel,
+  removeLabel as coreRemoveLabel,
+  clearCacheKey,
+  withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
+  formatErrorForUser,
+  type ReassignResult,
+} from "@issuectl/core";
+```
+
+Note: The `addComment` exported from `@issuectl/core` is the one in `packages/core/src/github/issues.ts` which takes `(octokit, owner, repo, number, body)`. Verify this is the correct signature — the data-layer version in `packages/core/src/data/comments.ts` takes `(db, octokit, ...)` and also clears comment caches. Use the data-layer version if it's the one exported from the index. Check: `grep "addComment" packages/core/src/index.ts`.
+
+If the exported `addComment` is the data-layer version (takes `db` as first param), use:
+```typescript
+const db = getDb();
+// ... (db already declared above)
+await withAuthRetry((octokit) =>
+  coreAddComment(db, octokit, owner, repo, number, comment.trim()),
+);
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `pnpm --filter @issuectl/core test`
+Expected: All existing tests pass (we didn't change core, just the server action)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/actions/issues.ts
+git commit -m "feat: add optional closing comment to closeIssue server action"
+```
+
+---
+
+### Task 3: Create `CloseIssueModal` Component
+
+**Files:**
+- Create: `packages/web/components/ui/CloseIssueModal.tsx`
+- Create: `packages/web/components/ui/CloseIssueModal.module.css`
+
+- [ ] **Step 1: Create the CSS module**
+
+Create `packages/web/components/ui/CloseIssueModal.module.css`:
+
+```css
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message {
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 10px 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--paper-ink);
+  background: var(--paper-bg);
+  resize: vertical;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--paper-accent);
+  box-shadow: 0 0 0 2px var(--paper-accent-soft);
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--paper-brick);
+}
+
+.danger {
+  background: var(--paper-brick);
+  color: var(--paper-bg);
+  border-color: var(--paper-brick);
+}
+
+.danger:hover {
+  background: #e5443c;
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+Create `packages/web/components/ui/CloseIssueModal.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+import styles from "./CloseIssueModal.module.css";
+
+type Props = {
+  issueNumber: number;
+  onConfirm: (comment: string) => void;
+  onCancel: () => void;
+  isPending?: boolean;
+  error?: string;
+};
+
+export function CloseIssueModal({
+  issueNumber,
+  onConfirm,
+  onCancel,
+  isPending,
+  error,
+}: Props) {
+  const [comment, setComment] = useState("");
+
+  return (
+    <Modal
+      title="Close Issue"
+      width={480}
+      onClose={onCancel}
+      disabled={isPending}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => onConfirm(comment)}
+            disabled={isPending}
+            className={styles.danger}
+          >
+            {isPending ? "Closing\u2026" : "Close Issue"}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.body}>
+        <p className={styles.message}>
+          Close issue #{issueNumber}? This can be reopened later from GitHub.
+        </p>
+        <textarea
+          className={styles.textarea}
+          placeholder="Add a closing comment\u2026"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          disabled={isPending}
+          rows={3}
+        />
+        {error && (
+          <p className={styles.error} role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/ui/CloseIssueModal.tsx packages/web/components/ui/CloseIssueModal.module.css
+git commit -m "feat: add CloseIssueModal with optional comment textarea"
+```
+
+---
+
+### Task 4: Extend SwipeRow for Bidirectional Swipe
+
+**Files:**
+- Modify: `packages/web/components/list/SwipeRow.tsx`
+- Modify: `packages/web/components/list/SwipeRow.module.css`
+
+- [ ] **Step 1: Update SwipeRow component for bidirectional support**
+
+Replace the entire content of `packages/web/components/list/SwipeRow.tsx`:
+
+```tsx
+"use client";
+
+import { useRef, useState, useCallback, type ReactNode } from "react";
+import styles from "./SwipeRow.module.css";
+
+const SWIPE_THRESHOLD = 60;
+
+type SwipeState = "idle" | "left" | "right";
+
+type Props = {
+  children: ReactNode;
+  onLaunch?: () => void;
+  onClose?: () => void;
+  disabled?: boolean;
+};
+
+export function SwipeRow({ children, onLaunch, onClose, disabled }: Props) {
+  const [swiped, setSwiped] = useState<SwipeState>("idle");
+  const startX = useRef<number | null>(null);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled) return;
+      startX.current = e.touches[0].clientX;
+    },
+    [disabled],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (startX.current === null) return;
+      const touch = e.changedTouches[0];
+      if (!touch) {
+        startX.current = null;
+        return;
+      }
+      const delta = touch.clientX - startX.current;
+      if (delta > SWIPE_THRESHOLD && onClose) {
+        // Swiped right — reveal close on left
+        setSwiped("right");
+      } else if (delta < -SWIPE_THRESHOLD && onLaunch) {
+        // Swiped left — reveal launch on right
+        setSwiped("left");
+      } else if (Math.abs(delta) > SWIPE_THRESHOLD) {
+        // Swipe in a direction with no handler — dismiss
+        setSwiped("idle");
+      }
+      startX.current = null;
+    },
+    [onLaunch, onClose],
+  );
+
+  const handleTouchCancel = useCallback(() => {
+    startX.current = null;
+  }, []);
+
+  const dismiss = useCallback(() => setSwiped("idle"), []);
+
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className={styles.wrapper}
+      data-swiped={swiped}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
+    >
+      {onClose && (
+        <div className={styles.actionsLeft}>
+          <button
+            className={`${styles.actionBtn} ${styles.closeBtn}`}
+            onClick={() => {
+              dismiss();
+              onClose();
+            }}
+          >
+            Close
+          </button>
+        </div>
+      )}
+      {onLaunch && (
+        <div className={styles.actionsRight}>
+          <button
+            className={`${styles.actionBtn} ${styles.launchBtn}`}
+            onClick={() => {
+              dismiss();
+              onLaunch();
+            }}
+          >
+            Launch
+          </button>
+        </div>
+      )}
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update SwipeRow CSS for bidirectional reveals**
+
+Replace the entire content of `packages/web/components/list/SwipeRow.module.css`:
+
+```css
+.wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+/* Left-side actions (close) — revealed on swipe-right */
+.actionsLeft {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  transform: translateX(-100%);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Right-side actions (launch) — revealed on swipe-left */
+.actionsRight {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  transform: translateX(100%);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.content {
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  background: var(--paper-bg);
+}
+
+/* Swiped left — content slides left, right actions revealed */
+.wrapper[data-swiped="left"] .actionsRight {
+  transform: translateX(0);
+}
+
+.wrapper[data-swiped="left"] .content {
+  transform: translateX(-80px);
+}
+
+/* Swiped right — content slides right, left actions revealed */
+.wrapper[data-swiped="right"] .actionsLeft {
+  transform: translateX(0);
+}
+
+.wrapper[data-swiped="right"] .content {
+  transform: translateX(80px);
+}
+
+.actionBtn {
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  font-family: var(--paper-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--paper-bg);
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.launchBtn {
+  background: var(--paper-ink);
+}
+
+.closeBtn {
+  background: var(--paper-brick, #c9553d);
+}
+
+@media (min-width: 768px) and (hover: hover) {
+  .wrapper {
+    overflow: visible;
+  }
+
+  .actionsLeft,
+  .actionsRight {
+    display: none;
+  }
+
+  .content {
+    transform: none !important;
+  }
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/SwipeRow.tsx packages/web/components/list/SwipeRow.module.css
+git commit -m "feat: extend SwipeRow with bidirectional swipe (right reveals close)"
+```
+
+---
+
+### Task 5: Remove Checkboxes and Wire Close in ListRow
+
+**Files:**
+- Modify: `packages/web/components/list/ListRow.tsx`
+- Modify: `packages/web/components/list/ListRow.module.css`
+
+- [ ] **Step 1: Update ListRow component**
+
+Replace the entire content of `packages/web/components/list/ListRow.tsx`:
+
+```tsx
+import Link from "next/link";
+import type { UnifiedListItem } from "@issuectl/core";
+import { Chip, LabelChip } from "@/components/paper";
+import { SyncDot } from "@/components/ui/SyncDot";
+import { SwipeRow } from "./SwipeRow";
+import styles from "./ListRow.module.css";
+
+type Props = {
+  item: UnifiedListItem;
+  onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onClose?: (owner: string, repo: string, issueNumber: number) => void;
+};
+
+// Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
+// use ISO strings. Normalize both to "N days ago" for display. Clamps
+// negative diffs to "today" so a clock-skewed future timestamp doesn't
+// render "-1d".
+function formatAge(updatedAt: string | number): string {
+  const now = Date.now();
+  const updated =
+    typeof updatedAt === "number"
+      ? updatedAt * 1000
+      : new Date(updatedAt).getTime();
+  if (!Number.isFinite(updated)) return "";
+  const diffDays = Math.floor((now - updated) / (24 * 60 * 60 * 1000));
+  if (diffDays < 1) return "today";
+  if (diffDays === 1) return "1d";
+  return `${diffDays}d`;
+}
+
+export function ListRow({ item, onLaunch, onClose }: Props) {
+  if (item.kind === "draft") {
+    return (
+      <div className={styles.item}>
+        <Link href={`/drafts/${item.draft.id}`} className={styles.rowLink}>
+          <div className={styles.title}>{item.draft.title}</div>
+          <div className={styles.meta}>
+            <Chip variant="dashed">no repo</Chip>
+            <span className={styles.sep}>·</span>
+            <SyncDot status="local" label="local draft" />
+            <span className={styles.sep}>·</span>
+            <span>{formatAge(item.draft.updatedAt)}</span>
+          </div>
+        </Link>
+      </div>
+    );
+  }
+
+  const { issue, repo, section } = item;
+  const titleClass =
+    section === "closed" ? `${styles.title} ${styles.done}` : styles.title;
+
+  const displayLabels = issue.labels.filter(
+    (l) => !l.name.startsWith("issuectl:"),
+  );
+
+  let actionLabel: string;
+  let actionAria: string;
+  switch (section) {
+    case "open":
+      actionLabel = "launch";
+      actionAria = "Launch issue";
+      break;
+    case "running":
+      actionLabel = "open";
+      actionAria = "Open active session";
+      break;
+    case "closed":
+      actionLabel = "view";
+      actionAria = "View issue";
+      break;
+    default: {
+      const _exhaustive: never = section;
+      throw new Error(`ListRow: unhandled section ${String(_exhaustive)}`);
+    }
+  }
+
+  const rowContent = (
+    <div className={styles.item} data-section={section}>
+      <Link
+        href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
+        className={styles.rowLink}
+      >
+        <div className={titleClass}>{issue.title}</div>
+        <div className={styles.meta}>
+          <Chip>{repo.name}</Chip>
+          <span className={styles.num}>#{issue.number}</span>
+          {displayLabels.length > 0 && (
+            <>
+              <span className={styles.sep}>·</span>
+              {displayLabels.map((l) => (
+                <LabelChip key={l.name} name={l.name} color={l.color} />
+              ))}
+            </>
+          )}
+          {(issue.commentCount ?? 0) > 0 && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.comments}>
+                <svg
+                  className={styles.commentIcon}
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2v2.19l2.72-2.72.53-.22h4.25a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+                </svg>
+                {issue.commentCount}
+              </span>
+            </>
+          )}
+          <span className={styles.sep}>·</span>
+          <span>{formatAge(issue.updatedAt)}</span>
+          {issue.user && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.author}>{issue.user.login}</span>
+            </>
+          )}
+          {section === "running" && (
+            <>
+              <span className={styles.sep}>·</span>
+              <span className={styles.activeLabel}>active</span>
+            </>
+          )}
+        </div>
+      </Link>
+      <div className={styles.actions}>
+        {section === "open" && onLaunch ? (
+          <button
+            className={styles.actionBtn}
+            onClick={() => onLaunch(repo.owner, repo.name, issue.number)}
+            aria-label={actionAria}
+          >
+            {actionLabel} →
+          </button>
+        ) : (
+          <Link
+            href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
+            className={`${styles.actionBtn} ${section === "running" ? styles.actionBtnRunning : ""}`}
+            aria-label={actionAria}
+          >
+            {actionLabel} →
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+
+  // Wrap in SwipeRow for open (launch + close) and running (close only)
+  if (section === "open" || section === "running") {
+    return (
+      <SwipeRow
+        onLaunch={
+          section === "open" && onLaunch
+            ? () => onLaunch(repo.owner, repo.name, issue.number)
+            : undefined
+        }
+        onClose={
+          onClose
+            ? () => onClose(repo.owner, repo.name, issue.number)
+            : undefined
+        }
+      >
+        {rowContent}
+      </SwipeRow>
+    );
+  }
+
+  return rowContent;
+}
+```
+
+- [ ] **Step 2: Update ListRow CSS — remove checkbox, reduce padding**
+
+In `packages/web/components/list/ListRow.module.css`:
+
+Remove the `.check` block entirely (lines 31-35):
+```css
+/* DELETE THIS BLOCK */
+.check {
+  position: absolute;
+  left: 24px;
+  top: 18px;
+}
+```
+
+Change `.rowLink` padding from `58px` left to `20px`:
+```css
+.rowLink {
+  padding: 16px 24px 8px 20px;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  min-width: 0;
+}
+```
+
+Change `.actions` left padding from `58px` to `20px`:
+```css
+.actions {
+  display: flex;
+  align-items: center;
+  padding: 0 20px 14px 20px;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+```
+
+Update the mobile media query to also hide actions for running rows (SwipeRow reveals close):
+```css
+@media (max-width: 767px), (hover: none) {
+  .item[data-section="open"] .actions,
+  .item[data-section="running"] .actions {
+    display: none;
+  }
+}
+```
+
+Update the desktop media query `.rowLink` padding:
+```css
+@media (min-width: 768px) and (hover: hover) {
+  /* ... */
+  .rowLink {
+    flex: 1;
+    padding: 16px 24px 16px 24px;
+  }
+  /* ... */
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: May show errors in `ListSection.tsx` / `ListContent.tsx` because `onClose` prop is not threaded yet. That's fine — we fix it in the next task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/ListRow.tsx packages/web/components/list/ListRow.module.css
+git commit -m "feat: remove checkboxes from list rows, add onClose prop, wire SwipeRow for close"
+```
+
+---
+
+### Task 6: Thread `onClose` Through ListSection and ListContent
+
+**Files:**
+- Modify: `packages/web/components/list/ListSection.tsx`
+- Modify: `packages/web/components/list/ListContent.tsx`
+
+- [ ] **Step 1: Add `onClose` to ListSection**
+
+Replace the content of `packages/web/components/list/ListSection.tsx`:
+
+```tsx
+import type { ReactNode } from "react";
+import type { UnifiedListItem } from "@issuectl/core";
+import { ListRow } from "./ListRow";
+import styles from "./ListSection.module.css";
+
+type Props = {
+  title: ReactNode | null;
+  items: UnifiedListItem[];
+  onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onClose?: (owner: string, repo: string, issueNumber: number) => void;
+};
+
+export function ListSection({ title, items, onLaunch, onClose }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      {title ? (
+        <div className={styles.section}>
+          <h3>{title}</h3>
+          <div className={styles.rule} />
+          <span className={styles.count}>{items.length}</span>
+        </div>
+      ) : null}
+      {items.map((item) => (
+        <ListRow
+          key={
+            item.kind === "draft"
+              ? `draft-${item.draft.id}`
+              : `issue-${item.repo.id}-${item.issue.number}`
+          }
+          item={item}
+          onLaunch={onLaunch}
+          onClose={onClose}
+        />
+      ))}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Add `CloseIssueModal` state and `onClose` handler to ListContent**
+
+Replace the content of `packages/web/components/list/ListContent.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useRef, useEffect, useCallback, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { Section, UnifiedList } from "@issuectl/core";
+import type { PrEntry } from "@/lib/page-filters";
+import { ListSection } from "./ListSection";
+import { PrListRow } from "./PrListRow";
+import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
+import { closeIssue } from "@/lib/actions/issues";
+import { endSession } from "@/lib/actions/launch";
+import { useToast } from "@/components/ui/ToastProvider";
+import styles from "./List.module.css";
+
+type Props = {
+  activeTab: "issues" | "prs";
+  activeSection: Section;
+  data: UnifiedList;
+  prs: PrEntry[];
+  activeRepo: string | null;
+  mineOnly: boolean;
+  /** Deployments indexed by "owner/repo#number" for session-end-before-close */
+  activeDeployments?: Map<string, number>;
+};
+
+const PAGE_SIZE = 15;
+
+const SECTION_EMPTY: Record<Section, { title: string; body: string }> = {
+  unassigned: {
+    title: "no drafts",
+    body: "start a draft with the + button — it'll live here until you assign it to a repo.",
+  },
+  open: {
+    title: "all clear",
+    body: "nothing on your plate. breathe, or draft the next one.",
+  },
+  running: {
+    title: "no running sessions",
+    body: "when you launch an issue with Claude Code, it lands here while the session is active.",
+  },
+  closed: {
+    title: "nothing closed yet",
+    body: "closed issues show up here once PRs merge and reconcile.",
+  },
+};
+
+type CloseTarget = {
+  owner: string;
+  repo: string;
+  number: number;
+};
+
+export function ListContent({
+  activeTab,
+  activeSection,
+  data,
+  prs,
+  activeRepo,
+  mineOnly,
+  activeDeployments,
+}: Props) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [closeTarget, setCloseTarget] = useState<CloseTarget | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [closeError, setCloseError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [activeSection]);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => prev + PAGE_SIZE);
+  }, []);
+
+  const handleLaunch = useCallback(
+    (owner: string, repo: string, issueNumber: number) => {
+      router.push(`/issues/${owner}/${repo}/${issueNumber}?launch=true`);
+    },
+    [router],
+  );
+
+  const handleCloseRequest = useCallback(
+    (owner: string, repo: string, issueNumber: number) => {
+      setCloseError(null);
+      setCloseTarget({ owner, repo, number: issueNumber });
+    },
+    [],
+  );
+
+  const handleCloseConfirm = useCallback(
+    (comment: string) => {
+      if (!closeTarget) return;
+      const { owner, repo, number } = closeTarget;
+      startTransition(async () => {
+        try {
+          // End active session if one exists for this issue
+          if (activeDeployments) {
+            const key = `${owner}/${repo}#${number}`;
+            const deploymentId = activeDeployments.get(key);
+            if (deploymentId !== undefined) {
+              const endResult = await endSession(deploymentId, owner, repo, number);
+              if (!endResult.success) {
+                showToast(
+                  "Terminal session could not be stopped cleanly — it will be cleaned up on next restart.",
+                  "warning",
+                );
+              }
+            }
+          }
+
+          const result = await closeIssue(owner, repo, number, comment || undefined);
+          if (!result.success) {
+            setCloseError(result.error);
+            return;
+          }
+          setCloseTarget(null);
+          showToast(
+            result.cacheStale
+              ? "Issue closed — reload if the list looks stale"
+              : "Issue closed",
+            "success",
+          );
+          router.replace("/?section=closed");
+        } catch (err) {
+          console.error("[issuectl] Close issue from list failed:", err);
+          setCloseError("Unable to reach the server. Check your connection and try again.");
+        }
+      });
+    },
+    [closeTarget, activeDeployments, showToast, router],
+  );
+
+  const handleCloseCancel = useCallback(() => {
+    setCloseTarget(null);
+    setCloseError(null);
+  }, []);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore, activeSection]);
+
+  if (activeTab === "issues") {
+    const total = data[activeSection].length;
+    const showing = Math.min(visibleCount, total);
+    return (
+      <>
+        {renderIssueSection({
+          activeSection,
+          data,
+          visibleCount,
+          onLaunch: handleLaunch,
+          onClose: handleCloseRequest,
+        })}
+        {total > PAGE_SIZE && (
+          <div className={styles.pageStatus}>
+            Showing {showing} of {total}
+          </div>
+        )}
+        {visibleCount < total && (
+          <div ref={sentinelRef} className={styles.sentinel} />
+        )}
+        {closeTarget && (
+          <CloseIssueModal
+            issueNumber={closeTarget.number}
+            onConfirm={handleCloseConfirm}
+            onCancel={handleCloseCancel}
+            isPending={isPending}
+            error={closeError ?? undefined}
+          />
+        )}
+      </>
+    );
+  }
+
+  if (prs.length === 0) {
+    let emptyMessage: string;
+    if (activeRepo && mineOnly) {
+      emptyMessage = `no open PRs from you in ${activeRepo}.`;
+    } else if (activeRepo) {
+      emptyMessage = `no open PRs in ${activeRepo}.`;
+    } else if (mineOnly) {
+      emptyMessage = "no open PRs from you across your repos.";
+    } else {
+      emptyMessage = "no open PRs across your repos.";
+    }
+
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyMark}>❧</div>
+        <h3>no pull requests</h3>
+        <p>
+          <em>{emptyMessage}</em>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {prs.map(({ repo, pull }) => (
+        <PrListRow
+          key={`pr-${repo.owner}-${repo.name}-${pull.number}`}
+          owner={repo.owner}
+          repoName={repo.name}
+          pull={pull}
+        />
+      ))}
+    </div>
+  );
+}
+
+function renderIssueSection({
+  activeSection,
+  data,
+  visibleCount,
+  onLaunch,
+  onClose,
+}: {
+  activeSection: Section;
+  data: UnifiedList;
+  visibleCount: number;
+  onLaunch: (owner: string, repo: string, issueNumber: number) => void;
+  onClose: (owner: string, repo: string, issueNumber: number) => void;
+}) {
+  const allItems = data[activeSection];
+
+  if (allItems.length === 0) {
+    const empty = SECTION_EMPTY[activeSection];
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyMark}>❧</div>
+        <h3>{empty.title}</h3>
+        <p>
+          <em>{empty.body}</em>
+        </p>
+      </div>
+    );
+  }
+
+  const items = allItems.slice(0, visibleCount);
+  return <ListSection title={null} items={items} onLaunch={onLaunch} onClose={onClose} />;
+}
+```
+
+**Note on `activeDeployments`:** This prop provides a lookup from issue key to deployment ID so the list can end sessions before closing. The caller (`DashboardContent`) will need to pass this data. If this proves too complex for this iteration, omit the session-end logic from the list close (users closing running issues from the list would just close without ending the session — the session cleanup happens on next restart anyway). The detail page still handles it properly.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: May show a type error in `DashboardContent.tsx` if `activeDeployments` is not passed. Since it's optional (`?`), it should pass. Verify.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/list/ListSection.tsx packages/web/components/list/ListContent.tsx
+git commit -m "feat: thread onClose through list, add CloseIssueModal to ListContent"
+```
+
+---
+
+### Task 7: Update Detail Page to Use CloseIssueModal
+
+**Files:**
+- Modify: `packages/web/components/detail/IssueActionSheet.tsx`
+
+- [ ] **Step 1: Replace ConfirmDialog with CloseIssueModal in IssueActionSheet**
+
+In `packages/web/components/detail/IssueActionSheet.tsx`:
+
+1. Replace the `ConfirmDialog` import with `CloseIssueModal`:
+
+```typescript
+import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
+```
+
+Remove:
+```typescript
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+```
+
+2. Replace the `handleCloseConfirm` function (currently at ~line 127-164):
+
+```typescript
+function handleCloseConfirm(comment: string) {
+  setError(null);
+  startTransition(async () => {
+    try {
+      // End active terminal session before closing the issue
+      const liveDeployment = deployments.find((d) => d.endedAt === null);
+      if (liveDeployment) {
+        const endResult = await endSession(liveDeployment.id, owner, repo, number);
+        if (!endResult.success) {
+          console.warn(
+            "[issuectl] Failed to end session while closing issue:",
+            endResult.error,
+          );
+          showToast(
+            "Terminal session could not be stopped cleanly — it will be cleaned up on next restart.",
+            "warning",
+          );
+        }
+      }
+      const result = await closeIssue(owner, repo, number, comment || undefined);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      setConfirmClose(false);
+      showToast(
+        result.cacheStale
+          ? "Issue closed — reload if the list looks stale"
+          : "Issue closed",
+        "success",
+      );
+      router.replace("/?section=closed");
+    } catch (err) {
+      console.error("[issuectl] Close issue failed:", err);
+      setError("Unable to reach the server. Check your connection and try again.");
+    }
+  });
+}
+```
+
+3. Replace the `{confirmClose && (<ConfirmDialog ... />)}` JSX (currently at ~line 287-296) with:
+
+```tsx
+{confirmClose && (
+  <CloseIssueModal
+    issueNumber={number}
+    onConfirm={handleCloseConfirm}
+    onCancel={() => setConfirmClose(false)}
+    isPending={isPending}
+    error={error ?? undefined}
+  />
+)}
+```
+
+- [ ] **Step 2: Verify the `ConfirmDialog` import is still used for reassign**
+
+Check: `ConfirmDialog` is still rendered for the reassign confirmation. If so, keep the import but only for reassign. If `ConfirmDialog` is ONLY used for close, remove the import entirely.
+
+Looking at the existing code: `ConfirmDialog` is used for BOTH close (line ~287) and reassign (line ~344). After this change, only the reassign still uses `ConfirmDialog`. **Keep the `ConfirmDialog` import.**
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/detail/IssueActionSheet.tsx
+git commit -m "feat: use CloseIssueModal with comment support on detail page"
+```
+
+---
+
+### Task 8: E2E Tests
+
+**Files:**
+- Modify or create: `packages/web/e2e/issue-close.spec.ts`
+
+- [ ] **Step 1: Create E2E test file**
+
+Create `packages/web/e2e/issue-close.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+const MOBILE_VIEWPORT = { width: 393, height: 852 };
+
+test.describe("Issue close UX", () => {
+  test.describe("swipe-to-close on mobile", () => {
+    test.use({ viewport: MOBILE_VIEWPORT });
+
+    test("swipe right reveals close button on open issue row", async ({ page }) => {
+      await page.goto("/");
+      // Wait for list to load
+      await page.waitForSelector('[data-section="open"]');
+
+      const row = page.locator('[data-section="open"]').first();
+      const box = await row.boundingBox();
+      if (!box) throw new Error("Row not visible");
+
+      // Simulate swipe right (touch start left, end right)
+      await page.touchscreen.tap(box.x + 30, box.y + box.height / 2);
+      await row.dispatchEvent("touchstart", {
+        touches: [{ clientX: box.x + 30, clientY: box.y + box.height / 2 }],
+      });
+      await row.dispatchEvent("touchend", {
+        changedTouches: [{ clientX: box.x + 130, clientY: box.y + box.height / 2 }],
+      });
+
+      // Close button should be visible
+      const closeBtn = page.getByRole("button", { name: "Close" });
+      await expect(closeBtn).toBeVisible();
+    });
+
+    test("tapping close button opens CloseIssueModal", async ({ page }) => {
+      await page.goto("/");
+      await page.waitForSelector('[data-section="open"]');
+
+      const row = page.locator('[data-section="open"]').first();
+      const box = await row.boundingBox();
+      if (!box) throw new Error("Row not visible");
+
+      // Swipe right
+      await row.dispatchEvent("touchstart", {
+        touches: [{ clientX: box.x + 30, clientY: box.y + box.height / 2 }],
+      });
+      await row.dispatchEvent("touchend", {
+        changedTouches: [{ clientX: box.x + 130, clientY: box.y + box.height / 2 }],
+      });
+
+      // Tap close
+      await page.getByRole("button", { name: "Close" }).click();
+
+      // Modal should appear
+      await expect(page.getByRole("dialog", { name: "Close Issue" })).toBeVisible();
+      await expect(page.getByPlaceholder("Add a closing comment")).toBeVisible();
+    });
+  });
+
+  test("close modal from detail page has comment field", async ({ page }) => {
+    // Navigate to an open issue detail page (assumes at least one issue exists)
+    await page.goto("/");
+    await page.waitForSelector('[data-section="open"]');
+    await page.locator('[data-section="open"] a').first().click();
+
+    // Wait for detail page
+    await page.waitForSelector("h1");
+
+    // Open action sheet and click close
+    // On desktop, the "Close issue" button is in the desktop bar
+    await page.getByRole("button", { name: "Close issue" }).click();
+
+    // Modal should have comment field
+    await expect(page.getByRole("dialog", { name: "Close Issue" })).toBeVisible();
+    await expect(page.getByPlaceholder("Add a closing comment")).toBeVisible();
+  });
+
+  test("FAB is 52px on mobile viewport", async ({ page }) => {
+    test.use({ viewport: MOBILE_VIEWPORT });
+    await page.goto("/");
+    await page.waitForSelector('[aria-label="Create a new draft"]');
+
+    const fab = page.locator('[aria-label="Create a new draft"]');
+    const box = await fab.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeCloseTo(52, 0);
+    expect(box!.height).toBeCloseTo(52, 0);
+  });
+
+  test("no checkboxes in issue list rows", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector('[data-section]');
+
+    // There should be no checkbox SVG elements in rows
+    const checkboxes = page.locator('[data-section] svg rect[rx="2"]');
+    await expect(checkboxes).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E tests**
+
+Run: `pnpm --filter @issuectl/web test:e2e -- --grep "Issue close"`
+Expected: Tests should pass if the dev server is running on :3847. Some tests may need adjustment based on actual page structure — iterate as needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/e2e/issue-close.spec.ts
+git commit -m "test: add E2E tests for swipe-to-close, close modal, and FAB sizing"
+```
+
+---
+
+## Execution Order
+
+Tasks 1-3 are independent and can be executed in parallel.
+Task 4 depends on nothing.
+Task 5 depends on Task 4 (SwipeRow must support `onClose` before ListRow uses it).
+Task 6 depends on Tasks 3 and 5 (CloseIssueModal and ListRow must exist).
+Task 7 depends on Tasks 2 and 3 (server action comment param and CloseIssueModal).
+Task 8 depends on all prior tasks.
+
+```
+Task 1 (FAB) ──────────────────────────────────────┐
+Task 2 (server action) ─────────────────────┐      │
+Task 3 (CloseIssueModal) ──────────┐        │      │
+Task 4 (SwipeRow bidirectional) ──┐ │        │      │
+                                  ▼ │        │      │
+Task 5 (ListRow + checkbox) ──────┤ │        │      │
+                                  ▼ ▼        ▼      │
+Task 6 (thread onClose) ─────────────────────┤      │
+                                             ▼      │
+Task 7 (detail page) ──────────────────────────────┤
+                                                    ▼
+Task 8 (E2E tests) ─────────────────────────────────
+```

--- a/docs/superpowers/specs/2026-04-20-issue-close-ux-design.md
+++ b/docs/superpowers/specs/2026-04-20-issue-close-ux-design.md
@@ -1,0 +1,130 @@
+# Issue Close UX & FAB Sizing
+
+**Date:** 2026-04-20
+**Status:** Approved
+**Scope:** Web package — list view, detail view, server actions, core close flow
+
+## Problem
+
+1. The issue list rows display non-interactive checkboxes that waste horizontal space and confuse mobile users (tapping the checkbox navigates to the issue, not toggling state).
+2. There is no way to close an issue from the list view — users must navigate into the detail page.
+3. GitHub's "comment and close" pattern is not supported — the current close modal is a bare confirmation with no comment field.
+4. The mobile FAB (create button) is slightly too small at 48px for comfortable tap targets.
+
+## Design
+
+### 1. Remove checkboxes from list rows
+
+Remove the `Checkbox` component from `ListRow` for both issue rows and draft rows. The section grouping (open / running / closed / drafts) already communicates state — the checkbox is redundant visual decoration.
+
+**Changes:**
+- Remove `<Checkbox>` render and the wrapping `<span className={styles.check}>` from `ListRow.tsx`
+- Reduce `rowLink` left padding from 58px to 20px (reclaiming space for the title)
+- Remove `.check` positioning styles from `ListRow.module.css`
+- Remove `Checkbox` import (verify no other consumers in the list context)
+
+### 2. Bidirectional swipe on open & running rows
+
+Extend the existing `SwipeRow` component to support both directions:
+
+| Direction | Gesture | Reveals | Sections | Color |
+|-----------|---------|---------|----------|-------|
+| Swipe left | Existing | "Launch" button (right side) | open only | `--paper-ink` (dark) |
+| Swipe right | New | "Close" button (left side) | open + running | `--paper-accent-danger` / red (#c9553d) |
+
+**Behavior:**
+- Only one direction can be revealed at a time — swiping the opposite direction dismisses the current reveal before opening the other side.
+- Closed rows: no swipe in either direction (no wrapper).
+- Running rows: close only (no launch — session is already active).
+- The swipe threshold remains at 60px.
+- Desktop (≥768px, hover): swipe is disabled; actions remain hover-revealed inline buttons.
+
+**SwipeRow API change:**
+```tsx
+type Props = {
+  children: ReactNode;
+  onLaunch?: () => void;   // swipe-left action (existing)
+  onClose?: () => void;    // swipe-right action (new)
+  disabled?: boolean;
+};
+```
+
+### 3. Close confirmation modal with optional comment
+
+Replace the current bare `ConfirmDialog` for closing with a richer modal that includes an optional comment field. This modal is used from both the list swipe and the detail page action sheet.
+
+**UI:**
+- Title: "Close Issue"
+- Optional textarea: placeholder "Add a closing comment…", no minimum length
+- Buttons: "Cancel" (secondary) and "Close Issue" (danger/primary)
+- Pending state: "Closing…" on the confirm button, inputs disabled
+- Error state: inline error message below the textarea
+
+**Component:** New `CloseIssueModal` component (or extend `ConfirmDialog` with a `children` slot for the textarea). Recommendation: dedicated `CloseIssueModal` since the comment + sequencing logic is specific to this action.
+
+### 4. Close flow (async, multi-step)
+
+The server action signature gains an optional `comment` parameter:
+
+```typescript
+export async function closeIssue(
+  owner: string,
+  repo: string,
+  number: number,
+  comment?: string,
+): Promise<{ success: true; cacheStale?: true } | { success: false; error: string }>
+```
+
+**Sequence:**
+1. If `comment` is provided and non-empty, call `addComment(octokit, owner, repo, number, comment)` via `withAuthRetry`.
+2. If the comment call fails, **abort** — return error. Do not close the issue without the user's intended comment.
+3. If comment succeeded (or was not provided), call `coreCloseIssue(octokit, owner, repo, number)` via `withAuthRetry`.
+4. Clear cache keys: `issue-detail:{owner}/{repo}#{number}` and `issues:{owner}/{repo}`.
+5. Revalidate the page path.
+
+**Running rows (active session):** The existing behavior is preserved — the caller (`IssueActionSheet` or the new list-level handler) ends the active session before invoking `closeIssue`. The `closeIssue` action itself does not manage sessions.
+
+**Optimistic UI:** The swipe row snaps back when the close button is tapped (the modal takes over). On success: toast ("Issue closed") + navigate to `/?section=closed`. On failure: error in the modal, user can retry or cancel.
+
+### 5. FAB size increase (mobile)
+
+Increase the mobile FAB from 48px to 52px for a more comfortable tap target.
+
+**Changes to `Fab.module.css`:**
+```css
+@media (max-width: 767px) {
+  .fab {
+    width: 52px;    /* was 48px */
+    height: 52px;   /* was 48px */
+    font-size: 30px; /* was 28px */
+  }
+}
+```
+
+No other FAB properties change. Desktop FAB remains hidden.
+
+## Out of scope
+
+- Reopening closed issues from the app (can be done from GitHub)
+- Comment field on reassign (auto-generated cross-reference is sufficient)
+- Batch-close multiple issues
+- Swipe gestures on desktop
+
+## Dependencies
+
+- `addComment` already exists in `@issuectl/core` (`packages/core/src/github/issues.ts`)
+- `closeIssue` server action already exists (`packages/web/lib/actions/issues.ts`)
+- `SwipeRow` component already exists with left-swipe infrastructure
+- `withAuthRetry` handles token refresh for both API calls
+
+## Testing
+
+| Layer | What to test |
+|-------|-------------|
+| Unit (core) | `closeIssue` with comment parameter posts comment then closes |
+| Unit (core) | `closeIssue` aborts if comment post fails |
+| Integration (web) | Server action with/without comment |
+| E2E (Playwright) | Swipe-right on mobile viewport reveals close button |
+| E2E (Playwright) | Close modal with comment submits and navigates |
+| E2E (Playwright) | Close modal without comment still works |
+| E2E (Playwright) | FAB renders at 52px on mobile viewport |

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@issuectl/core";
 import { Sheet, Button } from "@/components/paper";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
 import { FilterEdgeSwipe } from "@/components/list/FilterEdgeSwipe";
 import { LaunchModal } from "@/components/launch/LaunchModal";
 import { closeIssue, reassignIssueAction } from "@/lib/actions/issues";
@@ -124,7 +125,7 @@ export function IssueActionSheet({
     setConfirmClose(true);
   }
 
-  function handleCloseConfirm() {
+  function handleCloseConfirm(comment: string) {
     setError(null);
     startTransition(async () => {
       try {
@@ -143,7 +144,7 @@ export function IssueActionSheet({
             );
           }
         }
-        const result = await closeIssue(owner, repo, number);
+        const result = await closeIssue(owner, repo, number, comment || undefined);
         if (!result.success) {
           setError(result.error);
           return;
@@ -284,10 +285,8 @@ export function IssueActionSheet({
       )}
 
       {confirmClose && (
-        <ConfirmDialog
-          title="Close Issue"
-          message={`Close issue #${number}? This can be reopened later from GitHub.`}
-          confirmLabel="Close Issue"
+        <CloseIssueModal
+          issueNumber={number}
           onConfirm={handleCloseConfirm}
           onCancel={() => setConfirmClose(false)}
           isPending={isPending}

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -159,7 +159,7 @@ export function IssueActionSheet({
         router.replace("/?section=closed");
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
-        setError("Unable to reach the server. Check your connection and try again.");
+        setError("Something went wrong while closing the issue. Please try again.");
       }
     });
   }

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -80,8 +80,9 @@ export function ListContent({
     [],
   );
 
-  // Note: unlike IssueActionSheet, we don't end active sessions here.
-  // Running-row sessions are cleaned up on next app restart.
+  // Unlike IssueActionSheet (which has access to deployments), the list
+  // view does not track live sessions — so we skip session termination
+  // and only close the GitHub issue.
   const handleCloseConfirm = useCallback(
     (comment: string) => {
       if (!closeTarget) return;
@@ -103,7 +104,7 @@ export function ListContent({
           router.replace("/?section=closed");
         } catch (err) {
           console.error("[issuectl] Close issue from list failed:", err);
-          setCloseError("Unable to reach the server. Check your connection and try again.");
+          setCloseError("Something went wrong while closing the issue. Please try again.");
         }
       });
     },

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -80,6 +80,8 @@ export function ListContent({
     [],
   );
 
+  // Note: unlike IssueActionSheet, we don't end active sessions here.
+  // Running-row sessions are cleaned up on next app restart.
   const handleCloseConfirm = useCallback(
     (comment: string) => {
       if (!closeTarget) return;

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { Section, UnifiedList } from "@issuectl/core";
 import type { PrEntry } from "@/lib/page-filters";
 import { ListSection } from "./ListSection";
 import { PrListRow } from "./PrListRow";
+import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
+import { closeIssue } from "@/lib/actions/issues";
+import { useToast } from "@/components/ui/ToastProvider";
 import styles from "./List.module.css";
 
 type Props = {
@@ -49,6 +52,10 @@ export function ListContent({
   const router = useRouter();
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const { showToast } = useToast();
+  const [closeTarget, setCloseTarget] = useState<{ owner: string; repo: string; number: number } | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [closeError, setCloseError] = useState<string | null>(null);
 
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
@@ -64,6 +71,47 @@ export function ListContent({
     },
     [router],
   );
+
+  const handleCloseRequest = useCallback(
+    (owner: string, repo: string, issueNumber: number) => {
+      setCloseError(null);
+      setCloseTarget({ owner, repo, number: issueNumber });
+    },
+    [],
+  );
+
+  const handleCloseConfirm = useCallback(
+    (comment: string) => {
+      if (!closeTarget) return;
+      const { owner, repo, number } = closeTarget;
+      startTransition(async () => {
+        try {
+          const result = await closeIssue(owner, repo, number, comment || undefined);
+          if (!result.success) {
+            setCloseError(result.error);
+            return;
+          }
+          setCloseTarget(null);
+          showToast(
+            result.cacheStale
+              ? "Issue closed — reload if the list looks stale"
+              : "Issue closed",
+            "success",
+          );
+          router.replace("/?section=closed");
+        } catch (err) {
+          console.error("[issuectl] Close issue from list failed:", err);
+          setCloseError("Unable to reach the server. Check your connection and try again.");
+        }
+      });
+    },
+    [closeTarget, showToast, router],
+  );
+
+  const handleCloseCancel = useCallback(() => {
+    setCloseTarget(null);
+    setCloseError(null);
+  }, []);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -83,7 +131,7 @@ export function ListContent({
     const showing = Math.min(visibleCount, total);
     return (
       <>
-        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch })}
+        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch, onClose: handleCloseRequest })}
         {total > PAGE_SIZE && (
           <div className={styles.pageStatus}>
             Showing {showing} of {total}
@@ -91,6 +139,15 @@ export function ListContent({
         )}
         {visibleCount < total && (
           <div ref={sentinelRef} className={styles.sentinel} />
+        )}
+        {closeTarget && (
+          <CloseIssueModal
+            issueNumber={closeTarget.number}
+            onConfirm={handleCloseConfirm}
+            onCancel={handleCloseCancel}
+            isPending={isPending}
+            error={closeError ?? undefined}
+          />
         )}
       </>
     );
@@ -138,11 +195,13 @@ function renderIssueSection({
   data,
   visibleCount,
   onLaunch,
+  onClose,
 }: {
   activeSection: Section;
   data: UnifiedList;
   visibleCount: number;
   onLaunch: (owner: string, repo: string, issueNumber: number) => void;
+  onClose: (owner: string, repo: string, issueNumber: number) => void;
 }) {
   const allItems = data[activeSection];
 
@@ -160,5 +219,5 @@ function renderIssueSection({
   }
 
   const items = allItems.slice(0, visibleCount);
-  return <ListSection title={null} items={items} onLaunch={onLaunch} />;
+  return <ListSection title={null} items={items} onLaunch={onLaunch} onClose={onClose} />;
 }

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -20,18 +20,12 @@
 }
 
 .rowLink {
-  padding: 16px 24px 8px 58px;
+  padding: 16px 24px 8px 20px;
   display: block;
   color: inherit;
   text-decoration: none;
   position: relative;
   min-width: 0;
-}
-
-.check {
-  position: absolute;
-  left: 24px;
-  top: 18px;
 }
 
 /* Row actions (launch / open / view). Inline below the link on mobile;
@@ -41,15 +35,16 @@
 .actions {
   display: flex;
   align-items: center;
-  padding: 0 20px 14px 58px;
+  padding: 0 20px 14px 20px;
   gap: 8px;
   justify-content: flex-end;
   flex-shrink: 0;
 }
 
-/* Hide inline actions on mobile for open rows — SwipeRow reveals them */
+/* Hide inline actions on mobile for open/running rows — SwipeRow reveals them */
 @media (max-width: 767px), (hover: none) {
-  .item[data-section="open"] .actions {
+  .item[data-section="open"] .actions,
+  .item[data-section="running"] .actions {
     display: none;
   }
 }
@@ -104,7 +99,7 @@
 
   .rowLink {
     flex: 1;
-    padding: 16px 24px 16px 58px;
+    padding: 16px 24px 16px 24px;
   }
 
   .actions {

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { UnifiedListItem } from "@issuectl/core";
-import { Checkbox, Chip, LabelChip } from "@/components/paper";
+import { Chip, LabelChip } from "@/components/paper";
 import { SyncDot } from "@/components/ui/SyncDot";
 import { SwipeRow } from "./SwipeRow";
 import styles from "./ListRow.module.css";
@@ -8,6 +8,7 @@ import styles from "./ListRow.module.css";
 type Props = {
   item: UnifiedListItem;
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onClose?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
 // Drafts store updatedAt as unix seconds (SQLite INTEGER). GitHub issues
@@ -27,14 +28,11 @@ function formatAge(updatedAt: string | number): string {
   return `${diffDays}d`;
 }
 
-export function ListRow({ item, onLaunch }: Props) {
+export function ListRow({ item, onLaunch, onClose }: Props) {
   if (item.kind === "draft") {
     return (
       <div className={styles.item}>
         <Link href={`/drafts/${item.draft.id}`} className={styles.rowLink}>
-          <span className={styles.check}>
-            <Checkbox state="draft" />
-          </span>
           <div className={styles.title}>{item.draft.title}</div>
           <div className={styles.meta}>
             <Chip variant="dashed">no repo</Chip>
@@ -49,8 +47,6 @@ export function ListRow({ item, onLaunch }: Props) {
   }
 
   const { issue, repo, section } = item;
-  const checkState =
-    section === "closed" ? "done" : section === "running" ? "flight" : "open";
   const titleClass =
     section === "closed" ? `${styles.title} ${styles.done}` : styles.title;
 
@@ -90,9 +86,6 @@ export function ListRow({ item, onLaunch }: Props) {
         href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
         className={styles.rowLink}
       >
-        <span className={styles.check}>
-          <Checkbox state={checkState} />
-        </span>
         <div className={titleClass}>{issue.title}</div>
         <div className={styles.meta}>
           <Chip>{repo.name}</Chip>
@@ -159,10 +152,20 @@ export function ListRow({ item, onLaunch }: Props) {
     </div>
   );
 
-  if (section === "open" && onLaunch) {
+  // Wrap in SwipeRow for open (launch + close) and running (close only)
+  if (section === "open" || section === "running") {
     return (
       <SwipeRow
-        onLaunch={() => onLaunch(repo.owner, repo.name, issue.number)}
+        onLaunch={
+          section === "open" && onLaunch
+            ? () => onLaunch(repo.owner, repo.name, issue.number)
+            : undefined
+        }
+        onClose={
+          onClose
+            ? () => onClose(repo.owner, repo.name, issue.number)
+            : undefined
+        }
       >
         {rowContent}
       </SwipeRow>

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -7,9 +7,10 @@ type Props = {
   title: ReactNode | null;
   items: UnifiedListItem[];
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
+  onClose?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
-export function ListSection({ title, items, onLaunch }: Props) {
+export function ListSection({ title, items, onLaunch, onClose }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -30,6 +31,7 @@ export function ListSection({ title, items, onLaunch }: Props) {
           }
           item={item}
           onLaunch={onLaunch}
+          onClose={onClose}
         />
       ))}
     </>

--- a/packages/web/components/list/SwipeRow.module.css
+++ b/packages/web/components/list/SwipeRow.module.css
@@ -3,7 +3,19 @@
   overflow: hidden;
 }
 
-.actions {
+/* Left-side actions (close) — revealed on swipe-right */
+.actionsLeft {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  transform: translateX(-100%);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Right-side actions (launch) — revealed on swipe-left */
+.actionsRight {
   position: absolute;
   right: 0;
   top: 0;
@@ -13,17 +25,27 @@
   transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.wrapper[data-swiped="true"] .actions {
-  transform: translateX(0);
-}
-
 .content {
   transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
   background: var(--paper-bg);
 }
 
-.wrapper[data-swiped="true"] .content {
+/* Swiped left — content slides left, right actions revealed */
+.wrapper[data-swiped="left"] .actionsRight {
+  transform: translateX(0);
+}
+
+.wrapper[data-swiped="left"] .content {
   transform: translateX(-80px);
+}
+
+/* Swiped right — content slides right, left actions revealed */
+.wrapper[data-swiped="right"] .actionsLeft {
+  transform: translateX(0);
+}
+
+.wrapper[data-swiped="right"] .content {
+  transform: translateX(80px);
 }
 
 .actionBtn {
@@ -40,7 +62,11 @@
 }
 
 .launchBtn {
-  background: var(--paper-accent);
+  background: var(--paper-ink);
+}
+
+.closeBtn {
+  background: var(--paper-brick, #c9553d);
 }
 
 @media (min-width: 768px) and (hover: hover) {
@@ -48,7 +74,8 @@
     overflow: visible;
   }
 
-  .actions {
+  .actionsLeft,
+  .actionsRight {
     display: none;
   }
 

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -5,14 +5,17 @@ import styles from "./SwipeRow.module.css";
 
 const SWIPE_THRESHOLD = 60;
 
+type SwipeState = "idle" | "left" | "right";
+
 type Props = {
   children: ReactNode;
   onLaunch?: () => void;
+  onClose?: () => void;
   disabled?: boolean;
 };
 
-export function SwipeRow({ children, onLaunch, disabled }: Props) {
-  const [swiped, setSwiped] = useState(false);
+export function SwipeRow({ children, onLaunch, onClose, disabled }: Props) {
+  const [swiped, setSwiped] = useState<SwipeState>("idle");
   const startX = useRef<number | null>(null);
 
   const handleTouchStart = useCallback(
@@ -31,22 +34,27 @@ export function SwipeRow({ children, onLaunch, disabled }: Props) {
         startX.current = null;
         return;
       }
-      const delta = startX.current - touch.clientX;
-      if (delta > SWIPE_THRESHOLD) {
-        setSwiped(true);
-      } else if (delta < -SWIPE_THRESHOLD) {
-        setSwiped(false);
+      const delta = touch.clientX - startX.current;
+      if (delta > SWIPE_THRESHOLD && onClose) {
+        // Swiped right — reveal close on left
+        setSwiped("right");
+      } else if (delta < -SWIPE_THRESHOLD && onLaunch) {
+        // Swiped left — reveal launch on right
+        setSwiped("left");
+      } else if (Math.abs(delta) > SWIPE_THRESHOLD) {
+        // Swipe in a direction with no handler — dismiss
+        setSwiped("idle");
       }
       startX.current = null;
     },
-    [],
+    [onLaunch, onClose],
   );
 
   const handleTouchCancel = useCallback(() => {
     startX.current = null;
   }, []);
 
-  const close = useCallback(() => setSwiped(false), []);
+  const dismiss = useCallback(() => setSwiped("idle"), []);
 
   if (disabled) {
     return <>{children}</>;
@@ -60,19 +68,32 @@ export function SwipeRow({ children, onLaunch, disabled }: Props) {
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchCancel}
     >
-      <div className={styles.actions}>
-        {onLaunch && (
+      {onClose && (
+        <div className={styles.actionsLeft}>
+          <button
+            className={`${styles.actionBtn} ${styles.closeBtn}`}
+            onClick={() => {
+              dismiss();
+              onClose();
+            }}
+          >
+            Close
+          </button>
+        </div>
+      )}
+      {onLaunch && (
+        <div className={styles.actionsRight}>
           <button
             className={`${styles.actionBtn} ${styles.launchBtn}`}
             onClick={() => {
-              close();
+              dismiss();
               onLaunch();
             }}
           >
             Launch
           </button>
-        )}
-      </div>
+        </div>
+      )}
       <div className={styles.content}>{children}</div>
     </div>
   );

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -30,9 +30,9 @@
    Keeps a visible quick-create shortcut above the command sheet. */
 @media (max-width: 767px) {
   .fab {
-    width: 48px;
-    height: 48px;
-    font-size: 28px;
+    width: 52px;
+    height: 52px;
+    font-size: 30px;
     right: 20px;
     bottom: calc(64px + env(safe-area-inset-bottom, 0px));
   }

--- a/packages/web/components/ui/CloseIssueModal.module.css
+++ b/packages/web/components/ui/CloseIssueModal.module.css
@@ -1,0 +1,53 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message {
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 10px 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--paper-ink);
+  background: var(--paper-bg);
+  resize: vertical;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--paper-accent);
+  box-shadow: 0 0 0 2px var(--paper-accent-soft);
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--paper-brick);
+}
+
+.danger {
+  background: var(--paper-brick);
+  color: var(--paper-bg);
+  border-color: var(--paper-brick);
+}
+
+.danger:hover {
+  background: #e5443c;
+}

--- a/packages/web/components/ui/CloseIssueModal.tsx
+++ b/packages/web/components/ui/CloseIssueModal.tsx
@@ -54,6 +54,7 @@ export function CloseIssueModal({
           value={comment}
           onChange={(e) => setComment(e.target.value)}
           disabled={isPending}
+          maxLength={65536}
           rows={3}
         />
         {error && (

--- a/packages/web/components/ui/CloseIssueModal.tsx
+++ b/packages/web/components/ui/CloseIssueModal.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+import styles from "./CloseIssueModal.module.css";
+
+type Props = {
+  issueNumber: number;
+  onConfirm: (comment: string) => void;
+  onCancel: () => void;
+  isPending?: boolean;
+  error?: string;
+};
+
+export function CloseIssueModal({
+  issueNumber,
+  onConfirm,
+  onCancel,
+  isPending,
+  error,
+}: Props) {
+  const [comment, setComment] = useState("");
+
+  return (
+    <Modal
+      title="Close Issue"
+      width={480}
+      onClose={onCancel}
+      disabled={isPending}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => onConfirm(comment)}
+            disabled={isPending}
+            className={styles.danger}
+          >
+            {isPending ? "Closing\u2026" : "Close Issue"}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.body}>
+        <p className={styles.message}>
+          Close issue #{issueNumber}? This can be reopened later from GitHub.
+        </p>
+        <textarea
+          className={styles.textarea}
+          placeholder="Add a closing comment\u2026"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          disabled={isPending}
+          rows={3}
+        />
+        {error && (
+          <p className={styles.error} role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/packages/web/e2e/issue-close.spec.ts
+++ b/packages/web/e2e/issue-close.spec.ts
@@ -1,0 +1,461 @@
+import { test, expect } from "@playwright/test";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { initSchema, runMigrations } from "@issuectl/core";
+
+const execFileAsync = promisify(execFile);
+
+// Distinct from other specs: quick-create (3848), audit-verification (3850),
+// mobile-ux-patterns (3851), launch-ui (3852), pwa-offline (3853),
+// action-sheets (3854), create-with-repo (3855), data-freshness (3856).
+const TEST_PORT = 3857;
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const TEST_OWNER = "mean-weasel";
+const TEST_REPO = "issuectl-test-repo";
+
+// All tests run at iPhone 14 Pro dimensions — the viewport where
+// SwipeRow is active and the FAB uses its compact (52px) size.
+test.use({
+  viewport: { width: 393, height: 852 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+// Tests in this file pin the swipe-to-close UX introduced alongside
+// CloseIssueModal. Specifically:
+//
+// - Swiping right on an open/running issue row reveals a "Close" button
+// - Tapping that button opens CloseIssueModal (role=dialog, aria-label="Close Issue")
+// - The modal's textarea has the correct placeholder
+// - Issue list rows contain no checkbox SVG elements (regression guard)
+// - The FAB is 52px on mobile (regression guard for compact-FAB CSS)
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+}
+
+const STDERR_BUFFER_MAX_CHUNKS = 40;
+const serverStderrChunks: string[] = [];
+
+// A seeded open issue number used throughout the swipe/modal tests.
+const OPEN_ISSUE_NUMBER = 42;
+const OPEN_ISSUE_TITLE = "E2E issue-close: open issue for swipe test";
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  try {
+    initSchema(db);
+    runMigrations(db);
+
+    const defaults: Array<[string, string]> = [
+      ["branch_pattern", "issue-{number}-{slug}"],
+      ["cache_ttl", "300"],
+      ["worktree_dir", "~/.issuectl/worktrees/"],
+    ];
+    const insertSetting = db.prepare(
+      "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",
+    );
+    for (const [key, value] of defaults) {
+      insertSetting.run(key, value);
+    }
+
+    db.prepare("INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)").run(
+      TEST_OWNER,
+      TEST_REPO,
+    );
+
+    // Seed the issues list cache so the dashboard renders an open issue
+    // without needing a live GitHub API call.
+    const seedIssue = {
+      number: OPEN_ISSUE_NUMBER,
+      title: OPEN_ISSUE_TITLE,
+      body: "Created by issue-close.spec.ts",
+      state: "open",
+      labels: [],
+      user: { login: "test-bot", avatarUrl: "" },
+      commentCount: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      closedAt: null,
+      htmlUrl: `https://github.com/${TEST_OWNER}/${TEST_REPO}/issues/${OPEN_ISSUE_NUMBER}`,
+    };
+
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(
+      `issues:${TEST_OWNER}/${TEST_REPO}`,
+      JSON.stringify([seedIssue]),
+    );
+
+    // Seed the issue-header cache so the detail page renders without a
+    // live fetch — avoids background API noise during modal tests.
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(
+      `issue-header:${TEST_OWNER}/${TEST_REPO}#${OPEN_ISSUE_NUMBER}`,
+      JSON.stringify(seedIssue),
+    );
+
+    // Also seed the issue-content cache so the Suspense boundary resolves.
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(
+      `issue-content:${TEST_OWNER}/${TEST_REPO}#${OPEN_ISSUE_NUMBER}`,
+      JSON.stringify({ comments: [], linkedPRs: [] }),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      fetch(url)
+        .then((res) => {
+          if (res.ok || res.status === 404) resolve();
+          else if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        })
+        .catch(() => {
+          if (Date.now() > deadline) reject(new Error("Server timeout"));
+          else setTimeout(check, 500);
+        });
+    };
+    check();
+  });
+}
+
+let tmpDir: string;
+let dbPath: string;
+let server: ChildProcess;
+let skipReason: string | undefined;
+
+test.beforeAll(async () => {
+  const check = await canRun();
+  if (!check.ok) {
+    if (process.env.CI === "true") {
+      throw new Error(
+        `Issue-close suite cannot skip in CI: ${check.reason}. ` +
+          `This suite MUST run on PRs to pin the swipe-to-close UX.`,
+      );
+    }
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-e2e-issue-close-"));
+  dbPath = join(tmpDir, "test.db");
+  createTestDb(dbPath);
+
+  // Use an isolated .next output directory so this test server does not
+  // collide with the main dev server's .next/ cache (which would cause
+  // __webpack_modules__ errors from pack-file races).
+  const distDir = join(tmpDir, ".next-test");
+
+  server = spawn("npx", ["next", "dev", "--port", String(TEST_PORT)], {
+    cwd: join(import.meta.dirname, ".."),
+    env: {
+      ...process.env,
+      ISSUECTL_DB_PATH: dbPath,
+      NEXT_DIST_DIR: distDir,
+      NEXT_PRIVATE_SKIP_SETUP: "1",
+    },
+    stdio: "pipe",
+    detached: true,
+  });
+
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverStderrChunks.push(chunk.toString());
+    if (serverStderrChunks.length > STDERR_BUFFER_MAX_CHUNKS) {
+      serverStderrChunks.shift();
+    }
+  });
+
+  // 60s tolerates a cold `next dev` compile on a CI runner.
+  await waitForServer(BASE_URL, 60000).catch((err) => {
+    throw new Error(
+      `${err.message}. Server stderr: ${serverStderrChunks.join("").slice(-800)}`,
+    );
+  });
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus && serverStderrChunks.length > 0) {
+    await testInfo.attach("server-stderr", {
+      body: serverStderrChunks.join("").slice(-2000),
+      contentType: "text/plain",
+    });
+  }
+});
+
+test.afterAll(async () => {
+  if (server && server.pid) {
+    const killGroup = (signal: NodeJS.Signals) => {
+      try {
+        process.kill(-server.pid!, signal);
+      } catch {
+        /* already dead or orphaned */
+      }
+    };
+
+    const killTimeout = setTimeout(() => killGroup("SIGKILL"), 5000);
+    killGroup("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (server.exitCode !== null) {
+        resolve();
+        return;
+      }
+      server.on("close", () => resolve());
+    });
+    clearTimeout(killTimeout);
+  }
+
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  // Restore tsconfig.json and next-env.d.ts that `next dev` may have
+  // mutated when given a custom NEXT_DIST_DIR.
+  await execFileAsync("git", [
+    "checkout", "--", "packages/web/tsconfig.json", "packages/web/next-env.d.ts",
+  ], { cwd: join(import.meta.dirname, "../../..") }).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("did not match any")) {
+      console.warn(`[issue-close afterAll] git checkout failed: ${msg}`);
+    }
+  });
+});
+
+// ── Swipe-to-close: row reveal ────────────────────────────────────────
+
+test.describe("SwipeRow — swipe right reveals close button", () => {
+  test("swiping right on an open-section row reveals a Close button", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/?section=open`);
+
+    // Wait for the issue list to render — the seeded issue title must be visible.
+    await expect(page.getByText(OPEN_ISSUE_TITLE)).toBeVisible({ timeout: 15000 });
+
+    // Locate the SwipeRow wrapper. SwipeRow renders a <div data-swiped="idle">
+    // only for open and running rows.
+    const swipeWrapper = page.locator('[data-swiped]').first();
+    await expect(swipeWrapper).toBeVisible();
+
+    const box = await swipeWrapper.boundingBox();
+    expect(box, "SwipeRow has no bounding box").not.toBeNull();
+
+    // Simulate a right swipe (left-to-right) using touch events dispatched
+    // directly on the wrapper. A delta of 100px exceeds the 60px threshold
+    // defined in SwipeRow.tsx.
+    const startX = box!.x + 30;
+    const endX = box!.x + 130;
+    const midY = box!.y + box!.height / 2;
+
+    await page.evaluate(
+      ({ startX, endX, midY, wrapperSelector }) => {
+        const el = document.querySelector(wrapperSelector) as HTMLElement | null;
+        if (!el) throw new Error("SwipeRow wrapper not found");
+
+        const makeTouch = (x: number, y: number) =>
+          new Touch({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
+
+        el.dispatchEvent(
+          new TouchEvent("touchstart", {
+            touches: [makeTouch(startX, midY)],
+            changedTouches: [makeTouch(startX, midY)],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        el.dispatchEvent(
+          new TouchEvent("touchend", {
+            touches: [],
+            changedTouches: [makeTouch(endX, midY)],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      },
+      { startX, endX, midY, wrapperSelector: "[data-swiped]" },
+    );
+
+    // After a right-swipe the wrapper transitions to data-swiped="right"
+    // and the Close button (rendered inside actionsLeft) becomes visible.
+    await expect(swipeWrapper).toHaveAttribute("data-swiped", "right");
+    await expect(
+      swipeWrapper.getByRole("button", { name: "Close" }),
+    ).toBeVisible();
+  });
+});
+
+// ── Swipe-to-close: modal open ────────────────────────────────────────
+
+test.describe("SwipeRow — tapping Close opens CloseIssueModal", () => {
+  test("tapping the revealed Close button opens the close modal with a comment textarea", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/?section=open`);
+    await expect(page.getByText(OPEN_ISSUE_TITLE)).toBeVisible({ timeout: 15000 });
+
+    const swipeWrapper = page.locator('[data-swiped]').first();
+    const box = await swipeWrapper.boundingBox();
+    expect(box, "SwipeRow has no bounding box").not.toBeNull();
+
+    const startX = box!.x + 30;
+    const endX = box!.x + 130;
+    const midY = box!.y + box!.height / 2;
+
+    await page.evaluate(
+      ({ startX, endX, midY, wrapperSelector }) => {
+        const el = document.querySelector(wrapperSelector) as HTMLElement | null;
+        if (!el) throw new Error("SwipeRow wrapper not found");
+
+        const makeTouch = (x: number, y: number) =>
+          new Touch({ identifier: 1, target: el, clientX: x, clientY: y, pageX: x, pageY: y });
+
+        el.dispatchEvent(
+          new TouchEvent("touchstart", {
+            touches: [makeTouch(startX, midY)],
+            changedTouches: [makeTouch(startX, midY)],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        el.dispatchEvent(
+          new TouchEvent("touchend", {
+            touches: [],
+            changedTouches: [makeTouch(endX, midY)],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      },
+      { startX, endX, midY, wrapperSelector: "[data-swiped]" },
+    );
+
+    // Tap the revealed Close button.
+    await swipeWrapper.getByRole("button", { name: "Close" }).click();
+
+    // CloseIssueModal renders as a dialog with aria-label="Close Issue".
+    const modal = page.getByRole("dialog", { name: "Close Issue" });
+    await expect(modal).toBeVisible();
+
+    // The modal must contain a textarea for an optional closing comment.
+    const textarea = modal.locator("textarea");
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveAttribute(
+      "placeholder",
+      /closing comment/i,
+    );
+  });
+});
+
+// ── Detail page close modal ───────────────────────────────────────────
+
+test.describe("CloseIssueModal — detail page", () => {
+  test("close action on detail page opens modal with comment textarea", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    const issueUrl = `${BASE_URL}/issues/${TEST_OWNER}/${TEST_REPO}/${OPEN_ISSUE_NUMBER}`;
+    await page.goto(issueUrl);
+
+    // The detail page should render for the seeded issue.
+    // The action sheet handle is visible for open issues.
+    const handle = page.getByRole("button", { name: /Open Actions/ });
+    await expect(handle).toBeVisible({ timeout: 15000 });
+
+    // Open the action sheet.
+    await handle.click();
+    const sheet = page.getByRole("dialog", { name: "issue actions" });
+    await expect(sheet).toBeVisible();
+
+    // Click the close action inside the sheet.
+    await sheet.getByRole("button", { name: "Close issue" }).click();
+
+    // CloseIssueModal should appear with role=dialog and aria-label="Close Issue".
+    const modal = page.getByRole("dialog", { name: "Close Issue" });
+    await expect(modal).toBeVisible();
+
+    // Verify the comment textarea is present with the correct placeholder.
+    const textarea = modal.locator("textarea");
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveAttribute(
+      "placeholder",
+      /closing comment/i,
+    );
+  });
+});
+
+// ── No checkbox SVG in issue rows ─────────────────────────────────────
+
+test.describe("Issue list rows — no checkboxes", () => {
+  test("open-section issue rows do not contain checkbox SVG elements", async ({
+    page,
+  }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    await page.goto(`${BASE_URL}/?section=open`);
+    await expect(page.getByText(OPEN_ISSUE_TITLE)).toBeVisible({ timeout: 15000 });
+
+    // Count any SVG elements with role="checkbox" or type="checkbox" inputs
+    // inside list rows. There should be none — row selection via checkboxes
+    // was never part of the design and their absence prevents accidental
+    // inclusion via component imports.
+    const checkboxInputs = page.locator('[data-section="open"] input[type="checkbox"]');
+    await expect(checkboxInputs).toHaveCount(0);
+
+    // Also guard against SVG-based checkbox icons that might render with
+    // a recognisable aria role.
+    const checkboxRoles = page.locator('[data-section="open"] [role="checkbox"]');
+    await expect(checkboxRoles).toHaveCount(0);
+  });
+});
+
+// ── FAB sizing on mobile ──────────────────────────────────────────────
+
+test.describe("FAB — mobile sizing", () => {
+  test("FAB is 52x52 on a 393-wide mobile viewport", async ({ page }) => {
+    if (skipReason) test.skip(true, skipReason);
+
+    // Navigate to the issues tab — the FAB only renders there.
+    await page.goto(`${BASE_URL}/`);
+    await expect(page.locator("h1")).toBeVisible({ timeout: 15000 });
+
+    const fab = page.locator('[aria-label="Create a new draft"]');
+    await expect(fab).toBeVisible();
+
+    const box = await fab.boundingBox();
+    expect(box, "FAB has no bounding box").not.toBeNull();
+
+    expect(
+      box!.width,
+      `FAB width ${box!.width}px — expected 52px (mobile compact size)`,
+    ).toBeCloseTo(52, 0);
+
+    expect(
+      box!.height,
+      `FAB height ${box!.height}px — expected 52px (mobile compact size)`,
+    ).toBeCloseTo(52, 0);
+  });
+});

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -10,6 +10,7 @@ import {
   reassignIssue as coreReassignIssue,
   addLabel as coreAddLabel,
   removeLabel as coreRemoveLabel,
+  addComment as coreAddComment,
   clearCacheKey,
   withAuthRetry,
   withIdempotency,
@@ -138,6 +139,7 @@ export async function closeIssue(
   owner: string,
   repo: string,
   number: number,
+  comment?: string,
 ): Promise<{ success: true; cacheStale?: true } | { success: false; error: string }> {
   if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
     return { success: false, error: "Valid owner, repo, and issue number are required" };
@@ -148,6 +150,15 @@ export async function closeIssue(
     if (!getRepo(db, owner, repo)) {
       return { success: false, error: "Repository is not tracked" };
     }
+
+    // Post closing comment first — abort if this fails so the issue
+    // isn't closed without the user's intended comment.
+    if (comment && comment.trim()) {
+      await withAuthRetry((octokit) =>
+        coreAddComment(db, octokit, owner, repo, number, comment.trim()),
+      );
+    }
+
     await withAuthRetry((octokit) =>
       coreCloseIssue(octokit, owner, repo, number),
     );

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -144,6 +144,9 @@ export async function closeIssue(
   if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
     return { success: false, error: "Valid owner, repo, and issue number are required" };
   }
+  if (comment && comment.length > MAX_BODY) {
+    return { success: false, error: `Comment must be ${MAX_BODY} characters or fewer` };
+  }
 
   try {
     const db = getDb();
@@ -153,15 +156,27 @@ export async function closeIssue(
 
     // Post closing comment first — abort if this fails so the issue
     // isn't closed without the user's intended comment.
+    let commentPosted = false;
     if (comment && comment.trim()) {
       await withAuthRetry((octokit) =>
         coreAddComment(db, octokit, owner, repo, number, comment.trim()),
       );
+      commentPosted = true;
     }
 
-    await withAuthRetry((octokit) =>
-      coreCloseIssue(octokit, owner, repo, number),
-    );
+    try {
+      await withAuthRetry((octokit) =>
+        coreCloseIssue(octokit, owner, repo, number),
+      );
+    } catch (closeErr) {
+      console.error("[issuectl] Failed to close issue (comment was posted):", closeErr);
+      return {
+        success: false,
+        error: commentPosted
+          ? "Your comment was posted, but the issue could not be closed. Try closing again without re-entering your comment."
+          : formatErrorForUser(closeErr),
+      };
+    }
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
   } catch (err) {

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     {
       name: "desktop-chromium",
       use: { ...devices["Desktop Chrome"] },
-      testIgnore: /(mobile-ux-patterns|launch-ui|launch-flow|action-sheets|pull-to-refresh)\.spec\.ts/,
+      testIgnore: /(mobile-ux-patterns|launch-ui|launch-flow|action-sheets|pull-to-refresh|issue-close)\.spec\.ts/,
     },
     {
       name: "mobile-chromium",
@@ -28,7 +28,7 @@ export default defineConfig({
         isMobile: true,
         hasTouch: true,
       },
-      testMatch: /(mobile-ux-patterns|launch-ui|action-sheets|pull-to-refresh)\.spec\.ts/,
+      testMatch: /(mobile-ux-patterns|launch-ui|action-sheets|pull-to-refresh|issue-close)\.spec\.ts/,
     },
   ],
 });


### PR DESCRIPTION
## Summary

- **Swipe-to-close** on mobile issue list: swipe right reveals a "Close" button on open and running rows (bidirectional — swipe left still reveals "Launch")
- **Close with optional comment** modal replaces bare confirmation dialog, matching GitHub's "Comment and close" pattern
- **Remove decorative checkboxes** from list rows — frees horizontal space, eliminates tap confusion
- **FAB size bump** from 48px → 52px on mobile for better tap target
- **Fail-early close flow**: comment posts before close; if comment fails, issue stays open

## Key changes

| Area | What |
|------|------|
| `SwipeRow` | Bidirectional swipe (left=launch, right=close) |
| `ListRow` | Checkbox removed, `onClose` prop, SwipeRow wraps open+running |
| `CloseIssueModal` | New modal with optional comment textarea |
| `closeIssue` action | Added `comment?` param, length validation, partial-failure messaging |
| `IssueActionSheet` | Uses CloseIssueModal instead of ConfirmDialog |
| `Fab.module.css` | 48→52px on mobile |
| E2E | Playwright tests for swipe, modal, FAB, no-checkbox |

## Test plan

- [ ] Typecheck passes (`pnpm turbo typecheck`)
- [ ] On mobile viewport: swipe right on open issue reveals Close button
- [ ] Tapping Close opens modal with comment textarea
- [ ] Submitting close without comment closes issue on GitHub
- [ ] Submitting close with comment posts comment then closes
- [ ] If comment post fails, issue stays open with error shown
- [ ] Cancel dismisses modal without action
- [ ] Detail page close also shows comment modal
- [ ] Running rows: swipe right reveals Close (no Launch)
- [ ] Closed rows: no swipe gesture
- [ ] FAB renders at 52px on mobile
- [ ] No checkbox SVGs in list rows