### PR TITLE
fix: resolve blank terminal on mobile (#196)

### DIFF
--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -258,22 +258,19 @@ describe("spawnTtyd", () => {
     expect(result).toEqual({ pid: 42, port: 7700 });
     expect(unrefSpy).toHaveBeenCalled();
 
-    // Verify spawn arguments.
+    // Verify spawn arguments — use slice assertions so adding flags
+    // only requires updating the toEqual array, not re-indexing every line.
     const [bin, args, opts] = spawnSpy.mock.calls[0] as [string, string[], Record<string, unknown>];
     expect(bin).toBe("ttyd");
-    expect(args[0]).toBe("-W");
-    expect(args[1]).toBe("-i");
-    expect(args[2]).toBe("0.0.0.0");
-    expect(args[3]).toBe("-p");
-    expect(args[4]).toBe("7700");
-    expect(args[5]).toBe("-q");
-    expect(args[6]).toBe("/bin/bash");
-    expect(args[7]).toBe("-lic");
-    // Shell command should contain escaped paths and the claude command.
-    expect(args[8]).toContain("cd '/home/user/project'");
-    expect(args[8]).toContain("cat '/tmp/ctx.md'");
-    expect(args[8]).toContain("claude --dangerously-skip-permissions");
-    expect(args[8]).toContain("; exit");
+    expect(args.slice(0, -3)).toEqual([
+      "-W", "-i", "0.0.0.0", "-O", "-m", "1", "-p", "7700", "-q",
+    ]);
+    expect(args.slice(-3, -1)).toEqual(["/bin/bash", "-lic"]);
+    const shellCmd = args.at(-1)!;
+    expect(shellCmd).toContain("cd '/home/user/project'");
+    expect(shellCmd).toContain("cat '/tmp/ctx.md'");
+    expect(shellCmd).toContain("claude --dangerously-skip-permissions");
+    expect(shellCmd).toContain("; exit");
     expect(opts).toEqual({ detached: true, stdio: "ignore" });
     killSpy.mockRestore();
   });
@@ -289,7 +286,7 @@ describe("spawnTtyd", () => {
       claudeCommand: "claude",
     });
 
-    const shellCmd = (spawnSpy.mock.calls[0] as [string, string[]])[1][8];
+    const shellCmd = (spawnSpy.mock.calls[0] as [string, string[]])[1].at(-1)!;
     expect(shellCmd).toContain("cd '/home/user/it'\\''s a project'");
     killSpy.mockRestore();
   });

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -262,16 +262,18 @@ describe("spawnTtyd", () => {
     const [bin, args, opts] = spawnSpy.mock.calls[0] as [string, string[], Record<string, unknown>];
     expect(bin).toBe("ttyd");
     expect(args[0]).toBe("-W");
-    expect(args[1]).toBe("-p");
-    expect(args[2]).toBe("7700");
-    expect(args[3]).toBe("-q");
-    expect(args[4]).toBe("/bin/bash");
-    expect(args[5]).toBe("-lic");
+    expect(args[1]).toBe("-i");
+    expect(args[2]).toBe("0.0.0.0");
+    expect(args[3]).toBe("-p");
+    expect(args[4]).toBe("7700");
+    expect(args[5]).toBe("-q");
+    expect(args[6]).toBe("/bin/bash");
+    expect(args[7]).toBe("-lic");
     // Shell command should contain escaped paths and the claude command.
-    expect(args[6]).toContain("cd '/home/user/project'");
-    expect(args[6]).toContain("cat '/tmp/ctx.md'");
-    expect(args[6]).toContain("claude --dangerously-skip-permissions");
-    expect(args[6]).toContain("; exit");
+    expect(args[8]).toContain("cd '/home/user/project'");
+    expect(args[8]).toContain("cat '/tmp/ctx.md'");
+    expect(args[8]).toContain("claude --dangerously-skip-permissions");
+    expect(args[8]).toContain("; exit");
     expect(opts).toEqual({ detached: true, stdio: "ignore" });
     killSpy.mockRestore();
   });
@@ -287,7 +289,7 @@ describe("spawnTtyd", () => {
       claudeCommand: "claude",
     });
 
-    const shellCmd = (spawnSpy.mock.calls[0] as [string, string[]])[1][6];
+    const shellCmd = (spawnSpy.mock.calls[0] as [string, string[]])[1][8];
     expect(shellCmd).toContain("cd '/home/user/it'\\''s a project'");
     killSpy.mockRestore();
   });

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -162,9 +162,11 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
   const shellCommand =
     `cd ${shellEscape(workspacePath)} && cat ${shellEscape(contextFilePath)} | ${claudeCommand} ; exit`;
 
+  // Bind to all interfaces so mobile/LAN devices can reach the
+  // terminal when accessing the dashboard over the network.
   const child = spawn(
     "ttyd",
-    ["-W", "-p", String(port), "-q", "/bin/bash", "-lic", shellCommand],
+    ["-W", "-i", "0.0.0.0", "-p", String(port), "-q", "/bin/bash", "-lic", shellCommand],
     { detached: true, stdio: "ignore" },
   );
 

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -164,9 +164,14 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
 
   // Bind to all interfaces so mobile/LAN devices can reach the
   // terminal when accessing the dashboard over the network.
+  // Security: -O rejects WebSocket upgrades from a different origin,
+  // -m 1 limits each terminal to a single client. Full auth is not
+  // practical with ttyd iframes (browsers block basic-auth in iframe
+  // URLs), so access control relies on the trusted-LAN model. Use
+  // --local-only on untrusted networks (see spec §5.2).
   const child = spawn(
     "ttyd",
-    ["-W", "-i", "0.0.0.0", "-p", String(port), "-q", "/bin/bash", "-lic", shellCommand],
+    ["-W", "-i", "0.0.0.0", "-O", "-m", "1", "-p", String(port), "-q", "/bin/bash", "-lic", shellCommand],
     { detached: true, stdio: "ignore" },
   );
 

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -88,7 +88,7 @@ export function TerminalPanel({
         </div>
         <iframe
           className={styles.terminalFrame}
-          src={`http://localhost:${ttydPort}`}
+          src={`http://${typeof window !== "undefined" ? window.location.hostname : "localhost"}:${ttydPort}`}
           title={`Terminal — Issue #${issueNumber}`}
         />
       </div>

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -29,7 +29,15 @@ export function TerminalPanel({
 }: Props) {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [ttydHost, setTtydHost] = useState<string | null>(null);
   const router = useRouter();
+
+  // Resolve the ttyd hostname on the client to avoid SSR/hydration
+  // mismatch (server would render "localhost", client renders the
+  // actual hostname the user navigated to).
+  useEffect(() => {
+    setTtydHost(window.location.hostname);
+  }, []);
 
   function handleEndSession() {
     setError(null);
@@ -86,11 +94,15 @@ export function TerminalPanel({
             {isPending ? "Ending..." : "End Session"}
           </Button>
         </div>
-        <iframe
-          className={styles.terminalFrame}
-          src={`http://${typeof window !== "undefined" ? window.location.hostname : "localhost"}:${ttydPort}`}
-          title={`Terminal — Issue #${issueNumber}`}
-        />
+        {ttydHost ? (
+          <iframe
+            className={styles.terminalFrame}
+            src={`http://${ttydHost}:${ttydPort}`}
+            title={`Terminal — Issue #${issueNumber}`}
+          />
+        ) : (
+          <div className={styles.terminalFrame} />
+        )}
       </div>
     </div>
   );

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -103,9 +103,13 @@ const nextConfig: NextConfig = {
     // (sw.js) to register. Without an explicit directive, browsers
     // fall back to script-src — adding it prevents breakage if
     // script-src is ever tightened.
-    // ttyd terminal iframes run on localhost ports 7700-7799. CSP
-    // frame-src needs to allow these origins for the embedded terminal
-    // panel to load. A single wildcard origin covers the entire range.
+    // ttyd terminal iframes run on ports 7700-7799. The dashboard may
+    // be accessed from localhost or from a LAN device (phone/tablet) via
+    // the host's IP, so the iframe origin matches whatever hostname the
+    // user navigated to. CSP cannot express "same host, different port",
+    // so we allow any http origin for frames. This is acceptable for a
+    // single-user local tool — frame-ancestors 'none' still prevents
+    // the dashboard itself from being embedded elsewhere.
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
@@ -113,7 +117,7 @@ const nextConfig: NextConfig = {
       "img-src 'self' data: https://avatars.githubusercontent.com",
       "font-src 'self'",
       "connect-src 'self'",
-      "frame-src http://localhost:*",
+      "frame-src http://*:*",
       "worker-src 'self'",
       "frame-ancestors 'none'",
       "base-uri 'self'",

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -106,10 +106,12 @@ const nextConfig: NextConfig = {
     // ttyd terminal iframes run on ports 7700-7799. The dashboard may
     // be accessed from localhost or from a LAN device (phone/tablet) via
     // the host's IP, so the iframe origin matches whatever hostname the
-    // user navigated to. CSP cannot express "same host, different port",
-    // so we allow any http origin for frames. This is acceptable for a
-    // single-user local tool — frame-ancestors 'none' still prevents
-    // the dashboard itself from being embedded elsewhere.
+    // user navigated to. CSP cannot express "same host, different port"
+    // and does not support wildcards within IP addresses, so we allow
+    // any http origin for frames. Mitigations:
+    //   - ttyd uses -O (check-origin) to reject cross-origin WebSocket
+    //   - ttyd uses -m 1 (max 1 client) to limit terminal hijacking
+    //   - frame-ancestors 'none' prevents the dashboard from being embedded
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",


### PR DESCRIPTION
## Summary

Terminal was invisible on mobile/LAN devices due to three compounding issues:

- **ttyd bound to `127.0.0.1` only** — mobile devices on the LAN couldn't reach the host's loopback. Added `-i 0.0.0.0` to bind to all interfaces.
- **iframe src hardcoded to `localhost`** — changed to `window.location.hostname` so it resolves to whatever host the user accessed the dashboard through (works for both `localhost` on desktop and LAN IPs on mobile).
- **CSP `frame-src` only allowed `http://localhost:*`** — widened to `http://*:*` since the ttyd iframe origin depends on the access hostname. Acceptable for a single-user local tool (`frame-ancestors 'none'` still prevents the dashboard from being embedded).

Also investigated #198 (multiple launches killed) — found no kill-all mechanism in the architecture. Left a comment requesting reproduction steps.

Closes #196

## Test plan
- [x] `pnpm turbo typecheck` — zero errors
- [x] `pnpm turbo test` — 466 tests pass (updated ttyd spawn arg assertions)
- [x] Pre-commit hooks pass (typecheck + lint)
- [ ] Manual: access dashboard from mobile on LAN → terminal should load
- [ ] Manual: launch on desktop via localhost → still works as before
- [ ] Manual: verify CSP header includes `frame-src http://*:*`