### PR TITLE
feat: add inline title editing on issue detail page

### DIFF
--- a/packages/web/components/detail/EditableTitle.module.css
+++ b/packages/web/components/detail/EditableTitle.module.css
@@ -66,7 +66,6 @@
   gap: 8px;
 }
 
-
 @media (min-width: 768px) {
   .title {
     font-size: 36px;

--- a/packages/web/components/detail/EditableTitle.module.css
+++ b/packages/web/components/detail/EditableTitle.module.css
@@ -1,0 +1,112 @@
+.titleWrap {
+  position: relative;
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+  margin-bottom: 12px;
+}
+
+.editBtn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: none;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 2px 10px;
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+  z-index: 1;
+}
+
+.editBtn:hover {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink-muted);
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.input {
+  width: 100%;
+  padding: 6px 10px;
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: -0.4px;
+  color: var(--paper-ink);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--paper-ink-muted);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.actionBtn {
+  background: none;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 2px 10px;
+  font-family: var(--paper-sans);
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.actionBtn:hover {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink-muted);
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.saveBtn {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink-muted);
+}
+
+@media (min-width: 768px) {
+  .title {
+    font-size: 36px;
+    line-height: 1.15;
+    letter-spacing: -0.7px;
+    margin-bottom: 14px;
+  }
+
+  .editor {
+    margin-bottom: 14px;
+  }
+
+  .input {
+    font-size: 36px;
+    line-height: 1.15;
+    letter-spacing: -0.7px;
+  }
+}

--- a/packages/web/components/detail/EditableTitle.module.css
+++ b/packages/web/components/detail/EditableTitle.module.css
@@ -10,6 +10,7 @@
   letter-spacing: -0.4px;
   color: var(--paper-ink);
   margin-bottom: 12px;
+  padding-right: 60px;
 }
 
 .editBtn {
@@ -65,32 +66,6 @@
   gap: 8px;
 }
 
-.actionBtn {
-  background: none;
-  border: 1px solid var(--paper-line);
-  border-radius: var(--paper-radius-sm);
-  padding: 2px 10px;
-  font-family: var(--paper-sans);
-  font-size: var(--paper-fs-xs);
-  color: var(--paper-ink-muted);
-  cursor: pointer;
-  transition: color 0.1s, border-color 0.1s;
-}
-
-.actionBtn:hover {
-  color: var(--paper-ink);
-  border-color: var(--paper-ink-muted);
-}
-
-.actionBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.saveBtn {
-  color: var(--paper-ink);
-  border-color: var(--paper-ink-muted);
-}
 
 @media (min-width: 768px) {
   .title {

--- a/packages/web/components/detail/EditableTitle.tsx
+++ b/packages/web/components/detail/EditableTitle.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { updateIssue } from "@/lib/actions/issues";
+import { useToast } from "@/components/ui/ToastProvider";
+import styles from "./EditableTitle.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  initialTitle: string;
+};
+
+export function EditableTitle({ owner, repo, issueNumber, initialTitle }: Props) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState(initialTitle);
+  const [displayTitle, setDisplayTitle] = useState(initialTitle);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editing) {
+      setDisplayTitle(initialTitle);
+      setTitle(initialTitle);
+    }
+  }, [initialTitle, editing]);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const handleSave = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      showToast("Title cannot be empty", "error");
+      return;
+    }
+    if (trimmed === displayTitle) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      const result = await updateIssue({ owner, repo, number: issueNumber, title: trimmed });
+      if (!result.success) {
+        showToast(result.error ?? "Failed to update title", "error");
+        return;
+      }
+      setDisplayTitle(trimmed);
+      setTitle(trimmed);
+      setEditing(false);
+      router.refresh();
+      showToast(
+        result.cacheStale
+          ? "Title updated — reload if changes don't appear"
+          : "Title updated",
+        "success",
+      );
+    } catch (err) {
+      console.error("[issuectl] updateIssue title failed:", err);
+      showToast("Failed to update title", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setTitle(displayTitle);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !saving) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className={styles.editor}>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={saving}
+          maxLength={256}
+          aria-label="Edit issue title"
+        />
+        <div className={styles.actions}>
+          <button className={styles.actionBtn} onClick={handleCancel} disabled={saving}>
+            cancel
+          </button>
+          <button className={`${styles.actionBtn} ${styles.saveBtn}`} onClick={handleSave} disabled={saving}>
+            {saving ? "saving\u2026" : "save"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.titleWrap}>
+      <h1 className={styles.title}>{displayTitle}</h1>
+      <button
+        className={styles.editBtn}
+        onClick={() => {
+          setTitle(displayTitle);
+          setEditing(true);
+        }}
+        aria-label="Edit title"
+      >
+        edit
+      </button>
+    </div>
+  );
+}

--- a/packages/web/components/detail/EditableTitle.tsx
+++ b/packages/web/components/detail/EditableTitle.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/paper";
 import { updateIssue } from "@/lib/actions/issues";
 import { useToast } from "@/components/ui/ToastProvider";
 import styles from "./EditableTitle.module.css";
@@ -100,12 +101,12 @@ export function EditableTitle({ owner, repo, issueNumber, initialTitle }: Props)
           aria-label="Edit issue title"
         />
         <div className={styles.actions}>
-          <button className={styles.actionBtn} onClick={handleCancel} disabled={saving}>
+          <Button variant="ghost" onClick={handleCancel} disabled={saving}>
             cancel
-          </button>
-          <button className={`${styles.actionBtn} ${styles.saveBtn}`} onClick={handleSave} disabled={saving}>
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={saving}>
             {saving ? "saving\u2026" : "save"}
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/packages/web/components/detail/IssueDetail.module.css
+++ b/packages/web/components/detail/IssueDetail.module.css
@@ -7,16 +7,6 @@
   padding: 22px 24px 60px;
 }
 
-.title {
-  font-family: var(--paper-serif);
-  font-weight: 500;
-  font-size: 26px;
-  line-height: 1.2;
-  letter-spacing: -0.4px;
-  color: var(--paper-ink);
-  margin-bottom: 12px;
-}
-
 .contentError {
   font-family: var(--paper-serif);
   font-style: italic;
@@ -34,12 +24,5 @@
     max-width: 820px;
     margin: 0 auto;
     padding: 32px 40px 40px;
-  }
-
-  .title {
-    font-size: 36px;
-    line-height: 1.15;
-    letter-spacing: -0.7px;
-    margin-bottom: 14px;
   }
 }

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -10,6 +10,7 @@ import {
   MetaNum,
 } from "./DetailMeta";
 import { EditableBody } from "./EditableBody";
+import { EditableTitle } from "./EditableTitle";
 import { PriorityPicker } from "./PriorityPicker";
 import { IssueActionSheet } from "./IssueActionSheet";
 import styles from "./IssueDetail.module.css";
@@ -55,7 +56,12 @@ export function IssueDetail({
         }
       />
       <div className={styles.body}>
-        <h1 className={styles.title}>{issue.title}</h1>
+        <EditableTitle
+          owner={owner}
+          repo={repoName}
+          issueNumber={issue.number}
+          initialTitle={issue.title}
+        />
         <DetailMeta>
           <Chip>{repoName}</Chip>
           <MetaNum>#{issue.number}</MetaNum>


### PR DESCRIPTION
## Summary
- Fixes #238
- New `EditableTitle` component following the existing `EditableBody` pattern
- Click "edit" to enter inline editing mode with save/cancel actions
- Uses Paper `Button` for actions, Server Action `updateIssue` for mutation
- Keyboard support: Enter saves, Escape cancels
- Optimistic display update with toast feedback and `cacheStale` handling

## Test plan
- [ ] Navigate to an issue detail page, click "edit" on the title
- [ ] Verify the input is focused and text is selected
- [ ] Edit the title and press Enter — verify it saves and updates
- [ ] Press Escape — verify it cancels without saving
- [ ] Try saving an empty title — verify error toast
- [ ] Try saving the same title — verify it just closes the editor (no API call)