### PR TITLE
fix: redirect to dashboard root after closing issue

### DIFF
--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -156,7 +156,11 @@ export function IssueActionSheet({
             : "Issue closed",
           "success",
         );
-        router.replace("/?section=closed");
+        if (window.history.length > 1) {
+          router.back();
+        } else {
+          router.replace("/");
+        }
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
         setError("Something went wrong while closing the issue. Please try again.");

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -156,11 +156,7 @@ export function IssueActionSheet({
             : "Issue closed",
           "success",
         );
-        if (window.history.length > 1) {
-          router.back();
-        } else {
-          router.replace("/");
-        }
+        router.replace("/");
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
         setError("Something went wrong while closing the issue. Please try again.");


### PR DESCRIPTION
## Summary
- Fixes #239
- After closing an issue, the redirect was forcing `?section=closed` which overrode the user's filter state
- Changed `router.replace("/?section=closed")` to `router.replace("/")` — deterministic redirect to dashboard with default state

## Test plan
- [ ] Open an issue detail page, close the issue
- [ ] Verify redirect goes to `/` (dashboard root, open section)
- [ ] Verify no `?section=closed` in URL