### PR TITLE
fix(ios): surface error details and remove force-unwrap in list views

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -428,23 +428,21 @@ struct IssueListView: View {
             // but don't block the primary issue list.
             var supplementaryErrors: [String] = []
 
-            async let draftsFetch: DraftsResponse? = {
-                do { return try await api.listDrafts() }
-                catch { return nil }
+            async let draftsFetch: Result<DraftsResponse, Error> = {
+                do { return .success(try await api.listDrafts()) }
+                catch { return .failure(error) }
             }()
-            async let deploymentsFetch: ActiveDeploymentsResponse? = {
-                do { return try await api.activeDeployments() }
-                catch { return nil }
+            async let deploymentsFetch: Result<ActiveDeploymentsResponse, Error> = {
+                do { return .success(try await api.activeDeployments()) }
+                catch { return .failure(error) }
             }()
-            if let draftResult = await draftsFetch {
-                drafts = draftResult.drafts
-            } else {
-                supplementaryErrors.append("drafts")
+            switch await draftsFetch {
+            case .success(let result): drafts = result.drafts
+            case .failure(let error): supplementaryErrors.append("drafts (\(error.localizedDescription))")
             }
-            if let deploymentResult = await deploymentsFetch {
-                activeDeployments = deploymentResult.deployments
-            } else {
-                supplementaryErrors.append("sessions")
+            switch await deploymentsFetch {
+            case .success(let result): activeDeployments = result.deployments
+            case .failure(let error): supplementaryErrors.append("sessions (\(error.localizedDescription))")
             }
 
             do {
@@ -453,7 +451,7 @@ struct IssueListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                supplementaryErrors.append("user profile")
+                supplementaryErrors.append("user profile (\(error.localizedDescription))")
             }
 
             var failedRepos: [String] = []

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -420,11 +420,14 @@ struct IssueListView: View {
     private func loadAll(refresh: Bool = false) async {
         isLoading = true
         errorMessage = nil
+        actionError = nil
         do {
             repos = try await api.repos()
 
-            // Drafts, deployments, and user are supplementary — fetch independently so a failure
-            // doesn't block the primary issue list.
+            // Supplementary fetches — failures surface via actionError banner
+            // but don't block the primary issue list.
+            var supplementaryErrors: [String] = []
+
             async let draftsFetch: DraftsResponse? = {
                 do { return try await api.listDrafts() }
                 catch { return nil }
@@ -433,8 +436,16 @@ struct IssueListView: View {
                 do { return try await api.activeDeployments() }
                 catch { return nil }
             }()
-            drafts = await draftsFetch?.drafts ?? drafts
-            activeDeployments = await deploymentsFetch?.deployments ?? activeDeployments
+            if let draftResult = await draftsFetch {
+                drafts = draftResult.drafts
+            } else {
+                supplementaryErrors.append("drafts")
+            }
+            if let deploymentResult = await deploymentsFetch {
+                activeDeployments = deploymentResult.deployments
+            } else {
+                supplementaryErrors.append("sessions")
+            }
 
             do {
                 let user = try await api.currentUser()
@@ -442,6 +453,7 @@ struct IssueListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
+                supplementaryErrors.append("user profile")
             }
 
             var failedRepos: [String] = []
@@ -464,8 +476,9 @@ struct IssueListView: View {
                     }
                 }
             }
-            if !failedRepos.isEmpty {
-                actionError = "Failed to load: \(failedRepos.joined(separator: ", "))"
+            let allFailures = failedRepos + supplementaryErrors
+            if !allFailures.isEmpty {
+                actionError = "Failed to load: \(allFailures.joined(separator: ", "))"
             }
 
             // Fetch priorities for all displayed issues (best-effort)

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -245,7 +245,7 @@ struct PRListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                supplementaryErrors.append("user profile")
+                supplementaryErrors.append("user profile (\(error.localizedDescription))")
             }
 
             var failedRepos: [String] = []

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -237,7 +237,7 @@ struct PRListView: View {
         do {
             repos = try await api.repos()
 
-            // Fetch current user for "mine" filter — non-blocking
+            // Fetch current user for "mine" filter — failure is non-fatal
             var supplementaryErrors: [String] = []
             do {
                 let user = try await api.currentUser()

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -233,16 +233,19 @@ struct PRListView: View {
     private func loadAll(refresh: Bool = false) async {
         isLoading = true
         errorMessage = nil
+        actionError = nil
         do {
             repos = try await api.repos()
 
             // Fetch current user for "mine" filter — non-blocking
+            var supplementaryErrors: [String] = []
             do {
                 let user = try await api.currentUser()
                 currentUserLogin = user.login
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
+                supplementaryErrors.append("user profile")
             }
 
             var failedRepos: [String] = []
@@ -265,8 +268,9 @@ struct PRListView: View {
                     }
                 }
             }
-            if !failedRepos.isEmpty {
-                actionError = "Failed to load: \(failedRepos.joined(separator: ", "))"
+            let allFailures = failedRepos + supplementaryErrors
+            if !allFailures.isEmpty {
+                actionError = "Failed to load: \(allFailures.joined(separator: ", "))"
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -12,44 +12,53 @@ struct TerminalView: View {
 
     var body: some View {
         NavigationStack {
-            TerminalWebView(url: terminalURL)
-                .ignoresSafeArea(edges: .bottom)
-                .navigationTitle("\(deployment.repoFullName) #\(deployment.issueNumber)")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button("Done") { dismiss() }
-                            .accessibilityIdentifier("terminal-done-button")
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        HStack(spacing: 12) {
-                            Text(deployment.runningDuration)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Button(role: .destructive) {
-                                showEndConfirm = true
-                            } label: {
-                                Label("End", systemImage: "stop.circle.fill")
-                            }
-                            .accessibilityIdentifier("terminal-end-button")
+            Group {
+                if let url = terminalURL {
+                    TerminalWebView(url: url)
+                        .ignoresSafeArea(edges: .bottom)
+                } else {
+                    ContentUnavailableView(
+                        "Invalid Server URL",
+                        systemImage: "exclamationmark.triangle",
+                        description: Text("Could not connect to \(api.serverURL)")
+                    )
+                }
+            }
+            .navigationTitle("\(deployment.repoFullName) #\(deployment.issueNumber)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                        .accessibilityIdentifier("terminal-done-button")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    HStack(spacing: 12) {
+                        Text(deployment.runningDuration)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button(role: .destructive) {
+                            showEndConfirm = true
+                        } label: {
+                            Label("End", systemImage: "stop.circle.fill")
                         }
+                        .accessibilityIdentifier("terminal-end-button")
                     }
                 }
-                .confirmationDialog(
-                    "End this session?",
-                    isPresented: $showEndConfirm,
-                    titleVisibility: .visible
-                ) {
-                    Button("End Session", role: .destructive) {
-                        onEnd()
-                    }
+            }
+            .confirmationDialog(
+                "End this session?",
+                isPresented: $showEndConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("End Session", role: .destructive) {
+                    onEnd()
                 }
+            }
         }
     }
 
-    private var terminalURL: URL {
-        let base = api.serverURL
-        return URL(string: "\(base)/api/terminal/\(port)/")!
+    private var terminalURL: URL? {
+        URL(string: "\(api.serverURL)/api/terminal/\(port)/")
     }
 }
 

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -20,7 +20,7 @@ struct TerminalView: View {
                     ContentUnavailableView(
                         "Invalid Server URL",
                         systemImage: "exclamationmark.triangle",
-                        description: Text("Unable to parse server URL. Check your connection settings.")
+                        description: Text("Could not parse: \(api.serverURL)/api/terminal/\(port)/")
                     )
                 }
             }

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -20,7 +20,7 @@ struct TerminalView: View {
                     ContentUnavailableView(
                         "Invalid Server URL",
                         systemImage: "exclamationmark.triangle",
-                        description: Text("Could not connect to \(api.serverURL)")
+                        description: Text("Unable to parse server URL. Check your connection settings.")
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- Surface supplementary fetch failures (drafts, deployments, user profile) via actionError banner in IssueListView and PRListView using `Result<T, Error>` instead of discarding errors with `catch { return nil }`
- Clear stale actionError at the top of `loadAll()` so successful refreshes don't leave old error banners visible
- Replace force-unwrap `URL(string:)!` in TerminalView with optional binding + ContentUnavailableView fallback showing the malformed URL for diagnostics

## Test plan
- [ ] Verify issue list loads normally with no error banner
- [ ] Simulate a supplementary fetch failure (e.g., revoke token) and confirm the banner shows the error reason (e.g., "drafts (Unauthorized)")
- [ ] Pull-to-refresh after a failure and confirm the stale error banner clears
- [ ] Open a terminal session and verify the WebView renders correctly
- [ ] Verify TerminalView shows the diagnostic fallback when server URL is malformed