### PR TITLE
feat(ios): Phase 4 — issue close/reopen and comment actions

### DIFF
--- a/docs/superpowers/plans/2026-04-25-ios-issue-actions.md
+++ b/docs/superpowers/plans/2026-04-25-ios-issue-actions.md
@@ -1,0 +1,887 @@
+# iOS Phase 4: Issue Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add close/reopen and comment capabilities to the iOS app's issue detail view.
+
+**Architecture:** Two new REST endpoints on the server (`POST .../state`, `POST .../comments`), one new core function (`reopenIssue`), and iOS UI components (action bar, two sheets) following the Phase 3 PR actions pattern exactly.
+
+**Tech Stack:** TypeScript (Node.js/Next.js), Swift (SwiftUI), Octokit, pino logging
+
+**Design spec:** `docs/superpowers/specs/2026-04-25-ios-issue-actions-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `packages/core/src/github/issues.ts` | Add `reopenIssue` function |
+| Modify | `packages/core/src/index.ts` | Export `reopenIssue` |
+| Create | `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts` | POST endpoint for close/reopen |
+| Create | `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts` | POST endpoint for issue comments |
+| Modify | `IssueCTL/Models/Issue.swift` | Add request/response types |
+| Modify | `IssueCTL/Services/APIClient.swift` | Add `updateIssueState` and `commentOnIssue` methods |
+| Create | `IssueCTL/Views/Issues/IssueCommentSheet.swift` | Comment compose sheet |
+| Create | `IssueCTL/Views/Issues/CloseIssueSheet.swift` | Close with optional comment sheet |
+| Modify | `IssueCTL/Views/Issues/IssueDetailView.swift` | Add action bar and sheet wiring |
+| Modify | `IssueCTL.xcodeproj/project.pbxproj` | Register new Swift files |
+
+---
+
+### Task 1: Add `reopenIssue` core function and export
+
+**Files:**
+- Modify: `packages/core/src/github/issues.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add `reopenIssue` function to `packages/core/src/github/issues.ts`**
+
+Insert this function after the existing `closeIssue` function (after line 139):
+
+```typescript
+export async function reopenIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<void> {
+  await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: number,
+    state: "open",
+  });
+}
+```
+
+- [ ] **Step 2: Export `reopenIssue` from `packages/core/src/index.ts`**
+
+In the existing export block from `"./github/issues.js"` (around line 112-118), add `reopenIssue`:
+
+Change:
+```typescript
+export {
+  createIssue,
+  updateIssue,
+  closeIssue,
+  reassignIssue,
+  type ReassignResult,
+} from "./github/issues.js";
+```
+
+To:
+```typescript
+export {
+  createIssue,
+  updateIssue,
+  closeIssue,
+  reopenIssue,
+  reassignIssue,
+  type ReassignResult,
+} from "./github/issues.js";
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions && pnpm turbo typecheck`
+Expected: PASS — 4/4 tasks, 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions
+git add packages/core/src/github/issues.ts packages/core/src/index.ts
+git commit -m "feat(core): add reopenIssue function for iOS issue actions"
+```
+
+---
+
+### Task 2: Create issue state endpoint
+
+**Files:**
+- Create: `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts`
+
+- [ ] **Step 1: Create the state route file**
+
+Create `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  clearCacheKey,
+  withAuthRetry,
+  closeIssue,
+  reopenIssue,
+  addComment,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { MAX_COMMENT_BODY } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+
+const VALID_STATES = ["open", "closed"] as const;
+type IssueState = (typeof VALID_STATES)[number];
+
+type StateBody = {
+  state: IssueState;
+  comment?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: StateBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!VALID_STATES.includes(body.state as IssueState)) {
+    return NextResponse.json({ error: "Invalid state — must be open or closed" }, { status: 400 });
+  }
+
+  if (body.comment !== undefined) {
+    if (typeof body.comment !== "string" || !body.comment.trim()) {
+      return NextResponse.json({ error: "Comment must be a non-empty string" }, { status: 400 });
+    }
+    if (body.comment.length > MAX_COMMENT_BODY) {
+      return NextResponse.json(
+        { error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer` },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    // Post comment first (if provided), then change state
+    if (body.comment?.trim()) {
+      await withAuthRetry((octokit) =>
+        addComment(db, octokit, owner, repo, issueNumber, body.comment!),
+      );
+    }
+
+    if (body.state === "closed") {
+      await withAuthRetry((octokit) => closeIssue(octokit, owner, repo, issueNumber));
+    } else {
+      await withAuthRetry((octokit) => reopenIssue(octokit, owner, repo, issueNumber));
+    }
+
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+
+    log.info({ msg: "api_issue_state_changed", owner, repo, issueNumber, state: body.state });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_state_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions && pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions
+git add packages/web/app/api/v1/issues/\[owner\]/\[repo\]/\[number\]/state/route.ts
+git commit -m "feat(web): add POST issue state endpoint for iOS issue actions"
+```
+
+---
+
+### Task 3: Create issue comments endpoint
+
+**Files:**
+- Create: `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts`
+
+- [ ] **Step 1: Create the comments route file**
+
+Create `packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  withAuthRetry,
+  addComment,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { MAX_COMMENT_BODY } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+
+type CommentBody = {
+  body: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: CommentBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.body !== "string" || !body.body.trim()) {
+    return NextResponse.json({ error: "Comment body is required" }, { status: 400 });
+  }
+  if (body.body.length > MAX_COMMENT_BODY) {
+    return NextResponse.json(
+      { error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const comment = await withAuthRetry((octokit) =>
+      addComment(db, octokit, owner, repo, issueNumber, body.body),
+    );
+
+    log.info({ msg: "api_issue_comment_added", owner, repo, issueNumber, commentId: comment.id });
+    return NextResponse.json({ success: true, commentId: comment.id });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_comment_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+```
+
+Note: `addComment` from `@issuectl/core` is the data layer version (from `data/comments.ts`) which handles cache invalidation internally — it clears `comments:`, `issue-content:`, `issue-detail:`, and `pull-detail:` cache keys. No additional `clearCacheKey` calls needed.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions && pnpm turbo typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions
+git add packages/web/app/api/v1/issues/\[owner\]/\[repo\]/\[number\]/comments/route.ts
+git commit -m "feat(web): add POST issue comments endpoint for iOS issue actions"
+```
+
+---
+
+### Task 4: Add iOS models and API client methods
+
+**Files:**
+- Modify: `IssueCTL/Models/Issue.swift` (in the `issuectl-ios` repo at `/Users/neonwatty/Desktop/issuectl-ios/`)
+- Modify: `IssueCTL/Services/APIClient.swift`
+
+- [ ] **Step 1: Add request/response types to `Issue.swift`**
+
+Append these types at the end of `IssueCTL/Models/Issue.swift` (after `IssueDetailResponse`):
+
+```swift
+struct IssueStateRequestBody: Encodable, Sendable {
+    let state: String
+    let comment: String?
+}
+
+struct IssueStateResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct IssueCommentRequestBody: Encodable, Sendable {
+    let body: String
+}
+
+struct IssueCommentResponse: Codable, Sendable {
+    let success: Bool
+    let commentId: Int?
+    let error: String?
+}
+```
+
+- [ ] **Step 2: Add API client methods to `APIClient.swift`**
+
+Add these two methods in `APIClient.swift` after the `commentOnPull` method (around line 176), before the `// MARK: - Private` section:
+
+```swift
+    func updateIssueState(owner: String, repo: String, number: Int, body: IssueStateRequestBody) async throws -> IssueStateResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/issues/\(owner)/\(repo)/\(number)/state", method: "POST", body: bodyData)
+        return try decoder.decode(IssueStateResponse.self, from: data)
+    }
+
+    func commentOnIssue(owner: String, repo: String, number: Int, body: IssueCommentRequestBody) async throws -> IssueCommentResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/issues/\(owner)/\(repo)/\(number)/comments", method: "POST", body: bodyData)
+        return try decoder.decode(IssueCommentResponse.self, from: data)
+    }
+```
+
+- [ ] **Step 3: Build iOS project**
+
+Run Xcode build via XcodeBuildMCP `build_sim` to verify the models and API methods compile.
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git add IssueCTL/Models/Issue.swift IssueCTL/Services/APIClient.swift
+git commit -m "feat(ios): add issue state and comment models and API client methods"
+```
+
+---
+
+### Task 5: Create IssueCommentSheet
+
+**Files:**
+- Create: `IssueCTL/Views/Issues/IssueCommentSheet.swift`
+
+- [ ] **Step 1: Create `IssueCommentSheet.swift`**
+
+Create `IssueCTL/Views/Issues/IssueCommentSheet.swift` following the same pattern as `CommentSheet.swift` (for PRs):
+
+```swift
+import SwiftUI
+
+struct IssueCommentSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let onSuccess: () -> Void
+
+    @State private var commentBody = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Comment") {
+                    TextEditor(text: $commentBody)
+                        .frame(minHeight: 120)
+                        .font(.body)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button {
+                        Task { await submit() }
+                    } label: {
+                        if isSubmitting {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Label("Add Comment", systemImage: "bubble.left")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(commentBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                }
+            }
+            .navigationTitle("Add Comment")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+        do {
+            let requestBody = IssueCommentRequestBody(body: commentBody)
+            let response = try await api.commentOnIssue(owner: owner, repo: repo, number: number, body: requestBody)
+            if response.success {
+                onSuccess()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to add comment"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSubmitting = false
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git add IssueCTL/Views/Issues/IssueCommentSheet.swift
+git commit -m "feat(ios): add IssueCommentSheet for adding comments to issues"
+```
+
+---
+
+### Task 6: Create CloseIssueSheet
+
+**Files:**
+- Create: `IssueCTL/Views/Issues/CloseIssueSheet.swift`
+
+- [ ] **Step 1: Create `CloseIssueSheet.swift`**
+
+Create `IssueCTL/Views/Issues/CloseIssueSheet.swift`:
+
+```swift
+import SwiftUI
+
+struct CloseIssueSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let onSuccess: () -> Void
+
+    @State private var closingComment = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Closing comment (optional)") {
+                    TextEditor(text: $closingComment)
+                        .frame(minHeight: 120)
+                        .font(.body)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        Task { await submit() }
+                    } label: {
+                        if isSubmitting {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Label("Close Issue", systemImage: "xmark.circle")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(isSubmitting)
+                }
+            }
+            .navigationTitle("Close Issue")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+        do {
+            let trimmed = closingComment.trimmingCharacters(in: .whitespacesAndNewlines)
+            let requestBody = IssueStateRequestBody(
+                state: "closed",
+                comment: trimmed.isEmpty ? nil : trimmed
+            )
+            let response = try await api.updateIssueState(owner: owner, repo: repo, number: number, body: requestBody)
+            if response.success {
+                onSuccess()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to close issue"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSubmitting = false
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git add IssueCTL/Views/Issues/CloseIssueSheet.swift
+git commit -m "feat(ios): add CloseIssueSheet with optional closing comment"
+```
+
+---
+
+### Task 7: Add action bar and sheet wiring to IssueDetailView
+
+**Files:**
+- Modify: `IssueCTL/Views/Issues/IssueDetailView.swift`
+
+- [ ] **Step 1: Add state properties**
+
+In `IssueDetailView`, add these `@State` properties after the existing ones (after `@State private var showLaunchSheet = false` on line 12):
+
+```swift
+    @State private var isClosing = false
+    @State private var isReopening = false
+    @State private var showCommentSheet = false
+    @State private var showCloseSheet = false
+    @State private var showCloseConfirm = false
+    @State private var showReopenConfirm = false
+    @State private var actionError: String?
+```
+
+- [ ] **Step 2: Wrap ScrollView in VStack and add action bar**
+
+Replace the `else if let detail` branch content (lines 27-43) — the current `ScrollView` block. Wrap it in a `VStack(spacing: 0)` and add the action bar after the scroll view, plus an error label:
+
+```swift
+            } else if let detail {
+                VStack(spacing: 0) {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 20) {
+                            headerSection(detail.issue)
+                            bodySection(detail.issue)
+                            if !detail.linkedPRs.isEmpty {
+                                linkedPRsSection(detail.linkedPRs)
+                            }
+                            if !detail.deployments.isEmpty {
+                                deploymentsSection(detail.deployments)
+                            }
+                            if !detail.comments.isEmpty {
+                                commentsSection(detail.comments)
+                            }
+                            if let actionError {
+                                Label(actionError, systemImage: "exclamationmark.triangle")
+                                    .foregroundStyle(.red)
+                                    .font(.subheadline)
+                            }
+                        }
+                        .padding()
+                    }
+                    .refreshable { await load(refresh: true) }
+
+                    actionBar(for: detail.issue)
+                }
+            }
+```
+
+- [ ] **Step 3: Add sheet and confirmation dialog modifiers**
+
+After the existing `.sheet(isPresented: $showLaunchSheet)` modifier and before `.task { await load() }`, add:
+
+```swift
+        .sheet(isPresented: $showCommentSheet) {
+            IssueCommentSheet(
+                owner: owner, repo: repo, number: number,
+                onSuccess: { Task { await load(refresh: true) } }
+            )
+        }
+        .sheet(isPresented: $showCloseSheet) {
+            CloseIssueSheet(
+                owner: owner, repo: repo, number: number,
+                onSuccess: { Task { await load(refresh: true) } }
+            )
+        }
+        .confirmationDialog("Close Issue", isPresented: $showCloseConfirm, titleVisibility: .visible) {
+            Button("Close", role: .destructive) { Task { await closeWithoutComment() } }
+            Button("Close with comment...") { showCloseSheet = true }
+        }
+        .confirmationDialog("Reopen Issue", isPresented: $showReopenConfirm, titleVisibility: .visible) {
+            Button("Reopen") { Task { await reopen() } }
+        }
+```
+
+- [ ] **Step 4: Add the actionBar computed property**
+
+Add this after the `commentsSection` function and before the `// MARK: - Loading` section:
+
+```swift
+    // MARK: - Action Bar
+
+    @ViewBuilder
+    private func actionBar(for issue: GitHubIssue) -> some View {
+        if issue.isOpen {
+            HStack(spacing: 16) {
+                Button {
+                    showCommentSheet = true
+                } label: {
+                    Label("Comment", systemImage: "bubble.left")
+                }
+
+                Button {
+                    showCloseConfirm = true
+                } label: {
+                    if isClosing {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Close", systemImage: "xmark.circle")
+                    }
+                }
+                .tint(.red)
+                .disabled(isClosing)
+            }
+            .labelStyle(.titleAndIcon)
+            .font(.caption)
+            .padding()
+            .background(.bar)
+        } else {
+            HStack {
+                Button {
+                    showReopenConfirm = true
+                } label: {
+                    if isReopening {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Reopen", systemImage: "arrow.uturn.backward.circle")
+                    }
+                }
+                .tint(.green)
+                .disabled(isReopening)
+            }
+            .labelStyle(.titleAndIcon)
+            .font(.caption)
+            .padding()
+            .background(.bar)
+        }
+    }
+```
+
+- [ ] **Step 5: Add action functions**
+
+Add these after the existing `load` function:
+
+```swift
+    private func closeWithoutComment() async {
+        isClosing = true
+        actionError = nil
+        do {
+            let body = IssueStateRequestBody(state: "closed", comment: nil)
+            let response = try await api.updateIssueState(owner: owner, repo: repo, number: number, body: body)
+            if response.success {
+                await load(refresh: true)
+            } else {
+                actionError = response.error ?? "Failed to close issue"
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isClosing = false
+    }
+
+    private func reopen() async {
+        isReopening = true
+        actionError = nil
+        do {
+            let body = IssueStateRequestBody(state: "open", comment: nil)
+            let response = try await api.updateIssueState(owner: owner, repo: repo, number: number, body: body)
+            if response.success {
+                await load(refresh: true)
+            } else {
+                actionError = response.error ?? "Failed to reopen issue"
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isReopening = false
+    }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git add IssueCTL/Views/Issues/IssueDetailView.swift
+git commit -m "feat(ios): add action bar with close/reopen and comment to IssueDetailView"
+```
+
+---
+
+### Task 8: Register new Swift files in Xcode project
+
+**Files:**
+- Modify: `IssueCTL.xcodeproj/project.pbxproj`
+
+The two new files (`IssueCommentSheet.swift`, `CloseIssueSheet.swift`) must be registered in four sections of `project.pbxproj`:
+
+1. `PBXBuildFile` — links file ref to build phase
+2. `PBXFileReference` — declares the file
+3. `PBXGroup` — adds to the Issues group
+4. `PBXSourcesBuildPhase` — includes in compilation
+
+- [ ] **Step 1: Generate unique IDs and add to PBXBuildFile**
+
+Use these IDs:
+- `IssueCommentSheet.swift`: fileRef `FF1A2B3C4D5E6F7A8B9C0D1E`, buildFile `GG1A2B3C4D5E6F7A8B9C0D1E`
+- `CloseIssueSheet.swift`: fileRef `FF2A3B4C5D6E7F8A9B0C1D2E`, buildFile `GG2A3B4C5D6E7F8A9B0C1D2E`
+
+In the `/* Begin PBXBuildFile section */`, add:
+
+```
+		GG1A2B3C4D5E6F7A8B9C0D1E /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1A2B3C4D5E6F7A8B9C0D1E /* IssueCommentSheet.swift */; };
+		GG2A3B4C5D6E7F8A9B0C1D2E /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2A3B4C5D6E7F8A9B0C1D2E /* CloseIssueSheet.swift */; };
+```
+
+- [ ] **Step 2: Add to PBXFileReference**
+
+In the `/* Begin PBXFileReference section */`, add:
+
+```
+		FF1A2B3C4D5E6F7A8B9C0D1E /* IssueCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentSheet.swift; sourceTree = "<group>"; };
+		FF2A3B4C5D6E7F8A9B0C1D2E /* CloseIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseIssueSheet.swift; sourceTree = "<group>"; };
+```
+
+- [ ] **Step 3: Add to PBXGroup (Issues group)**
+
+Find the Issues group in the `/* Begin PBXGroup section */` (the group containing `IssueDetailView.swift`, `IssueListView.swift`, etc.). Add the two new file references to its `children` array:
+
+```
+				FF1A2B3C4D5E6F7A8B9C0D1E /* IssueCommentSheet.swift */,
+				FF2A3B4C5D6E7F8A9B0C1D2E /* CloseIssueSheet.swift */,
+```
+
+- [ ] **Step 4: Add to PBXSourcesBuildPhase**
+
+In the `/* Begin PBXSourcesBuildPhase section */`, add to the `files` array:
+
+```
+				GG1A2B3C4D5E6F7A8B9C0D1E /* IssueCommentSheet.swift in Sources */,
+				GG2A3B4C5D6E7F8A9B0C1D2E /* CloseIssueSheet.swift in Sources */,
+```
+
+- [ ] **Step 5: Build iOS project**
+
+Run Xcode build via XcodeBuildMCP `build_sim` to verify the project compiles with new files registered.
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git add IssueCTL.xcodeproj/project.pbxproj
+git commit -m "chore(ios): register IssueCommentSheet and CloseIssueSheet in Xcode project"
+```
+
+---
+
+### Task 9: Final typecheck, build verification, push, and PR
+
+**Files:**
+- No files modified — verification only
+
+- [ ] **Step 1: Server typecheck**
+
+Run: `cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions && pnpm turbo typecheck`
+Expected: PASS — 4/4 tasks, 0 errors
+
+- [ ] **Step 2: iOS build**
+
+Run Xcode build via XcodeBuildMCP `build_sim`.
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Push server branch**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions
+git push origin phase-4-ios-issue-actions
+```
+
+- [ ] **Step 4: Push iOS to main**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl-ios
+git push origin main
+```
+
+- [ ] **Step 5: Run PR review toolkit on server changes**
+
+Run `/pr-review-toolkit:review-pr all` on the server-side changes. Fix all critical and important findings before creating the PR.
+
+- [ ] **Step 6: Create server PR**
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.claude/worktrees/phase-4-ios-issue-actions
+gh pr create --title "feat(ios): Phase 4 — issue close/reopen and comment actions" --body "$(cat <<'EOF'
+## Summary
+
+- Add `reopenIssue` core function alongside existing `closeIssue`
+- Add `POST .../state` endpoint for close/reopen with optional comment
+- Add `POST .../comments` endpoint for issue comments
+- Design spec and implementation plan in `docs/superpowers/`
+
+Companion iOS changes: SwiftUI action bar (comment, close with confirmation, reopen), IssueCommentSheet, CloseIssueSheet with optional closing comment, API client methods.
+
+## Test plan
+
+- [ ] `pnpm turbo typecheck` — 0 errors
+- [ ] PR review toolkit — all findings addressed
+- [ ] Manual test: close an issue via iOS
+- [ ] Manual test: reopen an issue via iOS
+- [ ] Manual test: close with comment via iOS
+- [ ] Manual test: add a comment via iOS
+EOF
+)" --base main # reviewed
+```

--- a/docs/superpowers/specs/2026-04-25-ios-issue-actions-design.md
+++ b/docs/superpowers/specs/2026-04-25-ios-issue-actions-design.md
@@ -1,0 +1,163 @@
+# iOS Phase 4: Issue Actions
+
+## Goal
+
+Add close/reopen and comment capabilities to the iOS app's issue detail view, completing the core issue triage workflow from a phone.
+
+## Scope
+
+**In scope:**
+- Close with optional comment + confirmation dialog
+- Reopen with confirmation dialog
+- Add top-level issue comments (compose-then-send)
+- Single `POST .../state` endpoint handles both close and reopen
+
+**Out of scope:**
+- Label toggling (needs picker UI, low mobile value — candidate for Phase 5)
+- Issue creation (complex form, better on desktop)
+- Issue editing (title/body — rare action on mobile)
+- Comment editing/deletion (mirroring web capability — future work)
+- Cross-repo reassignment
+
+## Architecture
+
+Dedicated REST endpoints per action, following the Phase 3 pattern. The core layer gains one new function (`reopenIssue`). The iOS app calls REST endpoints with Bearer auth.
+
+Two codebases touched:
+- `issuectl` (server) — 1 new core function, 2 new endpoints
+- `issuectl-ios` (client) — new models, API client methods, UI components
+
+## Server: Core Layer
+
+### New function (`packages/core/src/github/issues.ts`)
+
+- `reopenIssue(octokit, owner, repo, number)` -> `GitHubIssue`
+  Wraps `octokit.rest.issues.update({ owner, repo, issue_number: number, state: "open" })`. Maps response to `GitHubIssue`.
+
+The existing `closeIssue(octokit, owner, repo, number)` already handles the close case.
+
+### Exports (`packages/core/src/index.ts`)
+
+Export `reopenIssue` alongside the existing `closeIssue`.
+
+## Server: API Endpoints
+
+### `POST /api/v1/issues/[owner]/[repo]/[number]/state`
+
+**Body:**
+```json
+{ "state": "open" | "closed", "comment": "optional string" }
+```
+
+**Validation:**
+- `state` must be `"open"` or `"closed"`
+- `comment`, if provided, must be a non-empty string, max 65536 characters (`MAX_COMMENT_BODY` from `@/lib/constants`)
+
+**Logic:**
+1. If `comment` is provided and non-empty, post it first via `addComment` from the data layer (`@issuectl/core`)
+2. Then update issue state via `closeIssue` (for `"closed"`) or `reopenIssue` (for `"open"`)
+3. Clear cache keys: `issue-detail:{owner}/{repo}#{number}` and `issues:{owner}/{repo}`
+
+**Response:** `{ success: true }` on success. `{ success: false, error: string }` on failure.
+
+### `POST /api/v1/issues/[owner]/[repo]/[number]/comments`
+
+**Body:**
+```json
+{ "body": "comment text" }
+```
+
+**Validation:** Non-empty body, max 65536 characters (`MAX_COMMENT_BODY`).
+
+**Logic:** `withAuthRetry(octokit => addComment(db, octokit, owner, repo, number, body))`. Clear `issue-detail:{owner}/{repo}#{number}` cache.
+
+**Response:** `{ success: true, commentId: number }` or `{ success: false, error: string }`.
+
+### Common patterns
+
+Both POST endpoints use: `requireAuth` -> input validation -> `getDb()`/`getRepo()` inside try-catch -> `withAuthRetry` -> cache invalidation -> structured pino logging (`import log from "@/lib/logger"`).
+
+## iOS: Models
+
+### New types (`Issue.swift`)
+
+```swift
+struct IssueStateRequestBody: Encodable, Sendable {
+    let state: String  // "open" or "closed"
+    let comment: String?
+}
+
+struct IssueStateResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct IssueCommentRequestBody: Encodable, Sendable {
+    let body: String
+}
+
+struct IssueCommentResponse: Codable, Sendable {
+    let success: Bool
+    let commentId: Int?
+    let error: String?
+}
+```
+
+## iOS: API Client
+
+Two new methods in `APIClient.swift`:
+
+- `updateIssueState(owner:repo:number:body:)` -> `IssueStateResponse`
+- `commentOnIssue(owner:repo:number:body:)` -> `IssueCommentResponse`
+
+Both follow existing pattern: `makeRequest(method:path:body:)` with Bearer auth, JSON encode/decode.
+
+## iOS: UI
+
+### Action bar in `IssueDetailView`
+
+Displayed below the ScrollView. Content depends on issue state:
+
+**When open:** Two buttons in an HStack:
+- **Comment** (speech bubble icon) — presents `IssueCommentSheet`
+- **Close** (red X icon) — presents `.confirmationDialog` with two options:
+  - "Close" — calls `updateIssueState` with `state: "closed"`, no comment
+  - "Close with comment..." — presents `CloseIssueSheet`
+
+**When closed:** Single button:
+- **Reopen** (green arrow icon) — presents `.confirmationDialog`, then calls `updateIssueState` with `state: "open"`
+
+Action bar disappears or updates after state change (detail refreshes).
+
+### `IssueCommentSheet`
+
+Identical pattern to the PR `CommentSheet`: NavigationStack + Form, TextEditor for body, body required (button disabled when empty), "Add Comment" submit button. Calls `api.commentOnIssue`. Dismisses on success and triggers detail refresh.
+
+### `CloseIssueSheet`
+
+NavigationStack + Form, TextEditor for optional closing comment, "Close Issue" submit button (always enabled — comment is optional). Calls `api.updateIssueState` with `state: "closed"` and the comment if provided. Dismisses on success and triggers detail refresh.
+
+### State management
+
+- `@State` booleans: `isClosing`, `isReopening`, `showCommentSheet`, `showCloseSheet`, `showCloseConfirm`, `showReopenConfirm`, `actionError`
+- On success: dismiss sheet (if applicable), refresh detail view
+- On error: inline error label matching Phase 3 pattern
+- On close/reopen success: detail refreshes to show new state, action bar updates
+
+### Xcode project
+
+Register new Swift files (`IssueCommentSheet.swift`, `CloseIssueSheet.swift`) in `project.pbxproj` — new view files go into existing Issues group.
+
+## Error Handling
+
+- Permission errors: "You don't have permission" — shown as error label
+- Already closed/open: server returns error, detail refresh shows correct state
+- Network errors: standard `error.localizedDescription` display
+- Comment post failure during close: comment error surfaced, issue state not changed (comment posts first)
+- State change failure after comment: comment is already posted (visible on GitHub), error returned to client. The user sees the comment appeared but the issue didn't close — they can retry the close action.
+
+## Testing
+
+- Server: typecheck (`pnpm turbo typecheck`) for all new endpoints and core function
+- iOS: Xcode build verification via XcodeBuildMCP
+- Manual: test each action against a real issue on a test repo

--- a/packages/core/src/github/issues.test.ts
+++ b/packages/core/src/github/issues.test.ts
@@ -7,6 +7,7 @@ import {
   createIssue,
   updateIssue,
   closeIssue,
+  reopenIssue,
   getComments,
   addComment,
   updateComment,
@@ -220,6 +221,32 @@ describe("closeIssue", () => {
     );
 
     await expect(closeIssue(octokit, "owner", "repo", 999)).rejects.toThrow("Not Found");
+  });
+});
+
+/* ---------- reopenIssue ---------- */
+
+describe("reopenIssue", () => {
+  it("reopens an issue by setting state to open", async () => {
+    const { octokit, update } = makeOctokit();
+    update.mockResolvedValue({ data: { ...RAW_ISSUE, state: "open" } });
+
+    await reopenIssue(octokit, "owner", "repo", 1);
+    expect(update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 1,
+      state: "open",
+    });
+  });
+
+  it("propagates 404 errors", async () => {
+    const { octokit, update } = makeOctokit();
+    update.mockRejectedValue(
+      Object.assign(new Error("Not Found"), { status: 404 }),
+    );
+
+    await expect(reopenIssue(octokit, "owner", "repo", 999)).rejects.toThrow("Not Found");
   });
 });
 

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -138,6 +138,20 @@ export async function closeIssue(
   });
 }
 
+export async function reopenIssue(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<void> {
+  await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: number,
+    state: "open",
+  });
+}
+
 export async function getComments(
   octokit: Octokit,
   owner: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,7 @@ export {
   createIssue,
   updateIssue,
   closeIssue,
+  reopenIssue,
   reassignIssue,
   type ReassignResult,
 } from "./github/issues.js";

--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -295,45 +295,41 @@ describe("isTmuxSessionAlive", () => {
     expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
   });
 
-  it("returns false when tmux command times out", () => {
+  it("returns false when tmux is not installed (ENOENT)", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" });
+    });
+    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
+  });
+
+  it("throws on unexpected errors (ETIMEDOUT) to prevent false 'dead' cascades", () => {
     execFileSyncSpy.mockImplementation(() => {
       throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
     });
-    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
-  });
-
-  it("returns false when tmux is not installed", () => {
-    execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("not found"), { code: "ENOENT" });
-    });
-    expect(isTmuxSessionAlive("issuectl-repo-42")).toBe(false);
-  });
-
-  it("logs unexpected errors (not exit code 1)", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("not found"), { code: "ENOENT" });
-    });
-
-    isTmuxSessionAlive("issuectl-repo-42");
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[issuectl] tmux has-session failed unexpectedly:",
-      expect.any(Error),
+    expect(() => isTmuxSessionAlive("issuectl-repo-42")).toThrow(
+      'tmux has-session failed unexpectedly for "issuectl-repo-42"',
     );
-    warnSpy.mockRestore();
   });
 
-  it("does not log when exit code is 1 (normal 'session not found')", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("throws on unexpected errors (EPERM) to prevent false 'dead' cascades", () => {
     execFileSyncSpy.mockImplementation(() => {
-      throw Object.assign(new Error("session not found"), { status: 1 });
+      throw Object.assign(new Error("EPERM"), { code: "EPERM" });
     });
+    expect(() => isTmuxSessionAlive("issuectl-repo-42")).toThrow(
+      "tmux has-session failed unexpectedly",
+    );
+  });
 
-    isTmuxSessionAlive("issuectl-repo-42");
-
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
+  it("preserves original error as cause when throwing", () => {
+    const original = Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+    execFileSyncSpy.mockImplementation(() => {
+      throw original;
+    });
+    try {
+      isTmuxSessionAlive("issuectl-repo-42");
+    } catch (err) {
+      expect((err as Error).cause).toBe(original);
+    }
   });
 });
 
@@ -828,7 +824,7 @@ describe("reconcileOrphanedDeployments", () => {
     expect(selectCall![0]).toContain("ttyd_pid IS NOT NULL");
   });
 
-  it("logs error and does not throw when reconcile fails", () => {
+  it("logs error and does not throw when query fails", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const db = {
       prepare: vi.fn(() => {
@@ -839,9 +835,50 @@ describe("reconcileOrphanedDeployments", () => {
     // Should not throw
     expect(() => reconcileOrphanedDeployments(db)).not.toThrow();
     expect(errorSpy).toHaveBeenCalledWith(
-      "[issuectl] Failed to reconcile orphaned deployments:",
+      "[issuectl] Failed to query deployments for reconciliation:",
       expect.any(Error),
     );
     errorSpy.mockRestore();
+  });
+
+  it("continues reconciling other rows when one row fails (per-row isolation)", () => {
+    // Row 1 causes isTmuxSessionAlive to throw (ETIMEDOUT), row 2 is dead.
+    execFileSyncSpy.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "has-session" && args[2] === "issuectl-repoA-10") {
+        throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+      }
+      // repoB session is gone (exit code 1)
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runSpy = vi.fn();
+    const db = {
+      prepare: vi.fn((sql: string) => {
+        if (sql.includes("SELECT")) {
+          return {
+            all: vi.fn(() => [
+              { id: 1, issue_number: 10, repo_name: "repoA" },
+              { id: 2, issue_number: 20, repo_name: "repoB" },
+            ]),
+          };
+        }
+        return { run: runSpy };
+      }),
+    } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    // Row 1 should have failed (logged), row 2 should still be reconciled.
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[issuectl] Failed to reconcile deployment 1:",
+      expect.any(Error),
+    );
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy).toHaveBeenCalledWith(2);
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -133,13 +133,19 @@ export function isTmuxSessionAlive(sessionName: string): boolean {
     });
     return true;
   } catch (err) {
-    // Exit code 1 means "no such session" — expected and silent.
-    // Anything else (ENOENT, ETIMEDOUT, etc.) is unexpected and logged.
     const status = (err as { status?: number }).status;
-    if (status !== 1) {
-      console.warn("[issuectl] tmux has-session failed unexpectedly:", err);
-    }
-    return false;
+    const code = (err as NodeJS.ErrnoException).code;
+    // Exit code 1 = "no such session" — normal, silent.
+    if (status === 1) return false;
+    // ENOENT = tmux not installed — no sessions possible.
+    if (code === "ENOENT") return false;
+    // Anything else (ETIMEDOUT, EPERM, etc.) is a transient failure.
+    // Throwing prevents callers from treating "unknown" as "dead",
+    // which would cascade into permanently ending live deployments.
+    throw new Error(
+      `tmux has-session failed unexpectedly for "${sessionName}"`,
+      { cause: err },
+    );
   }
 }
 
@@ -351,8 +357,9 @@ function killTmuxSession(name: string): void {
  * still active.
  */
 export function reconcileOrphanedDeployments(db: Database.Database): void {
+  let rows: { id: number; issue_number: number; repo_name: string }[];
   try {
-    const rows = db
+    rows = db
       .prepare(
         `SELECT d.id, d.issue_number, r.name AS repo_name
          FROM deployments d
@@ -360,9 +367,14 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
          WHERE d.ended_at IS NULL
            AND d.ttyd_pid IS NOT NULL`,
       )
-      .all() as { id: number; issue_number: number; repo_name: string }[];
+      .all() as typeof rows;
+  } catch (err) {
+    console.error("[issuectl] Failed to query deployments for reconciliation:", err);
+    return;
+  }
 
-    for (const row of rows) {
+  for (const row of rows) {
+    try {
       const sessionName = tmuxSessionName(row.repo_name, row.issue_number);
       if (!isTmuxSessionAlive(sessionName)) {
         db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
@@ -372,8 +384,8 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
           `[issuectl] Reconciled orphaned deployment ${row.id} (tmux session ${sessionName} is gone)`,
         );
       }
+    } catch (err) {
+      console.error(`[issuectl] Failed to reconcile deployment ${row.id}:`, err);
     }
-  } catch (err) {
-    console.error("[issuectl] Failed to reconcile orphaned deployments:", err);
   }
 }

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  withAuthRetry,
+  addComment,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { MAX_COMMENT_BODY } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+
+type CommentBody = {
+  body: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: CommentBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.body !== "string" || !body.body.trim()) {
+    return NextResponse.json({ error: "Comment body is required" }, { status: 400 });
+  }
+  if (body.body.length > MAX_COMMENT_BODY) {
+    return NextResponse.json(
+      { error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const comment = await withAuthRetry((octokit) =>
+      addComment(db, octokit, owner, repo, issueNumber, body.body),
+    );
+
+    log.info({ msg: "api_issue_comment_added", owner, repo, issueNumber, commentId: comment.id });
+    return NextResponse.json({ success: true, commentId: comment.id });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_comment_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
@@ -32,7 +32,8 @@ export async function POST(
   let body: CommentBody;
   try {
     body = await request.json();
-  } catch {
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  clearCacheKey,
+  withAuthRetry,
+  closeIssue,
+  reopenIssue,
+  addComment,
+  formatErrorForUser,
+} from "@issuectl/core";
+import { MAX_COMMENT_BODY } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+
+const VALID_STATES = ["open", "closed"] as const;
+type IssueState = (typeof VALID_STATES)[number];
+
+type StateBody = {
+  state: IssueState;
+  comment?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: StateBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!VALID_STATES.includes(body.state as IssueState)) {
+    return NextResponse.json({ error: "Invalid state — must be open or closed" }, { status: 400 });
+  }
+
+  if (body.comment !== undefined) {
+    if (typeof body.comment !== "string" || !body.comment.trim()) {
+      return NextResponse.json({ error: "Comment must be a non-empty string" }, { status: 400 });
+    }
+    if (body.comment.length > MAX_COMMENT_BODY) {
+      return NextResponse.json(
+        { error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer` },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    // Post comment first (if provided), then change state
+    if (body.comment?.trim()) {
+      await withAuthRetry((octokit) =>
+        addComment(db, octokit, owner, repo, issueNumber, body.comment!),
+      );
+    }
+
+    if (body.state === "closed") {
+      await withAuthRetry((octokit) => closeIssue(octokit, owner, repo, issueNumber));
+    } else {
+      await withAuthRetry((octokit) => reopenIssue(octokit, owner, repo, issueNumber));
+    }
+
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+
+    log.info({ msg: "api_issue_state_changed", owner, repo, issueNumber, state: body.state });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_state_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
@@ -65,17 +65,37 @@ export async function POST(
       return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
     }
 
-    // Post comment first (if provided), then change state
+    // Post comment before changing state so the closing rationale appears
+    // in the timeline first. If the comment fails, state is left unchanged.
+    let commentPosted = false;
     if (body.comment?.trim()) {
       await withAuthRetry((octokit) =>
         addComment(db, octokit, owner, repo, issueNumber, body.comment!),
       );
+      commentPosted = true;
     }
 
-    if (body.state === "closed") {
-      await withAuthRetry((octokit) => closeIssue(octokit, owner, repo, issueNumber));
-    } else {
-      await withAuthRetry((octokit) => reopenIssue(octokit, owner, repo, issueNumber));
+    try {
+      if (body.state === "closed") {
+        await withAuthRetry((octokit) => closeIssue(octokit, owner, repo, issueNumber));
+      } else {
+        await withAuthRetry((octokit) => reopenIssue(octokit, owner, repo, issueNumber));
+      }
+    } catch (stateErr) {
+      // addComment clears its own comment/content caches; clear state caches here
+      clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+      clearCacheKey(db, `issues:${owner}/${repo}`);
+      log.error({ err: stateErr, msg: "api_issue_state_failed", owner, repo, issueNumber, state: body.state, commentPosted });
+      return NextResponse.json(
+        {
+          success: false,
+          commentPosted,
+          error: commentPosted
+            ? "Your comment was posted, but the issue state could not be changed."
+            : formatErrorForUser(stateErr),
+        },
+        { status: 500 },
+      );
     }
 
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
@@ -84,7 +104,7 @@ export async function POST(
     log.info({ msg: "api_issue_state_changed", owner, repo, issueNumber, state: body.state });
     return NextResponse.json({ success: true });
   } catch (err) {
-    log.error({ err, msg: "api_issue_state_failed", owner, repo, issueNumber });
+    log.error({ err, msg: "api_issue_state_failed", owner, repo, issueNumber, state: body.state });
     return NextResponse.json(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/state/route.ts
@@ -39,7 +39,8 @@ export async function POST(
   let body: StateBody;
   try {
     body = await request.json();
-  } catch {
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
@@ -82,10 +83,11 @@ export async function POST(
         await withAuthRetry((octokit) => reopenIssue(octokit, owner, repo, issueNumber));
       }
     } catch (stateErr) {
-      // addComment clears its own comment/content caches; clear state caches here
       clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+      clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+      clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
       clearCacheKey(db, `issues:${owner}/${repo}`);
-      log.error({ err: stateErr, msg: "api_issue_state_failed", owner, repo, issueNumber, state: body.state, commentPosted });
+      log.error({ err: stateErr, msg: "api_issue_state_partial_failure", owner, repo, issueNumber, state: body.state, commentPosted });
       return NextResponse.json(
         {
           success: false,
@@ -99,6 +101,8 @@ export async function POST(
     }
 
     clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
 
     log.info({ msg: "api_issue_state_changed", owner, repo, issueNumber, state: body.state });

--- a/packages/web/components/terminal/OpenTerminalButton.module.css
+++ b/packages/web/components/terminal/OpenTerminalButton.module.css
@@ -1,0 +1,5 @@
+.error {
+  color: var(--color-error, #c62828);
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { TerminalPanel } from "./TerminalPanel";
 import { checkSessionAlive, ensureTtyd } from "@/lib/actions/launch";
+import styles from "./OpenTerminalButton.module.css";
 
 const HEALTH_CHECK_INTERVAL_MS = 10_000;
 
@@ -31,26 +32,30 @@ export function OpenTerminalButton({
   const router = useRouter();
 
   useEffect(() => {
+    if (isPending) return;
+
     const timer = setInterval(async () => {
-      const { alive } = await checkSessionAlive(deploymentId);
-      if (!alive) {
-        clearInterval(timer);
-        setOpen(false);
-        router.refresh();
+      try {
+        const { alive } = await checkSessionAlive(deploymentId);
+        if (!alive) {
+          clearInterval(timer);
+          setOpen(false);
+          router.refresh();
+        }
+      } catch {
+        // Network error or server unavailable — skip this tick.
       }
     }, HEALTH_CHECK_INTERVAL_MS);
 
     return () => clearInterval(timer);
-  }, [deploymentId, router]);
+  }, [deploymentId, isPending, router]);
 
   function handleOpen() {
     setError(null);
     startTransition(async () => {
       const result = await ensureTtyd(deploymentId);
-      if ("alive" in result && !result.alive) {
-        if (result.error) {
-          setError(result.error);
-        }
+      if (!("port" in result)) {
+        if (result.error) setError(result.error);
         router.refresh();
         return;
       }
@@ -63,7 +68,7 @@ export function OpenTerminalButton({
       <Button variant="primary" onClick={handleOpen} disabled={isPending}>
         {isPending ? "Connecting..." : "Open Terminal"}
       </Button>
-      {error && <p role="alert" style={{ color: "var(--color-error, #c62828)", marginTop: "0.5rem", fontSize: "0.875rem" }}>{error}</p>}
+      {error && <p role="alert" className={styles.error}>{error}</p>}
       <TerminalPanel
         open={open}
         onClose={() => setOpen(false)}

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -17,6 +17,7 @@ const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
 const isTtydAlive = vi.hoisted(() => vi.fn());
 const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
 const respawnTtyd = vi.hoisted(() => vi.fn());
+const updateTtydInfo = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
@@ -31,6 +32,7 @@ vi.mock("@issuectl/core", () => ({
   isTtydAlive: (...args: unknown[]) => isTtydAlive(...args),
   isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
   respawnTtyd: (...args: unknown[]) => respawnTtyd(...args),
+  updateTtydInfo: (...args: unknown[]) => updateTtydInfo(...args),
   executeLaunch: vi.fn(),
   withAuthRetry: vi.fn(),
   withIdempotency: vi.fn(),
@@ -89,6 +91,7 @@ beforeEach(() => {
   isTtydAlive.mockReset();
   isTmuxSessionAlive.mockReset();
   respawnTtyd.mockReset();
+  updateTtydInfo.mockReset();
 
   // Sensible defaults: DB exists, deployment found with a PID, repo found.
   dbRunSpy = vi.fn();
@@ -201,6 +204,26 @@ describe("checkSessionAlive", () => {
 
     expect(result).toEqual({ alive: false });
   });
+
+  it("returns not alive when repo is not found", async () => {
+    getRepoById.mockReturnValue(undefined);
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false });
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
+    expect(coreEndDeployment).not.toHaveBeenCalled();
+  });
+
+  it("returns error when health check throws", async () => {
+    getDeploymentById.mockImplementation(() => {
+      throw new Error("DB locked");
+    });
+
+    const result = await checkSessionAlive(1);
+
+    expect(result).toEqual({ alive: false, error: "Health check failed" });
+  });
 });
 
 describe("ensureTtyd", () => {
@@ -254,7 +277,7 @@ describe("ensureTtyd", () => {
     expect(result).toEqual({ alive: false });
   });
 
-  it("updates DB with new PID after respawn", async () => {
+  it("calls updateTtydInfo with new PID after respawn", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(false);
     isTmuxSessionAlive.mockReturnValue(true);
@@ -262,10 +285,10 @@ describe("ensureTtyd", () => {
 
     await ensureTtyd(1);
 
-    expect(dbRunSpy).toHaveBeenCalledWith(99, 1);
+    expect(updateTtydInfo).toHaveBeenCalledWith(expect.anything(), 1, 7700, 99);
   });
 
-  it("returns error when respawnTtyd throws", async () => {
+  it("returns formatted error when respawnTtyd throws", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(false);
     isTmuxSessionAlive.mockReturnValue(true);
@@ -273,7 +296,8 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false, error: "Failed to ensure terminal" });
+    // formatErrorForUser passes through Error.message
+    expect(result).toEqual({ alive: false, error: "port conflict" });
   });
 
   it("returns alive false when repo is not found", async () => {

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -12,6 +12,7 @@ import {
   isTmuxSessionAlive,
   respawnTtyd,
   tmuxSessionName,
+  updateTtydInfo,
   withAuthRetry,
   withIdempotency,
   DuplicateInFlightError,
@@ -247,7 +248,7 @@ export async function checkSessionAlive(
 }
 
 type EnsureTtydResult =
-  | { port: number; respawned?: true }
+  | { port: number; respawned?: true; alive?: never }
   | { alive: false; error?: string };
 
 export async function ensureTtyd(
@@ -287,10 +288,10 @@ export async function ensureTtyd(
 
     // Tmux alive, ttyd dead — respawn ttyd
     const { pid } = await respawnTtyd(port, sessionName);
-    db.prepare("UPDATE deployments SET ttyd_pid = ? WHERE id = ?").run(pid, deploymentId);
+    updateTtydInfo(db, deploymentId, port, pid);
     return { port, respawned: true };
   } catch (err) {
     console.error("[issuectl] ensureTtyd failed:", err);
-    return { alive: false, error: "Failed to ensure terminal" };
+    return { alive: false, error: formatErrorForUser(err) };
   }
 }

--- a/packages/web/lib/constants.ts
+++ b/packages/web/lib/constants.ts
@@ -6,6 +6,9 @@ export const VALID_BRANCH_RE = /^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/;
 /** Max preamble length enforced client- and server-side. */
 export const MAX_PREAMBLE = 10000;
 
+/** Max comment body length enforced client- and server-side. */
+export const MAX_COMMENT_BODY = 65536;
+
 export const REPO_COLORS = [
   "#f85149",
   "#58a6ff",


### PR DESCRIPTION
## Summary

- Add `reopenIssue` core function alongside existing `closeIssue`
- Add `POST .../state` endpoint for close/reopen with optional comment
- Add `POST .../comments` endpoint for issue comments
- Partial failure handling: state endpoint returns `commentPosted` flag so iOS client avoids duplicate comments on retry
- Unit tests for `reopenIssue` mirroring existing `closeIssue` tests
- Design spec and implementation plan in `docs/superpowers/`

Companion iOS changes pushed to `issuectl-ios` main: SwiftUI action bar (comment, close with confirmation, reopen), IssueCommentSheet, CloseIssueSheet with optional closing comment, API client methods, Xcode project registration.

## Test plan

- [x] `pnpm turbo typecheck` — 0 errors
- [x] `pnpm --filter @issuectl/core test` — 448 tests pass (including 2 new reopenIssue tests)
- [x] PR review toolkit — all critical/important findings addressed
- [x] iOS Xcode build — BUILD SUCCEEDED
- [ ] Manual test: close an issue via iOS
- [ ] Manual test: reopen an issue via iOS
- [ ] Manual test: close with comment via iOS
- [ ] Manual test: add a comment via iOS