### PR TITLE
fix: add horizontal padding to mobile FiltersSheet

### DIFF
--- a/packages/web/components/list/FiltersSheet.module.css
+++ b/packages/web/components/list/FiltersSheet.module.css
@@ -1,7 +1,7 @@
 .clearBar {
   display: flex;
   justify-content: flex-end;
-  padding: 0 4px 4px;
+  padding: 0 20px 4px;
   min-height: 32px;
 }
 
@@ -33,7 +33,7 @@
   letter-spacing: 0.5px;
   font-weight: 600;
   color: var(--paper-ink-muted);
-  padding: 12px 4px 6px;
+  padding: 12px 20px 6px;
 }
 
 .row,
@@ -41,7 +41,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 8px;
+  padding: 14px 20px;
   min-height: 56px;
   border-bottom: 1px solid var(--paper-line-soft);
   text-decoration: none;
@@ -49,9 +49,6 @@
   font-family: var(--paper-serif);
   font-size: 16px;
   border-radius: var(--paper-radius-md);
-  margin: 0 -8px;
-  padding-left: 16px;
-  padding-right: 16px;
 }
 
 .row:hover,
@@ -97,6 +94,7 @@
 /* ── Mobile-only command sections ── */
 .mobileOnly {
   display: block;
+  padding: 0 20px;
 }
 
 @media (min-width: 768px) and (hover: hover) {


### PR DESCRIPTION
## Summary
- Fixed mobile filter bottom sheet content being flush against the left/right edges
- Added consistent 20px horizontal padding to `.mobileOnly`, `.clearBar`, `.groupLabel`, and `.row`/`.rowActive` — matching the established pattern used by other Sheet consumers (CreateDraftSheet, ContentSkeleton)
- Removed stale `margin: 0 -8px` and redundant `padding-left`/`padding-right` overrides from rows that were bleeding content outside the sheet boundary

## Test plan
- [ ] Open the dashboard on a mobile device or in a narrow viewport (<768px)
- [ ] Tap the filter icon to open the FiltersSheet
- [ ] Verify the "view" label, Issues/PRs toggle, section chips, "clear all", "REPOSITORY" label, and repo rows all have proper horizontal inset from the sheet edges
- [ ] Verify the bottom action links (Create Draft, Launch Claude Code, etc.) are properly padded
- [ ] Verify desktop (>=768px) behavior is unchanged — the `.mobileOnly` sections are hidden on desktop

Closes #211