### PR TITLE
feat(ios): mine filter and natural language issue parsing

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
+		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
 		2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
@@ -17,6 +18,7 @@
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
 		493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
 		49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */; };
+		5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */; };
 		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
 		59D20056C3E281403735631D /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7701223E13D43C4F74244B0 /* Repo.swift */; };
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
@@ -82,12 +84,14 @@
 		C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailView.swift; sourceTree = "<group>"; };
 		CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftDetailView.swift; sourceTree = "<group>"; };
 		D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseIssueSheet.swift; sourceTree = "<group>"; };
+		D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ListEnhancements.swift"; sourceTree = "<group>"; };
 		D882E51722D47D736257AB4F /* IssueListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListView.swift; sourceTree = "<group>"; };
 		DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Drafts.swift"; sourceTree = "<group>"; };
 		DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickCreateSheet.swift; sourceTree = "<group>"; };
 		E9F091BF822565D8E0F15E7A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRepoSheet.swift; sourceTree = "<group>"; };
 		F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTabs.swift; sourceTree = "<group>"; };
+		F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MineFilterChip.swift; sourceTree = "<group>"; };
 		FD234C4632456D401809E8A5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FE149A3F324BCC15AB57153E /* LabelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPicker.swift; sourceTree = "<group>"; };
 		FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequest.swift; sourceTree = "<group>"; };
@@ -150,6 +154,7 @@
 				E9F091BF822565D8E0F15E7A /* APIClient.swift */,
 				2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */,
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
+				D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
 			);
@@ -237,6 +242,7 @@
 			children = (
 				4403330B1342AA7C19FA797D /* Constants.swift */,
 				FE149A3F324BCC15AB57153E /* LabelPicker.swift */,
+				F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
 				F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */,
 			);
@@ -318,6 +324,7 @@
 			files = (
 				83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */,
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
+				5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,
@@ -340,6 +347,7 @@
 				BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */,
 				581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
+				2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,
 				65142BB24364562CB5305E0F /* PRListView.swift in Sources */,

--- a/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
+++ b/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// MARK: - Response types for list enhancement endpoints
+
+struct UserResponse: Codable, Sendable {
+    let login: String
+}
+
+struct ParsedIssue: Codable, Identifiable, Sendable {
+    let id: String
+    let originalText: String
+    let title: String
+    let body: String
+    let type: String
+    let repoOwner: String?
+    let repoName: String?
+    let repoConfidence: Double
+    let suggestedLabels: [String]
+    let clarity: String
+}
+
+struct ParseResponse: Codable, Sendable {
+    let parsed: ParsedIssuesData
+}
+
+struct ParsedIssuesData: Codable, Sendable {
+    let issues: [ParsedIssue]
+    let suggestedOrder: [String]
+}
+
+struct ParseRequestBody: Encodable, Sendable {
+    let input: String
+}
+
+struct ReviewedIssue: Encodable, Sendable {
+    let id: String
+    let title: String
+    let body: String
+    let owner: String
+    let repo: String
+    let labels: [String]
+    let accepted: Bool
+}
+
+struct BatchCreateRequestBody: Encodable, Sendable {
+    let issues: [ReviewedIssue]
+}
+
+struct BatchCreateResult: Codable, Sendable {
+    let created: Int
+    let drafted: Int
+    let failed: Int
+    let results: [BatchCreateItemResult]
+}
+
+struct BatchCreateItemResult: Codable, Identifiable, Sendable {
+    let id: String
+    let success: Bool
+    let issueNumber: Int?
+    let draftId: String?
+    let error: String?
+    let owner: String
+    let repo: String
+}
+
+// MARK: - APIClient extension for list enhancements
+
+extension APIClient {
+
+    /// Fetch the authenticated GitHub user login.
+    func currentUser() async throws -> UserResponse {
+        let (data, _) = try await requestData(path: "/api/v1/user")
+        return try makeDecoder().decode(UserResponse.self, from: data)
+    }
+
+    /// Parse natural language text into structured issues via Claude.
+    func parseNaturalLanguage(input: String) async throws -> ParsedIssuesData {
+        let body = ParseRequestBody(input: input)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(path: "/api/v1/parse", method: "POST", body: bodyData)
+        return try makeDecoder().decode(ParseResponse.self, from: data).parsed
+    }
+
+    /// Batch create issues from reviewed/accepted parsed results.
+    func batchCreateIssues(issues: [ReviewedIssue]) async throws -> BatchCreateResult {
+        let body = BatchCreateRequestBody(issues: issues)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await requestData(path: "/api/v1/parse/create", method: "POST", body: bodyData)
+        return try makeDecoder().decode(BatchCreateResult.self, from: data)
+    }
+
+    // MARK: - Internal helpers
+
+    /// Exposed wrapper around the private `request` method.
+    /// Uses the same auth / error-handling logic as every other endpoint.
+    private func requestData(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+        guard let base = URL(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+
+        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
+        urlRequest.httpMethod = method
+        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body { urlRequest.httpBody = body }
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw APIError.unauthorized
+        }
+        if httpResponse.statusCode >= 400 {
+            let errorBody = try? JSONDecoder().decode(ErrorBody.self, from: data)
+            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
+        }
+
+        return (data, httpResponse)
+    }
+
+    private func makeDecoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+}
+
+/// Matches the shape of error responses from the server.
+/// Named differently from the private `ErrorResponse` in APIClient.swift
+/// to avoid collision.
+private struct ErrorBody: Codable {
+    let error: String
+}

--- a/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
+++ b/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
@@ -69,67 +69,23 @@ extension APIClient {
 
     /// Fetch the authenticated GitHub user login.
     func currentUser() async throws -> UserResponse {
-        let (data, _) = try await requestData(path: "/api/v1/user")
-        return try makeDecoder().decode(UserResponse.self, from: data)
+        let (data, _) = try await request(path: "/api/v1/user")
+        return try decoder.decode(UserResponse.self, from: data)
     }
 
     /// Parse natural language text into structured issues via Claude.
     func parseNaturalLanguage(input: String) async throws -> ParsedIssuesData {
         let body = ParseRequestBody(input: input)
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(path: "/api/v1/parse", method: "POST", body: bodyData)
-        return try makeDecoder().decode(ParseResponse.self, from: data).parsed
+        let (data, _) = try await request(path: "/api/v1/parse", method: "POST", body: bodyData)
+        return try decoder.decode(ParseResponse.self, from: data).parsed
     }
 
     /// Batch create issues from reviewed/accepted parsed results.
     func batchCreateIssues(issues: [ReviewedIssue]) async throws -> BatchCreateResult {
         let body = BatchCreateRequestBody(issues: issues)
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await requestData(path: "/api/v1/parse/create", method: "POST", body: bodyData)
-        return try makeDecoder().decode(BatchCreateResult.self, from: data)
+        let (data, _) = try await request(path: "/api/v1/parse/create", method: "POST", body: bodyData)
+        return try decoder.decode(BatchCreateResult.self, from: data)
     }
-
-    // MARK: - Internal helpers
-
-    /// Exposed wrapper around the private `request` method.
-    /// Uses the same auth / error-handling logic as every other endpoint.
-    private func requestData(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
-        guard let base = URL(string: serverURL) else {
-            throw APIError.notConfigured
-        }
-
-        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
-        urlRequest.httpMethod = method
-        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let body { urlRequest.httpBody = body }
-
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw APIError.invalidResponse
-        }
-
-        if httpResponse.statusCode == 401 {
-            throw APIError.unauthorized
-        }
-        if httpResponse.statusCode >= 400 {
-            let errorBody = try? JSONDecoder().decode(ErrorBody.self, from: data)
-            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Unknown error")
-        }
-
-        return (data, httpResponse)
-    }
-
-    private func makeDecoder() -> JSONDecoder {
-        let d = JSONDecoder()
-        d.keyDecodingStrategy = .convertFromSnakeCase
-        return d
-    }
-}
-
-/// Matches the shape of error responses from the server.
-/// Named differently from the private `ErrorResponse` in APIClient.swift
-/// to avoid collision.
-private struct ErrorBody: Codable {
-    let error: String
 }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -12,6 +12,9 @@ struct IssueListView: View {
     @State private var selectedRepoIds: Set<Int> = []
     @State private var sortOrder: SortOrder = .updated
     @State private var showCreateSheet = false
+    @State private var showParseSheet = false
+    @State private var mineOnly = false
+    @State private var currentUserLogin: String?
 
     // Swipe action state
     @State private var showCloseConfirm = false
@@ -45,15 +48,21 @@ struct IssueListView: View {
         runningIssuesByRepo[repoFullName]?.contains(issue.number) ?? false
     }
 
-    // Issues filtered by selected repos (before section/sort filtering)
+    // Issues filtered by selected repos and "mine" toggle (before section/sort filtering)
     private var repoFilteredIssues: [GitHubIssue] {
+        var items: [GitHubIssue]
         if selectedRepoIds.isEmpty {
-            return allIssues
+            items = allIssues
+        } else {
+            let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
+            items = issuesByRepo
+                .filter { selectedRepoNames.contains($0.key) }
+                .values.flatMap { $0 }
         }
-        let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
-        return issuesByRepo
-            .filter { selectedRepoNames.contains($0.key) }
-            .values.flatMap { $0 }
+        if mineOnly, let login = currentUserLogin {
+            items = items.filter { $0.user?.login == login }
+        }
+        return items
     }
 
     private var filteredIssues: [GitHubIssue] {
@@ -125,8 +134,12 @@ struct IssueListView: View {
                 SectionTabs(selected: $section, counts: sectionCounts)
                     .padding(.vertical, 8)
 
-                RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    .padding(.bottom, 8)
+                HStack(spacing: 0) {
+                    RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
+                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil)
+                        .padding(.trailing, 16)
+                }
+                .padding(.bottom, 8)
 
                 Divider()
 
@@ -169,8 +182,17 @@ struct IssueListView: View {
                     }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showCreateSheet = true
+                    Menu {
+                        Button {
+                            showCreateSheet = true
+                        } label: {
+                            Label("Quick Create", systemImage: "plus")
+                        }
+                        Button {
+                            showParseSheet = true
+                        } label: {
+                            Label("Parse with AI", systemImage: "text.viewfinder")
+                        }
                     } label: {
                         Image(systemName: "plus")
                     }
@@ -184,6 +206,9 @@ struct IssueListView: View {
             }
             .sheet(isPresented: $showCreateSheet) {
                 QuickCreateSheet(repos: repos, onSuccess: { Task { await loadAll(refresh: true) } })
+            }
+            .sheet(isPresented: $showParseSheet) {
+                ParseView()
             }
             .sheet(isPresented: $showLaunchSheet) {
                 if let target = launchTarget {
@@ -374,7 +399,7 @@ struct IssueListView: View {
         do {
             repos = try await api.repos()
 
-            // Drafts and deployments are supplementary — fetch independently so a failure
+            // Drafts, deployments, and user are supplementary — fetch independently so a failure
             // doesn't block the primary issue list.
             async let draftsFetch: DraftsResponse? = {
                 do { return try await api.listDrafts() }
@@ -384,9 +409,16 @@ struct IssueListView: View {
                 do { return try await api.activeDeployments() }
                 catch { return nil }
             }()
+            async let userFetch: UserResponse? = {
+                do { return try await api.currentUser() }
+                catch { return nil }
+            }()
 
             drafts = await draftsFetch?.drafts ?? drafts
             activeDeployments = await deploymentsFetch?.deployments ?? activeDeployments
+            if let user = await userFetch {
+                currentUserLogin = user.login
+            }
 
             var failedRepos: [String] = []
             await withTaskGroup(of: (String, String, [GitHubIssue]?).self) { group in

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -15,6 +15,7 @@ struct IssueListView: View {
     @State private var showParseSheet = false
     @State private var mineOnly = false
     @State private var currentUserLogin: String?
+    @State private var userFetchFailed = false
 
     // Swipe action state
     @State private var showCloseConfirm = false
@@ -136,7 +137,7 @@ struct IssueListView: View {
 
                 HStack(spacing: 0) {
                     RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil)
+                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil, isDisabled: userFetchFailed)
                         .padding(.trailing, 16)
                 }
                 .padding(.bottom, 8)
@@ -409,15 +410,15 @@ struct IssueListView: View {
                 do { return try await api.activeDeployments() }
                 catch { return nil }
             }()
-            async let userFetch: UserResponse? = {
-                do { return try await api.currentUser() }
-                catch { return nil }
-            }()
-
             drafts = await draftsFetch?.drafts ?? drafts
             activeDeployments = await deploymentsFetch?.deployments ?? activeDeployments
-            if let user = await userFetch {
+
+            do {
+                let user = try await api.currentUser()
                 currentUserLogin = user.login
+                userFetchFailed = false
+            } catch {
+                userFetchFailed = true
             }
 
             var failedRepos: [String] = []

--- a/ios/IssueCTL/Views/Issues/ParseResultRow.swift
+++ b/ios/IssueCTL/Views/Issues/ParseResultRow.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct ParseResultRow: View {
+    let issue: ParsedIssue
+    let repos: [Repo]
+    let isAccepted: Bool
+    let onToggleAccepted: () -> Void
+    let selectedRepo: (owner: String, name: String)?
+    let onSelectRepo: (String, String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(issue.title)
+                        .font(.body.weight(.medium))
+                        .foregroundStyle(isAccepted ? .primary : .secondary)
+                        .strikethrough(!isAccepted)
+
+                    if !issue.body.isEmpty {
+                        Text(issue.body)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    onToggleAccepted()
+                } label: {
+                    Image(systemName: isAccepted ? "checkmark.circle.fill" : "circle")
+                        .font(.title3)
+                        .foregroundStyle(isAccepted ? .green : .secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(spacing: 8) {
+                // Type badge
+                Text(issue.type.capitalized)
+                    .font(.caption2.weight(.medium))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(typeColor(issue.type).opacity(0.15))
+                    .foregroundStyle(typeColor(issue.type))
+                    .clipShape(Capsule())
+
+                // Clarity indicator
+                if issue.clarity != "clear" {
+                    Label(issue.clarity == "ambiguous" ? "Ambiguous" : "Unknown repo",
+                          systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+
+                // Labels
+                ForEach(issue.suggestedLabels.prefix(3), id: \.self) { label in
+                    Text(label)
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+
+            // Repo picker
+            if isAccepted {
+                Menu {
+                    ForEach(repos) { repo in
+                        Button {
+                            onSelectRepo(repo.owner, repo.name)
+                        } label: {
+                            if selectedRepo?.owner == repo.owner && selectedRepo?.name == repo.name {
+                                Label(repo.fullName, systemImage: "checkmark")
+                            } else {
+                                Text(repo.fullName)
+                            }
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "folder")
+                            .font(.caption2)
+                        Text(selectedRepo.map { "\($0.owner)/\($0.name)" } ?? "Select repo...")
+                            .font(.caption)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.secondary.opacity(0.1))
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(selectedRepo != nil ? Color.primary : Color.orange)
+            }
+        }
+        .padding(.vertical, 4)
+        .opacity(isAccepted ? 1.0 : 0.6)
+    }
+
+    private func typeColor(_ type: String) -> Color {
+        switch type {
+        case "bug": .red
+        case "feature": .blue
+        case "enhancement": .green
+        case "refactor": .purple
+        case "docs": .orange
+        case "chore": .secondary
+        default: .secondary
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Issues/ParseView.swift
+++ b/ios/IssueCTL/Views/Issues/ParseView.swift
@@ -13,6 +13,7 @@ struct ParseView: View {
     @State private var repos: [Repo] = []
     @State private var errorMessage: String?
     @State private var creationResult: BatchCreateResult?
+    @State private var repoLoadError: String?
 
     private var hasParsed: Bool { !parsedIssues.isEmpty }
     private var acceptedCount: Int { acceptedIds.count }
@@ -39,11 +40,7 @@ struct ParseView: View {
                 }
             }
             .task {
-                do {
-                    repos = try await api.repos()
-                } catch {
-                    // Non-fatal — repo picker will just be empty
-                }
+                await loadRepos()
             }
         }
     }
@@ -72,6 +69,23 @@ struct ParseView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+            if let repoLoadError {
+                VStack(spacing: 8) {
+                    Label("Failed to load repositories", systemImage: "exclamationmark.triangle")
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+                    Text(repoLoadError)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Retry") { Task { await loadRepos() } }
+                        .font(.subheadline)
+                        .buttonStyle(.bordered)
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
             }
 
             if let errorMessage {
@@ -199,11 +213,9 @@ struct ParseView: View {
             if result.failed > 0 {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(result.results.filter { !$0.success }) { item in
-                        if let error = item.error {
-                            Label(error, systemImage: "xmark.circle")
-                                .font(.caption)
-                                .foregroundStyle(.red)
-                        }
+                        Label(item.error ?? "Unknown error", systemImage: "xmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
                     }
                 }
                 .padding()
@@ -221,6 +233,15 @@ struct ParseView: View {
     }
 
     // MARK: - Actions
+
+    private func loadRepos() async {
+        repoLoadError = nil
+        do {
+            repos = try await api.repos()
+        } catch {
+            repoLoadError = error.localizedDescription
+        }
+    }
 
     private func parse() async {
         isParsing = true
@@ -251,19 +272,20 @@ struct ParseView: View {
         isCreating = true
         errorMessage = nil
         do {
-            let reviewed = parsedIssues.map { issue in
-                let accepted = acceptedIds.contains(issue.id)
-                let repo = repoSelections[issue.id]
-                return ReviewedIssue(
-                    id: issue.id,
-                    title: issue.title,
-                    body: issue.body,
-                    owner: repo?.owner ?? "",
-                    repo: repo?.name ?? "",
-                    labels: issue.suggestedLabels,
-                    accepted: accepted
-                )
-            }
+            let reviewed = parsedIssues
+                .filter { acceptedIds.contains($0.id) }
+                .map { issue in
+                    let repo = repoSelections[issue.id]
+                    return ReviewedIssue(
+                        id: issue.id,
+                        title: issue.title,
+                        body: issue.body,
+                        owner: repo?.owner ?? "",
+                        repo: repo?.name ?? "",
+                        labels: issue.suggestedLabels,
+                        accepted: true
+                    )
+                }
             creationResult = try await api.batchCreateIssues(issues: reviewed)
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/IssueCTL/Views/Issues/ParseView.swift
+++ b/ios/IssueCTL/Views/Issues/ParseView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+
+struct ParseView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var input = ""
+    @State private var isParsing = false
+    @State private var isCreating = false
+    @State private var parsedIssues: [ParsedIssue] = []
+    @State private var acceptedIds: Set<String> = []
+    @State private var repoSelections: [String: (owner: String, name: String)] = [:]
+    @State private var repos: [Repo] = []
+    @State private var errorMessage: String?
+    @State private var creationResult: BatchCreateResult?
+
+    private var hasParsed: Bool { !parsedIssues.isEmpty }
+    private var acceptedCount: Int { acceptedIds.count }
+    private var canCreate: Bool {
+        acceptedCount > 0 && acceptedIds.allSatisfy { repoSelections[$0] != nil }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let creationResult {
+                    creationResultView(creationResult)
+                } else if hasParsed {
+                    reviewView
+                } else {
+                    inputView
+                }
+            }
+            .navigationTitle("Parse Issues")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .task {
+                do {
+                    repos = try await api.repos()
+                } catch {
+                    // Non-fatal — repo picker will just be empty
+                }
+            }
+        }
+    }
+
+    // MARK: - Input View
+
+    @ViewBuilder
+    private var inputView: some View {
+        VStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Describe your issues in natural language. You can list multiple issues, use bullet points, or just write freely.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                TextEditor(text: $input)
+                    .frame(minHeight: 200)
+                    .padding(8)
+                    .background(Color(.systemGray6))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(Color.secondary.opacity(0.2))
+                    )
+
+                Text("\(input.count) / 8192")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+            }
+
+            Button {
+                Task { await parse() }
+            } label: {
+                HStack {
+                    if isParsing {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(isParsing ? "Parsing..." : "Parse with AI")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isParsing || input.count > 8192)
+
+            Spacer()
+        }
+        .padding()
+    }
+
+    // MARK: - Review View
+
+    @ViewBuilder
+    private var reviewView: some View {
+        VStack(spacing: 0) {
+            // Summary bar
+            HStack {
+                Text("\(parsedIssues.count) issues found")
+                    .font(.subheadline.weight(.medium))
+                Spacer()
+                Text("\(acceptedCount) accepted")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            List {
+                if let errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.subheadline)
+                }
+
+                ForEach(parsedIssues) { issue in
+                    ParseResultRow(
+                        issue: issue,
+                        repos: repos,
+                        isAccepted: acceptedIds.contains(issue.id),
+                        onToggleAccepted: {
+                            if acceptedIds.contains(issue.id) {
+                                acceptedIds.remove(issue.id)
+                            } else {
+                                acceptedIds.insert(issue.id)
+                            }
+                        },
+                        selectedRepo: repoSelections[issue.id],
+                        onSelectRepo: { owner, name in
+                            repoSelections[issue.id] = (owner, name)
+                        }
+                    )
+                }
+            }
+            .listStyle(.plain)
+
+            Divider()
+
+            // Bottom action bar
+            HStack(spacing: 12) {
+                Button {
+                    // Reset to input view
+                    parsedIssues = []
+                    acceptedIds = []
+                    repoSelections = [:]
+                    errorMessage = nil
+                } label: {
+                    Text("Start Over")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    Task { await createIssues() }
+                } label: {
+                    HStack {
+                        if isCreating {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(isCreating ? "Creating..." : "Create \(acceptedCount) Issue\(acceptedCount == 1 ? "" : "s")")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canCreate || isCreating)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Creation Result View
+
+    @ViewBuilder
+    private func creationResultView(_ result: BatchCreateResult) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: result.failed == 0 ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(result.failed == 0 ? .green : .orange)
+
+            Text(resultSummary(result))
+                .font(.headline)
+                .multilineTextAlignment(.center)
+
+            if result.failed > 0 {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(result.results.filter { !$0.success }) { item in
+                        if let error = item.error {
+                            Label(error, systemImage: "xmark.circle")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+
+            Spacer()
+
+            Button("Done") { dismiss() }
+                .buttonStyle(.borderedProminent)
+                .frame(maxWidth: .infinity)
+        }
+        .padding()
+    }
+
+    // MARK: - Actions
+
+    private func parse() async {
+        isParsing = true
+        errorMessage = nil
+        do {
+            let result = try await api.parseNaturalLanguage(input: input)
+            parsedIssues = result.issues
+
+            // Auto-accept all and pre-select repos where confidence is high
+            acceptedIds = Set(result.issues.map(\.id))
+            for issue in result.issues {
+                if let owner = issue.repoOwner, let name = issue.repoName,
+                   issue.repoConfidence >= 0.7,
+                   repos.contains(where: { $0.owner == owner && $0.name == name }) {
+                    repoSelections[issue.id] = (owner, name)
+                } else if repos.count == 1, let repo = repos.first {
+                    // Single repo — auto-assign
+                    repoSelections[issue.id] = (repo.owner, repo.name)
+                }
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isParsing = false
+    }
+
+    private func createIssues() async {
+        isCreating = true
+        errorMessage = nil
+        do {
+            let reviewed = parsedIssues.map { issue in
+                let accepted = acceptedIds.contains(issue.id)
+                let repo = repoSelections[issue.id]
+                return ReviewedIssue(
+                    id: issue.id,
+                    title: issue.title,
+                    body: issue.body,
+                    owner: repo?.owner ?? "",
+                    repo: repo?.name ?? "",
+                    labels: issue.suggestedLabels,
+                    accepted: accepted
+                )
+            }
+            creationResult = try await api.batchCreateIssues(issues: reviewed)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isCreating = false
+    }
+
+    private func resultSummary(_ result: BatchCreateResult) -> String {
+        var parts: [String] = []
+        if result.created > 0 {
+            parts.append("\(result.created) issue\(result.created == 1 ? "" : "s") created")
+        }
+        if result.drafted > 0 {
+            parts.append("\(result.drafted) draft\(result.drafted == 1 ? "" : "s") saved")
+        }
+        if result.failed > 0 {
+            parts.append("\(result.failed) failed")
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -9,6 +9,8 @@ struct PRListView: View {
     @State private var section: PRSection = .open
     @State private var selectedRepoIds: Set<Int> = []
     @State private var sortOrder: SortOrder = .updated
+    @State private var mineOnly = false
+    @State private var currentUserLogin: String?
 
     // Swipe state
     @State private var showMergeConfirm = false
@@ -20,15 +22,21 @@ struct PRListView: View {
         pullsByRepo.values.flatMap { $0 }
     }
 
-    // Pulls filtered by selected repos (before section/sort filtering)
+    // Pulls filtered by selected repos and "mine" toggle (before section/sort filtering)
     private var repoFilteredPulls: [GitHubPull] {
+        var items: [GitHubPull]
         if selectedRepoIds.isEmpty {
-            return allPulls
+            items = allPulls
+        } else {
+            let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
+            items = pullsByRepo
+                .filter { selectedRepoNames.contains($0.key) }
+                .values.flatMap { $0 }
         }
-        let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
-        return pullsByRepo
-            .filter { selectedRepoNames.contains($0.key) }
-            .values.flatMap { $0 }
+        if mineOnly, let login = currentUserLogin {
+            items = items.filter { $0.user?.login == login }
+        }
+        return items
     }
 
     private var filteredPulls: [GitHubPull] {
@@ -81,8 +89,12 @@ struct PRListView: View {
                 SectionTabs(selected: $section, counts: sectionCounts)
                     .padding(.vertical, 8)
 
-                RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    .padding(.bottom, 8)
+                HStack(spacing: 0) {
+                    RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
+                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil)
+                        .padding(.trailing, 16)
+                }
+                .padding(.bottom, 8)
 
                 Divider()
 
@@ -220,6 +232,14 @@ struct PRListView: View {
         errorMessage = nil
         do {
             repos = try await api.repos()
+
+            // Fetch current user for "mine" filter — non-blocking
+            if currentUserLogin == nil {
+                if let user = try? await api.currentUser() {
+                    currentUserLogin = user.login
+                }
+            }
+
             var failedRepos: [String] = []
             await withTaskGroup(of: (String, String, [GitHubPull]?).self) { group in
                 for repo in repos {

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -11,6 +11,7 @@ struct PRListView: View {
     @State private var sortOrder: SortOrder = .updated
     @State private var mineOnly = false
     @State private var currentUserLogin: String?
+    @State private var userFetchFailed = false
 
     // Swipe state
     @State private var showMergeConfirm = false
@@ -91,7 +92,7 @@ struct PRListView: View {
 
                 HStack(spacing: 0) {
                     RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil)
+                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil, isDisabled: userFetchFailed)
                         .padding(.trailing, 16)
                 }
                 .padding(.bottom, 8)
@@ -234,10 +235,12 @@ struct PRListView: View {
             repos = try await api.repos()
 
             // Fetch current user for "mine" filter — non-blocking
-            if currentUserLogin == nil {
-                if let user = try? await api.currentUser() {
-                    currentUserLogin = user.login
-                }
+            do {
+                let user = try await api.currentUser()
+                currentUserLogin = user.login
+                userFetchFailed = false
+            } catch {
+                userFetchFailed = true
             }
 
             var failedRepos: [String] = []

--- a/ios/IssueCTL/Views/Shared/MineFilterChip.swift
+++ b/ios/IssueCTL/Views/Shared/MineFilterChip.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 
 /// A toggle chip that filters lists to show only items created by the current user.
+/// Shows as disabled (grayed out) when the user fetch failed, rather than hiding entirely.
 struct MineFilterChip: View {
     @Binding var isOn: Bool
     let isAvailable: Bool
+    var isDisabled: Bool = false
+
+    private var shouldShow: Bool { isAvailable || isDisabled }
 
     var body: some View {
-        if isAvailable {
+        if shouldShow {
             Button {
                 isOn.toggle()
             } label: {
@@ -27,8 +31,10 @@ struct MineFilterChip: View {
                         .strokeBorder(isOn ? Color.accentColor : Color.secondary.opacity(0.3), lineWidth: 1)
                 )
                 .clipShape(Capsule())
+                .opacity(isDisabled ? 0.4 : 1.0)
             }
             .buttonStyle(.plain)
+            .disabled(isDisabled)
         }
     }
 }

--- a/ios/IssueCTL/Views/Shared/MineFilterChip.swift
+++ b/ios/IssueCTL/Views/Shared/MineFilterChip.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// A toggle chip that filters lists to show only items created by the current user.
+struct MineFilterChip: View {
+    @Binding var isOn: Bool
+    let isAvailable: Bool
+
+    var body: some View {
+        if isAvailable {
+            Button {
+                isOn.toggle()
+            } label: {
+                HStack(spacing: 4) {
+                    if isOn {
+                        Image(systemName: "checkmark")
+                            .font(.caption2)
+                    }
+                    Text("Mine")
+                        .font(.caption.weight(.medium))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(isOn ? Color.accentColor.opacity(0.2) : Color.clear)
+                .foregroundStyle(isOn ? Color.accentColor : Color.secondary)
+                .overlay(
+                    Capsule()
+                        .strokeBorder(isOn ? Color.accentColor : Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}

--- a/packages/web/app/api/v1/parse/create/route.ts
+++ b/packages/web/app/api/v1/parse/create/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { batchCreateIssues } from "@/lib/actions/parse";
+
+export const dynamic = "force-dynamic";
+
+const MAX_BATCH_SIZE = 25;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const body = await request.json();
+    const issues = body?.issues;
+
+    if (!Array.isArray(issues) || issues.length === 0) {
+      return NextResponse.json(
+        { error: "Request body must include a non-empty 'issues' array" },
+        { status: 400 },
+      );
+    }
+
+    if (issues.length > MAX_BATCH_SIZE) {
+      return NextResponse.json(
+        { error: `Maximum ${MAX_BATCH_SIZE} issues per batch` },
+        { status: 400 },
+      );
+    }
+
+    const result = await batchCreateIssues(issues);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[issuectl] POST /api/v1/parse/create failed:", err);
+    return NextResponse.json(
+      { error: "Failed to create issues" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/parse/create/route.ts
+++ b/packages/web/app/api/v1/parse/create/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { formatErrorForUser } from "@issuectl/core";
 import { batchCreateIssues } from "@/lib/actions/parse";
 
 export const dynamic = "force-dynamic";
@@ -28,12 +30,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    for (const issue of issues) {
+      if (
+        typeof issue.title !== "string" ||
+        typeof issue.owner !== "string" ||
+        typeof issue.repo !== "string" ||
+        typeof issue.accepted !== "boolean"
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "Each issue must have title (string), owner (string), repo (string), and accepted (boolean)",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
     const result = await batchCreateIssues(issues);
     return NextResponse.json(result);
   } catch (err) {
-    console.error("[issuectl] POST /api/v1/parse/create failed:", err);
+    log.error({ err, msg: "api_parse_create_failed" });
     return NextResponse.json(
-      { error: "Failed to create issues" },
+      { error: formatErrorForUser(err) },
       { status: 500 },
     );
   }

--- a/packages/web/app/api/v1/parse/route.ts
+++ b/packages/web/app/api/v1/parse/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { formatErrorForUser } from "@issuectl/core";
 import { parseNaturalLanguage } from "@/lib/actions/parse";
 
 export const dynamic = "force-dynamic";
@@ -36,9 +38,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result.data);
   } catch (err) {
-    console.error("[issuectl] POST /api/v1/parse failed:", err);
+    log.error({ err, msg: "api_parse_failed" });
     return NextResponse.json(
-      { error: "Failed to parse input" },
+      { error: formatErrorForUser(err) },
       { status: 500 },
     );
   }

--- a/packages/web/app/api/v1/parse/route.ts
+++ b/packages/web/app/api/v1/parse/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { parseNaturalLanguage } from "@/lib/actions/parse";
+
+export const dynamic = "force-dynamic";
+
+const MAX_PARSE_INPUT = 8192;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const body = await request.json();
+    const input = body?.input;
+
+    if (typeof input !== "string" || !input.trim()) {
+      return NextResponse.json(
+        { error: "Request body must include a non-empty 'input' string" },
+        { status: 400 },
+      );
+    }
+
+    if (input.length > MAX_PARSE_INPUT) {
+      return NextResponse.json(
+        { error: `Input must be ${MAX_PARSE_INPUT} characters or fewer` },
+        { status: 400 },
+      );
+    }
+
+    const result = await parseNaturalLanguage(input);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 422 });
+    }
+
+    return NextResponse.json(result.data);
+  } catch (err) {
+    console.error("[issuectl] POST /api/v1/parse failed:", err);
+    return NextResponse.json(
+      { error: "Failed to parse input" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `MineFilterChip` toggle for filtering issues/PRs by current user
- Adds `ParseView` with three-phase NLP flow: input → review → create
- Adds `ParseResultRow` for displaying parsed issue previews
- Mine filter integrated into both `IssueListView` and `PRListView`
- Adds `POST /api/v1/parse` and `POST /api/v1/parse/create` endpoints
- `APIClient+ListEnhancements.swift` extension for list enhancement API calls

Closes #267, closes #268

## Review findings addressed
- User fetch failure shows disabled Mine chip instead of hiding it
- `createIssues()` now filters to accepted-only issues
- All routes use structured `log.error` and `formatErrorForUser`
- Repo fetch failure in ParseView shows error with retry button
- Per-issue shape validation in parse/create route
- Failed items with nil error now display "Unknown error"
- Deduplicated `request()` helper (now `internal` on APIClient)

## Test plan
- [ ] Mine filter chip — toggle on/off, verify filtering
- [ ] Mine chip disabled state when user fetch fails
- [ ] Parse flow: enter text → review parsed issues → create
- [ ] Reject some parsed issues → verify only accepted ones created
- [ ] Parse with no repos loaded — verify error + retry
- [ ] Invalid parse input — verify 400 responses