### PR TITLE
feat(ios): image uploads on issues via photo picker

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
+		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
 		2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
 		327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D2FEDC36ACDF7207272AE3 /* ParseView.swift */; };
@@ -44,6 +45,7 @@
 		BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
 		C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13760098C8ED1658B27AD54B /* CommentSheet.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
+		CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */; };
 		DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75027D57516F296784BEDA4B /* PRRowView.swift */; };
 		E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2D036E0950B774A3A43 /* LaunchView.swift */; };
 		E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
@@ -74,6 +76,7 @@
 		472896A74FFDCC9B621A984E /* PRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentSheet.swift; sourceTree = "<group>"; };
 		5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSheet.swift; sourceTree = "<group>"; };
+		5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
 		6BE8B812763DC773F8484C7D /* ParseResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultRow.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
 		767FFF9158E604C69C4007DB /* PRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDetailView.swift; sourceTree = "<group>"; };
@@ -82,6 +85,7 @@
 		7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRowView.swift; sourceTree = "<group>"; };
 		80A4F0FF399CC75CAB4F1A1C /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommentSheet.swift; sourceTree = "<group>"; };
+		894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentButton.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,6 +167,7 @@
 				22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */,
 				2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */,
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
+				5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */,
 				D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
@@ -250,6 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				4403330B1342AA7C19FA797D /* Constants.swift */,
+				894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */,
 				FE149A3F324BCC15AB57153E /* LabelPicker.swift */,
 				F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
@@ -337,6 +343,7 @@
 				34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */,
 				83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */,
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
+				CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */,
 				5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
@@ -351,6 +358,7 @@
 				3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */,
 				9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */,
 				E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */,
+				1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */,
 				EE08B250394D4614915429E1 /* Issue.swift in Sources */,
 				78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */,
 				87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */,

--- a/ios/IssueCTL/Services/APIClient+ImageUpload.swift
+++ b/ios/IssueCTL/Services/APIClient+ImageUpload.swift
@@ -1,0 +1,68 @@
+import Foundation
+import UIKit
+
+// MARK: - Image Upload Response
+
+struct ImageUploadResponse: Codable, Sendable {
+    let url: String
+}
+
+// MARK: - APIClient Image Upload
+
+extension APIClient {
+
+    /// Upload an image to GitHub via the server's image upload endpoint.
+    /// Uses multipart form data since the standard JSON request helper
+    /// cannot handle file uploads.
+    func uploadImage(image: UIImage, owner: String, repo: String) async throws -> String {
+        guard let base = URL(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+            throw APIError.invalidResponse
+        }
+
+        let boundary = UUID().uuidString
+        var urlRequest = URLRequest(url: base.appendingPathComponent("/api/v1/images/upload"))
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+
+        // owner field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"owner\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(owner)\r\n".data(using: .utf8)!)
+
+        // repo field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"repo\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(repo)\r\n".data(using: .utf8)!)
+
+        // file field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"image.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(imageData)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+
+        urlRequest.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        if httpResponse.statusCode == 401 { throw APIError.unauthorized }
+        if httpResponse.statusCode >= 400 {
+            let errorBody = try? JSONDecoder().decode(ImageUploadErrorResponse.self, from: data)
+            throw APIError.serverError(httpResponse.statusCode, errorBody?.error ?? "Upload failed")
+        }
+
+        return try decoder.decode(ImageUploadResponse.self, from: data).url
+    }
+}
+
+private struct ImageUploadErrorResponse: Codable {
+    let error: String
+}

--- a/ios/IssueCTL/Views/Issues/EditIssueSheet.swift
+++ b/ios/IssueCTL/Views/Issues/EditIssueSheet.swift
@@ -52,6 +52,13 @@ struct EditIssueSheet: View {
                     TextEditor(text: $issueBody)
                         .frame(minHeight: 200)
                         .font(.body)
+                    ImageAttachmentButton(owner: owner, repo: repo) { markdown in
+                        if issueBody.isEmpty {
+                            issueBody = markdown
+                        } else {
+                            issueBody += "\n\n\(markdown)"
+                        }
+                    }
                 }
 
                 if let errorMessage {

--- a/ios/IssueCTL/Views/Issues/IssueCommentSheet.swift
+++ b/ios/IssueCTL/Views/Issues/IssueCommentSheet.swift
@@ -20,6 +20,13 @@ struct IssueCommentSheet: View {
                     TextEditor(text: $commentBody)
                         .frame(minHeight: 120)
                         .font(.body)
+                    ImageAttachmentButton(owner: owner, repo: repo) { markdown in
+                        if commentBody.isEmpty {
+                            commentBody = markdown
+                        } else {
+                            commentBody += "\n\n\(markdown)"
+                        }
+                    }
                 }
 
                 if let errorMessage {

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -53,6 +53,15 @@ struct QuickCreateSheet: View {
                                     .allowsHitTesting(false)
                             }
                         }
+                    if let repo = selectedRepo {
+                        ImageAttachmentButton(owner: repo.owner, repo: repo.name) { markdown in
+                            if bodyText.isEmpty {
+                                bodyText = markdown
+                            } else {
+                                bodyText += "\n\n\(markdown)"
+                            }
+                        }
+                    }
                 }
 
                 Section("Repository") {

--- a/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
+++ b/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
@@ -13,6 +13,17 @@ struct ImageAttachmentButton: View {
     @State private var isUploading = false
     @State private var errorMessage: String?
 
+    @ViewBuilder
+    private var pickerLabel: some View {
+        if isUploading {
+            ProgressView()
+                .controlSize(.small)
+        } else {
+            Label("Attach Image", systemImage: "photo")
+                .font(.callout)
+        }
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             PhotosPicker(
@@ -20,13 +31,7 @@ struct ImageAttachmentButton: View {
                 matching: .images,
                 photoLibrary: .shared()
             ) {
-                if isUploading {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    Label("Attach Image", systemImage: "photo")
-                        .font(.callout)
-                }
+                pickerLabel
             }
             .disabled(isUploading)
 

--- a/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
+++ b/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
@@ -1,0 +1,72 @@
+import PhotosUI
+import SwiftUI
+import UIKit
+
+struct ImageAttachmentButton: View {
+    @Environment(APIClient.self) private var api
+
+    let owner: String
+    let repo: String
+    let onUpload: (String) -> Void
+
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var isUploading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            PhotosPicker(
+                selection: $selectedItem,
+                matching: .images,
+                photoLibrary: .shared()
+            ) {
+                if isUploading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Attach Image", systemImage: "photo")
+                        .font(.callout)
+                }
+            }
+            .disabled(isUploading)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(1)
+            }
+        }
+        .onChange(of: selectedItem) { _, newItem in
+            guard let newItem else { return }
+            Task { await upload(item: newItem) }
+            selectedItem = nil
+        }
+    }
+
+    private func upload(item: PhotosPickerItem) async {
+        isUploading = true
+        errorMessage = nil
+
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else {
+                errorMessage = "Could not load image"
+                isUploading = false
+                return
+            }
+            guard let uiImage = UIImage(data: data) else {
+                errorMessage = "Invalid image data"
+                isUploading = false
+                return
+            }
+
+            let url = try await api.uploadImage(image: uiImage, owner: owner, repo: repo)
+            let markdown = "![image](\(url))"
+            onUpload(markdown)
+        } catch {
+            errorMessage = "Upload failed"
+        }
+
+        isUploading = false
+    }
+}

--- a/packages/web/app/api/v1/images/upload/route.ts
+++ b/packages/web/app/api/v1/images/upload/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getGhToken,
+  uploadImageToGitHub,
+  formatErrorForUser,
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+const OWNER_REPO_RE = /^[\w.-]+$/;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_image_upload_parse_failed" });
+    return NextResponse.json({ error: "Invalid multipart form data" }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+  const owner = formData.get("owner");
+  const repo = formData.get("repo");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+  if (typeof owner !== "string" || !OWNER_REPO_RE.test(owner)) {
+    return NextResponse.json({ error: "Invalid or missing owner" }, { status: 400 });
+  }
+  if (typeof repo !== "string" || !OWNER_REPO_RE.test(repo)) {
+    return NextResponse.json({ error: "Invalid or missing repo" }, { status: 400 });
+  }
+  if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: "Only PNG, JPG, GIF, and WEBP images are supported" },
+      { status: 400 },
+    );
+  }
+  if (file.size > MAX_IMAGE_SIZE) {
+    return NextResponse.json(
+      { error: "Image must be 10 MB or smaller" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const token = await getGhToken();
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const result = await uploadImageToGitHub(token, owner, repo, {
+      name: file.name,
+      type: file.type,
+      data: buffer,
+    });
+
+    log.info({ msg: "api_image_uploaded", owner, repo, fileName: file.name });
+    return NextResponse.json({ url: result.url });
+  } catch (err) {
+    log.error({ err, msg: "api_image_upload_failed", owner, repo });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ImageAttachmentButton` using PhotosUI `PhotosPicker` with upload progress
- Adds `POST /api/v1/images/upload` endpoint (multipart, validates type/size, uses core's orphan branch uploader)
- `APIClient+ImageUpload.swift` extension with multipart form-data upload
- Wired into `QuickCreateSheet`, `EditIssueSheet`, and `IssueCommentSheet`
- Uploaded images are inserted as markdown `![image](url)` into text fields
- Fixes `currentUser()` ambiguity (removed duplicate from DetailActions)

Closes #266

## Test plan
- [ ] Tap image button in issue creation — photo picker opens
- [ ] Select image — verify upload progress shown
- [ ] Upload succeeds — verify markdown inserted into body
- [ ] Upload fails — verify error message displayed
- [ ] Verify file type validation (only png/jpg/gif/webp)
- [ ] Verify file size validation (max 10MB)