### PR TITLE
feat: terminal session persistence — tmux liveness, ttyd respawn

### DIFF
--- a/docs/superpowers/plans/2026-04-25-terminal-persistence.md
+++ b/docs/superpowers/plans/2026-04-25-terminal-persistence.md
@@ -1,0 +1,1110 @@
+# Terminal Session Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix terminal sessions being killed when the user navigates away, by using tmux session existence (not ttyd PID) as the liveness signal and respawning ttyd on demand.
+
+**Architecture:** ttyd is treated as a disposable web frontend. `isTmuxSessionAlive(sessionName)` replaces `isTtydAlive(pid)` as the deployment liveness signal in health checks and reconciliation. A new `ensureTtyd` server action respawns ttyd before the terminal panel opens if it has exited. A new `respawnTtyd` core function handles the spawn-without-tmux-creation path.
+
+**Tech Stack:** TypeScript, Vitest (unit tests), Playwright (e2e), `tmux has-session`, `child_process.spawn`/`execFileSync`
+
+**Spec:** `docs/superpowers/specs/2026-04-25-terminal-persistence-design.md`
+
+---
+
+### Task 1: Add `isTmuxSessionAlive` to core
+
+**Files:**
+- Modify: `packages/core/src/launch/ttyd.ts`
+- Modify: `packages/core/src/launch/ttyd.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write failing tests for `isTmuxSessionAlive`**
+
+Add to `packages/core/src/launch/ttyd.test.ts` after the `isTtydAlive` describe block:
+
+```typescript
+/* ------------------------------------------------------------------ */
+/*  isTmuxSessionAlive                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("isTmuxSessionAlive", () => {
+  beforeEach(() => {
+    execFileSyncSpy.mockReset();
+  });
+
+  it("returns true when tmux session exists (exit code 0)", () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(""));
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(true);
+    expect(execFileSyncSpy).toHaveBeenCalledWith(
+      "tmux", ["has-session", "-t", "issuectl-repo-42"],
+      expect.objectContaining({ stdio: "ignore", timeout: 10_000 }),
+    );
+  });
+
+  it("returns false when tmux session does not exist (exit code 1)", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("returns false when tmux command times out", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("returns false when tmux is not installed", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+});
+```
+
+Update the import at the top of the test file to include `isTmuxSessionAlive`:
+
+```typescript
+import {
+  verifyTtyd,
+  killTtyd,
+  isTtydAlive,
+  isTmuxSessionAlive,
+  allocatePort,
+  spawnTtyd,
+  reconcileOrphanedDeployments,
+  tmuxSessionName,
+} from "./ttyd.js";
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -A2 "isTmuxSessionAlive"`
+Expected: Errors about `isTmuxSessionAlive` not being exported
+
+- [ ] **Step 3: Implement `isTmuxSessionAlive`**
+
+Add to `packages/core/src/launch/ttyd.ts` after the `isTtydAlive` function:
+
+```typescript
+/* ------------------------------------------------------------------ */
+/*  isTmuxSessionAlive                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Check whether a tmux session with the given name still exists.
+ * This is the deployment liveness signal — tmux hosts the actual
+ * work (Claude Code), while ttyd is just a disposable web frontend.
+ */
+export function isTmuxSessionAlive(sessionName: string): boolean {
+  try {
+    execFileSync("tmux", ["has-session", "-t", sessionName], {
+      stdio: "ignore",
+      timeout: TMUX_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+Add to `packages/core/src/index.ts` export list alongside the existing `isTtydAlive` export:
+
+```typescript
+  isTmuxSessionAlive,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|isTmuxSessionAlive)"`
+Expected: All 4 `isTmuxSessionAlive` tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/launch/ttyd.ts packages/core/src/launch/ttyd.test.ts packages/core/src/index.ts
+git commit -m "feat(core): add isTmuxSessionAlive for deployment liveness checks"
+```
+
+---
+
+### Task 2: Add `respawnTtyd` to core
+
+**Files:**
+- Modify: `packages/core/src/launch/ttyd.ts`
+- Modify: `packages/core/src/launch/ttyd.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write failing tests for `respawnTtyd`**
+
+Add to `packages/core/src/launch/ttyd.test.ts` after the `spawnTtyd` describe block:
+
+```typescript
+/* ------------------------------------------------------------------ */
+/*  respawnTtyd                                                        */
+/* ------------------------------------------------------------------ */
+
+describe("respawnTtyd", () => {
+  beforeEach(() => {
+    spawnSpy.mockReset();
+    execFileSyncSpy.mockReset();
+  });
+
+  it("spawns ttyd against existing tmux session and returns new PID", async () => {
+    const unrefSpy = vi.fn();
+    spawnSpy.mockReturnValue({ pid: 88, unref: unrefSpy, on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await respawnTtyd(7700, "issuectl-repo-42");
+
+    expect(result).toEqual({ pid: 88 });
+    expect(unrefSpy).toHaveBeenCalled();
+
+    const [bin, args, opts] = spawnSpy.mock.calls[0] as [string, string[], Record<string, unknown>];
+    expect(bin).toBe("ttyd");
+    expect(args).toEqual([
+      "-W", "-i", "127.0.0.1", "-p", "7700", "-q",
+      "tmux", "attach-session", "-t", "issuectl-repo-42",
+    ]);
+    expect(opts).toEqual({ detached: true, stdio: "ignore" });
+    killSpy.mockRestore();
+  });
+
+  it("does NOT create a new tmux session", async () => {
+    spawnSpy.mockReturnValue({ pid: 88, unref: vi.fn(), on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await respawnTtyd(7700, "issuectl-repo-42");
+
+    // execFileSync should NOT have been called (no tmux new-session)
+    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it("throws when ttyd dies immediately after respawn", async () => {
+    spawnSpy.mockReturnValue({ pid: 99, unref: vi.fn(), on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+
+    await expect(respawnTtyd(7700, "issuectl-repo-42")).rejects.toThrow(
+      "ttyd process 99 died immediately after respawn",
+    );
+    killSpy.mockRestore();
+  });
+
+  it("throws when no PID is returned", async () => {
+    spawnSpy.mockReturnValue({ pid: undefined, unref: vi.fn(), on: vi.fn() });
+
+    await expect(respawnTtyd(7700, "issuectl-repo-42")).rejects.toThrow(
+      "Failed to respawn ttyd: no PID returned",
+    );
+  });
+});
+```
+
+Update the import to include `respawnTtyd`:
+
+```typescript
+import {
+  verifyTtyd,
+  killTtyd,
+  isTtydAlive,
+  isTmuxSessionAlive,
+  allocatePort,
+  spawnTtyd,
+  respawnTtyd,
+  reconcileOrphanedDeployments,
+  tmuxSessionName,
+} from "./ttyd.js";
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -A2 "respawnTtyd"`
+Expected: Errors about `respawnTtyd` not being exported
+
+- [ ] **Step 3: Implement `respawnTtyd`**
+
+Add to `packages/core/src/launch/ttyd.ts` after the `spawnTtyd` function (before `killTmuxSession`):
+
+```typescript
+/* ------------------------------------------------------------------ */
+/*  respawnTtyd                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Respawn a ttyd process against an existing tmux session. Used when
+ * ttyd has exited (e.g. `-q` exit-on-disconnect) but the tmux session
+ * is still alive. Unlike `spawnTtyd`, this does NOT create a new tmux
+ * session — it attaches to the one that already exists.
+ */
+export async function respawnTtyd(
+  port: number,
+  sessionName: string,
+): Promise<{ pid: number }> {
+  const child = spawn(
+    "ttyd",
+    ["-W", "-i", "127.0.0.1", "-p", String(port), "-q",
+     "tmux", "attach-session", "-t", sessionName],
+    { detached: true, stdio: "ignore" },
+  );
+
+  child.on("error", (err) => {
+    console.error(`[issuectl] ttyd respawn process ${child.pid} errored:`, err);
+  });
+  child.unref();
+
+  if (child.pid === undefined) {
+    throw new Error("Failed to respawn ttyd: no PID returned");
+  }
+
+  await new Promise((r) => setTimeout(r, 300));
+  if (!isTtydAlive(child.pid)) {
+    throw new Error(
+      `ttyd process ${child.pid} died immediately after respawn. Check that port ${port} is available.`,
+    );
+  }
+
+  return { pid: child.pid };
+}
+```
+
+Add to `packages/core/src/index.ts` export list alongside the existing `spawnTtyd` export:
+
+```typescript
+  respawnTtyd,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|respawnTtyd)"`
+Expected: All 4 `respawnTtyd` tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/launch/ttyd.ts packages/core/src/launch/ttyd.test.ts packages/core/src/index.ts
+git commit -m "feat(core): add respawnTtyd for on-demand ttyd restart"
+```
+
+---
+
+### Task 3: Switch `reconcileOrphanedDeployments` to tmux liveness
+
+**Files:**
+- Modify: `packages/core/src/launch/ttyd.ts`
+- Modify: `packages/core/src/launch/ttyd.test.ts`
+
+- [ ] **Step 1: Update existing reconcile tests to use tmux liveness**
+
+Replace the entire `reconcileOrphanedDeployments` describe block in `packages/core/src/launch/ttyd.test.ts`:
+
+```typescript
+describe("reconcileOrphanedDeployments", () => {
+  beforeEach(() => {
+    execFileSyncSpy.mockReset();
+  });
+
+  it("marks deployments as ended only when tmux session is gone", () => {
+    // Session "issuectl-repoA-10" is alive, "issuectl-repoB-20" is dead.
+    execFileSyncSpy.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "has-session" && args[2] === "issuectl-repoA-10") {
+        return Buffer.from("");
+      }
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runSpy = vi.fn();
+    const db = {
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+              { id: 2, issue_number: 20, repo_name: "repoB" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
+    } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    // Only deployment 2 should be ended (tmux session gone).
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy).toHaveBeenCalledWith(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Reconciled orphaned deployment 2"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("does nothing when all tmux sessions are alive", () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(""));
+
+    const runSpy = vi.fn();
+    const db = {
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
+    } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|reconcile)"`
+Expected: FAIL — current implementation checks PID, not tmux session; also the query shape doesn't match
+
+- [ ] **Step 3: Update `reconcileOrphanedDeployments` implementation**
+
+Replace the function in `packages/core/src/launch/ttyd.ts`:
+
+```typescript
+/**
+ * Find active deployments whose tmux session has ended and mark them
+ * as ended. Called during startup so the UI never shows a phantom
+ * session. Uses tmux session existence (not ttyd PID) as the liveness
+ * signal — ttyd may have exited due to `-q` while the session was
+ * still active.
+ */
+export function reconcileOrphanedDeployments(db: Database.Database): void {
+  const rows = db
+    .prepare(
+      `SELECT d.id, d.issue_number, r.name AS repo_name
+       FROM deployments d
+       JOIN repos r ON r.id = d.repo_id
+       WHERE d.ended_at IS NULL`,
+    )
+    .all() as { id: number; issue_number: number; repo_name: string }[];
+
+  for (const row of rows) {
+    const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
+    if (!isTmuxSessionAlive(sessionName)) {
+      db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
+        row.id,
+      );
+      console.warn(
+        `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/core test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|reconcile)"`
+Expected: Both reconcile tests PASS
+
+- [ ] **Step 5: Run full core test suite**
+
+Run: `pnpm --filter @issuectl/core test`
+Expected: All tests pass (no regressions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/launch/ttyd.ts packages/core/src/launch/ttyd.test.ts
+git commit -m "fix(core): reconcile deployments by tmux session, not ttyd PID"
+```
+
+---
+
+### Task 4: Rename `checkTtydAlive` → `checkSessionAlive` and switch to tmux liveness
+
+**Files:**
+- Modify: `packages/web/lib/actions/launch.ts`
+- Modify: `packages/web/lib/actions/launch.test.ts`
+- Modify: `packages/web/components/terminal/OpenTerminalButton.tsx`
+
+- [ ] **Step 1: Write failing tests for new `checkSessionAlive` behavior**
+
+Add to `packages/web/lib/actions/launch.test.ts`. First, update the mock setup to include the new core exports. Replace the `vi.mock("@issuectl/core", ...)` block:
+
+```typescript
+const isTtydAlive = vi.hoisted(() => vi.fn());
+const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
+const respawnTtyd = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  killTtyd: (...args: unknown[]) => killTtyd(...args),
+  endDeployment: (...args: unknown[]) => coreEndDeployment(...args),
+  cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
+  tmuxSessionName: (repo: string, issueNumber: number) =>
+    `issuectl-${repo}-${issueNumber}`,
+  isTtydAlive: (...args: unknown[]) => isTtydAlive(...args),
+  isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
+  respawnTtyd: (...args: unknown[]) => respawnTtyd(...args),
+  executeLaunch: vi.fn(),
+  withAuthRetry: vi.fn(),
+  withIdempotency: vi.fn(),
+  DuplicateInFlightError: class DuplicateInFlightError extends Error {},
+  formatErrorForUser: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+```
+
+Update the import to include the new server actions:
+
+```typescript
+import { endSession, checkSessionAlive, ensureTtyd } from "./launch.js";
+```
+
+Add to `beforeEach`:
+
+```typescript
+  isTtydAlive.mockReset();
+  isTmuxSessionAlive.mockReset();
+  respawnTtyd.mockReset();
+```
+
+Add the test block after the `endSession` describe:
+
+```typescript
+describe("checkSessionAlive", () => {
+  it("returns alive when tmux session exists (even if ttyd is dead)", async () => {
+    isTmuxSessionAlive.mockReturnValue(true);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: true });
+    expect(coreEndDeployment).not.toHaveBeenCalled();
+  });
+
+  it("ends deployment and returns not alive when tmux session is gone", async () => {
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(coreEndDeployment).toHaveBeenCalled();
+  });
+
+  it("returns not alive when deployment is already ended", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), endedAt: "2026-01-01" });
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
+  });
+
+  it("returns not alive when deployment does not exist", async () => {
+    getDeploymentById.mockReturnValue(undefined);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/web test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|checkSession)"`
+Expected: FAIL — `checkSessionAlive` not exported from launch.js
+
+- [ ] **Step 3: Implement `checkSessionAlive` and remove old `checkTtydAlive`**
+
+In `packages/web/lib/actions/launch.ts`, update the import from `@issuectl/core`:
+
+```typescript
+import {
+  getDb,
+  getRepo,
+  getDeploymentById,
+  executeLaunch,
+  endDeployment as coreEndDeployment,
+  killTtyd,
+  isTmuxSessionAlive,
+  tmuxSessionName,
+  withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
+  formatErrorForUser,
+  cleanupStaleContextFiles,
+  type WorkspaceMode,
+} from "@issuectl/core";
+```
+
+Replace the `checkTtydAlive` function with:
+
+```typescript
+export async function checkSessionAlive(
+  deploymentId: number,
+): Promise<{ alive: boolean; error?: string }> {
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    if (!deployment || deployment.endedAt !== null) {
+      return { alive: false };
+    }
+
+    const repo = db
+      .prepare("SELECT name FROM repos WHERE id = ?")
+      .get(deployment.repoId) as { name: string } | undefined;
+    if (!repo) {
+      return { alive: false };
+    }
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (isTmuxSessionAlive(sessionName)) {
+      return { alive: true };
+    }
+
+    // Tmux session is gone — the work is truly done. End the deployment.
+    coreEndDeployment(db, deploymentId);
+    return { alive: false };
+  } catch (err) {
+    console.error("[issuectl] Session health check failed:", err);
+    return { alive: false, error: "Health check failed" };
+  }
+}
+```
+
+- [ ] **Step 4: Update `OpenTerminalButton` to use the new name**
+
+In `packages/web/components/terminal/OpenTerminalButton.tsx`, change the import:
+
+```typescript
+import { checkSessionAlive } from "@/lib/actions/launch";
+```
+
+And update the call inside the `useEffect`:
+
+```typescript
+  useEffect(() => {
+    const timer = setInterval(async () => {
+      const { alive } = await checkSessionAlive(deploymentId);
+      if (!alive) {
+        clearInterval(timer);
+        setOpen(false);
+        router.refresh();
+      }
+    }, HEALTH_CHECK_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [deploymentId, router]);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/web test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|checkSession|endSession)"`
+Expected: All `checkSessionAlive` and `endSession` tests PASS
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: Clean (no errors). Confirms `checkTtydAlive` has no remaining references.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/lib/actions/launch.ts packages/web/lib/actions/launch.test.ts packages/web/components/terminal/OpenTerminalButton.tsx
+git commit -m "fix(web): rename checkTtydAlive to checkSessionAlive, use tmux liveness"
+```
+
+---
+
+### Task 5: Add `ensureTtyd` server action
+
+**Files:**
+- Modify: `packages/web/lib/actions/launch.ts`
+- Modify: `packages/web/lib/actions/launch.test.ts`
+- Modify: `packages/web/components/terminal/OpenTerminalButton.tsx`
+
+- [ ] **Step 1: Write failing tests for `ensureTtyd`**
+
+Add to `packages/web/lib/actions/launch.test.ts` after the `checkSessionAlive` describe block:
+
+```typescript
+describe("ensureTtyd", () => {
+  it("returns port immediately when ttyd is alive", async () => {
+    getDeploymentById.mockReturnValue(makeDeployment(42));
+    isTtydAlive.mockReturnValue(true);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ port: null });
+    expect(respawnTtyd).not.toHaveBeenCalled();
+  });
+
+  it("returns port immediately when ttyd is alive and port is set", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(true);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ port: 7700 });
+    expect(respawnTtyd).not.toHaveBeenCalled();
+  });
+
+  it("respawns ttyd when dead but tmux alive", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(true);
+    respawnTtyd.mockResolvedValue({ pid: 99 });
+
+    const fakeDb = {
+      prepare: vi.fn(() => ({
+        get: vi.fn(() => ({ name: "repo" })),
+        run: vi.fn(),
+      })),
+    };
+    getDb.mockReturnValue(fakeDb);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ port: 7700, respawned: true });
+    expect(respawnTtyd).toHaveBeenCalledWith(7700, "issuectl-repo-7");
+    // ttyd_pid should be updated in DB
+    expect(fakeDb.prepare).toHaveBeenCalledWith(
+      "UPDATE deployments SET ttyd_pid = ? WHERE id = ?",
+    );
+  });
+
+  it("returns alive false when both ttyd and tmux are dead", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    const fakeDb = {
+      prepare: vi.fn(() => ({
+        get: vi.fn(() => ({ name: "repo" })),
+        run: vi.fn(),
+      })),
+    };
+    getDb.mockReturnValue(fakeDb);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(respawnTtyd).not.toHaveBeenCalled();
+    expect(coreEndDeployment).toHaveBeenCalled();
+  });
+
+  it("returns alive false when deployment already ended", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), endedAt: "2026-01-01" });
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+  });
+
+  it("returns alive false when deployment has no ttydPid", async () => {
+    getDeploymentById.mockReturnValue(makeDeployment(null));
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @issuectl/web test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|ensureTtyd)"`
+Expected: FAIL — `ensureTtyd` not exported
+
+- [ ] **Step 3: Implement `ensureTtyd`**
+
+Add to `packages/web/lib/actions/launch.ts`, updating the import first:
+
+```typescript
+import {
+  getDb,
+  getRepo,
+  getDeploymentById,
+  executeLaunch,
+  endDeployment as coreEndDeployment,
+  killTtyd,
+  isTtydAlive,
+  isTmuxSessionAlive,
+  respawnTtyd,
+  tmuxSessionName,
+  withAuthRetry,
+  withIdempotency,
+  DuplicateInFlightError,
+  formatErrorForUser,
+  cleanupStaleContextFiles,
+  type WorkspaceMode,
+} from "@issuectl/core";
+```
+
+Add the function after `checkSessionAlive`:
+
+```typescript
+type EnsureTtydResult =
+  | { port: number | null; respawned?: true }
+  | { alive: false; error?: string };
+
+export async function ensureTtyd(
+  deploymentId: number,
+): Promise<EnsureTtydResult> {
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    if (!deployment || deployment.endedAt !== null) {
+      return { alive: false };
+    }
+    if (!deployment.ttydPid) {
+      return { alive: false };
+    }
+
+    // ttyd is still running — return immediately
+    if (isTtydAlive(deployment.ttydPid)) {
+      return { port: deployment.ttydPort };
+    }
+
+    // ttyd is dead — check if the tmux session is still alive
+    const repo = db
+      .prepare("SELECT name FROM repos WHERE id = ?")
+      .get(deployment.repoId) as { name: string } | undefined;
+    if (!repo) {
+      return { alive: false };
+    }
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (!isTmuxSessionAlive(sessionName)) {
+      // Both dead — session is truly over
+      coreEndDeployment(db, deploymentId);
+      return { alive: false };
+    }
+
+    // Tmux alive, ttyd dead — respawn ttyd
+    const { pid } = await respawnTtyd(deployment.ttydPort!, sessionName);
+    db.prepare("UPDATE deployments SET ttyd_pid = ? WHERE id = ?").run(pid, deploymentId);
+    return { port: deployment.ttydPort, respawned: true };
+  } catch (err) {
+    console.error("[issuectl] ensureTtyd failed:", err);
+    return { alive: false, error: "Failed to ensure terminal" };
+  }
+}
+```
+
+- [ ] **Step 4: Update `OpenTerminalButton` to call `ensureTtyd` before opening**
+
+Replace the contents of `packages/web/components/terminal/OpenTerminalButton.tsx`:
+
+```typescript
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/paper";
+import { TerminalPanel } from "./TerminalPanel";
+import { checkSessionAlive, ensureTtyd } from "@/lib/actions/launch";
+
+const HEALTH_CHECK_INTERVAL_MS = 10_000;
+
+type Props = {
+  ttydPort: number;
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  issueTitle: string;
+};
+
+export function OpenTerminalButton({
+  ttydPort,
+  deploymentId,
+  owner,
+  repo,
+  issueNumber,
+  issueTitle,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setInterval(async () => {
+      const { alive } = await checkSessionAlive(deploymentId);
+      if (!alive) {
+        clearInterval(timer);
+        setOpen(false);
+        router.refresh();
+      }
+    }, HEALTH_CHECK_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [deploymentId, router]);
+
+  function handleOpen() {
+    startTransition(async () => {
+      const result = await ensureTtyd(deploymentId);
+      if ("alive" in result && !result.alive) {
+        router.refresh();
+        return;
+      }
+      setOpen(true);
+    });
+  }
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleOpen} disabled={isPending}>
+        {isPending ? "Connecting..." : "Open Terminal"}
+      </Button>
+      <TerminalPanel
+        open={open}
+        onClose={() => setOpen(false)}
+        ttydPort={ttydPort}
+        deploymentId={deploymentId}
+        owner={owner}
+        repo={repo}
+        issueNumber={issueNumber}
+        issueTitle={issueTitle}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @issuectl/web test -- --reporter=verbose 2>&1 | grep -E "(PASS|FAIL|ensureTtyd|checkSession|endSession)"`
+Expected: All tests PASS
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: Clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/web/lib/actions/launch.ts packages/web/lib/actions/launch.test.ts packages/web/components/terminal/OpenTerminalButton.tsx
+git commit -m "feat(web): add ensureTtyd to respawn terminal on demand before opening"
+```
+
+---
+
+### Task 6: Integration test — ttyd respawn with real processes
+
+**Files:**
+- Create: `packages/web/e2e/terminal-respawn.spec.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `packages/web/e2e/terminal-respawn.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { execFile, execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import WebSocket from "ws";
+
+/**
+ * Integration test: verify that ttyd can be respawned against an
+ * existing tmux session after the original ttyd exits (due to -q
+ * exit-on-disconnect). This proves the core reconnection cycle.
+ *
+ * Requirements: macOS, tmux, ttyd. Skipped otherwise.
+ */
+
+const execFileAsync = promisify(execFile);
+const TEST_PORT = 7791;
+const SESSION_NAME = "issuectl-test-respawn";
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  if (process.platform !== "darwin") {
+    return { ok: false, reason: "Not macOS" };
+  }
+  for (const bin of ["ttyd", "tmux"]) {
+    try {
+      await execFileAsync("which", [bin]);
+    } catch {
+      return { ok: false, reason: `${bin} not installed` };
+    }
+  }
+  return { ok: true };
+}
+
+function cleanupTmuxSession(): void {
+  try {
+    execFileSync("tmux", ["kill-session", "-t", SESSION_NAME], { stdio: "ignore" });
+  } catch { /* may not exist */ }
+}
+
+function cleanupTtyd(proc: ChildProcess | null): void {
+  if (proc?.pid) {
+    try { process.kill(proc.pid, "SIGTERM"); } catch { /* already dead */ }
+  }
+}
+
+function spawnTtyd(): ChildProcess {
+  const proc = spawn(
+    "ttyd",
+    ["-W", "-i", "127.0.0.1", "-p", String(TEST_PORT), "-q",
+     "tmux", "attach-session", "-t", SESSION_NAME],
+    { detached: true, stdio: "ignore" },
+  );
+  proc.unref();
+  return proc;
+}
+
+function isTtydAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Connect a WebSocket client, perform the ttyd handshake, collect
+ * output for `ms` milliseconds, then close.
+ */
+function collectTerminalOutput(url: string, ms: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: string[] = [];
+    const ws = new WebSocket(url, ["tty"]);
+    const timer = setTimeout(() => {
+      ws.close();
+      resolve(chunks.join(""));
+    }, ms);
+
+    ws.on("open", () => {
+      ws.send("{}");
+      ws.send("1" + JSON.stringify({ columns: 120, rows: 40 }));
+    });
+
+    ws.on("message", (data: Buffer | string) => {
+      const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      if (buf.length > 0 && buf[0] === 0x30) {
+        chunks.push(buf.subarray(1).toString("utf-8"));
+      }
+    });
+
+    ws.on("error", (err) => {
+      clearTimeout(timer);
+      ws.close();
+      reject(err);
+    });
+  });
+}
+
+test.describe("ttyd respawn", () => {
+  let ttydProc: ChildProcess | null = null;
+
+  test.beforeAll(async () => {
+    const { ok, reason } = await canRun();
+    test.skip(!ok, reason ?? "Prerequisites not met");
+  });
+
+  test.afterEach(() => {
+    cleanupTtyd(ttydProc);
+    ttydProc = null;
+    cleanupTmuxSession();
+  });
+
+  test("reconnects to same tmux session after ttyd exits and respawns", async () => {
+    cleanupTmuxSession();
+
+    // 1. Create a tmux session with a unique marker
+    const marker = `RESPAWN_TEST_${Date.now()}`;
+    execFileSync("tmux", [
+      "new-session", "-d", "-s", SESSION_NAME, "-x", "120", "-y", "40",
+      `bash -c 'echo ${marker}; sleep 60'`,
+    ]);
+
+    // 2. Spawn ttyd with -q (exits when last client disconnects)
+    ttydProc = spawnTtyd();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // 3. Connect a client, verify it sees the marker, then disconnect
+    const wsUrl = `ws://127.0.0.1:${TEST_PORT}/ws`;
+    const text1 = await collectTerminalOutput(wsUrl, 2000);
+    expect(text1).toContain(marker);
+
+    // 4. Wait for ttyd to exit (it should die after last client disconnects)
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(isTtydAlive(ttydProc.pid!)).toBe(false);
+
+    // 5. Verify tmux session is still alive
+    expect(() => {
+      execFileSync("tmux", ["has-session", "-t", SESSION_NAME], { stdio: "ignore" });
+    }).not.toThrow();
+
+    // 6. Respawn ttyd against the same session
+    ttydProc = spawnTtyd();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // 7. Connect a new client — should see the tmux session (marker in scrollback)
+    const text2 = await collectTerminalOutput(wsUrl, 2000);
+
+    // The marker should be visible in the terminal scrollback — the
+    // tmux session preserved state across the ttyd restart.
+    // Note: scrollback visibility depends on tmux scroll position,
+    // so we verify the connection succeeds and receives output.
+    expect(text2.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `pnpm --filter @issuectl/web test:e2e -- terminal-respawn`
+Expected: PASS (or skip if ttyd/tmux not installed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/e2e/terminal-respawn.spec.ts
+git commit -m "test(e2e): verify ttyd respawn reconnects to existing tmux session"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `pnpm turbo test`
+Expected: All tests pass
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm turbo typecheck`
+Expected: Clean
+
+- [ ] **Step 3: Verify no stale references to `checkTtydAlive`**
+
+Run: `grep -r "checkTtydAlive" packages/ --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v .next`
+Expected: No matches (fully renamed)
+
+- [ ] **Step 4: Verify `isTtydAlive` is no longer exported from core index (optional cleanup)**
+
+Check `packages/core/src/index.ts` — `isTtydAlive` should still be exported since `ensureTtyd` uses it via `@issuectl/core`. This is correct.
+
+- [ ] **Step 5: Run e2e tests**
+
+Run: `pnpm --filter @issuectl/web test:e2e`
+Expected: All tests pass (terminal-respawn may be skipped if no ttyd/tmux)

--- a/docs/superpowers/specs/2026-04-25-terminal-persistence-design.md
+++ b/docs/superpowers/specs/2026-04-25-terminal-persistence-design.md
@@ -1,0 +1,107 @@
+# Terminal Session Persistence
+
+**Date:** 2026-04-25
+**Status:** Approved
+**Issue:** Terminal sessions are killed when the user navigates away from the issue detail page
+
+## Problem
+
+When a user opens the terminal panel and then navigates back to the issue list, the deployment is marked as ended even though Claude Code is still running inside the tmux session. The root cause is a three-step cascade:
+
+1. **ttyd is spawned with `-q` (exit on all clients disconnect).** When the iframe unmounts on navigation, the WebSocket closes, ttyd has 0 clients, and ttyd exits.
+2. **`checkSessionAlive` polls the ttyd PID.** When `process.kill(pid, 0)` returns ESRCH, it calls `coreEndDeployment()`, marking the deployment as ended.
+3. **The tmux session (and Claude Code inside it) is still alive**, but the UI now says the session is over.
+
+The fundamental error is using ttyd process liveness as the session liveness signal. ttyd is a disposable web frontend for tmux — it can die and be restarted without affecting the actual work session.
+
+## Approach
+
+**Keep `-q` (ttyd exits when last client disconnects), respawn ttyd on demand, check tmux for liveness.**
+
+- ttyd is treated as a disposable view layer. It exits when nobody's watching and is respawned when someone wants to look again.
+- Tmux session existence is the single source of truth for "is the session still running."
+- No schema changes needed — session names are derivable via `tmuxSessionName(repo, issueNumber)`.
+
+## Design
+
+### 1. Core liveness: tmux replaces ttyd PID
+
+**New function: `isTmuxSessionAlive(sessionName: string): boolean`**
+
+Runs `tmux has-session -t <name>`. Returns `true` on exit code 0, `false` on exit code 1 (no session) or timeout.
+
+**Callers that switch from ttyd PID to tmux session check:**
+
+- **`checkSessionAlive` server action** — Renamed to `checkSessionAlive` to reflect the new semantics. Checks tmux session instead of ttyd PID. Returns `{ alive: true }` when the tmux session exists (even if ttyd has exited). Only ends the deployment when the tmux session is gone.
+- **`reconcileOrphanedDeployments`** — Same switch. On startup, scans active deployments, ends only those whose tmux session no longer exists.
+- **`endSession` server action** — Already calls `killTtyd(pid, sessionName)` which kills both. No change needed beyond ensuring tmux cleanup happens even if the ttyd PID is stale.
+
+`isTtydAlive` remains as a private helper for the post-spawn health check inside `spawnTtyd` and for the `ensureTtyd` "is the web frontend up?" check. It is no longer the deployment liveness signal.
+
+### 2. ttyd respawn on demand
+
+**New server action: `ensureTtyd(deploymentId: number)`**
+
+Called before opening the terminal panel. Returns `{ port }` on success or `{ alive: false }` if the session is truly over.
+
+Flow:
+1. Look up the deployment row (gets `ttydPort`, `ttydPid`, repo, issueNumber)
+2. If deployment already ended (`endedAt` set), return `{ alive: false }`
+3. Derive session name via `tmuxSessionName(repo, issueNumber)`
+4. Check `isTtydAlive(pid)` — if alive, return `{ port }` immediately
+5. Check `isTmuxSessionAlive(sessionName)` — if tmux is also gone, call `coreEndDeployment`, return `{ alive: false }`
+6. Tmux alive but ttyd dead: call `respawnTtyd(port, sessionName)`, update `ttyd_pid` in DB, return `{ port, respawned: true }`
+
+**New core function: `respawnTtyd(port: number, sessionName: string): Promise<{ pid: number }>`**
+
+The spawn half of `spawnTtyd` without tmux creation:
+```
+spawn("ttyd", ["-W", "-i", "127.0.0.1", "-p", <port>, "-q",
+  "tmux", "attach-session", "-t", <sessionName>])
+```
+Followed by the same 300ms health check. Returns the new PID.
+
+**`OpenTerminalButton` changes:**
+- Before setting `open=true`, calls `ensureTtyd(deploymentId)`
+- If `alive: false`, triggers the "session ended" flow (close panel, refresh)
+- If success, sets `open=true` — the iframe loads with ttyd guaranteed to be listening
+
+### 3. Testing
+
+Five testable behaviors:
+
+**Test 1: `isTmuxSessionAlive` unit test** (packages/core, vitest)
+- Mock `execFileSync` for `tmux has-session`
+- `true` when exit code 0, `false` when exit code 1, `false` on timeout
+- Throws on unexpected errors
+
+**Test 2: `checkSessionAlive` decoupled from ttyd PID** (packages/web, vitest)
+- Mock: deployment exists, `isTtydAlive` returns `false`, `isTmuxSessionAlive` returns `true`
+- Assert: returns `{ alive: true }`, does NOT call `coreEndDeployment`
+- Counter-case: both dead -> returns `{ alive: false }`, DOES end deployment
+
+**Test 3: `ensureTtyd` respawns when ttyd dead but tmux alive** (packages/web, vitest)
+- Mock: `isTtydAlive` false, `isTmuxSessionAlive` true, `respawnTtyd` returns new PID
+- Assert: returns `{ port, respawned: true }`, DB row updated with new PID
+- Counter-case: tmux also dead -> returns `{ alive: false }`, no respawn
+
+**Test 4: `reconcileOrphanedDeployments` uses tmux check** (packages/core, vitest)
+- Mock: two active deployments, one with live tmux, one without
+- Assert: only the tmux-dead deployment gets ended
+
+**Test 5: ttyd respawn integration test** (packages/web/e2e, Playwright)
+- Skipped when ttyd/tmux unavailable (same pattern as `shared-terminal.spec.ts`)
+- Create real tmux session, spawn ttyd with `-q`, connect WS client, disconnect -> ttyd dies
+- Call `respawnTtyd` against same session name and port
+- Connect new WS client -> verify terminal output from still-running tmux session
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `packages/core/src/launch/ttyd.ts` | Add `isTmuxSessionAlive`, `respawnTtyd`. Keep `isTtydAlive` as internal helper. |
+| `packages/core/src/launch/ttyd.test.ts` | Tests 1, 4: `isTmuxSessionAlive` unit tests, reconcile uses tmux check |
+| `packages/web/lib/actions/launch.ts` | Rename `checkTtydAlive` → `checkSessionAlive`. Add `ensureTtyd` server action. Use tmux liveness. |
+| `packages/web/lib/actions/launch.test.ts` | Tests 2, 3: `checkSessionAlive` decoupled, `ensureTtyd` respawn logic |
+| `packages/web/components/terminal/OpenTerminalButton.tsx` | Call `ensureTtyd` before opening panel |
+| `packages/web/e2e/terminal-respawn.spec.ts` | Test 5: real ttyd respawn integration test |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -188,6 +188,7 @@ export {
 export {
   verifyTtyd,
   spawnTtyd,
+  respawnTtyd,
   killTtyd,
   isTtydAlive,
   isTmuxSessionAlive,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,6 +190,7 @@ export {
   spawnTtyd,
   killTtyd,
   isTtydAlive,
+  isTmuxSessionAlive,
   allocatePort,
   reconcileOrphanedDeployments,
   tmuxSessionName,

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -295,45 +295,41 @@ describe("isTmuxSessionAlive", () => {
     expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
   });
 
-  it("returns false when tmux command times out", () => {
+  it("returns false when tmux is not installed (ENOENT)", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("throws on unexpected errors (ETIMEDOUT) to prevent false 'dead' cascades", () => {
     execFileSyncSpy.mockImplementation(() => {
       throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
     });
-    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
-  });
-
-  it("returns false when tmux is not installed", () => {
-    execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("not found"), { code: "ENOENT" });
-    });
-    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
-  });
-
-  it("logs unexpected errors (not exit code 1)", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("not found"), { code: "ENOENT" });
-    });
-
-    isTmuxSessionAlive("issuectl-repo-42");
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[issuectl] tmux has-session failed unexpectedly:",
-      expect.any(Error),
+    expect(() => isTmuxSessionAlive("issuectl-repo-42")).toThrow(
+      'tmux has-session failed unexpectedly for "issuectl-repo-42"',
     );
-    warnSpy.mockRestore();
   });
 
-  it("does not log when exit code is 1 (normal 'session not found')", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("throws on unexpected errors (EPERM) to prevent false 'dead' cascades", () => {
     execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("session not found"), { status: 1 });
+      throw Object.assign(new Error("EPERM"), { code: "EPERM" });
     });
+    expect(() => isTmuxSessionAlive("issuectl-repo-42")).toThrow(
+      "tmux has-session failed unexpectedly",
+    );
+  });
 
-    isTmuxSessionAlive("issuectl-repo-42");
-
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
+  it("preserves original error as cause when throwing", () => {
+    const original = Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+    execFileSyncSpy.mockImplementation(() => {
+      throw original;
+    });
+    try {
+      isTmuxSessionAlive("issuectl-repo-42");
+    } catch (err) {
+      expect((err as Error).cause).toBe(original);
+    }
   });
 });
 
@@ -828,7 +824,7 @@ describe("reconcileOrphanedDeployments", () => {
     expect(selectCall![0]).toContain("ttyd_pid IS NOT NULL");
   });
 
-  it("logs error and does not throw when reconcile fails", () => {
+  it("logs error and does not throw when query fails", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const db = {
       prepare: vi.fn(() => {
@@ -839,9 +835,50 @@ describe("reconcileOrphanedDeployments", () => {
     // Should not throw
     expect(() => reconcileOrphanedDeployments(db)).not.toThrow();
     expect(errorSpy).toHaveBeenCalledWith(
-      "[issuectl] Failed to reconcile orphaned deployments:",
+      "[issuectl] Failed to query deployments for reconciliation:",
       expect.any(Error),
     );
     errorSpy.mockRestore();
+  });
+
+  it("continues reconciling other rows when one row fails (per-row isolation)", () => {
+    // Row 1 causes isTmuxSessionAlive to throw (ETIMEDOUT), row 2 is dead.
+    execFileSyncSpy.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "has-session" && args[2] === "issuectl-repoA-10") {
+        throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+      }
+      // repoB session is gone (exit code 1)
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runSpy = vi.fn();
+    const db = {
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+              { id: 2, issue_number: 20, repo_name: "repoB" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
+    } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    // Row 1 should have failed (logged), row 2 should still be reconciled.
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[issuectl] Failed to reconcile deployment 1:",
+      expect.any(Error),
+    );
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy).toHaveBeenCalledWith(2);
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -709,54 +709,66 @@ describe("respawnTtyd", () => {
 /* ------------------------------------------------------------------ */
 
 describe("reconcileOrphanedDeployments", () => {
-  it("marks dead deployments as ended", () => {
-    // pid 111 is dead, pid 222 is alive.
-    const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
-      if (pid === 111) throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
-      return true;
+  beforeEach(() => {
+    execFileSyncSpy.mockReset();
+  });
+
+  it("marks deployments as ended only when tmux session is gone", () => {
+    // Session "issuectl-repoA-10" is alive, "issuectl-repoB-20" is dead.
+    execFileSyncSpy.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "has-session" && args[2] === "issuectl-repoA-10") {
+        return Buffer.from("");
+      }
+      throw Object.assign(new Error("session not found"), { status: 1 });
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const runSpy = vi.fn();
     const db = {
-      prepare: vi.fn(() => ({
-        all: vi.fn(() => [
-          { id: 1, ttyd_pid: 111 },
-          { id: 2, ttyd_pid: 222 },
-        ]),
-        run: runSpy,
-      })),
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+              { id: 2, issue_number: 20, repo_name: "repoB" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
     } as unknown as Database.Database;
 
     reconcileOrphanedDeployments(db);
 
-    // The UPDATE should be called once for the dead process (id=1).
+    // Only deployment 2 should be ended (tmux session gone).
     expect(runSpy).toHaveBeenCalledTimes(1);
-    expect(runSpy).toHaveBeenCalledWith(1);
+    expect(runSpy).toHaveBeenCalledWith(2);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Reconciled orphaned deployment 1"),
+      expect.stringContaining("Reconciled orphaned deployment 2"),
     );
 
-    killSpy.mockRestore();
     warnSpy.mockRestore();
   });
 
-  it("does nothing when all deployments are alive", () => {
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+  it("does nothing when all tmux sessions are alive", () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(""));
 
     const runSpy = vi.fn();
     const db = {
-      prepare: vi.fn(() => ({
-        all: vi.fn(() => [{ id: 1, ttyd_pid: 100 }]),
-        run: runSpy,
-      })),
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
     } as unknown as Database.Database;
 
     reconcileOrphanedDeployments(db);
 
-    // run should never be called because the process is alive
     expect(runSpy).not.toHaveBeenCalled();
-
-    killSpy.mockRestore();
   });
 });

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -31,6 +31,7 @@ import {
   verifyTtyd,
   killTtyd,
   isTtydAlive,
+  isTmuxSessionAlive,
   allocatePort,
   spawnTtyd,
   reconcileOrphanedDeployments,
@@ -265,6 +266,46 @@ describe("isTtydAlive", () => {
     });
     expect(() => isTtydAlive(1)).toThrow("EINVAL");
     killSpy.mockRestore();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isTmuxSessionAlive                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("isTmuxSessionAlive", () => {
+  beforeEach(() => {
+    execFileSyncSpy.mockReset();
+  });
+
+  it("returns true when tmux session exists (exit code 0)", () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(""));
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(true);
+    expect(execFileSyncSpy).toHaveBeenCalledWith(
+      "tmux", ["has-session", "-t", "issuectl-repo-42"],
+      expect.objectContaining({ stdio: "ignore", timeout: 10_000 }),
+    );
+  });
+
+  it("returns false when tmux session does not exist (exit code 1)", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("returns false when tmux command times out", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("returns false when tmux is not installed", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
   });
 });
 

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -34,6 +34,7 @@ import {
   isTmuxSessionAlive,
   allocatePort,
   spawnTtyd,
+  respawnTtyd,
   reconcileOrphanedDeployments,
   tmuxSessionName,
 } from "./ttyd.js";
@@ -638,6 +639,68 @@ describe("spawnTtyd", () => {
       "ttyd process 99 died immediately after spawn",
     );
     killSpy.mockRestore();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  respawnTtyd                                                        */
+/* ------------------------------------------------------------------ */
+
+describe("respawnTtyd", () => {
+  beforeEach(() => {
+    spawnSpy.mockReset();
+    execFileSyncSpy.mockReset();
+  });
+
+  it("spawns ttyd against existing tmux session and returns new PID", async () => {
+    const unrefSpy = vi.fn();
+    spawnSpy.mockReturnValue({ pid: 88, unref: unrefSpy, on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await respawnTtyd(7700, "issuectl-repo-42");
+
+    expect(result).toEqual({ pid: 88 });
+    expect(unrefSpy).toHaveBeenCalled();
+
+    const [bin, args, opts] = spawnSpy.mock.calls[0] as [string, string[], Record<string, unknown>];
+    expect(bin).toBe("ttyd");
+    expect(args).toEqual([
+      "-W", "-i", "127.0.0.1", "-p", "7700", "-q",
+      "tmux", "attach-session", "-t", "issuectl-repo-42",
+    ]);
+    expect(opts).toEqual({ detached: true, stdio: "ignore" });
+    killSpy.mockRestore();
+  });
+
+  it("does NOT create a new tmux session", async () => {
+    spawnSpy.mockReturnValue({ pid: 88, unref: vi.fn(), on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await respawnTtyd(7700, "issuectl-repo-42");
+
+    // execFileSync should NOT have been called (no tmux new-session)
+    expect(execFileSyncSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it("throws when ttyd dies immediately after respawn", async () => {
+    spawnSpy.mockReturnValue({ pid: 99, unref: vi.fn(), on: vi.fn() });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+
+    await expect(respawnTtyd(7700, "issuectl-repo-42")).rejects.toThrow(
+      "ttyd process 99 died immediately after respawn",
+    );
+    killSpy.mockRestore();
+  });
+
+  it("throws when no PID is returned", async () => {
+    spawnSpy.mockReturnValue({ pid: undefined, unref: vi.fn(), on: vi.fn() });
+
+    await expect(respawnTtyd(7700, "issuectl-repo-42")).rejects.toThrow(
+      "Failed to respawn ttyd: no PID returned",
+    );
   });
 });
 

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -308,6 +308,33 @@ describe("isTmuxSessionAlive", () => {
     });
     expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
   });
+
+  it("logs unexpected errors (not exit code 1)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+
+    isTmuxSessionAlive("issuectl-repo-42");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[issuectl] tmux has-session failed unexpectedly:",
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not log when exit code is 1 (normal 'session not found')", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+
+    isTmuxSessionAlive("issuectl-repo-42");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -702,6 +729,15 @@ describe("respawnTtyd", () => {
       "Failed to respawn ttyd: no PID returned",
     );
   });
+
+  it("rejects invalid session names containing dots or colons", async () => {
+    await expect(respawnTtyd(7700, "issuectl-my.project-42")).rejects.toThrow(
+      "Invalid tmux session name",
+    );
+
+    // spawn should never have been called
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -770,5 +806,42 @@ describe("reconcileOrphanedDeployments", () => {
     reconcileOrphanedDeployments(db);
 
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("only queries deployments that have a ttyd_pid (excludes pending)", () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(""));
+
+    const prepareSpy = vi.fn((sql: string) => {
+      if (sql.includes("SELECT")) {
+        return { all: vi.fn(() => []) };
+      }
+      return { run: vi.fn() };
+    });
+    const db = { prepare: prepareSpy } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    const selectCall = prepareSpy.mock.calls.find(
+      (c: unknown[]) => (c[0] as string).includes("SELECT"),
+    );
+    expect(selectCall).toBeDefined();
+    expect(selectCall![0]).toContain("ttyd_pid IS NOT NULL");
+  });
+
+  it("logs error and does not throw when reconcile fails", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = {
+      prepare: vi.fn(() => {
+        throw new Error("DB locked");
+      }),
+    } as unknown as Database.Database;
+
+    // Should not throw
+    expect(() => reconcileOrphanedDeployments(db)).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[issuectl] Failed to reconcile orphaned deployments:",
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -132,7 +132,13 @@ export function isTmuxSessionAlive(sessionName: string): boolean {
       timeout: TMUX_TIMEOUT_MS,
     });
     return true;
-  } catch {
+  } catch (err) {
+    // Exit code 1 means "no such session" — expected and silent.
+    // Anything else (ENOENT, ETIMEDOUT, etc.) is unexpected and logged.
+    const status = (err as { status?: number }).status;
+    if (status !== 1) {
+      console.warn("[issuectl] tmux has-session failed unexpectedly:", err);
+    }
     return false;
   }
 }
@@ -291,6 +297,12 @@ export async function respawnTtyd(
   port: number,
   sessionName: string,
 ): Promise<{ pid: number }> {
+  if (!TMUX_SESSION_RE.test(sessionName)) {
+    throw new Error(
+      `Invalid tmux session name: ${JSON.stringify(sessionName)}. Only alphanumeric, hyphens, and underscores are allowed.`,
+    );
+  }
+
   const child = spawn(
     "ttyd",
     ["-W", "-i", "127.0.0.1", "-p", String(port), "-q",
@@ -339,24 +351,29 @@ function killTmuxSession(name: string): void {
  * still active.
  */
 export function reconcileOrphanedDeployments(db: Database.Database): void {
-  const rows = db
-    .prepare(
-      `SELECT d.id, d.issue_number, r.name AS repo_name
-       FROM deployments d
-       JOIN repos r ON r.id = d.repo_id
-       WHERE d.ended_at IS NULL`,
-    )
-    .all() as { id: number; issue_number: number; repo_name: string }[];
+  try {
+    const rows = db
+      .prepare(
+        `SELECT d.id, d.issue_number, r.name AS repo_name
+         FROM deployments d
+         JOIN repos r ON r.id = d.repo_id
+         WHERE d.ended_at IS NULL
+           AND d.ttyd_pid IS NOT NULL`,
+      )
+      .all() as { id: number; issue_number: number; repo_name: string }[];
 
-  for (const row of rows) {
-    const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
-    if (!isTmuxSessionAlive(sessionName)) {
-      db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
-        row.id,
-      );
-      console.warn(
-        `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
-      );
+    for (const row of rows) {
+      const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
+      if (!isTmuxSessionAlive(sessionName)) {
+        db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
+          row.id,
+        );
+        console.warn(
+          `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
+        );
+      }
     }
+  } catch (err) {
+    console.error("[issuectl] Failed to reconcile orphaned deployments:", err);
   }
 }

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -117,6 +117,27 @@ export function isTtydAlive(pid: number): boolean {
 }
 
 /* ------------------------------------------------------------------ */
+/*  isTmuxSessionAlive                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Check whether a tmux session with the given name still exists.
+ * This is the deployment liveness signal — tmux hosts the actual
+ * work (Claude Code), while ttyd is just a disposable web frontend.
+ */
+export function isTmuxSessionAlive(sessionName: string): boolean {
+  try {
+    execFileSync("tmux", ["has-session", "-t", sessionName], {
+      stdio: "ignore",
+      timeout: TMUX_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* ------------------------------------------------------------------ */
 /*  allocatePort                                                       */
 /* ------------------------------------------------------------------ */
 

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -332,24 +332,30 @@ function killTmuxSession(name: string): void {
 /* ------------------------------------------------------------------ */
 
 /**
- * Find active deployments whose ttyd process has died and mark them
+ * Find active deployments whose tmux session has ended and mark them
  * as ended. Called during startup so the UI never shows a phantom
- * session.
+ * session. Uses tmux session existence (not ttyd PID) as the liveness
+ * signal — ttyd may have exited due to `-q` while the session was
+ * still active.
  */
 export function reconcileOrphanedDeployments(db: Database.Database): void {
   const rows = db
     .prepare(
-      "SELECT id, ttyd_pid FROM deployments WHERE ended_at IS NULL AND ttyd_pid IS NOT NULL",
+      `SELECT d.id, d.issue_number, r.name AS repo_name
+       FROM deployments d
+       JOIN repos r ON r.id = d.repo_id
+       WHERE d.ended_at IS NULL`,
     )
-    .all() as { id: number; ttyd_pid: number }[];
+    .all() as { id: number; issue_number: number; repo_name: string }[];
 
   for (const row of rows) {
-    if (!isTtydAlive(row.ttyd_pid)) {
+    const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
+    if (!isTmuxSessionAlive(sessionName)) {
       db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
         row.id,
       );
       console.warn(
-        `[issuectl] Reconciled orphaned deployment ${row.id} (ttyd pid ${row.ttyd_pid} is dead)`,
+        `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
       );
     }
   }

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -133,13 +133,19 @@ export function isTmuxSessionAlive(sessionName: string): boolean {
     });
     return true;
   } catch (err) {
-    // Exit code 1 means "no such session" — expected and silent.
-    // Anything else (ENOENT, ETIMEDOUT, etc.) is unexpected and logged.
     const status = (err as { status?: number }).status;
-    if (status !== 1) {
-      console.warn("[issuectl] tmux has-session failed unexpectedly:", err);
-    }
-    return false;
+    const code = (err as NodeJS.ErrnoException).code;
+    // Exit code 1 = "no such session" — normal, silent.
+    if (status === 1) return false;
+    // ENOENT = tmux not installed — no sessions possible.
+    if (code === "ENOENT") return false;
+    // Anything else (ETIMEDOUT, EPERM, etc.) is a transient failure.
+    // Throwing prevents callers from treating "unknown" as "dead",
+    // which would cascade into permanently ending live deployments.
+    throw new Error(
+      `tmux has-session failed unexpectedly for "${sessionName}"`,
+      { cause: err },
+    );
   }
 }
 
@@ -351,8 +357,9 @@ function killTmuxSession(name: string): void {
  * still active.
  */
 export function reconcileOrphanedDeployments(db: Database.Database): void {
+  let rows: { id: number; issue_number: number; repo_name: string }[];
   try {
-    const rows = db
+    rows = db
       .prepare(
         `SELECT d.id, d.issue_number, r.name AS repo_name
          FROM deployments d
@@ -360,9 +367,14 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
          WHERE d.ended_at IS NULL
            AND d.ttyd_pid IS NOT NULL`,
       )
-      .all() as { id: number; issue_number: number; repo_name: string }[];
+      .all() as typeof rows;
+  } catch (err) {
+    console.error("[issuectl] Failed to query deployments for reconciliation:", err);
+    return;
+  }
 
-    for (const row of rows) {
+  for (const row of rows) {
+    try {
       const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
       if (!isTmuxSessionAlive(sessionName)) {
         db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
@@ -372,8 +384,8 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
           `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
         );
       }
+    } catch (err) {
+      console.error(`[issuectl] Failed to reconcile deployment ${row.id}:`, err);
     }
-  } catch (err) {
-    console.error("[issuectl] Failed to reconcile orphaned deployments:", err);
   }
 }

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -277,6 +277,46 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
   return { pid: child.pid, port };
 }
 
+/* ------------------------------------------------------------------ */
+/*  respawnTtyd                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Respawn a ttyd process against an existing tmux session. Used when
+ * ttyd has exited (e.g. `-q` exit-on-disconnect) but the tmux session
+ * is still alive. Unlike `spawnTtyd`, this does NOT create a new tmux
+ * session — it attaches to the one that already exists.
+ */
+export async function respawnTtyd(
+  port: number,
+  sessionName: string,
+): Promise<{ pid: number }> {
+  const child = spawn(
+    "ttyd",
+    ["-W", "-i", "127.0.0.1", "-p", String(port), "-q",
+     "tmux", "attach-session", "-t", sessionName],
+    { detached: true, stdio: "ignore" },
+  );
+
+  child.on("error", (err) => {
+    console.error(`[issuectl] ttyd respawn process ${child.pid} errored:`, err);
+  });
+  child.unref();
+
+  if (child.pid === undefined) {
+    throw new Error("Failed to respawn ttyd: no PID returned");
+  }
+
+  await new Promise((r) => setTimeout(r, 300));
+  if (!isTtydAlive(child.pid)) {
+    throw new Error(
+      `ttyd process ${child.pid} died immediately after respawn. Check that port ${port} is available.`,
+    );
+  }
+
+  return { pid: child.pid };
+}
+
 /** Best-effort cleanup of a tmux session. */
 function killTmuxSession(name: string): void {
   try {

--- a/packages/web/components/terminal/OpenTerminalButton.module.css
+++ b/packages/web/components/terminal/OpenTerminalButton.module.css
@@ -1,0 +1,5 @@
+.error {
+  color: var(--color-error, #c62828);
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { TerminalPanel } from "./TerminalPanel";
 import { checkSessionAlive, ensureTtyd } from "@/lib/actions/launch";
+import styles from "./OpenTerminalButton.module.css";
 
 const HEALTH_CHECK_INTERVAL_MS = 10_000;
 
@@ -31,26 +32,30 @@ export function OpenTerminalButton({
   const router = useRouter();
 
   useEffect(() => {
+    if (isPending) return;
+
     const timer = setInterval(async () => {
-      const { alive } = await checkSessionAlive(deploymentId);
-      if (!alive) {
-        clearInterval(timer);
-        setOpen(false);
-        router.refresh();
+      try {
+        const { alive } = await checkSessionAlive(deploymentId);
+        if (!alive) {
+          clearInterval(timer);
+          setOpen(false);
+          router.refresh();
+        }
+      } catch {
+        // Network error or server unavailable — skip this tick.
       }
     }, HEALTH_CHECK_INTERVAL_MS);
 
     return () => clearInterval(timer);
-  }, [deploymentId, router]);
+  }, [deploymentId, isPending, router]);
 
   function handleOpen() {
     setError(null);
     startTransition(async () => {
       const result = await ensureTtyd(deploymentId);
-      if ("alive" in result && !result.alive) {
-        if (result.error) {
-          setError(result.error);
-        }
+      if (!("port" in result)) {
+        if (result.error) setError(result.error);
         router.refresh();
         return;
       }
@@ -63,7 +68,7 @@ export function OpenTerminalButton({
       <Button variant="primary" onClick={handleOpen} disabled={isPending}>
         {isPending ? "Connecting..." : "Open Terminal"}
       </Button>
-      {error && <p role="alert" style={{ color: "var(--color-error, #c62828)", marginTop: "0.5rem", fontSize: "0.875rem" }}>{error}</p>}
+      {error && <p role="alert" className={styles.error}>{error}</p>}
       <TerminalPanel
         open={open}
         onClose={() => setOpen(false)}

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { TerminalPanel } from "./TerminalPanel";
-import { checkSessionAlive } from "@/lib/actions/launch";
+import { checkSessionAlive, ensureTtyd } from "@/lib/actions/launch";
 
 const HEALTH_CHECK_INTERVAL_MS = 10_000;
 
@@ -26,6 +26,7 @@ export function OpenTerminalButton({
   issueTitle,
 }: Props) {
   const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
   useEffect(() => {
@@ -41,10 +42,21 @@ export function OpenTerminalButton({
     return () => clearInterval(timer);
   }, [deploymentId, router]);
 
+  function handleOpen() {
+    startTransition(async () => {
+      const result = await ensureTtyd(deploymentId);
+      if ("alive" in result && !result.alive) {
+        router.refresh();
+        return;
+      }
+      setOpen(true);
+    });
+  }
+
   return (
     <>
-      <Button variant="primary" onClick={() => setOpen(true)}>
-        Open Terminal
+      <Button variant="primary" onClick={handleOpen} disabled={isPending}>
+        {isPending ? "Connecting..." : "Open Terminal"}
       </Button>
       <TerminalPanel
         open={open}

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { TerminalPanel } from "./TerminalPanel";
-import { checkTtydAlive } from "@/lib/actions/launch";
+import { checkSessionAlive } from "@/lib/actions/launch";
 
 const HEALTH_CHECK_INTERVAL_MS = 10_000;
 
@@ -30,7 +30,7 @@ export function OpenTerminalButton({
 
   useEffect(() => {
     const timer = setInterval(async () => {
-      const { alive } = await checkTtydAlive(deploymentId);
+      const { alive } = await checkSessionAlive(deploymentId);
       if (!alive) {
         clearInterval(timer);
         setOpen(false);

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -26,6 +26,7 @@ export function OpenTerminalButton({
   issueTitle,
 }: Props) {
   const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -43,9 +44,13 @@ export function OpenTerminalButton({
   }, [deploymentId, router]);
 
   function handleOpen() {
+    setError(null);
     startTransition(async () => {
       const result = await ensureTtyd(deploymentId);
       if ("alive" in result && !result.alive) {
+        if (result.error) {
+          setError(result.error);
+        }
         router.refresh();
         return;
       }
@@ -58,6 +63,7 @@ export function OpenTerminalButton({
       <Button variant="primary" onClick={handleOpen} disabled={isPending}>
         {isPending ? "Connecting..." : "Open Terminal"}
       </Button>
+      {error && <p role="alert" style={{ color: "var(--color-error, #c62828)", marginTop: "0.5rem", fontSize: "0.875rem" }}>{error}</p>}
       <TerminalPanel
         open={open}
         onClose={() => setOpen(false)}

--- a/packages/web/e2e/terminal-respawn.spec.ts
+++ b/packages/web/e2e/terminal-respawn.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from "@playwright/test";
+import { execFile, execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import WebSocket from "ws";
+
+/**
+ * Integration test: verify that ttyd can be respawned against an
+ * existing tmux session after the original ttyd exits (due to -q
+ * exit-on-disconnect). This proves the core reconnection cycle.
+ *
+ * Requirements: macOS, tmux, ttyd. Skipped otherwise.
+ */
+
+const execFileAsync = promisify(execFile);
+const TEST_PORT = 7791;
+const SESSION_NAME = "issuectl-test-respawn";
+
+async function canRun(): Promise<{ ok: boolean; reason?: string }> {
+  if (process.platform !== "darwin") {
+    return { ok: false, reason: "Not macOS" };
+  }
+  for (const bin of ["ttyd", "tmux"]) {
+    try {
+      await execFileAsync("which", [bin]);
+    } catch {
+      return { ok: false, reason: `${bin} not installed` };
+    }
+  }
+  return { ok: true };
+}
+
+function cleanupTmuxSession(): void {
+  try {
+    execFileSync("tmux", ["kill-session", "-t", SESSION_NAME], { stdio: "ignore" });
+  } catch { /* may not exist */ }
+}
+
+function cleanupTtyd(proc: ChildProcess | null): void {
+  if (proc?.pid) {
+    try { process.kill(proc.pid, "SIGTERM"); } catch { /* already dead */ }
+  }
+}
+
+function spawnTtyd(): ChildProcess {
+  const proc = spawn(
+    "ttyd",
+    ["-W", "-i", "127.0.0.1", "-p", String(TEST_PORT), "-q",
+     "tmux", "attach-session", "-t", SESSION_NAME],
+    { detached: true, stdio: "ignore" },
+  );
+  proc.unref();
+  return proc;
+}
+
+function isTtydAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Connect a WebSocket client, perform the ttyd handshake, collect
+ * output for `ms` milliseconds, then close.
+ */
+function collectTerminalOutput(url: string, ms: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: string[] = [];
+    const ws = new WebSocket(url, ["tty"]);
+    const timer = setTimeout(() => {
+      ws.close();
+      resolve(chunks.join(""));
+    }, ms);
+
+    ws.on("open", () => {
+      ws.send("{}");
+      ws.send("1" + JSON.stringify({ columns: 120, rows: 40 }));
+    });
+
+    ws.on("message", (data: Buffer | string) => {
+      const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      if (buf.length > 0 && buf[0] === 0x30) {
+        chunks.push(buf.subarray(1).toString("utf-8"));
+      }
+    });
+
+    ws.on("error", (err) => {
+      clearTimeout(timer);
+      ws.close();
+      reject(err);
+    });
+  });
+}
+
+test.describe("ttyd respawn", () => {
+  let ttydProc: ChildProcess | null = null;
+
+  test.beforeAll(async () => {
+    const { ok, reason } = await canRun();
+    test.skip(!ok, reason ?? "Prerequisites not met");
+  });
+
+  test.afterEach(() => {
+    cleanupTtyd(ttydProc);
+    ttydProc = null;
+    cleanupTmuxSession();
+  });
+
+  test("reconnects to same tmux session after ttyd exits and respawns", async () => {
+    cleanupTmuxSession();
+
+    // 1. Create a tmux session with a unique marker
+    const marker = `RESPAWN_TEST_${Date.now()}`;
+    execFileSync("tmux", [
+      "new-session", "-d", "-s", SESSION_NAME, "-x", "120", "-y", "40",
+      `bash -c 'echo ${marker}; sleep 60'`,
+    ]);
+
+    // 2. Spawn ttyd with -q (exits when last client disconnects)
+    ttydProc = spawnTtyd();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // 3. Connect a client, verify it sees the marker, then disconnect
+    const wsUrl = `ws://127.0.0.1:${TEST_PORT}/ws`;
+    const text1 = await collectTerminalOutput(wsUrl, 2000);
+    expect(text1).toContain(marker);
+
+    // 4. Wait for ttyd to exit (it should die after last client disconnects)
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(isTtydAlive(ttydProc.pid!)).toBe(false);
+
+    // 5. Verify tmux session is still alive
+    expect(() => {
+      execFileSync("tmux", ["has-session", "-t", SESSION_NAME], { stdio: "ignore" });
+    }).not.toThrow();
+
+    // 6. Respawn ttyd against the same session
+    ttydProc = spawnTtyd();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // 7. Connect a new client — should see the tmux session (marker in scrollback)
+    const text2 = await collectTerminalOutput(wsUrl, 2000);
+
+    // The marker should be visible in the terminal scrollback — the
+    // tmux session preserved state across the ttyd restart.
+    // Note: scrollback visibility depends on tmux scroll position,
+    // so we verify the connection succeeds and receives output.
+    expect(text2.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -38,7 +38,7 @@ vi.mock("@issuectl/core", () => ({
 }));
 
 // Import AFTER mocks so the mocked module is in place.
-import { endSession, checkSessionAlive } from "./launch.js";
+import { endSession, checkSessionAlive, ensureTtyd } from "./launch.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -191,6 +191,58 @@ describe("checkSessionAlive", () => {
     getDeploymentById.mockReturnValue(undefined);
 
     const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+  });
+});
+
+describe("ensureTtyd", () => {
+  it("returns port immediately when ttyd is alive", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(true);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ port: 7700 });
+    expect(respawnTtyd).not.toHaveBeenCalled();
+  });
+
+  it("respawns ttyd when dead but tmux alive", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(true);
+    respawnTtyd.mockResolvedValue({ pid: 99 });
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ port: 7700, respawned: true });
+    expect(respawnTtyd).toHaveBeenCalledWith(7700, "issuectl-repo-7");
+  });
+
+  it("returns alive false when both ttyd and tmux are dead", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(respawnTtyd).not.toHaveBeenCalled();
+    expect(coreEndDeployment).toHaveBeenCalled();
+  });
+
+  it("returns alive false when deployment already ended", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), endedAt: "2026-01-01" });
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+  });
+
+  it("returns alive false when deployment has no ttydPid", async () => {
+    getDeploymentById.mockReturnValue(makeDeployment(null));
+
+    const result = await ensureTtyd(1);
 
     expect(result).toEqual({ alive: false });
   });

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -17,6 +17,7 @@ const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
 const isTtydAlive = vi.hoisted(() => vi.fn());
 const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
 const respawnTtyd = vi.hoisted(() => vi.fn());
+const updateTtydInfo = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
@@ -31,6 +32,7 @@ vi.mock("@issuectl/core", () => ({
   isTtydAlive: (...args: unknown[]) => isTtydAlive(...args),
   isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
   respawnTtyd: (...args: unknown[]) => respawnTtyd(...args),
+  updateTtydInfo: (...args: unknown[]) => updateTtydInfo(...args),
   executeLaunch: vi.fn(),
   withAuthRetry: vi.fn(),
   withIdempotency: vi.fn(),
@@ -89,6 +91,7 @@ beforeEach(() => {
   isTtydAlive.mockReset();
   isTmuxSessionAlive.mockReset();
   respawnTtyd.mockReset();
+  updateTtydInfo.mockReset();
 
   // Sensible defaults: DB exists, deployment found with a PID, repo found.
   dbRunSpy = vi.fn();
@@ -201,6 +204,26 @@ describe("checkSessionAlive", () => {
 
     expect(result).toEqual({ alive: false });
   });
+
+  it("returns not alive when repo is not found", async () => {
+    getRepoById.mockReturnValue(undefined);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
+    expect(coreEndDeployment).not.toHaveBeenCalled();
+  });
+
+  it("returns error when health check throws", async () => {
+    getDeploymentById.mockImplementation(() => {
+      throw new Error("DB locked");
+    });
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false, error: "Health check failed" });
+  });
 });
 
 describe("ensureTtyd", () => {
@@ -254,7 +277,7 @@ describe("ensureTtyd", () => {
     expect(result).toEqual({ alive: false });
   });
 
-  it("updates DB with new PID after respawn", async () => {
+  it("calls updateTtydInfo with new PID after respawn", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(false);
     isTmuxSessionAlive.mockReturnValue(true);
@@ -262,10 +285,10 @@ describe("ensureTtyd", () => {
 
     await ensureTtyd(1);
 
-    expect(dbRunSpy).toHaveBeenCalledWith(99, 1);
+    expect(updateTtydInfo).toHaveBeenCalledWith(expect.anything(), 1, 7700, 99);
   });
 
-  it("returns error when respawnTtyd throws", async () => {
+  it("returns formatted error when respawnTtyd throws", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(false);
     isTmuxSessionAlive.mockReturnValue(true);
@@ -273,7 +296,8 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false, error: "Failed to ensure terminal" });
+    // formatErrorForUser passes through Error.message
+    expect(result).toEqual({ alive: false, error: "port conflict" });
   });
 
   it("returns alive false when repo is not found", async () => {

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -13,6 +13,9 @@ const getRepo = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const coreEndDeployment = vi.hoisted(() => vi.fn());
 const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
+const isTtydAlive = vi.hoisted(() => vi.fn());
+const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
+const respawnTtyd = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
@@ -23,9 +26,9 @@ vi.mock("@issuectl/core", () => ({
   cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
   tmuxSessionName: (repo: string, issueNumber: number) =>
     `issuectl-${repo}-${issueNumber}`,
-  // The rest of the exports used only by launchIssue — provide stubs so
-  // TypeScript/vitest don't trip over missing exports.
-  isTtydAlive: vi.fn(),
+  isTtydAlive: (...args: unknown[]) => isTtydAlive(...args),
+  isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
+  respawnTtyd: (...args: unknown[]) => respawnTtyd(...args),
   executeLaunch: vi.fn(),
   withAuthRetry: vi.fn(),
   withIdempotency: vi.fn(),
@@ -35,7 +38,7 @@ vi.mock("@issuectl/core", () => ({
 }));
 
 // Import AFTER mocks so the mocked module is in place.
-import { endSession } from "./launch.js";
+import { endSession, checkSessionAlive } from "./launch.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -78,8 +81,17 @@ beforeEach(() => {
   coreEndDeployment.mockReset();
   cleanupStaleContextFiles.mockReset();
 
+  isTtydAlive.mockReset();
+  isTmuxSessionAlive.mockReset();
+  respawnTtyd.mockReset();
+
   // Sensible defaults: DB exists, deployment found with a PID, repo found.
-  getDb.mockReturnValue({});
+  getDb.mockReturnValue({
+    prepare: vi.fn(() => ({
+      get: vi.fn(() => ({ name: "repo" })),
+      run: vi.fn(),
+    })),
+  });
   getDeploymentById.mockReturnValue(makeDeployment(42));
   getRepo.mockReturnValue(makeRepoRecord());
   coreEndDeployment.mockReturnValue(undefined);
@@ -144,5 +156,42 @@ describe("endSession", () => {
       success: false,
       error: "Deployment does not match the specified issue",
     });
+  });
+});
+
+describe("checkSessionAlive", () => {
+  it("returns alive when tmux session exists (even if ttyd is dead)", async () => {
+    isTmuxSessionAlive.mockReturnValue(true);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: true });
+    expect(coreEndDeployment).not.toHaveBeenCalled();
+  });
+
+  it("ends deployment and returns not alive when tmux session is gone", async () => {
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(coreEndDeployment).toHaveBeenCalled();
+  });
+
+  it("returns not alive when deployment is already ended", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), endedAt: "2026-01-01" });
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
+  });
+
+  it("returns not alive when deployment does not exist", async () => {
+    getDeploymentById.mockReturnValue(undefined);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
   });
 });

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -10,6 +10,7 @@ vi.mock("next/cache", () => ({ revalidatePath }));
 const getDb = vi.hoisted(() => vi.fn());
 const getDeploymentById = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
+const getRepoById = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const coreEndDeployment = vi.hoisted(() => vi.fn());
 const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
@@ -21,6 +22,7 @@ vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
   getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
   getRepo: (...args: unknown[]) => getRepo(...args),
+  getRepoById: (...args: unknown[]) => getRepoById(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   endDeployment: (...args: unknown[]) => coreEndDeployment(...args),
   cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
@@ -72,11 +74,14 @@ const ARGS = [1, "owner", "repo", 7] as const;
 // Setup
 // ---------------------------------------------------------------------------
 
+let dbRunSpy: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
   revalidatePath.mockReset();
   getDb.mockReset();
   getDeploymentById.mockReset();
   getRepo.mockReset();
+  getRepoById.mockReset();
   killTtyd.mockReset();
   coreEndDeployment.mockReset();
   cleanupStaleContextFiles.mockReset();
@@ -86,14 +91,16 @@ beforeEach(() => {
   respawnTtyd.mockReset();
 
   // Sensible defaults: DB exists, deployment found with a PID, repo found.
+  dbRunSpy = vi.fn();
   getDb.mockReturnValue({
     prepare: vi.fn(() => ({
       get: vi.fn(() => ({ name: "repo" })),
-      run: vi.fn(),
+      run: dbRunSpy,
     })),
   });
   getDeploymentById.mockReturnValue(makeDeployment(42));
   getRepo.mockReturnValue(makeRepoRecord());
+  getRepoById.mockReturnValue(makeRepoRecord());
   coreEndDeployment.mockReturnValue(undefined);
   cleanupStaleContextFiles.mockReturnValue(Promise.resolve());
 });
@@ -245,5 +252,38 @@ describe("ensureTtyd", () => {
     const result = await ensureTtyd(1);
 
     expect(result).toEqual({ alive: false });
+  });
+
+  it("updates DB with new PID after respawn", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(true);
+    respawnTtyd.mockResolvedValue({ pid: 99 });
+
+    await ensureTtyd(1);
+
+    expect(dbRunSpy).toHaveBeenCalledWith(99, 1);
+  });
+
+  it("returns error when respawnTtyd throws", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(true);
+    respawnTtyd.mockRejectedValue(new Error("port conflict"));
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false, error: "Failed to ensure terminal" });
+  });
+
+  it("returns alive false when repo is not found", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    getRepoById.mockReturnValue(undefined);
+
+    const result = await ensureTtyd(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -12,6 +12,7 @@ import {
   isTmuxSessionAlive,
   respawnTtyd,
   tmuxSessionName,
+  updateTtydInfo,
   withAuthRetry,
   withIdempotency,
   DuplicateInFlightError,
@@ -247,7 +248,7 @@ export async function checkSessionAlive(
 }
 
 type EnsureTtydResult =
-  | { port: number; respawned?: true }
+  | { port: number; respawned?: true; alive?: never }
   | { alive: false; error?: string };
 
 export async function ensureTtyd(
@@ -287,10 +288,10 @@ export async function ensureTtyd(
 
     // Tmux alive, ttyd dead — respawn ttyd
     const { pid } = await respawnTtyd(port, sessionName);
-    db.prepare("UPDATE deployments SET ttyd_pid = ? WHERE id = ?").run(pid, deploymentId);
+    updateTtydInfo(db, deploymentId, port, pid);
     return { port, respawned: true };
   } catch (err) {
     console.error("[issuectl] ensureTtyd failed:", err);
-    return { alive: false, error: "Failed to ensure terminal" };
+    return { alive: false, error: formatErrorForUser(err) };
   }
 }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -7,7 +7,9 @@ import {
   executeLaunch,
   endDeployment as coreEndDeployment,
   killTtyd,
+  isTtydAlive,
   isTmuxSessionAlive,
+  respawnTtyd,
   tmuxSessionName,
   withAuthRetry,
   withIdempotency,
@@ -239,5 +241,52 @@ export async function checkSessionAlive(
   } catch (err) {
     console.error("[issuectl] Session health check failed:", err);
     return { alive: false, error: "Health check failed" };
+  }
+}
+
+type EnsureTtydResult =
+  | { port: number; respawned?: true }
+  | { alive: false; error?: string };
+
+export async function ensureTtyd(
+  deploymentId: number,
+): Promise<EnsureTtydResult> {
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    if (!deployment || deployment.endedAt !== null) {
+      return { alive: false };
+    }
+    if (!deployment.ttydPid) {
+      return { alive: false };
+    }
+
+    // ttyd is still running — return immediately
+    if (isTtydAlive(deployment.ttydPid)) {
+      return { port: deployment.ttydPort! };
+    }
+
+    // ttyd is dead — check if the tmux session is still alive
+    const repo = db
+      .prepare("SELECT name FROM repos WHERE id = ?")
+      .get(deployment.repoId) as { name: string } | undefined;
+    if (!repo) {
+      return { alive: false };
+    }
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (!isTmuxSessionAlive(sessionName)) {
+      // Both dead — session is truly over
+      coreEndDeployment(db, deploymentId);
+      return { alive: false };
+    }
+
+    // Tmux alive, ttyd dead — respawn ttyd
+    const { pid } = await respawnTtyd(deployment.ttydPort!, sessionName);
+    db.prepare("UPDATE deployments SET ttyd_pid = ? WHERE id = ?").run(pid, deploymentId);
+    return { port: deployment.ttydPort!, respawned: true };
+  } catch (err) {
+    console.error("[issuectl] ensureTtyd failed:", err);
+    return { alive: false, error: "Failed to ensure terminal" };
   }
 }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -7,7 +7,7 @@ import {
   executeLaunch,
   endDeployment as coreEndDeployment,
   killTtyd,
-  isTtydAlive,
+  isTmuxSessionAlive,
   tmuxSessionName,
   withAuthRetry,
   withIdempotency,
@@ -211,7 +211,7 @@ export async function endSession(
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 
-export async function checkTtydAlive(
+export async function checkSessionAlive(
   deploymentId: number,
 ): Promise<{ alive: boolean; error?: string }> {
   try {
@@ -220,17 +220,24 @@ export async function checkTtydAlive(
     if (!deployment || deployment.endedAt !== null) {
       return { alive: false };
     }
-    if (!deployment.ttydPid) {
+
+    const repo = db
+      .prepare("SELECT name FROM repos WHERE id = ?")
+      .get(deployment.repoId) as { name: string } | undefined;
+    if (!repo) {
       return { alive: false };
     }
-    const alive = isTtydAlive(deployment.ttydPid);
-    if (!alive) {
-      // Process died — clean up the deployment
-      coreEndDeployment(db, deploymentId);
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (isTmuxSessionAlive(sessionName)) {
+      return { alive: true };
     }
-    return { alive };
+
+    // Tmux session is gone — the work is truly done. End the deployment.
+    coreEndDeployment(db, deploymentId);
+    return { alive: false };
   } catch (err) {
-    console.error("[issuectl] Health check failed:", err);
+    console.error("[issuectl] Session health check failed:", err);
     return { alive: false, error: "Health check failed" };
   }
 }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -3,6 +3,7 @@
 import {
   getDb,
   getRepo,
+  getRepoById,
   getDeploymentById,
   executeLaunch,
   endDeployment as coreEndDeployment,
@@ -226,9 +227,7 @@ export async function checkSessionAlive(
       return { alive: false };
     }
 
-    const repo = db
-      .prepare("SELECT name FROM repos WHERE id = ?")
-      .get(deployment.repoId) as { name: string } | undefined;
+    const repo = getRepoById(db, deployment.repoId);
     if (!repo) {
       return { alive: false };
     }
@@ -274,9 +273,7 @@ export async function ensureTtyd(
     }
 
     // ttyd is dead — check if the tmux session is still alive
-    const repo = db
-      .prepare("SELECT name FROM repos WHERE id = ?")
-      .get(deployment.repoId) as { name: string } | undefined;
+    const repo = getRepoById(db, deployment.repoId);
     if (!repo) {
       return { alive: false };
     }

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -216,6 +216,9 @@ export async function endSession(
 export async function checkSessionAlive(
   deploymentId: number,
 ): Promise<{ alive: boolean; error?: string }> {
+  if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
+    return { alive: false };
+  }
   try {
     const db = getDb();
     const deployment = getDeploymentById(db, deploymentId);
@@ -251,19 +254,23 @@ type EnsureTtydResult =
 export async function ensureTtyd(
   deploymentId: number,
 ): Promise<EnsureTtydResult> {
+  if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
+    return { alive: false };
+  }
   try {
     const db = getDb();
     const deployment = getDeploymentById(db, deploymentId);
     if (!deployment || deployment.endedAt !== null) {
       return { alive: false };
     }
-    if (!deployment.ttydPid) {
+    if (!deployment.ttydPid || deployment.ttydPort === null) {
       return { alive: false };
     }
+    const port = deployment.ttydPort;
 
     // ttyd is still running — return immediately
     if (isTtydAlive(deployment.ttydPid)) {
-      return { port: deployment.ttydPort! };
+      return { port };
     }
 
     // ttyd is dead — check if the tmux session is still alive
@@ -282,9 +289,9 @@ export async function ensureTtyd(
     }
 
     // Tmux alive, ttyd dead — respawn ttyd
-    const { pid } = await respawnTtyd(deployment.ttydPort!, sessionName);
+    const { pid } = await respawnTtyd(port, sessionName);
     db.prepare("UPDATE deployments SET ttyd_pid = ? WHERE id = ?").run(pid, deploymentId);
-    return { port: deployment.ttydPort!, respawned: true };
+    return { port, respawned: true };
   } catch (err) {
     console.error("[issuectl] ensureTtyd failed:", err);
     return { alive: false, error: "Failed to ensure terminal" };


### PR DESCRIPTION
## Summary

- **Decouple session liveness from ttyd PID.** `checkSessionAlive` now checks `isTmuxSessionAlive()` instead of `isTtydAlive()` — navigating away from the terminal no longer kills the deployment while Claude Code is still running inside tmux.
- **On-demand ttyd respawn.** New `ensureTtyd` server action respawns ttyd against the existing tmux session when the user reopens the terminal panel. `OpenTerminalButton` calls it before opening so the iframe always connects to a live ttyd.
- **Reconciler uses tmux, not PID.** `reconcileOrphanedDeployments` JOINs the repos table and checks tmux session existence, only ending deployments whose tmux session is truly gone. Pending deployments (no ttyd_pid) are excluded. Per-row error isolation prevents one bad deployment from blocking reconciliation of others.
- **Safe error cascading.** `isTmuxSessionAlive` throws on unexpected errors (ETIMEDOUT, EPERM) instead of returning false, preventing transient tmux failures from permanently ending all active deployments.

## Changes

| Area | What |
|---|---|
| `packages/core/src/launch/ttyd.ts` | Add `isTmuxSessionAlive` (throws on unexpected errors), `respawnTtyd` (with `TMUX_SESSION_RE` validation). Update `reconcileOrphanedDeployments`: tmux liveness, `ttyd_pid IS NOT NULL` filter, per-row try/catch. |
| `packages/core/src/launch/ttyd.test.ts` | 16 new tests: `isTmuxSessionAlive` (5 incl. throw behavior), `respawnTtyd` (5 incl. validation), reconcile (3 new: query filter, error handling, per-row isolation) |
| `packages/web/lib/actions/launch.ts` | Rename `checkTtydAlive` → `checkSessionAlive`, add `ensureTtyd` action with `EnsureTtydResult` (alive?: never discriminant). Use `getRepoById` + `updateTtydInfo` from core. `formatErrorForUser` for actionable error messages. |
| `packages/web/lib/actions/launch.test.ts` | 14 new tests covering `checkSessionAlive` (6) and `ensureTtyd` (8) |
| `packages/web/components/terminal/OpenTerminalButton.tsx` | Call `ensureTtyd` before opening, CSS Module error display, try/catch in health-check polling, pause polling during pending transition |
| `packages/web/e2e/terminal-respawn.spec.ts` | Real ttyd/tmux respawn integration test (skipped when binaries unavailable) |
| `docs/superpowers/specs/` | Design spec |
| `docs/superpowers/plans/` | Implementation plan |

## Test plan

- [x] 446 core unit tests pass (`pnpm --filter @issuectl/core test`)
- [x] 169 web unit tests pass (`pnpm --filter @issuectl/web test`)
- [x] Typecheck clean across all 3 packages (`pnpm turbo typecheck`)
- [x] E2E respawn test passes on macOS with ttyd/tmux installed (7.4s)
- [x] PR review toolkit run (all 6 agents), all Critical and Important issues addressed
- [ ] Manual: launch issue → open terminal → navigate away → return → "Open Terminal" reconnects to live session
- [ ] Manual: launch issue → open terminal → wait for Claude Code to finish → session auto-ends