### PR TITLE
feat: terminal idle detection for ttyd sessions

### DIFF
--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -60,6 +60,7 @@ function makeDeployment(issueNumber: number, ended = false): Deployment {
     endedAt: ended ? "2026-04-02T00:00:00Z" : null,
     ttydPort: null,
     ttydPid: null,
+    idleSince: null,
   };
 }
 

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -113,6 +113,32 @@ describe("groupIntoSections", () => {
     expect(result.open).toEqual([]);
   });
 
+  it("propagates idleSince to running items and omits it from open items", () => {
+    const runningIssue = makeIssue({ number: 5 });
+    const openIssue = makeIssue({ number: 6 });
+    const idleDep = { ...makeDeployment(5, false), idleSince: "2026-04-25T00:00:00Z" };
+    const result = groupIntoSections({
+      drafts: [],
+      perRepo: [
+        {
+          repo,
+          issues: [runningIssue, openIssue],
+          deployments: [idleDep],
+          priorities: [],
+        },
+      ],
+    });
+    expect(result.running).toHaveLength(1);
+    const runningItem = result.running[0];
+    if (runningItem.kind !== "issue") throw new Error("expected issue");
+    expect(runningItem.idleSince).toBe("2026-04-25T00:00:00Z");
+
+    expect(result.open).toHaveLength(1);
+    const openItem = result.open[0];
+    if (openItem.kind !== "issue") throw new Error("expected issue");
+    expect(openItem.idleSince).toBeUndefined();
+  });
+
   it("treats an issue with only ended deployments as open", () => {
     const issue = makeIssue({ number: 3 });
     const result = groupIntoSections({

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -86,8 +86,7 @@ export function groupIntoSections(
 
   for (const { repo, issues, deployments, priorities } of input.perRepo) {
     // Map issue number → idleSince for active (non-ended) deployments.
-    // Also doubles as the "has active deployment" check (idleSinceMap.has),
-    // replacing the old activeLaunchSet.
+    // Also used as the "has active deployment" check via .has().
     const idleSinceMap = new Map<number, string | null>(
       deployments
         .filter((d) => d.endedAt === null)

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -93,6 +93,14 @@ export function groupIntoSections(
         .map((d) => d.issueNumber),
     );
 
+    // Map issue number → idleSince for active deployments so the UI can
+    // distinguish idle sessions from truly active ones.
+    const idleSinceMap = new Map<number, string | null>(
+      deployments
+        .filter((d) => d.endedAt === null)
+        .map((d) => [d.issueNumber, d.idleSince]),
+    );
+
     const priorityMap = new Map<number, Priority>(
       priorities.map((p) => [p.issueNumber, p.priority]),
     );
@@ -117,6 +125,7 @@ export function groupIntoSections(
         issue,
         priority,
         section,
+        ...(section === "running" ? { idleSince: idleSinceMap.get(issue.number) ?? null } : {}),
       };
 
       if (section === "open") open.push(item);

--- a/packages/core/src/data/unified-list.ts
+++ b/packages/core/src/data/unified-list.ts
@@ -85,16 +85,9 @@ export function groupIntoSections(
   const closed: IssueListItem[] = [];
 
   for (const { repo, issues, deployments, priorities } of input.perRepo) {
-    // A deployment row with ended_at IS NULL means there's a live
-    // worktree / Claude session still open for that issue.
-    const activeLaunchSet = new Set(
-      deployments
-        .filter((d) => d.endedAt === null)
-        .map((d) => d.issueNumber),
-    );
-
-    // Map issue number → idleSince for active deployments so the UI can
-    // distinguish idle sessions from truly active ones.
+    // Map issue number → idleSince for active (non-ended) deployments.
+    // Also doubles as the "has active deployment" check (idleSinceMap.has),
+    // replacing the old activeLaunchSet.
     const idleSinceMap = new Map<number, string | null>(
       deployments
         .filter((d) => d.endedAt === null)
@@ -113,7 +106,7 @@ export function groupIntoSections(
       let section: "open" | "running" | "closed";
       if (issue.state === "closed") {
         section = "closed";
-      } else if (activeLaunchSet.has(issue.number)) {
+      } else if (idleSinceMap.has(issue.number)) {
         section = "running";
       } else {
         section = "open";

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -15,6 +15,8 @@ import {
   endDeployment,
   activateDeployment,
   deletePendingDeployment,
+  setIdleSince,
+  clearIdleSince,
 } from "./deployments.js";
 
 function seedRepo(db: Database.Database) {
@@ -702,5 +704,53 @@ describe("hasLiveDeploymentForIssue", () => {
       workspacePath: "/x",
     });
     expect(hasLiveDeploymentForIssue(db, repoId, 99)).toBe(false);
+  });
+});
+
+describe("setIdleSince / clearIdleSince", () => {
+  let db: Database.Database;
+  let repoId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repoId = seedRepo(db).id;
+  });
+
+  it("deployment starts with idleSince null", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 1,
+      branchName: "issue-1",
+      workspaceMode: "existing",
+      workspacePath: "/tmp",
+    });
+    expect(dep.idleSince).toBeNull();
+  });
+
+  it("setIdleSince marks a deployment as idle", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 2,
+      branchName: "issue-2",
+      workspaceMode: "existing",
+      workspacePath: "/tmp",
+    });
+    setIdleSince(db, dep.id);
+    const updated = getDeploymentById(db, dep.id)!;
+    expect(updated.idleSince).toBeTruthy();
+  });
+
+  it("clearIdleSince removes idle marker", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 3,
+      branchName: "issue-3",
+      workspaceMode: "existing",
+      workspacePath: "/tmp",
+    });
+    setIdleSince(db, dep.id);
+    clearIdleSince(db, dep.id);
+    const updated = getDeploymentById(db, dep.id)!;
+    expect(updated.idleSince).toBeNull();
   });
 });

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -292,6 +292,24 @@ describe("endDeployment", () => {
     expect(updated!.endedAt).toBeTruthy();
   });
 
+  it("clears idle_since when ending an idle deployment", () => {
+    const repo = seedRepo(db);
+    const dep = recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 2,
+      branchName: "idle-branch",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    setIdleSince(db, dep.id);
+    expect(getDeploymentById(db, dep.id)!.idleSince).toBeTruthy();
+
+    endDeployment(db, dep.id);
+    const ended = getDeploymentById(db, dep.id)!;
+    expect(ended.endedAt).toBeTruthy();
+    expect(ended.idleSince).toBeNull();
+  });
+
   it("throws when deployment does not exist", () => {
     expect(() => endDeployment(db, 999)).toThrow(
       "No active deployment found with id 999",

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -169,7 +169,7 @@ export function endDeployment(
   deploymentId: number,
 ): void {
   const result = db
-    .prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ? AND ended_at IS NULL")
+    .prepare("UPDATE deployments SET ended_at = datetime('now'), idle_since = NULL WHERE id = ? AND ended_at IS NULL")
     .run(deploymentId);
   if (result.changes === 0) {
     throw new Error(`No active deployment found with id ${deploymentId}`);

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -14,6 +14,7 @@ type DeploymentRow = {
   ended_at: string | null;
   ttyd_port: number | null;
   ttyd_pid: number | null;
+  idle_since: string | null;
 };
 
 function rowToDeployment(row: DeploymentRow): Deployment {
@@ -30,6 +31,7 @@ function rowToDeployment(row: DeploymentRow): Deployment {
     endedAt: row.ended_at,
     ttydPort: row.ttyd_port,
     ttydPid: row.ttyd_pid,
+    idleSince: row.idle_since,
   };
 }
 
@@ -309,4 +311,22 @@ export function getActiveDeployments(
     owner: row.owner,
     repoName: row.repo_name,
   }));
+}
+
+export function setIdleSince(
+  db: Database.Database,
+  deploymentId: number,
+): void {
+  db.prepare(
+    "UPDATE deployments SET idle_since = datetime('now') WHERE id = ? AND idle_since IS NULL",
+  ).run(deploymentId);
+}
+
+export function clearIdleSince(
+  db: Database.Database,
+  deploymentId: number,
+): void {
+  db.prepare(
+    "UPDATE deployments SET idle_since = NULL WHERE id = ?",
+  ).run(deploymentId);
 }

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -238,6 +238,12 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 12,
+    up(db) {
+      db.exec(`ALTER TABLE deployments ADD COLUMN idle_since TEXT;`);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -34,15 +34,15 @@ describe("initSchema", () => {
     ]);
   });
 
-  it("sets schema_version to 11", () => {
+  it("sets schema_version to 12", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
   });
 });
 
@@ -59,7 +59,7 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
   });
 
   it("migrates v1 schema through v9 and drops claude_aliases", () => {
@@ -75,7 +75,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -99,7 +99,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -142,7 +142,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -161,7 +161,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
   it("initSchema on a fresh DB produces schema version 9", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -227,7 +227,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -315,7 +315,7 @@ describe("schema v8 — deployments FK cascade", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
 
     // Pre-existing row should have been copied over with its state intact
     const row = db
@@ -398,7 +398,7 @@ describe("schema v9 — live deployment unique index", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
     // Row id=1 (older duplicate) → ended. id=2 (most recent live) → live.
     // id=3 (historic ended) → still ended, untouched.
     const live = db
@@ -550,7 +550,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
       runMigrations(db);
     }).not.toThrow();
 
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
 
     // Verify the dedupe ran and the index now exists.
     const live = db
@@ -580,7 +580,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
 
   it("v10 migration creates github_accessible_repos with expected columns", () => {
     const db = createTestDb();
-    expect(getSchemaVersion(db)).toBe(11);
+    expect(getSchemaVersion(db)).toBe(12);
 
     const cols = db
       .prepare("PRAGMA table_info(github_accessible_repos)")

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 11;
+const SCHEMA_VERSION = 12;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -31,7 +31,8 @@ const CREATE_TABLES = `
     launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
     ended_at         TEXT,
     ttyd_port        INTEGER,
-    ttyd_pid         INTEGER
+    ttyd_pid         INTEGER,
+    idle_since       TEXT
   );
 
   CREATE TABLE IF NOT EXISTS cache (

--- a/packages/core/src/db/settings.test.ts
+++ b/packages/core/src/db/settings.test.ts
@@ -63,13 +63,15 @@ describe("seedDefaults", () => {
   it("inserts all default settings", () => {
     seedDefaults(db);
     const settings = getSettings(db);
-    expect(settings).toHaveLength(4);
+    expect(settings).toHaveLength(6);
 
     const keys = settings.map((s) => s.key);
     expect(keys).toContain("branch_pattern");
     expect(keys).toContain("cache_ttl");
     expect(keys).toContain("worktree_dir");
     expect(keys).toContain("claude_extra_args");
+    expect(keys).toContain("idle_grace_period");
+    expect(keys).toContain("idle_threshold");
   });
 
   it("seedDefaults sets claude_extra_args to --dangerously-skip-permissions by default", () => {
@@ -81,6 +83,12 @@ describe("seedDefaults", () => {
     setSetting(db, "cache_ttl", "999");
     seedDefaults(db);
     expect(getSetting(db, "cache_ttl")).toBe("999");
+  });
+
+  it("seeds idle_grace_period and idle_threshold defaults", () => {
+    seedDefaults(db);
+    expect(getSetting(db, "idle_grace_period")).toBe("300");
+    expect(getSetting(db, "idle_threshold")).toBe("300");
   });
 
   it("is idempotent", () => {

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -7,6 +7,8 @@ const DEFAULT_SETTINGS: Setting[] = [
   { key: "cache_ttl", value: "300" },
   { key: "worktree_dir", value: "~/.issuectl/worktrees/" },
   { key: "claude_extra_args", value: "--dangerously-skip-permissions" },
+  { key: "idle_grace_period", value: "300" },
+  { key: "idle_threshold", value: "300" },
 ];
 
 export function getSetting(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export {
   cleanupOrphanedDeployments,
   pruneEndedDeployments,
   getActiveDeployments,
+  setIdleSince,
+  clearIdleSince,
 } from "./db/deployments.js";
 export type { ActiveDeploymentWithRepo } from "./db/deployments.js";
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,7 @@ export type UnifiedListItem =
       issue: GitHubIssue;
       priority: Priority;
       section: Exclude<Section, "unassigned">;
+      idleSince?: string | null;
     };
 
 // Narrow helpers for places that want a specific variant.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,7 +13,9 @@ export type SettingKey =
   | "worktree_dir"
   | "claude_extra_args"
   | "default_repo_id"
-  | "api_token";
+  | "api_token"
+  | "idle_grace_period"
+  | "idle_threshold";
 
 export type Setting = {
   key: SettingKey;
@@ -45,6 +47,7 @@ export type Deployment = {
   endedAt: string | null;
   ttydPort: number | null;
   ttydPid: number | null;
+  idleSince: string | null;
 };
 
 export type CacheEntry<T = unknown> = {

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -52,6 +52,8 @@ export default async function SettingsPage({
   const branchPattern = settingMap.branch_pattern ?? "issue-{number}-{slug}";
   const cacheTTL = settingMap.cache_ttl ?? "300";
   const claudeExtraArgs = settingMap.claude_extra_args ?? "";
+  const idleGracePeriod = settingMap.idle_grace_period ?? "300";
+  const idleThreshold = settingMap.idle_threshold ?? "300";
 
   return (
     <PullToRefreshWrapper>
@@ -66,6 +68,8 @@ export default async function SettingsPage({
           branchPattern={branchPattern}
           cacheTTL={cacheTTL}
           claudeExtraArgs={claudeExtraArgs}
+          idleGracePeriod={idleGracePeriod}
+          idleThreshold={idleThreshold}
         />
 
         <section className={styles.section}>

--- a/packages/web/components/issue/DeploymentTimeline.tsx
+++ b/packages/web/components/issue/DeploymentTimeline.tsx
@@ -31,7 +31,11 @@ function buildEntries(
 
   for (const dep of deployments) {
     entries.push({
-      label: dep.endedAt ? "Session ended" : "Claude Code active",
+      label: dep.endedAt
+        ? "Session ended"
+        : dep.idleSince
+          ? "Claude Code idle"
+          : "Claude Code active",
       ref: dep.branchName,
       date: dep.endedAt ?? dep.launchedAt,
       type: "launched",

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -184,3 +184,9 @@
   color: var(--paper-accent);
   font-weight: 600;
 }
+
+.idleLabel {
+  color: var(--paper-ink-faint);
+  font-weight: 600;
+  font-style: italic;
+}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -125,7 +125,11 @@ export function ListRow({ item, onLaunch, onClose }: Props) {
           {section === "running" && (
             <>
               <span className={styles.sep}>·</span>
-              <span className={styles.activeLabel}>active</span>
+              {item.idleSince ? (
+                <span className={styles.idleLabel}>idle</span>
+              ) : (
+                <span className={styles.activeLabel}>active</span>
+              )}
             </>
           )}
         </div>

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -17,23 +17,31 @@ type Props = {
   branchPattern: string;
   cacheTTL: string;
   claudeExtraArgs: string;
+  idleGracePeriod: string;
+  idleThreshold: string;
 };
 
 type FormValues = {
   branch_pattern: string;
   cache_ttl: string;
   claude_extra_args: string;
+  idle_grace_period: string;
+  idle_threshold: string;
 };
 
 export function SettingsForm({
   branchPattern,
   cacheTTL,
   claudeExtraArgs,
+  idleGracePeriod,
+  idleThreshold,
 }: Props) {
   const [values, setValues] = useState<FormValues>({
     branch_pattern: branchPattern,
     cache_ttl: cacheTTL,
     claude_extra_args: claudeExtraArgs,
+    idle_grace_period: idleGracePeriod,
+    idle_threshold: idleThreshold,
   });
   const [error, setError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
@@ -51,6 +59,8 @@ export function SettingsForm({
     branch_pattern: branchPattern,
     cache_ttl: cacheTTL,
     claude_extra_args: claudeExtraArgs,
+    idle_grace_period: idleGracePeriod,
+    idle_threshold: idleThreshold,
   };
 
   const isDirty = (Object.keys(originals) as (keyof FormValues)[]).some(
@@ -192,6 +202,46 @@ export function SettingsForm({
                   ))}
                 </div>
               )}
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionTitle}>Terminal Idle Detection</div>
+        <div className={styles.row}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="sf-idle-grace">Grace Period (seconds)</label>
+            <input
+              id="sf-idle-grace"
+              className={styles.input}
+              value={values.idle_grace_period}
+              onChange={(e) => handleChange("idle_grace_period", e.target.value)}
+              disabled={isPending}
+              autoComplete="off"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              enterKeyHint="done"
+            />
+            <div className={styles.help}>
+              Seconds after launch before idle detection begins. Default 300 (5 min).
+            </div>
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="sf-idle-threshold">Idle Threshold (seconds)</label>
+            <input
+              id="sf-idle-threshold"
+              className={styles.input}
+              value={values.idle_threshold}
+              onChange={(e) => handleChange("idle_threshold", e.target.value)}
+              disabled={isPending}
+              autoComplete="off"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              enterKeyHint="done"
+            />
+            <div className={styles.help}>
+              Seconds of no terminal output before marking idle. Default 300 (5 min).
+            </div>
           </div>
         </div>
       </section>

--- a/packages/web/lib/actions/settings.test.ts
+++ b/packages/web/lib/actions/settings.test.ts
@@ -180,6 +180,42 @@ describe("updateSetting", () => {
   });
 });
 
+describe("idle setting validation", () => {
+  it("rejects negative idle_grace_period", async () => {
+    const result = await updateSetting("idle_grace_period", "-1");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non-negative");
+  });
+
+  it("rejects idle_threshold over 86400", async () => {
+    const result = await updateSetting("idle_threshold", "100000");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("86400");
+  });
+
+  it("accepts valid idle_grace_period", async () => {
+    const result = await updateSetting("idle_grace_period", "600");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid idle_threshold", async () => {
+    const result = await updateSetting("idle_threshold", "300");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-numeric idle_grace_period", async () => {
+    const result = await updateSetting("idle_grace_period", "abc");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non-negative");
+  });
+
+  it("rejects non-numeric idle_threshold", async () => {
+    const result = await updateSetting("idle_threshold", "abc");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non-negative");
+  });
+});
+
 describe("updateSettings (batch)", () => {
   it("returns success for empty updates", async () => {
     const result = await updateSettings({});

--- a/packages/web/lib/actions/settings.ts
+++ b/packages/web/lib/actions/settings.ts
@@ -11,6 +11,8 @@ const VALID_KEYS: readonly SettingKey[] = [
   "worktree_dir",
   "claude_extra_args",
   "default_repo_id",
+  "idle_grace_period",
+  "idle_threshold",
 ];
 
 const ALLOW_EMPTY = new Set<SettingKey>(["claude_extra_args", "default_repo_id"]);
@@ -69,6 +71,15 @@ function validateOne(
     const result = validateClaudeArgs(trimmed);
     if (!result.ok) {
       return { ok: false, error: result.errors.join(" ") };
+    }
+  }
+  if (key === "idle_grace_period" || key === "idle_threshold") {
+    const num = Number(trimmed);
+    if (!Number.isFinite(num) || num < 0) {
+      return { ok: false, error: `${key === "idle_grace_period" ? "Grace period" : "Idle threshold"} must be a non-negative number` };
+    }
+    if (num > 86400) {
+      return { ok: false, error: `${key === "idle_grace_period" ? "Grace period" : "Idle threshold"} cannot exceed 86400 seconds (24 hours)` };
     }
   }
   return { ok: true, trimmed };

--- a/packages/web/lib/idle-checker.test.ts
+++ b/packages/web/lib/idle-checker.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { checkIdleDeployments } from "./idle-checker";
+
+// Mock the modules the checker depends on
+vi.mock("./idle-registry", () => ({
+  getRegisteredPorts: vi.fn(),
+  getLastPtyOutput: vi.fn(),
+}));
+
+vi.mock("@issuectl/core", async () => {
+  const actual = await vi.importActual<object>("@issuectl/core");
+  return {
+    ...actual,
+    getDb: vi.fn(),
+    getActiveDeploymentByPort: vi.fn(),
+    setIdleSince: vi.fn(),
+    clearIdleSince: vi.fn(),
+    getSetting: vi.fn(),
+  };
+});
+
+vi.mock("./logger", () => ({
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { getRegisteredPorts, getLastPtyOutput } from "./idle-registry";
+import {
+  getDb,
+  getActiveDeploymentByPort,
+  setIdleSince,
+  clearIdleSince,
+  getSetting,
+} from "@issuectl/core";
+
+const mockGetRegisteredPorts = vi.mocked(getRegisteredPorts);
+const mockGetLastPtyOutput = vi.mocked(getLastPtyOutput);
+const mockGetDb = vi.mocked(getDb);
+const mockGetActiveDeploymentByPort = vi.mocked(getActiveDeploymentByPort);
+const mockSetIdleSince = vi.mocked(setIdleSince);
+const mockClearIdleSince = vi.mocked(clearIdleSince);
+const mockGetSetting = vi.mocked(getSetting);
+
+describe("checkIdleDeployments", () => {
+  const fakeDb = {} as ReturnType<typeof getDb>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockGetDb.mockReturnValue(fakeDb);
+    // Default settings: 300s grace, 300s threshold
+    mockGetSetting.mockImplementation((_db, key) => {
+      if (key === "idle_grace_period") return "300";
+      if (key === "idle_threshold") return "300";
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("marks a deployment as idle when no PTY output exceeds threshold", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    mockGetRegisteredPorts.mockReturnValue([7700]);
+    // Last output was 400s ago (exceeds 300s threshold)
+    mockGetLastPtyOutput.mockReturnValue(now - 400_000);
+    mockGetActiveDeploymentByPort.mockReturnValue({
+      id: 1,
+      repoId: 1,
+      issueNumber: 1,
+      branchName: "issue-1",
+      workspaceMode: "existing" as const,
+      workspacePath: "/tmp",
+      linkedPrNumber: null,
+      state: "active" as const,
+      launchedAt: new Date(now - 600_000).toISOString(),
+      endedAt: null,
+      ttydPort: 7700,
+      ttydPid: 1234,
+      idleSince: null,
+    });
+
+    checkIdleDeployments();
+
+    expect(mockSetIdleSince).toHaveBeenCalledWith(fakeDb, 1);
+    expect(mockClearIdleSince).not.toHaveBeenCalled();
+  });
+
+  it("clears idle when PTY output resumes", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    mockGetRegisteredPorts.mockReturnValue([7700]);
+    // Last output was 10s ago (within threshold)
+    mockGetLastPtyOutput.mockReturnValue(now - 10_000);
+    mockGetActiveDeploymentByPort.mockReturnValue({
+      id: 1,
+      repoId: 1,
+      issueNumber: 1,
+      branchName: "issue-1",
+      workspaceMode: "existing" as const,
+      workspacePath: "/tmp",
+      linkedPrNumber: null,
+      state: "active" as const,
+      launchedAt: new Date(now - 600_000).toISOString(),
+      endedAt: null,
+      ttydPort: 7700,
+      ttydPid: 1234,
+      idleSince: new Date(now - 60_000).toISOString(), // was idle
+    });
+
+    checkIdleDeployments();
+
+    expect(mockClearIdleSince).toHaveBeenCalledWith(fakeDb, 1);
+    expect(mockSetIdleSince).not.toHaveBeenCalled();
+  });
+
+  it("skips deployments still in grace period", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    mockGetRegisteredPorts.mockReturnValue([7700]);
+    // Last output was 400s ago but deployment launched only 200s ago
+    mockGetLastPtyOutput.mockReturnValue(now - 400_000);
+    mockGetActiveDeploymentByPort.mockReturnValue({
+      id: 1,
+      repoId: 1,
+      issueNumber: 1,
+      branchName: "issue-1",
+      workspaceMode: "existing" as const,
+      workspacePath: "/tmp",
+      linkedPrNumber: null,
+      state: "active" as const,
+      launchedAt: new Date(now - 200_000).toISOString(), // only 200s old
+      endedAt: null,
+      ttydPort: 7700,
+      ttydPid: 1234,
+      idleSince: null,
+    });
+
+    checkIdleDeployments();
+
+    expect(mockSetIdleSince).not.toHaveBeenCalled();
+    expect(mockClearIdleSince).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/lib/idle-checker.test.ts
+++ b/packages/web/lib/idle-checker.test.ts
@@ -123,6 +123,37 @@ describe("checkIdleDeployments", () => {
     expect(mockSetIdleSince).not.toHaveBeenCalled();
   });
 
+  it("continues checking remaining ports when one port throws", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    mockGetRegisteredPorts.mockReturnValue([7700, 7701]);
+    mockGetLastPtyOutput.mockReturnValue(now - 400_000);
+    // First port throws, second returns a valid deployment
+    mockGetActiveDeploymentByPort
+      .mockImplementationOnce(() => { throw new Error("SQLITE_BUSY"); })
+      .mockReturnValueOnce({
+        id: 2,
+        repoId: 1,
+        issueNumber: 2,
+        branchName: "issue-2",
+        workspaceMode: "existing" as const,
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active" as const,
+        launchedAt: new Date(now - 600_000).toISOString(),
+        endedAt: null,
+        ttydPort: 7701,
+        ttydPid: 5678,
+        idleSince: null,
+      });
+
+    checkIdleDeployments();
+
+    // Second port should still be processed
+    expect(mockSetIdleSince).toHaveBeenCalledWith(fakeDb, 2);
+  });
+
   it("skips deployments still in grace period", () => {
     const now = Date.now();
     vi.setSystemTime(now);

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -20,41 +20,51 @@ let timer: ReturnType<typeof setInterval> | null = null;
  */
 export function checkIdleDeployments(): void {
   const db = getDb();
+  const rawGrace = getSetting(db, "idle_grace_period");
   const graceSec =
-    Number(getSetting(db, "idle_grace_period")) || DEFAULT_GRACE_SECONDS;
+    rawGrace !== null && rawGrace !== undefined
+      ? Number(rawGrace)
+      : DEFAULT_GRACE_SECONDS;
+  const rawThreshold = getSetting(db, "idle_threshold");
   const thresholdSec =
-    Number(getSetting(db, "idle_threshold")) || DEFAULT_THRESHOLD_SECONDS;
+    rawThreshold !== null && rawThreshold !== undefined
+      ? Number(rawThreshold)
+      : DEFAULT_THRESHOLD_SECONDS;
   const now = Date.now();
 
   for (const port of getRegisteredPorts()) {
-    const lastOutput = getLastPtyOutput(port);
-    if (lastOutput === undefined) continue;
+    try {
+      const lastOutput = getLastPtyOutput(port);
+      if (lastOutput === undefined) continue;
 
-    const deployment = getActiveDeploymentByPort(db, port);
-    if (!deployment) continue;
+      const deployment = getActiveDeploymentByPort(db, port);
+      if (!deployment) continue;
 
-    // Skip if still within grace period after launch
-    const launchedAtMs = new Date(deployment.launchedAt).getTime();
-    if (now - launchedAtMs < graceSec * 1000) continue;
+      // Skip if still within grace period after launch
+      const launchedAtMs = new Date(deployment.launchedAt).getTime();
+      if (now - launchedAtMs < graceSec * 1000) continue;
 
-    const silentMs = now - lastOutput;
-    const isIdle = silentMs > thresholdSec * 1000;
+      const silentMs = now - lastOutput;
+      const isIdle = silentMs > thresholdSec * 1000;
 
-    if (isIdle && !deployment.idleSince) {
-      setIdleSince(db, deployment.id);
-      log.info({
-        msg: "idle_detected",
-        port,
-        deploymentId: deployment.id,
-        silentSec: Math.round(silentMs / 1000),
-      });
-    } else if (!isIdle && deployment.idleSince) {
-      clearIdleSince(db, deployment.id);
-      log.info({
-        msg: "idle_cleared",
-        port,
-        deploymentId: deployment.id,
-      });
+      if (isIdle && !deployment.idleSince) {
+        setIdleSince(db, deployment.id);
+        log.info({
+          msg: "idle_detected",
+          port,
+          deploymentId: deployment.id,
+          silentSec: Math.round(silentMs / 1000),
+        });
+      } else if (!isIdle && deployment.idleSince) {
+        clearIdleSince(db, deployment.id);
+        log.info({
+          msg: "idle_cleared",
+          port,
+          deploymentId: deployment.id,
+        });
+      }
+    } catch (err) {
+      log.error({ msg: "idle_check_error", port, err });
     }
   }
 }

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -10,7 +10,7 @@ import log from "./logger";
 
 const DEFAULT_GRACE_SECONDS = 300;
 const DEFAULT_THRESHOLD_SECONDS = 300;
-const CHECK_INTERVAL_MS = 60_000; // check every 60s
+const CHECK_INTERVAL_MS = 60_000;
 
 let timer: ReturnType<typeof setInterval> | null = null;
 

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -16,20 +16,20 @@ let timer: ReturnType<typeof setInterval> | null = null;
 
 /**
  * Inspect all registered WS connections and update idle_since in the DB.
- * Exported for testing — the interval calls this internally.
+ * Called on a 60s interval by startIdleChecker; exported so tests can
+ * invoke it directly.
  */
 export function checkIdleDeployments(): void {
-  const db = getDb();
-  const rawGrace = getSetting(db, "idle_grace_period");
-  const graceSec =
-    rawGrace !== null && rawGrace !== undefined
-      ? Number(rawGrace)
-      : DEFAULT_GRACE_SECONDS;
-  const rawThreshold = getSetting(db, "idle_threshold");
-  const thresholdSec =
-    rawThreshold !== null && rawThreshold !== undefined
-      ? Number(rawThreshold)
-      : DEFAULT_THRESHOLD_SECONDS;
+  let db;
+  try {
+    db = getDb();
+  } catch (err) {
+    log.error({ msg: "idle_check_db_unavailable", err });
+    return;
+  }
+
+  const graceSec = parseSetting(db, "idle_grace_period", DEFAULT_GRACE_SECONDS);
+  const thresholdSec = parseSetting(db, "idle_threshold", DEFAULT_THRESHOLD_SECONDS);
   const now = Date.now();
 
   for (const port of getRegisteredPorts()) {
@@ -42,6 +42,10 @@ export function checkIdleDeployments(): void {
 
       // Skip if still within grace period after launch
       const launchedAtMs = new Date(deployment.launchedAt).getTime();
+      if (!Number.isFinite(launchedAtMs)) {
+        log.warn({ msg: "idle_check_invalid_launch_date", port, deploymentId: deployment.id, launchedAt: deployment.launchedAt });
+        continue;
+      }
       if (now - launchedAtMs < graceSec * 1000) continue;
 
       const silentMs = now - lastOutput;
@@ -67,6 +71,21 @@ export function checkIdleDeployments(): void {
       log.error({ msg: "idle_check_error", port, err });
     }
   }
+}
+
+function parseSetting(
+  db: Parameters<typeof getSetting>[0],
+  key: Parameters<typeof getSetting>[1],
+  defaultValue: number,
+): number {
+  const raw = getSetting(db, key);
+  if (raw === undefined) return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    log.warn({ msg: "idle_setting_invalid", key, rawValue: raw, usingDefault: defaultValue });
+    return defaultValue;
+  }
+  return parsed;
 }
 
 export function startIdleChecker(): void {

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -1,0 +1,74 @@
+import {
+  getDb,
+  getActiveDeploymentByPort,
+  getSetting,
+  setIdleSince,
+  clearIdleSince,
+} from "@issuectl/core";
+import { getRegisteredPorts, getLastPtyOutput } from "./idle-registry";
+import log from "./logger";
+
+const DEFAULT_GRACE_SECONDS = 300;
+const DEFAULT_THRESHOLD_SECONDS = 300;
+const CHECK_INTERVAL_MS = 60_000; // check every 60s
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Inspect all registered WS connections and update idle_since in the DB.
+ * Exported for testing — the interval calls this internally.
+ */
+export function checkIdleDeployments(): void {
+  const db = getDb();
+  const graceSec =
+    Number(getSetting(db, "idle_grace_period")) || DEFAULT_GRACE_SECONDS;
+  const thresholdSec =
+    Number(getSetting(db, "idle_threshold")) || DEFAULT_THRESHOLD_SECONDS;
+  const now = Date.now();
+
+  for (const port of getRegisteredPorts()) {
+    const lastOutput = getLastPtyOutput(port);
+    if (lastOutput === undefined) continue;
+
+    const deployment = getActiveDeploymentByPort(db, port);
+    if (!deployment) continue;
+
+    // Skip if still within grace period after launch
+    const launchedAtMs = new Date(deployment.launchedAt).getTime();
+    if (now - launchedAtMs < graceSec * 1000) continue;
+
+    const silentMs = now - lastOutput;
+    const isIdle = silentMs > thresholdSec * 1000;
+
+    if (isIdle && !deployment.idleSince) {
+      setIdleSince(db, deployment.id);
+      log.info({
+        msg: "idle_detected",
+        port,
+        deploymentId: deployment.id,
+        silentSec: Math.round(silentMs / 1000),
+      });
+    } else if (!isIdle && deployment.idleSince) {
+      clearIdleSince(db, deployment.id);
+      log.info({
+        msg: "idle_cleared",
+        port,
+        deploymentId: deployment.id,
+      });
+    }
+  }
+}
+
+export function startIdleChecker(): void {
+  if (timer) return;
+  timer = setInterval(checkIdleDeployments, CHECK_INTERVAL_MS);
+  timer.unref();
+  log.info({ msg: "idle_checker_started", intervalMs: CHECK_INTERVAL_MS });
+}
+
+export function stopIdleChecker(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/packages/web/lib/idle-registry.test.ts
+++ b/packages/web/lib/idle-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerPort,
+  unregisterPort,
+  recordPtyOutput,
+  getLastPtyOutput,
+  getRegisteredPorts,
+} from "./idle-registry";
+
+describe("idle-registry", () => {
+  beforeEach(() => {
+    // Clear all registrations between tests
+    for (const port of getRegisteredPorts()) {
+      unregisterPort(port);
+    }
+  });
+
+  it("registerPort creates an entry with the given timestamp", () => {
+    registerPort(7700, 1000);
+    expect(getLastPtyOutput(7700)).toBe(1000);
+  });
+
+  it("unregisterPort removes the entry", () => {
+    registerPort(7700, 1000);
+    unregisterPort(7700);
+    expect(getLastPtyOutput(7700)).toBeUndefined();
+  });
+
+  it("recordPtyOutput updates the timestamp", () => {
+    registerPort(7700, 1000);
+    recordPtyOutput(7700, 2000);
+    expect(getLastPtyOutput(7700)).toBe(2000);
+  });
+
+  it("recordPtyOutput is a no-op for unregistered ports", () => {
+    recordPtyOutput(7700, 2000);
+    expect(getLastPtyOutput(7700)).toBeUndefined();
+  });
+
+  it("getRegisteredPorts returns all active ports", () => {
+    registerPort(7700, 1000);
+    registerPort(7701, 1000);
+    expect(getRegisteredPorts()).toEqual([7700, 7701]);
+  });
+});

--- a/packages/web/lib/idle-registry.ts
+++ b/packages/web/lib/idle-registry.ts
@@ -1,0 +1,32 @@
+/**
+ * In-memory registry mapping ttyd port numbers to the timestamp (ms)
+ * of the last PTY output frame seen on that port's WebSocket connection.
+ * The idle checker reads this to decide which deployments have gone idle.
+ *
+ * This is intentionally not persisted — if the server restarts, all
+ * connections are lost anyway, so there's nothing to mark idle.
+ */
+
+const registry = new Map<number, number>();
+
+export function registerPort(port: number, nowMs: number): void {
+  registry.set(port, nowMs);
+}
+
+export function unregisterPort(port: number): void {
+  registry.delete(port);
+}
+
+export function recordPtyOutput(port: number, nowMs: number): void {
+  if (registry.has(port)) {
+    registry.set(port, nowMs);
+  }
+}
+
+export function getLastPtyOutput(port: number): number | undefined {
+  return registry.get(port);
+}
+
+export function getRegisteredPorts(): number[] {
+  return [...registry.keys()];
+}

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -3,6 +3,7 @@ import { Duplex } from "node:stream";
 import { WebSocketServer, WebSocket } from "ws";
 import { getDb, getActiveDeploymentByPort } from "@issuectl/core";
 import log from "./logger";
+import { registerPort, unregisterPort, recordPtyOutput } from "./idle-registry";
 
 const PORT_MIN = 7700;
 const PORT_MAX = 7799;
@@ -141,6 +142,7 @@ export function handleUpgrade(
 
   wss.handleUpgrade(req, socket, head, (clientWs) => {
     _activeWsCount++;
+    registerPort(port, Date.now());
 
     const clientIp =
       (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim()
@@ -208,6 +210,7 @@ export function handleUpgrade(
 
       upstream.on("message", (data, isBinary) => {
         stats.framesFromTtyd++;
+        recordPtyOutput(port, Date.now());
 
         if (clientWs.readyState !== WebSocket.OPEN) {
           stats.droppedFrames++;
@@ -259,6 +262,7 @@ export function handleUpgrade(
       cleanedUp = true;
       _activeWsCount--;
       clearInterval(tickTimer);
+      unregisterPort(port);
 
       const uptimeSec = ((Date.now() - stats.connectedAt) / 1000).toFixed(1);
       log.info({

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -4,6 +4,7 @@ import next from "next";
 import log, { logPath } from "./lib/logger";
 import { handleUpgrade, activeWsCount } from "./lib/terminal-proxy";
 import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./lib/network-info.js";
+import { startIdleChecker } from "./lib/idle-checker";
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
 
@@ -185,6 +186,7 @@ server.listen(port, () => {
   } else {
     console.log("> LAN auto-switch: disabled (could not detect IPs)");
   }
+  startIdleChecker();
 });
 
 // Refresh IPs every 30 minutes to handle DHCP/ISP changes.

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -4,7 +4,7 @@ import next from "next";
 import log, { logPath } from "./lib/logger";
 import { handleUpgrade, activeWsCount } from "./lib/terminal-proxy";
 import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./lib/network-info.js";
-import { startIdleChecker } from "./lib/idle-checker";
+import { startIdleChecker, stopIdleChecker } from "./lib/idle-checker";
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
 
@@ -215,6 +215,7 @@ let shuttingDown = false;
 function shutdown() {
   if (shuttingDown) return;
   shuttingDown = true;
+  stopIdleChecker();
   log.info({ msg: "server_shutdown" });
   server.close(() => {
     log.flush(() => process.exit(0));

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -186,7 +186,11 @@ server.listen(port, () => {
   } else {
     console.log("> LAN auto-switch: disabled (could not detect IPs)");
   }
-  startIdleChecker();
+  try {
+    startIdleChecker();
+  } catch (err) {
+    log.error({ msg: "idle_checker_start_failed", err });
+  }
 });
 
 // Refresh IPs every 30 minutes to handle DHCP/ISP changes.


### PR DESCRIPTION
## Summary

- Adds idle detection for ttyd terminal sessions, tracking PTY output silence and tagging deployments as idle/active in the database and dashboard UI
- Uses a two-tier architecture: in-memory registry for high-frequency PTY frame tracking, SQLite for durable idle/active state transitions on a 60s polling interval
- Both the grace period (delay before monitoring starts) and idle threshold are user-configurable via a new Settings panel section, defaulting to 300s each

## Changes

**Core (schema + DB):**
- Schema v11→v12 migration adding `idle_since TEXT` column to deployments
- `setIdleSince` / `clearIdleSince` DB functions; `endDeployment` atomically clears `idle_since`
- `idle_grace_period` and `idle_threshold` settings with 300s defaults
- `idleSince` field threaded through `Deployment` type and `UnifiedListItem`

**Web (runtime + UI):**
- `idle-registry.ts` — in-memory `Map<port, timestamp>` recording last PTY output per connection
- `idle-checker.ts` — 60s interval loop comparing last output to threshold, writing state transitions to SQLite with NaN guards, per-port error isolation, and graceful degradation
- WebSocket proxy integration (`terminal-proxy.ts`) recording PTY output timestamps
- Settings UI section for grace period + idle threshold with server-side validation
- Dashboard list rows show idle/active labels; deployment timeline shows three-way status
- Checker starts on boot, stops on graceful shutdown

**Tests:**
- 7 new test files/sections covering: DB operations, settings validation, registry, idle checker (including error resilience), unified-list propagation, schema migration

## Test plan

- [x] `pnpm turbo typecheck` — 0 errors
- [x] `pnpm turbo test` — 457 tests passing (7 new)
- [x] Lint — 0 errors (warnings are pre-existing)
- [x] `/simplify` review — all findings addressed
- [x] Code-reviewer agent — all findings addressed
- [x] `/pr-review-toolkit:review-pr all` — 6 agents, all critical/important findings fixed

Closes #240