### PR TITLE
feat(web): Phase 2 API endpoints — launch, terminal, sessions

### DIFF
--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -283,7 +283,9 @@ export function deletePendingDeployment(
   }
 }
 
-export type ActiveDeploymentWithRepo = Deployment & {
+export type ActiveDeploymentWithRepo = Omit<Deployment, "state" | "endedAt"> & {
+  state: "active";
+  endedAt: null;
   owner: string;
   repoName: string;
 };
@@ -302,6 +304,8 @@ export function getActiveDeployments(
     .all() as Array<DeploymentRow & { owner: string; repo_name: string }>;
   return rows.map((row) => ({
     ...rowToDeployment(row),
+    state: "active" as const,
+    endedAt: null,
     owner: row.owner,
     repoName: row.repo_name,
   }));

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -282,3 +282,27 @@ export function deletePendingDeployment(
     );
   }
 }
+
+export type ActiveDeploymentWithRepo = Deployment & {
+  owner: string;
+  repoName: string;
+};
+
+export function getActiveDeployments(
+  db: Database.Database,
+): ActiveDeploymentWithRepo[] {
+  const rows = db
+    .prepare(
+      `SELECT d.*, r.owner, r.name as repo_name
+       FROM deployments d
+       JOIN repos r ON d.repo_id = r.id
+       WHERE d.state = 'active' AND d.ended_at IS NULL
+       ORDER BY d.launched_at DESC`,
+    )
+    .all() as Array<DeploymentRow & { owner: string; repo_name: string }>;
+  return rows.map((row) => ({
+    ...rowToDeployment(row),
+    owner: row.owner,
+    repoName: row.repo_name,
+  }));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,7 +71,9 @@ export {
   deletePendingDeployment,
   cleanupOrphanedDeployments,
   pruneEndedDeployments,
+  getActiveDeployments,
 } from "./db/deployments.js";
+export type { ActiveDeploymentWithRepo } from "./db/deployments.js";
 export {
   getCacheTtl,
   getCached,

--- a/packages/web/app/api/v1/deployments/[id]/end/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/end/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import {
+  getDb,
+  getRepo,
+  getDeploymentById,
+  endDeployment,
+  killTtyd,
+  tmuxSessionName,
+  formatErrorForUser,
+  cleanupStaleContextFiles,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type EndSessionBody = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id: idStr } = await params;
+  const deploymentId = parseInt(idStr, 10);
+  if (Number.isNaN(deploymentId) || deploymentId <= 0) {
+    return NextResponse.json({ error: "Invalid deployment ID" }, { status: 400 });
+  }
+
+  let body: EndSessionBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.owner || !body.repo) {
+    return NextResponse.json({ error: "Invalid repository reference" }, { status: 400 });
+  }
+  if (!Number.isInteger(body.issueNumber) || body.issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    if (!deployment) {
+      return NextResponse.json({ error: "Deployment not found" }, { status: 404 });
+    }
+
+    const repoRecord = getRepo(db, body.owner, body.repo);
+    if (!repoRecord) {
+      return NextResponse.json({ error: "Repository not found" }, { status: 404 });
+    }
+
+    if (deployment.repoId !== repoRecord.id || deployment.issueNumber !== body.issueNumber) {
+      return NextResponse.json({ error: "Deployment does not match the specified issue" }, { status: 400 });
+    }
+
+    if (deployment.ttydPid) {
+      try {
+        killTtyd(deployment.ttydPid, tmuxSessionName(body.repo, body.issueNumber));
+      } catch (killErr) {
+        console.warn(
+          "[issuectl] Failed to kill ttyd process, proceeding with session end:",
+          { deploymentId, pid: deployment.ttydPid },
+          killErr,
+        );
+      }
+    }
+    endDeployment(db, deploymentId);
+
+    cleanupStaleContextFiles().catch((err) => {
+      console.warn("[issuectl] Failed to clean up stale context files:", err);
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(`[issuectl] POST /api/v1/deployments/${deploymentId}/end failed:`, err);
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/deployments/[id]/end/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/end/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
 import {
   getDb,
   getRepo,
@@ -7,7 +8,6 @@ import {
   endDeployment,
   killTtyd,
   tmuxSessionName,
-  formatErrorForUser,
   cleanupStaleContextFiles,
 } from "@issuectl/core";
 
@@ -62,26 +62,26 @@ export async function POST(
       return NextResponse.json({ error: "Deployment does not match the specified issue" }, { status: 400 });
     }
 
+    if (deployment.endedAt !== null) {
+      return NextResponse.json({ success: true });
+    }
+
     if (deployment.ttydPid) {
       try {
         killTtyd(deployment.ttydPid, tmuxSessionName(body.repo, body.issueNumber));
       } catch (killErr) {
-        console.warn(
-          "[issuectl] Failed to kill ttyd process, proceeding with session end:",
-          { deploymentId, pid: deployment.ttydPid },
-          killErr,
-        );
+        log.warn({ err: killErr, msg: "kill_ttyd_failed", deploymentId, pid: deployment.ttydPid });
       }
     }
     endDeployment(db, deploymentId);
 
-    cleanupStaleContextFiles().catch((err) => {
-      console.warn("[issuectl] Failed to clean up stale context files:", err);
+    cleanupStaleContextFiles().catch((cleanupErr) => {
+      log.warn({ err: cleanupErr, msg: "context_file_cleanup_failed" });
     });
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error(`[issuectl] POST /api/v1/deployments/${deploymentId}/end failed:`, err);
-    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+    log.error({ err, msg: "api_end_session_failed", deploymentId });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/packages/web/app/api/v1/deployments/route.ts
+++ b/packages/web/app/api/v1/deployments/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getActiveDeployments } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const db = getDb();
+    const deployments = getActiveDeployments(db);
+    return NextResponse.json({ deployments });
+  } catch (err) {
+    console.error("[issuectl] GET /api/v1/deployments failed:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/v1/deployments/route.ts
+++ b/packages/web/app/api/v1/deployments/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
 import { getDb, getActiveDeployments } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +14,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const deployments = getActiveDeployments(db);
     return NextResponse.json({ deployments });
   } catch (err) {
-    console.error("[issuectl] GET /api/v1/deployments failed:", err);
+    log.error({ err, msg: "api_deployments_list_failed" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import {
+  getDb,
+  getRepo,
+  executeLaunch,
+  withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
+  formatErrorForUser,
+  type WorkspaceMode,
+} from "@issuectl/core";
+import { VALID_BRANCH_RE, MAX_PREAMBLE } from "@/lib/constants";
+import { randomUUID } from "node:crypto";
+
+export const dynamic = "force-dynamic";
+
+type LaunchRequestBody = {
+  branchName: string;
+  workspaceMode: WorkspaceMode;
+  selectedCommentIndices: number[];
+  selectedFilePaths: string[];
+  preamble?: string;
+  forceResume?: boolean;
+};
+
+const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
+  "existing",
+  "worktree",
+  "clone",
+];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: LaunchRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const trimmedBranch = (body.branchName ?? "").trim();
+  if (!trimmedBranch) {
+    return NextResponse.json({ error: "Branch name is required" }, { status: 400 });
+  }
+  if (!VALID_BRANCH_RE.test(trimmedBranch)) {
+    return NextResponse.json({ error: "Branch name contains invalid characters" }, { status: 400 });
+  }
+  if (!VALID_WORKSPACE_MODES.includes(body.workspaceMode)) {
+    return NextResponse.json({ error: "Invalid workspace mode" }, { status: 400 });
+  }
+  if (!Array.isArray(body.selectedCommentIndices) ||
+      body.selectedCommentIndices.some((i) => !Number.isInteger(i) || i < 0)) {
+    return NextResponse.json({ error: "Invalid comment selection" }, { status: 400 });
+  }
+  if (!Array.isArray(body.selectedFilePaths)) {
+    return NextResponse.json({ error: "Invalid file paths" }, { status: 400 });
+  }
+  for (const filePath of body.selectedFilePaths) {
+    if (typeof filePath !== "string" || filePath.length === 0) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+    if (filePath.includes("\0") || filePath.startsWith("/") || filePath.includes("..")) {
+      return NextResponse.json({ error: "File paths must be relative without '..' or null bytes" }, { status: 400 });
+    }
+  }
+  if (body.preamble && body.preamble.length > MAX_PREAMBLE) {
+    return NextResponse.json(
+      { error: `Preamble must be ${MAX_PREAMBLE} characters or fewer` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const idempotencyKey = randomUUID();
+    const runLaunch = async () => {
+      const r = await withAuthRetry((octokit) =>
+        executeLaunch(db, octokit, {
+          owner,
+          repo,
+          issueNumber,
+          branchName: trimmedBranch,
+          workspaceMode: body.workspaceMode,
+          selectedComments: body.selectedCommentIndices,
+          selectedFiles: body.selectedFilePaths,
+          preamble: body.preamble || undefined,
+          forceResume: body.forceResume,
+        }),
+      );
+      return {
+        deploymentId: r.deploymentId,
+        ttydPort: r.ttydPort,
+        labelWarning: r.labelWarning ?? null,
+      };
+    };
+    const result = await withIdempotency(db, "launch-issue", idempotencyKey, runLaunch);
+
+    return NextResponse.json({
+      success: true,
+      deploymentId: result.deploymentId,
+      ttydPort: result.ttydPort,
+      ...(result.labelWarning ? { labelWarning: result.labelWarning } : {}),
+    });
+  } catch (err) {
+    if (err instanceof DuplicateInFlightError) {
+      return NextResponse.json(
+        { error: "This launch is already in progress — please wait." },
+        { status: 409 },
+      );
+    }
+    console.error(`[issuectl] POST /api/v1/launch/${owner}/${repo}/${issueNumber} failed:`, err);
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
 import {
   getDb,
   getRepo,
   executeLaunch,
   withAuthRetry,
   withIdempotency,
+  isValidNonce,
   DuplicateInFlightError,
   formatErrorForUser,
   type WorkspaceMode,
 } from "@issuectl/core";
 import { VALID_BRANCH_RE, MAX_PREAMBLE } from "@/lib/constants";
-import { randomUUID } from "node:crypto";
 
 export const dynamic = "force-dynamic";
 
@@ -22,6 +23,7 @@ type LaunchRequestBody = {
   selectedFilePaths: string[];
   preamble?: string;
   forceResume?: boolean;
+  idempotencyKey?: string;
 };
 
 const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
@@ -81,6 +83,9 @@ export async function POST(
       { status: 400 },
     );
   }
+  if (body.idempotencyKey !== undefined && !isValidNonce(body.idempotencyKey)) {
+    return NextResponse.json({ error: "Invalid idempotency key" }, { status: 400 });
+  }
 
   try {
     const db = getDb();
@@ -88,7 +93,6 @@ export async function POST(
       return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
     }
 
-    const idempotencyKey = randomUUID();
     const runLaunch = async () => {
       const r = await withAuthRetry((octokit) =>
         executeLaunch(db, octokit, {
@@ -109,7 +113,9 @@ export async function POST(
         labelWarning: r.labelWarning ?? null,
       };
     };
-    const result = await withIdempotency(db, "launch-issue", idempotencyKey, runLaunch);
+    const result = body.idempotencyKey
+      ? await withIdempotency(db, "launch-issue", body.idempotencyKey, runLaunch)
+      : await runLaunch();
 
     return NextResponse.json({
       success: true,
@@ -119,12 +125,13 @@ export async function POST(
     });
   } catch (err) {
     if (err instanceof DuplicateInFlightError) {
+      log.warn({ msg: "launch_duplicate_in_flight", owner, repo, issueNumber });
       return NextResponse.json(
         { error: "This launch is already in progress — please wait." },
         { status: 409 },
       );
     }
-    console.error(`[issuectl] POST /api/v1/launch/${owner}/${repo}/${issueNumber} failed:`, err);
+    log.error({ err, msg: "api_launch_failed", owner, repo, issueNumber });
     return NextResponse.json(
       { error: formatErrorForUser(err) },
       { status: 500 },


### PR DESCRIPTION
## Summary
- Add GET `/api/v1/deployments` endpoint listing active deployments with repo info (for iOS Active Sessions tab)
- Add POST `/api/v1/launch/[owner]/[repo]/[number]` endpoint with full input validation, client-generated idempotency key, and `withAuthRetry` wrapping
- Add POST `/api/v1/deployments/[id]/end` endpoint with ownership validation, idempotent already-ended guard, and ttyd/tmux cleanup
- Add `getActiveDeployments()` to core with narrowed `ActiveDeploymentWithRepo` type (`state: "active"`, `endedAt: null`)
- All routes use structured pino logger (not console.error)

## Test plan
- [ ] `pnpm turbo typecheck` passes
- [ ] GET `/api/v1/deployments` returns active sessions with owner/repoName fields
- [ ] POST launch endpoint validates branch name, workspace mode, file paths (no traversal), preamble length
- [ ] POST launch with duplicate idempotency key returns 409
- [ ] POST end-session on already-ended deployment returns idempotent 200
- [ ] Structured log entries appear in `~/.issuectl/logs/web.log`