### PR TITLE
fix: retain filters when returning from settings, add desktop New Issue link

### DIFF
--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -22,11 +22,20 @@ function SectionSkeleton() {
   return <div className={styles.sectionSkeleton} />;
 }
 
-export default async function SettingsPage() {
+export default async function SettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ from?: string }>;
+}) {
+  const { from } = await searchParams;
+  // Validate the return URL: only allow relative paths starting with "/"
+  // to prevent open-redirect attacks via absolute or protocol-relative URLs.
+  const returnHref = from && from.startsWith("/") && !from.startsWith("//") ? from : "/";
+
   if (!dbExists()) {
     return (
       <>
-        <PageHeader title="Settings" breadcrumb={<Link href="/">← dashboard</Link>} />
+        <PageHeader title="Settings" breadcrumb={<Link href={returnHref}>← dashboard</Link>} />
         <div className={styles.content}>
           <p style={{ color: "var(--text-secondary)" }}>
             Run <code>issuectl init</code> to get started.
@@ -46,7 +55,7 @@ export default async function SettingsPage() {
 
   return (
     <PullToRefreshWrapper>
-      <PageHeader title="Settings" breadcrumb={<Link href="/">← dashboard</Link>} />
+      <PageHeader title="Settings" breadcrumb={<Link href={returnHref}>← dashboard</Link>} />
       <div className={styles.content}>
         <section className={styles.section}>
           <div className={styles.sectionTitle}>Tracked Repositories</div>

--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -42,6 +42,7 @@ type Props = {
   activeSection: Section;
   sectionHref: (section: Section) => string;
   sectionCounts: Record<Section, number | null> | null;
+  settingsHref: string;
   onCreateDraft: () => void;
 };
 
@@ -64,6 +65,7 @@ export function FiltersSheet({
   activeSection,
   sectionHref,
   sectionCounts,
+  settingsHref,
   onCreateDraft,
 }: Props) {
   return (
@@ -260,7 +262,7 @@ export function FiltersSheet({
           </span>
         </Link>
 
-        <Link href="/settings" className={styles.commandLink} onClick={onClose}>
+        <Link href={settingsHref} className={styles.commandLink} onClick={onClose}>
           <span className={styles.commandLinkIcon}>
             <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="9" cy="9" r="3" />

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -119,6 +119,14 @@ export function List({
       sort: activeTab === "issues" ? activeSort : null,
     });
 
+  // Build the canonical URL for the current dashboard view and pass it as
+  // `from` to settings, so the settings breadcrumb returns to this filtered view.
+  const currentHref = chipHref(activeRepo);
+  const settingsHref =
+    currentHref === "/"
+      ? "/settings"
+      : `/settings?from=${encodeURIComponent(currentHref)}`;
+
   const sectionHref = (section: Section) =>
     buildHref({ repo: activeRepo, section, sort: activeSort });
 
@@ -186,9 +194,11 @@ export function List({
 
         <CacheAge cachedAt={cachedAt ?? null} />
         <nav className={styles.desktopNav}>
+          <Link href="/new" className={styles.desktopNavLink}>New Issue</Link>
+          <span className={styles.desktopNavSep}>·</span>
           <Link href="/parse" className={styles.desktopNavLink}>Quick Create</Link>
           <span className={styles.desktopNavSep}>·</span>
-          <Link href="/settings" className={styles.desktopNavLink}>Settings</Link>
+          <Link href={settingsHref} className={styles.desktopNavLink}>Settings</Link>
         </nav>
 
         {/* Mobile: single menu button to open command sheet */}
@@ -404,6 +414,7 @@ export function List({
         activeSection={activeSection}
         sectionHref={sectionHref}
         sectionCounts={sectionCounts}
+        settingsHref={settingsHref}
         onCreateDraft={() => {
           setFiltersOpen(false);
           // Delay opening CreateDraftSheet until the FiltersSheet exit


### PR DESCRIPTION
## Summary
- **Filter retention:** Settings navigation now carries the current filter state as a `from` query parameter. The "← dashboard" breadcrumb on the settings page reads this parameter and links back to the exact filtered view instead of always returning to `/`.
- **Desktop New Issue link:** Added a "New Issue" link to the desktop nav bar (linking to `/new`) for direct access to the full issue creation form.
- **Open-redirect protection:** The `from` parameter is validated to only accept relative paths (rejects absolute URLs, protocol-relative `//`, etc.).

## Test plan
- [ ] Navigate to the issue list, apply filters (repo, section, sort), then click Settings — verify the "← dashboard" breadcrumb returns to the filtered view
- [ ] Verify the same works from the mobile command sheet Settings link
- [ ] Verify that navigating to Settings from an unfiltered view produces a clean `/settings` URL (no `?from=%2F`)
- [ ] Click "New Issue" in the desktop nav — verify it navigates to `/new`
- [ ] Manually test open-redirect: visit `/settings?from=//evil.com` — verify breadcrumb links to `/` not `//evil.com`