### PR TITLE
fix: add mobile back button to terminal panel

### DIFF
--- a/packages/web/components/terminal/TerminalPanel.module.css
+++ b/packages/web/components/terminal/TerminalPanel.module.css
@@ -66,6 +66,10 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+.backButton:hover {
+  background: var(--paper-bg-warm);
+}
+
 .backButton:active {
   background: var(--paper-bg-warmer);
 }

--- a/packages/web/components/terminal/TerminalPanel.module.css
+++ b/packages/web/components/terminal/TerminalPanel.module.css
@@ -39,75 +39,43 @@
   transform: translateX(0);
 }
 
-/* Mobile: keep the left-edge swipe handle */
-.handle {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 16px;
+.header {
   display: flex;
   align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--paper-ink-muted);
-  background: transparent;
-  transition: color 0.15s ease;
-  z-index: 1;
-  user-select: none;
-  border: none;
-  padding: 0;
-  font: inherit;
+  gap: 12px;
+  padding: calc(10px + env(safe-area-inset-top, 0px)) 16px 10px 8px;
+  border-bottom: 1px solid var(--paper-line);
+  flex-shrink: 0;
 }
 
-.handle:hover {
-  color: var(--paper-ink);
-  background: transparent;
-}
-
-.handleChevron {
-  font-size: 16px;
-  font-weight: 700;
-  opacity: 0;
-}
-
+/* Mobile: back arrow button */
 .backButton {
-  color: var(--paper-ink);
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 44px;
   min-height: 44px;
+  margin-left: -10px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--paper-ink);
   border-radius: var(--paper-radius-sm);
   transition: background 0.1s;
-  -webkit-tap-highlight-color: transparent;
   flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .backButton:active {
   background: var(--paper-bg-warmer);
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px 10px 8px;
-  border-bottom: 1px solid var(--paper-line);
-  flex-shrink: 0;
-}
-
 .closeButton {
   display: none;
 }
 
-/* Desktop: hide swipe handle + back button, show X button */
+/* Desktop: hide back arrow, show X button */
 @media (min-width: 768px) and (hover: hover) {
-  .handle {
-    display: none;
-  }
-
   .backButton {
     display: none;
   }

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -87,6 +87,7 @@ export function TerminalPanel({
             </svg>
           </Link>
           <button
+            type="button"
             className={styles.backButton}
             onClick={onClose}
             aria-label="Back to issue"

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -58,14 +58,6 @@ export function TerminalPanel({
     <div className={styles.overlay} data-open={open}>
       <div className={styles.backdrop} onClick={onClose} />
       <div className={styles.panel} data-open={open}>
-        <button
-          type="button"
-          className={styles.handle}
-          onClick={onClose}
-          aria-label="Close terminal"
-        >
-          <span className={styles.handleChevron}>{"\u203A"}</span>
-        </button>
         <div className={styles.header}>
           <Link
             href={`/${owner}/${repo}/${issueNumber}`}
@@ -94,6 +86,27 @@ export function TerminalPanel({
               />
             </svg>
           </Link>
+          <button
+            className={styles.backButton}
+            onClick={onClose}
+            aria-label="Back to issue"
+          >
+            <svg
+              width="12"
+              height="20"
+              viewBox="0 0 12 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M10 2L2 10L10 18"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
           <button
             className={styles.closeButton}
             onClick={onClose}


### PR DESCRIPTION
## Summary
- Replace the invisible left-edge swipe handle in the terminal panel with an explicit back arrow button visible on mobile
- Button uses the same left-arrow SVG and 44×44px touch target as `DetailTopBar` for design consistency
- Desktop continues to show the × close button (mutually exclusive via CSS media query)
- Adds `env(safe-area-inset-top)` to the terminal header for iPhone notch/Dynamic Island safety

## Test plan
- [ ] Open an issue with an active terminal session on a mobile device (or responsive mode at <768px)
- [ ] Verify the back arrow button is visible in the top-left of the terminal header
- [ ] Tap the back button — terminal panel should close and return to the issue detail view
- [ ] Resize to desktop width (≥768px) — verify the back arrow disappears and the × button appears instead
- [ ] Verify the × button still closes the terminal on desktop

Closes #225