### PR TITLE
fix: raise server action body limit for mobile image uploads (#192)

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -48,6 +48,14 @@ const nextConfig: NextConfig = {
       dynamic: 0,
     },
   },
+  serverActions: {
+    // Next.js defaults to 1 MB for server action request bodies.
+    // Image uploads from mobile phones are typically 3-8 MB, so the
+    // default silently rejects them before the action code runs. This
+    // matches the explicit 10 MB limit enforced in useImageUpload and
+    // the uploadImage server action.
+    bodySizeLimit: "10mb",
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,
   },


### PR DESCRIPTION
## Summary

Image uploads from mobile phones silently fail because Next.js server actions default to a 1 MB body size limit. Mobile photos are typically 3-8 MB, so they're rejected before the `uploadImage` action code even runs.

Added `serverActions.bodySizeLimit: "10mb"` to `next.config.ts`, matching the explicit 10 MB limit already enforced in both the client (`useImageUpload` hook) and server (`uploadImageToGitHub` core function).

Closes #192

## Test plan
- [x] `pnpm turbo typecheck` — zero errors
- [x] `pnpm turbo test` — 466 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual: upload photo from phone camera → should succeed
- [ ] Manual: upload photo from desktop (regression check) → should still work