### PR TITLE
feat(web): add issue and PR read endpoints for iOS API v1

### DIFF
--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
@@ -17,12 +17,12 @@ export async function GET(
     return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
   }
 
-  const db = getDb();
-  if (!getRepo(db, owner, repo)) {
-    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
-  }
-
   try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
     const result = await withAuthRetry((octokit) =>
       getIssueDetail(db, octokit, owner, repo, issueNumber, { forceRefresh }),

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getRepo, getIssueDetail, withAuthRetry } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  const db = getDb();
+  if (!getRepo(db, owner, repo)) {
+    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+  }
+
+  try {
+    const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
+    const result = await withAuthRetry((octokit) =>
+      getIssueDetail(db, octokit, owner, repo, issueNumber, { forceRefresh }),
+    );
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(`[issuectl] GET /api/v1/issues/${owner}/${repo}/${issueNumber} failed:`, err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getRepo, getIssues, withAuthRetry } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+  const db = getDb();
+  if (!getRepo(db, owner, repo)) {
+    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+  }
+
+  try {
+    const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
+    const result = await withAuthRetry((octokit) =>
+      getIssues(db, octokit, owner, repo, { forceRefresh }),
+    );
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(`[issuectl] GET /api/v1/issues/${owner}/${repo} failed:`, err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
@@ -12,12 +12,13 @@ export async function GET(
   if (denied) return denied;
 
   const { owner, repo } = await params;
-  const db = getDb();
-  if (!getRepo(db, owner, repo)) {
-    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
-  }
 
   try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
     const result = await withAuthRetry((octokit) =>
       getIssues(db, octokit, owner, repo, { forceRefresh }),

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/route.ts
@@ -17,12 +17,12 @@ export async function GET(
     return NextResponse.json({ error: "Invalid pull request number" }, { status: 400 });
   }
 
-  const db = getDb();
-  if (!getRepo(db, owner, repo)) {
-    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
-  }
-
   try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
     const result = await withAuthRetry((octokit) =>
       getPullDetail(db, octokit, owner, repo, pullNumber, { forceRefresh }),

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getRepo, getPullDetail, withAuthRetry } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const pullNumber = parseInt(numStr, 10);
+  if (Number.isNaN(pullNumber) || pullNumber <= 0) {
+    return NextResponse.json({ error: "Invalid pull request number" }, { status: 400 });
+  }
+
+  const db = getDb();
+  if (!getRepo(db, owner, repo)) {
+    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+  }
+
+  try {
+    const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
+    const result = await withAuthRetry((octokit) =>
+      getPullDetail(db, octokit, owner, repo, pullNumber, { forceRefresh }),
+    );
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(`[issuectl] GET /api/v1/pulls/${owner}/${repo}/${pullNumber} failed:`, err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getRepo, getPulls, withAuthRetry } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+  const db = getDb();
+  if (!getRepo(db, owner, repo)) {
+    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+  }
+
+  try {
+    const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
+    const result = await withAuthRetry((octokit) =>
+      getPulls(db, octokit, owner, repo, { forceRefresh }),
+    );
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(`[issuectl] GET /api/v1/pulls/${owner}/${repo} failed:`, err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
@@ -12,12 +12,13 @@ export async function GET(
   if (denied) return denied;
 
   const { owner, repo } = await params;
-  const db = getDb();
-  if (!getRepo(db, owner, repo)) {
-    return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
-  }
 
   try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
     const result = await withAuthRetry((octokit) =>
       getPulls(db, octokit, owner, repo, { forceRefresh }),


### PR DESCRIPTION
## Summary
- Add 4 new REST API endpoints for the iOS app to read issues and pull requests
- `GET /api/v1/issues/:owner/:repo` — list issues for a tracked repo
- `GET /api/v1/issues/:owner/:repo/:number` — issue detail with comments, deployments, linked PRs
- `GET /api/v1/pulls/:owner/:repo` — list pull requests for a tracked repo
- `GET /api/v1/pulls/:owner/:repo/:number` — PR detail with checks, changed files, linked issue
- All endpoints use Bearer token auth (`requireAuth`), `withAuthRetry` for GitHub API calls, and support `?refresh=true` for cache bypass

## Test plan
- [ ] Verify all 4 endpoints return correct JSON when called with valid Bearer token
- [ ] Verify 401 response with missing/invalid token
- [ ] Verify 404 response for untracked repos
- [ ] Verify 400 response for invalid issue/PR numbers (negative, zero, NaN)
- [ ] Verify `?refresh=true` bypasses cache
- [ ] Verify `getDb()`/`getRepo()` failures return JSON 500 (not HTML error page)
- [ ] Type-check passes: `pnpm turbo typecheck`