### PR TITLE
feat: version display — splash screen + persistent badge

### DIFF
--- a/docs/superpowers/plans/2026-04-21-version-display.md
+++ b/docs/superpowers/plans/2026-04-21-version-display.md
@@ -1,0 +1,448 @@
+# Version Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a splash screen on cold load and a persistent version badge in the top bar so the current app version is always visible.
+
+**Architecture:** A pure-CSS splash overlay (Server Component in `layout.tsx`) fades out after 1.5s on every full page load. A small monospace version pill is added next to the brand in `List.tsx` (main list) and `PageHeader.tsx` (all other pages). Redundant version strings in Settings and FiltersSheet are removed.
+
+**Tech Stack:** Next.js App Router, CSS Modules, CSS keyframe animations, `process.env.NEXT_PUBLIC_APP_VERSION`
+
+**Spec:** `docs/superpowers/specs/2026-04-21-version-display-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/web/components/ui/SplashOverlay.tsx` | Create | Server Component — renders full-screen overlay with logo + version |
+| `packages/web/components/ui/SplashOverlay.module.css` | Create | Splash layout, fade-out animation, pointer-events handling |
+| `packages/web/app/layout.tsx` | Modify | Render `<SplashOverlay />` above `{children}` |
+| `packages/web/components/list/List.tsx` | Modify | Add version badge next to brand mark |
+| `packages/web/components/list/List.module.css` | Modify | Add `.versionBadge` styles |
+| `packages/web/components/ui/PageHeader.tsx` | Modify | Add version badge next to title |
+| `packages/web/components/ui/PageHeader.module.css` | Modify | Add `.versionBadge` styles |
+| `packages/web/app/settings/page.tsx` | Modify | Remove `versionFooter` div |
+| `packages/web/app/settings/page.module.css` | Modify | Remove `.versionFooter` rule |
+| `packages/web/components/list/FiltersSheet.tsx` | Modify | Remove version `<span>` |
+| `packages/web/components/list/FiltersSheet.module.css` | Modify | Remove `.version` rule |
+
+---
+
+### Task 1: Create the SplashOverlay component
+
+**Files:**
+- Create: `packages/web/components/ui/SplashOverlay.tsx`
+- Create: `packages/web/components/ui/SplashOverlay.module.css`
+
+- [ ] **Step 1: Create the CSS module**
+
+```css
+/* packages/web/components/ui/SplashOverlay.module.css */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: var(--paper-bg);
+  animation: fadeOut 0.5s ease-out 1s forwards;
+  pointer-events: auto;
+}
+
+.overlay[style] {
+  /* After animation completes, pointer-events is set to none
+     via animation-fill-mode: forwards on the keyframe */
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  to {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.logoMark {
+  width: 56px;
+  height: 56px;
+  background: var(--paper-accent);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--paper-mono);
+  font-weight: 700;
+  font-size: 24px;
+  color: var(--paper-bg);
+  letter-spacing: -1px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  color: var(--paper-ink);
+}
+
+.version {
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-muted);
+  letter-spacing: 0.5px;
+}
+```
+
+- [ ] **Step 2: Create the Server Component**
+
+```tsx
+/* packages/web/components/ui/SplashOverlay.tsx */
+
+import styles from "./SplashOverlay.module.css";
+
+export function SplashOverlay() {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || "dev";
+
+  return (
+    <div className={styles.overlay} aria-hidden="true">
+      <div className={styles.logoMark}>ic</div>
+      <div className={styles.title}>issuectl</div>
+      <div className={styles.version}>v{version}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @issuectl/web typecheck`
+Expected: passes (no imports of this component yet, but the file itself must be valid)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/components/ui/SplashOverlay.tsx packages/web/components/ui/SplashOverlay.module.css
+git commit -m "feat: add SplashOverlay component with fade-out animation"
+```
+
+---
+
+### Task 2: Wire SplashOverlay into the root layout
+
+**Files:**
+- Modify: `packages/web/app/layout.tsx`
+
+- [ ] **Step 1: Add the import and render the overlay**
+
+In `packages/web/app/layout.tsx`, add the import at the top with the other component imports:
+
+```tsx
+import { SplashOverlay } from "@/components/ui/SplashOverlay";
+```
+
+Then render `<SplashOverlay />` as the first child inside `<body>`, before the auth conditional:
+
+```tsx
+<body>
+  <SplashOverlay />
+  {auth.authenticated ? (
+    <ToastProvider>
+      <OfflineIndicator />
+      {children}
+    </ToastProvider>
+  ) : (
+    <AuthErrorScreen />
+  )}
+</body>
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @issuectl/web typecheck`
+Expected: passes
+
+- [ ] **Step 3: Visual verification**
+
+Run: `pnpm turbo dev`
+Open `http://localhost:3847` in a browser. Verify:
+- The splash overlay appears centered with the `ic` logo, "issuectl" title, and version string
+- It fades out after ~1.5s (1s delay + 0.5s fade)
+- The dashboard is visible and interactive after the fade
+- Hard-refresh the page — splash plays again
+- Navigate to another page (e.g., Settings) via a link — splash does NOT replay
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/app/layout.tsx
+git commit -m "feat: render SplashOverlay in root layout"
+```
+
+---
+
+### Task 3: Add persistent version badge to the main list top bar
+
+**Files:**
+- Modify: `packages/web/components/list/List.tsx`
+- Modify: `packages/web/components/list/List.module.css`
+
+- [ ] **Step 1: Add the CSS for the version badge**
+
+In `packages/web/components/list/List.module.css`, add the `.versionBadge` rule after the `.brand .dot` block (after line 38):
+
+```css
+.versionBadge {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  background: var(--paper-accent-soft);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+  margin-left: 6px;
+  vertical-align: 6px;
+  letter-spacing: 0.3px;
+}
+```
+
+- [ ] **Step 2: Add the badge to the JSX**
+
+In `packages/web/components/list/List.tsx`, inside the `<h1 className={styles.brand}>` element (around line 159), add the version badge after the `<span className={styles.dot} />`:
+
+Replace:
+
+```tsx
+<h1 className={styles.brand}>
+  <span className={styles.brandFull}>issuectl</span>
+  <span className={styles.brandCompact}>ic</span>
+  <span className={styles.dot} />
+</h1>
+```
+
+With:
+
+```tsx
+<h1 className={styles.brand}>
+  <span className={styles.brandFull}>issuectl</span>
+  <span className={styles.brandCompact}>ic</span>
+  <span className={styles.dot} />
+  <span className={styles.versionBadge}>
+    v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+  </span>
+</h1>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @issuectl/web typecheck`
+Expected: passes
+
+- [ ] **Step 4: Visual verification**
+
+Open `http://localhost:3847`. Verify:
+- On mobile viewport: the version badge appears next to the `ic` brand monogram without crowding the context breadcrumb
+- On desktop viewport (≥768px): the version badge appears next to the full `issuectl` brand
+- The badge uses muted green pill styling consistent with existing chips
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/components/list/List.tsx packages/web/components/list/List.module.css
+git commit -m "feat: add persistent version badge to list top bar"
+```
+
+---
+
+### Task 4: Add persistent version badge to PageHeader
+
+**Files:**
+- Modify: `packages/web/components/ui/PageHeader.tsx`
+- Modify: `packages/web/components/ui/PageHeader.module.css`
+
+- [ ] **Step 1: Add the CSS for the version badge**
+
+In `packages/web/components/ui/PageHeader.module.css`, add after the `.breadcrumb a:hover` block (after line 59):
+
+```css
+.versionBadge {
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  background: var(--paper-accent-soft);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+  margin-left: 8px;
+  letter-spacing: 0.3px;
+  vertical-align: middle;
+}
+```
+
+- [ ] **Step 2: Add the badge to the JSX**
+
+In `packages/web/components/ui/PageHeader.tsx`, add the version badge inside `.titleRow` after the `<h1>`:
+
+Replace:
+
+```tsx
+<div className={styles.titleRow}>
+  <h1 className={styles.title}>{title}</h1>
+  {actions && <div className={styles.actions}>{actions}</div>}
+</div>
+```
+
+With:
+
+```tsx
+<div className={styles.titleRow}>
+  <h1 className={styles.title}>
+    {title}
+    <span className={styles.versionBadge}>
+      v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+    </span>
+  </h1>
+  {actions && <div className={styles.actions}>{actions}</div>}
+</div>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @issuectl/web typecheck`
+Expected: passes
+
+- [ ] **Step 4: Visual verification**
+
+Navigate to Settings (`/settings`), New Issue (`/new`), and an issue detail page. Verify:
+- The version badge appears next to the page title on each page
+- Styling matches the badge in the main list top bar
+- Badge doesn't push the title to wrap on mobile
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/components/ui/PageHeader.tsx packages/web/components/ui/PageHeader.module.css
+git commit -m "feat: add persistent version badge to PageHeader"
+```
+
+---
+
+### Task 5: Remove redundant version displays
+
+**Files:**
+- Modify: `packages/web/app/settings/page.tsx`
+- Modify: `packages/web/app/settings/page.module.css`
+- Modify: `packages/web/components/list/FiltersSheet.tsx`
+- Modify: `packages/web/components/list/FiltersSheet.module.css`
+
+- [ ] **Step 1: Remove the version footer from Settings page**
+
+In `packages/web/app/settings/page.tsx`, remove the `versionFooter` div (lines 76-78):
+
+Remove:
+
+```tsx
+        <div className={styles.versionFooter}>
+          issuectl v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+        </div>
+```
+
+- [ ] **Step 2: Remove the `.versionFooter` CSS rule from Settings**
+
+In `packages/web/app/settings/page.module.css`, remove the `.versionFooter` block (lines 33-41):
+
+Remove:
+
+```css
+.versionFooter {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--paper-line);
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  text-align: center;
+}
+```
+
+- [ ] **Step 3: Remove the version string from FiltersSheet**
+
+In `packages/web/components/list/FiltersSheet.tsx`, remove the version `<span>` (lines 278-280):
+
+Remove:
+
+```tsx
+        <span className={styles.version}>
+          v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+        </span>
+```
+
+- [ ] **Step 4: Remove the `.version` CSS rule from FiltersSheet**
+
+In `packages/web/components/list/FiltersSheet.module.css`, remove the `.version` block (lines 258-265):
+
+Remove:
+
+```css
+.version {
+  display: block;
+  text-align: center;
+  font-family: var(--paper-mono);
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+  padding: 16px 0 4px;
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @issuectl/web typecheck`
+Expected: passes
+
+- [ ] **Step 6: Visual verification**
+
+- Open Settings (`/settings`) — no version footer at the bottom of the page
+- Open the command sheet on mobile — no version string at the bottom
+- Both pages still have the version badge in the top bar / page header from Tasks 3-4
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/app/settings/page.tsx packages/web/app/settings/page.module.css packages/web/components/list/FiltersSheet.tsx packages/web/components/list/FiltersSheet.module.css
+git commit -m "refactor: remove redundant version displays from Settings and FiltersSheet"
+```
+
+---
+
+### Task 6: Final integration check
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: all packages pass
+
+- [ ] **Step 2: End-to-end walkthrough**
+
+Open `http://localhost:3847` in a fresh browser tab (or hard-refresh). Verify the full flow:
+
+1. Splash screen appears with `ic` logo, "issuectl" title, and version
+2. Splash fades out after ~1.5s revealing the dashboard
+3. Version badge is visible in the top bar next to the brand
+4. Navigate to Settings — version badge appears next to "Settings" title
+5. Navigate to an issue detail page — version badge appears next to the issue title
+6. Navigate back to the list — no splash replay, badge still visible
+7. Hard-refresh — splash replays
+8. Open command sheet on mobile — no version string at bottom (removed)
+9. Check Settings page — no version footer at bottom (removed)
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `pnpm turbo test`
+Expected: all tests pass (no existing tests reference the removed version elements)

--- a/docs/superpowers/specs/2026-04-21-version-display-design.md
+++ b/docs/superpowers/specs/2026-04-21-version-display-design.md
@@ -1,0 +1,76 @@
+# Version Display: Splash Screen + Persistent Badge
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Problem
+
+The app version is buried in two low-visibility spots (Settings page footer and FiltersSheet bottom). When iterating quickly, there's no easy way to:
+1. **Glance at the current version** without navigating away from the current page.
+2. **Confirm a deploy landed** — after pushing a new version, there's no immediate visual signal that the app updated.
+
+## Solution
+
+Two complementary pieces:
+
+1. **Splash screen** — a full-screen overlay on cold load showing the logo and version, fading out after ~1.5s.
+2. **Persistent version badge** — a small monospace pill next to the brand mark in the top bar, visible on every page.
+
+## Design Decisions
+
+### Splash Screen
+
+- **Trigger:** Every full page load (browser fetches HTML). Does not re-trigger on client-side navigations. When the service worker serves a cached shell, there is no full reload, so no splash — meaning the splash fires exactly when a new version has landed.
+- **Duration:** ~1.5s fade-out via CSS `animation`. No JS timers.
+- **Implementation:** A `SplashOverlay` Server Component rendered in `layout.tsx` above `{children}`. Pure HTML + CSS animation. No client JS, no `useState`, no `useEffect`.
+- **Animation:** `opacity: 1 → 0` keyframe with `animation-fill-mode: forwards`. The overlay gets `pointer-events: none` at `opacity: 0` so it doesn't block interaction after fading.
+- **Visual:** Reuses existing branding from `WelcomeScreen` — the `i` logo mark (56px green rounded square), "issuectl" in Fraunces serif, version string in monospace below. Centered vertically and horizontally on `--paper-bg` background.
+- **WelcomeScreen coexistence:** The splash always renders regardless of auth/DB state. It fades in 1.5s and the welcome screen has its own visual hierarchy underneath. The brief overlap is harmless and avoids conditional logic.
+
+### Persistent Version Badge
+
+- **Location:** Next to the brand mark in the top bar. Appears in two components:
+  - `List.tsx` — next to the `issuectl` / `ic` brand in `.topBar`
+  - `PageHeader.tsx` — next to the page title on detail/settings/new-issue pages
+- **Visual treatment:**
+  - Font: `--paper-mono`, `--paper-fs-xs` (11px)
+  - Color: `--paper-ink-muted`
+  - Background: `--paper-accent-soft` pill with `--paper-radius-sm`
+  - Matches existing chip/badge visual language
+- **Mobile:** Badge shows alongside the compact `ic` brand. Small enough to fit without crowding.
+- **Version source:** `process.env.NEXT_PUBLIC_APP_VERSION` — already resolved at build time in `next.config.ts`. No new plumbing.
+
+### Cleanup
+
+The following existing version displays become redundant and are removed:
+- `packages/web/app/settings/page.tsx` — `versionFooter` div
+- `packages/web/app/settings/page.module.css` — `.versionFooter` styles
+- `packages/web/components/list/FiltersSheet.tsx` — version string at the bottom of the sheet
+
+## File Changes
+
+### New files
+| File | Purpose |
+|------|---------|
+| `packages/web/components/ui/SplashOverlay.tsx` | Full-screen fade-out overlay, Server Component |
+| `packages/web/components/ui/SplashOverlay.module.css` | Splash animation and layout styles |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `packages/web/app/layout.tsx` | Render `<SplashOverlay />` inside `<body>`, above `{children}` |
+| `packages/web/components/list/List.tsx` | Add version badge next to brand mark in `.topBar` |
+| `packages/web/components/ui/PageHeader.tsx` | Add version badge next to title |
+| `packages/web/app/settings/page.tsx` | Remove `versionFooter` div |
+| `packages/web/app/settings/page.module.css` | Remove `.versionFooter` styles |
+| `packages/web/components/list/FiltersSheet.tsx` | Remove version string |
+
+### Not touched
+- `next.config.ts` — version resolution already works
+- No new dependencies, env vars, or data layer changes
+
+## Edge Cases
+
+- **Service worker / PWA:** Splash only fires on full page loads. When SW serves cached shell, no reload occurs, so no splash. This is correct behavior — the splash signals "fresh HTML from server."
+- **Fast loads:** If the dashboard renders before the 1.5s animation completes, the splash fades over the ready content. The overlay has `pointer-events: none` once faded, so early interaction is not blocked.
+- **No version available:** Falls back to `"dev"` via existing `process.env.NEXT_PUBLIC_APP_VERSION || "dev"` pattern.

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -71,9 +71,9 @@ export default async function RootLayout({ children }: Props) {
       className={`${fraunces.variable} ${inter.variable} ${ibmPlexMono.variable}`}
     >
       <body>
-        <SplashOverlay />
         {auth.authenticated ? (
           <ToastProvider>
+            <SplashOverlay />
             <OfflineIndicator />
             {children}
           </ToastProvider>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Fraunces, Inter, IBM_Plex_Mono } from "next/font/google";
 import { AuthErrorScreen } from "@/components/auth/AuthErrorScreen";
 import { OfflineIndicator } from "@/components/ui/OfflineIndicator";
+import { SplashOverlay } from "@/components/ui/SplashOverlay";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 import { getAuthStatus } from "@/lib/auth";
 import "./globals.css";
@@ -70,6 +71,7 @@ export default async function RootLayout({ children }: Props) {
       className={`${fraunces.variable} ${inter.variable} ${ibmPlexMono.variable}`}
     >
       <body>
+        <SplashOverlay />
         {auth.authenticated ? (
           <ToastProvider>
             <OfflineIndicator />

--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -29,13 +29,3 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
 }
-
-.versionFooter {
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 1px solid var(--paper-line);
-  font-family: var(--paper-mono);
-  font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-muted);
-  text-align: center;
-}

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -72,8 +72,6 @@ export default async function SettingsPage() {
             <AuthSection />
           </Suspense>
         </section>
-
-
       </div>
     </PullToRefreshWrapper>
   );

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -73,9 +73,7 @@ export default async function SettingsPage() {
           </Suspense>
         </section>
 
-        <div className={styles.versionFooter}>
-          issuectl v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
-        </div>
+
       </div>
     </PullToRefreshWrapper>
   );

--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -254,12 +254,3 @@
   background: var(--paper-bg-warmer, #e6dec4);
   color: var(--paper-ink);
 }
-
-.version {
-  display: block;
-  text-align: center;
-  font-family: var(--paper-mono);
-  font-size: 11px;
-  color: var(--paper-ink-faint);
-  padding: 16px 0 4px;
-}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -274,8 +274,6 @@ export function FiltersSheet({
             <span className={styles.commandLinkDesc}>repos, tokens, preferences</span>
           </span>
         </Link>
-
-
       </div>
     </Sheet>
   );

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -275,9 +275,7 @@ export function FiltersSheet({
           </span>
         </Link>
 
-        <span className={styles.version}>
-          v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
-        </span>
+
       </div>
     </Sheet>
   );

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -37,6 +37,19 @@
   vertical-align: 6px;
 }
 
+.versionBadge {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  background: var(--paper-accent-soft);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+  margin-left: 6px;
+  vertical-align: 6px;
+  letter-spacing: 0.3px;
+}
+
 /* Mobile monogram: show "ic", hide "issuectl" */
 .brandCompact {
   display: inline;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -38,16 +38,8 @@
 }
 
 .versionBadge {
-  font-family: var(--paper-mono);
-  font-style: normal;
-  font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-muted);
-  background: var(--paper-accent-soft);
-  padding: 1px 6px;
-  border-radius: var(--paper-radius-sm);
   margin-left: 6px;
   vertical-align: 6px;
-  letter-spacing: 0.3px;
 }
 
 /* Mobile monogram: show "ic", hide "issuectl" */

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -14,8 +14,9 @@ import { FilterEdgeSwipe } from "./FilterEdgeSwipe";
 import { useListCounts } from "./ListCountContext";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
-import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
 import { CacheAge } from "@/components/ui/CacheAge";
+import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
+import { VersionBadge } from "@/components/ui/VersionBadge";
 
 type Repo = { owner: string; name: string };
 
@@ -159,9 +160,7 @@ export function List({
           <span className={styles.brandFull}>issuectl</span>
           <span className={styles.brandCompact}>ic</span>
           <span className={styles.dot} />
-          <span className={styles.versionBadge}>
-            v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
-          </span>
+          <VersionBadge className={styles.versionBadge} />
         </h1>
 
         {/* Mobile: context breadcrumb — tappable to open sheet */}

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -159,6 +159,9 @@ export function List({
           <span className={styles.brandFull}>issuectl</span>
           <span className={styles.brandCompact}>ic</span>
           <span className={styles.dot} />
+          <span className={styles.versionBadge}>
+            v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+          </span>
         </h1>
 
         {/* Mobile: context breadcrumb — tappable to open sheet */}

--- a/packages/web/components/ui/PageHeader.module.css
+++ b/packages/web/components/ui/PageHeader.module.css
@@ -57,3 +57,15 @@
 .breadcrumb a:hover {
   color: var(--paper-ink);
 }
+
+.versionBadge {
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  background: var(--paper-accent-soft);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+  margin-left: 8px;
+  letter-spacing: 0.3px;
+  vertical-align: middle;
+}

--- a/packages/web/components/ui/PageHeader.module.css
+++ b/packages/web/components/ui/PageHeader.module.css
@@ -59,13 +59,6 @@
 }
 
 .versionBadge {
-  font-family: var(--paper-mono);
-  font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-muted);
-  background: var(--paper-accent-soft);
-  padding: 1px 6px;
-  border-radius: var(--paper-radius-sm);
   margin-left: 8px;
-  letter-spacing: 0.3px;
   vertical-align: middle;
 }

--- a/packages/web/components/ui/PageHeader.tsx
+++ b/packages/web/components/ui/PageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { VersionBadge } from "@/components/ui/VersionBadge";
 import styles from "./PageHeader.module.css";
 
 type Props = {
@@ -14,9 +15,7 @@ export function PageHeader({ title, actions, breadcrumb }: Props) {
       <div className={styles.titleRow}>
         <h1 className={styles.title}>
           {title}
-          <span className={styles.versionBadge}>
-            v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
-          </span>
+          <VersionBadge className={styles.versionBadge} />
         </h1>
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>

--- a/packages/web/components/ui/PageHeader.tsx
+++ b/packages/web/components/ui/PageHeader.tsx
@@ -12,7 +12,12 @@ export function PageHeader({ title, actions, breadcrumb }: Props) {
     <div className={styles.header}>
       {breadcrumb && <div className={styles.breadcrumb}>{breadcrumb}</div>}
       <div className={styles.titleRow}>
-        <h1 className={styles.title}>{title}</h1>
+        <h1 className={styles.title}>
+          {title}
+          <span className={styles.versionBadge}>
+            v{process.env.NEXT_PUBLIC_APP_VERSION || "dev"}
+          </span>
+        </h1>
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>
     </div>

--- a/packages/web/components/ui/SplashOverlay.module.css
+++ b/packages/web/components/ui/SplashOverlay.module.css
@@ -23,6 +23,14 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    animation: none;
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
 .logoMark {
   width: 56px;
   height: 56px;

--- a/packages/web/components/ui/SplashOverlay.module.css
+++ b/packages/web/components/ui/SplashOverlay.module.css
@@ -1,0 +1,54 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: var(--paper-bg);
+  animation: fadeOut 0.5s ease-out 1s forwards;
+  pointer-events: auto;
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  to {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.logoMark {
+  width: 56px;
+  height: 56px;
+  background: var(--paper-accent);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--paper-mono);
+  font-weight: 700;
+  font-size: 24px;
+  color: var(--paper-bg);
+  letter-spacing: -1px;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  color: var(--paper-ink);
+}
+
+.version {
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-muted);
+  letter-spacing: 0.5px;
+}

--- a/packages/web/components/ui/SplashOverlay.tsx
+++ b/packages/web/components/ui/SplashOverlay.tsx
@@ -1,0 +1,13 @@
+import styles from "./SplashOverlay.module.css";
+
+export function SplashOverlay() {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || "dev";
+
+  return (
+    <div className={styles.overlay} aria-hidden="true">
+      <div className={styles.logoMark}>ic</div>
+      <div className={styles.title}>issuectl</div>
+      <div className={styles.version}>v{version}</div>
+    </div>
+  );
+}

--- a/packages/web/components/ui/VersionBadge.module.css
+++ b/packages/web/components/ui/VersionBadge.module.css
@@ -1,0 +1,10 @@
+.badge {
+  font-family: var(--paper-mono);
+  font-style: normal;
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  background: var(--paper-accent-soft);
+  padding: 1px 6px;
+  border-radius: var(--paper-radius-sm);
+  letter-spacing: 0.3px;
+}

--- a/packages/web/components/ui/VersionBadge.tsx
+++ b/packages/web/components/ui/VersionBadge.tsx
@@ -1,0 +1,15 @@
+import styles from "./VersionBadge.module.css";
+
+type Props = {
+  className?: string;
+};
+
+export function VersionBadge({ className }: Props) {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || "dev";
+
+  return (
+    <span className={`${styles.badge} ${className ?? ""}`}>
+      v{version}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- **Splash screen** on every cold page load — centered logo + version fades out after ~1.5s via CSS animation. Server Component, zero client JS.
- **Persistent version badge** next to the brand mark in the top bar (List) and page title (PageHeader) — always visible, no navigation required.
- **Cleanup** — removed redundant version displays from Settings footer and FiltersSheet.
- **Shared `VersionBadge` component** — DRYs up the badge across List and PageHeader with context-specific CSS overrides.
- **Accessibility** — `prefers-reduced-motion` media query immediately hides the splash overlay so reduced-motion users are never blocked.

Spec: `docs/superpowers/specs/2026-04-21-version-display-design.md`
Plan: `docs/superpowers/plans/2026-04-21-version-display.md`

## Test plan

- [ ] Hard-refresh the app — splash appears with logo + version, fades after ~1.5s
- [ ] Navigate between pages — splash does NOT replay, version badge visible on every page
- [ ] Check Settings and FiltersSheet — old version displays removed
- [ ] Enable `prefers-reduced-motion` in browser/OS — splash is skipped, app loads normally
- [ ] Trigger auth failure — splash does not appear over AuthErrorScreen
- [ ] `pnpm turbo typecheck` — all packages pass
- [ ] `pnpm turbo test` — all 357 tests pass