### PR TITLE
fix(ios): ux polish, feature parity, and error handling

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
 		34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */; };
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
+		42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */; };
+		435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3403F8C644518F599E01A976 /* ReassignSheet.swift */; };
 		4451AE4574EA7D0F86AEE021 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403330B1342AA7C19FA797D /* Constants.swift */; };
 		48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
 		493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
@@ -37,6 +39,7 @@
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
 		8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */; };
 		8F6B1136F0F654026188BFF6 /* EditRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */; };
+		90BE1758390002096CF585BA /* APIClient+AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */; };
 		916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */; };
 		9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */; };
 		9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
@@ -46,6 +49,7 @@
 		A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767FFF9158E604C69C4007DB /* PRDetailView.swift */; };
 		AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */; };
 		B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */; };
+		B4D3E5DC8306990F763058B6 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */; };
 		BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */; };
 		BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
 		C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13760098C8ED1658B27AD54B /* CommentSheet.swift */; };
@@ -76,6 +80,7 @@
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
 		3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Priority.swift"; sourceTree = "<group>"; };
+		3403F8C644518F599E01A976 /* ReassignSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReassignSheet.swift; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		3F39642CB180355E5C62A75E /* ImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightbox.swift; sourceTree = "<group>"; };
@@ -88,6 +93,8 @@
 		5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
 		6BE8B812763DC773F8484C7D /* ParseResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultRow.swift; sourceTree = "<group>"; };
 		6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorBanner.swift; sourceTree = "<group>"; };
+		6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
+		723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListView.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
 		767FFF9158E604C69C4007DB /* PRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDetailView.swift; sourceTree = "<group>"; };
 		78D638F823877AD0CAA946A4 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
@@ -100,6 +107,7 @@
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+AdvancedSettings.swift"; sourceTree = "<group>"; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAccessibleRepo.swift; sourceTree = "<group>"; };
 		B7701223E13D43C4F74244B0 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
@@ -178,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				E9F091BF822565D8E0F15E7A /* APIClient.swift */,
+				AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */,
 				22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */,
 				2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */,
 				DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */,
@@ -203,8 +212,10 @@
 			isa = PBXGroup;
 			children = (
 				F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */,
+				6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */,
 				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
 				093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */,
+				723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -302,6 +313,7 @@
 				6BE8B812763DC773F8484C7D /* ParseResultRow.swift */,
 				45D2FEDC36ACDF7207272AE3 /* ParseView.swift */,
 				DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */,
+				3403F8C644518F599E01A976 /* ReassignSheet.swift */,
 			);
 			path = Issues;
 			sourceTree = "<group>";
@@ -361,6 +373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90BE1758390002096CF585BA /* APIClient+AdvancedSettings.swift in Sources */,
 				34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */,
 				83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */,
 				F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */,
@@ -370,6 +383,7 @@
 				B19FE4C33598B3FD1BBAC6AA /* APIClient+Settings.swift in Sources */,
 				9A70F3F0F0470F2847F716F7 /* APIClient.swift in Sources */,
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,
+				B4D3E5DC8306990F763058B6 /* AdvancedSettingsView.swift in Sources */,
 				916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */,
 				AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */,
 				C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */,
@@ -406,6 +420,7 @@
 				327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */,
 				9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */,
 				0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */,
+				435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */,
 				59D20056C3E281403735631D /* Repo.swift in Sources */,
 				BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */,
 				332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */,
@@ -416,6 +431,7 @@
 				89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */,
 				6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */,
 				C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */,
+				42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
+++ b/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+// MARK: - Settings types
+
+struct SettingsResponse: Codable, Sendable {
+    let settings: [String: String]
+}
+
+struct SettingsUpdateRequest: Encodable, Sendable {
+    let updates: [String: String]
+
+    func encode(to encoder: Encoder) throws {
+        // Encode as flat key-value (not nested under "updates")
+        var container = encoder.singleValueContainer()
+        try container.encode(updates)
+    }
+}
+
+// MARK: - Worktree types
+
+struct WorktreeInfo: Codable, Identifiable, Sendable {
+    let path: String
+    let name: String
+    let repo: String?
+    let owner: String?
+    let localPath: String?
+    let issueNumber: Int?
+    let stale: Bool
+
+    var id: String { path }
+    var repoFullName: String? {
+        guard let owner, let repo else { return nil }
+        return "\(owner)/\(repo)"
+    }
+}
+
+struct WorktreesResponse: Codable, Sendable {
+    let worktrees: [WorktreeInfo]
+}
+
+struct WorktreeCleanupRequest: Encodable, Sendable {
+    let path: String?
+}
+
+struct WorktreeCleanupResponse: Codable, Sendable {
+    let success: Bool
+    let removed: Int?
+    let error: String?
+}
+
+// MARK: - Reassign types
+
+struct ReassignRequest: Encodable, Sendable {
+    let targetOwner: String
+    let targetRepo: String
+}
+
+struct ReassignResponse: Codable, Sendable {
+    let success: Bool
+    let newIssueNumber: Int?
+    let newOwner: String?
+    let newRepo: String?
+    let cleanupWarning: String?
+    let error: String?
+}
+
+// MARK: - APIClient extensions
+
+extension APIClient {
+
+    // MARK: Settings
+
+    func getSettings() async throws -> [String: String] {
+        let (data, _) = try await request(path: "/api/v1/settings")
+        let response = try decoder.decode(SettingsResponse.self, from: data)
+        return response.settings
+    }
+
+    func updateSettings(_ updates: [String: String]) async throws -> SuccessResponse {
+        let bodyData = try JSONEncoder().encode(updates)
+        let (data, _) = try await request(path: "/api/v1/settings", method: "PATCH", body: bodyData)
+        return try decoder.decode(SuccessResponse.self, from: data)
+    }
+
+    // MARK: Worktrees
+
+    func listWorktrees() async throws -> [WorktreeInfo] {
+        let (data, _) = try await request(path: "/api/v1/worktrees")
+        let response = try decoder.decode(WorktreesResponse.self, from: data)
+        return response.worktrees
+    }
+
+    func cleanupWorktree(path: String) async throws -> SuccessResponse {
+        let body = WorktreeCleanupRequest(path: path)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/worktrees/cleanup", method: "POST", body: bodyData)
+        return try decoder.decode(SuccessResponse.self, from: data)
+    }
+
+    func cleanupStaleWorktrees() async throws -> WorktreeCleanupResponse {
+        let body: [String: String?] = [:]
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/worktrees/cleanup", method: "POST", body: bodyData)
+        return try decoder.decode(WorktreeCleanupResponse.self, from: data)
+    }
+
+    // MARK: Issue Reassignment
+
+    func reassignIssue(
+        owner: String, repo: String, number: Int,
+        targetOwner: String, targetRepo: String
+    ) async throws -> ReassignResponse {
+        let body = ReassignRequest(targetOwner: targetOwner, targetRepo: targetRepo)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(
+            path: "/api/v1/issues/\(owner)/\(repo)/\(number)/reassign",
+            method: "POST",
+            body: bodyData
+        )
+        return try decoder.decode(ReassignResponse.self, from: data)
+    }
+}

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -436,14 +436,34 @@ struct IssueDetailView: View {
     private func load(refresh: Bool = false) async {
         isLoading = true
         errorMessage = nil
+        actionError = nil
         do {
             async let detailResult = api.issueDetail(owner: owner, repo: repo, number: number, refresh: refresh)
-            async let userResult = api.currentUser()
-            async let priorityResult = api.getPriority(owner: owner, repo: repo, number: number)
+            async let userResult: Result<UserResponse, Error> = {
+                do { return .success(try await api.currentUser()) }
+                catch { return .failure(error) }
+            }()
+            async let priorityResult: Result<Priority, Error> = {
+                do { return .success(try await api.getPriority(owner: owner, repo: repo, number: number)) }
+                catch { return .failure(error) }
+            }()
             detail = try await detailResult
-            // Best-effort: don't fail the whole load if user/priority fetch fails
-            currentUserLogin = try? await userResult.login
-            currentPriority = (try? await priorityResult) ?? .normal
+
+            // Supplementary fetches — failures are non-fatal but surfaced
+            var failures: [String] = []
+            switch await userResult {
+            case .success(let user): currentUserLogin = user.login
+            case .failure(let error): failures.append("user profile (\(error.localizedDescription))")
+            }
+            switch await priorityResult {
+            case .success(let priority): currentPriority = priority
+            case .failure(let error):
+                currentPriority = .normal
+                failures.append("priority (\(error.localizedDescription))")
+            }
+            if !failures.isEmpty {
+                actionError = "Failed to load: \(failures.joined(separator: ", "))"
+            }
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -31,6 +31,7 @@ struct IssueDetailView: View {
     // Priority state
     @State private var currentPriority: Priority = .normal
     @State private var isLoadingPriority = false
+    @State private var showReassignSheet = false
 
     var body: some View {
         Group {
@@ -110,6 +111,11 @@ struct IssueDetailView: View {
                         }
                         Divider()
                         Button {
+                            showReassignSheet = true
+                        } label: {
+                            Label("Reassign to Repo…", systemImage: "arrow.triangle.swap")
+                        }
+                        Button {
                             showLaunchSheet = true
                         } label: {
                             Label("Launch", systemImage: "play.fill")
@@ -117,6 +123,16 @@ struct IssueDetailView: View {
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }
+                }
+            }
+        }
+        .sheet(isPresented: $showReassignSheet) {
+            if let detail {
+                ReassignSheet(
+                    owner: owner, repo: repo, number: number,
+                    issueTitle: detail.issue.title
+                ) { newOwner, newRepo, newNumber in
+                    Task { await load(refresh: true) }
                 }
             }
         }
@@ -211,6 +227,9 @@ struct IssueDetailView: View {
             showActionError = newValue != nil
         }
         .task { await load() }
+        .onAppear {
+            actionError = nil
+        }
     }
 
     // MARK: - Sections

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -457,20 +457,22 @@ struct IssueListView: View {
                 failures.append("user profile (\(error.localizedDescription))")
             }
 
-            await withTaskGroup(of: (String, String, [GitHubIssue]?).self) { group in
+            await withTaskGroup(of: (String, String, [GitHubIssue]?, Error?).self) { group in
                 for repo in repos {
                     group.addTask {
                         do {
                             let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.issues)
+                            return (repo.fullName, repo.name, response.issues, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil)
+                            return (repo.fullName, repo.name, nil, error)
                         }
                     }
                 }
-                for await (fullName, name, issues) in group {
+                for await (fullName, name, issues, error) in group {
                     if let issues {
                         issuesByRepo[fullName] = issues
+                    } else if let error {
+                        failures.append("\(name) (\(error.localizedDescription))")
                     } else {
                         failures.append(name)
                     }
@@ -480,38 +482,45 @@ struct IssueListView: View {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }
 
-            // Fetch priorities for all displayed issues (best-effort)
-            await loadPriorities()
+            // Fetch priorities for all displayed issues — failures are non-fatal
+            let priorityFailures = await loadPriorities()
+            if !priorityFailures.isEmpty && failures.isEmpty {
+                // Only show priority failures if there aren't already more important errors
+                actionError = "Failed to load: \(priorityFailures.joined(separator: ", "))"
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
         isLoading = false
     }
 
-    private func loadPriorities() async {
+    private func loadPriorities() async -> [String] {
         isLoadingPriorities = true
         var newPriorities: [String: Priority] = [:]
-        await withTaskGroup(of: [(String, Priority)].self) { group in
+        var priorityErrors: [String] = []
+        await withTaskGroup(of: ([(String, Priority)], String?).self) { group in
             let uniqueRepos = Set(repos.map { ($0.owner, $0.name) }.map { "\($0.0)/\($0.1)" })
             for repoFullName in uniqueRepos {
                 guard let repo = repos.first(where: { $0.fullName == repoFullName }) else { continue }
                 group.addTask {
                     do {
                         let items = try await api.listPriorities(owner: repo.owner, repo: repo.name)
-                        return items.map { ("\(repo.owner)/\(repo.name)#\($0.issueNumber)", $0.priority) }
+                        return (items.map { ("\(repo.owner)/\(repo.name)#\($0.issueNumber)", $0.priority) }, nil)
                     } catch {
-                        return []
+                        return ([], "\(repo.name) priorities (\(error.localizedDescription))")
                     }
                 }
             }
-            for await pairs in group {
+            for await (pairs, errorMsg) in group {
                 for (key, priority) in pairs {
                     newPriorities[key] = priority
                 }
+                if let errorMsg { priorityErrors.append(errorMsg) }
             }
         }
         priorities = newPriorities
         isLoadingPriorities = false
+        return priorityErrors
     }
 }
 

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -291,6 +291,7 @@ struct IssueListView: View {
                 Label(actionError, systemImage: "exclamationmark.triangle")
                     .foregroundStyle(.red)
                     .font(.subheadline)
+                    .lineLimit(3)
             }
             ForEach(filteredIssues, id: \.htmlUrl) { issue in
                 let color = repoIndex(for: issue).map { RepoColors.color(for: $0) } ?? .secondary
@@ -305,6 +306,7 @@ struct IssueListView: View {
                     )) {
                         IssueRowView(issue: issue, repoColor: color, isRunning: running)
                     }
+                    .accessibilityIdentifier("issue-row-\(issue.number)")
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if issue.isOpen {
                             Button {
@@ -369,6 +371,7 @@ struct IssueListView: View {
                         }
                         .padding(.vertical, 2)
                     }
+                    .accessibilityIdentifier("draft-row-\(draft.id)")
                     .swipeActions(edge: .trailing) {
                         Button(role: .destructive) {
                             deleteDraftTarget = draft.id
@@ -426,7 +429,7 @@ struct IssueListView: View {
 
             // Supplementary fetches — failures surface via actionError banner
             // but don't block the primary issue list.
-            var supplementaryErrors: [String] = []
+            var failures: [String] = []
 
             async let draftsFetch: Result<DraftsResponse, Error> = {
                 do { return .success(try await api.listDrafts()) }
@@ -438,11 +441,11 @@ struct IssueListView: View {
             }()
             switch await draftsFetch {
             case .success(let result): drafts = result.drafts
-            case .failure(let error): supplementaryErrors.append("drafts (\(error.localizedDescription))")
+            case .failure(let error): failures.append("drafts (\(error.localizedDescription))")
             }
             switch await deploymentsFetch {
             case .success(let result): activeDeployments = result.deployments
-            case .failure(let error): supplementaryErrors.append("sessions (\(error.localizedDescription))")
+            case .failure(let error): failures.append("sessions (\(error.localizedDescription))")
             }
 
             do {
@@ -451,10 +454,9 @@ struct IssueListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                supplementaryErrors.append("user profile (\(error.localizedDescription))")
+                failures.append("user profile (\(error.localizedDescription))")
             }
 
-            var failedRepos: [String] = []
             await withTaskGroup(of: (String, String, [GitHubIssue]?).self) { group in
                 for repo in repos {
                     group.addTask {
@@ -470,13 +472,12 @@ struct IssueListView: View {
                     if let issues {
                         issuesByRepo[fullName] = issues
                     } else {
-                        failedRepos.append(name)
+                        failures.append(name)
                     }
                 }
             }
-            let allFailures = failedRepos + supplementaryErrors
-            if !allFailures.isEmpty {
-                actionError = "Failed to load: \(allFailures.joined(separator: ", "))"
+            if !failures.isEmpty {
+                actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }
 
             // Fetch priorities for all displayed issues (best-effort)

--- a/ios/IssueCTL/Views/Issues/ReassignSheet.swift
+++ b/ios/IssueCTL/Views/Issues/ReassignSheet.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct ReassignSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    let owner: String
+    let repo: String
+    let number: Int
+    let issueTitle: String
+    var onSuccess: (String, String, Int) -> Void
+
+    @State private var repos: [Repo] = []
+    @State private var selectedRepo: Repo?
+    @State private var isLoading = true
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    private var availableRepos: [Repo] {
+        repos.filter { $0.owner != owner || $0.name != repo }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent("Issue", value: "#\(number)")
+                    Text(issueTitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Source")
+                } footer: {
+                    Text("This issue will be re-created in the target repo and closed in \(owner)/\(repo).")
+                }
+
+                Section {
+                    if isLoading {
+                        HStack {
+                            Spacer()
+                            ProgressView("Loading repos...")
+                            Spacer()
+                        }
+                    } else if availableRepos.isEmpty {
+                        Text("No other tracked repos available.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(availableRepos) { targetRepo in
+                            Button {
+                                selectedRepo = targetRepo
+                            } label: {
+                                HStack {
+                                    Text(targetRepo.fullName)
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                    if selectedRepo?.id == targetRepo.id {
+                                        Image(systemName: "checkmark")
+                                            .foregroundStyle(.blue)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Target Repository")
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Reassign Issue")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSubmitting)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSubmitting {
+                        ProgressView()
+                    } else {
+                        Button("Reassign") {
+                            Task { await submit() }
+                        }
+                        .disabled(selectedRepo == nil)
+                    }
+                }
+            }
+            .interactiveDismissDisabled(isSubmitting)
+            .task { await loadRepos() }
+        }
+    }
+
+    private func loadRepos() async {
+        isLoading = true
+        do {
+            repos = try await api.repos()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func submit() async {
+        guard let target = selectedRepo else { return }
+
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+
+        do {
+            let response = try await api.reassignIssue(
+                owner: owner, repo: repo, number: number,
+                targetOwner: target.owner, targetRepo: target.name
+            )
+            if response.success, let newNumber = response.newIssueNumber,
+               let newOwner = response.newOwner, let newRepo = response.newRepo {
+                onSuccess(newOwner, newRepo, newNumber)
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to reassign issue"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -51,6 +51,7 @@ struct PRDetailView: View {
                                 Label(actionError, systemImage: "exclamationmark.triangle")
                                     .foregroundStyle(.red)
                                     .font(.subheadline)
+                                    .lineLimit(3)
                             }
                         }
                         .padding()
@@ -66,6 +67,9 @@ struct PRDetailView: View {
         .navigationTitle("#\(number)")
         .navigationBarTitleDisplayMode(.inline)
         .task { await load() }
+        .onAppear {
+            actionError = nil
+        }
         .sheet(isPresented: $showRequestChanges) {
             RequestChangesSheet(
                 owner: owner, repo: repo, number: number,

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -181,6 +181,7 @@ struct PRListView: View {
                 Label(actionError, systemImage: "exclamationmark.triangle")
                     .foregroundStyle(.red)
                     .font(.subheadline)
+                    .lineLimit(3)
             }
             ForEach(filteredPulls, id: \.htmlUrl) { pull in
                 let color = repoIndex(for: pull).map { RepoColors.color(for: $0) } ?? .secondary
@@ -194,6 +195,7 @@ struct PRListView: View {
                     )) {
                         PRRowView(pull: pull, repoColor: color)
                     }
+                    .accessibilityIdentifier("pr-row-\(pull.number)")
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if pull.isOpen {
                             Button {
@@ -238,17 +240,16 @@ struct PRListView: View {
             repos = try await api.repos()
 
             // Fetch current user for "mine" filter — failure is non-fatal
-            var supplementaryErrors: [String] = []
+            var failures: [String] = []
             do {
                 let user = try await api.currentUser()
                 currentUserLogin = user.login
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                supplementaryErrors.append("user profile (\(error.localizedDescription))")
+                failures.append("user profile (\(error.localizedDescription))")
             }
 
-            var failedRepos: [String] = []
             await withTaskGroup(of: (String, String, [GitHubPull]?).self) { group in
                 for repo in repos {
                     group.addTask {
@@ -264,13 +265,12 @@ struct PRListView: View {
                     if let pulls {
                         pullsByRepo[fullName] = pulls
                     } else {
-                        failedRepos.append(name)
+                        failures.append(name)
                     }
                 }
             }
-            let allFailures = failedRepos + supplementaryErrors
-            if !allFailures.isEmpty {
-                actionError = "Failed to load: \(allFailures.joined(separator: ", "))"
+            if !failures.isEmpty {
+                actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -250,20 +250,22 @@ struct PRListView: View {
                 failures.append("user profile (\(error.localizedDescription))")
             }
 
-            await withTaskGroup(of: (String, String, [GitHubPull]?).self) { group in
+            await withTaskGroup(of: (String, String, [GitHubPull]?, Error?).self) { group in
                 for repo in repos {
                     group.addTask {
                         do {
                             let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.pulls)
+                            return (repo.fullName, repo.name, response.pulls, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil)
+                            return (repo.fullName, repo.name, nil, error)
                         }
                     }
                 }
-                for await (fullName, name, pulls) in group {
+                for await (fullName, name, pulls, error) in group {
                     if let pulls {
                         pullsByRepo[fullName] = pulls
+                    } else if let error {
+                        failures.append("\(name) (\(error.localizedDescription))")
                     } else {
                         failures.append(name)
                     }

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -34,6 +34,7 @@ struct SessionListView: View {
                     List {
                         ForEach(deployments) { deployment in
                             SessionRowView(deployment: deployment)
+                                .accessibilityIdentifier("session-row-\(deployment.id)")
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     if deployment.ttydPort != nil {

--- a/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+struct AdvancedSettingsView: View {
+    @Environment(APIClient.self) private var api
+    @State private var settings: [String: String] = [:]
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var isSaving = false
+    @State private var saveError: String?
+
+    // Editable fields
+    @State private var cacheTTL = ""
+    @State private var claudeExtraArgs = ""
+    @State private var idleGracePeriod = ""
+    @State private var idleThreshold = ""
+    @State private var branchPattern = ""
+    @State private var worktreeDir = ""
+
+    private var hasChanges: Bool {
+        cacheTTL != (settings["cache_ttl"] ?? "") ||
+        claudeExtraArgs != (settings["claude_extra_args"] ?? "") ||
+        idleGracePeriod != (settings["idle_grace_period"] ?? "") ||
+        idleThreshold != (settings["idle_threshold"] ?? "") ||
+        branchPattern != (settings["branch_pattern"] ?? "") ||
+        worktreeDir != (settings["worktree_dir"] ?? "")
+    }
+
+    var body: some View {
+        Form {
+            if isLoading {
+                Section {
+                    HStack {
+                        Spacer()
+                        ProgressView("Loading settings...")
+                        Spacer()
+                    }
+                }
+            } else if let errorMessage {
+                Section {
+                    ContentUnavailableView {
+                        Label("Error", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(errorMessage)
+                    } actions: {
+                        Button("Retry") { Task { await load() } }
+                    }
+                }
+            } else {
+                Section {
+                    TextField("Cache TTL (seconds)", text: $cacheTTL)
+                        .keyboardType(.numberPad)
+                } header: {
+                    Text("Cache")
+                } footer: {
+                    Text("How long to cache GitHub data (0–604800 seconds). Default: 300.")
+                }
+
+                Section {
+                    TextField("Extra arguments", text: $claudeExtraArgs)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Claude CLI")
+                } footer: {
+                    Text("Additional arguments passed to Claude Code on launch.")
+                }
+
+                Section {
+                    TextField("Grace period (seconds)", text: $idleGracePeriod)
+                        .keyboardType(.numberPad)
+                    TextField("Threshold (seconds)", text: $idleThreshold)
+                        .keyboardType(.numberPad)
+                } header: {
+                    Text("Idle Timeout")
+                } footer: {
+                    Text("Grace period before checking idle. Threshold defines when a session is considered idle.")
+                }
+
+                Section {
+                    TextField("Branch pattern", text: $branchPattern)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Default Branch Pattern")
+                } footer: {
+                    Text("Default naming pattern for branches (e.g. issue-{{number}}-{{slug}}).")
+                }
+
+                Section {
+                    TextField("Worktree directory", text: $worktreeDir)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Worktree Directory")
+                } footer: {
+                    Text("Directory where git worktrees are created.")
+                }
+
+                if let saveError {
+                    Section {
+                        Label(saveError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Advanced Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                if isSaving {
+                    ProgressView()
+                } else {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .disabled(!hasChanges)
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            settings = try await api.getSettings()
+            cacheTTL = settings["cache_ttl"] ?? ""
+            claudeExtraArgs = settings["claude_extra_args"] ?? ""
+            idleGracePeriod = settings["idle_grace_period"] ?? ""
+            idleThreshold = settings["idle_threshold"] ?? ""
+            branchPattern = settings["branch_pattern"] ?? ""
+            worktreeDir = settings["worktree_dir"] ?? ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func save() async {
+        isSaving = true
+        saveError = nil
+        defer { isSaving = false }
+
+        var updates: [String: String] = [:]
+        if cacheTTL != (settings["cache_ttl"] ?? "") { updates["cache_ttl"] = cacheTTL }
+        if claudeExtraArgs != (settings["claude_extra_args"] ?? "") { updates["claude_extra_args"] = claudeExtraArgs }
+        if idleGracePeriod != (settings["idle_grace_period"] ?? "") { updates["idle_grace_period"] = idleGracePeriod }
+        if idleThreshold != (settings["idle_threshold"] ?? "") { updates["idle_threshold"] = idleThreshold }
+        if branchPattern != (settings["branch_pattern"] ?? "") { updates["branch_pattern"] = branchPattern }
+        if worktreeDir != (settings["worktree_dir"] ?? "") { updates["worktree_dir"] = worktreeDir }
+
+        guard !updates.isEmpty else { return }
+
+        do {
+            let response = try await api.updateSettings(updates)
+            if response.success {
+                settings.merge(updates) { _, new in new }
+            } else {
+                saveError = response.error ?? "Failed to save settings"
+            }
+        } catch {
+            saveError = error.localizedDescription
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
             Form {
                 serverInfoSection
                 reposSection
+                managementSection
                 disconnectSection
             }
             .navigationTitle("Settings")
@@ -31,6 +32,14 @@ struct SettingsView: View {
                         Image(systemName: "plus")
                     }
                     .accessibilityLabel("Add repository")
+                }
+            }
+            .navigationDestination(for: SettingsDestination.self) { dest in
+                switch dest {
+                case .advancedSettings:
+                    AdvancedSettingsView()
+                case .worktrees:
+                    WorktreeListView()
                 }
             }
             .sheet(isPresented: $showAddRepo) {
@@ -153,6 +162,19 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Management Section
+
+    private var managementSection: some View {
+        Section("Management") {
+            NavigationLink(value: SettingsDestination.advancedSettings) {
+                Label("Advanced Settings", systemImage: "slider.horizontal.3")
+            }
+            NavigationLink(value: SettingsDestination.worktrees) {
+                Label("Worktrees", systemImage: "arrow.triangle.branch")
+            }
+        }
+    }
+
     // MARK: - Disconnect Section
 
     private var disconnectSection: some View {
@@ -218,6 +240,11 @@ struct SettingsView: View {
             }
         }
     }
+}
+
+enum SettingsDestination: Hashable {
+    case advancedSettings
+    case worktrees
 }
 
 // MARK: - Repo Row

--- a/ios/IssueCTL/Views/Settings/WorktreeListView.swift
+++ b/ios/IssueCTL/Views/Settings/WorktreeListView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+struct WorktreeListView: View {
+    @Environment(APIClient.self) private var api
+    @State private var worktrees: [WorktreeInfo] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var actionError: String?
+    @State private var isCleaningStale = false
+    @State private var cleaningPath: String?
+
+    var body: some View {
+        Group {
+            if isLoading && worktrees.isEmpty {
+                ProgressView("Loading worktrees...")
+            } else if let errorMessage {
+                ContentUnavailableView {
+                    Label("Error", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                }
+            } else if worktrees.isEmpty {
+                ContentUnavailableView(
+                    "No Worktrees",
+                    systemImage: "folder",
+                    description: Text("No git worktrees found.")
+                )
+            } else {
+                List {
+                    if let actionError {
+                        Label(actionError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.subheadline)
+                            .lineLimit(3)
+                    }
+
+                    let staleCount = worktrees.filter(\.stale).count
+                    if staleCount > 0 {
+                        Section {
+                            Button {
+                                Task { await cleanupStale() }
+                            } label: {
+                                HStack {
+                                    Label("Clean Up \(staleCount) Stale", systemImage: "trash")
+                                    if isCleaningStale {
+                                        Spacer()
+                                        ProgressView()
+                                    }
+                                }
+                            }
+                            .disabled(isCleaningStale)
+                        }
+                    }
+
+                    Section {
+                        ForEach(worktrees) { worktree in
+                            WorktreeRow(
+                                worktree: worktree,
+                                isCleaning: cleaningPath == worktree.path
+                            )
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    Task { await cleanup(path: worktree.path) }
+                                } label: {
+                                    Label("Remove", systemImage: "trash")
+                                }
+                                .disabled(cleaningPath != nil)
+                            }
+                        }
+                    } header: {
+                        Text("\(worktrees.count) Worktree\(worktrees.count == 1 ? "" : "s")")
+                    }
+                }
+                .refreshable { await load() }
+            }
+        }
+        .navigationTitle("Worktrees")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        actionError = nil
+        do {
+            worktrees = try await api.listWorktrees()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func cleanup(path: String) async {
+        cleaningPath = path
+        actionError = nil
+        do {
+            let response = try await api.cleanupWorktree(path: path)
+            if response.success {
+                worktrees.removeAll { $0.path == path }
+            } else {
+                actionError = response.error ?? "Failed to remove worktree"
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+        cleaningPath = nil
+    }
+
+    private func cleanupStale() async {
+        isCleaningStale = true
+        actionError = nil
+        do {
+            let response = try await api.cleanupStaleWorktrees()
+            if response.success {
+                await load()
+            } else {
+                actionError = response.error ?? "Failed to clean up stale worktrees"
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isCleaningStale = false
+    }
+}
+
+private struct WorktreeRow: View {
+    let worktree: WorktreeInfo
+    let isCleaning: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(worktree.name)
+                    .font(.body)
+                if worktree.stale {
+                    Text("Stale")
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.15))
+                        .foregroundStyle(.orange)
+                        .clipShape(Capsule())
+                }
+                if isCleaning {
+                    Spacer()
+                    ProgressView()
+                }
+            }
+            if let repoName = worktree.repoFullName {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.caption2)
+                    Text(repoName)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            if let issueNumber = worktree.issueNumber {
+                HStack(spacing: 4) {
+                    Image(systemName: "number")
+                        .font(.caption2)
+                    Text("Issue #\(issueNumber)")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Text(worktree.path)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -9,19 +9,32 @@ struct TerminalView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var showEndConfirm = false
+    @State private var loadError: String?
 
     var body: some View {
         NavigationStack {
             Group {
                 if let url = terminalURL {
-                    TerminalWebView(url: url)
-                        .ignoresSafeArea(edges: .bottom)
+                    if let loadError {
+                        ContentUnavailableView {
+                            Label("Terminal Connection Failed", systemImage: "wifi.exclamationmark")
+                        } description: {
+                            Text(loadError)
+                        } actions: {
+                            Button("Retry") { self.loadError = nil }
+                        }
+                    } else {
+                        TerminalWebView(url: url, loadError: $loadError)
+                            .ignoresSafeArea(edges: .bottom)
+                    }
                 } else {
-                    ContentUnavailableView(
-                        "Invalid Server URL",
-                        systemImage: "exclamationmark.triangle",
-                        description: Text("Could not parse: \(api.serverURL)/api/terminal/\(port)/")
-                    )
+                    ContentUnavailableView {
+                        Label("Invalid Server URL", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text("Could not parse: \(api.serverURL)/api/terminal/\(port)/")
+                    } actions: {
+                        Button("Dismiss") { dismiss() }
+                    }
                 }
             }
             .navigationTitle("\(deployment.repoFullName) #\(deployment.issueNumber)")
@@ -64,6 +77,11 @@ struct TerminalView: View {
 
 struct TerminalWebView: UIViewRepresentable {
     let url: URL
+    @Binding var loadError: String?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(loadError: $loadError)
+    }
 
     func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
@@ -72,6 +90,7 @@ struct TerminalWebView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .black
         webView.scrollView.isScrollEnabled = false
+        webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -79,6 +98,26 @@ struct TerminalWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {
         if webView.url != url {
             webView.load(URLRequest(url: url))
+        }
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        @Binding var loadError: String?
+
+        init(loadError: Binding<String?>) {
+            _loadError = loadError
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            loadError = nil
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            loadError = error.localizedDescription
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            loadError = error.localizedDescription
         }
     }
 }

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/reassign/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/[number]/reassign/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getRepo,
+  clearCacheKey,
+  withAuthRetry,
+  reassignIssue,
+  formatErrorForUser,
+  type ReassignResult,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type ReassignBody = {
+  targetOwner: string;
+  targetRepo: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string; number: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo, number: numStr } = await params;
+  const issueNumber = parseInt(numStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ error: "Invalid issue number" }, { status: 400 });
+  }
+
+  let body: ReassignBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.targetOwner || typeof body.targetOwner !== "string") {
+    return NextResponse.json({ error: "targetOwner is required and must be a string" }, { status: 400 });
+  }
+  if (!body.targetRepo || typeof body.targetRepo !== "string") {
+    return NextResponse.json({ error: "targetRepo is required and must be a string" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+
+    // Look up source repo by owner/name
+    const sourceRepo = getRepo(db, owner, repo);
+    if (!sourceRepo) {
+      return NextResponse.json({ error: "Source repository not tracked" }, { status: 404 });
+    }
+
+    // Look up target repo by owner/name
+    const targetRepo = getRepo(db, body.targetOwner, body.targetRepo);
+    if (!targetRepo) {
+      return NextResponse.json({ error: "Target repository not tracked" }, { status: 404 });
+    }
+
+    if (sourceRepo.id === targetRepo.id) {
+      return NextResponse.json({ error: "Cannot re-assign to the same repo" }, { status: 400 });
+    }
+
+    const result: ReassignResult = await withAuthRetry((octokit) =>
+      reassignIssue(db, octokit, sourceRepo.id, issueNumber, targetRepo.id),
+    );
+
+    // Caches are already invalidated inside reassignIssue, but clear
+    // any remaining detail/header keys for the source issue.
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+    clearCacheKey(db, `issues:${body.targetOwner}/${body.targetRepo}`);
+
+    log.info({
+      msg: "api_issue_reassigned",
+      owner,
+      repo,
+      issueNumber,
+      targetOwner: result.newOwner,
+      targetRepo: result.newRepo,
+      newIssueNumber: result.newIssueNumber,
+    });
+
+    return NextResponse.json({
+      success: true,
+      newIssueNumber: result.newIssueNumber,
+      newOwner: result.newOwner,
+      newRepo: result.newRepo,
+      ...(result.cleanupWarning ? { cleanupWarning: result.cleanupWarning } : {}),
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_issue_reassign_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/settings/route.ts
+++ b/packages/web/app/api/v1/settings/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  getDb,
+  getSettings,
+  setSetting,
+  formatErrorForUser,
+  type SettingKey,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+const EDITABLE_KEYS: readonly SettingKey[] = [
+  "branch_pattern",
+  "cache_ttl",
+  "worktree_dir",
+  "claude_extra_args",
+  "default_repo_id",
+  "idle_grace_period",
+  "idle_threshold",
+];
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const db = getDb();
+    const settings = getSettings(db);
+    const filtered = settings.filter((s) => EDITABLE_KEYS.includes(s.key));
+    return NextResponse.json({
+      settings: Object.fromEntries(filtered.map((s) => [s.key, s.value])),
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_settings_get_failed" });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let body: Record<string, string>;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: "Body must be a JSON object" }, { status: 400 });
+  }
+
+  const keys = Object.keys(body);
+  if (keys.length === 0) {
+    return NextResponse.json({ error: "No settings provided" }, { status: 400 });
+  }
+
+  for (const key of keys) {
+    if (!EDITABLE_KEYS.includes(key as SettingKey)) {
+      return NextResponse.json(
+        { error: `Invalid setting key: ${key}` },
+        { status: 400 },
+      );
+    }
+    if (typeof body[key] !== "string") {
+      return NextResponse.json(
+        { error: `Value for "${key}" must be a string` },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const db = getDb();
+    for (const key of keys) {
+      setSetting(db, key as SettingKey, body[key]);
+    }
+    log.info({ msg: "api_settings_updated", keys });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_settings_update_failed" });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/worktrees/cleanup/route.ts
+++ b/packages/web/app/api/v1/worktrees/cleanup/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { formatErrorForUser } from "@issuectl/core";
+import { cleanupWorktree, cleanupStaleWorktrees } from "@/lib/actions/worktrees";
+
+export const dynamic = "force-dynamic";
+
+type CleanupBody = {
+  path?: string;
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let body: CleanupBody;
+  try {
+    body = await request.json();
+  } catch (parseErr) {
+    log.warn({ err: parseErr, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: "Body must be a JSON object" }, { status: 400 });
+  }
+
+  try {
+    if (body.path) {
+      if (typeof body.path !== "string") {
+        return NextResponse.json(
+          { error: "path must be a string" },
+          { status: 400 },
+        );
+      }
+
+      const result = await cleanupWorktree(body.path);
+      if (!result.success) {
+        log.warn({ msg: "api_worktree_cleanup_failed", path: body.path, error: result.error });
+        return NextResponse.json(
+          { success: false, error: result.error },
+          { status: 422 },
+        );
+      }
+
+      log.info({ msg: "api_worktree_cleaned", path: body.path });
+      return NextResponse.json({ success: true });
+    }
+
+    // No path — clean all stale worktrees
+    const result = await cleanupStaleWorktrees();
+    if (!result.success) {
+      log.warn({ msg: "api_worktrees_cleanup_stale_failed", removed: result.removed, error: result.error });
+      return NextResponse.json(
+        { success: false, removed: result.removed, error: result.error },
+        { status: 422 },
+      );
+    }
+
+    log.info({ msg: "api_worktrees_stale_cleaned", removed: result.removed });
+    return NextResponse.json({ success: true, removed: result.removed });
+  } catch (err) {
+    log.error({ err, msg: "api_worktrees_cleanup_error" });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/worktrees/route.ts
+++ b/packages/web/app/api/v1/worktrees/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { formatErrorForUser } from "@issuectl/core";
+import { listWorktrees } from "@/lib/actions/worktrees";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const worktrees = await listWorktrees();
+    return NextResponse.json({ worktrees });
+  } catch (err) {
+    log.error({ err, msg: "api_worktrees_list_failed" });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Surface supplementary fetch failures (drafts, deployments, user profile) via actionError banner instead of silently swallowing them
- Remove force-unwrap crash in TerminalView URL construction with graceful ContentUnavailableView fallback
- Add retry button for terminal connection failures and dismiss action for invalid URLs
- Clear stale actionError on refresh, add .lineLimit(3) to error banners, add a11y identifiers
- Merge supplementaryErrors/failedRepos into single failures array (code simplification)
- Add feature parity: Advanced Settings view, Worktree management, Issue Reassign flow
- Add REST API routes: `/api/v1/settings`, `/api/v1/worktrees`, `/api/v1/issues/.../reassign`

## Test plan
- [ ] Build and run on iOS simulator — verify all tabs load
- [ ] Trigger fetch failure (disconnect server) — verify error banners appear with detail text
- [ ] Pull to refresh — verify stale errors clear
- [ ] Open terminal for a running session — verify WebView loads
- [ ] Navigate to Settings → Advanced Settings — verify form loads/saves
- [ ] Navigate to Settings → Worktrees — verify list loads
- [ ] Open issue detail → action menu → Reassign — verify sheet appears with repo picker
- [ ] Swipe actions on issues/PRs still work
- [ ] Back gesture on all screens — no blank screens