### PR TITLE
feat(ios): issue editing, comment management, and labels

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
+		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
 		4451AE4574EA7D0F86AEE021 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403330B1342AA7C19FA797D /* Constants.swift */; };
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
 		493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
@@ -23,19 +24,23 @@
 		661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D638F823877AD0CAA946A4 /* CommentView.swift */; };
 		6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */; };
 		78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E1C810B3BD014B117301B /* IssueCTLApp.swift */; };
+		83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */; };
 		87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
+		9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */; };
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
 		9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
 		A18D8982D49319C633EE661A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C1581E55A12781F1E76A1 /* ContentView.swift */; };
 		A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767FFF9158E604C69C4007DB /* PRDetailView.swift */; };
 		AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */; };
 		B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */; };
+		BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */; };
 		BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
 		C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13760098C8ED1658B27AD54B /* CommentSheet.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
 		DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75027D57516F296784BEDA4B /* PRRowView.swift */; };
 		E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2D036E0950B774A3A43 /* LaunchView.swift */; };
+		E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
 		E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */; };
 		EE08B250394D4614915429E1 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A4F0FF399CC75CAB4F1A1C /* Issue.swift */; };
 		F17CDC8FC484D666EB0B35C0 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6FD670361C44AE6DB85ECE /* KeychainService.swift */; };
@@ -51,7 +56,10 @@
 		13760098C8ED1658B27AD54B /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		223E1C810B3BD014B117301B /* IssueCTLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLApp.swift; sourceTree = "<group>"; };
+		22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIssueSheet.swift; sourceTree = "<group>"; };
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
+		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
+		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		4403330B1342AA7C19FA797D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -63,6 +71,7 @@
 		7A6FD670361C44AE6DB85ECE /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRowView.swift; sourceTree = "<group>"; };
 		80A4F0FF399CC75CAB4F1A1C /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
+		80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommentSheet.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,6 +80,7 @@
 		BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerHealth.swift; sourceTree = "<group>"; };
 		C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoListView.swift; sourceTree = "<group>"; };
 		C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailView.swift; sourceTree = "<group>"; };
+		CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftDetailView.swift; sourceTree = "<group>"; };
 		D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseIssueSheet.swift; sourceTree = "<group>"; };
 		D882E51722D47D736257AB4F /* IssueListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListView.swift; sourceTree = "<group>"; };
 		DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Drafts.swift"; sourceTree = "<group>"; };
@@ -138,6 +148,7 @@
 			isa = PBXGroup;
 			children = (
 				E9F091BF822565D8E0F15E7A /* APIClient.swift */,
+				2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */,
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
@@ -237,10 +248,14 @@
 			children = (
 				D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */,
 				78D638F823877AD0CAA946A4 /* CommentView.swift */,
+				CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */,
+				80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */,
+				22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */,
 				488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */,
 				C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */,
 				D882E51722D47D736257AB4F /* IssueListView.swift */,
 				7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */,
+				3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */,
 				DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */,
 			);
 			path = Issues;
@@ -301,6 +316,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */,
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
@@ -311,6 +327,9 @@
 				4451AE4574EA7D0F86AEE021 /* Constants.swift in Sources */,
 				A18D8982D49319C633EE661A /* ContentView.swift in Sources */,
 				48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */,
+				3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */,
+				9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */,
+				E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */,
 				EE08B250394D4614915429E1 /* Issue.swift in Sources */,
 				78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */,
 				87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */,
@@ -318,6 +337,7 @@
 				5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */,
 				1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */,
 				F17CDC8FC484D666EB0B35C0 /* KeychainService.swift in Sources */,
+				BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */,
 				581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,

--- a/ios/IssueCTL/Services/APIClient+DetailActions.swift
+++ b/ios/IssueCTL/Services/APIClient+DetailActions.swift
@@ -45,44 +45,19 @@ struct LabelsListResponse: Codable, Sendable {
     let labels: [GitHubLabel]
 }
 
+struct CurrentUserResponse: Codable, Sendable {
+    let login: String
+}
+
 // MARK: - APIClient Extension
 
 extension APIClient {
-    /// Internal request helper — mirrors the private `request` method on APIClient.
-    /// Needed because `private` scope is file-limited in Swift and this file
-    /// cannot call the original. Uses the publicly-readable `serverURL` and
-    /// `apiToken` properties.
-    func requestData(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
-        guard let base = URL(string: serverURL) else {
-            throw APIError.notConfigured
-        }
 
-        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
-        urlRequest.httpMethod = method
-        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let body { urlRequest.httpBody = body }
+    // MARK: - Current User
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw APIError.invalidResponse
-        }
-
-        if httpResponse.statusCode == 401 {
-            throw APIError.unauthorized
-        }
-        if httpResponse.statusCode >= 400 {
-            let errorBody = try? JSONDecoder().decode(DetailActionErrorResponse.self, from: data)
-            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
-        }
-
-        return (data, httpResponse)
-    }
-
-    func makeDecoder() -> JSONDecoder {
-        let d = JSONDecoder()
-        d.keyDecodingStrategy = .convertFromSnakeCase
-        return d
+    func currentUser() async throws -> CurrentUserResponse {
+        let (data, _) = try await request(path: "/api/v1/user")
+        return try decoder.decode(CurrentUserResponse.self, from: data)
     }
 
     // MARK: - Issue Editing (#263)
@@ -92,12 +67,12 @@ extension APIClient {
         body: UpdateIssueRequestBody
     ) async throws -> UpdateIssueResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(
+        let (data, _) = try await request(
             path: "/api/v1/issues/\(owner)/\(repo)/\(number)",
             method: "PATCH",
             body: bodyData
         )
-        return try makeDecoder().decode(UpdateIssueResponse.self, from: data)
+        return try decoder.decode(UpdateIssueResponse.self, from: data)
     }
 
     // MARK: - Comment Edit & Delete (#265)
@@ -107,12 +82,12 @@ extension APIClient {
         body: EditCommentRequestBody
     ) async throws -> EditCommentResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(
+        let (data, _) = try await request(
             path: "/api/v1/issues/\(owner)/\(repo)/\(number)/comments",
             method: "PATCH",
             body: bodyData
         )
-        return try makeDecoder().decode(EditCommentResponse.self, from: data)
+        return try decoder.decode(EditCommentResponse.self, from: data)
     }
 
     func deleteComment(
@@ -120,23 +95,23 @@ extension APIClient {
         body: DeleteCommentRequestBody
     ) async throws -> DeleteCommentResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(
+        let (data, _) = try await request(
             path: "/api/v1/issues/\(owner)/\(repo)/\(number)/comments",
             method: "DELETE",
             body: bodyData
         )
-        return try makeDecoder().decode(DeleteCommentResponse.self, from: data)
+        return try decoder.decode(DeleteCommentResponse.self, from: data)
     }
 
     // MARK: - Label Management (#264)
 
     func listRepoLabels(owner: String, repo: String) async throws -> LabelsListResponse {
-        let (data, _) = try await requestData(
+        let (data, _) = try await request(
             path: "/api/v1/repos/\(owner)/\(repo)/labels",
             method: "GET",
             body: nil
         )
-        return try makeDecoder().decode(LabelsListResponse.self, from: data)
+        return try decoder.decode(LabelsListResponse.self, from: data)
     }
 
     func toggleLabel(
@@ -144,15 +119,11 @@ extension APIClient {
         body: ToggleLabelRequestBody
     ) async throws -> ToggleLabelResponse {
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(
+        let (data, _) = try await request(
             path: "/api/v1/issues/\(owner)/\(repo)/\(number)/labels",
             method: "POST",
             body: bodyData
         )
-        return try makeDecoder().decode(ToggleLabelResponse.self, from: data)
+        return try decoder.decode(ToggleLabelResponse.self, from: data)
     }
-}
-
-private struct DetailActionErrorResponse: Codable {
-    let error: String
 }

--- a/ios/IssueCTL/Services/APIClient+DetailActions.swift
+++ b/ios/IssueCTL/Services/APIClient+DetailActions.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+// MARK: - Request/Response Types for Detail Actions
+
+struct UpdateIssueRequestBody: Encodable, Sendable {
+    let title: String?
+    let body: String?
+}
+
+struct UpdateIssueResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct EditCommentRequestBody: Encodable, Sendable {
+    let commentId: Int
+    let body: String
+}
+
+struct EditCommentResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct DeleteCommentRequestBody: Encodable, Sendable {
+    let commentId: Int
+}
+
+struct DeleteCommentResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct ToggleLabelRequestBody: Encodable, Sendable {
+    let label: String
+    let action: String // "add" or "remove"
+}
+
+struct ToggleLabelResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+struct LabelsListResponse: Codable, Sendable {
+    let labels: [GitHubLabel]
+}
+
+// MARK: - APIClient Extension
+
+extension APIClient {
+    /// Internal request helper — mirrors the private `request` method on APIClient.
+    /// Needed because `private` scope is file-limited in Swift and this file
+    /// cannot call the original. Uses the publicly-readable `serverURL` and
+    /// `apiToken` properties.
+    func requestData(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+        guard let base = URL(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+
+        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
+        urlRequest.httpMethod = method
+        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body { urlRequest.httpBody = body }
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw APIError.unauthorized
+        }
+        if httpResponse.statusCode >= 400 {
+            let errorBody = try? JSONDecoder().decode(DetailActionErrorResponse.self, from: data)
+            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
+        }
+
+        return (data, httpResponse)
+    }
+
+    func makeDecoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+
+    // MARK: - Issue Editing (#263)
+
+    func updateIssue(
+        owner: String, repo: String, number: Int,
+        body: UpdateIssueRequestBody
+    ) async throws -> UpdateIssueResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)",
+            method: "PATCH",
+            body: bodyData
+        )
+        return try makeDecoder().decode(UpdateIssueResponse.self, from: data)
+    }
+
+    // MARK: - Comment Edit & Delete (#265)
+
+    func editComment(
+        owner: String, repo: String, number: Int,
+        body: EditCommentRequestBody
+    ) async throws -> EditCommentResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/comments",
+            method: "PATCH",
+            body: bodyData
+        )
+        return try makeDecoder().decode(EditCommentResponse.self, from: data)
+    }
+
+    func deleteComment(
+        owner: String, repo: String, number: Int,
+        body: DeleteCommentRequestBody
+    ) async throws -> DeleteCommentResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/comments",
+            method: "DELETE",
+            body: bodyData
+        )
+        return try makeDecoder().decode(DeleteCommentResponse.self, from: data)
+    }
+
+    // MARK: - Label Management (#264)
+
+    func listRepoLabels(owner: String, repo: String) async throws -> LabelsListResponse {
+        let (data, _) = try await requestData(
+            path: "/api/v1/repos/\(owner)/\(repo)/labels",
+            method: "GET",
+            body: nil
+        )
+        return try makeDecoder().decode(LabelsListResponse.self, from: data)
+    }
+
+    func toggleLabel(
+        owner: String, repo: String, number: Int,
+        body: ToggleLabelRequestBody
+    ) async throws -> ToggleLabelResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/labels",
+            method: "POST",
+            body: bodyData
+        )
+        return try makeDecoder().decode(ToggleLabelResponse.self, from: data)
+    }
+}
+
+private struct DetailActionErrorResponse: Codable {
+    let error: String
+}

--- a/ios/IssueCTL/Views/Issues/EditCommentSheet.swift
+++ b/ios/IssueCTL/Views/Issues/EditCommentSheet.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct EditCommentSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let commentId: Int
+    let currentBody: String
+    let onSuccess: () -> Void
+
+    @State private var commentBody: String
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    init(
+        owner: String, repo: String, number: Int,
+        commentId: Int, currentBody: String,
+        onSuccess: @escaping () -> Void
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.commentId = commentId
+        self.currentBody = currentBody
+        self.onSuccess = onSuccess
+        _commentBody = State(initialValue: currentBody)
+    }
+
+    private var hasChanges: Bool {
+        commentBody.trimmingCharacters(in: .whitespacesAndNewlines) != currentBody
+    }
+
+    private var isValid: Bool {
+        !commentBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && hasChanges
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Comment") {
+                    TextEditor(text: $commentBody)
+                        .frame(minHeight: 200)
+                        .font(.body)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button {
+                        Task { await submit() }
+                    } label: {
+                        if isSubmitting {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Label("Save Changes", systemImage: "checkmark.circle")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(!isValid || isSubmitting)
+                }
+            }
+            .navigationTitle("Edit Comment")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+        do {
+            let trimmedBody = commentBody.trimmingCharacters(in: .whitespacesAndNewlines)
+            let requestBody = EditCommentRequestBody(
+                commentId: commentId,
+                body: trimmedBody
+            )
+            let response = try await api.editComment(
+                owner: owner, repo: repo, number: number,
+                body: requestBody
+            )
+            if response.success {
+                onSuccess()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to edit comment"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSubmitting = false
+    }
+}

--- a/ios/IssueCTL/Views/Issues/EditIssueSheet.swift
+++ b/ios/IssueCTL/Views/Issues/EditIssueSheet.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct EditIssueSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let currentTitle: String
+    let currentBody: String?
+    let onSuccess: () -> Void
+
+    @State private var title: String
+    @State private var issueBody: String
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    init(
+        owner: String, repo: String, number: Int,
+        currentTitle: String, currentBody: String?,
+        onSuccess: @escaping () -> Void
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.currentTitle = currentTitle
+        self.currentBody = currentBody
+        self.onSuccess = onSuccess
+        _title = State(initialValue: currentTitle)
+        _issueBody = State(initialValue: currentBody ?? "")
+    }
+
+    private var hasChanges: Bool {
+        title.trimmingCharacters(in: .whitespacesAndNewlines) != currentTitle ||
+        issueBody.trimmingCharacters(in: .whitespacesAndNewlines) != (currentBody ?? "")
+    }
+
+    private var isValid: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && hasChanges
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Issue title", text: $title)
+                        .font(.body)
+                }
+
+                Section("Description") {
+                    TextEditor(text: $issueBody)
+                        .frame(minHeight: 200)
+                        .font(.body)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button {
+                        Task { await submit() }
+                    } label: {
+                        if isSubmitting {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            Label("Save Changes", systemImage: "checkmark.circle")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(!isValid || isSubmitting)
+                }
+            }
+            .navigationTitle("Edit Issue")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+        do {
+            let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedBody = issueBody.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Only send fields that changed
+            let requestBody = UpdateIssueRequestBody(
+                title: trimmedTitle != currentTitle ? trimmedTitle : nil,
+                body: trimmedBody != (currentBody ?? "") ? trimmedBody : nil
+            )
+            let response = try await api.updateIssue(
+                owner: owner, repo: repo, number: number,
+                body: requestBody
+            )
+            if response.success {
+                onSuccess()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to update issue"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSubmitting = false
+    }
+}

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -18,6 +18,13 @@ struct IssueDetailView: View {
     @State private var showReopenConfirm = false
     @State private var actionError: String?
 
+    // Detail actions state (#263, #264, #265)
+    @State private var showEditSheet = false
+    @State private var showLabelSheet = false
+    @State private var editingComment: GitHubComment?
+    @State private var deletingComment: GitHubComment?
+    @State private var isDeletingComment = false
+
     var body: some View {
         Group {
             if isLoading && detail == nil {
@@ -67,10 +74,25 @@ struct IssueDetailView: View {
         .toolbar {
             if detail != nil {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showLaunchSheet = true
+                    Menu {
+                        Button {
+                            showEditSheet = true
+                        } label: {
+                            Label("Edit Issue", systemImage: "pencil")
+                        }
+                        Button {
+                            showLabelSheet = true
+                        } label: {
+                            Label("Manage Labels", systemImage: "tag")
+                        }
+                        Divider()
+                        Button {
+                            showLaunchSheet = true
+                        } label: {
+                            Label("Launch", systemImage: "play.fill")
+                        }
                     } label: {
-                        Label("Launch", systemImage: "play.fill")
+                        Image(systemName: "ellipsis.circle")
                     }
                 }
             }
@@ -99,12 +121,54 @@ struct IssueDetailView: View {
                 onSuccess: { Task { await load(refresh: true) } }
             )
         }
+        .sheet(isPresented: $showEditSheet) {
+            if let detail {
+                EditIssueSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentTitle: detail.issue.title,
+                    currentBody: detail.issue.body,
+                    onSuccess: { Task { await load(refresh: true) } }
+                )
+            }
+        }
+        .sheet(isPresented: $showLabelSheet) {
+            if let detail {
+                LabelManagementSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentLabels: detail.issue.labels,
+                    onSuccess: { Task { await load(refresh: true) } }
+                )
+            }
+        }
+        .sheet(item: $editingComment) { comment in
+            EditCommentSheet(
+                owner: owner, repo: repo, number: number,
+                commentId: comment.id, currentBody: comment.body,
+                onSuccess: { Task { await load(refresh: true) } }
+            )
+        }
         .confirmationDialog("Close Issue", isPresented: $showCloseConfirm, titleVisibility: .visible) {
             Button("Close", role: .destructive) { Task { await closeWithoutComment() } }
             Button("Close with comment...") { showCloseSheet = true }
         }
         .confirmationDialog("Reopen Issue", isPresented: $showReopenConfirm, titleVisibility: .visible) {
             Button("Reopen") { Task { await reopen() } }
+        }
+        .confirmationDialog(
+            "Delete Comment",
+            isPresented: .init(
+                get: { deletingComment != nil },
+                set: { if !$0 { deletingComment = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let comment = deletingComment {
+                    Task { await deleteComment(comment) }
+                }
+            }
+        } message: {
+            Text("Are you sure you want to delete this comment? This cannot be undone.")
         }
         .task { await load() }
     }
@@ -213,6 +277,20 @@ struct IssueDetailView: View {
 
             ForEach(comments) { comment in
                 CommentView(comment: comment)
+                    .contextMenu {
+                        Button {
+                            editingComment = comment
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+
+                        Button(role: .destructive) {
+                            deletingComment = comment
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+
                 if comment.id != comments.last?.id {
                     Divider()
                 }
@@ -314,6 +392,27 @@ struct IssueDetailView: View {
             actionError = error.localizedDescription
         }
         isReopening = false
+    }
+
+    private func deleteComment(_ comment: GitHubComment) async {
+        isDeletingComment = true
+        actionError = nil
+        do {
+            let requestBody = DeleteCommentRequestBody(commentId: comment.id)
+            let response = try await api.deleteComment(
+                owner: owner, repo: repo, number: number,
+                body: requestBody
+            )
+            if response.success {
+                await load(refresh: true)
+            } else {
+                actionError = response.error ?? "Failed to delete comment"
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isDeletingComment = false
+        deletingComment = nil
     }
 }
 

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -24,6 +24,8 @@ struct IssueDetailView: View {
     @State private var editingComment: GitHubComment?
     @State private var deletingComment: GitHubComment?
     @State private var isDeletingComment = false
+    @State private var currentUserLogin: String?
+    @State private var showActionError = false
 
     var body: some View {
         Group {
@@ -56,14 +58,6 @@ struct IssueDetailView: View {
                         .padding()
                     }
                     .refreshable { await load(refresh: true) }
-
-                    if let actionError {
-                        Label(actionError, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.subheadline)
-                            .padding(.horizontal)
-                            .padding(.vertical, 6)
-                    }
 
                     actionBar(for: detail.issue)
                 }
@@ -169,6 +163,14 @@ struct IssueDetailView: View {
             }
         } message: {
             Text("Are you sure you want to delete this comment? This cannot be undone.")
+        }
+        .alert("Error", isPresented: $showActionError) {
+            Button("OK") { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
+        .onChange(of: actionError) { _, newValue in
+            showActionError = newValue != nil
         }
         .task { await load() }
     }
@@ -276,20 +278,25 @@ struct IssueDetailView: View {
                 .font(.headline)
 
             ForEach(comments) { comment in
-                CommentView(comment: comment)
-                    .contextMenu {
-                        Button {
-                            editingComment = comment
-                        } label: {
-                            Label("Edit", systemImage: "pencil")
-                        }
+                let isOwnComment = currentUserLogin != nil && comment.user?.login == currentUserLogin
+                if isOwnComment {
+                    CommentView(comment: comment)
+                        .contextMenu {
+                            Button {
+                                editingComment = comment
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
 
-                        Button(role: .destructive) {
-                            deletingComment = comment
-                        } label: {
-                            Label("Delete", systemImage: "trash")
+                            Button(role: .destructive) {
+                                deletingComment = comment
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
                         }
-                    }
+                } else {
+                    CommentView(comment: comment)
+                }
 
                 if comment.id != comments.last?.id {
                     Divider()
@@ -353,7 +360,11 @@ struct IssueDetailView: View {
         isLoading = true
         errorMessage = nil
         do {
-            detail = try await api.issueDetail(owner: owner, repo: repo, number: number, refresh: refresh)
+            async let detailResult = api.issueDetail(owner: owner, repo: repo, number: number, refresh: refresh)
+            async let userResult = api.currentUser()
+            detail = try await detailResult
+            // Best-effort: don't fail the whole load if user fetch fails
+            currentUserLogin = try? await userResult.login
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/IssueCTL/Views/Issues/LabelManagementSheet.swift
+++ b/ios/IssueCTL/Views/Issues/LabelManagementSheet.swift
@@ -13,8 +13,9 @@ struct LabelManagementSheet: View {
     @State private var repoLabels: [GitHubLabel] = []
     @State private var activeLabels: Set<String>
     @State private var isLoading = true
-    @State private var isToggling: String?
+    @State private var togglingLabels: Set<String> = []
     @State private var errorMessage: String?
+    @State private var loadError: String?
     @State private var searchText = ""
 
     init(
@@ -44,6 +45,14 @@ struct LabelManagementSheet: View {
             Group {
                 if isLoading {
                     ProgressView("Loading labels...")
+                } else if loadError != nil {
+                    ContentUnavailableView {
+                        Label("Failed to Load", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text("Could not load labels.")
+                    } actions: {
+                        Button("Retry") { Task { await loadLabels() } }
+                    }
                 } else if repoLabels.isEmpty {
                     ContentUnavailableView {
                         Label("No Labels", systemImage: "tag")
@@ -81,7 +90,7 @@ struct LabelManagementSheet: View {
     @ViewBuilder
     private func labelRow(_ label: GitHubLabel) -> some View {
         let isActive = activeLabels.contains(label.name)
-        let isCurrentlyToggling = isToggling == label.name
+        let isCurrentlyToggling = togglingLabels.contains(label.name)
 
         Button {
             Task { await toggle(label: label, isActive: isActive) }
@@ -120,17 +129,18 @@ struct LabelManagementSheet: View {
 
     private func loadLabels() async {
         isLoading = true
+        loadError = nil
         do {
             let response = try await api.listRepoLabels(owner: owner, repo: repo)
             repoLabels = response.labels.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         } catch {
-            errorMessage = error.localizedDescription
+            loadError = error.localizedDescription
         }
         isLoading = false
     }
 
     private func toggle(label: GitHubLabel, isActive: Bool) async {
-        isToggling = label.name
+        togglingLabels.insert(label.name)
         errorMessage = nil
         do {
             let requestBody = ToggleLabelRequestBody(
@@ -154,7 +164,7 @@ struct LabelManagementSheet: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-        isToggling = nil
+        togglingLabels.remove(label.name)
     }
 }
 

--- a/ios/IssueCTL/Views/Issues/LabelManagementSheet.swift
+++ b/ios/IssueCTL/Views/Issues/LabelManagementSheet.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct LabelManagementSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let currentLabels: [GitHubLabel]
+    let onSuccess: () -> Void
+
+    @State private var repoLabels: [GitHubLabel] = []
+    @State private var activeLabels: Set<String>
+    @State private var isLoading = true
+    @State private var isToggling: String?
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    init(
+        owner: String, repo: String, number: Int,
+        currentLabels: [GitHubLabel],
+        onSuccess: @escaping () -> Void
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.currentLabels = currentLabels
+        self.onSuccess = onSuccess
+        _activeLabels = State(initialValue: Set(currentLabels.map(\.name)))
+    }
+
+    private var filteredLabels: [GitHubLabel] {
+        if searchText.isEmpty {
+            return repoLabels
+        }
+        return repoLabels.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView("Loading labels...")
+                } else if repoLabels.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Labels", systemImage: "tag")
+                    } description: {
+                        Text("This repository has no labels defined.")
+                    }
+                } else {
+                    List {
+                        ForEach(filteredLabels) { label in
+                            labelRow(label)
+                        }
+                    }
+                    .searchable(text: $searchText, prompt: "Filter labels")
+                }
+            }
+            .navigationTitle("Labels")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .alert("Error", isPresented: .init(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+            .task { await loadLabels() }
+        }
+    }
+
+    @ViewBuilder
+    private func labelRow(_ label: GitHubLabel) -> some View {
+        let isActive = activeLabels.contains(label.name)
+        let isCurrentlyToggling = isToggling == label.name
+
+        Button {
+            Task { await toggle(label: label, isActive: isActive) }
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(Color(hex: label.color) ?? .secondary)
+                    .frame(width: 14, height: 14)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label.name)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+
+                    if let description = label.description, !description.isEmpty {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if isCurrentlyToggling {
+                    ProgressView().controlSize(.small)
+                } else if isActive {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .disabled(isCurrentlyToggling)
+    }
+
+    private func loadLabels() async {
+        isLoading = true
+        do {
+            let response = try await api.listRepoLabels(owner: owner, repo: repo)
+            repoLabels = response.labels.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func toggle(label: GitHubLabel, isActive: Bool) async {
+        isToggling = label.name
+        errorMessage = nil
+        do {
+            let requestBody = ToggleLabelRequestBody(
+                label: label.name,
+                action: isActive ? "remove" : "add"
+            )
+            let response = try await api.toggleLabel(
+                owner: owner, repo: repo, number: number,
+                body: requestBody
+            )
+            if response.success {
+                if isActive {
+                    activeLabels.remove(label.name)
+                } else {
+                    activeLabels.insert(label.name)
+                }
+                onSuccess()
+            } else {
+                errorMessage = response.error ?? "Failed to toggle label"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isToggling = nil
+    }
+}
+

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/comments/route.ts
@@ -6,6 +6,8 @@ import {
   getRepo,
   withAuthRetry,
   addComment,
+  editComment,
+  removeComment,
   formatErrorForUser,
 } from "@issuectl/core";
 import { MAX_COMMENT_BODY } from "@/lib/constants";
@@ -61,6 +63,116 @@ export async function POST(
     return NextResponse.json({ success: true, commentId: comment.id });
   } catch (err) {
     log.error({ err, msg: "api_issue_comment_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+type EditCommentBody = {
+  commentId: number;
+  body: string;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: EditCommentBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!Number.isInteger(body.commentId) || body.commentId <= 0) {
+    return NextResponse.json({ error: "Valid commentId is required" }, { status: 400 });
+  }
+  if (typeof body.body !== "string" || !body.body.trim()) {
+    return NextResponse.json({ error: "Comment body is required" }, { status: 400 });
+  }
+  if (body.body.length > MAX_COMMENT_BODY) {
+    return NextResponse.json(
+      { error: `Comment must be ${MAX_COMMENT_BODY} characters or fewer` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    await withAuthRetry((octokit) =>
+      editComment(db, octokit, owner, repo, issueNumber, body.commentId, body.body),
+    );
+
+    log.info({ msg: "api_issue_comment_edited", owner, repo, issueNumber, commentId: body.commentId });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_comment_edit_failed", owner, repo, issueNumber, commentId: body.commentId });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+type DeleteCommentBody = {
+  commentId: number;
+};
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: DeleteCommentBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!Number.isInteger(body.commentId) || body.commentId <= 0) {
+    return NextResponse.json({ error: "Valid commentId is required" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    await withAuthRetry((octokit) =>
+      removeComment(db, octokit, owner, repo, issueNumber, body.commentId),
+    );
+
+    log.info({ msg: "api_issue_comment_deleted", owner, repo, issueNumber, commentId: body.commentId });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_comment_delete_failed", owner, repo, issueNumber, commentId: body.commentId });
     return NextResponse.json(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/labels/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/labels/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  addLabel,
+  removeLabel,
+  clearCacheKey,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type ToggleLabelBody = {
+  label: string;
+  action: "add" | "remove";
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: ToggleLabelBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.label !== "string" || !body.label.trim()) {
+    return NextResponse.json({ error: "Label name is required" }, { status: 400 });
+  }
+  if (body.action !== "add" && body.action !== "remove") {
+    return NextResponse.json({ error: "Action must be 'add' or 'remove'" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    if (body.action === "add") {
+      await withAuthRetry((octokit) =>
+        addLabel(octokit, owner, repo, issueNumber, body.label),
+      );
+    } else {
+      await withAuthRetry((octokit) =>
+        removeLabel(octokit, owner, repo, issueNumber, body.label),
+      );
+    }
+
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+
+    log.info({ msg: "api_issue_label_toggled", owner, repo, issueNumber, label: body.label, action: body.action });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_label_toggle_failed", owner, repo, issueNumber, label: body.label });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/labels/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/labels/route.ts
@@ -46,6 +46,8 @@ export async function POST(
     return NextResponse.json({ error: "Action must be 'add' or 'remove'" }, { status: 400 });
   }
 
+  const labelName = body.label.trim();
+
   try {
     const db = getDb();
     if (!getRepo(db, owner, repo)) {
@@ -54,11 +56,11 @@ export async function POST(
 
     if (body.action === "add") {
       await withAuthRetry((octokit) =>
-        addLabel(octokit, owner, repo, issueNumber, body.label),
+        addLabel(octokit, owner, repo, issueNumber, labelName),
       );
     } else {
       await withAuthRetry((octokit) =>
-        removeLabel(octokit, owner, repo, issueNumber, body.label),
+        removeLabel(octokit, owner, repo, issueNumber, labelName),
       );
     }
 
@@ -67,10 +69,10 @@ export async function POST(
     clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
     clearCacheKey(db, `issues:${owner}/${repo}`);
 
-    log.info({ msg: "api_issue_label_toggled", owner, repo, issueNumber, label: body.label, action: body.action });
+    log.info({ msg: "api_issue_label_toggled", owner, repo, issueNumber, label: labelName, action: body.action });
     return NextResponse.json({ success: true });
   } catch (err) {
-    log.error({ err, msg: "api_issue_label_toggle_failed", owner, repo, issueNumber, label: body.label });
+    log.error({ err, msg: "api_issue_label_toggle_failed", owner, repo, issueNumber, label: labelName });
     return NextResponse.json(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
@@ -1,8 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
-import { getDb, getRepo, getIssueDetail, withAuthRetry } from "@issuectl/core";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  getIssueDetail,
+  updateIssue,
+  clearCacheKey,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
+
+const MAX_TITLE = 256;
+const MAX_BODY = 65536;
 
 export async function GET(
   request: NextRequest,
@@ -31,5 +43,83 @@ export async function GET(
   } catch (err) {
     console.error(`[issuectl] GET /api/v1/issues/${owner}/${repo}/${issueNumber} failed:`, err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+type PatchBody = {
+  title?: string;
+  body?: string;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: PatchBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (body.title !== undefined && (typeof body.title !== "string" || !body.title.trim())) {
+    return NextResponse.json({ error: "Title cannot be empty" }, { status: 400 });
+  }
+  if (body.title !== undefined && body.title.length > MAX_TITLE) {
+    return NextResponse.json(
+      { error: `Title must be ${MAX_TITLE} characters or fewer` },
+      { status: 400 },
+    );
+  }
+  if (body.body !== undefined && typeof body.body !== "string") {
+    return NextResponse.json({ error: "Body must be a string" }, { status: 400 });
+  }
+  if (body.body !== undefined && body.body.length > MAX_BODY) {
+    return NextResponse.json(
+      { error: `Body must be ${MAX_BODY} characters or fewer` },
+      { status: 400 },
+    );
+  }
+
+  if (body.title === undefined && body.body === undefined) {
+    return NextResponse.json({ error: "At least one of title or body is required" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    await withAuthRetry((octokit) =>
+      updateIssue(octokit, owner, repo, issueNumber, {
+        title: body.title?.trim(),
+        body: body.body !== undefined ? body.body.trim() : undefined,
+      }),
+    );
+
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+
+    log.info({ msg: "api_issue_updated", owner, repo, issueNumber });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_update_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
   }
 }

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/route.ts
@@ -41,8 +41,8 @@ export async function GET(
     );
     return NextResponse.json(result);
   } catch (err) {
-    console.error(`[issuectl] GET /api/v1/issues/${owner}/${repo}/${issueNumber} failed:`, err);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    log.error({ err, msg: "api_issue_detail_failed", owner, repo, issueNumber });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
   }
 }
 
@@ -101,6 +101,8 @@ export async function PATCH(
       return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
     }
 
+    // Note: body.trim() may produce an empty string — this is intentional.
+    // GitHub allows clearing an issue body to empty.
     await withAuthRetry((octokit) =>
       updateIssue(octokit, owner, repo, issueNumber, {
         title: body.title?.trim(),

--- a/packages/web/app/api/v1/user/route.ts
+++ b/packages/web/app/api/v1/user/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { withAuthRetry, formatErrorForUser } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const result = await withAuthRetry(async (octokit) => {
+      const { data } = await octokit.rest.users.getAuthenticated();
+      return { login: data.login };
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    log.error({ err, msg: "api_user_failed" });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `EditIssueSheet` for editing issue title/body
- Adds `EditCommentSheet` for editing comments
- Adds `LabelManagementSheet` for toggling labels on issues
- Context menus on `IssueDetailView` for edit/delete comments (ownership-gated)
- Adds `PATCH/DELETE /api/v1/issues/[owner]/[repo]/[number]/comments` endpoints
- Adds `POST /api/v1/issues/[owner]/[repo]/[number]/labels` toggle endpoint
- `APIClient+DetailActions.swift` extension for detail action API calls

Closes #263, closes #264, closes #265

## Review findings addressed
- Comment ownership verification (only show edit/delete for own comments)
- Comment delete errors now shown as modal alerts
- Label load failure shows retry button instead of "No Labels"
- Label toggle race condition fixed (Set instead of single String)
- Label name trimmed server-side before GitHub API call
- GET handler uses structured logging instead of console.error
- Deduplicated `request()` helper (now `internal` on APIClient)

## Test plan
- [ ] Edit an issue title/body — verify changes persist
- [ ] Edit own comment — verify context menu appears
- [ ] Verify edit/delete hidden on other users' comments
- [ ] Delete a comment — verify modal alert on error
- [ ] Toggle labels on/off — verify concurrent toggles work
- [ ] Label load failure — verify retry button appears