### PR TITLE
fix: image upload via orphan branch + mobile screenshot rendering

### DIFF
--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -98,9 +98,10 @@ describe("uploadImageToGitHub", () => {
       "application/json",
     );
 
-    const body = JSON.parse(init.body as string) as { message: string; content: string };
+    const body = JSON.parse(init.body as string) as { message: string; content: string; branch: string };
     expect(body.message).toMatch(/^chore\(issuectl\): upload image test\.png$/);
     expect(body.content).toBe(Buffer.from(VALID_FILE.data).toString("base64"));
+    expect(body.branch).toBe("issuectl-assets");
   });
 
   // 2. Invalid file type
@@ -204,7 +205,47 @@ describe("uploadImageToGitHub", () => {
     ).rejects.toThrow("invalid JSON");
   });
 
-  // 7. Filename sanitization in the request URL
+  // 7. Branch creation retry on 404
+  it("creates the upload branch and retries when branch does not exist", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    // First PUT returns 404 (branch doesn't exist)
+    const notFoundResponse = {
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response;
+    // Git Data API calls for branch creation (blob, tree, commit, ref)
+    const gitOkResponse = (sha: string) => ({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({ sha }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+    // Retry PUT succeeds
+    const successResponse = makeContentsApiOkResponse(
+      "https://raw.githubusercontent.com/test-owner/test-repo/issuectl-assets/.github/issuectl/uploads/test.png",
+    ) as unknown as Response;
+
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse)       // 1st PUT → 404
+      .mockResolvedValueOnce(gitOkResponse("blob1"))  // create blob
+      .mockResolvedValueOnce(gitOkResponse("tree1"))  // create tree
+      .mockResolvedValueOnce(gitOkResponse("cmt1"))   // create commit
+      .mockResolvedValueOnce(gitOkResponse("ref1"))   // create ref
+      .mockResolvedValueOnce(successResponse);         // 2nd PUT → 201
+
+    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+
+    expect(result.url).toBe(
+      "https://raw.githubusercontent.com/test-owner/test-repo/issuectl-assets/.github/issuectl/uploads/test.png",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  // 8. Filename sanitization in the request URL
   it("sanitizes the filename in the upload path", async () => {
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockResolvedValue(

--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -245,7 +245,137 @@ describe("uploadImageToGitHub", () => {
     expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
-  // 8. Filename sanitization in the request URL
+  // 8. 422 with "Branch not found" triggers retry
+  it("retries when 422 body contains 'Branch not found'", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const branchNotFoundResponse = {
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue('{"message":"Branch not found"}'),
+    } as unknown as Response;
+    const gitOkResponse = (sha: string) => ({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({ sha }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+    const successResponse = makeContentsApiOkResponse(
+      "https://raw.githubusercontent.com/o/r/issuectl-assets/f.png",
+    ) as unknown as Response;
+
+    fetchMock
+      .mockResolvedValueOnce(branchNotFoundResponse)   // 1st PUT → 422 "Branch not found"
+      .mockResolvedValueOnce(gitOkResponse("blob1"))
+      .mockResolvedValueOnce(gitOkResponse("tree1"))
+      .mockResolvedValueOnce(gitOkResponse("cmt1"))
+      .mockResolvedValueOnce(gitOkResponse("ref1"))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+    expect(result.url).toContain("issuectl-assets");
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  // 9. 422 for non-branch reasons does NOT retry
+  it("throws immediately on 422 unrelated to missing branch", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue('{"message":"path already exists"}'),
+    } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("path already exists");
+  });
+
+  // 10. createUploadBranch step failure propagates
+  it("throws when blob creation fails during branch setup", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, status: 404, statusText: "Not Found",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue(""),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false, status: 403, statusText: "Forbidden",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue("Resource not accessible"),
+      } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("Failed to create upload branch blob (403)");
+  });
+
+  // 11. 422 on ref creation (race condition) is tolerated
+  it("tolerates 422 'Reference already exists' on ref creation", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const gitOkResponse = (sha: string) => ({
+      ok: true, status: 201, statusText: "Created",
+      json: vi.fn().mockResolvedValue({ sha }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+    const successResponse = makeContentsApiOkResponse(
+      "https://raw.githubusercontent.com/o/r/issuectl-assets/f.png",
+    ) as unknown as Response;
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, status: 404, statusText: "Not Found",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue(""),
+      } as unknown as Response)                          // 1st PUT → 404
+      .mockResolvedValueOnce(gitOkResponse("blob1"))
+      .mockResolvedValueOnce(gitOkResponse("tree1"))
+      .mockResolvedValueOnce(gitOkResponse("cmt1"))
+      .mockResolvedValueOnce({
+        ok: false, status: 422, statusText: "Unprocessable Entity",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue('{"message":"Reference already exists"}'),
+      } as unknown as Response)                          // ref → 422 race condition
+      .mockResolvedValueOnce(successResponse);           // retry PUT → 201
+
+    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+    expect(result.url).toContain("issuectl-assets");
+  });
+
+  // 12. 422 on ref creation for non-race reasons throws
+  it("throws when ref creation returns 422 for non-race reasons", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const gitOkResponse = (sha: string) => ({
+      ok: true, status: 201, statusText: "Created",
+      json: vi.fn().mockResolvedValue({ sha }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, status: 404, statusText: "Not Found",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue(""),
+      } as unknown as Response)
+      .mockResolvedValueOnce(gitOkResponse("blob1"))
+      .mockResolvedValueOnce(gitOkResponse("tree1"))
+      .mockResolvedValueOnce(gitOkResponse("cmt1"))
+      .mockResolvedValueOnce({
+        ok: false, status: 422, statusText: "Unprocessable Entity",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue('{"message":"Invalid SHA"}'),
+      } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("Failed to create upload branch ref (422)");
+  });
+
+  // 13. Filename sanitization in the request URL
   it("sanitizes the filename in the upload path", async () => {
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockResolvedValue(

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -24,12 +24,26 @@ export type UploadResult = {
   fileName: string;
 };
 
-/** Branch used for image uploads — avoids default branch protection rules. */
+/** Dedicated branch for image uploads — writes to the default branch would fail under branch protection rules. */
 const UPLOAD_BRANCH = "issuectl-assets";
+
+/** Extract and validate the `sha` field from a GitHub Git Data API response. */
+function extractSha(json: unknown, context: string): string {
+  const obj = json as Record<string, unknown>;
+  if (typeof obj?.sha !== "string" || obj.sha.length === 0) {
+    throw new Error(`${context}: response missing 'sha' field`);
+  }
+  return obj.sha;
+}
 
 /**
  * Create the issuectl-assets orphan branch via the Git Data API.
- * Uses a single-file tree so the branch is non-empty.
+ * An orphan branch keeps uploaded assets out of the default branch history.
+ * The branch includes a single README because GitHub requires at least one
+ * file in the tree for the ref to be valid.
+ *
+ * On partial failure, earlier steps may leave orphan Git objects (blobs,
+ * trees, commits) — these are garbage-collected by Git automatically.
  */
 async function createUploadBranch(
   token: string,
@@ -55,9 +69,12 @@ async function createUploadBranch(
     }),
   });
   if (!blobRes.ok) {
-    throw new Error(`Failed to create blob (${blobRes.status})`);
+    const body = await blobRes.text().catch(() => "");
+    const err = new Error(`Failed to create upload branch blob (${blobRes.status}): ${body || blobRes.statusText}`);
+    Object.assign(err, { status: blobRes.status });
+    throw err;
   }
-  const { sha: blobSha } = (await blobRes.json()) as { sha: string };
+  const blobSha = extractSha(await blobRes.json(), "Blob creation");
 
   // 2. Create a tree containing the README
   const treeRes = await fetch(`${api}/trees`, {
@@ -68,9 +85,12 @@ async function createUploadBranch(
     }),
   });
   if (!treeRes.ok) {
-    throw new Error(`Failed to create tree (${treeRes.status})`);
+    const body = await treeRes.text().catch(() => "");
+    const err = new Error(`Failed to create upload branch tree (${treeRes.status}): ${body || treeRes.statusText}`);
+    Object.assign(err, { status: treeRes.status });
+    throw err;
   }
-  const { sha: treeSha } = (await treeRes.json()) as { sha: string };
+  const treeSha = extractSha(await treeRes.json(), "Tree creation");
 
   // 3. Create an orphan commit (no parents)
   const commitRes = await fetch(`${api}/commits`, {
@@ -83,9 +103,12 @@ async function createUploadBranch(
     }),
   });
   if (!commitRes.ok) {
-    throw new Error(`Failed to create commit (${commitRes.status})`);
+    const body = await commitRes.text().catch(() => "");
+    const err = new Error(`Failed to create upload branch commit (${commitRes.status}): ${body || commitRes.statusText}`);
+    Object.assign(err, { status: commitRes.status });
+    throw err;
   }
-  const { sha: commitSha } = (await commitRes.json()) as { sha: string };
+  const commitSha = extractSha(await commitRes.json(), "Commit creation");
 
   // 4. Create the branch ref
   const refRes = await fetch(
@@ -99,9 +122,21 @@ async function createUploadBranch(
       }),
     },
   );
-  // 422 = ref already exists (race condition with concurrent upload) — safe to ignore
-  if (!refRes.ok && refRes.status !== 422) {
-    throw new Error(`Failed to create branch ref (${refRes.status})`);
+  if (!refRes.ok) {
+    if (refRes.status === 422) {
+      const refBody = await refRes.text().catch(() => "");
+      // 422 with "Reference already exists" means a concurrent upload already created the branch — safe to ignore
+      if (!refBody.includes("Reference already exists")) {
+        const err = new Error(`Failed to create upload branch ref (422): ${refBody || refRes.statusText}`);
+        Object.assign(err, { status: 422 });
+        throw err;
+      }
+    } else {
+      const body = await refRes.text().catch(() => "");
+      const err = new Error(`Failed to create upload branch ref (${refRes.status}): ${body || refRes.statusText}`);
+      Object.assign(err, { status: refRes.status });
+      throw err;
+    }
   }
 }
 
@@ -152,7 +187,7 @@ export async function uploadImageToGitHub(
     body: putBody,
   });
 
-  // Branch doesn't exist yet — create it and retry
+  // 404 or 422 may indicate the upload branch doesn't exist — check response body and create if needed
   if (response.status === 404 || response.status === 422) {
     const text = await response.text().catch(() => "");
     const branchMissing =
@@ -166,6 +201,11 @@ export async function uploadImageToGitHub(
         headers: putHeaders,
         body: putBody,
       });
+    } else {
+      // 422 for a non-branch reason — throw immediately with the text we already consumed
+      throw new Error(
+        `GitHub image upload failed (${response.status}): ${text || response.statusText}`,
+      );
     }
   }
 

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -24,6 +24,87 @@ export type UploadResult = {
   fileName: string;
 };
 
+/** Branch used for image uploads — avoids default branch protection rules. */
+const UPLOAD_BRANCH = "issuectl-assets";
+
+/**
+ * Create the issuectl-assets orphan branch via the Git Data API.
+ * Uses a single-file tree so the branch is non-empty.
+ */
+async function createUploadBranch(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+  };
+  const api = `https://api.github.com/repos/${owner}/${repo}/git`;
+
+  // 1. Create a blob with a small README
+  const blobRes = await fetch(`${api}/blobs`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      content: Buffer.from(
+        "# issuectl assets\n\nImages uploaded by [issuectl](https://github.com/mean-weasel/issuectl).\n",
+      ).toString("base64"),
+      encoding: "base64",
+    }),
+  });
+  if (!blobRes.ok) {
+    throw new Error(`Failed to create blob (${blobRes.status})`);
+  }
+  const { sha: blobSha } = (await blobRes.json()) as { sha: string };
+
+  // 2. Create a tree containing the README
+  const treeRes = await fetch(`${api}/trees`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      tree: [{ path: "README.md", mode: "100644", type: "blob", sha: blobSha }],
+    }),
+  });
+  if (!treeRes.ok) {
+    throw new Error(`Failed to create tree (${treeRes.status})`);
+  }
+  const { sha: treeSha } = (await treeRes.json()) as { sha: string };
+
+  // 3. Create an orphan commit (no parents)
+  const commitRes = await fetch(`${api}/commits`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      message: "chore: initialize issuectl-assets branch",
+      tree: treeSha,
+      parents: [],
+    }),
+  });
+  if (!commitRes.ok) {
+    throw new Error(`Failed to create commit (${commitRes.status})`);
+  }
+  const { sha: commitSha } = (await commitRes.json()) as { sha: string };
+
+  // 4. Create the branch ref
+  const refRes = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        ref: `refs/heads/${UPLOAD_BRANCH}`,
+        sha: commitSha,
+      }),
+    },
+  );
+  // 422 = ref already exists (race condition with concurrent upload) — safe to ignore
+  if (!refRes.ok && refRes.status !== 422) {
+    throw new Error(`Failed to create branch ref (${refRes.status})`);
+  }
+}
+
 export async function uploadImageToGitHub(
   token: string,
   owner: string,
@@ -53,21 +134,40 @@ export async function uploadImageToGitHub(
   const path = `.github/issuectl/uploads/${timestamp}-${random}-${sanitized}`;
   const content = Buffer.from(file.data).toString("base64");
 
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
-    {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        message: `chore(issuectl): upload image ${sanitized}`,
-        content,
-      }),
-    },
-  );
+  const putBody = JSON.stringify({
+    message: `chore(issuectl): upload image ${sanitized}`,
+    content,
+    branch: UPLOAD_BRANCH,
+  });
+  const putHeaders = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+  };
+  const putUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+
+  let response = await fetch(putUrl, {
+    method: "PUT",
+    headers: putHeaders,
+    body: putBody,
+  });
+
+  // Branch doesn't exist yet — create it and retry
+  if (response.status === 404 || response.status === 422) {
+    const text = await response.text().catch(() => "");
+    const branchMissing =
+      response.status === 404 ||
+      text.includes("Branch not found") ||
+      text.includes("No commit found");
+    if (branchMissing) {
+      await createUploadBranch(token, owner, repo);
+      response = await fetch(putUrl, {
+        method: "PUT",
+        headers: putHeaders,
+        body: putBody,
+      });
+    }
+  }
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");

--- a/packages/web/components/detail/BodyText.module.css
+++ b/packages/web/components/detail/BodyText.module.css
@@ -87,7 +87,9 @@
 }
 
 .body img {
+  display: block;
   max-width: 100%;
+  height: auto;
   border-radius: var(--paper-radius-md);
 }
 


### PR DESCRIPTION
## Summary
- Upload images to a dedicated `issuectl-assets` orphan branch instead of the default branch, fixing 409 errors on repos with branch protection rules (required PRs, merge queues)
- Auto-create the orphan branch via Git Data API (blob → tree → commit → ref) on first upload, with race-condition tolerance
- Add `extractSha` runtime validation, include response bodies in error messages, attach `.status` for proper error classification
- Add `display: block` and `height: auto` to `.body img` in `BodyText.module.css`, completing the responsive image triple so screenshots render at correct aspect ratio on narrow mobile viewports

Combines #214 and #217 — both fix the image experience across different layers (core upload infrastructure + CSS rendering).

## Test plan
- [x] 25 unit tests pass (branch creation retry, 422 handling, race tolerance, blob failure propagation)
- [x] Typecheck passes across all 3 packages
- [x] Live-tested image upload and rendering on mobile (iOS Safari) and desktop
- [x] PR review toolkit run (all 6 agents) — all critical/important findings addressed

Closes #216
Supersedes #214, #217