### PR TITLE
fix: image upload via Contents API + restore desktop scroll and New Issue button

### DIFF
--- a/docs/superpowers/plans/2026-04-23-fix-image-upload.md
+++ b/docs/superpowers/plans/2026-04-23-fix-image-upload.md
@@ -1,0 +1,569 @@
+# Fix Image Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the non-functional `uploads.github.com` endpoint with the GitHub Contents API so image uploads work with PAT/OAuth tokens.
+
+**Architecture:** The only production code change is in `packages/core/src/github/uploads.ts` — swap the `fetch` target from the undocumented multipart endpoint to the standard GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`). The function signature, validation logic, exports, and all callers remain unchanged. CSP and image config in `packages/web/next.config.ts` are widened to allow GitHub image domains.
+
+**Tech Stack:** Node.js `fetch`, GitHub REST API (Contents), base64 encoding, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-23-fix-image-upload-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/core/src/github/uploads.ts` | Modify | Replace upload implementation (Contents API), add `sanitizeFilename` helper |
+| `packages/core/src/github/uploads.test.ts` | Modify | Update mocks/assertions for Contents API |
+| `packages/web/next.config.ts` | Modify | Widen CSP `img-src`, add `images.remotePatterns` entries |
+| `packages/web/e2e/audit-verification.spec.ts` | Modify | Update CSP `img-src` assertion string |
+
+No new files. No changes to `packages/core/src/index.ts` (exports stay the same). No changes to `packages/web/lib/actions/uploads.ts` or its tests.
+
+---
+
+### Task 1: Add `sanitizeFilename` helper with tests
+
+**Files:**
+- Modify: `packages/core/src/github/uploads.ts`
+- Modify: `packages/core/src/github/uploads.test.ts`
+
+- [ ] **Step 1: Write failing tests for `sanitizeFilename`**
+
+Add this `describe` block at the bottom of `packages/core/src/github/uploads.test.ts`, after the existing `MAX_IMAGE_SIZE` describe:
+
+```ts
+describe("sanitizeFilename", () => {
+  it("passes through simple alphanumeric names", () => {
+    expect(sanitizeFilename("photo.png")).toBe("photo.png");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(sanitizeFilename("my photo.png")).toBe("my-photo.png");
+  });
+
+  it("strips characters that are not alphanumeric, hyphens, dots, or underscores", () => {
+    expect(sanitizeFilename("image (1).png")).toBe("image-1.png");
+  });
+
+  it("handles filenames with unicode characters", () => {
+    expect(sanitizeFilename("café_résumé.jpg")).toBe("caf_rsum.jpg");
+  });
+
+  it("returns 'image' when all characters are stripped", () => {
+    expect(sanitizeFilename("///")).toBe("image");
+  });
+
+  it("collapses multiple consecutive hyphens", () => {
+    expect(sanitizeFilename("a   b---c.png")).toBe("a-b-c.png");
+  });
+});
+```
+
+Update the import at the top of the test file to include `sanitizeFilename`:
+
+```ts
+import { uploadImageToGitHub, ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, sanitizeFilename } from "./uploads.js";
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @issuectl/core test -- --run uploads`
+Expected: FAIL — `sanitizeFilename` is not exported from `./uploads.js`
+
+- [ ] **Step 3: Implement `sanitizeFilename` and export it**
+
+Add this function to `packages/core/src/github/uploads.ts`, after the `MAX_IMAGE_SIZE` constant (before `uploadImageToGitHub`):
+
+```ts
+/**
+ * Sanitize a filename for use in a GitHub repo path.
+ * Keeps alphanumeric, hyphens, dots, and underscores.
+ */
+export function sanitizeFilename(name: string): string {
+  const sanitized = name
+    .replace(/\s+/g, "-")
+    .replace(/[^a-zA-Z0-9._-]/g, "")
+    .replace(/-{2,}/g, "-");
+  return sanitized || "image";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @issuectl/core test -- --run uploads`
+Expected: All `sanitizeFilename` tests PASS. Existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/github/uploads.ts packages/core/src/github/uploads.test.ts
+git commit -m "feat(core): add sanitizeFilename helper for upload paths"
+```
+
+---
+
+### Task 2: Replace `uploadImageToGitHub` implementation
+
+**Files:**
+- Modify: `packages/core/src/github/uploads.ts`
+- Modify: `packages/core/src/github/uploads.test.ts`
+
+- [ ] **Step 1: Rewrite the upload tests for the Contents API**
+
+Replace the test helpers `makeOkResponse` and `makeErrorResponse` and all tests inside `describe("uploadImageToGitHub", ...)` in `packages/core/src/github/uploads.test.ts`. Keep the `beforeEach`/`afterEach` that stubs `fetch`. Keep the `ALLOWED_IMAGE_TYPES` and `MAX_IMAGE_SIZE` describe blocks unchanged. Keep the new `sanitizeFilename` describe block from Task 1.
+
+Replace the helpers with:
+
+```ts
+function makeContentsApiOkResponse(downloadUrl: string) {
+  return {
+    ok: true,
+    status: 201,
+    statusText: "Created",
+    json: vi.fn().mockResolvedValue({
+      content: {
+        name: "test.png",
+        path: ".github/issuectl/uploads/test.png",
+        download_url: downloadUrl,
+      },
+      commit: { sha: "abc123def456" },
+    }),
+    text: vi.fn().mockResolvedValue(""),
+  };
+}
+
+function makeErrorResponse(status: number, text = "") {
+  return {
+    ok: false,
+    status,
+    statusText: "Error",
+    json: vi.fn().mockResolvedValue({}),
+    text: vi.fn().mockResolvedValue(text),
+  };
+}
+```
+
+Replace all tests inside `describe("uploadImageToGitHub", ...)` with:
+
+```ts
+describe("uploadImageToGitHub", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Happy path — Contents API
+  // -----------------------------------------------------------------------
+  it("returns { url, fileName } from Contents API download_url", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/test-owner/test-repo/main/.github/issuectl/uploads/test.png") as unknown as Response,
+    );
+
+    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+
+    expect(result.url).toBe(
+      "https://raw.githubusercontent.com/test-owner/test-repo/main/.github/issuectl/uploads/test.png",
+    );
+    expect(result.fileName).toBe("test.png");
+  });
+
+  it("sends a PUT to the Contents API with base64-encoded content", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
+    );
+
+    await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(
+      /^https:\/\/api\.github\.com\/repos\/test-owner\/test-repo\/contents\/\.github\/issuectl\/uploads\/\d+-[a-z0-9]+-test\.png$/,
+    );
+    expect(init.method).toBe("PUT");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      `Bearer ${TOKEN}`,
+    );
+    expect((init.headers as Record<string, string>)["Accept"]).toBe(
+      "application/vnd.github+json",
+    );
+
+    const body = JSON.parse(init.body as string) as { message: string; content: string };
+    expect(body.message).toMatch(/^chore\(issuectl\): upload image test\.png$/);
+    expect(body.content).toBe(Buffer.from(VALID_FILE.data).toString("base64"));
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Invalid file type
+  // -----------------------------------------------------------------------
+  it("throws with 'Unsupported image type' for image/svg+xml", async () => {
+    const svgFile = { ...VALID_FILE, type: "image/svg+xml" };
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, svgFile),
+    ).rejects.toThrow("Unsupported image type");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. File too large
+  // -----------------------------------------------------------------------
+  it("throws with 'Image too large' when data exceeds MAX_IMAGE_SIZE", async () => {
+    const bigFile = { ...VALID_FILE, data: Buffer.alloc(MAX_IMAGE_SIZE + 1, 0) };
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, bigFile),
+    ).rejects.toThrow("Image too large");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw when data is exactly MAX_IMAGE_SIZE bytes", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
+    );
+    const atLimitFile = {
+      ...VALID_FILE,
+      data: Buffer.alloc(MAX_IMAGE_SIZE, 0),
+    };
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, atLimitFile),
+    ).resolves.toBeDefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. HTTP errors
+  // -----------------------------------------------------------------------
+  it("throws with the HTTP status when response is not ok (403)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      makeErrorResponse(403, "Forbidden") as unknown as Response,
+    );
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("403");
+  });
+
+  it("throws when response status is 500", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      makeErrorResponse(500, "Internal Server Error") as unknown as Response,
+    );
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("GitHub image upload failed");
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Missing download_url in response
+  // -----------------------------------------------------------------------
+  it("throws when response has no content.download_url", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({ content: {} }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("returned no URL");
+  });
+
+  it("throws when response has no content field at all", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("returned no URL");
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Malformed JSON response
+  // -----------------------------------------------------------------------
+  it("throws a descriptive error when response.json() throws", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+      text: vi.fn().mockResolvedValue("<html>not json</html>"),
+    } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("invalid JSON");
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Filename sanitization in the request URL
+  // -----------------------------------------------------------------------
+  it("sanitizes the filename in the upload path", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
+    );
+
+    const fileWithSpaces = { ...VALID_FILE, name: "my photo (1).png" };
+    await uploadImageToGitHub(TOKEN, OWNER, REPO, fileWithSpaces);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("my-photo-1.png");
+    expect(url).not.toContain(" ");
+    expect(url).not.toContain("(");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/core test -- --run uploads`
+Expected: FAIL — tests reference the new response structure but `uploadImageToGitHub` still uses the old endpoint.
+
+- [ ] **Step 3: Replace the `uploadImageToGitHub` implementation**
+
+Replace the entire `uploadImageToGitHub` function body in `packages/core/src/github/uploads.ts`. Keep the function signature, keep the validation at the top. Replace everything from the `const formData = new FormData()` line to the end of the function:
+
+```ts
+export async function uploadImageToGitHub(
+  token: string,
+  owner: string,
+  repo: string,
+  file: {
+    name: string;
+    type: string;
+    data: Buffer | Uint8Array;
+  },
+): Promise<UploadResult> {
+  if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+    throw new Error(
+      `Unsupported image type: ${file.type}. Allowed: PNG, JPG, GIF, WEBP.`,
+    );
+  }
+
+  if (file.data.byteLength > MAX_IMAGE_SIZE) {
+    const sizeMB = (file.data.byteLength / 1024 / 1024).toFixed(1);
+    throw new Error(
+      `Image too large: ${sizeMB} MB. Maximum is 10 MB.`,
+    );
+  }
+
+  const sanitized = sanitizeFilename(file.name);
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 8);
+  const path = `.github/issuectl/uploads/${timestamp}-${random}-${sanitized}`;
+  const content = Buffer.from(file.data).toString("base64");
+
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: `chore(issuectl): upload image ${sanitized}`,
+        content,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `GitHub image upload failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+
+  let result: { content?: { download_url?: string } };
+  try {
+    result = (await response.json()) as typeof result;
+  } catch {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `GitHub returned invalid JSON after upload (status ${response.status}). Body: ${text.slice(0, 200)}`,
+    );
+  }
+
+  const url = result.content?.download_url;
+  if (!url) {
+    throw new Error(
+      "GitHub image upload succeeded but returned no URL. Response: " +
+        JSON.stringify(result).slice(0, 200),
+    );
+  }
+
+  return { url, fileName: file.name };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/core test -- --run uploads`
+Expected: ALL tests PASS (sanitizeFilename + uploadImageToGitHub + ALLOWED_IMAGE_TYPES + MAX_IMAGE_SIZE)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/github/uploads.ts packages/core/src/github/uploads.test.ts
+git commit -m "fix(core): replace broken uploads.github.com with Contents API
+
+The undocumented uploads.github.com endpoint rejects PAT/OAuth
+tokens with 422 Bad Size. Switch to the standard GitHub Contents
+API which works with any token type."
+```
+
+---
+
+### Task 3: Widen CSP and image config
+
+**Files:**
+- Modify: `packages/web/next.config.ts:79-82,121,139`
+- Modify: `packages/web/e2e/audit-verification.spec.ts:185`
+
+- [ ] **Step 1: Update `images.remotePatterns` in `next.config.ts`**
+
+In `packages/web/next.config.ts`, find the `images` block (around line 79):
+
+```ts
+  images: {
+    remotePatterns: [
+      { hostname: "avatars.githubusercontent.com" },
+    ],
+  },
+```
+
+Replace with:
+
+```ts
+  images: {
+    remotePatterns: [
+      { hostname: "avatars.githubusercontent.com" },
+      { hostname: "raw.githubusercontent.com" },
+      { hostname: "user-images.githubusercontent.com" },
+      { hostname: "github.com" },
+    ],
+  },
+```
+
+- [ ] **Step 2: Update the main CSP `img-src` directive**
+
+In `packages/web/next.config.ts`, find the main `img-src` line (around line 121):
+
+```ts
+      "img-src 'self' data: https://avatars.githubusercontent.com",
+```
+
+Replace with:
+
+```ts
+      "img-src 'self' data: https://avatars.githubusercontent.com https://raw.githubusercontent.com https://user-images.githubusercontent.com https://github.com",
+```
+
+- [ ] **Step 3: Update the terminal CSP `img-src` directive**
+
+In `packages/web/next.config.ts`, find the terminal `img-src` line (around line 139):
+
+```ts
+      "img-src 'self' data:",
+```
+
+No change needed — terminal proxy routes don't render user-uploaded images.
+
+- [ ] **Step 4: Update the e2e CSP assertion**
+
+In `packages/web/e2e/audit-verification.spec.ts`, find the `REQUIRED_DIRECTIVES` array (around line 185):
+
+```ts
+    "img-src 'self' data: https://avatars.githubusercontent.com",
+```
+
+Replace with:
+
+```ts
+    "img-src 'self' data: https://avatars.githubusercontent.com https://raw.githubusercontent.com https://user-images.githubusercontent.com https://github.com",
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: PASS with no type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/web/next.config.ts packages/web/e2e/audit-verification.spec.ts
+git commit -m "fix(web): widen CSP img-src for GitHub image domains
+
+Add raw.githubusercontent.com (Contents API uploads),
+user-images.githubusercontent.com (GitHub web UI uploads),
+and github.com (newer CDN format) to both CSP img-src and
+images.remotePatterns."
+```
+
+---
+
+### Task 4: Verify build and run server action tests
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run server action tests (should pass without changes)**
+
+Run: `pnpm --filter @issuectl/web test -- --run uploads`
+Expected: PASS — these tests mock `uploadImageToGitHub` at the module level, so the implementation change doesn't affect them.
+
+- [ ] **Step 2: Run full build**
+
+Run: `pnpm turbo build`
+Expected: PASS — all packages build successfully.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `pnpm turbo test`
+Expected: All core and web unit tests PASS.
+
+- [ ] **Step 4: Manual verification (optional)**
+
+To verify the upload works end-to-end against a real GitHub repo:
+
+1. Start the dev server: `pnpm turbo dev`
+2. Open the dashboard in a browser
+3. Navigate to an issue detail page
+4. Click the "attach" button in the comment composer
+5. Select a PNG or JPEG image
+6. Verify the placeholder text appears, then is replaced with `![filename](https://raw.githubusercontent.com/...)`
+7. Post the comment and verify the image renders in the dashboard
+8. Check the target repo on GitHub — a commit should exist at `.github/issuectl/uploads/{filename}` with the image
+
+---
+
+## Summary of Changes
+
+| Change | Why |
+|---|---|
+| `sanitizeFilename` helper | Generate safe file paths for the Contents API |
+| Replace `fetch` to `uploads.github.com` with `PUT` to `api.github.com/repos/.../contents/...` | The old endpoint rejects PAT/OAuth tokens |
+| Base64-encode file instead of multipart form | Contents API requires JSON body with base64 content |
+| Parse `content.download_url` instead of `href`/`asset.href` | Different response shape from Contents API |
+| Widen CSP `img-src` | Allow GitHub image domains in the dashboard |
+| Add `images.remotePatterns` entries | Allow `next/image` with GitHub image domains |

--- a/docs/superpowers/specs/2026-04-23-fix-image-upload-design.md
+++ b/docs/superpowers/specs/2026-04-23-fix-image-upload-design.md
@@ -1,0 +1,119 @@
+# Fix Image Upload — Replace Broken GitHub Endpoint
+
+Replace the non-functional `uploads.github.com` endpoint with the GitHub Contents API for image uploads.
+
+## Problem
+
+The `uploadImageToGitHub` function in `packages/core/src/github/uploads.ts` uses GitHub's undocumented `uploads.github.com/repos/{owner}/{repo}/issues/uploads` endpoint. This endpoint is designed for GitHub.com's web frontend and authenticates via browser session cookies, not API tokens. Every upload attempt with a PAT or OAuth token (from `gh auth token`) fails with `422 Bad Size` — a misleading error that occurs before the endpoint even inspects the file, because it rejects the auth mechanism.
+
+This was confirmed via both `curl` and Node.js `fetch` with files of various sizes (69 bytes to 27 KB). The error is consistent regardless of file size, format, or additional form fields.
+
+PR #202 raised the Next.js `bodySizeLimit` to 10 MB, which fixed the Server Action layer but did not address the underlying GitHub endpoint failure. The upload has never worked in production.
+
+## Solution
+
+Replace the upload mechanism with the **GitHub Contents API** (`PUT /repos/{owner}/{repo}/contents/{path}`), which is documented, stable, and works with any GitHub token type.
+
+Additionally, widen the CSP `img-src` directive and `images.remotePatterns` config to allow all GitHub image-hosting domains so that images render correctly in the dashboard.
+
+## Design
+
+### Upload flow (unchanged from caller's perspective)
+
+```
+User action (drag/drop, paste, attach click)
+  → useImageUpload() hook validates file type/size       [unchanged]
+  → Insert placeholder: ![Uploading image…]()            [unchanged]
+  → Call uploadImage server action                        [unchanged]
+  → Server action calls uploadImageToGitHub() in core     [unchanged]
+  → GitHub Contents API creates file in repo              [NEW]
+  → Return raw.githubusercontent.com URL                  [NEW]
+  → Replace placeholder: ![image](https://raw.git...)    [unchanged]
+```
+
+### Core function changes: `uploadImageToGitHub`
+
+**File:** `packages/core/src/github/uploads.ts`
+
+The function signature stays identical:
+
+```ts
+export async function uploadImageToGitHub(
+  token: string,
+  owner: string,
+  repo: string,
+  file: { name: string; type: string; data: Buffer | Uint8Array },
+): Promise<UploadResult>
+```
+
+**Internal changes:**
+
+1. **Endpoint:** `PUT https://api.github.com/repos/{owner}/{repo}/contents/{path}` instead of `POST https://uploads.github.com/repos/{owner}/{repo}/issues/uploads`
+2. **Request body:** JSON with base64-encoded content instead of multipart form data
+3. **Upload path:** `.github/issuectl/uploads/{timestamp}-{random6}-{sanitized_filename}` — the timestamp and random suffix prevent collisions
+4. **Commit message:** `chore(issuectl): upload image {filename}`
+5. **Response parsing:** Extract `content.download_url` from the Contents API response instead of `href` / `asset.href` from the old endpoint
+6. **Filename sanitization:** Strip characters that are invalid in file paths (keep alphanumeric, hyphens, dots, underscores)
+
+**Validation** (type checking, size checking) remains unchanged at the top of the function.
+
+### CSP and image config changes
+
+**File:** `packages/web/next.config.ts`
+
+**`img-src` directive** — add three GitHub image domains:
+
+```
+img-src 'self' data: https://avatars.githubusercontent.com https://raw.githubusercontent.com https://user-images.githubusercontent.com https://github.com
+```
+
+- `raw.githubusercontent.com` — serves images uploaded via the Contents API (the new upload path)
+- `user-images.githubusercontent.com` — serves images uploaded via GitHub.com's web UI (existing comments)
+- `github.com` — serves images at `github.com/user-attachments/assets/...` URLs (newer GitHub CDN format)
+
+**`images.remotePatterns`** — add matching entries so any future use of `next/image` with these domains works without additional config changes.
+
+### Test changes
+
+**File:** `packages/core/src/github/uploads.test.ts`
+
+- Mock `fetch` for the Contents API `PUT` instead of the old multipart `POST`
+- Verify request URL follows the pattern `https://api.github.com/repos/{owner}/{repo}/contents/.github/issuectl/uploads/{filename}`
+- Verify request body contains `message` and base64-encoded `content` fields
+- Verify response parsing extracts `content.download_url`
+- Verify filename sanitization (strips unsafe characters)
+- Keep all existing validation tests (type check, size check) — they test code that doesn't change
+
+**File:** `packages/web/lib/actions/uploads.test.ts` — no changes needed. This file mocks `uploadImageToGitHub` at the module level, so the Server Action tests are unaffected.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `packages/core/src/github/uploads.ts` | Replace upload implementation (Contents API) |
+| `packages/core/src/github/uploads.test.ts` | Update mocks/assertions for new API |
+| `packages/web/next.config.ts` | Widen CSP `img-src`, add `images.remotePatterns` |
+| `packages/web/e2e/audit-verification.spec.ts` | Update CSP assertion string if it exists |
+
+## What doesn't change
+
+- `useImageUpload` hook
+- `CommentComposer` and `NewIssuePage` components
+- Server Action (`packages/web/lib/actions/uploads.ts`)
+- `ALLOWED_IMAGE_TYPES`, `MAX_IMAGE_SIZE` constants
+- `UploadResult` type
+- `bodySizeLimit: "10mb"` in next.config (still needed for the Server Action)
+- Function signature of `uploadImageToGitHub`
+
+## Trade-offs
+
+**Commits per upload:** Each image upload creates a commit in the target repo at `.github/issuectl/uploads/`. This is the primary trade-off vs. the old CDN approach. Mitigated by: the path is in a dotfile directory most users never browse, and the commit message clearly identifies it as auto-generated.
+
+**URL permanence:** `raw.githubusercontent.com` URLs are permanent as long as the file exists in the repo. If someone deletes the file or force-pushes over the commit, the image breaks. This is acceptable for a developer tool.
+
+## Out of scope
+
+- Local image caching / serving via Next.js API routes
+- Upload to an orphan branch (extra complexity for marginal benefit)
+- Migration of existing broken image references
+- Image compression or resizing before upload

--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { uploadImageToGitHub, ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./uploads.js";
+import { uploadImageToGitHub, ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE, sanitizeFilename } from "./uploads.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -242,5 +242,31 @@ describe("ALLOWED_IMAGE_TYPES", () => {
 describe("MAX_IMAGE_SIZE", () => {
   it("is exactly 10 MB", () => {
     expect(MAX_IMAGE_SIZE).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("passes through simple alphanumeric names", () => {
+    expect(sanitizeFilename("photo.png")).toBe("photo.png");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(sanitizeFilename("my photo.png")).toBe("my-photo.png");
+  });
+
+  it("strips characters that are not alphanumeric, hyphens, dots, or underscores", () => {
+    expect(sanitizeFilename("image (1).png")).toBe("image-1.png");
+  });
+
+  it("handles filenames with unicode characters", () => {
+    expect(sanitizeFilename("café_résumé.jpg")).toBe("caf_rsum.jpg");
+  });
+
+  it("returns 'image' when all characters are stripped", () => {
+    expect(sanitizeFilename("///")).toBe("image");
+  });
+
+  it("collapses multiple consecutive hyphens", () => {
+    expect(sanitizeFilename("a   b---c.png")).toBe("a-b-c.png");
   });
 });

--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -9,17 +9,19 @@ function makeSmallBuffer(bytes = 100): Buffer {
   return Buffer.alloc(bytes, 0);
 }
 
-/** Buffer that is exactly 1 byte over the limit. */
-function makeOversizedBuffer(): Buffer {
-  return Buffer.alloc(MAX_IMAGE_SIZE + 1, 0);
-}
-
-function makeOkResponse(body: unknown) {
+function makeContentsApiOkResponse(downloadUrl: string) {
   return {
     ok: true,
-    status: 200,
-    statusText: "OK",
-    json: vi.fn().mockResolvedValue(body),
+    status: 201,
+    statusText: "Created",
+    json: vi.fn().mockResolvedValue({
+      content: {
+        name: "test.png",
+        path: ".github/issuectl/uploads/test.png",
+        download_url: downloadUrl,
+      },
+      commit: { sha: "abc123def456" },
+    }),
     text: vi.fn().mockResolvedValue(""),
   };
 }
@@ -57,51 +59,48 @@ describe("uploadImageToGitHub", () => {
     vi.unstubAllGlobals();
   });
 
-  // -------------------------------------------------------------------------
-  // 1. Happy path — top-level href
-  // -------------------------------------------------------------------------
-  it("returns { url, fileName } when response has top-level href", async () => {
+  // 1. Happy path — Contents API
+  it("returns { url, fileName } from Contents API download_url", async () => {
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockResolvedValue(
-      makeOkResponse({ href: "https://cdn.example.com/img.png" }) as unknown as Response,
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/test-owner/test-repo/main/.github/issuectl/uploads/test.png") as unknown as Response,
     );
 
     const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
 
-    expect(result).toEqual({
-      url: "https://cdn.example.com/img.png",
-      fileName: "test.png",
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(
-      `https://uploads.github.com/repos/${OWNER}/${REPO}/issues/uploads`,
+    expect(result.url).toBe(
+      "https://raw.githubusercontent.com/test-owner/test-repo/main/.github/issuectl/uploads/test.png",
     );
-    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
-      `Bearer ${TOKEN}`,
-    );
-    expect(init.method).toBe("POST");
-  });
-
-  // -------------------------------------------------------------------------
-  // 2. Alternate response shape — nested asset.href
-  // -------------------------------------------------------------------------
-  it("parses the nested asset.href shape", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue(
-      makeOkResponse({
-        asset: { href: "https://cdn.example.com/img.png", name: "img.png" },
-      }) as unknown as Response,
-    );
-
-    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
-
-    expect(result.url).toBe("https://cdn.example.com/img.png");
     expect(result.fileName).toBe("test.png");
   });
 
-  // -------------------------------------------------------------------------
-  // 3. Invalid file type
-  // -------------------------------------------------------------------------
+  it("sends a PUT to the Contents API with base64-encoded content", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
+    );
+
+    await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(
+      /^https:\/\/api\.github\.com\/repos\/test-owner\/test-repo\/contents\/\.github\/issuectl\/uploads\/\d+-[a-z0-9]+-test\.png$/,
+    );
+    expect(init.method).toBe("PUT");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      `Bearer ${TOKEN}`,
+    );
+    expect((init.headers as Record<string, string>)["Accept"]).toBe(
+      "application/vnd.github+json",
+    );
+
+    const body = JSON.parse(init.body as string) as { message: string; content: string };
+    expect(body.message).toMatch(/^chore\(issuectl\): upload image test\.png$/);
+    expect(body.content).toBe(Buffer.from(VALID_FILE.data).toString("base64"));
+  });
+
+  // 2. Invalid file type
   it("throws with 'Unsupported image type' for image/svg+xml", async () => {
     const svgFile = { ...VALID_FILE, type: "image/svg+xml" };
 
@@ -109,21 +108,12 @@ describe("uploadImageToGitHub", () => {
       uploadImageToGitHub(TOKEN, OWNER, REPO, svgFile),
     ).rejects.toThrow("Unsupported image type");
 
-    // No network call should have been made.
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it("throws for every type not in ALLOWED_IMAGE_TYPES", async () => {
-    expect(ALLOWED_IMAGE_TYPES.has("image/svg+xml")).toBe(false);
-    expect(ALLOWED_IMAGE_TYPES.has("image/bmp")).toBe(false);
-    expect(ALLOWED_IMAGE_TYPES.has("application/pdf")).toBe(false);
-  });
-
-  // -------------------------------------------------------------------------
-  // 4. File too large
-  // -------------------------------------------------------------------------
+  // 3. File too large
   it("throws with 'Image too large' when data exceeds MAX_IMAGE_SIZE", async () => {
-    const bigFile = { ...VALID_FILE, data: makeOversizedBuffer() };
+    const bigFile = { ...VALID_FILE, data: Buffer.alloc(MAX_IMAGE_SIZE + 1, 0) };
 
     await expect(
       uploadImageToGitHub(TOKEN, OWNER, REPO, bigFile),
@@ -134,22 +124,19 @@ describe("uploadImageToGitHub", () => {
 
   it("does NOT throw when data is exactly MAX_IMAGE_SIZE bytes", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(
-      makeOkResponse({ href: "https://cdn.example.com/img.png" }) as unknown as Response,
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
     );
     const atLimitFile = {
       ...VALID_FILE,
       data: Buffer.alloc(MAX_IMAGE_SIZE, 0),
     };
 
-    // Should not throw
     await expect(
       uploadImageToGitHub(TOKEN, OWNER, REPO, atLimitFile),
     ).resolves.toBeDefined();
   });
 
-  // -------------------------------------------------------------------------
-  // 5. HTTP error
-  // -------------------------------------------------------------------------
+  // 4. HTTP errors
   it("throws with the HTTP status when response is not ok (403)", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(
       makeErrorResponse(403, "Forbidden") as unknown as Response,
@@ -170,37 +157,41 @@ describe("uploadImageToGitHub", () => {
     ).rejects.toThrow("GitHub image upload failed");
   });
 
-  // -------------------------------------------------------------------------
-  // 6. Missing URL in response
-  // -------------------------------------------------------------------------
-  it("throws when the response body has no url (empty object)", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue(
-      makeOkResponse({}) as unknown as Response,
-    );
+  // 5. Missing download_url in response
+  it("throws when response has no content.download_url", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({ content: {} }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
 
     await expect(
       uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
     ).rejects.toThrow("returned no URL");
   });
 
-  it("throws when the response body has asset but no href inside it", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue(
-      makeOkResponse({ asset: { name: "img.png" } }) as unknown as Response,
-    );
+  it("throws when response has no content field at all", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
 
     await expect(
       uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
     ).rejects.toThrow("returned no URL");
   });
 
-  // -------------------------------------------------------------------------
-  // 7. Malformed JSON response
-  // -------------------------------------------------------------------------
+  // 6. Malformed JSON response
   it("throws a descriptive error when response.json() throws", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue({
       ok: true,
-      status: 200,
-      statusText: "OK",
+      status: 201,
+      statusText: "Created",
       json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
       text: vi.fn().mockResolvedValue("<html>not json</html>"),
     } as unknown as Response);
@@ -210,18 +201,20 @@ describe("uploadImageToGitHub", () => {
     ).rejects.toThrow("invalid JSON");
   });
 
-  it("includes a snippet of the body in the malformed-JSON error", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      json: vi.fn().mockRejectedValue(new SyntaxError("bad json")),
-      text: vi.fn().mockResolvedValue("body text here"),
-    } as unknown as Response);
+  // 7. Filename sanitization in the request URL
+  it("sanitizes the filename in the upload path", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      makeContentsApiOkResponse("https://raw.githubusercontent.com/o/r/main/f.png") as unknown as Response,
+    );
 
-    await expect(
-      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
-    ).rejects.toThrow("body text here");
+    const fileWithSpaces = { ...VALID_FILE, name: "my photo (1).png" };
+    await uploadImageToGitHub(TOKEN, OWNER, REPO, fileWithSpaces);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("my-photo-1.png");
+    expect(url).not.toContain(" ");
+    expect(url).not.toContain("(");
   });
 });
 

--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -94,6 +94,9 @@ describe("uploadImageToGitHub", () => {
     expect((init.headers as Record<string, string>)["Accept"]).toBe(
       "application/vnd.github+json",
     );
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
 
     const body = JSON.parse(init.body as string) as { message: string; content: string };
     expect(body.message).toMatch(/^chore\(issuectl\): upload image test\.png$/);

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -24,13 +24,6 @@ export type UploadResult = {
   fileName: string;
 };
 
-/**
- * Upload an image to GitHub's CDN via the undocumented issue-uploads endpoint.
- *
- * This is the same endpoint GitHub.com's web UI uses when you paste or drag
- * an image into an issue/PR textarea. While undocumented, this endpoint has
- * been stable for years and is widely relied on by third-party tools.
- */
 export async function uploadImageToGitHub(
   token: string,
   owner: string,
@@ -54,22 +47,25 @@ export async function uploadImageToGitHub(
     );
   }
 
-  const formData = new FormData();
-  formData.append(
-    "file",
-    new Blob([file.data], { type: file.type }),
-    file.name,
-  );
+  const sanitized = sanitizeFilename(file.name);
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 8);
+  const path = `.github/issuectl/uploads/${timestamp}-${random}-${sanitized}`;
+  const content = Buffer.from(file.data).toString("base64");
 
   const response = await fetch(
-    `https://uploads.github.com/repos/${owner}/${repo}/issues/uploads`,
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
     {
-      method: "POST",
+      method: "PUT",
       headers: {
         Authorization: `Bearer ${token}`,
-        Accept: "application/json",
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
       },
-      body: formData,
+      body: JSON.stringify({
+        message: `chore(issuectl): upload image ${sanitized}`,
+        content,
+      }),
     },
   );
 
@@ -80,7 +76,7 @@ export async function uploadImageToGitHub(
     );
   }
 
-  let result: { href?: string; asset?: { href?: string; name?: string } };
+  let result: { content?: { download_url?: string } };
   try {
     result = (await response.json()) as typeof result;
   } catch {
@@ -90,7 +86,7 @@ export async function uploadImageToGitHub(
     );
   }
 
-  const url = result.href ?? result.asset?.href;
+  const url = result.content?.download_url;
   if (!url) {
     throw new Error(
       "GitHub image upload succeeded but returned no URL. Response: " +

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -79,10 +79,10 @@ export async function uploadImageToGitHub(
   let result: { content?: { download_url?: string } };
   try {
     result = (await response.json()) as typeof result;
-  } catch {
-    const text = await response.text().catch(() => "");
+  } catch (err) {
     throw new Error(
-      `GitHub returned invalid JSON after upload (status ${response.status}). Body: ${text.slice(0, 200)}`,
+      `GitHub returned invalid JSON after upload (status ${response.status}): ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -7,6 +7,18 @@ export const ALLOWED_IMAGE_TYPES = new Set([
 
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
 
+/**
+ * Sanitize a filename for use in a GitHub repo path.
+ * Keeps alphanumeric, hyphens, dots, and underscores.
+ */
+export function sanitizeFilename(name: string): string {
+  const sanitized = name
+    .replace(/\s+/g, "-")
+    .replace(/[^a-zA-Z0-9._-]/g, "")
+    .replace(/-{2,}/g, "-");
+  return sanitized || "image";
+}
+
 export type UploadResult = {
   url: string;
   fileName: string;

--- a/packages/web/components/list/List.module.css
+++ b/packages/web/components/list/List.module.css
@@ -179,6 +179,32 @@
   align-self: center;
 }
 
+/* Desktop-only primary create button. Links to /new for the full
+ * issue creation form with labels, body, and repo selection. */
+.desktopNewIssueBtn {
+  display: none;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 13px;
+  color: #fff;
+  background: var(--paper-accent);
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-sm);
+  padding: 6px 14px;
+  margin-left: 12px;
+  align-self: center;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.desktopNewIssueBtn:hover {
+  background: var(--paper-accent-dim);
+  border-color: var(--paper-accent-dim);
+}
+
 /* Desktop-only inline draft button. On mobile, the command sheet's
  * "Create Draft" action provides this functionality instead. */
 .desktopDraftBtn {
@@ -191,7 +217,7 @@
   border: 1px solid var(--paper-accent-soft);
   border-radius: var(--paper-radius-sm);
   padding: 6px 12px;
-  margin-left: 16px;
+  margin-left: 8px;
   align-self: center;
   cursor: pointer;
   transition:
@@ -314,6 +340,10 @@
 
   .desktopDate {
     display: block;
+  }
+
+  .desktopNewIssueBtn {
+    display: inline-flex;
   }
 
   .desktopDraftBtn {

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -194,8 +194,6 @@ export function List({
 
         <CacheAge cachedAt={cachedAt ?? null} />
         <nav className={styles.desktopNav}>
-          <Link href="/new" className={styles.desktopNavLink}>New Issue</Link>
-          <span className={styles.desktopNavSep}>·</span>
           <Link href="/parse" className={styles.desktopNavLink}>Quick Create</Link>
           <span className={styles.desktopNavSep}>·</span>
           <Link href={settingsHref} className={styles.desktopNavLink}>Settings</Link>
@@ -284,13 +282,18 @@ export function List({
           {weekday} · <b>{short}</b>
         </div>
         {activeTab === "issues" && (
-          <button
-            type="button"
-            className={styles.desktopDraftBtn}
-            onClick={() => setCreateOpen(true)}
-          >
-            + draft
-          </button>
+          <>
+            <Link href="/new" className={styles.desktopNewIssueBtn}>
+              + new issue
+            </Link>
+            <button
+              type="button"
+              className={styles.desktopDraftBtn}
+              onClick={() => setCreateOpen(true)}
+            >
+              + draft
+            </button>
+          </>
         )}
         <button
           type="button"

--- a/packages/web/components/ui/PullToRefreshWrapper.module.css
+++ b/packages/web/components/ui/PullToRefreshWrapper.module.css
@@ -1,5 +1,5 @@
 .container {
-  min-height: 100dvh;
+  height: 100dvh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;

--- a/packages/web/e2e/audit-verification.spec.ts
+++ b/packages/web/e2e/audit-verification.spec.ts
@@ -182,7 +182,7 @@ test.describe("Adv-R2 #4 — Content-Security-Policy header", () => {
   // just pins the load-bearing directives.
   const REQUIRED_DIRECTIVES = [
     "default-src 'self'",
-    "img-src 'self' data: https://avatars.githubusercontent.com",
+    "img-src 'self' data: https://avatars.githubusercontent.com https://raw.githubusercontent.com https://user-images.githubusercontent.com https://github.com",
     "frame-ancestors 'none'",
   ];
 

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -79,6 +79,9 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       { hostname: "avatars.githubusercontent.com" },
+      { hostname: "raw.githubusercontent.com" },
+      { hostname: "user-images.githubusercontent.com" },
+      { hostname: "github.com" },
     ],
   },
   async headers() {
@@ -118,7 +121,7 @@ const nextConfig: NextConfig = {
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: https://avatars.githubusercontent.com",
+      "img-src 'self' data: https://avatars.githubusercontent.com https://raw.githubusercontent.com https://user-images.githubusercontent.com https://github.com",
       "font-src 'self'",
       "connect-src 'self'",
       "frame-src 'self'",


### PR DESCRIPTION
## Summary
- Replace broken `uploads.github.com` endpoint with GitHub Contents API for image uploads, with sanitized filenames and improved error messages
- Fix desktop scrolling — PullToRefreshWrapper `min-height: 100dvh` prevented overflow-y from creating a scroll context; changed to `height: 100dvh`
- Add prominent green `+ new issue` button in the tabs row on desktop (was a barely visible nav text link)
- Widen CSP `img-src` to allow GitHub user-content image domains

## Test plan
- [ ] Desktop: verify vertical scrolling works on the issue list
- [ ] Desktop: verify `+ new issue` button is visible in the tabs row and links to `/new`
- [ ] Desktop: verify `+ draft` button still works next to `+ new issue`
- [ ] Mobile: verify pull-to-refresh still works
- [ ] Mobile: verify the new button is hidden (mobile uses FAB + command sheet)
- [ ] Upload an image via issue creation and verify it renders in the issue body