### PR TITLE
feat: add inline quick-create to mobile filters sheet

### DIFF
--- a/packages/web/components/list/FiltersSheet.tsx
+++ b/packages/web/components/list/FiltersSheet.tsx
@@ -5,6 +5,7 @@ import type { Section, SortMode } from "@issuectl/core";
 import { Sheet } from "@/components/paper";
 import { REPO_COLORS } from "@/lib/constants";
 import { repoKey } from "@/lib/repo-key";
+import { QuickCreateInline } from "./QuickCreateInline";
 import styles from "./FiltersSheet.module.css";
 
 type Repo = { owner: string; name: string };
@@ -221,6 +222,8 @@ export function FiltersSheet({
       <div className={styles.mobileOnly}>
         <div className={styles.commandDivider} />
 
+        <QuickCreateInline onCreated={onClose} />
+
         <button
           className={styles.commandLink}
           onClick={() => {
@@ -259,8 +262,8 @@ export function FiltersSheet({
             </svg>
           </span>
           <span className={styles.commandLinkText}>
-            Quick Create
-            <span className={styles.commandLinkDesc}>paste a GitHub URL to create an issue</span>
+            Create from URL
+            <span className={styles.commandLinkDesc}>paste a GitHub issue URL to import</span>
           </span>
         </Link>
 

--- a/packages/web/components/list/QuickCreateInline.module.css
+++ b/packages/web/components/list/QuickCreateInline.module.css
@@ -1,0 +1,63 @@
+.container {
+  padding: 0 0 8px;
+}
+
+.inputRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--paper-serif);
+  font-size: 16px;
+  line-height: 1.3;
+  color: var(--paper-ink);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 10px 12px;
+  min-height: 44px;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--paper-ink-faint);
+  font-style: italic;
+}
+
+.input:focus {
+  border-color: var(--paper-accent);
+}
+
+.input:disabled {
+  opacity: 0.5;
+}
+
+.createBtn {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+  border: none;
+  border-radius: var(--paper-radius-md);
+  font-size: 22px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.createBtn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.createBtn:not(:disabled):hover {
+  opacity: 0.85;
+}

--- a/packages/web/components/list/QuickCreateInline.module.css
+++ b/packages/web/components/list/QuickCreateInline.module.css
@@ -20,7 +20,6 @@
   border-radius: var(--paper-radius-md);
   padding: 10px 12px;
   min-height: 44px;
-  outline: none;
 }
 
 .input::placeholder {
@@ -29,6 +28,7 @@
 }
 
 .input:focus {
+  outline: none;
   border-color: var(--paper-accent);
 }
 

--- a/packages/web/components/list/QuickCreateInline.tsx
+++ b/packages/web/components/list/QuickCreateInline.tsx
@@ -42,7 +42,10 @@ export function QuickCreateInline({ onCreated }: Props) {
             key,
           );
           if (!assignResult.success) {
-            showToast(assignResult.error, "error");
+            showToast("Draft saved but assignment failed \u2014 assign it manually", "warning");
+            setTitle("");
+            router.refresh();
+            onCreated();
             return;
           }
           const msg = assignResult.cleanupWarning

--- a/packages/web/components/list/QuickCreateInline.tsx
+++ b/packages/web/components/list/QuickCreateInline.tsx
@@ -26,12 +26,14 @@ export function QuickCreateInline({ onCreated }: Props) {
     if (!trimmed) return;
 
     startTransition(async () => {
+      let draftCreated = false;
       try {
         const draftResult = await createDraftAction({ title: trimmed });
         if (!draftResult.success) {
           showToast(draftResult.error, "error");
           return;
         }
+        draftCreated = true;
 
         const defaultRepoId = await getDefaultRepoIdAction();
         if (defaultRepoId) {
@@ -43,27 +45,28 @@ export function QuickCreateInline({ onCreated }: Props) {
           );
           if (!assignResult.success) {
             showToast("Draft saved but assignment failed \u2014 assign it manually", "warning");
-            setTitle("");
-            router.refresh();
-            onCreated();
-            return;
+          } else {
+            const msg = assignResult.cleanupWarning
+              ?? `Issue #${assignResult.issueNumber} created`;
+            showToast(msg, assignResult.cleanupWarning ? "warning" : "success");
           }
-          const msg = assignResult.cleanupWarning
-            ?? `Issue #${assignResult.issueNumber} created`;
-          showToast(msg, assignResult.cleanupWarning ? "warning" : "success");
-          setTitle("");
-          router.refresh();
-          onCreated();
-          return;
+        } else {
+          showToast("Draft saved", "success");
         }
 
-        showToast("Draft saved", "success");
         setTitle("");
         router.refresh();
         onCreated();
       } catch (err) {
         console.error("[issuectl] Quick create failed:", err);
-        showToast("Failed to create", "error");
+        if (draftCreated) {
+          showToast("Draft saved but something went wrong \u2014 assign it manually", "warning");
+          setTitle("");
+          router.refresh();
+          onCreated();
+        } else {
+          showToast("Failed to create", "error");
+        }
       }
     });
   }

--- a/packages/web/components/list/QuickCreateInline.tsx
+++ b/packages/web/components/list/QuickCreateInline.tsx
@@ -41,19 +41,23 @@ export function QuickCreateInline({ onCreated }: Props) {
             defaultRepoId,
             key,
           );
-          if (assignResult.success) {
-            showToast(`Issue #${assignResult.issueNumber} created`, "success");
-            setTitle("");
-            onCreated();
-            router.refresh();
+          if (!assignResult.success) {
+            showToast(assignResult.error, "error");
             return;
           }
+          const msg = assignResult.cleanupWarning
+            ?? `Issue #${assignResult.issueNumber} created`;
+          showToast(msg, assignResult.cleanupWarning ? "warning" : "success");
+          setTitle("");
+          router.refresh();
+          onCreated();
+          return;
         }
 
         showToast("Draft saved", "success");
         setTitle("");
-        onCreated();
         router.refresh();
+        onCreated();
       } catch (err) {
         console.error("[issuectl] Quick create failed:", err);
         showToast("Failed to create", "error");
@@ -83,12 +87,14 @@ export function QuickCreateInline({ onCreated }: Props) {
           autoComplete="off"
           autoCapitalize="sentences"
           enterKeyHint="done"
+          aria-label="Issue title"
         />
         <button
           type="button"
           className={styles.createBtn}
           onClick={handleSubmit}
           disabled={isPending || !title.trim()}
+          aria-label={isPending ? "Creating\u2026" : "Create issue"}
         >
           {isPending ? "\u2026" : "+"}
         </button>

--- a/packages/web/components/list/QuickCreateInline.tsx
+++ b/packages/web/components/list/QuickCreateInline.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  createDraftAction,
+  assignDraftAction,
+  getDefaultRepoIdAction,
+} from "@/lib/actions/drafts";
+import { useToast } from "@/components/ui/ToastProvider";
+import { newIdempotencyKey } from "@/lib/idempotency-key";
+import styles from "./QuickCreateInline.module.css";
+
+type Props = {
+  onCreated: () => void;
+};
+
+export function QuickCreateInline({ onCreated }: Props) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [title, setTitle] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit() {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    startTransition(async () => {
+      try {
+        const draftResult = await createDraftAction({ title: trimmed });
+        if (!draftResult.success) {
+          showToast(draftResult.error, "error");
+          return;
+        }
+
+        const defaultRepoId = await getDefaultRepoIdAction();
+        if (defaultRepoId) {
+          const key = newIdempotencyKey();
+          const assignResult = await assignDraftAction(
+            draftResult.id,
+            defaultRepoId,
+            key,
+          );
+          if (assignResult.success) {
+            showToast(`Issue #${assignResult.issueNumber} created`, "success");
+            setTitle("");
+            onCreated();
+            router.refresh();
+            return;
+          }
+        }
+
+        showToast("Draft saved", "success");
+        setTitle("");
+        onCreated();
+        router.refresh();
+      } catch (err) {
+        console.error("[issuectl] Quick create failed:", err);
+        showToast("Failed to create", "error");
+      }
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !isPending && title.trim()) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputRow}>
+        <input
+          className={styles.input}
+          type="text"
+          placeholder="Quick create issue..."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={isPending}
+          maxLength={256}
+          autoComplete="off"
+          autoCapitalize="sentences"
+          enterKeyHint="done"
+        />
+        <button
+          type="button"
+          className={styles.createBtn}
+          onClick={handleSubmit}
+          disabled={isPending || !title.trim()}
+        >
+          {isPending ? "\u2026" : "+"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Fixes #241
- New `QuickCreateInline` component: compact input + "+" button for rapid issue creation
- Auto-assigns to default repo when available, falls back to draft-only
- Tracks draft creation state so catch block gives accurate feedback (prevents orphaned draft duplicates)
- Consolidated cleanup epilogue to single occurrence
- Integrated into FiltersSheet mobile actions; existing "Quick Create" link renamed to "Create from URL"

## Test plan
- [ ] Open FiltersSheet on mobile — verify inline create form appears
- [ ] Type a title and tap "+" — verify issue is created and list refreshes
- [ ] Verify the "+" button is disabled when input is empty or pending
- [ ] Test with no default repo — verify "Draft saved" toast
- [ ] Verify "Create from URL" link still works