### PR TITLE
fix: resolve 5 quick-win issues (#170, #172, #193, #194, #197)

### DIFF
--- a/packages/web/components/detail/CommentComposer.tsx
+++ b/packages/web/components/detail/CommentComposer.tsx
@@ -18,9 +18,10 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  onCommentPosted?: (body: string) => void;
 };
 
-export function CommentComposer({ owner, repo, issueNumber }: Props) {
+export function CommentComposer({ owner, repo, issueNumber, onCommentPosted }: Props) {
   const router = useRouter();
   const { showToast } = useToast();
   const { body, setBody, clear: clearDraft } = useCommentDraft(owner, repo, issueNumber);
@@ -86,7 +87,11 @@ export function CommentComposer({ owner, repo, issueNumber }: Props) {
         return;
       }
 
-      // succeeded
+      // succeeded — notify parent outside try so a callback bug
+      // doesn't produce a misleading "Failed to post comment" error
+      try { onCommentPosted?.(body); } catch (e) {
+        console.error("[issuectl] onCommentPosted callback failed:", e);
+      }
       clearDraft();
       router.refresh();
       const data = result.data as { cacheStale?: boolean };

--- a/packages/web/components/detail/CommentSection.tsx
+++ b/packages/web/components/detail/CommentSection.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { GitHubComment } from "@issuectl/core";
+import { CommentList } from "./CommentList";
+import { CommentComposer } from "./CommentComposer";
+
+type Props = {
+  initialComments: GitHubComment[];
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export function CommentSection({ initialComments, owner, repo, issueNumber }: Props) {
+  const [pendingComments, setPendingComments] = useState<GitHubComment[]>([]);
+  const prevCountRef = useRef(initialComments.length);
+
+  // When server-rendered comments update (e.g. from router.refresh()),
+  // clear pending optimistic comments — the server data is authoritative.
+  useEffect(() => {
+    if (initialComments.length > prevCountRef.current) {
+      setPendingComments([]);
+    }
+    prevCountRef.current = initialComments.length;
+  }, [initialComments.length]);
+
+  const allComments = [...initialComments, ...pendingComments];
+
+  const handleCommentPosted = (body: string) => {
+    const optimistic: GitHubComment = {
+      id: -Date.now(),
+      body,
+      user: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      htmlUrl: "",
+    };
+    setPendingComments((prev) => [...prev, optimistic]);
+  };
+
+  return (
+    <>
+      <CommentList comments={allComments} />
+      <CommentComposer
+        owner={owner}
+        repo={repo}
+        issueNumber={issueNumber}
+        onCommentPosted={handleCommentPosted}
+      />
+    </>
+  );
+}

--- a/packages/web/components/detail/EditableBody.module.css
+++ b/packages/web/components/detail/EditableBody.module.css
@@ -1,0 +1,55 @@
+.bodyWrap {
+  position: relative;
+}
+
+.editBtn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: none;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 2px 10px;
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+  z-index: 1;
+}
+
+.editBtn:hover {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink-muted);
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 12px;
+  font-family: var(--paper-mono);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  resize: vertical;
+  line-height: 1.6;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--paper-ink-muted);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/packages/web/components/detail/EditableBody.tsx
+++ b/packages/web/components/detail/EditableBody.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { LightboxBodyText } from "./LightboxBodyText";
+import { Button } from "@/components/paper";
+import { updateIssue } from "@/lib/actions/issues";
+import { useToast } from "@/components/ui/ToastProvider";
+import styles from "./EditableBody.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  initialBody: string | null;
+};
+
+export function EditableBody({ owner, repo, issueNumber, initialBody }: Props) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const [body, setBody] = useState(initialBody ?? "");
+  const [displayBody, setDisplayBody] = useState(initialBody);
+  const [saving, setSaving] = useState(false);
+
+  // Sync with server data when not editing (e.g. after router.refresh()
+  // or if another user edits the body via the GitHub UI).
+  useEffect(() => {
+    if (!editing) {
+      setDisplayBody(initialBody);
+      setBody(initialBody ?? "");
+    }
+  }, [initialBody, editing]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const result = await updateIssue({ owner, repo, number: issueNumber, body });
+      if (!result.success) {
+        showToast(result.error ?? "Failed to update", "error");
+        return;
+      }
+      setDisplayBody(body);
+      setEditing(false);
+      router.refresh();
+      showToast(
+        result.cacheStale
+          ? "Description updated — reload if changes don't appear"
+          : "Description updated",
+        "success",
+      );
+    } catch (err) {
+      console.error("[issuectl] updateIssue failed:", err);
+      showToast("Failed to update description", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setBody(displayBody ?? "");
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className={styles.editor}>
+        <textarea
+          className={styles.textarea}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={10}
+          disabled={saving}
+          autoFocus
+          maxLength={65536}
+        />
+        <div className={styles.actions}>
+          <Button variant="ghost" onClick={handleCancel} disabled={saving}>
+            cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={saving}>
+            {saving ? "saving\u2026" : "save"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.bodyWrap}>
+      <button
+        className={styles.editBtn}
+        onClick={() => {
+          setBody(displayBody ?? "");
+          setEditing(true);
+        }}
+        aria-label="Edit description"
+      >
+        edit
+      </button>
+      <LightboxBodyText body={displayBody} />
+    </div>
+  );
+}

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -9,7 +9,7 @@ import {
   MetaSeparator,
   MetaNum,
 } from "./DetailMeta";
-import { LightboxBodyText } from "./LightboxBodyText";
+import { EditableBody } from "./EditableBody";
 import { PriorityPicker } from "./PriorityPicker";
 import { IssueActionSheet } from "./IssueActionSheet";
 import styles from "./IssueDetail.module.css";
@@ -92,7 +92,12 @@ export function IssueDetail({
             hasLiveDeployment={hasLiveDeployment}
           />
         )}
-        <LightboxBodyText body={issue.body} />
+        <EditableBody
+          owner={owner}
+          repo={repoName}
+          issueNumber={issue.number}
+          initialBody={issue.body}
+        />
         {children}
       </div>
     </div>

--- a/packages/web/components/detail/IssueDetailContent.tsx
+++ b/packages/web/components/detail/IssueDetailContent.tsx
@@ -1,8 +1,7 @@
 import { getDb, getOctokit, getIssueContent } from "@issuectl/core";
 import type { Deployment, GitHubIssue } from "@issuectl/core";
 import { LaunchCard } from "./LaunchCard";
-import { CommentList } from "./CommentList";
-import { CommentComposer } from "./CommentComposer";
+import { CommentSection } from "./CommentSection";
 import styles from "./IssueDetail.module.css";
 
 type Props = {
@@ -14,8 +13,9 @@ type Props = {
 
 /**
  * Streaming content section: calls getIssueContent to fetch comments,
- * then renders the LaunchCard (active deployment banner only), the
- * comment list, and the comment composer. Wrapped in Suspense by the page.
+ * then renders the LaunchCard (active deployment banner) and the
+ * CommentSection (comment list + composer with optimistic updates).
+ * Wrapped in Suspense by the page.
  *
  * Handles errors inline so a transient failure in getIssueContent
  * shows a degraded state instead of tearing down the whole page via the
@@ -63,8 +63,8 @@ export async function IssueDetailContent({
         issueTitle={issue.title}
         deployments={deployments}
       />
-      <CommentList comments={comments} />
-      <CommentComposer
+      <CommentSection
+        initialComments={comments}
         owner={owner}
         repo={repoName}
         issueNumber={issue.number}

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -56,6 +56,16 @@ export function SwipeRow({ children, onLaunch, onClose, disabled }: Props) {
 
   const dismiss = useCallback(() => setSwiped("idle"), []);
 
+  const handleContentClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (swiped === "idle") return;
+      e.preventDefault();
+      e.stopPropagation();
+      dismiss();
+    },
+    [swiped, dismiss],
+  );
+
   if (disabled) {
     return <>{children}</>;
   }
@@ -94,7 +104,9 @@ export function SwipeRow({ children, onLaunch, onClose, disabled }: Props) {
           </button>
         </div>
       )}
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content} onClick={handleContentClick}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/web/components/terminal/TerminalPanel.module.css
+++ b/packages/web/components/terminal/TerminalPanel.module.css
@@ -45,14 +45,14 @@
   left: 0;
   top: 0;
   bottom: 0;
-  width: 28px;
+  width: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   color: var(--paper-ink-muted);
-  background: linear-gradient(90deg, var(--paper-bg-warm) 0%, transparent 100%);
-  transition: color 0.15s ease, background 0.15s ease;
+  background: transparent;
+  transition: color 0.15s ease;
   z-index: 1;
   user-select: none;
   border: none;
@@ -62,12 +62,13 @@
 
 .handle:hover {
   color: var(--paper-ink);
-  background: linear-gradient(90deg, var(--paper-bg-warmer) 0%, transparent 100%);
+  background: transparent;
 }
 
 .handleChevron {
   font-size: 16px;
   font-weight: 700;
+  opacity: 0;
 }
 
 .header {

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -39,15 +39,13 @@ const appVersion = resolveVersion();
 
 const nextConfig: NextConfig = {
   experimental: {
-    // Next.js 15 defaults the client Router Cache for dynamic pages to
-    // 0 seconds, so every back-navigation re-renders the page on the
-    // server. Raising this to 30 seconds lets the client reuse the
-    // cached RSC payload when navigating back from an issue detail to
-    // the list, making back-nav feel instant. Data freshness is still
-    // handled by the core layer's stale-while-revalidate cache, and
-    // users can pull-to-refresh to force a reload.
+    // Keep Next.js 15's default of 0 seconds for the client Router
+    // Cache on dynamic pages. This ensures mutations (create issue,
+    // add comment, close issue) are immediately visible when
+    // navigating back to the list. The Suspense skeleton provides
+    // perceived performance during the server re-render.
     staleTimes: {
-      dynamic: 30,
+      dynamic: 0,
     },
   },
   env: {


### PR DESCRIPTION
## Summary

Batch fix for 5 quick-win issues plus 3 already-implemented closures (8 issues total).

### Fixed with code changes
- **#170** — New issue doesn't appear on list after creation. Root cause: `staleTimes.dynamic: 30` kept the client Router Cache stale for 30s after mutations. Set to 0 (Next.js 15 default).
- **#172** — Comment doesn't appear after posting until page refresh. Added `CommentSection` client wrapper with optimistic comment display — new comments appear instantly.
- **#193** — No way to re-center a swiped issue card. Added tap-to-dismiss: tapping displaced content resets the swipe to idle.
- **#194** — Can't edit issue description, only comment. Added `EditableBody` component with inline edit/save using the existing `updateIssue` server action.
- **#197** — Left aura on mobile terminal interfering with visibility. Made the handle transparent, hidden the chevron, reduced width.

### Closed as already implemented
- **#195** / **#174** — `claude_extra_args` already defaults to `--dangerously-skip-permissions`
- **#178** — Launch already applies `issuectl:in-progress` label

### PR review findings addressed
- Fixed empty `avatarUrl` in optimistic comments that would crash Next.js `<Image>`
- Isolated `onCommentPosted` callback from main try block to prevent misattributed errors
- Added `useEffect` sync for `EditableBody.displayBody` to track prop changes
- Added `cacheStale` handling in `EditableBody` consistent with rest of codebase
- Updated stale JSDoc in `IssueDetailContent`
- Extracted SwipeRow onClick handler for clarity

## Test plan
- [x] `pnpm turbo typecheck` — zero errors across all 3 packages
- [x] `pnpm turbo test` — 466 tests pass (371 core + 95 web)
- [x] Pre-commit hooks pass (typecheck + lint)
- [ ] Manual: create issue → verify it appears on list immediately
- [ ] Manual: post comment → verify it appears instantly (optimistic)
- [ ] Manual: edit issue body → verify save/cancel work correctly
- [ ] Manual: swipe card → tap content → verify it resets to idle
- [ ] Manual: open terminal on mobile → verify no left aura