### PR TITLE
feat: replace repo toggle with dropdown selector

### DIFF
--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -122,14 +122,25 @@
 }
 
 /* ── Repo picker ── */
-.repoDisplay {
+.repoToggle {
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   padding: 10px 12px;
+  min-height: 44px;
   background: var(--paper-bg-warm);
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif), sans-serif;
+  font-size: var(--paper-fs-md);
+  cursor: pointer;
+  text-align: left;
+}
+
+.repoToggle:hover {
+  background: var(--paper-bg-warmer);
 }
 
 .repoDot {
@@ -141,25 +152,23 @@
 }
 
 .repoName {
+  flex: 1;
   font-size: var(--paper-fs-md);
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.repoChange {
-  margin-left: auto;
-  font-size: var(--paper-fs-base);
+.repoChevron {
+  font-size: var(--paper-fs-md);
   color: var(--paper-ink-muted);
-  background: none;
-  border: none;
-  padding: 8px;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  cursor: pointer;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
 }
 
-.repoChange:hover {
-  color: var(--paper-ink-soft);
+.repoChevron[data-open="true"] {
+  transform: rotate(180deg);
 }
 
 .repoList {
@@ -168,17 +177,18 @@
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   overflow: hidden;
+  margin-top: 6px;
 }
 
 .repoOption {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
+  gap: 12px;
+  padding: 14px 12px;
   min-height: 44px;
   background: var(--paper-bg-warm);
   border: none;
-  border-bottom: 1px solid var(--paper-line);
+  border-bottom: 1px solid var(--paper-line-soft);
   color: var(--paper-ink);
   font-family: var(--paper-serif), sans-serif;
   font-size: var(--paper-fs-md);
@@ -196,8 +206,20 @@
 
 .repoOptionSelected {
   composes: repoOption;
+  background: var(--paper-accent-soft);
+}
+
+.repoOptionLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repoCheck {
   color: var(--paper-accent);
-  font-weight: 600;
+  font-size: 18px;
+  flex-shrink: 0;
 }
 
 /* ── Text inputs — 16px on mobile kills iOS auto-zoom on focus. ── */

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -122,6 +122,21 @@
 }
 
 /* ── Repo picker ── */
+.repoDisplay {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  min-height: 44px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif), sans-serif;
+  font-size: var(--paper-fs-md);
+}
+
 .repoToggle {
   display: flex;
   align-items: center;
@@ -139,8 +154,13 @@
   text-align: left;
 }
 
-.repoToggle:hover {
+.repoToggle:hover:not(:disabled) {
   background: var(--paper-bg-warmer);
+}
+
+.repoToggle:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 .repoDot {
@@ -209,6 +229,10 @@
   background: var(--paper-accent-soft);
 }
 
+.repoOptionSelected:hover {
+  background: var(--paper-accent-soft);
+}
+
 .repoOptionLabel {
   flex: 1;
   overflow: hidden;
@@ -218,7 +242,7 @@
 
 .repoCheck {
   color: var(--paper-accent);
-  font-size: 18px;
+  font-size: var(--paper-fs-xl);
   flex-shrink: 0;
 }
 

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -206,6 +206,7 @@
   gap: 12px;
   padding: 14px 12px;
   min-height: 44px;
+  width: 100%;
   background: var(--paper-bg-warm);
   border: none;
   border-bottom: 1px solid var(--paper-line-soft);

--- a/packages/web/app/new/NewIssuePage.module.css
+++ b/packages/web/app/new/NewIssuePage.module.css
@@ -138,18 +138,7 @@
 }
 
 .repoToggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 10px 12px;
-  min-height: 44px;
-  background: var(--paper-bg-warm);
-  border: 1px solid var(--paper-line);
-  border-radius: var(--paper-radius-md);
-  color: var(--paper-ink);
-  font-family: var(--paper-serif), sans-serif;
-  font-size: var(--paper-fs-md);
+  composes: repoDisplay;
   cursor: pointer;
   text-align: left;
 }

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -186,7 +186,7 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
               <span className={styles.repoChevron} data-open={showRepoPicker}>&#x25BE;</span>
             </button>
           )}
-          {showRepoPicker && repos.length > 1 && (
+          {showRepoPicker && (
             <div className={styles.repoList}>
               {repos.map((r) => {
                 const isSelected =

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -168,7 +168,18 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
 
         <div className={styles.field}>
           <div className={styles.fieldLabel}>Repository</div>
-          {showRepoPicker ? (
+          <button
+            type="button"
+            className={styles.repoToggle}
+            onClick={() => setShowRepoPicker(!showRepoPicker)}
+          >
+            <span className={styles.repoDot} />
+            <span className={styles.repoName}>{selectedRepo.owner}/{selectedRepo.repo}</span>
+            {repos.length > 1 && (
+              <span className={styles.repoChevron} data-open={showRepoPicker}>&#x25BE;</span>
+            )}
+          </button>
+          {showRepoPicker && repos.length > 1 && (
             <div className={styles.repoList}>
               {repos.map((r) => {
                 const isSelected =
@@ -177,30 +188,15 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
                   <button
                     key={`${r.owner}/${r.repo}`}
                     type="button"
-                    className={`${styles.repoOption} ${isSelected ? styles.repoOptionSelected : ""}`}
+                    className={isSelected ? styles.repoOptionSelected : styles.repoOption}
                     onClick={() => handleSelectRepo(r)}
                   >
                     <span className={styles.repoDot} />
-                    {r.owner}/{r.repo}
+                    <span className={styles.repoOptionLabel}>{r.owner}/{r.repo}</span>
+                    {isSelected && <span className={styles.repoCheck}>&#x2713;</span>}
                   </button>
                 );
               })}
-            </div>
-          ) : (
-            <div className={styles.repoDisplay}>
-              <span className={styles.repoDot} />
-              <span className={styles.repoName}>
-                {selectedRepo.owner}/{selectedRepo.repo}
-              </span>
-              {repos.length > 1 && (
-                <button
-                  type="button"
-                  className={styles.repoChange}
-                  onClick={() => setShowRepoPicker(true)}
-                >
-                  change
-                </button>
-              )}
             </div>
           )}
         </div>

--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -168,17 +168,24 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
 
         <div className={styles.field}>
           <div className={styles.fieldLabel}>Repository</div>
-          <button
-            type="button"
-            className={styles.repoToggle}
-            onClick={() => setShowRepoPicker(!showRepoPicker)}
-          >
-            <span className={styles.repoDot} />
-            <span className={styles.repoName}>{selectedRepo.owner}/{selectedRepo.repo}</span>
-            {repos.length > 1 && (
+          {repos.length <= 1 ? (
+            <div className={styles.repoDisplay}>
+              <span className={styles.repoDot} />
+              <span className={styles.repoName}>{selectedRepo.owner}/{selectedRepo.repo}</span>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className={styles.repoToggle}
+              onClick={() => setShowRepoPicker(!showRepoPicker)}
+              disabled={isPending}
+              aria-expanded={showRepoPicker}
+            >
+              <span className={styles.repoDot} />
+              <span className={styles.repoName}>{selectedRepo.owner}/{selectedRepo.repo}</span>
               <span className={styles.repoChevron} data-open={showRepoPicker}>&#x25BE;</span>
-            )}
-          </button>
+            </button>
+          )}
           {showRepoPicker && repos.length > 1 && (
             <div className={styles.repoList}>
               {repos.map((r) => {

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -91,8 +91,7 @@
   margin-top: 6px;
 }
 
-.repoRow,
-.repoRowSelected {
+.repoRow {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -109,8 +108,7 @@
   width: 100%;
 }
 
-.repoRow:last-child,
-.repoRowSelected:last-child {
+.repoRow:last-child {
   border-bottom: none;
 }
 
@@ -118,18 +116,18 @@
   background: var(--paper-bg-warmer);
 }
 
+.repoRow:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .repoRowSelected {
+  composes: repoRow;
   background: var(--paper-accent-soft);
 }
 
 .repoRowSelected:hover {
   background: var(--paper-accent-soft);
-}
-
-.repoRow:disabled,
-.repoRowSelected:disabled {
-  opacity: 0.5;
-  cursor: default;
 }
 
 .repoDot {

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -55,7 +55,7 @@
   text-align: left;
 }
 
-.repoToggle:hover {
+.repoToggle:hover:not(:disabled) {
   background: var(--paper-bg-warmer);
 }
 

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -31,63 +31,126 @@
   font-style: italic;
 }
 
-/* ── Repo chip row ────────────────────────────────── */
+/* ── Repo dropdown ────────────────────────────────── */
 
 .repoSection {
   margin-bottom: 18px;
 }
 
-.chipRow {
+.repoToggle {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 4px;
-  max-height: 72px;
-  overflow-y: auto;
-}
-
-.repoChip,
-.repoChipSelected {
-  display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: var(--paper-radius-sm);
-  font-family: var(--paper-mono);
-  font-size: var(--paper-fs-xs);
-  font-weight: 600;
-  letter-spacing: 0.3px;
-  white-space: nowrap;
-  line-height: 1.4;
-  border: 1px solid var(--paper-line);
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
-}
-
-.repoChip {
-  background: transparent;
-  color: var(--paper-ink-muted);
-}
-
-.repoChip:hover {
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  min-height: 44px;
+  margin-top: 4px;
   background: var(--paper-bg-warm);
-  color: var(--paper-ink-soft);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-size: var(--paper-fs-base);
+  cursor: pointer;
+  text-align: left;
 }
 
-.repoChipSelected {
-  background: var(--paper-accent-soft);
-  color: var(--paper-accent);
-  border-color: var(--paper-accent-dim);
+.repoToggle:hover {
+  background: var(--paper-bg-warmer);
 }
 
-.repoChipSelected:hover {
-  background: var(--paper-accent-soft);
-  color: var(--paper-accent);
-}
-
-.repoChip:disabled,
-.repoChipSelected:disabled {
+.repoToggle:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+.repoSummary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repoChevron {
+  font-size: var(--paper-fs-base);
+  color: var(--paper-ink-muted);
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.repoChevron[data-open="true"] {
+  transform: rotate(180deg);
+}
+
+.repoDropdown {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  overflow: hidden;
+  margin-top: 6px;
+}
+
+.repoRow,
+.repoRowSelected {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 12px;
+  min-height: 44px;
+  background: var(--paper-bg-warm);
+  border: none;
+  border-bottom: 1px solid var(--paper-line-soft);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-size: var(--paper-fs-base);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.repoRow:last-child,
+.repoRowSelected:last-child {
+  border-bottom: none;
+}
+
+.repoRow:hover {
+  background: var(--paper-bg-warmer);
+}
+
+.repoRowSelected {
+  background: var(--paper-accent-soft);
+}
+
+.repoRowSelected:hover {
+  background: var(--paper-accent-soft);
+}
+
+.repoRow:disabled,
+.repoRowSelected:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.repoDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--paper-accent);
+  flex-shrink: 0;
+}
+
+.repoRowLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repoCheck {
+  color: var(--paper-accent);
+  font-size: 18px;
+  flex-shrink: 0;
 }
 
 /* ── Actions / feedback ────────────────────────────── */

--- a/packages/web/components/list/CreateDraftSheet.module.css
+++ b/packages/web/components/list/CreateDraftSheet.module.css
@@ -149,7 +149,7 @@
 
 .repoCheck {
   color: var(--paper-accent);
-  font-size: 18px;
+  font-size: var(--paper-fs-xl);
   flex-shrink: 0;
 }
 

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -40,6 +40,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
   const [loadingRepos, setLoadingRepos] = useState(false);
   const [selectedRepoIds, setSelectedRepoIds] = useState<Set<number>>(new Set());
   const [defaultRepoId, setDefaultRepoId] = useState<number | null>(null);
+  const [showRepos, setShowRepos] = useState(false);
 
   // Load tracked repos and default repo when the sheet opens.
   useEffect(() => {
@@ -211,6 +212,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
     setError(null);
     setProgress(null);
     setSelectedRepoIds(new Set());
+    setShowRepos(false);
     onClose();
   };
 
@@ -246,29 +248,46 @@ export function CreateDraftSheet({ open, onClose }: Props) {
           style={title.length > 50 ? { fontSize: 20, lineHeight: 1.3 } : undefined}
         />
 
-        {/* Repo chip row — toggleable multi-select */}
+        {/* Repo dropdown — toggleable multi-select */}
         {!loadingRepos && repos.length > 0 && (
           <div className={styles.repoSection}>
             <label className={styles.label}>Repos</label>
-            <div className={styles.chipRow}>
-              {repos.map((repo) => {
-                const isSelected = selectedRepoIds.has(repo.id);
-                return (
-                  <button
-                    key={repo.id}
-                    type="button"
-                    className={
-                      isSelected ? styles.repoChipSelected : styles.repoChip
-                    }
-                    onClick={() => toggleRepo(repo.id)}
-                    disabled={saving}
-                    aria-pressed={isSelected}
-                  >
-                    {repo.name}
-                  </button>
-                );
-              })}
-            </div>
+            <button
+              type="button"
+              className={styles.repoToggle}
+              onClick={() => setShowRepos(!showRepos)}
+              disabled={saving}
+            >
+              <span className={styles.repoSummary}>
+                {selectedRepoIds.size === 0
+                  ? "No repos \u2014 save as draft"
+                  : selectedRepoIds.size === 1
+                    ? repos.find((r) => selectedRepoIds.has(r.id))?.name ?? "1 repo"
+                    : `${selectedRepoIds.size} repos`}
+              </span>
+              <span className={styles.repoChevron} data-open={showRepos}>&#x25BE;</span>
+            </button>
+            {showRepos && (
+              <div className={styles.repoDropdown}>
+                {repos.map((repo) => {
+                  const isSelected = selectedRepoIds.has(repo.id);
+                  return (
+                    <button
+                      key={repo.id}
+                      type="button"
+                      className={isSelected ? styles.repoRowSelected : styles.repoRow}
+                      onClick={() => toggleRepo(repo.id)}
+                      disabled={saving}
+                      aria-pressed={isSelected}
+                    >
+                      <span className={styles.repoDot} />
+                      <span className={styles.repoRowLabel}>{repo.owner}/{repo.name}</span>
+                      {isSelected && <span className={styles.repoCheck}>&#x2713;</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
 

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -46,6 +46,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
   useEffect(() => {
     if (!open) return;
     setSelectedRepoIds(new Set());
+    setShowRepos(false);
     setLoadingRepos(true);
     Promise.all([listReposAction(), getDefaultRepoIdAction()])
       .then(([repoList, defaultId]) => {
@@ -257,6 +258,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
               className={styles.repoToggle}
               onClick={() => setShowRepos(!showRepos)}
               disabled={saving}
+              aria-expanded={showRepos}
             >
               <span className={styles.repoSummary}>
                 {selectedRepoIds.size === 0


### PR DESCRIPTION
## Summary
- Fixes #236
- Replace toggle-expand repo lists with dropdown + chevron + checkmarks in NewIssuePage and CreateDraftSheet
- Single-repo case renders a non-interactive display div instead of a pointless toggle
- Accessibility: `aria-expanded`, `aria-pressed`, `disabled` states
- CSS: `composes` to reduce duplication, design token usage, hover guards for disabled state

## Test plan
- [ ] Open /new with multiple repos — verify dropdown opens/closes, checkmark shows on selected
- [ ] Open /new with a single repo — verify static display (no clickable toggle)
- [ ] Open CreateDraftSheet — verify dropdown works with multi-select
- [ ] Verify disabled states work during submission
- [ ] Test on mobile viewport (touch targets, overflow)