### PR TITLE
fix(web,ios): resolve Next.js route conflict for repos endpoints

### DIFF
--- a/ios/IssueCTL/Services/APIClient+Settings.swift
+++ b/ios/IssueCTL/Services/APIClient+Settings.swift
@@ -34,9 +34,9 @@ extension APIClient {
         return repo
     }
 
-    /// Remove a tracked repository by ID.
-    func removeRepo(id: Int) async throws {
-        let (data, _) = try await request(path: "/api/v1/repos/\(id)", method: "DELETE", body: nil)
+    /// Remove a tracked repository by owner and name.
+    func removeRepo(owner: String, name: String) async throws {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(name)", method: "DELETE", body: nil)
         let response = try decoder.decode(RemoveRepoResponse.self, from: data)
         guard response.success else {
             throw APIError.serverError(400, response.error ?? "Failed to remove repository")

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -191,7 +191,7 @@ struct SettingsView: View {
         Task {
             for repo in reposToDelete {
                 do {
-                    try await api.removeRepo(id: repo.id)
+                    try await api.removeRepo(owner: repo.owner, name: repo.name)
                 } catch {
                     // Restore on failure
                     removeError = "Failed to remove \(repo.fullName): \(error.localizedDescription)"

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -1,26 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
-import { getDb, removeRepo, getRepoById } from "@issuectl/core";
+import { getDb, removeRepo, getRepo } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ owner: string; repo: string }> },
 ): Promise<NextResponse> {
   const denied = requireAuth(request);
   if (denied) return denied;
 
-  const { id: idStr } = await params;
-  const id = Number(idStr);
-  if (!Number.isInteger(id) || id <= 0) {
-    return NextResponse.json({ error: "Invalid repo id" }, { status: 400 });
-  }
+  const { owner, repo: repoName } = await params;
 
   try {
     const db = getDb();
-    const repo = getRepoById(db, id);
+    const repo = getRepo(db, owner, repoName);
     if (!repo) {
       return NextResponse.json(
         { success: false, error: "Repository not found" },
@@ -28,11 +24,11 @@ export async function DELETE(
       );
     }
 
-    removeRepo(db, id);
-    log.info({ msg: "api_repo_removed", repoId: id, owner: repo.owner, name: repo.name });
+    removeRepo(db, repo.id);
+    log.info({ msg: "api_repo_removed", repoId: repo.id, owner, name: repoName });
     return NextResponse.json({ success: true });
   } catch (err) {
-    log.error({ err, msg: "api_repo_remove_failed", repoId: id });
+    log.error({ err, msg: "api_repo_remove_failed", owner, name: repoName });
     return NextResponse.json(
       { success: false, error: err instanceof Error ? err.message : "Unexpected error" },
       { status: 500 },

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
-import { getDb, removeRepo, getRepo } from "@issuectl/core";
+import { getDb, removeRepo, getRepo, formatErrorForUser } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
@@ -13,6 +13,12 @@ export async function DELETE(
   if (denied) return denied;
 
   const { owner, repo: repoName } = await params;
+  if (!owner || !repoName) {
+    return NextResponse.json(
+      { success: false, error: "Owner and repo name are required" },
+      { status: 400 },
+    );
+  }
 
   try {
     const db = getDb();
@@ -30,7 +36,7 @@ export async function DELETE(
   } catch (err) {
     log.error({ err, msg: "api_repo_remove_failed", owner, name: repoName });
     return NextResponse.json(
-      { success: false, error: err instanceof Error ? err.message : "Unexpected error" },
+      { success: false, error: formatErrorForUser(err) },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary
- Moves the DELETE endpoint from `repos/[id]/route.ts` to `repos/[owner]/[repo]/route.ts` to fix a Next.js App Router slug name conflict (`[id]` vs `[owner]` at the same path depth)
- Updates iOS `APIClient+Settings` to use `owner/name` path instead of numeric ID
- Looks up repos via `getRepo(db, owner, name)` instead of `getRepoById(db, id)`
- Adds input validation and uses `formatErrorForUser` for consistency with sibling routes

## Context
After merging PRs #269-#274 (iOS batches + reassignment), both `repos/[id]/` and `repos/[owner]/[repo]/` routes existed at the same level. Next.js forbids different dynamic segment names at the same depth, causing dev server startup failures and E2E test breakage.

## Test plan
- [x] TypeScript typecheck passes
- [x] iOS build succeeds (generic/platform=iOS Simulator)
- [x] Lint passes (warnings only, pre-existing)
- [x] PR review toolkit (code-reviewer, silent-failure-hunter, code-simplifier) — all findings addressed
- [ ] E2E tests pass (CI will verify)