### PR TITLE
fix(ci): use generic simulator destination for iOS builds

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,7 +32,7 @@ jobs:
           xcodebuild build \
             -project ios/IssueCTL.xcodeproj \
             -scheme IssueCTL \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- Changes iOS CI xcodebuild destination from `iPhone 16,OS=latest` to `generic/platform=iOS Simulator`
- The specific simulator name was intermittently unavailable on `macos-15` runners
- Generic destination is sufficient for build-only verification (no app launch needed)

## Test plan
- [ ] iOS CI workflow passes on this PR (validates the fix itself)