### PR TITLE
feat(ios,web): add GitHub repo discovery and repo editing

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
 		493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
 		49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */; };
+		51D419285114BB9B1F7B6D5A /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */; };
 		5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */; };
 		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
 		59D20056C3E281403735631D /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7701223E13D43C4F74244B0 /* Repo.swift */; };
@@ -35,6 +36,7 @@
 		87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
 		8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */; };
+		8F6B1136F0F654026188BFF6 /* EditRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */; };
 		916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */; };
 		9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */; };
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
@@ -93,10 +95,12 @@
 		80A4F0FF399CC75CAB4F1A1C /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommentSheet.swift; sourceTree = "<group>"; };
 		894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentButton.swift; sourceTree = "<group>"; };
+		9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepoSheet.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAccessibleRepo.swift; sourceTree = "<group>"; };
 		B7701223E13D43C4F74244B0 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
 		BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerHealth.swift; sourceTree = "<group>"; };
 		C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoListView.swift; sourceTree = "<group>"; };
@@ -197,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */,
+				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
 				093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -206,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				28E6C0859937F6A85F709D99 /* Deployment.swift */,
+				AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */,
 				80A4F0FF399CC75CAB4F1A1C /* Issue.swift */,
 				FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */,
 				B7701223E13D43C4F74244B0 /* Repo.swift */,
@@ -371,6 +377,8 @@
 				3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */,
 				9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */,
 				E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */,
+				8F6B1136F0F654026188BFF6 /* EditRepoSheet.swift in Sources */,
+				51D419285114BB9B1F7B6D5A /* GitHubAccessibleRepo.swift in Sources */,
 				1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */,
 				C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */,
 				EE08B250394D4614915429E1 /* Issue.swift in Sources */,

--- a/ios/IssueCTL/Models/GitHubAccessibleRepo.swift
+++ b/ios/IssueCTL/Models/GitHubAccessibleRepo.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct GitHubAccessibleRepo: Codable, Identifiable, Sendable {
+    let owner: String
+    let name: String
+    let `private`: Bool
+    let pushedAt: String?
+
+    var id: String { "\(owner)/\(name)" }
+    var fullName: String { "\(owner)/\(name)" }
+}
+
+struct GitHubAccessibleReposResponse: Codable, Sendable {
+    let repos: [GitHubAccessibleRepo]
+    let syncedAt: Int?
+    let isStale: Bool
+}

--- a/ios/IssueCTL/Services/APIClient+Settings.swift
+++ b/ios/IssueCTL/Services/APIClient+Settings.swift
@@ -19,8 +19,8 @@ struct RemoveRepoResponse: Codable, Sendable {
 }
 
 struct UpdateRepoRequest: Encodable, Sendable {
-    let localPath: String?
-    let branchPattern: String?
+    let localPath: String
+    let branchPattern: String
 }
 
 struct UpdateRepoResponse: Codable, Sendable {
@@ -63,7 +63,7 @@ extension APIClient {
     }
 
     /// Update a tracked repository's localPath and/or branchPattern.
-    func updateRepo(owner: String, name: String, localPath: String?, branchPattern: String?) async throws -> Repo {
+    func updateRepo(owner: String, name: String, localPath: String, branchPattern: String) async throws -> Repo {
         let body = UpdateRepoRequest(localPath: localPath, branchPattern: branchPattern)
         let bodyData = try JSONEncoder().encode(body)
         let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(name)", method: "PATCH", body: bodyData)

--- a/ios/IssueCTL/Services/APIClient+Settings.swift
+++ b/ios/IssueCTL/Services/APIClient+Settings.swift
@@ -18,6 +18,17 @@ struct RemoveRepoResponse: Codable, Sendable {
     let error: String?
 }
 
+struct UpdateRepoRequest: Encodable, Sendable {
+    let localPath: String?
+    let branchPattern: String?
+}
+
+struct UpdateRepoResponse: Codable, Sendable {
+    let success: Bool
+    let repo: Repo?
+    let error: String?
+}
+
 // MARK: - APIClient Settings extension
 
 extension APIClient {
@@ -41,5 +52,25 @@ extension APIClient {
         guard response.success else {
             throw APIError.serverError(400, response.error ?? "Failed to remove repository")
         }
+    }
+
+    /// Fetch accessible GitHub repos (cached or refreshed).
+    func githubRepos(refresh: Bool = false) async throws -> GitHubAccessibleReposResponse {
+        var path = "/api/v1/repos/github"
+        if refresh { path += "?refresh=true" }
+        let (data, _) = try await request(path: path)
+        return try decoder.decode(GitHubAccessibleReposResponse.self, from: data)
+    }
+
+    /// Update a tracked repository's localPath and/or branchPattern.
+    func updateRepo(owner: String, name: String, localPath: String?, branchPattern: String?) async throws -> Repo {
+        let body = UpdateRepoRequest(localPath: localPath, branchPattern: branchPattern)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(name)", method: "PATCH", body: bodyData)
+        let response = try decoder.decode(UpdateRepoResponse.self, from: data)
+        guard response.success, let repo = response.repo else {
+            throw APIError.serverError(400, response.error ?? "Failed to update repository")
+        }
+        return repo
     }
 }

--- a/ios/IssueCTL/Views/Settings/AddRepoSheet.swift
+++ b/ios/IssueCTL/Views/Settings/AddRepoSheet.swift
@@ -111,19 +111,10 @@ struct AddRepoSheet: View {
                 ProgressView("Loading repos...")
                 Spacer()
             }
-        } else if let error = browseError, browseRepos.isEmpty {
-            Label(error, systemImage: "exclamationmark.triangle")
-                .foregroundStyle(.secondary)
-        } else if browseRepos.isEmpty {
-            Text("No accessible repos found.")
-                .foregroundStyle(.secondary)
         } else {
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField("Search repos...", text: $browseSearch)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
+            if let error = browseError {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
             }
 
             Button {
@@ -137,32 +128,45 @@ struct AddRepoSheet: View {
                     }
                 }
             }
-            .disabled(isRefreshing)
+            .disabled(isRefreshing || isBrowseLoading)
 
-            ForEach(filteredBrowseRepos) { repo in
-                Button {
-                    owner = repo.owner
-                    name = repo.name
-                } label: {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(repo.fullName)
-                                .foregroundStyle(.primary)
-                            if let pushedAt = repo.pushedAt {
-                                Text("Pushed: \(pushedAt)")
-                                    .font(.caption2)
+            if browseRepos.isEmpty && browseError == nil {
+                Text("No repos loaded yet. Tap Refresh to fetch from GitHub.")
+                    .foregroundStyle(.secondary)
+            } else if !browseRepos.isEmpty {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("Search repos...", text: $browseSearch)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                }
+
+                ForEach(filteredBrowseRepos) { repo in
+                    Button {
+                        owner = repo.owner
+                        name = repo.name
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(repo.fullName)
+                                    .foregroundStyle(.primary)
+                                if let pushedAt = repo.pushedAt {
+                                    Text("Pushed: \(pushedAt)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            if repo.private {
+                                Image(systemName: "lock.fill")
+                                    .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
-                        }
-                        Spacer()
-                        if repo.private {
-                            Image(systemName: "lock.fill")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        if repo.owner == owner && repo.name == name {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(.blue)
+                            if repo.owner == owner && repo.name == name {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.blue)
+                            }
                         }
                     }
                 }

--- a/ios/IssueCTL/Views/Settings/AddRepoSheet.swift
+++ b/ios/IssueCTL/Views/Settings/AddRepoSheet.swift
@@ -8,12 +8,28 @@ struct AddRepoSheet: View {
     @State private var isSubmitting = false
     @State private var errorMessage: String?
 
+    // Browse state
+    @State private var showBrowse = false
+    @State private var browseRepos: [GitHubAccessibleRepo] = []
+    @State private var isBrowseLoading = false
+    @State private var browseError: String?
+    @State private var browseSearch = ""
+    @State private var isRefreshing = false
+
     /// Called with the newly added repo on success.
     var onAdded: (Repo) -> Void
 
     private var isValid: Bool {
         !owner.trimmingCharacters(in: .whitespaces).isEmpty
             && !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var filteredBrowseRepos: [GitHubAccessibleRepo] {
+        if browseSearch.isEmpty { return browseRepos }
+        let query = browseSearch.lowercased()
+        return browseRepos.filter { repo in
+            repo.fullName.lowercased().contains(query)
+        }
     }
 
     var body: some View {
@@ -31,7 +47,27 @@ struct AddRepoSheet: View {
                 } header: {
                     Text("GitHub Repository")
                 } footer: {
-                    Text("Enter the owner and name exactly as they appear on GitHub (e.g. owner: \"apple\", name: \"swift\").")
+                    Text("Enter the owner and name exactly as they appear on GitHub, or browse your accessible repos below.")
+                }
+
+                Section {
+                    Button {
+                        showBrowse.toggle()
+                        if showBrowse && browseRepos.isEmpty {
+                            Task { await loadBrowseRepos(refresh: false) }
+                        }
+                    } label: {
+                        HStack {
+                            Label("Browse Accessible Repos", systemImage: "list.bullet.rectangle")
+                            Spacer()
+                            Image(systemName: showBrowse ? "chevron.up" : "chevron.down")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if showBrowse {
+                        browseContent
+                    }
                 }
 
                 if let errorMessage {
@@ -64,6 +100,99 @@ struct AddRepoSheet: View {
             .interactiveDismissDisabled(isSubmitting)
         }
     }
+
+    // MARK: - Browse Content
+
+    @ViewBuilder
+    private var browseContent: some View {
+        if isBrowseLoading && browseRepos.isEmpty {
+            HStack {
+                Spacer()
+                ProgressView("Loading repos...")
+                Spacer()
+            }
+        } else if let error = browseError, browseRepos.isEmpty {
+            Label(error, systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.secondary)
+        } else if browseRepos.isEmpty {
+            Text("No accessible repos found.")
+                .foregroundStyle(.secondary)
+        } else {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search repos...", text: $browseSearch)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
+
+            Button {
+                Task { await loadBrowseRepos(refresh: true) }
+            } label: {
+                HStack {
+                    Label("Refresh from GitHub", systemImage: "arrow.clockwise")
+                    if isRefreshing {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isRefreshing)
+
+            ForEach(filteredBrowseRepos) { repo in
+                Button {
+                    owner = repo.owner
+                    name = repo.name
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(repo.fullName)
+                                .foregroundStyle(.primary)
+                            if let pushedAt = repo.pushedAt {
+                                Text("Pushed: \(pushedAt)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        if repo.private {
+                            Image(systemName: "lock.fill")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        if repo.owner == owner && repo.name == name {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.blue)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Browse Loading
+
+    private func loadBrowseRepos(refresh: Bool) async {
+        if refresh {
+            isRefreshing = true
+        } else {
+            isBrowseLoading = true
+        }
+        browseError = nil
+        defer {
+            isBrowseLoading = false
+            isRefreshing = false
+        }
+
+        do {
+            let response = try await api.githubRepos(refresh: refresh)
+            browseRepos = response.repos
+        } catch {
+            browseError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Submit
 
     private func submit() async {
         let trimmedOwner = owner.trimmingCharacters(in: .whitespaces)

--- a/ios/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/ios/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -99,8 +99,8 @@ struct EditRepoSheet: View {
             let updated = try await api.updateRepo(
                 owner: repo.owner,
                 name: repo.name,
-                localPath: trimmedPath.isEmpty ? nil : trimmedPath,
-                branchPattern: trimmedPattern.isEmpty ? nil : trimmedPattern
+                localPath: trimmedPath,
+                branchPattern: trimmedPattern
             )
             onUpdated(updated)
             dismiss()

--- a/ios/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/ios/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct EditRepoSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    let repo: Repo
+    var onUpdated: (Repo) -> Void
+
+    @State private var localPath: String
+    @State private var branchPattern: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(repo: Repo, onUpdated: @escaping (Repo) -> Void) {
+        self.repo = repo
+        self.onUpdated = onUpdated
+        _localPath = State(initialValue: repo.localPath ?? "")
+        _branchPattern = State(initialValue: repo.branchPattern ?? "")
+    }
+
+    private var hasChanges: Bool {
+        let currentPath = localPath.trimmingCharacters(in: .whitespaces)
+        let currentPattern = branchPattern.trimmingCharacters(in: .whitespaces)
+        let originalPath = repo.localPath ?? ""
+        let originalPattern = repo.branchPattern ?? ""
+        return currentPath != originalPath || currentPattern != originalPattern
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent("Owner", value: repo.owner)
+                    LabeledContent("Name", value: repo.name)
+                } header: {
+                    Text("Repository")
+                }
+
+                Section {
+                    TextField("Local path", text: $localPath)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Local Path")
+                } footer: {
+                    Text("Absolute path to the local git clone (e.g. ~/code/my-repo).")
+                }
+
+                Section {
+                    TextField("Branch pattern", text: $branchPattern)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Branch Pattern")
+                } footer: {
+                    Text("Pattern for naming branches (e.g. feature/{{number}}-{{slug}}).")
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Edit Repository")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .disabled(!hasChanges)
+                    }
+                }
+            }
+            .interactiveDismissDisabled(isSaving)
+        }
+    }
+
+    private func save() async {
+        let trimmedPath = localPath.trimmingCharacters(in: .whitespaces)
+        let trimmedPattern = branchPattern.trimmingCharacters(in: .whitespaces)
+
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            let updated = try await api.updateRepo(
+                owner: repo.owner,
+                name: repo.name,
+                localPath: trimmedPath.isEmpty ? nil : trimmedPath,
+                branchPattern: trimmedPattern.isEmpty ? nil : trimmedPattern
+            )
+            onUpdated(updated)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -41,6 +41,8 @@ struct SettingsView: View {
                 EditRepoSheet(repo: repo) { updated in
                     if let idx = repos.firstIndex(where: { $0.id == updated.id }) {
                         repos[idx] = updated
+                    } else {
+                        Task { await loadRepos() }
                     }
                 }
             }

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @State private var healthError: String?
     @State private var removeError: String?
     @State private var refreshError: String?
+    @State private var editingRepo: Repo?
 
     var body: some View {
         NavigationStack {
@@ -34,6 +35,13 @@ struct SettingsView: View {
             .sheet(isPresented: $showAddRepo) {
                 AddRepoSheet { newRepo in
                     repos.insert(newRepo, at: 0)
+                }
+            }
+            .sheet(item: $editingRepo) { repo in
+                EditRepoSheet(repo: repo) { updated in
+                    if let idx = repos.firstIndex(where: { $0.id == updated.id }) {
+                        repos[idx] = updated
+                    }
                 }
             }
             .confirmationDialog(
@@ -121,7 +129,12 @@ struct SettingsView: View {
                 }
             } else {
                 ForEach(repos) { repo in
-                    RepoRow(repo: repo)
+                    Button {
+                        editingRepo = repo
+                    } label: {
+                        RepoRow(repo: repo)
+                    }
+                    .tint(.primary)
                 }
                 .onDelete(perform: deleteRepos)
             }
@@ -210,10 +223,21 @@ private struct RepoRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(repo.fullName)
-                .font(.body)
+            HStack {
+                Text(repo.fullName)
+                    .font(.body)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             if let localPath = repo.localPath {
                 Text(localPath)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let branchPattern = repo.branchPattern {
+                Text("Branch: \(branchPattern)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
+++ b/ios/IssueCTL/Views/Shared/ImageAttachmentButton.swift
@@ -13,17 +13,6 @@ struct ImageAttachmentButton: View {
     @State private var isUploading = false
     @State private var errorMessage: String?
 
-    @ViewBuilder
-    private var pickerLabel: some View {
-        if isUploading {
-            ProgressView()
-                .controlSize(.small)
-        } else {
-            Label("Attach Image", systemImage: "photo")
-                .font(.callout)
-        }
-    }
-
     var body: some View {
         HStack(spacing: 8) {
             PhotosPicker(
@@ -31,7 +20,13 @@ struct ImageAttachmentButton: View {
                 matching: .images,
                 photoLibrary: .shared()
             ) {
-                pickerLabel
+                if isUploading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Attach Image", systemImage: "photo")
+                        .font(.callout)
+                }
             }
             .disabled(isUploading)
 

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
-import { getDb, removeRepo, getRepo, formatErrorForUser } from "@issuectl/core";
+import { getDb, removeRepo, getRepo, updateRepo, formatErrorForUser } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +35,76 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (err) {
     log.error({ err, msg: "api_repo_remove_failed", owner, name: repoName });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+type UpdateRepoBody = {
+  localPath?: string;
+  branchPattern?: string;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo: repoName } = await params;
+  if (!owner || !repoName) {
+    return NextResponse.json(
+      { success: false, error: "Owner and repo name are required" },
+      { status: 400 },
+    );
+  }
+
+  let body: UpdateRepoBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  if (body.localPath !== undefined && typeof body.localPath !== "string") {
+    return NextResponse.json(
+      { success: false, error: "localPath must be a string" },
+      { status: 400 },
+    );
+  }
+  if (body.branchPattern !== undefined && typeof body.branchPattern !== "string") {
+    return NextResponse.json(
+      { success: false, error: "branchPattern must be a string" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const repo = getRepo(db, owner, repoName);
+    if (!repo) {
+      return NextResponse.json(
+        { success: false, error: "Repository not found" },
+        { status: 404 },
+      );
+    }
+
+    const updates: { localPath?: string; branchPattern?: string } = {};
+    if (body.localPath !== undefined) updates.localPath = body.localPath;
+    if (body.branchPattern !== undefined) updates.branchPattern = body.branchPattern;
+
+    const updated = updateRepo(db, repo.id, updates);
+    log.info({ msg: "api_repo_updated", repoId: repo.id, owner, name: repoName, updates });
+    return NextResponse.json({ success: true, repo: updated });
+  } catch (err) {
+    log.error({ err, msg: "api_repo_update_failed", owner, name: repoName });
     return NextResponse.json(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -96,9 +96,9 @@ export async function PATCH(
       );
     }
 
-    const updates: { localPath?: string; branchPattern?: string } = {};
-    if (body.localPath !== undefined) updates.localPath = body.localPath;
-    if (body.branchPattern !== undefined) updates.branchPattern = body.branchPattern;
+    const updates: { localPath?: string | null; branchPattern?: string | null } = {};
+    if (body.localPath !== undefined) updates.localPath = body.localPath || null;
+    if (body.branchPattern !== undefined) updates.branchPattern = body.branchPattern || null;
 
     const updated = updateRepo(db, repo.id, updates);
     log.info({ msg: "api_repo_updated", repoId: repo.id, owner, name: repoName, updates });

--- a/packages/web/app/api/v1/repos/github/route.ts
+++ b/packages/web/app/api/v1/repos/github/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   } catch (err) {
     log.error({ err, msg: "api_github_repos_failed", refresh });
     return NextResponse.json(
-      { error: formatErrorForUser(err) },
+      { success: false, error: formatErrorForUser(err) },
       { status: 500 },
     );
   }

--- a/packages/web/app/api/v1/repos/github/route.ts
+++ b/packages/web/app/api/v1/repos/github/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  readCachedAccessibleRepos,
+  refreshAccessibleRepos,
+  withAuthRetry,
+  formatErrorForUser,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const refresh = request.nextUrl.searchParams.get("refresh") === "true";
+
+  try {
+    const db = getDb();
+
+    if (refresh) {
+      const snapshot = await withAuthRetry((octokit) =>
+        refreshAccessibleRepos(db, octokit),
+      );
+      return NextResponse.json(snapshot);
+    }
+
+    const snapshot = readCachedAccessibleRepos(db);
+    return NextResponse.json(snapshot);
+  } catch (err) {
+    log.error({ err, msg: "api_github_repos_failed", refresh });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoint for cached GitHub accessible repos with refresh support
- Add PATCH endpoint for updating repo `localPath` and `branchPattern` (empty string -> null normalization)
- Add GitHub repo browsing in `AddRepoSheet` with search, private badge, and tap-to-fill
- Add `EditRepoSheet` for editing localPath/branchPattern with change detection

## Test plan
- [ ] Verify "Browse Accessible Repos" section loads repos in AddRepoSheet
- [ ] Verify search filters repos, refresh button works, private badge shows
- [ ] Verify tapping a repo fills owner/name fields
- [ ] Verify EditRepoSheet opens from repo row with current values
- [ ] Verify saving changes updates repo, clearing fields sends empty string -> null