### PR TITLE
feat(ios,web): add priority system and unassigned filter

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
 		9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
 		A18D8982D49319C633EE661A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C1581E55A12781F1E76A1 /* ContentView.swift */; };
+		A3CBDBDDDEF8192FEB9DCBC0 /* APIClient+Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */; };
 		A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767FFF9158E604C69C4007DB /* PRDetailView.swift */; };
 		AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */; };
 		B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */; };
@@ -68,6 +69,7 @@
 		22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Assignment.swift"; sourceTree = "<group>"; };
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
+		3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Priority.swift"; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
 				5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */,
 				D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */,
+				3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */,
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
 			);
@@ -345,6 +348,7 @@
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
 				CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */,
 				5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */,
+				A3CBDBDDDEF8192FEB9DCBC0 /* APIClient+Priority.swift in Sources */,
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,

--- a/ios/IssueCTL/Services/APIClient+Priority.swift
+++ b/ios/IssueCTL/Services/APIClient+Priority.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// MARK: - Priority Model
+
+enum Priority: String, Codable, CaseIterable, Sendable {
+    case low
+    case normal
+    case high
+
+    var sortIndex: Int {
+        switch self {
+        case .high: 0
+        case .normal: 1
+        case .low: 2
+        }
+    }
+}
+
+// MARK: - Request/Response Types
+
+struct PriorityResponse: Codable, Sendable {
+    let priority: Priority
+}
+
+struct SetPriorityRequestBody: Encodable, Sendable {
+    let priority: String
+}
+
+struct SetPriorityResponse: Codable, Sendable {
+    let success: Bool
+    let error: String?
+}
+
+// MARK: - APIClient Extension
+
+extension APIClient {
+
+    /// Fetch the current priority for an issue.
+    func getPriority(owner: String, repo: String, number: Int) async throws -> Priority {
+        let (data, _) = try await request(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/priority"
+        )
+        return try decoder.decode(PriorityResponse.self, from: data).priority
+    }
+
+    /// Set the priority for an issue.
+    func setPriority(owner: String, repo: String, number: Int, priority: Priority) async throws -> SetPriorityResponse {
+        let body = SetPriorityRequestBody(priority: priority.rawValue)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/priority",
+            method: "PUT",
+            body: bodyData
+        )
+        return try decoder.decode(SetPriorityResponse.self, from: data)
+    }
+}

--- a/ios/IssueCTL/Services/APIClient+Priority.swift
+++ b/ios/IssueCTL/Services/APIClient+Priority.swift
@@ -31,6 +31,17 @@ struct SetPriorityResponse: Codable, Sendable {
     let error: String?
 }
 
+struct IssuePriorityItem: Codable, Sendable {
+    let repoId: Int
+    let issueNumber: Int
+    let priority: Priority
+    let updatedAt: Int
+}
+
+struct PrioritiesListResponse: Codable, Sendable {
+    let priorities: [IssuePriorityItem]
+}
+
 // MARK: - APIClient Extension
 
 extension APIClient {
@@ -41,6 +52,14 @@ extension APIClient {
             path: "/api/v1/issues/\(owner)/\(repo)/\(number)/priority"
         )
         return try decoder.decode(PriorityResponse.self, from: data).priority
+    }
+
+    /// Fetch all priorities for a repo in one call.
+    func listPriorities(owner: String, repo: String) async throws -> [IssuePriorityItem] {
+        let (data, _) = try await request(
+            path: "/api/v1/issues/\(owner)/\(repo)/priorities"
+        )
+        return try decoder.decode(PrioritiesListResponse.self, from: data).priorities
     }
 
     /// Set the priority for an issue.

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -430,6 +430,8 @@ struct IssueDetailView: View {
     }
 
     private func updatePriority(_ priority: Priority) async {
+        guard !isLoadingPriority else { return }
+        isLoadingPriority = true
         actionError = nil
         let previousPriority = currentPriority
         // Optimistic update
@@ -444,6 +446,7 @@ struct IssueDetailView: View {
             currentPriority = previousPriority
             actionError = error.localizedDescription
         }
+        isLoadingPriority = false
     }
 
     private func closeWithoutComment() async {

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -28,6 +28,10 @@ struct IssueDetailView: View {
     @State private var currentUserLogin: String?
     @State private var showActionError = false
 
+    // Priority state
+    @State private var currentPriority: Priority = .normal
+    @State private var isLoadingPriority = false
+
     var body: some View {
         Group {
             if isLoading && detail == nil {
@@ -84,6 +88,23 @@ struct IssueDetailView: View {
                             showAssigneeSheet = true
                         } label: {
                             Label("Manage Assignees", systemImage: "person.badge.plus")
+                        }
+                        Divider()
+                        Menu {
+                            ForEach(Priority.allCases, id: \.self) { priority in
+                                Button {
+                                    Task { await updatePriority(priority) }
+                                } label: {
+                                    HStack {
+                                        Text(priority.rawValue.capitalized)
+                                        if priority == currentPriority {
+                                            Image(systemName: "checkmark")
+                                        }
+                                    }
+                                }
+                            }
+                        } label: {
+                            Label("Priority", systemImage: "arrow.up.arrow.down")
                         }
                         Divider()
                         Button {
@@ -200,6 +221,8 @@ struct IssueDetailView: View {
 
             HStack(spacing: 8) {
                 StateBadge(isOpen: issue.isOpen)
+
+                PriorityBadge(priority: currentPriority)
 
                 if let user = issue.user {
                     Text(user.login)
@@ -395,13 +418,31 @@ struct IssueDetailView: View {
         do {
             async let detailResult = api.issueDetail(owner: owner, repo: repo, number: number, refresh: refresh)
             async let userResult = api.currentUser()
+            async let priorityResult = api.getPriority(owner: owner, repo: repo, number: number)
             detail = try await detailResult
-            // Best-effort: don't fail the whole load if user fetch fails
+            // Best-effort: don't fail the whole load if user/priority fetch fails
             currentUserLogin = try? await userResult.login
+            currentPriority = (try? await priorityResult) ?? .normal
         } catch {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func updatePriority(_ priority: Priority) async {
+        let previousPriority = currentPriority
+        // Optimistic update
+        currentPriority = priority
+        do {
+            let response = try await api.setPriority(owner: owner, repo: repo, number: number, priority: priority)
+            if !response.success {
+                currentPriority = previousPriority
+                actionError = response.error ?? "Failed to set priority"
+            }
+        } catch {
+            currentPriority = previousPriority
+            actionError = error.localizedDescription
+        }
     }
 
     private func closeWithoutComment() async {
@@ -516,5 +557,41 @@ struct FlowLayout: Layout {
         }
 
         return (CGSize(width: maxWidth, height: totalHeight), positions)
+    }
+}
+
+struct PriorityBadge: View {
+    let priority: Priority
+
+    var body: some View {
+        // Only show badge for non-default priorities
+        if priority != .normal {
+            HStack(spacing: 4) {
+                Image(systemName: iconName)
+                Text(priority.rawValue.capitalized)
+            }
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(badgeColor.opacity(0.15))
+            .foregroundStyle(badgeColor)
+            .clipShape(Capsule())
+        }
+    }
+
+    private var badgeColor: Color {
+        switch priority {
+        case .high: .red
+        case .normal: .secondary
+        case .low: .blue
+        }
+    }
+
+    private var iconName: String {
+        switch priority {
+        case .high: "arrow.up"
+        case .normal: "minus"
+        case .low: "arrow.down"
+        }
     }
 }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -430,6 +430,7 @@ struct IssueDetailView: View {
     }
 
     private func updatePriority(_ priority: Priority) async {
+        actionError = nil
         let previousPriority = currentPriority
         // Optimistic update
         currentPriority = priority

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -472,25 +472,21 @@ struct IssueListView: View {
 
     private func loadPriorities() async {
         isLoadingPriorities = true
-        await withTaskGroup(of: (String, Priority?).self) { group in
-            for (repoFullName, issues) in issuesByRepo {
+        await withTaskGroup(of: [(String, Priority)].self) { group in
+            let uniqueRepos = Set(repos.map { ($0.owner, $0.name) }.map { "\($0.0)/\($0.1)" })
+            for repoFullName in uniqueRepos {
                 guard let repo = repos.first(where: { $0.fullName == repoFullName }) else { continue }
-                for issue in issues {
-                    let key = "\(repo.owner)/\(repo.name)#\(issue.number)"
-                    group.addTask {
-                        do {
-                            let priority = try await api.getPriority(
-                                owner: repo.owner, repo: repo.name, number: issue.number
-                            )
-                            return (key, priority)
-                        } catch {
-                            return (key, nil)
-                        }
+                group.addTask {
+                    do {
+                        let items = try await api.listPriorities(owner: repo.owner, repo: repo.name)
+                        return items.map { ("\(repo.owner)/\(repo.name)#\($0.issueNumber)", $0.priority) }
+                    } catch {
+                        return []
                     }
                 }
             }
-            for await (key, priority) in group {
-                if let priority {
+            for await pairs in group {
+                for (key, priority) in pairs {
                     priorities[key] = priority
                 }
             }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -472,6 +472,8 @@ struct IssueListView: View {
 
     private func loadPriorities() async {
         isLoadingPriorities = true
+        var newPriorities: [String: Priority] = [:]
+        var hadFailure = false
         await withTaskGroup(of: [(String, Priority)].self) { group in
             let uniqueRepos = Set(repos.map { ($0.owner, $0.name) }.map { "\($0.0)/\($0.1)" })
             for repoFullName in uniqueRepos {
@@ -486,11 +488,13 @@ struct IssueListView: View {
                 }
             }
             for await pairs in group {
+                if pairs.isEmpty { hadFailure = true }
                 for (key, priority) in pairs {
-                    priorities[key] = priority
+                    newPriorities[key] = priority
                 }
             }
         }
+        priorities = newPriorities
         isLoadingPriorities = false
     }
 }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -31,6 +31,10 @@ struct IssueListView: View {
     @State private var actionError: String?
     @State private var errorDismissTask: Task<Void, Never>?
 
+    // Priority data keyed by "owner/repo#number"
+    @State private var priorities: [String: Priority] = [:]
+    @State private var isLoadingPriorities = false
+
     private var allIssues: [GitHubIssue] {
         issuesByRepo.values.flatMap { $0 }
     }
@@ -79,17 +83,26 @@ struct IssueListView: View {
             guard let repo = repoFor(issue: issue) else { return false }
             return issue.isOpen && isRunning(issue, in: repo.fullName)
         }
+        case .unassigned: items = items.filter { issue in
+            issue.isOpen && (issue.assignees ?? []).isEmpty
+        }
         case .closed: items = items.filter { !$0.isOpen }
         }
 
         switch sortOrder {
         case .updated: items.sort { $0.updatedAt > $1.updatedAt }
         case .created: items.sort { $0.createdAt > $1.createdAt }
-        // Comment count as rough engagement proxy — GitHub issues have no native priority field
-        case .priority: items.sort { $0.commentCount > $1.commentCount }
+        case .priority: items.sort { prioritySortIndex(for: $0) < prioritySortIndex(for: $1) }
         }
 
         return items
+    }
+
+    /// Returns a sort index for priority sorting (high=0, normal=1, low=2).
+    private func prioritySortIndex(for issue: GitHubIssue) -> Int {
+        guard let repo = repoFor(issue: issue) else { return Priority.normal.sortIndex }
+        let key = "\(repo.owner)/\(repo.name)#\(issue.number)"
+        return (priorities[key] ?? .normal).sortIndex
     }
 
     private var sectionCounts: [IssueSection: Int] {
@@ -102,11 +115,15 @@ struct IssueListView: View {
             guard let repo = repoFor(issue: issue) else { return false }
             return issue.isOpen && isRunning(issue, in: repo.fullName)
         }
+        let unassigned = items.filter { issue in
+            issue.isOpen && (issue.assignees ?? []).isEmpty
+        }
         let closed = items.filter { !$0.isOpen }
         return [
             .drafts: drafts.count,
             .open: open.count,
             .running: running.count,
+            .unassigned: unassigned.count,
             .closed: closed.count,
         ]
     }
@@ -444,10 +461,41 @@ struct IssueListView: View {
             if !failedRepos.isEmpty {
                 actionError = "Failed to load: \(failedRepos.joined(separator: ", "))"
             }
+
+            // Fetch priorities for all displayed issues (best-effort)
+            await loadPriorities()
         } catch {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func loadPriorities() async {
+        isLoadingPriorities = true
+        await withTaskGroup(of: (String, Priority?).self) { group in
+            for (repoFullName, issues) in issuesByRepo {
+                guard let repo = repos.first(where: { $0.fullName == repoFullName }) else { continue }
+                for issue in issues {
+                    let key = "\(repo.owner)/\(repo.name)#\(issue.number)"
+                    group.addTask {
+                        do {
+                            let priority = try await api.getPriority(
+                                owner: repo.owner, repo: repo.name, number: issue.number
+                            )
+                            return (key, priority)
+                        } catch {
+                            return (key, nil)
+                        }
+                    }
+                }
+            }
+            for await (key, priority) in group {
+                if let priority {
+                    priorities[key] = priority
+                }
+            }
+        }
+        isLoadingPriorities = false
     }
 }
 

--- a/ios/IssueCTL/Views/Shared/SectionTabs.swift
+++ b/ios/IssueCTL/Views/Shared/SectionTabs.swift
@@ -37,7 +37,7 @@ struct SectionTabs<Section: Hashable & CaseIterable & RawRepresentable>: View wh
 }
 
 enum IssueSection: String, CaseIterable {
-    case drafts, open, running, closed
+    case drafts, open, running, unassigned, closed
 }
 
 enum PRSection: String, CaseIterable {

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/priority/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/priority/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  getPriority,
+  setPriority,
+  formatErrorForUser,
+} from "@issuectl/core";
+import type { Priority } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+const VALID_PRIORITIES: readonly string[] = ["low", "normal", "high"];
+
+type PriorityBody = {
+  priority: string;
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    const repoRecord = getRepo(db, owner, repo);
+    if (!repoRecord) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const priority = getPriority(db, repoRecord.id, issueNumber);
+    return NextResponse.json({ priority });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_priority_get_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: PriorityBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!VALID_PRIORITIES.includes(body.priority)) {
+    return NextResponse.json(
+      { error: "Invalid priority — must be low, normal, or high" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const repoRecord = getRepo(db, owner, repo);
+    if (!repoRecord) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    setPriority(db, repoRecord.id, issueNumber, body.priority as Priority);
+
+    log.info({ msg: "api_issue_priority_set", owner, repo, issueNumber, priority: body.priority });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_priority_set_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/priority/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/priority/route.ts
@@ -70,7 +70,7 @@ export async function PUT(
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (!VALID_PRIORITIES.includes(body.priority)) {
+  if (typeof body?.priority !== "string" || !VALID_PRIORITIES.includes(body.priority)) {
     return NextResponse.json(
       { error: "Invalid priority — must be low, normal, or high" },
       { status: 400 },

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/priorities/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/priorities/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { getDb, getRepo, listPrioritiesForRepo, formatErrorForUser } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+
+  try {
+    const db = getDb();
+    const repoRecord = getRepo(db, owner, repo);
+    if (!repoRecord) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const priorities = listPrioritiesForRepo(db, repoRecord.id);
+    return NextResponse.json({ priorities });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_priorities_list_failed", owner, repo });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoints for per-issue priority (GET/PUT) and batch priorities per repo
- Add `Priority` enum, picker in issue detail toolbar, colored `PriorityBadge` in header
- Add priority-based sort option in issue list using batch endpoint (no N+1)
- Add unassigned filter tab to `SectionTabs`

## Test plan
- [ ] Verify priority can be set/changed from issue detail overflow menu
- [ ] Verify priority badge appears for high (red) and low (blue), hidden for normal
- [ ] Verify priority sort orders high -> normal -> low
- [ ] Verify unassigned filter shows only issues with no assignees
- [ ] Verify batch priority loading (network tab: one call per repo, not per issue)