### PR TITLE
fix: preserve filter state on back-navigation from detail pages

### DIFF
--- a/packages/web/components/detail/DetailTopBar.tsx
+++ b/packages/web/components/detail/DetailTopBar.tsx
@@ -19,14 +19,13 @@ export function DetailTopBar({
   const router = useRouter();
 
   function handleBack(e: React.MouseEvent) {
-    // Use browser history when the referrer is our own app, so filter
-    // state in query params is preserved. When the user arrived from an
-    // external link (Slack, email, etc.), fall through to the hard
-    // <Link> href to avoid navigating them out of the app.
-    if (
-      window.history.length > 1 &&
-      document.referrer.startsWith(window.location.origin)
-    ) {
+    // Prefer browser history so filter state in query params is
+    // preserved. We intentionally skip the old document.referrer check
+    // because it never updates during SPA navigations, causing the
+    // fallback <Link> to fire and drop all filters. If the user arrived
+    // from an external link, router.back() simply takes them back there
+    // — standard back-button behavior.
+    if (window.history.length > 1) {
       e.preventDefault();
       router.back();
     }

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -9,6 +9,7 @@ import { PrListRow } from "./PrListRow";
 import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
 import { closeIssue } from "@/lib/actions/issues";
 import { useToast } from "@/components/ui/ToastProvider";
+import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 
 type Props = {
@@ -101,14 +102,14 @@ export function ListContent({
               : "Issue closed",
             "success",
           );
-          router.replace("/?section=closed");
+          router.replace(buildHref({ section: "closed", repo: activeRepo }));
         } catch (err) {
           console.error("[issuectl] Close issue from list failed:", err);
           setCloseError("Something went wrong while closing the issue. Please try again.");
         }
       });
     },
-    [closeTarget, showToast, router],
+    [closeTarget, showToast, router, activeRepo],
   );
 
   const handleCloseCancel = useCallback(() => {

--- a/packages/web/e2e/data-freshness.spec.ts
+++ b/packages/web/e2e/data-freshness.spec.ts
@@ -285,10 +285,7 @@ test.describe("Data freshness — filters persist on back-nav (#129)", () => {
     await issueLink.click();
     await expect(page).toHaveURL(/\/issues\//, { timeout: 15000 });
 
-    // Use browser back (not the Back link) to test history-based filter
-    // preservation. The Back link relies on document.referrer which is
-    // empty after page.goto() in Playwright, so it falls through to a
-    // hard <Link href="/"> that drops query params.
+    // Use browser back to test history-based filter preservation.
     await page.goBack();
     await page.waitForURL(
       (url) => url.searchParams.has("repo") && url.searchParams.has("section"),


### PR DESCRIPTION
## Summary
- Replaced the broken `document.referrer` check in `DetailTopBar` with `window.history.length > 1` — `document.referrer` never updates during SPA navigations, so `router.back()` was almost never called and filters were always dropped
- Preserved the active repo filter when closing an issue from the list view by using `buildHref()` instead of a hardcoded `"/?section=closed"` URL
- Updated a stale E2E test comment that referenced the old `document.referrer` logic

## Test plan
- [ ] Navigate to issues list, select a repo filter, click into an issue, click the back button — verify the repo filter is preserved
- [ ] Repeat with section and sort filters active
- [ ] Repeat the same flow for PR detail pages
- [ ] Close an issue from the list while a repo filter is active — verify the repo filter is preserved after redirect to the closed section
- [ ] Open the app in a fresh tab directly to an issue URL — verify the back button navigates to `/`
- [ ] Run `pnpm turbo typecheck` — passes with 0 errors

Closes #189