### PR TITLE
feat(ios): draft editing and label support

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
 		493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
 		49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */; };
+		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
 		59D20056C3E281403735631D /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7701223E13D43C4F74244B0 /* Repo.swift */; };
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
 		65142BB24364562CB5305E0F /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472896A74FFDCC9B621A984E /* PRListView.swift */; };
@@ -38,6 +39,7 @@
 		E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */; };
 		EE08B250394D4614915429E1 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A4F0FF399CC75CAB4F1A1C /* Issue.swift */; };
 		F17CDC8FC484D666EB0B35C0 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6FD670361C44AE6DB85ECE /* KeychainService.swift */; };
+		F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */; };
 		FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */; };
 		FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4010BC691DB71B872353344A /* SessionListView.swift */; };
 /* End PBXBuildFile section */
@@ -71,11 +73,13 @@
 		C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailView.swift; sourceTree = "<group>"; };
 		D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseIssueSheet.swift; sourceTree = "<group>"; };
 		D882E51722D47D736257AB4F /* IssueListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListView.swift; sourceTree = "<group>"; };
+		DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Drafts.swift"; sourceTree = "<group>"; };
 		DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickCreateSheet.swift; sourceTree = "<group>"; };
 		E9F091BF822565D8E0F15E7A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRepoSheet.swift; sourceTree = "<group>"; };
 		F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTabs.swift; sourceTree = "<group>"; };
 		FD234C4632456D401809E8A5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		FE149A3F324BCC15AB57153E /* LabelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPicker.swift; sourceTree = "<group>"; };
 		FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -134,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				E9F091BF822565D8E0F15E7A /* APIClient.swift */,
+				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
 			);
@@ -220,6 +225,7 @@
 			isa = PBXGroup;
 			children = (
 				4403330B1342AA7C19FA797D /* Constants.swift */,
+				FE149A3F324BCC15AB57153E /* LabelPicker.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
 				F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */,
 			);
@@ -295,6 +301,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,
@@ -311,6 +318,7 @@
 				5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */,
 				1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */,
 				F17CDC8FC484D666EB0B35C0 /* KeychainService.swift in Sources */,
+				581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,

--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -122,6 +122,7 @@ struct AssignDraftResponse: Codable, Sendable {
     let issueNumber: Int?
     let issueUrl: String?
     let cleanupWarning: String?
+    let labelsWarning: String?
     let error: String?
 }
 

--- a/ios/IssueCTL/Services/APIClient+Drafts.swift
+++ b/ios/IssueCTL/Services/APIClient+Drafts.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// MARK: - Models for draft editing and label fetching
+
+struct UpdateDraftRequestBody: Encodable, Sendable {
+    let title: String?
+    let body: String?
+    let priority: String?
+}
+
+struct UpdateDraftResponse: Codable, Sendable {
+    let success: Bool
+    let draft: Draft?
+    let error: String?
+}
+
+struct LabelsResponse: Codable, Sendable {
+    let labels: [GitHubLabel]
+}
+
+struct AssignDraftWithLabelsRequestBody: Encodable, Sendable {
+    let repoId: Int
+    let labels: [String]?
+}
+
+// MARK: - APIClient extension for draft editing and labels
+
+extension APIClient {
+    /// Internal helper that mirrors the private `request` method in APIClient.
+    /// Needed because Swift extensions in separate files cannot access private members.
+    func extensionRequest(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+        guard let base = URL(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+
+        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
+        urlRequest.httpMethod = method
+        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body { urlRequest.httpBody = body }
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw APIError.unauthorized
+        }
+        if httpResponse.statusCode >= 400 {
+            let errorBody = try? JSONDecoder().decode(ExtensionErrorResponse.self, from: data)
+            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
+        }
+
+        return (data, httpResponse)
+    }
+
+    private static let extensionDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    func updateDraft(id: String, body: UpdateDraftRequestBody) async throws -> UpdateDraftResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await extensionRequest(path: "/api/v1/drafts/\(id)", method: "PATCH", body: bodyData)
+        return try Self.extensionDecoder.decode(UpdateDraftResponse.self, from: data)
+    }
+
+    func repoLabels(owner: String, repo: String) async throws -> [GitHubLabel] {
+        let (data, _) = try await extensionRequest(path: "/api/v1/repos/\(owner)/\(repo)/labels")
+        let response = try Self.extensionDecoder.decode(LabelsResponse.self, from: data)
+        return response.labels
+    }
+
+    func assignDraftWithLabels(id: String, body: AssignDraftWithLabelsRequestBody) async throws -> AssignDraftResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await extensionRequest(path: "/api/v1/drafts/\(id)/assign", method: "POST", body: bodyData)
+        return try Self.extensionDecoder.decode(AssignDraftResponse.self, from: data)
+    }
+}
+
+private struct ExtensionErrorResponse: Codable {
+    let error: String
+}

--- a/ios/IssueCTL/Services/APIClient+Drafts.swift
+++ b/ios/IssueCTL/Services/APIClient+Drafts.swift
@@ -26,60 +26,21 @@ struct AssignDraftWithLabelsRequestBody: Encodable, Sendable {
 // MARK: - APIClient extension for draft editing and labels
 
 extension APIClient {
-    /// Internal helper that mirrors the private `request` method in APIClient.
-    /// Needed because Swift extensions in separate files cannot access private members.
-    func extensionRequest(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
-        guard let base = URL(string: serverURL) else {
-            throw APIError.notConfigured
-        }
-
-        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
-        urlRequest.httpMethod = method
-        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let body { urlRequest.httpBody = body }
-
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw APIError.invalidResponse
-        }
-
-        if httpResponse.statusCode == 401 {
-            throw APIError.unauthorized
-        }
-        if httpResponse.statusCode >= 400 {
-            let errorBody = try? JSONDecoder().decode(ExtensionErrorResponse.self, from: data)
-            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
-        }
-
-        return (data, httpResponse)
-    }
-
-    private static let extensionDecoder: JSONDecoder = {
-        let d = JSONDecoder()
-        d.keyDecodingStrategy = .convertFromSnakeCase
-        return d
-    }()
-
     func updateDraft(id: String, body: UpdateDraftRequestBody) async throws -> UpdateDraftResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await extensionRequest(path: "/api/v1/drafts/\(id)", method: "PATCH", body: bodyData)
-        return try Self.extensionDecoder.decode(UpdateDraftResponse.self, from: data)
+        let (data, _) = try await request(path: "/api/v1/drafts/\(id)", method: "PATCH", body: bodyData)
+        return try decoder.decode(UpdateDraftResponse.self, from: data)
     }
 
     func repoLabels(owner: String, repo: String) async throws -> [GitHubLabel] {
-        let (data, _) = try await extensionRequest(path: "/api/v1/repos/\(owner)/\(repo)/labels")
-        let response = try Self.extensionDecoder.decode(LabelsResponse.self, from: data)
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/labels")
+        let response = try decoder.decode(LabelsResponse.self, from: data)
         return response.labels
     }
 
     func assignDraftWithLabels(id: String, body: AssignDraftWithLabelsRequestBody) async throws -> AssignDraftResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await extensionRequest(path: "/api/v1/drafts/\(id)/assign", method: "POST", body: bodyData)
-        return try Self.extensionDecoder.decode(AssignDraftResponse.self, from: data)
+        let (data, _) = try await request(path: "/api/v1/drafts/\(id)/assign", method: "POST", body: bodyData)
+        return try decoder.decode(AssignDraftResponse.self, from: data)
     }
-}
-
-private struct ExtensionErrorResponse: Codable {
-    let error: String
 }

--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -90,8 +90,10 @@ struct DraftDetailView: View {
     }
 
     private func updateHasChanges() {
-        let titleChanged = title != draft.title
-        let bodyChanged = bodyText != (draft.body ?? "")
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let titleChanged = trimmedTitle != draft.title
+        let bodyChanged = trimmedBody != (draft.body ?? "")
         let priorityChanged = priority != (draft.priority ?? "normal")
         hasChanges = titleChanged || bodyChanged || priorityChanged
     }

--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct DraftDetailView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let draft: Draft
+    let onSaved: () -> Void
+
+    @State private var title: String
+    @State private var bodyText: String
+    @State private var priority: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var hasChanges = false
+
+    init(draft: Draft, onSaved: @escaping () -> Void) {
+        self.draft = draft
+        self.onSaved = onSaved
+        _title = State(initialValue: draft.title)
+        _bodyText = State(initialValue: draft.body ?? "")
+        _priority = State(initialValue: draft.priority ?? "normal")
+    }
+
+    private var canSave: Bool {
+        hasChanges
+            && !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isSaving
+    }
+
+    var body: some View {
+        Form {
+            Section("Title") {
+                TextField("Issue title", text: $title)
+                    .font(.body)
+            }
+
+            Section("Description") {
+                TextEditor(text: $bodyText)
+                    .font(.body)
+                    .frame(minHeight: 120)
+                    .overlay(alignment: .topLeading) {
+                        if bodyText.isEmpty {
+                            Text("Optional description...")
+                                .foregroundStyle(.tertiary)
+                                .font(.body)
+                                .padding(.top, 8)
+                                .padding(.leading, 5)
+                                .allowsHitTesting(false)
+                        }
+                    }
+            }
+
+            Section("Priority") {
+                Picker("Priority", selection: $priority) {
+                    Text("Low").tag("low")
+                    Text("Normal").tag("normal")
+                    Text("High").tag("high")
+                }
+                .pickerStyle(.segmented)
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Edit Draft")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task { await save() }
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Save")
+                    }
+                }
+                .disabled(!canSave)
+            }
+        }
+        .onChange(of: title) { _, _ in updateHasChanges() }
+        .onChange(of: bodyText) { _, _ in updateHasChanges() }
+        .onChange(of: priority) { _, _ in updateHasChanges() }
+    }
+
+    private func updateHasChanges() {
+        let titleChanged = title != draft.title
+        let bodyChanged = bodyText != (draft.body ?? "")
+        let priorityChanged = priority != (draft.priority ?? "normal")
+        hasChanges = titleChanged || bodyChanged || priorityChanged
+    }
+
+    private func save() async {
+        isSaving = true
+        errorMessage = nil
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            let updateBody = UpdateDraftRequestBody(
+                title: trimmedTitle != draft.title ? trimmedTitle : nil,
+                body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
+                priority: priority != (draft.priority ?? "normal") ? priority : nil
+            )
+            let response = try await api.updateDraft(id: draft.id, body: updateBody)
+            if response.success {
+                onSaved()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to save draft"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSaving = false
+    }
+}

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -179,6 +179,9 @@ struct IssueListView: View {
             .navigationDestination(for: IssueDestination.self) { dest in
                 IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
+            .navigationDestination(for: DraftDestination.self) { dest in
+                DraftDetailView(draft: dest.draft, onSaved: { Task { await loadAll(refresh: true) } })
+            }
             .sheet(isPresented: $showCreateSheet) {
                 QuickCreateSheet(repos: repos, onSuccess: { Task { await loadAll(refresh: true) } })
             }
@@ -299,16 +302,24 @@ struct IssueListView: View {
         } else {
             List {
                 ForEach(drafts) { draft in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(draft.title)
-                            .font(.body)
-                        if let priority = draft.priority, priority != "normal" {
-                            Text(priority.capitalized)
-                                .font(.caption2)
-                                .foregroundStyle(priority == "high" ? .red : .secondary)
+                    NavigationLink(value: DraftDestination(draft: draft)) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(draft.title)
+                                .font(.body)
+                            if let body = draft.body, !body.isEmpty {
+                                Text(body)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                            if let priority = draft.priority, priority != "normal" {
+                                Text(priority.capitalized)
+                                    .font(.caption2)
+                                    .foregroundStyle(priority == "high" ? .red : .secondary)
+                            }
                         }
+                        .padding(.vertical, 2)
                     }
-                    .padding(.vertical, 2)
                     .swipeActions(edge: .trailing) {
                         Button(role: .destructive) {
                             deleteDraftTarget = draft.id
@@ -411,4 +422,16 @@ struct IssueDestination: Hashable {
     let owner: String
     let repo: String
     let number: Int
+}
+
+struct DraftDestination: Hashable {
+    let draft: Draft
+
+    static func == (lhs: DraftDestination, rhs: DraftDestination) -> Bool {
+        lhs.draft.id == rhs.draft.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(draft.id)
+    }
 }

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -8,10 +8,16 @@ struct QuickCreateSheet: View {
     let onSuccess: () -> Void
 
     @State private var title = ""
+    @State private var bodyText = ""
     @State private var selectedRepoId: Int?
     @State private var priority: String = "normal"
     @State private var isSubmitting = false
     @State private var errorMessage: String?
+
+    // Labels
+    @State private var availableLabels: [GitHubLabel] = []
+    @State private var selectedLabels: Set<String> = []
+    @State private var isLoadingLabels = false
 
     private var selectedRepo: Repo? {
         repos.first { $0.id == selectedRepoId }
@@ -32,6 +38,22 @@ struct QuickCreateSheet: View {
                         .font(.body)
                 }
 
+                Section("Description") {
+                    TextEditor(text: $bodyText)
+                        .font(.body)
+                        .frame(minHeight: 100)
+                        .overlay(alignment: .topLeading) {
+                            if bodyText.isEmpty {
+                                Text("Optional description...")
+                                    .foregroundStyle(.tertiary)
+                                    .font(.body)
+                                    .padding(.top, 8)
+                                    .padding(.leading, 5)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                }
+
                 Section("Repository") {
                     Picker("Repo", selection: $selectedRepoId) {
                         Text("None (local draft)").tag(nil as Int?)
@@ -44,6 +66,16 @@ struct QuickCreateSheet: View {
                             }
                             .tag(repo.id as Int?)
                         }
+                    }
+                }
+
+                if selectedRepo != nil {
+                    Section("Labels") {
+                        LabelPicker(
+                            labels: availableLabels,
+                            selectedLabels: $selectedLabels,
+                            isLoading: isLoadingLabels
+                        )
                     }
                 }
 
@@ -85,18 +117,37 @@ struct QuickCreateSheet: View {
                     Button("Cancel") { dismiss() }
                 }
             }
+            .onChange(of: selectedRepoId) { _, newValue in
+                selectedLabels = []
+                availableLabels = []
+                if let repoId = newValue, let repo = repos.first(where: { $0.id == repoId }) {
+                    Task { await loadLabels(owner: repo.owner, repo: repo.name) }
+                }
+            }
         }
+    }
+
+    private func loadLabels(owner: String, repo: String) async {
+        isLoadingLabels = true
+        do {
+            availableLabels = try await api.repoLabels(owner: owner, repo: repo)
+        } catch {
+            // Label loading is non-critical — the user can still create without labels
+            availableLabels = []
+        }
+        isLoadingLabels = false
     }
 
     private func submit() async {
         isSubmitting = true
         errorMessage = nil
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
             let createBody = CreateDraftRequestBody(
                 title: trimmedTitle,
-                body: nil,
+                body: trimmedBody.isEmpty ? nil : trimmedBody,
                 priority: priority
             )
             let createResponse = try await api.createDraft(body: createBody)
@@ -109,8 +160,9 @@ struct QuickCreateSheet: View {
 
             // If a repo is selected, assign the draft to create a GitHub issue
             if let repoId = selectedRepoId {
-                let assignBody = AssignDraftRequestBody(repoId: repoId)
-                let assignResponse = try await api.assignDraft(id: draftId, body: assignBody)
+                let labels = selectedLabels.isEmpty ? nil : Array(selectedLabels)
+                let assignBody = AssignDraftWithLabelsRequestBody(repoId: repoId, labels: labels)
+                let assignResponse = try await api.assignDraftWithLabels(id: draftId, body: assignBody)
                 if !assignResponse.success {
                     errorMessage = assignResponse.error ?? "Draft created but failed to assign to repo"
                     isSubmitting = false

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -18,6 +18,7 @@ struct QuickCreateSheet: View {
     @State private var availableLabels: [GitHubLabel] = []
     @State private var selectedLabels: Set<String> = []
     @State private var isLoadingLabels = false
+    @State private var labelLoadError: String?
 
     private var selectedRepo: Repo? {
         repos.first { $0.id == selectedRepoId }
@@ -69,13 +70,25 @@ struct QuickCreateSheet: View {
                     }
                 }
 
-                if selectedRepo != nil {
+                if let repo = selectedRepo {
                     Section("Labels") {
-                        LabelPicker(
-                            labels: availableLabels,
-                            selectedLabels: $selectedLabels,
-                            isLoading: isLoadingLabels
-                        )
+                        if let labelError = labelLoadError {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Label(labelError, systemImage: "exclamationmark.triangle")
+                                    .foregroundStyle(.orange)
+                                    .font(.callout)
+                                Button("Retry") {
+                                    Task { await loadLabels(owner: repo.owner, repo: repo.name) }
+                                }
+                                .font(.callout)
+                            }
+                        } else {
+                            LabelPicker(
+                                labels: availableLabels,
+                                selectedLabels: $selectedLabels,
+                                isLoading: isLoadingLabels
+                            )
+                        }
                     }
                 }
 
@@ -120,6 +133,7 @@ struct QuickCreateSheet: View {
             .onChange(of: selectedRepoId) { _, newValue in
                 selectedLabels = []
                 availableLabels = []
+                labelLoadError = nil
                 if let repoId = newValue, let repo = repos.first(where: { $0.id == repoId }) {
                     Task { await loadLabels(owner: repo.owner, repo: repo.name) }
                 }
@@ -129,11 +143,12 @@ struct QuickCreateSheet: View {
 
     private func loadLabels(owner: String, repo: String) async {
         isLoadingLabels = true
+        labelLoadError = nil
         do {
             availableLabels = try await api.repoLabels(owner: owner, repo: repo)
         } catch {
-            // Label loading is non-critical — the user can still create without labels
             availableLabels = []
+            labelLoadError = "Failed to load labels"
         }
         isLoadingLabels = false
     }
@@ -171,6 +186,13 @@ struct QuickCreateSheet: View {
                 if let warning = assignResponse.cleanupWarning {
                     // Issue was created on GitHub but draft cleanup failed on server.
                     // Show warning and refresh, but don't auto-dismiss so user sees it.
+                    errorMessage = "Issue created. Note: \(warning)"
+                    isSubmitting = false
+                    onSuccess()
+                    return
+                }
+                if let warning = assignResponse.labelsWarning {
+                    // Issue was created on GitHub but labels could not be applied.
                     errorMessage = "Issue created. Note: \(warning)"
                     isSubmitting = false
                     onSuccess()

--- a/ios/IssueCTL/Views/Shared/LabelPicker.swift
+++ b/ios/IssueCTL/Views/Shared/LabelPicker.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct LabelPicker: View {
+    let labels: [GitHubLabel]
+    @Binding var selectedLabels: Set<String>
+    let isLoading: Bool
+
+    var body: some View {
+        if isLoading {
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading labels...")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        } else if labels.isEmpty {
+            Text("No labels available")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        } else {
+            FlowLayout(spacing: 8) {
+                ForEach(labels) { label in
+                    LabelChip(
+                        label: label,
+                        isSelected: selectedLabels.contains(label.name),
+                        onToggle: {
+                            if selectedLabels.contains(label.name) {
+                                selectedLabels.remove(label.name)
+                            } else {
+                                selectedLabels.insert(label.name)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct LabelChip: View {
+    let label: GitHubLabel
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    private var labelColor: Color {
+        Color(hex: label.color) ?? .secondary
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(labelColor)
+                    .frame(width: 10, height: 10)
+                Text(label.name)
+                    .font(.caption)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? labelColor.opacity(0.2) : Color(.systemGray6))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isSelected ? labelColor : Color.clear, lineWidth: 1.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityLabel("\(label.name) label")
+    }
+}
+
+// FlowLayout is defined in IssueDetailView.swift and reused here.

--- a/packages/web/app/api/v1/drafts/[id]/assign/route.ts
+++ b/packages/web/app/api/v1/drafts/[id]/assign/route.ts
@@ -52,6 +52,7 @@ export async function POST(
 
   try {
     const db = getDb();
+    let labelsWarning: string | undefined;
     const result = await withAuthRetry(async (octokit) => {
       const assignResult = await assignDraftToRepo(db, octokit, id, body.repoId);
 
@@ -63,7 +64,10 @@ export async function POST(
             await addLabels(octokit, repo.owner, repo.name, assignResult.issueNumber, body.labels);
           } catch (labelErr) {
             log.warn({ err: labelErr, msg: "api_draft_assign_labels_failed", draftId: id, labels: body.labels });
+            labelsWarning = "Issue created but labels could not be applied";
           }
+        } else {
+          log.error({ msg: "api_draft_assign_repo_not_found_for_labels", draftId: id, repoId: body.repoId });
         }
       }
 
@@ -85,6 +89,7 @@ export async function POST(
       success: true,
       issueNumber: result.issueNumber,
       issueUrl: result.issueUrl,
+      ...(labelsWarning ? { labelsWarning } : {}),
     });
   } catch (err) {
     if (err instanceof DraftPartialCommitError) {

--- a/packages/web/app/api/v1/drafts/[id]/assign/route.ts
+++ b/packages/web/app/api/v1/drafts/[id]/assign/route.ts
@@ -9,6 +9,7 @@ import {
   formatErrorForUser,
   getRepoById,
   clearCacheKey,
+  addLabels,
 } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
@@ -17,6 +18,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 type AssignBody = {
   repoId: number;
+  labels?: string[];
 };
 
 export async function POST(
@@ -42,12 +44,31 @@ export async function POST(
   if (typeof body.repoId !== "number" || !Number.isInteger(body.repoId) || body.repoId <= 0) {
     return NextResponse.json({ error: "repoId must be a positive integer" }, { status: 400 });
   }
+  if (body.labels !== undefined) {
+    if (!Array.isArray(body.labels) || body.labels.some((l: unknown) => typeof l !== "string")) {
+      return NextResponse.json({ error: "labels must be an array of strings" }, { status: 400 });
+    }
+  }
 
   try {
     const db = getDb();
-    const result = await withAuthRetry((octokit) =>
-      assignDraftToRepo(db, octokit, id, body.repoId),
-    );
+    const result = await withAuthRetry(async (octokit) => {
+      const assignResult = await assignDraftToRepo(db, octokit, id, body.repoId);
+
+      // Apply labels after issue creation (best-effort)
+      if (body.labels && body.labels.length > 0) {
+        const repo = getRepoById(db, body.repoId);
+        if (repo) {
+          try {
+            await addLabels(octokit, repo.owner, repo.name, assignResult.issueNumber, body.labels);
+          } catch (labelErr) {
+            log.warn({ err: labelErr, msg: "api_draft_assign_labels_failed", draftId: id, labels: body.labels });
+          }
+        }
+      }
+
+      return assignResult;
+    });
 
     // Clear issue cache so next fetch includes the new issue
     try {

--- a/packages/web/app/api/v1/drafts/[id]/route.ts
+++ b/packages/web/app/api/v1/drafts/[id]/route.ts
@@ -109,6 +109,10 @@ export async function PATCH(
     if (body.body !== undefined) update.body = body.body;
     if (body.priority !== undefined) update.priority = body.priority as Priority;
 
+    if (Object.keys(update).length === 0) {
+      return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+    }
+
     const draft = updateDraft(db, id, update);
     if (!draft) {
       return NextResponse.json({ success: false, error: "Draft not found" }, { status: 404 });

--- a/packages/web/app/api/v1/drafts/[id]/route.ts
+++ b/packages/web/app/api/v1/drafts/[id]/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
-import { getDb, deleteDraft, formatErrorForUser } from "@issuectl/core";
+import {
+  getDb,
+  deleteDraft,
+  updateDraft,
+  formatErrorForUser,
+  type DraftUpdate,
+  type Priority,
+} from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VALID_PRIORITIES: readonly string[] = ["low", "normal", "high"];
+const MAX_TITLE = 256;
+const MAX_BODY = 65536;
 
 export async function DELETE(
   request: NextRequest,
@@ -29,6 +39,84 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (err) {
     log.error({ err, msg: "api_draft_delete_failed", draftId: id });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+type PatchBody = {
+  title?: string;
+  body?: string;
+  priority?: string;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+  if (!id || !UUID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid draft id" }, { status: 400 });
+  }
+
+  let body: PatchBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Validate fields
+  if (body.title !== undefined) {
+    if (typeof body.title !== "string" || !body.title.trim()) {
+      return NextResponse.json({ error: "Title must be a non-empty string" }, { status: 400 });
+    }
+    if (body.title.length > MAX_TITLE) {
+      return NextResponse.json(
+        { error: `Title must be ${MAX_TITLE} characters or fewer` },
+        { status: 400 },
+      );
+    }
+  }
+  if (body.body !== undefined) {
+    if (typeof body.body !== "string") {
+      return NextResponse.json({ error: "Body must be a string" }, { status: 400 });
+    }
+    if (body.body.length > MAX_BODY) {
+      return NextResponse.json(
+        { error: `Body must be ${MAX_BODY} characters or fewer` },
+        { status: 400 },
+      );
+    }
+  }
+  if (body.priority !== undefined && !VALID_PRIORITIES.includes(body.priority)) {
+    return NextResponse.json(
+      { error: "Priority must be low, normal, or high" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const update: DraftUpdate = {};
+    if (body.title !== undefined) update.title = body.title;
+    if (body.body !== undefined) update.body = body.body;
+    if (body.priority !== undefined) update.priority = body.priority as Priority;
+
+    const draft = updateDraft(db, id, update);
+    if (!draft) {
+      return NextResponse.json({ success: false, error: "Draft not found" }, { status: 404 });
+    }
+    log.info({ msg: "api_draft_updated", draftId: id });
+    return NextResponse.json({ success: true, draft });
+  } catch (err) {
+    log.error({ err, msg: "api_draft_update_failed", draftId: id });
     return NextResponse.json(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { getDb, getRepo, withAuthRetry, listLabels, formatErrorForUser } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const labels = await withAuthRetry((octokit) =>
+      listLabels(octokit, owner, repo),
+    );
+    log.info({ msg: "api_labels_listed", owner, repo, count: labels.length });
+    return NextResponse.json({ labels });
+  } catch (err) {
+    log.error({ err, msg: "api_labels_list_failed", owner, repo });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `DraftDetailView` for editing draft issues with unsaved-changes tracking
- Expands `QuickCreateSheet` with body field and label picker
- New reusable `LabelPicker` component for selecting GitHub labels
- Adds `PATCH /api/v1/drafts/[id]` endpoint for draft updates
- Adds `GET /api/v1/repos/[owner]/[repo]/labels` endpoint for label listing
- `APIClient+Drafts.swift` extension for draft/label API calls

Closes #258, closes #259, closes #260

## Review findings addressed
- Trim mismatch in unsaved-changes detection
- Label application warnings surfaced in UI
- Label loading error state with retry button
- Empty PATCH body rejection (400)
- Deduplicated `request()` helper (now `internal` on APIClient)

## Test plan
- [ ] Create a draft with body and labels — verify labels applied on assign
- [ ] Edit a draft — verify unsaved changes indicator works
- [ ] Label picker loading/error/empty states
- [ ] PATCH with no changes returns 400