### PR TITLE
feat(ios): issue reassignment with collaborator picker

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -12,7 +12,9 @@
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
 		2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
+		327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D2FEDC36ACDF7207272AE3 /* ParseView.swift */; };
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
+		34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */; };
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
 		4451AE4574EA7D0F86AEE021 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403330B1342AA7C19FA797D /* Constants.swift */; };
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
@@ -25,10 +27,12 @@
 		65142BB24364562CB5305E0F /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472896A74FFDCC9B621A984E /* PRListView.swift */; };
 		661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D638F823877AD0CAA946A4 /* CommentView.swift */; };
 		6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */; };
+		6BD63A6BA0C7651A5C860A82 /* ParseResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE8B812763DC773F8484C7D /* ParseResultRow.swift */; };
 		78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E1C810B3BD014B117301B /* IssueCTLApp.swift */; };
 		83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */; };
 		87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
+		916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */; };
 		9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */; };
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
 		9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
@@ -59,14 +63,18 @@
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		223E1C810B3BD014B117301B /* IssueCTLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLApp.swift; sourceTree = "<group>"; };
 		22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIssueSheet.swift; sourceTree = "<group>"; };
+		22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Assignment.swift"; sourceTree = "<group>"; };
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		4403330B1342AA7C19FA797D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		45D2FEDC36ACDF7207272AE3 /* ParseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseView.swift; sourceTree = "<group>"; };
 		472896A74FFDCC9B621A984E /* PRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentSheet.swift; sourceTree = "<group>"; };
+		5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSheet.swift; sourceTree = "<group>"; };
+		6BE8B812763DC773F8484C7D /* ParseResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultRow.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
 		767FFF9158E604C69C4007DB /* PRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDetailView.swift; sourceTree = "<group>"; };
 		78D638F823877AD0CAA946A4 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
@@ -152,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				E9F091BF822565D8E0F15E7A /* APIClient.swift */,
+				22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */,
 				2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */,
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
 				D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */,
@@ -252,6 +261,7 @@
 		F68AB3C989164D8B4EF2E542 /* Issues */ = {
 			isa = PBXGroup;
 			children = (
+				5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */,
 				D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */,
 				78D638F823877AD0CAA946A4 /* CommentView.swift */,
 				CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */,
@@ -262,6 +272,8 @@
 				D882E51722D47D736257AB4F /* IssueListView.swift */,
 				7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */,
 				3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */,
+				6BE8B812763DC773F8484C7D /* ParseResultRow.swift */,
+				45D2FEDC36ACDF7207272AE3 /* ParseView.swift */,
 				DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */,
 			);
 			path = Issues;
@@ -322,12 +334,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */,
 				83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */,
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
 				5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,
+				916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */,
 				AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */,
 				C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */,
 				661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */,
@@ -352,6 +366,8 @@
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,
 				65142BB24364562CB5305E0F /* PRListView.swift in Sources */,
 				DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */,
+				6BD63A6BA0C7651A5C860A82 /* ParseResultRow.swift in Sources */,
+				327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */,
 				9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */,
 				0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */,
 				59D20056C3E281403735631D /* Repo.swift in Sources */,

--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -19,6 +19,7 @@ struct GitHubIssue: Codable, Identifiable, Sendable {
     let body: String?
     let state: String
     let labels: [GitHubLabel]
+    let assignees: [GitHubUser]?
     let user: GitHubUser?
     let commentCount: Int
     let createdAt: String

--- a/ios/IssueCTL/Services/APIClient+Assignment.swift
+++ b/ios/IssueCTL/Services/APIClient+Assignment.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - Request/Response Types for Assignment
+
+struct CollaboratorInfo: Codable, Identifiable, Sendable {
+    let login: String
+    let avatarUrl: String
+
+    var id: String { login }
+}
+
+struct CollaboratorsResponse: Codable, Sendable {
+    let collaborators: [CollaboratorInfo]
+}
+
+struct AssigneesUpdateResponse: Codable, Sendable {
+    let assignees: [String]
+}
+
+// MARK: - APIClient Extension
+
+extension APIClient {
+
+    /// Fetch collaborators for a repository (possible assignees).
+    func collaborators(owner: String, repo: String) async throws -> [CollaboratorInfo] {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/collaborators")
+        return try decoder.decode(CollaboratorsResponse.self, from: data).collaborators
+    }
+
+    /// Update the assignees on an issue. Sends the full desired list; the server computes the diff.
+    func updateAssignees(owner: String, repo: String, number: Int, assignees: [String]) async throws -> [String] {
+        let body = try JSONEncoder().encode(["assignees": assignees])
+        let (data, _) = try await request(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/assignees",
+            method: "PUT",
+            body: body
+        )
+        return try decoder.decode(AssigneesUpdateResponse.self, from: data).assignees
+    }
+}

--- a/ios/IssueCTL/Services/APIClient+DetailActions.swift
+++ b/ios/IssueCTL/Services/APIClient+DetailActions.swift
@@ -45,20 +45,9 @@ struct LabelsListResponse: Codable, Sendable {
     let labels: [GitHubLabel]
 }
 
-struct CurrentUserResponse: Codable, Sendable {
-    let login: String
-}
-
 // MARK: - APIClient Extension
 
 extension APIClient {
-
-    // MARK: - Current User
-
-    func currentUser() async throws -> CurrentUserResponse {
-        let (data, _) = try await request(path: "/api/v1/user")
-        return try decoder.decode(CurrentUserResponse.self, from: data)
-    }
 
     // MARK: - Issue Editing (#263)
 

--- a/ios/IssueCTL/Views/Issues/AssigneeSheet.swift
+++ b/ios/IssueCTL/Views/Issues/AssigneeSheet.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+struct AssigneeSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let owner: String
+    let repo: String
+    let number: Int
+    let currentAssignees: [String]
+    let onUpdate: ([String]) -> Void
+
+    @State private var collaborators: [CollaboratorInfo] = []
+    @State private var activeAssignees: Set<String>
+    @State private var isLoading = true
+    @State private var togglingAssignees: Set<String> = []
+    @State private var errorMessage: String?
+    @State private var loadError: String?
+    @State private var searchText = ""
+
+    init(
+        owner: String, repo: String, number: Int,
+        currentAssignees: [String],
+        onUpdate: @escaping ([String]) -> Void
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.currentAssignees = currentAssignees
+        self.onUpdate = onUpdate
+        _activeAssignees = State(initialValue: Set(currentAssignees))
+    }
+
+    private var filteredCollaborators: [CollaboratorInfo] {
+        if searchText.isEmpty {
+            return collaborators
+        }
+        return collaborators.filter {
+            $0.login.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView("Loading collaborators...")
+                } else if loadError != nil {
+                    ContentUnavailableView {
+                        Label("Failed to Load", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text("Could not load collaborators.")
+                    } actions: {
+                        Button("Retry") { Task { await loadCollaborators() } }
+                    }
+                } else if collaborators.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Collaborators", systemImage: "person.2")
+                    } description: {
+                        Text("This repository has no collaborators.")
+                    }
+                } else {
+                    List {
+                        ForEach(filteredCollaborators) { collaborator in
+                            collaboratorRow(collaborator)
+                        }
+                    }
+                    .searchable(text: $searchText, prompt: "Filter collaborators")
+                }
+            }
+            .navigationTitle("Assignees")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .alert("Error", isPresented: .init(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+            .task { await loadCollaborators() }
+        }
+    }
+
+    @ViewBuilder
+    private func collaboratorRow(_ collaborator: CollaboratorInfo) -> some View {
+        let isActive = activeAssignees.contains(collaborator.login)
+        let isCurrentlyToggling = togglingAssignees.contains(collaborator.login)
+
+        Button {
+            Task { await toggle(collaborator: collaborator, isActive: isActive) }
+        } label: {
+            HStack(spacing: 10) {
+                AsyncImage(url: URL(string: collaborator.avatarUrl)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                        .foregroundStyle(.secondary)
+                }
+                .frame(width: 28, height: 28)
+                .clipShape(Circle())
+
+                Text(collaborator.login)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                if isCurrentlyToggling {
+                    ProgressView().controlSize(.small)
+                } else if isActive {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .disabled(isCurrentlyToggling)
+        .accessibilityLabel("\(collaborator.login)\(isActive ? ", assigned" : "")")
+        .accessibilityHint(isActive ? "Double-tap to unassign" : "Double-tap to assign")
+    }
+
+    private func loadCollaborators() async {
+        isLoading = true
+        loadError = nil
+        do {
+            let result = try await api.collaborators(owner: owner, repo: repo)
+            collaborators = result.sorted {
+                $0.login.localizedCaseInsensitiveCompare($1.login) == .orderedAscending
+            }
+        } catch {
+            loadError = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func toggle(collaborator: CollaboratorInfo, isActive: Bool) async {
+        togglingAssignees.insert(collaborator.login)
+        errorMessage = nil
+
+        // Optimistic update
+        var newAssignees: Set<String>
+        if isActive {
+            newAssignees = activeAssignees
+            newAssignees.remove(collaborator.login)
+        } else {
+            newAssignees = activeAssignees
+            newAssignees.insert(collaborator.login)
+        }
+        let previousAssignees = activeAssignees
+        activeAssignees = newAssignees
+
+        do {
+            let finalAssignees = try await api.updateAssignees(
+                owner: owner, repo: repo, number: number,
+                assignees: Array(newAssignees)
+            )
+            activeAssignees = Set(finalAssignees)
+            onUpdate(finalAssignees)
+        } catch {
+            // Rollback optimistic update
+            activeAssignees = previousAssignees
+            errorMessage = error.localizedDescription
+        }
+        togglingAssignees.remove(collaborator.login)
+    }
+}

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -21,6 +21,7 @@ struct IssueDetailView: View {
     // Detail actions state (#263, #264, #265)
     @State private var showEditSheet = false
     @State private var showLabelSheet = false
+    @State private var showAssigneeSheet = false
     @State private var editingComment: GitHubComment?
     @State private var deletingComment: GitHubComment?
     @State private var isDeletingComment = false
@@ -79,6 +80,11 @@ struct IssueDetailView: View {
                         } label: {
                             Label("Manage Labels", systemImage: "tag")
                         }
+                        Button {
+                            showAssigneeSheet = true
+                        } label: {
+                            Label("Manage Assignees", systemImage: "person.badge.plus")
+                        }
                         Divider()
                         Button {
                             showLaunchSheet = true
@@ -131,6 +137,15 @@ struct IssueDetailView: View {
                     owner: owner, repo: repo, number: number,
                     currentLabels: detail.issue.labels,
                     onSuccess: { Task { await load(refresh: true) } }
+                )
+            }
+        }
+        .sheet(isPresented: $showAssigneeSheet) {
+            if let detail {
+                AssigneeSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentAssignees: (detail.issue.assignees ?? []).map(\.login),
+                    onUpdate: { _ in Task { await load(refresh: true) } }
                 )
             }
         }
@@ -201,6 +216,24 @@ struct IssueDetailView: View {
                 FlowLayout(spacing: 6) {
                     ForEach(issue.labels) { label in
                         LabelBadge(label: label)
+                    }
+                }
+            }
+
+            if let assignees = issue.assignees, !assignees.isEmpty {
+                HStack(spacing: 6) {
+                    Image(systemName: "person.2")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    FlowLayout(spacing: 4) {
+                        ForEach(assignees, id: \.login) { assignee in
+                            Text(assignee.login)
+                                .font(.caption)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.secondary.opacity(0.12))
+                                .clipShape(Capsule())
+                        }
                     }
                 }
             }

--- a/packages/core/src/data/issues.test.ts
+++ b/packages/core/src/data/issues.test.ts
@@ -53,6 +53,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     body: "Check `src/index.ts` and https://github.com/owner/repo/blob/main/lib/utils.ts for context",
     state: "open",
     labels: [],
+    assignees: [],
     user: null,
     commentCount: 0,
     createdAt: "2026-01-01T00:00:00Z",

--- a/packages/core/src/data/unified-list.test.ts
+++ b/packages/core/src/data/unified-list.test.ts
@@ -24,6 +24,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     body: "",
     state: "open",
     labels: [],
+    assignees: [],
     user: null,
     commentCount: 0,
     createdAt: "2026-04-01T00:00:00Z",

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from "@octokit/rest";
 import type Database from "better-sqlite3";
-import type { GitHubIssue, GitHubComment, RawGitHubUser } from "./types.js";
+import type { GitHubIssue, GitHubUser, GitHubComment, RawGitHubUser } from "./types.js";
 import { mapUser } from "./types.js";
 import { getRepoById } from "../db/repos.js";
 import { clearCacheKey } from "../db/cache.js";
@@ -13,6 +13,7 @@ function mapIssue(raw: unknown): GitHubIssue {
     body: string | null;
     state: string;
     labels: Array<{ name?: string; color?: string; description?: string | null } | string>;
+    assignees: RawGitHubUser[] | null;
     user: RawGitHubUser;
     comments: number;
     created_at: string;
@@ -32,6 +33,9 @@ function mapIssue(raw: unknown): GitHubIssue {
         color: l.color ?? "",
         description: l.description ?? null,
       })),
+    assignees: (r.assignees ?? [])
+      .map((a) => mapUser(a))
+      .filter((u): u is GitHubUser => u !== null),
     user: mapUser(r.user),
     commentCount: r.comments ?? 0,
     createdAt: r.created_at,

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -15,6 +15,7 @@ export type GitHubIssue = {
   body: string | null;
   state: "open" | "closed";
   labels: GitHubLabel[];
+  assignees: GitHubUser[];
   user: GitHubUser | null;
   commentCount: number;
   createdAt: string;

--- a/packages/core/src/lifecycle/reconcile.test.ts
+++ b/packages/core/src/lifecycle/reconcile.test.ts
@@ -16,6 +16,7 @@ function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
     body: "body",
     state: "open",
     labels: [],
+    assignees: [],
     user: null,
     commentCount: 0,
     createdAt: "2026-01-01T00:00:00Z",

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/assignees/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/assignees/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  clearCacheKey,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type AssigneesBody = {
+  assignees: string[];
+};
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: AssigneesBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.assignees)) {
+    return NextResponse.json({ error: "assignees must be an array of strings" }, { status: 400 });
+  }
+
+  const desired = body.assignees.filter((a) => typeof a === "string" && a.trim());
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const finalAssignees = await withAuthRetry(async (octokit) => {
+      // Fetch current assignees
+      const { data: issue } = await octokit.rest.issues.get({
+        owner,
+        repo,
+        issue_number: issueNumber,
+      });
+
+      const current = (issue.assignees ?? [])
+        .map((a) => a.login)
+        .filter(Boolean);
+
+      const toAdd = desired.filter((a) => !current.includes(a));
+      const toRemove = current.filter((a) => !desired.includes(a));
+
+      if (toAdd.length > 0) {
+        await octokit.rest.issues.addAssignees({
+          owner,
+          repo,
+          issue_number: issueNumber,
+          assignees: toAdd,
+        });
+      }
+
+      if (toRemove.length > 0) {
+        await octokit.rest.issues.removeAssignees({
+          owner,
+          repo,
+          issue_number: issueNumber,
+          assignees: toRemove,
+        });
+      }
+
+      // Re-fetch to get the final state
+      const { data: updated } = await octokit.rest.issues.get({
+        owner,
+        repo,
+        issue_number: issueNumber,
+      });
+
+      return (updated.assignees ?? [])
+        .map((a) => a.login)
+        .filter(Boolean);
+    });
+
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+
+    log.info({ msg: "api_issue_assignees_updated", owner, repo, issueNumber, assignees: finalAssignees });
+    return NextResponse.json({ assignees: finalAssignees });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_assignees_update_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/collaborators/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/collaborators/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { getDb, getRepo, withAuthRetry, formatErrorForUser } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const collaborators = await withAuthRetry(async (octokit) => {
+      const { data } = await octokit.rest.repos.listCollaborators({
+        owner,
+        repo,
+        per_page: 100,
+      });
+      return data.map((c) => ({
+        login: c.login,
+        avatarUrl: c.avatar_url,
+      }));
+    });
+
+    log.info({ msg: "api_collaborators_listed", owner, repo, count: collaborators.length });
+    return NextResponse.json({ collaborators });
+  } catch (err) {
+    log.error({ err, msg: "api_collaborators_list_failed", owner, repo });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `AssigneeSheet` with searchable collaborator list and optimistic toggle UI
- Adds `PUT /api/v1/issues/[owner]/[repo]/[number]/assignees` endpoint (computes diff, syncs with GitHub)
- Adds `GET /api/v1/repos/[owner]/[repo]/collaborators` endpoint
- `APIClient+Assignment.swift` extension for assignment API calls
- Wired into `IssueDetailView` toolbar with assignee display capsules
- Adds `assignees` field to `GitHubIssue` type in core and iOS models
- Fixes pre-existing `currentUser()` ambiguity between DetailActions and ListEnhancements extensions

Closes #262

## Test plan
- [ ] Open issue detail — verify assignees displayed
- [ ] Tap "Manage Assignees" — verify collaborator list loads
- [ ] Toggle assignment on/off — verify optimistic UI with rollback on error
- [ ] Search collaborators — verify filtering works
- [ ] Error state — verify retry button on load failure