### PR TITLE
fix: mobile layout issues in terminal panel and launch banner

### DIFF
--- a/packages/web/components/launch/LaunchActiveBanner.module.css
+++ b/packages/web/components/launch/LaunchActiveBanner.module.css
@@ -12,6 +12,18 @@
   gap: 14px;
 }
 
+@media (max-width: 767px) {
+  .banner {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .text {
+    min-width: 0;
+    flex-basis: calc(100% - 34px);
+  }
+}
+
 .spinner {
   width: 20px;
   height: 20px;

--- a/packages/web/components/launch/LaunchActiveBanner.module.css
+++ b/packages/web/components/launch/LaunchActiveBanner.module.css
@@ -20,7 +20,7 @@
 
   .text {
     min-width: 0;
-    flex-basis: calc(100% - 34px);
+    flex-basis: calc(100% - 30px);
   }
 }
 

--- a/packages/web/components/terminal/TerminalPanel.module.css
+++ b/packages/web/components/terminal/TerminalPanel.module.css
@@ -48,6 +48,15 @@
   flex-shrink: 0;
 }
 
+@media (max-width: 767px) {
+  .header {
+    gap: 8px;
+    padding-right: 12px;
+    padding-left: 4px;
+    flex-wrap: wrap;
+  }
+}
+
 /* Mobile: back arrow button */
 .backButton {
   display: inline-flex;
@@ -112,6 +121,7 @@
 
 .headerTitle {
   flex: 1;
+  min-width: 0;
   font-family: var(--paper-mono);
   font-size: var(--paper-fs-sm);
   color: var(--paper-ink-muted);

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";
@@ -59,33 +58,6 @@ export function TerminalPanel({
       <div className={styles.backdrop} onClick={onClose} />
       <div className={styles.panel} data-open={open}>
         <div className={styles.header}>
-          <Link
-            href={`/${owner}/${repo}/${issueNumber}`}
-            className={styles.backButton}
-            aria-label="Back"
-            onClick={(e) => {
-              if (window.history.length > 1) {
-                e.preventDefault();
-                onClose();
-              }
-            }}
-          >
-            <svg
-              width="12"
-              height="20"
-              viewBox="0 0 12 20"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="M10 2L2 10L10 18"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </Link>
           <button
             type="button"
             className={styles.backButton}

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";
@@ -61,7 +61,13 @@ export function TerminalPanel({
           <button
             type="button"
             className={styles.backButton}
-            onClick={onClose}
+            onClick={() => {
+              if (window.history.length > 1) {
+                onClose();
+              } else {
+                router.push(`/issues/${owner}/${repo}/${issueNumber}`);
+              }
+            }}
             aria-label="Back to issue"
           >
             <svg


### PR DESCRIPTION
## Summary
- Fixes #242
- Remove duplicate back button `<Link>` in TerminalPanel; consolidate navigation logic into remaining button
- Add mobile media queries for header flex-wrap, reduced gaps, and text truncation
- Fix LaunchActiveBanner flex-basis calc: spinner (20px) + gap (10px) = 30px, not 34px
- Remove unused `useCallback` import

## Test plan
- [ ] Open terminal panel on mobile viewport — verify header wraps cleanly
- [ ] Verify back button navigates correctly (close panel or push to issue detail)
- [ ] Verify LaunchActiveBanner text doesn't overflow on narrow screens
- [ ] Verify close button and End Session button are accessible