### PR TITLE
fix: post-merge cleanup for PR #208

### DIFF
--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -194,7 +194,9 @@ export async function endSession(
     coreEndDeployment(db, deploymentId);
 
     // Best-effort cleanup of stale context temp files
-    cleanupStaleContextFiles().catch(() => { /* best-effort */ });
+    cleanupStaleContextFiles().catch((err) => {
+      console.warn("[issuectl] Failed to clean up stale context files:", err);
+    });
   } catch (err) {
     console.error("[issuectl] Failed to end session:", err);
     return { success: false, error: formatErrorForUser(err) };
@@ -209,7 +211,7 @@ export async function endSession(
 
 export async function checkTtydAlive(
   deploymentId: number,
-): Promise<{ alive: boolean }> {
+): Promise<{ alive: boolean; error?: string }> {
   try {
     const db = getDb();
     const deployment = getDeploymentById(db, deploymentId);
@@ -227,6 +229,6 @@ export async function checkTtydAlive(
     return { alive };
   } catch (err) {
     console.error("[issuectl] Health check failed:", err);
-    return { alive: false };
+    return { alive: false, error: "Health check failed" };
   }
 }

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -117,7 +117,9 @@ export function handleUpgrade(
       console.log(`[issuectl:diag] ws_connect port=${port} client=${clientIp}`);
     }
 
-    const diagTimer = setInterval(() => logStats(stats, "ws_tick"), DIAG_INTERVAL_MS);
+    const diagTimer = DIAG_ENABLED
+      ? setInterval(() => logStats(stats, "ws_tick"), DIAG_INTERVAL_MS)
+      : undefined;
 
     // Forward the subprotocol (ttyd requires "tty") so the upstream
     // handshake succeeds and the terminal session initializes.
@@ -171,7 +173,7 @@ export function handleUpgrade(
     function cleanup() {
       if (cleanedUp) return;
       cleanedUp = true;
-      clearInterval(diagTimer);
+      if (diagTimer !== undefined) clearInterval(diagTimer);
       logStats(stats, "ws_close");
     }
 

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -68,7 +68,10 @@ interface WsStats {
   connectedAt: number;
 }
 
+const DIAG_ENABLED = !!process.env.ISSUECTL_DIAG;
+
 function logStats(s: WsStats, label: string): void {
+  if (!DIAG_ENABLED) return;
   const uptimeSec = ((Date.now() - s.connectedAt) / 1000).toFixed(1);
   console.log(
     `[issuectl:diag] ${label} port=${s.port} client=${s.clientIp} ` +
@@ -110,7 +113,9 @@ export function handleUpgrade(
       connectedAt: Date.now(),
     };
 
-    console.log(`[issuectl:diag] ws_connect port=${port} client=${clientIp}`);
+    if (DIAG_ENABLED) {
+      console.log(`[issuectl:diag] ws_connect port=${port} client=${clientIp}`);
+    }
 
     const diagTimer = setInterval(() => logStats(stats, "ws_tick"), DIAG_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary

- Gate WebSocket frame diagnostic logging behind `ISSUECTL_DIAG` env var (was unconditionally logging every 5s per connection)
- Gate the `setInterval` timer itself behind `ISSUECTL_DIAG` to avoid no-op timer overhead per connection
- Add `console.warn` to the empty `.catch()` on `cleanupStaleContextFiles()` so failures are visible
- Add `error` field to `checkTtydAlive` return type so UI can distinguish "not alive" from "health check failed"

## Test plan

- [x] `pnpm turbo typecheck` passes
- [x] `pnpm turbo build` passes (lint warnings are pre-existing, no new ones)
- [x] Existing `checkTtydAlive` caller (`OpenTerminalButton.tsx`) is backward-compatible — destructures only `{ alive }`
- [x] PR review toolkit run (code-reviewer, silent-failure-hunter, code-simplifier) — all critical/important findings addressed