### PR TITLE
fix: screenshots in comments not rendering on mobile

### DIFF
--- a/packages/web/components/detail/BodyText.module.css
+++ b/packages/web/components/detail/BodyText.module.css
@@ -87,7 +87,9 @@
 }
 
 .body img {
+  display: block;
   max-width: 100%;
+  height: auto;
   border-radius: var(--paper-radius-md);
 }
 


### PR DESCRIPTION
## Summary
- Add `display: block` and `height: auto` to `.body img` in `BodyText.module.css`
- Without these, screenshot images in markdown comments could collapse or distort on narrow mobile viewports where `max-width: 100%` constrains width but the height was not explicitly set to scale proportionally
- Completes the standard responsive image triple (`display: block` + `max-width: 100%` + `height: auto`) that was missing two of its three properties

## Test plan
- [ ] Open an issue with screenshot images in comments on a mobile viewport (375px wide)
- [ ] Verify screenshots render at correct aspect ratio and fit within the comment container
- [ ] Verify screenshots in the issue body (EditableBody) also render correctly on mobile
- [ ] Verify desktop rendering is unchanged
- [ ] Verify lightbox still opens when clicking images

Closes #216