### PR TITLE
fix: speed up back-navigation and fix mobile bottom layout

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -16,8 +16,6 @@ import { ListCountProvider } from "@/components/list/ListCountContext";
 import { ContentSkeleton } from "@/components/list/ContentSkeleton";
 import { DashboardContent } from "./DashboardContent";
 
-export const dynamic = "force-dynamic";
-
 type Props = {
   searchParams: Promise<{
     tab?: string;

--- a/packages/web/components/list/FilterEdgeSwipe.module.css
+++ b/packages/web/components/list/FilterEdgeSwipe.module.css
@@ -1,9 +1,11 @@
 .zone {
   position: fixed;
   left: 50%;
-  /* Offset above the home indicator and Safari's bottom toolbar so the
-     grab handle stays above system UI and remains easily tappable. */
-  bottom: env(safe-area-inset-bottom, 0px);
+  /* In-browser: Safari's compact bottom toolbar (~49px) sits above the
+     home-indicator safe area. Push the handle above both so it stays
+     visible and tappable. In standalone PWA mode the toolbar is gone,
+     so a lower override restores the tighter position. */
+  bottom: calc(54px + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   z-index: 40;
   width: 160px;
@@ -24,6 +26,12 @@
   /* Capture vertical pan gestures so upward swipes reach our handlers
      rather than scrolling the list behind. */
   touch-action: none;
+}
+
+@media (display-mode: standalone) {
+  .zone {
+    bottom: env(safe-area-inset-bottom, 0px);
+  }
 }
 
 @media (min-width: 768px) and (hover: hover) {

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -2,8 +2,9 @@
   max-width: 1200px;
   margin: 0 auto;
   /* Bottom padding provides scroll-end breathing room so the last row
-     clears the filter handle and safe-area inset. */
-  padding: 4px 0 calc(80px + env(safe-area-inset-bottom, 0px));
+     clears the filter handle, FAB, and safe-area inset. Desktop has
+     no fixed bottom elements, so a smaller value suffices. */
+  padding: 4px 0 80px;
   background: var(--paper-bg);
   min-height: 100dvh;
   position: relative;
@@ -583,6 +584,12 @@
 /* ── Responsive: desktop shows chip row + inline mine toggle, hides filter
      button + scope pill. Mobile inverts. ── */
 @media (max-width: 767px) {
+  .container {
+    /* Mobile: the FilterEdgeSwipe handle sits ~54px above the safe-area
+       inset (to clear Safari's toolbar). Add enough padding so the last
+       list row clears the handle gradient and is readable past the FAB. */
+    padding-bottom: calc(140px + env(safe-area-inset-bottom, 0px));
+  }
   .desktopChipRow {
     display: none;
   }

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -154,19 +154,16 @@ export function ListRow({ item, onLaunch, onClose }: Props) {
 
   // Wrap in SwipeRow for open (launch + close) and running (close only)
   if (section === "open" || section === "running") {
+    const bindClose = onClose
+      ? () => onClose(repo.owner, repo.name, issue.number)
+      : undefined;
+    const bindLaunch =
+      section === "open" && onLaunch
+        ? () => onLaunch(repo.owner, repo.name, issue.number)
+        : undefined;
+
     return (
-      <SwipeRow
-        onLaunch={
-          section === "open" && onLaunch
-            ? () => onLaunch(repo.owner, repo.name, issue.number)
-            : undefined
-        }
-        onClose={
-          onClose
-            ? () => onClose(repo.owner, repo.name, issue.number)
-            : undefined
-        }
-      >
+      <SwipeRow onLaunch={bindLaunch} onClose={bindClose}>
         {rowContent}
       </SwipeRow>
     );

--- a/packages/web/components/paper/Fab.module.css
+++ b/packages/web/components/paper/Fab.module.css
@@ -26,15 +26,16 @@
   opacity: 0.92;
 }
 
-/* Mobile: compact FAB to avoid crowding the bottom sheet handle.
-   Keeps a visible quick-create shortcut above the command sheet. */
+/* Mobile: compact FAB positioned above the FilterEdgeSwipe handle
+   (which itself sits above Safari's toolbar). Keeps a visible
+   quick-create shortcut that doesn't crowd the handle. */
 @media (max-width: 767px) {
   .fab {
     width: 52px;
     height: 52px;
     font-size: 30px;
     right: 20px;
-    bottom: calc(64px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(108px + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -38,6 +38,18 @@ function resolveVersion(): string {
 const appVersion = resolveVersion();
 
 const nextConfig: NextConfig = {
+  experimental: {
+    // Next.js 15 defaults the client Router Cache for dynamic pages to
+    // 0 seconds, so every back-navigation re-renders the page on the
+    // server. Raising this to 30 seconds lets the client reuse the
+    // cached RSC payload when navigating back from an issue detail to
+    // the list, making back-nav feel instant. Data freshness is still
+    // handled by the core layer's stale-while-revalidate cache, and
+    // users can pull-to-refresh to force a reload.
+    staleTimes: {
+      dynamic: 30,
+    },
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,
   },


### PR DESCRIPTION
## Summary
- Remove redundant `force-dynamic` from the main list page (already dynamic via `searchParams`) and add `staleTimes.dynamic: 30` so the client Router Cache makes back-navigation instant for 30 seconds
- Reposition the FilterEdgeSwipe handle, FAB, and container padding to sit above Safari's compact bottom toolbar (~49px) on mobile, with a `display-mode: standalone` override for PWA mode
- Minor ListRow.tsx cleanup: extract SwipeRow prop bindings to named variables

## Test plan
- [ ] Open the app on mobile Safari, verify the grab handle bar is clearly visible above Safari's toolbar
- [ ] Verify the FAB ("+" button) sits above the handle and doesn't overlap content
- [ ] Scroll to the bottom of a long issue list — last row should not ghost/fade through the handle gradient
- [ ] Navigate into an issue detail, press back — list should load instantly (within 30s window)
- [ ] Pull-to-refresh on the list page — should still fetch fresh data
- [ ] If installed as PWA (Add to Home Screen), verify the handle sits at the bottom edge without extra toolbar clearance
- [ ] Desktop layout unchanged — no FAB, no handle, no extra bottom padding