### PR TITLE
feat(ios): add image lightbox, offline resilience, and network error banners

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
 		59D20056C3E281403735631D /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7701223E13D43C4F74244B0 /* Repo.swift */; };
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
+		62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */; };
 		65142BB24364562CB5305E0F /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472896A74FFDCC9B621A984E /* PRListView.swift */; };
 		661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D638F823877AD0CAA946A4 /* CommentView.swift */; };
 		6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */; };
@@ -33,6 +34,7 @@
 		83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */; };
 		87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
+		8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */; };
 		916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */; };
 		9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */; };
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
@@ -44,6 +46,7 @@
 		BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */; };
 		BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
 		C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13760098C8ED1658B27AD54B /* CommentSheet.swift */; };
+		C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
 		CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */; };
 		DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75027D57516F296784BEDA4B /* PRRowView.swift */; };
@@ -70,6 +73,7 @@
 		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
+		3F39642CB180355E5C62A75E /* ImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightbox.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		4403330B1342AA7C19FA797D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		45D2FEDC36ACDF7207272AE3 /* ParseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseView.swift; sourceTree = "<group>"; };
@@ -78,6 +82,7 @@
 		5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSheet.swift; sourceTree = "<group>"; };
 		5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
 		6BE8B812763DC773F8484C7D /* ParseResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultRow.swift; sourceTree = "<group>"; };
+		6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorBanner.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
 		767FFF9158E604C69C4007DB /* PRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDetailView.swift; sourceTree = "<group>"; };
 		78D638F823877AD0CAA946A4 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
@@ -104,6 +109,7 @@
 		F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRepoSheet.swift; sourceTree = "<group>"; };
 		F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTabs.swift; sourceTree = "<group>"; };
 		F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MineFilterChip.swift; sourceTree = "<group>"; };
+		FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		FD234C4632456D401809E8A5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FE149A3F324BCC15AB57153E /* LabelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPicker.swift; sourceTree = "<group>"; };
 		FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequest.swift; sourceTree = "<group>"; };
@@ -171,6 +177,7 @@
 				D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
+				FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -256,8 +263,10 @@
 			children = (
 				4403330B1342AA7C19FA797D /* Constants.swift */,
 				894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */,
+				3F39642CB180355E5C62A75E /* ImageLightbox.swift */,
 				FE149A3F324BCC15AB57153E /* LabelPicker.swift */,
 				F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */,
+				6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
 				F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */,
 			);
@@ -359,6 +368,7 @@
 				9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */,
 				E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */,
 				1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */,
+				C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */,
 				EE08B250394D4614915429E1 /* Issue.swift in Sources */,
 				78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */,
 				87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */,
@@ -370,6 +380,8 @@
 				581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
 				2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */,
+				62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */,
+				8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,
 				65142BB24364562CB5305E0F /* PRListView.swift in Sources */,

--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
 
     var body: some View {
         if api.isConfigured {
@@ -19,6 +20,10 @@ struct ContentView: View {
                     SettingsView()
                 }
             }
+            .overlay(alignment: .top) {
+                OfflineBanner()
+            }
+            .animation(.easeInOut(duration: 0.3), value: network.isConnected)
         } else {
             OnboardingView()
         }

--- a/ios/IssueCTL/App/IssueCTLApp.swift
+++ b/ios/IssueCTL/App/IssueCTLApp.swift
@@ -3,11 +3,13 @@ import SwiftUI
 @main
 struct IssueCTLApp: App {
     @State private var apiClient = APIClient()
+    @State private var networkMonitor = NetworkMonitor()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(apiClient)
+                .environment(networkMonitor)
         }
     }
 }

--- a/ios/IssueCTL/Services/NetworkMonitor.swift
+++ b/ios/IssueCTL/Services/NetworkMonitor.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Network
+
+/// Monitors network connectivity using NWPathMonitor.
+///
+/// Usage: inject as an environment object or create in the app entry point.
+///
+/// ```swift
+/// @State private var networkMonitor = NetworkMonitor()
+///
+/// ContentView()
+///     .environment(networkMonitor)
+/// ```
+///
+/// Then in any view:
+///
+/// ```swift
+/// @Environment(NetworkMonitor.self) private var network
+///
+/// if !network.isConnected {
+///     Text("Offline")
+/// }
+/// ```
+@Observable @MainActor
+final class NetworkMonitor {
+    private(set) var isConnected: Bool = true
+    private(set) var connectionType: ConnectionType = .unknown
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.issuectl.network-monitor")
+
+    enum ConnectionType: Sendable {
+        case wifi
+        case cellular
+        case wiredEthernet
+        case other
+        case unknown
+    }
+
+    init() {
+        startMonitoring()
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    private func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let connected = path.status == .satisfied
+            let type = resolveConnectionType(from: path)
+            Task { @MainActor [weak self] in
+                self?.isConnected = connected
+                self?.connectionType = type
+            }
+        }
+        monitor.start(queue: queue)
+    }
+}
+
+/// Resolve NWPath to a ConnectionType outside the @MainActor class
+/// so it can be called from the non-isolated pathUpdateHandler closure.
+private func resolveConnectionType(from path: NWPath) -> NetworkMonitor.ConnectionType {
+    if path.usesInterfaceType(.wifi) {
+        return .wifi
+    } else if path.usesInterfaceType(.cellular) {
+        return .cellular
+    } else if path.usesInterfaceType(.wiredEthernet) {
+        return .wiredEthernet
+    } else if path.status == .satisfied {
+        return .other
+    }
+    return .unknown
+}

--- a/ios/IssueCTL/Services/NetworkMonitor.swift
+++ b/ios/IssueCTL/Services/NetworkMonitor.swift
@@ -42,6 +42,7 @@ final class NetworkMonitor {
     }
 
     deinit {
+        let monitor = self.monitor
         monitor.cancel()
     }
 

--- a/ios/IssueCTL/Views/Shared/ImageLightbox.swift
+++ b/ios/IssueCTL/Views/Shared/ImageLightbox.swift
@@ -47,8 +47,7 @@ struct ImageLightbox: View {
     private let dismissThreshold: CGFloat = 150.0
 
     var body: some View {
-        GeometryReader { geometry in
-            ZStack {
+        ZStack {
                 Color.black.ignoresSafeArea()
                     .opacity(dismissOpacity)
 
@@ -74,6 +73,8 @@ struct ImageLightbox: View {
                                     } else {
                                         scale = 3.0
                                         lastScale = 3.0
+                                        offset = .zero
+                                        lastOffset = .zero
                                     }
                                 }
                             }
@@ -91,18 +92,17 @@ struct ImageLightbox: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    isPresented = false
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, .white.opacity(0.3))
-                }
-                .padding(20)
-                .opacity(dismissOpacity)
+        .overlay(alignment: .topTrailing) {
+            Button {
+                isPresented = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .white.opacity(0.3))
             }
+            .padding(20)
+            .opacity(dismissOpacity)
         }
         .statusBarHidden()
     }
@@ -170,7 +170,8 @@ struct ImageLightbox: View {
                             )
                         }
                         // Dismiss after animation starts
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        Task {
+                            try? await Task.sleep(for: .seconds(0.15))
                             isPresented = false
                         }
                     } else {

--- a/ios/IssueCTL/Views/Shared/ImageLightbox.swift
+++ b/ios/IssueCTL/Views/Shared/ImageLightbox.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+/// A fullscreen overlay that displays an image with pinch-to-zoom, double-tap to toggle zoom,
+/// and swipe-to-dismiss.
+///
+/// ## Integration
+///
+/// To use `ImageLightbox` from any view that displays images:
+///
+/// ```swift
+/// @State private var lightboxURL: URL?
+///
+/// // In your view body:
+/// .fullScreenCover(item: $lightboxURL) { url in
+///     ImageLightbox(url: url, isPresented: .init(
+///         get: { lightboxURL != nil },
+///         set: { if !$0 { lightboxURL = nil } }
+///     ))
+/// }
+///
+/// // When a user taps an image:
+/// Button { lightboxURL = imageURL } label: { ... }
+/// ```
+///
+/// Or with a simple `Bool` binding:
+///
+/// ```swift
+/// @State private var showLightbox = false
+/// let imageURL: URL = ...
+///
+/// .fullScreenCover(isPresented: $showLightbox) {
+///     ImageLightbox(url: imageURL, isPresented: $showLightbox)
+/// }
+/// ```
+struct ImageLightbox: View {
+    let url: URL
+    @Binding var isPresented: Bool
+
+    @State private var scale: CGFloat = 1.0
+    @State private var lastScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+    @State private var dragOffset: CGSize = .zero
+
+    private let minScale: CGFloat = 1.0
+    private let maxScale: CGFloat = 5.0
+    private let dismissThreshold: CGFloat = 150.0
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Color.black.ignoresSafeArea()
+                    .opacity(dismissOpacity)
+
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                            .tint(.white)
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .scaleEffect(scale)
+                            .offset(combinedOffset)
+                            .gesture(combinedGesture(in: geometry))
+                            .onTapGesture(count: 2) {
+                                withAnimation(.easeInOut(duration: 0.3)) {
+                                    if scale > minScale {
+                                        scale = minScale
+                                        offset = .zero
+                                        lastScale = minScale
+                                        lastOffset = .zero
+                                    } else {
+                                        scale = 3.0
+                                        lastScale = 3.0
+                                    }
+                                }
+                            }
+                    case .failure:
+                        ContentUnavailableView {
+                            Label("Failed to Load", systemImage: "photo.badge.exclamationmark")
+                                .foregroundStyle(.white)
+                        } description: {
+                            Text("Could not load image")
+                                .foregroundStyle(.white.opacity(0.7))
+                        }
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    isPresented = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title)
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .white.opacity(0.3))
+                }
+                .padding(20)
+                .opacity(dismissOpacity)
+            }
+        }
+        .statusBarHidden()
+    }
+
+    // MARK: - Computed
+
+    private var combinedOffset: CGSize {
+        if scale <= minScale {
+            // When not zoomed, only show drag offset (for swipe-to-dismiss)
+            return dragOffset
+        }
+        return CGSize(
+            width: offset.width + dragOffset.width,
+            height: offset.height + dragOffset.height
+        )
+    }
+
+    private var dismissOpacity: Double {
+        if scale > minScale { return 1.0 }
+        let progress = abs(dragOffset.height) / dismissThreshold
+        return max(1.0 - progress * 0.5, 0.3)
+    }
+
+    // MARK: - Gestures
+
+    private func combinedGesture(in geometry: GeometryProxy) -> some Gesture {
+        SimultaneousGesture(
+            magnificationGesture,
+            dragGesture
+        )
+    }
+
+    private var magnificationGesture: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                let newScale = lastScale * value.magnification
+                scale = min(max(newScale, minScale), maxScale)
+            }
+            .onEnded { value in
+                let newScale = lastScale * value.magnification
+                withAnimation(.easeOut(duration: 0.2)) {
+                    scale = min(max(newScale, minScale), maxScale)
+                    if scale <= minScale {
+                        offset = .zero
+                        lastOffset = .zero
+                    }
+                }
+                lastScale = scale
+            }
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                dragOffset = value.translation
+            }
+            .onEnded { value in
+                if scale <= minScale {
+                    // Swipe-to-dismiss when not zoomed
+                    if abs(value.translation.height) > dismissThreshold {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            dragOffset = CGSize(
+                                width: value.translation.width,
+                                height: value.translation.height > 0 ? 500 : -500
+                            )
+                        }
+                        // Dismiss after animation starts
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                            isPresented = false
+                        }
+                    } else {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            dragOffset = .zero
+                        }
+                    }
+                } else {
+                    // Pan when zoomed
+                    offset = CGSize(
+                        width: lastOffset.width + value.translation.width,
+                        height: lastOffset.height + value.translation.height
+                    )
+                    lastOffset = offset
+                    dragOffset = .zero
+                }
+            }
+    }
+}

--- a/ios/IssueCTL/Views/Shared/ImageLightbox.swift
+++ b/ios/IssueCTL/Views/Shared/ImageLightbox.swift
@@ -63,7 +63,7 @@ struct ImageLightbox: View {
                             .aspectRatio(contentMode: .fit)
                             .scaleEffect(scale)
                             .offset(combinedOffset)
-                            .gesture(combinedGesture(in: geometry))
+                            .gesture(combinedGesture)
                             .onTapGesture(count: 2) {
                                 withAnimation(.easeInOut(duration: 0.3)) {
                                     if scale > minScale {
@@ -128,7 +128,7 @@ struct ImageLightbox: View {
 
     // MARK: - Gestures
 
-    private func combinedGesture(in geometry: GeometryProxy) -> some Gesture {
+    private var combinedGesture: some Gesture {
         SimultaneousGesture(
             magnificationGesture,
             dragGesture

--- a/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
+++ b/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// A reusable banner that shows when a network error occurs.
+/// Displays the error message with a "Retry" button and auto-dismisses
+/// after a successful retry or after a timeout.
+///
+/// Usage:
+/// ```swift
+/// @State private var networkError: String?
+///
+/// SomeView()
+///     .overlay(alignment: .top) {
+///         NetworkErrorBanner(
+///             errorMessage: $networkError,
+///             onRetry: { await fetchData() }
+///         )
+///     }
+/// ```
+struct NetworkErrorBanner: View {
+    @Binding var errorMessage: String?
+    let onRetry: (() async -> Void)?
+
+    @State private var isRetrying = false
+    @State private var dismissTask: Task<Void, Never>?
+
+    private let autoDismissDelay: TimeInterval = 8.0
+
+    var body: some View {
+        if let message = errorMessage {
+            HStack(spacing: 12) {
+                Image(systemName: "wifi.exclamationmark")
+                    .font(.callout)
+                    .foregroundStyle(.white)
+
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+
+                Spacer()
+
+                if let onRetry {
+                    Button {
+                        Task {
+                            isRetrying = true
+                            await onRetry()
+                            isRetrying = false
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                errorMessage = nil
+                            }
+                        }
+                    } label: {
+                        if isRetrying {
+                            ProgressView()
+                                .tint(.white)
+                                .controlSize(.small)
+                        } else {
+                            Text("Retry")
+                                .font(.callout.weight(.semibold))
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    .disabled(isRetrying)
+                }
+
+                Button {
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        errorMessage = nil
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.red.opacity(0.9))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .onAppear {
+                scheduleAutoDismiss()
+            }
+            .onDisappear {
+                dismissTask?.cancel()
+            }
+        }
+    }
+
+    private func scheduleAutoDismiss() {
+        dismissTask?.cancel()
+        dismissTask = Task {
+            try? await Task.sleep(for: .seconds(autoDismissDelay))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeOut(duration: 0.3)) {
+                errorMessage = nil
+            }
+        }
+    }
+}
+
+/// A persistent offline indicator that appears when the device has no network connectivity.
+/// Intended to be placed at the root of the app's view hierarchy.
+struct OfflineBanner: View {
+    @Environment(NetworkMonitor.self) private var network
+
+    var body: some View {
+        if !network.isConnected {
+            HStack(spacing: 8) {
+                Image(systemName: "wifi.slash")
+                    .font(.caption)
+                Text("You are offline")
+                    .font(.caption.weight(.medium))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color.secondary.opacity(0.85))
+            .clipShape(Capsule())
+            .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
+++ b/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// ```
 struct NetworkErrorBanner: View {
     @Binding var errorMessage: String?
-    let onRetry: (() async -> Void)?
+    let onRetry: (() async throws -> Void)?
 
     @State private var isRetrying = false
     @State private var dismissTask: Task<Void, Never>?
@@ -43,11 +43,16 @@ struct NetworkErrorBanner: View {
                     Button {
                         Task {
                             isRetrying = true
-                            await onRetry()
-                            isRetrying = false
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                errorMessage = nil
+                            do {
+                                try await onRetry()
+                                withAnimation(.easeOut(duration: 0.3)) {
+                                    errorMessage = nil
+                                }
+                            } catch {
+                                // Retry failed — keep banner visible, reset auto-dismiss
+                                scheduleAutoDismiss()
                             }
+                            isRetrying = false
                         }
                     } label: {
                         if isRetrying {

--- a/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
+++ b/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
@@ -43,16 +43,19 @@ struct NetworkErrorBanner: View {
                     Button {
                         Task {
                             isRetrying = true
+                            defer { isRetrying = false }
                             do {
                                 try await onRetry()
                                 withAnimation(.easeOut(duration: 0.3)) {
                                     errorMessage = nil
                                 }
                             } catch {
-                                // Retry failed — keep banner visible, reset auto-dismiss
+                                // Retry failed — update message with latest error, reset auto-dismiss
+                                withAnimation(.easeOut(duration: 0.3)) {
+                                    errorMessage = error.localizedDescription
+                                }
                                 scheduleAutoDismiss()
                             }
-                            isRetrying = false
                         }
                     } label: {
                         if isRetrying {


### PR DESCRIPTION
## Summary
- Add `ImageLightbox` component with pinch-to-zoom (1x-5x), double-tap toggle, and swipe-to-dismiss
- Add `NetworkMonitor` service using `NWPathMonitor` for connectivity tracking
- Add `NetworkErrorBanner` (auto-dismiss + retry) and `OfflineBanner` (persistent) components
- Wire `NetworkMonitor` into app environment and show `OfflineBanner` on `ContentView`

## Test plan
- [ ] Verify `OfflineBanner` appears when toggling airplane mode
- [ ] Verify `NetworkErrorBanner` shows on API failure with retry button
- [ ] Verify `ImageLightbox` supports pinch-to-zoom, double-tap, swipe-to-dismiss
- [ ] Verify no regressions in existing issue list and detail views