### PR TITLE
fix: replace launch icons with Claude sparkle SVG

### DIFF
--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -247,7 +247,12 @@ export function IssueActionSheet({
       >
         {!hasLiveDeployment && (
           <button className={styles.item} onClick={handleLaunchTap}>
-            <span className={styles.icon}>&#x25B6;</span>
+            <span className={styles.icon}>
+              <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+                <path d="M8 2Q8.7 7 15 8Q8.7 9 8 15Q7.3 9 1 8Q7.3 7 8 2Z" fill="currentColor" />
+                <path d="M14 2Q14.3 4.5 17 5Q14.3 5.3 14 8Q13.7 5.3 11 5Q13.7 4.7 14 2Z" fill="currentColor" opacity="0.5" />
+              </svg>
+            </span>
             Launch with Claude
           </button>
         )}

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -237,11 +237,9 @@ export function FiltersSheet({
 
         <Link href="/?section=open" className={styles.commandLink} onClick={onClose}>
           <span className={`${styles.commandLinkIcon} ${styles.claudeIcon}`}>
-            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M3 14l2-2M5 12l4-8M9 4l4 8M13 12l2 2" />
-              <circle cx="9" cy="4" r="1.5" fill="currentColor" stroke="none" />
-              <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
-              <circle cx="13" cy="12" r="1" fill="currentColor" stroke="none" />
+            <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+              <path d="M8 2Q8.7 7 15 8Q8.7 9 8 15Q7.3 9 1 8Q7.3 7 8 2Z" fill="currentColor" />
+              <path d="M14 2Q14.3 4.5 17 5Q14.3 5.3 14 8Q13.7 5.3 11 5Q13.7 4.7 14 2Z" fill="currentColor" opacity="0.5" />
             </svg>
           </span>
           <span className={styles.commandLinkText}>


### PR DESCRIPTION
## Summary
- Replace the generic line-graph SVG icon for "Launch Claude Code" in the mobile command sheet (FiltersSheet) with a recognizable Claude sparkle mark
- Replace the ▶ play character for "Launch with Claude" in the issue detail action sheet (IssueActionSheet) with the same sparkle icon
- Sparkle uses a 4-point star with a smaller accent sparkle at 50% opacity, rendered as filled paths for a bolder look that stands apart from the stroke-based icons

## Test plan
- [x] Typecheck passes (`pnpm turbo typecheck`)
- [x] Visual verification via Playwright screenshot on iPhone 13 viewport
- [ ] Open the swipe-up command sheet on mobile and verify the sparkle icon renders next to "Launch Claude Code"
- [ ] Open an issue detail page and verify the sparkle icon renders next to "Launch with Claude" in the action sheet

Closes #177