### PR TITLE
fix(core): address PR review — error handling, sha validation, test coverage

### DIFF
--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -313,6 +313,26 @@ describe("uploadImageToGitHub", () => {
     expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
+  // 8c. Malformed SHA from Git Data API is rejected
+  it("throws when Git Data API returns a malformed SHA", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, status: 404, statusText: "Not Found",
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue(""),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true, status: 201, statusText: "Created",
+        json: vi.fn().mockResolvedValue({ sha: "short" }),
+        text: vi.fn().mockResolvedValue(""),
+      } as unknown as Response);
+
+    await expect(
+      uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE),
+    ).rejects.toThrow("missing or malformed 'sha' field");
+  });
+
   // 9. 422 for non-branch reasons does NOT retry
   it("throws immediately on 422 unrelated to missing branch", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue({

--- a/packages/core/src/github/uploads.test.ts
+++ b/packages/core/src/github/uploads.test.ts
@@ -231,10 +231,10 @@ describe("uploadImageToGitHub", () => {
 
     fetchMock
       .mockResolvedValueOnce(notFoundResponse)       // 1st PUT → 404
-      .mockResolvedValueOnce(gitOkResponse("blob1"))  // create blob
-      .mockResolvedValueOnce(gitOkResponse("tree1"))  // create tree
-      .mockResolvedValueOnce(gitOkResponse("cmt1"))   // create commit
-      .mockResolvedValueOnce(gitOkResponse("ref1"))   // create ref
+      .mockResolvedValueOnce(gitOkResponse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))  // create blob
+      .mockResolvedValueOnce(gitOkResponse("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))  // create tree
+      .mockResolvedValueOnce(gitOkResponse("cccccccccccccccccccccccccccccccccccccccc"))   // create commit
+      .mockResolvedValueOnce(gitOkResponse("dddddddddddddddddddddddddddddddddddddddd"))   // create ref
       .mockResolvedValueOnce(successResponse);         // 2nd PUT → 201
 
     const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
@@ -268,10 +268,44 @@ describe("uploadImageToGitHub", () => {
 
     fetchMock
       .mockResolvedValueOnce(branchNotFoundResponse)   // 1st PUT → 422 "Branch not found"
-      .mockResolvedValueOnce(gitOkResponse("blob1"))
-      .mockResolvedValueOnce(gitOkResponse("tree1"))
-      .mockResolvedValueOnce(gitOkResponse("cmt1"))
-      .mockResolvedValueOnce(gitOkResponse("ref1"))
+      .mockResolvedValueOnce(gitOkResponse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+      .mockResolvedValueOnce(gitOkResponse("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+      .mockResolvedValueOnce(gitOkResponse("cccccccccccccccccccccccccccccccccccccccc"))
+      .mockResolvedValueOnce(gitOkResponse("dddddddddddddddddddddddddddddddddddddddd"))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
+    expect(result.url).toContain("issuectl-assets");
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  // 8b. 422 with "No commit found" triggers retry
+  it("retries when 422 body contains 'No commit found'", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    const noCommitResponse = {
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: vi.fn().mockResolvedValue({}),
+      text: vi.fn().mockResolvedValue('{"message":"No commit found for the ref issuectl-assets"}'),
+    } as unknown as Response;
+    const gitOkResponse = (sha: string) => ({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: vi.fn().mockResolvedValue({ sha }),
+      text: vi.fn().mockResolvedValue(""),
+    } as unknown as Response);
+    const successResponse = makeContentsApiOkResponse(
+      "https://raw.githubusercontent.com/o/r/issuectl-assets/f.png",
+    ) as unknown as Response;
+
+    fetchMock
+      .mockResolvedValueOnce(noCommitResponse)            // 1st PUT → 422 "No commit found"
+      .mockResolvedValueOnce(gitOkResponse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+      .mockResolvedValueOnce(gitOkResponse("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+      .mockResolvedValueOnce(gitOkResponse("cccccccccccccccccccccccccccccccccccccccc"))
+      .mockResolvedValueOnce(gitOkResponse("dddddddddddddddddddddddddddddddddddddddd"))
       .mockResolvedValueOnce(successResponse);
 
     const result = await uploadImageToGitHub(TOKEN, OWNER, REPO, VALID_FILE);
@@ -332,9 +366,9 @@ describe("uploadImageToGitHub", () => {
         json: vi.fn().mockResolvedValue({}),
         text: vi.fn().mockResolvedValue(""),
       } as unknown as Response)                          // 1st PUT → 404
-      .mockResolvedValueOnce(gitOkResponse("blob1"))
-      .mockResolvedValueOnce(gitOkResponse("tree1"))
-      .mockResolvedValueOnce(gitOkResponse("cmt1"))
+      .mockResolvedValueOnce(gitOkResponse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+      .mockResolvedValueOnce(gitOkResponse("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+      .mockResolvedValueOnce(gitOkResponse("cccccccccccccccccccccccccccccccccccccccc"))
       .mockResolvedValueOnce({
         ok: false, status: 422, statusText: "Unprocessable Entity",
         json: vi.fn().mockResolvedValue({}),
@@ -361,9 +395,9 @@ describe("uploadImageToGitHub", () => {
         json: vi.fn().mockResolvedValue({}),
         text: vi.fn().mockResolvedValue(""),
       } as unknown as Response)
-      .mockResolvedValueOnce(gitOkResponse("blob1"))
-      .mockResolvedValueOnce(gitOkResponse("tree1"))
-      .mockResolvedValueOnce(gitOkResponse("cmt1"))
+      .mockResolvedValueOnce(gitOkResponse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+      .mockResolvedValueOnce(gitOkResponse("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+      .mockResolvedValueOnce(gitOkResponse("cccccccccccccccccccccccccccccccccccccccc"))
       .mockResolvedValueOnce({
         ok: false, status: 422, statusText: "Unprocessable Entity",
         json: vi.fn().mockResolvedValue({}),

--- a/packages/core/src/github/uploads.ts
+++ b/packages/core/src/github/uploads.ts
@@ -27,13 +27,26 @@ export type UploadResult = {
 /** Dedicated branch for image uploads — writes to the default branch would fail under branch protection rules. */
 const UPLOAD_BRANCH = "issuectl-assets";
 
+const SHA_RE = /^[0-9a-f]{40}$/;
+
 /** Extract and validate the `sha` field from a GitHub Git Data API response. */
 function extractSha(json: unknown, context: string): string {
   const obj = json as Record<string, unknown>;
-  if (typeof obj?.sha !== "string" || obj.sha.length === 0) {
-    throw new Error(`${context}: response missing 'sha' field`);
+  if (typeof obj?.sha !== "string" || !SHA_RE.test(obj.sha)) {
+    throw new Error(`${context}: response missing or malformed 'sha' field`);
   }
   return obj.sha;
+}
+
+/** Build and throw a descriptive error for a failed GitHub API call. */
+async function throwApiError(res: Response, context: string): Promise<never> {
+  const body = await res.text().catch((e) => {
+    console.error(`[uploads] failed to read ${context} error body:`, e);
+    return "";
+  });
+  const err = new Error(`${context} (${res.status}): ${body || res.statusText}`);
+  Object.assign(err, { status: res.status });
+  throw err;
 }
 
 /**
@@ -69,10 +82,7 @@ async function createUploadBranch(
     }),
   });
   if (!blobRes.ok) {
-    const body = await blobRes.text().catch(() => "");
-    const err = new Error(`Failed to create upload branch blob (${blobRes.status}): ${body || blobRes.statusText}`);
-    Object.assign(err, { status: blobRes.status });
-    throw err;
+    await throwApiError(blobRes, "Failed to create upload branch blob");
   }
   const blobSha = extractSha(await blobRes.json(), "Blob creation");
 
@@ -85,10 +95,7 @@ async function createUploadBranch(
     }),
   });
   if (!treeRes.ok) {
-    const body = await treeRes.text().catch(() => "");
-    const err = new Error(`Failed to create upload branch tree (${treeRes.status}): ${body || treeRes.statusText}`);
-    Object.assign(err, { status: treeRes.status });
-    throw err;
+    await throwApiError(treeRes, "Failed to create upload branch tree");
   }
   const treeSha = extractSha(await treeRes.json(), "Tree creation");
 
@@ -103,28 +110,25 @@ async function createUploadBranch(
     }),
   });
   if (!commitRes.ok) {
-    const body = await commitRes.text().catch(() => "");
-    const err = new Error(`Failed to create upload branch commit (${commitRes.status}): ${body || commitRes.statusText}`);
-    Object.assign(err, { status: commitRes.status });
-    throw err;
+    await throwApiError(commitRes, "Failed to create upload branch commit");
   }
   const commitSha = extractSha(await commitRes.json(), "Commit creation");
 
   // 4. Create the branch ref
-  const refRes = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        ref: `refs/heads/${UPLOAD_BRANCH}`,
-        sha: commitSha,
-      }),
-    },
-  );
+  const refRes = await fetch(`${api}/refs`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      ref: `refs/heads/${UPLOAD_BRANCH}`,
+      sha: commitSha,
+    }),
+  });
   if (!refRes.ok) {
     if (refRes.status === 422) {
-      const refBody = await refRes.text().catch(() => "");
+      const refBody = await refRes.text().catch((e) => {
+        console.error("[uploads] failed to read ref error body:", e);
+        return "";
+      });
       // 422 with "Reference already exists" means a concurrent upload already created the branch — safe to ignore
       if (!refBody.includes("Reference already exists")) {
         const err = new Error(`Failed to create upload branch ref (422): ${refBody || refRes.statusText}`);
@@ -132,10 +136,7 @@ async function createUploadBranch(
         throw err;
       }
     } else {
-      const body = await refRes.text().catch(() => "");
-      const err = new Error(`Failed to create upload branch ref (${refRes.status}): ${body || refRes.statusText}`);
-      Object.assign(err, { status: refRes.status });
-      throw err;
+      await throwApiError(refRes, "Failed to create upload branch ref");
     }
   }
 }
@@ -189,7 +190,10 @@ export async function uploadImageToGitHub(
 
   // 404 or 422 may indicate the upload branch doesn't exist — check response body and create if needed
   if (response.status === 404 || response.status === 422) {
-    const text = await response.text().catch(() => "");
+    const text = await response.text().catch((e) => {
+      console.error("[uploads] failed to read upload error body:", e);
+      return "";
+    });
     const branchMissing =
       response.status === 404 ||
       text.includes("Branch not found") ||
@@ -210,7 +214,10 @@ export async function uploadImageToGitHub(
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
+    const text = await response.text().catch((e) => {
+      console.error("[uploads] failed to read upload error body:", e);
+      return "";
+    });
     throw new Error(
       `GitHub image upload failed (${response.status}): ${text || response.statusText}`,
     );

--- a/packages/web/e2e/viewport-health.spec.ts
+++ b/packages/web/e2e/viewport-health.spec.ts
@@ -280,11 +280,14 @@ test.afterAll(async () => {
 // ── Test describes ────────────────────────────────────────────────────
 
 test.describe("Viewport health — no horizontal overflow", () => {
+  test.beforeEach(() => {
+    if (skipReason) test.skip(true, skipReason);
+  });
+
   for (const route of ROUTES) {
     test(`${route.label} (${route.path}) — no horizontal overflow at any iPhone size`, async ({
       browser,
     }) => {
-      if (skipReason) test.skip(true, skipReason);
       await forEachViewport(browser, route.path, async (page) => {
         await assertNoHorizontalOverflow(page);
       });
@@ -294,7 +297,6 @@ test.describe("Viewport health — no horizontal overflow", () => {
   test(`issue detail (/issues/${TEST_OWNER}/${TEST_REPO}/1) — no horizontal overflow at any iPhone size`, async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, `/issues/${TEST_OWNER}/${TEST_REPO}/1`, async (page) => {
       await assertNoHorizontalOverflow(page);
     });
@@ -303,7 +305,6 @@ test.describe("Viewport health — no horizontal overflow", () => {
   test(`draft detail (/drafts/${DRAFT_ID}) — no horizontal overflow at any iPhone size`, async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, `/drafts/${DRAFT_ID}`, async (page) => {
       await assertNoHorizontalOverflow(page);
     });
@@ -311,10 +312,13 @@ test.describe("Viewport health — no horizontal overflow", () => {
 });
 
 test.describe("Viewport health — no element bleed", () => {
+  test.beforeEach(() => {
+    if (skipReason) test.skip(true, skipReason);
+  });
+
   test("dashboard (/) — no element bleed at any iPhone size", async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, "/", async (page) => {
       await assertNoElementBleed(page);
     });
@@ -323,7 +327,6 @@ test.describe("Viewport health — no element bleed", () => {
   test(`issue detail (/issues/${TEST_OWNER}/${TEST_REPO}/1) — no element bleed at any iPhone size`, async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, `/issues/${TEST_OWNER}/${TEST_REPO}/1`, async (page) => {
       await assertNoElementBleed(page);
     });
@@ -332,7 +335,6 @@ test.describe("Viewport health — no element bleed", () => {
   test("new draft form (/new) — no element bleed at any iPhone size", async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, "/new", async (page) => {
       await assertNoElementBleed(page);
     });
@@ -340,10 +342,13 @@ test.describe("Viewport health — no element bleed", () => {
 });
 
 test.describe("Viewport health — no dead whitespace (#223)", () => {
+  test.beforeEach(() => {
+    if (skipReason) test.skip(true, skipReason);
+  });
+
   test("dashboard (/) — no dead whitespace at any iPhone size", async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, "/", async (page) => {
       await assertNoDeadWhitespace(page);
     });
@@ -352,7 +357,6 @@ test.describe("Viewport health — no dead whitespace (#223)", () => {
   test(`issue detail (/issues/${TEST_OWNER}/${TEST_REPO}/1) — no dead whitespace at any iPhone size`, async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
     await forEachViewport(browser, `/issues/${TEST_OWNER}/${TEST_REPO}/1`, async (page) => {
       await assertNoDeadWhitespace(page);
     });
@@ -360,8 +364,11 @@ test.describe("Viewport health — no dead whitespace (#223)", () => {
 });
 
 test.describe("Viewport health — sheet content overflow (#222, #224)", () => {
-  test("command sheet contents stay within viewport", async ({ browser }) => {
+  test.beforeEach(() => {
     if (skipReason) test.skip(true, skipReason);
+  });
+
+  test("command sheet contents stay within viewport", async ({ browser }) => {
     await forEachViewport(browser, "/", async (page, vp) => {
       // Open the command sheet
       await page.click('button[aria-label="Open command sheet"]');
@@ -387,24 +394,12 @@ test.describe("Viewport health — sheet content overflow (#222, #224)", () => {
   test("command sheet with open sheet — no element bleed", async ({
     browser,
   }) => {
-    if (skipReason) test.skip(true, skipReason);
-    const context = await browser.newContext({
-      viewport: { width: 390, height: 844 },
-      isMobile: true,
-      hasTouch: true,
-      deviceScaleFactor: 3,
-    });
-    const page = await context.newPage();
-    try {
-      await page.goto(`${BASE_URL}/`);
-      await page.waitForLoadState("networkidle");
+    await forEachViewport(browser, "/", async (page) => {
       await page.click('button[aria-label="Open command sheet"]');
       const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible();
       await page.waitForTimeout(300);
       await assertNoElementBleed(page);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/packages/web/lib/api-auth.test.ts
+++ b/packages/web/lib/api-auth.test.ts
@@ -43,4 +43,20 @@ describe("validateApiToken", () => {
     const headers = new Headers({ Authorization: "Basic abc123" });
     expect(validateApiToken(headers)).toBe(false);
   });
+
+  it("returns false when getDb() throws (DB unavailable)", () => {
+    vi.mocked(getDb).mockImplementation(() => {
+      throw new Error("SQLITE_CANTOPEN");
+    });
+    const headers = new Headers({ Authorization: "Bearer abc123" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
+
+  it("returns false when getSetting() throws", () => {
+    vi.mocked(getSetting).mockImplementation(() => {
+      throw new Error("SQLITE_CORRUPT");
+    });
+    const headers = new Headers({ Authorization: "Bearer abc123" });
+    expect(validateApiToken(headers)).toBe(false);
+  });
 });

--- a/packages/web/lib/api-auth.ts
+++ b/packages/web/lib/api-auth.ts
@@ -1,18 +1,28 @@
 import { getDb, getSetting } from "@issuectl/core";
 import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
+import log from "./logger";
 
 /**
  * Validate a bearer token from request headers against the stored api_token.
- * Uses timing-safe comparison to prevent timing attacks.
+ * Uses timing-safe comparison to prevent timing attacks. Note: a length
+ * mismatch causes an early return, which reveals that the token length
+ * differs — acceptable because the token is a random secret, not a password.
  */
 export function validateApiToken(headers: Headers): boolean {
   const authHeader = headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) return false;
 
   const provided = authHeader.slice(7);
-  const db = getDb();
-  const stored = getSetting(db, "api_token");
+
+  let stored: string | undefined;
+  try {
+    const db = getDb();
+    stored = getSetting(db, "api_token");
+  } catch (err) {
+    log.error({ err, msg: "api_auth_db_error" });
+    return false;
+  }
   if (!stored) return false;
 
   // Timing-safe comparison — both must be the same length
@@ -32,6 +42,7 @@ export function validateApiToken(headers: Headers): boolean {
  */
 export function requireAuth(request: NextRequest): NextResponse | null {
   if (!validateApiToken(request.headers)) {
+    log.warn({ msg: "api_auth_failed", url: request.nextUrl.pathname });
     return NextResponse.json(
       { error: "Unauthorized" },
       { status: 401 },

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -112,7 +112,7 @@ interface WsStats {
   bytesToClient: number;
   /** High-water mark of clientWs.bufferedAmount. */
   peakBufferedAmount: number;
-  /** Frames dropped because client was not OPEN or safeSend failed (disjoint from backpressureDrops). */
+  /** Frames dropped in either direction because the destination was not OPEN or safeSend failed (disjoint from backpressureDrops). */
   droppedFrames: number;
   /** Frames dropped due to backpressure (buffer > threshold). Disjoint from droppedFrames; cumulative across episodes. */
   backpressureDrops: number;

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -190,7 +190,9 @@ export function handleUpgrade(
     const pendingClientMsgs: { data: Buffer | ArrayBuffer | Buffer[]; isBinary: boolean }[] = [];
     clientWs.on("message", (data, isBinary) => {
       if (upstream.readyState === WebSocket.OPEN) {
-        safeSend(upstream, data, { binary: isBinary }, "client_to_upstream", port);
+        if (!safeSend(upstream, data, { binary: isBinary }, "client_to_upstream", port)) {
+          stats.droppedFrames++;
+        }
       } else if (upstream.readyState === WebSocket.CONNECTING) {
         pendingClientMsgs.push({ data, isBinary });
       }

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -172,7 +172,8 @@ function crashExit(label: string, err: Error): void {
   log.fatal({ err, msg: label });
   try {
     log.flush(() => process.exit(1));
-  } catch {
+  } catch (flushErr) {
+    console.error("Failed to flush logs during crash:", flushErr);
     process.exit(1);
   }
   setTimeout(() => process.exit(1), 1000).unref();

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -38,7 +38,13 @@ function logRequest(req: IncomingMessage, res: ServerResponse): void {
 
 const server = createServer((req, res) => {
   logRequest(req, res);
-  handle(req, res);
+  handle(req, res).catch((err) => {
+    log.error({ err, msg: "next_request_handler_error", url: req.url });
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+    }
+    res.end("Internal Server Error");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -134,7 +140,11 @@ server.listen(port, () => {
 // Graceful shutdown
 // ---------------------------------------------------------------------------
 
+let shuttingDown = false;
+
 function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
   log.info({ msg: "server_shutdown" });
   server.close(() => {
     log.flush(() => process.exit(0));
@@ -157,17 +167,22 @@ process.on("SIGTERM", shutdown);
 // timeout in case the callback never fires. The console.error
 // fallback guarantees the crash is visible on stderr regardless.
 
-process.on("uncaughtException", (err) => {
-  console.error("FATAL uncaught_exception:", err);
-  log.fatal({ err, msg: "uncaught_exception" });
-  log.flush(() => process.exit(1));
+function crashExit(label: string, err: Error): void {
+  console.error(`FATAL ${label}:`, err);
+  log.fatal({ err, msg: label });
+  try {
+    log.flush(() => process.exit(1));
+  } catch {
+    process.exit(1);
+  }
   setTimeout(() => process.exit(1), 1000).unref();
+}
+
+process.on("uncaughtException", (err) => {
+  crashExit("uncaught_exception", err);
 });
 
 process.on("unhandledRejection", (reason) => {
   const err = reason instanceof Error ? reason : new Error(String(reason));
-  console.error("FATAL unhandled_rejection:", err);
-  log.fatal({ err, msg: "unhandled_rejection" });
-  log.flush(() => process.exit(1));
-  setTimeout(() => process.exit(1), 1000).unref();
+  crashExit("unhandled_rejection", err);
 });


### PR DESCRIPTION
## Summary
- **api-auth**: wrap DB access in try-catch (fail-closed), add auth failure logging, update JSDoc
- **server**: catch Next.js handler errors, idempotent shutdown guard, `crashExit` helper with flush error logging
- **terminal-proxy**: count client-to-upstream send failures, update `droppedFrames` JSDoc for bidirectional tracking
- **uploads**: extract `throwApiError` helper (4x dedup), fix ref URL consistency, validate SHA-1 format, log `.catch()` errors
- **uploads.test**: add "No commit found" 422 retry test, malformed SHA rejection test, use valid 40-char hex mock SHAs
- **viewport-health**: hoist `skipReason` to `beforeEach`, use `forEachViewport` in last test

## Test plan
- [x] `pnpm turbo typecheck` — all packages pass
- [x] `pnpm --filter @issuectl/core test` — 430 tests pass (2 new: malformed SHA, "No commit found" 422)
- [x] `pnpm --filter @issuectl/web test` — 130 tests pass (2 new: DB failure, getSetting throw)
- [x] PR review toolkit — all 6 agents run, critical/important findings addressed