### PR TITLE
feat: add REST API v1 for iOS app connectivity

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,5 @@
 import { confirm, input } from "@inquirer/prompts";
-import { dbExists, getDb, closeDb, seedDefaults, addRepo } from "@issuectl/core";
+import { dbExists, getDb, closeDb, seedDefaults, addRepo, generateApiToken } from "@issuectl/core";
 import * as log from "../utils/logger.js";
 import { requireAuth } from "../utils/auth.js";
 import { validateOwnerRepo, parseOwnerRepo } from "../utils/validation.js";
@@ -35,6 +35,11 @@ export async function initCommand(): Promise<void> {
     process.exit(1);
   }
   log.success("Database created and defaults seeded.");
+
+  const token = generateApiToken(db);
+  log.success("API token generated for mobile access.");
+  log.info(`Token: ${token}`);
+  log.info("Use this token in the iOS app to connect to this server.");
 
   const addFirst = await confirm({
     message: "Add your first repository?",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -36,7 +36,15 @@ export async function initCommand(): Promise<void> {
   }
   log.success("Database created and defaults seeded.");
 
-  const token = generateApiToken(db);
+  let token: string;
+  try {
+    token = generateApiToken(db);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`Failed to generate API token: ${message}`);
+    log.info("The database was created successfully. Try running `issuectl init` again.");
+    process.exit(1);
+  }
   log.success("API token generated for mobile access.");
   log.info(`Token: ${token}`);
   log.info("Use this token in the iOS app to connect to this server.");

--- a/packages/core/src/db/settings.test.ts
+++ b/packages/core/src/db/settings.test.ts
@@ -6,6 +6,7 @@ import {
   setSetting,
   getSettings,
   seedDefaults,
+  generateApiToken,
 } from "./settings.js";
 
 describe("getSetting / setSetting", () => {
@@ -87,5 +88,25 @@ describe("seedDefaults", () => {
     const countAfterFirst = getSettings(db).length;
     seedDefaults(db);
     expect(getSettings(db)).toHaveLength(countAfterFirst);
+  });
+});
+
+describe("generateApiToken", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("generates and stores a 64-char hex token", () => {
+    const token = generateApiToken(db);
+    expect(token).toMatch(/^[a-f0-9]{64}$/);
+    expect(getSetting(db, "api_token")).toBe(token);
+  });
+
+  it("returns existing token if already set", () => {
+    const first = generateApiToken(db);
+    const second = generateApiToken(db);
+    expect(second).toBe(first);
   });
 });

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type Database from "better-sqlite3";
 import type { Setting, SettingKey } from "../types.js";
 
@@ -30,6 +31,15 @@ export function setSetting(
 
 export function getSettings(db: Database.Database): Setting[] {
   return db.prepare("SELECT key, value FROM settings ORDER BY key").all() as Setting[];
+}
+
+export function generateApiToken(db: Database.Database): string {
+  const existing = getSetting(db, "api_token");
+  if (existing) return existing;
+
+  const token = randomBytes(32).toString("hex");
+  setSetting(db, "api_token", token);
+  return token;
 }
 
 export function seedDefaults(db: Database.Database): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   setSetting,
   getSettings,
   seedDefaults,
+  generateApiToken,
 } from "./db/settings.js";
 export {
   createDraft,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,8 @@ export type SettingKey =
   | "cache_ttl"
   | "worktree_dir"
   | "claude_extra_args"
-  | "default_repo_id";
+  | "default_repo_id"
+  | "api_token";
 
 export type Setting = {
   key: SettingKey;

--- a/packages/web/app/api/v1/health/route.ts
+++ b/packages/web/app/api/v1/health/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  return NextResponse.json({
+    ok: true,
+    version: process.env.npm_package_version ?? "0.0.0",
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/packages/web/app/api/v1/health/route.ts
+++ b/packages/web/app/api/v1/health/route.ts
@@ -7,17 +7,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const denied = requireAuth(request);
   if (denied) return denied;
 
-  try {
-    return NextResponse.json({
-      ok: true,
-      version: process.env.npm_package_version ?? "0.0.0",
-      timestamp: new Date().toISOString(),
-    });
-  } catch (err) {
-    console.error("[issuectl] GET /api/v1/health failed:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json({
+    ok: true,
+    version: process.env.npm_package_version ?? "0.0.0",
+    timestamp: new Date().toISOString(),
+  });
 }

--- a/packages/web/app/api/v1/health/route.ts
+++ b/packages/web/app/api/v1/health/route.ts
@@ -7,9 +7,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const denied = requireAuth(request);
   if (denied) return denied;
 
-  return NextResponse.json({
-    ok: true,
-    version: process.env.npm_package_version ?? "0.0.0",
-    timestamp: new Date().toISOString(),
-  });
+  try {
+    return NextResponse.json({
+      ok: true,
+      version: process.env.npm_package_version ?? "0.0.0",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error("[issuectl] GET /api/v1/health failed:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
 }

--- a/packages/web/app/api/v1/repos/route.ts
+++ b/packages/web/app/api/v1/repos/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, listRepos } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const db = getDb();
+    const repos = listRepos(db);
+    return NextResponse.json({ repos });
+  } catch (err) {
+    console.error("[issuectl] GET /api/v1/repos failed:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/repos/route.ts
+++ b/packages/web/app/api/v1/repos/route.ts
@@ -14,9 +14,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ repos });
   } catch (err) {
     console.error("[issuectl] GET /api/v1/repos failed:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/packages/web/lib/actions/settings.test.ts
+++ b/packages/web/lib/actions/settings.test.ts
@@ -130,6 +130,13 @@ describe("updateSetting", () => {
     expect(result.error).toMatch(/invalid/i);
   });
 
+  it("rejects api_token as a user-editable key", async () => {
+    const result = await updateSetting("api_token" as never, "attacker-controlled");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid/i);
+    expect(fakeDb.settings.has("api_token")).toBe(false);
+  });
+
   it("rejects non-numeric cache_ttl", async () => {
     const result = await updateSetting("cache_ttl", "abc");
     expect(result.success).toBe(false);

--- a/packages/web/lib/actions/settings.ts
+++ b/packages/web/lib/actions/settings.ts
@@ -4,13 +4,14 @@ import { revalidatePath } from "next/cache";
 import { getDb, setSetting, validateClaudeArgs } from "@issuectl/core";
 import type { SettingKey } from "@issuectl/core";
 
-const VALID_KEYS = [
+// User-editable keys only — api_token is managed internally and excluded.
+const VALID_KEYS: readonly SettingKey[] = [
   "branch_pattern",
   "cache_ttl",
   "worktree_dir",
   "claude_extra_args",
   "default_repo_id",
-] as const satisfies readonly SettingKey[];
+];
 
 const ALLOW_EMPTY = new Set<SettingKey>(["claude_extra_args", "default_repo_id"]);
 

--- a/packages/web/lib/api-auth.test.ts
+++ b/packages/web/lib/api-auth.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
 
 vi.mock("@issuectl/core", () => ({
   getDb: vi.fn(),
   getSetting: vi.fn(),
 }));
 
-import { validateApiToken } from "./api-auth.js";
+import { validateApiToken, requireAuth } from "./api-auth.js";
 import { getDb, getSetting } from "@issuectl/core";
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost:3847/api/v1/test", { headers });
+}
 
 describe("validateApiToken", () => {
   beforeEach(() => {
@@ -25,9 +30,21 @@ describe("validateApiToken", () => {
     expect(validateApiToken(headers)).toBe(false);
   });
 
-  it("returns false for wrong token", () => {
+  it("returns false for same-length wrong token (exercises timingSafeEqual)", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers({ Authorization: "Bearer xyz789" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("returns false for different-length wrong token", () => {
     vi.mocked(getSetting).mockReturnValue("abc123");
     const headers = new Headers({ Authorization: "Bearer wrong" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("returns false for empty bearer token", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers({ Authorization: "Bearer " });
     expect(validateApiToken(headers)).toBe(false);
   });
 
@@ -41,5 +58,44 @@ describe("validateApiToken", () => {
     vi.mocked(getSetting).mockReturnValue("abc123");
     const headers = new Headers({ Authorization: "Basic abc123" });
     expect(validateApiToken(headers)).toBe(false);
+  });
+});
+
+describe("requireAuth", () => {
+  beforeEach(() => {
+    vi.mocked(getDb).mockReturnValue({} as any);
+  });
+
+  it("returns null when token is valid (allows route to proceed)", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const result = requireAuth(makeRequest({ Authorization: "Bearer abc123" }));
+    expect(result).toBeNull();
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const result = requireAuth(makeRequest({ Authorization: "Bearer wrong" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+    const body = await result!.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when no Authorization header is present", async () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const result = requireAuth(makeRequest());
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  it("returns 500 when database is unavailable", async () => {
+    vi.mocked(getDb).mockImplementation(() => {
+      throw new Error("SQLITE_CANTOPEN");
+    });
+    const result = requireAuth(makeRequest({ Authorization: "Bearer abc123" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(500);
+    const body = await result!.json();
+    expect(body.error).toBe("Internal server error");
   });
 });

--- a/packages/web/lib/api-auth.test.ts
+++ b/packages/web/lib/api-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@issuectl/core", () => ({
+  getDb: vi.fn(),
+  getSetting: vi.fn(),
+}));
+
+import { validateApiToken } from "./api-auth.js";
+import { getDb, getSetting } from "@issuectl/core";
+
+describe("validateApiToken", () => {
+  beforeEach(() => {
+    vi.mocked(getDb).mockReturnValue({} as any);
+  });
+
+  it("returns true for a valid bearer token", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers({ Authorization: "Bearer abc123" });
+    expect(validateApiToken(headers)).toBe(true);
+  });
+
+  it("returns false for a missing Authorization header", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers();
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("returns false for wrong token", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers({ Authorization: "Bearer wrong" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("returns false when no token is configured", () => {
+    vi.mocked(getSetting).mockReturnValue(undefined);
+    const headers = new Headers({ Authorization: "Bearer anything" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("ignores non-Bearer schemes", () => {
+    vi.mocked(getSetting).mockReturnValue("abc123");
+    const headers = new Headers({ Authorization: "Basic abc123" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+});

--- a/packages/web/lib/api-auth.ts
+++ b/packages/web/lib/api-auth.ts
@@ -19,11 +19,19 @@ export function validateApiToken(headers: Headers): boolean {
 }
 
 export function requireAuth(request: NextRequest): NextResponse | null {
-  if (!validateApiToken(request.headers)) {
+  try {
+    if (!validateApiToken(request.headers)) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+    return null;
+  } catch (err) {
+    console.error("[issuectl] Auth check failed:", err);
     return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 },
+      { error: "Internal server error" },
+      { status: 500 },
     );
   }
-  return null;
 }

--- a/packages/web/lib/api-auth.ts
+++ b/packages/web/lib/api-auth.ts
@@ -1,0 +1,29 @@
+import { getDb, getSetting } from "@issuectl/core";
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+export function validateApiToken(headers: Headers): boolean {
+  const authHeader = headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return false;
+
+  const provided = authHeader.slice(7);
+  const db = getDb();
+  const stored = getSetting(db, "api_token");
+  if (!stored) return false;
+
+  if (provided.length !== stored.length) return false;
+  return timingSafeEqual(
+    Buffer.from(provided),
+    Buffer.from(stored),
+  );
+}
+
+export function requireAuth(request: NextRequest): NextResponse | null {
+  if (!validateApiToken(request.headers)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+  return null;
+}

--- a/packages/web/lib/api-auth.ts
+++ b/packages/web/lib/api-auth.ts
@@ -1,12 +1,13 @@
-import { getDb, getSetting } from "@issuectl/core";
-import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, getSetting } from "@issuectl/core";
 
 export function validateApiToken(headers: Headers): boolean {
   const authHeader = headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) return false;
 
   const provided = authHeader.slice(7);
+  if (!provided) return false;
   const db = getDb();
   const stored = getSetting(db, "api_token");
   if (!stored) return false;


### PR DESCRIPTION
## Summary

- Add `api_token` to core settings with secure token generation (`randomBytes(32).toString("hex")`)
- Add bearer token auth middleware (`api-auth.ts`) using `timingSafeEqual` for timing-safe comparison
- Add `/api/v1/health` endpoint — authenticated health check returning `{ ok, version, timestamp }`
- Add `/api/v1/repos` endpoint — authenticated repo list returning `{ repos: [...] }`
- Generate API token during `issuectl init` and display it for iOS app configuration
- Exclude `api_token` from user-editable settings in the web UI

## Error handling

- `requireAuth` wrapped in try-catch — DB failures return structured 500 instead of crashing
- Repos route handler has error boundary with `[issuectl]` prefixed logging
- `generateApiToken` in CLI init wrapped in try-catch with actionable recovery message
- Empty bearer token explicitly rejected before DB access

## Test plan

- [x] `generateApiToken` — generation, persistence, and idempotency (2 tests)
- [x] `validateApiToken` — valid token, missing header, same-length wrong token, different-length wrong token, empty bearer, no configured token, non-Bearer scheme (7 tests)
- [x] `requireAuth` — null on success, 401 on invalid, 401 on missing header, 500 on DB crash (4 tests)
- [x] `api_token` rejected by `updateSetting` server action (1 test)
- [x] All 565 tests pass (430 core + 135 web)
- [x] Typecheck clean across all packages
- [x] End-to-end verified: iOS simulator app → LAN IP → Next.js server → SQLite → JSON → SwiftUI