### PR TITLE
feat(ios): close parity gaps with web dashboard

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
 		2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
+		31F1727D0042386D7B07C93A /* CacheAgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2841D89323711B68449BB980 /* CacheAgeLabel.swift */; };
 		327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D2FEDC36ACDF7207272AE3 /* ParseView.swift */; };
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
 		34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */; };
@@ -77,6 +78,7 @@
 		223E1C810B3BD014B117301B /* IssueCTLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLApp.swift; sourceTree = "<group>"; };
 		22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIssueSheet.swift; sourceTree = "<group>"; };
 		22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Assignment.swift"; sourceTree = "<group>"; };
+		2841D89323711B68449BB980 /* CacheAgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheAgeLabel.swift; sourceTree = "<group>"; };
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
 		3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Priority.swift"; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 		E81A7D2E7B5E3CA762AC518E /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				2841D89323711B68449BB980 /* CacheAgeLabel.swift */,
 				4403330B1342AA7C19FA797D /* Constants.swift */,
 				894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */,
 				3F39642CB180355E5C62A75E /* ImageLightbox.swift */,
@@ -385,6 +388,7 @@
 				FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */,
 				B4D3E5DC8306990F763058B6 /* AdvancedSettingsView.swift in Sources */,
 				916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */,
+				31F1727D0042386D7B07C93A /* CacheAgeLabel.swift in Sources */,
 				AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */,
 				C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */,
 				661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */,

--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -14,6 +14,15 @@ struct DraftDetailView: View {
     @State private var errorMessage: String?
     @State private var hasChanges = false
 
+    @State private var repos: [Repo] = []
+    @State private var selectedRepoId: Int?
+    @State private var availableLabels: [GitHubLabel] = []
+    @State private var selectedLabels: Set<String> = []
+    @State private var isAssigning = false
+    @State private var isLoadingLabels = false
+    @State private var reposError: String?
+    @State private var labelLoadError: String?
+
     init(draft: Draft, onSaved: @escaping () -> Void) {
         self.draft = draft
         self.onSaved = onSaved
@@ -63,6 +72,73 @@ struct DraftDetailView: View {
                 .accessibilityIdentifier("priority-picker")
             }
 
+            Section("Assign to Repository") {
+                if let reposError {
+                    Label(reposError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                    Button("Retry") { Task { await loadRepos() } }
+                        .font(.subheadline)
+                }
+
+                Picker("Repository", selection: $selectedRepoId) {
+                    Text("None (keep as draft)").tag(nil as Int?)
+                    ForEach(repos) { repo in
+                        Text(repo.fullName).tag(repo.id as Int?)
+                    }
+                }
+                .accessibilityIdentifier("assign-repo-picker")
+
+                if let labelLoadError {
+                    Label(labelLoadError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                    Button("Retry") {
+                        if let repoId = selectedRepoId, let repo = repos.first(where: { $0.id == repoId }) {
+                            Task { await loadLabels(owner: repo.owner, name: repo.name) }
+                        }
+                    }
+                    .font(.subheadline)
+                } else if isLoadingLabels {
+                    HStack {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading labels...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if !availableLabels.isEmpty {
+                    ForEach(availableLabels) { label in
+                        Toggle(isOn: Binding(
+                            get: { selectedLabels.contains(label.name) },
+                            set: { isOn in
+                                if isOn { selectedLabels.insert(label.name) }
+                                else { selectedLabels.remove(label.name) }
+                            }
+                        )) {
+                            LabelBadge(label: label)
+                        }
+                    }
+                }
+
+                if selectedRepoId != nil {
+                    Button {
+                        Task { await assignToRepo() }
+                    } label: {
+                        if isAssigning {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        } else {
+                            let repoName = repos.first(where: { $0.id == selectedRepoId })?.name ?? "Repo"
+                            Label("Create Issue in \(repoName)", systemImage: "arrow.up.circle")
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .disabled(isAssigning)
+                    .accessibilityIdentifier("assign-draft-button")
+                }
+            }
+
             if let errorMessage {
                 Section {
                     Label(errorMessage, systemImage: "exclamationmark.triangle")
@@ -88,9 +164,18 @@ struct DraftDetailView: View {
                 .accessibilityIdentifier("save-draft-button")
             }
         }
+        .task { await loadRepos() }
         .onChange(of: title) { _, _ in updateHasChanges() }
         .onChange(of: bodyText) { _, _ in updateHasChanges() }
         .onChange(of: priority) { _, _ in updateHasChanges() }
+        .onChange(of: selectedRepoId) { _, newValue in
+            if let repoId = newValue, let repo = repos.first(where: { $0.id == repoId }) {
+                Task { await loadLabels(owner: repo.owner, name: repo.name) }
+            } else {
+                availableLabels = []
+                selectedLabels = []
+            }
+        }
     }
 
     private func updateHasChanges() {
@@ -100,6 +185,52 @@ struct DraftDetailView: View {
         let bodyChanged = trimmedBody != (draft.body ?? "")
         let priorityChanged = priority != (draft.priority ?? "normal")
         hasChanges = titleChanged || bodyChanged || priorityChanged
+    }
+
+    private func loadRepos() async {
+        reposError = nil
+        do {
+            repos = try await api.repos()
+        } catch {
+            reposError = "Failed to load repositories"
+        }
+    }
+
+    private func loadLabels(owner: String, name: String) async {
+        isLoadingLabels = true
+        selectedLabels = []
+        labelLoadError = nil
+        defer { isLoadingLabels = false }
+        do {
+            let labels = try await api.repoLabels(owner: owner, repo: name)
+            guard repos.first(where: { $0.owner == owner && $0.name == name })?.id == selectedRepoId else { return }
+            availableLabels = labels
+        } catch {
+            availableLabels = []
+            labelLoadError = "Failed to load labels"
+        }
+    }
+
+    private func assignToRepo() async {
+        guard let repoId = selectedRepoId else { return }
+        isAssigning = true
+        errorMessage = nil
+        do {
+            let body = AssignDraftWithLabelsRequestBody(
+                repoId: repoId,
+                labels: selectedLabels.isEmpty ? nil : Array(selectedLabels)
+            )
+            let response = try await api.assignDraftWithLabels(id: draft.id, body: body)
+            if response.success {
+                onSaved()
+                dismiss()
+            } else {
+                errorMessage = response.error ?? "Failed to assign draft"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isAssigning = false
     }
 
     private func save() async {

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -36,6 +36,12 @@ struct IssueListView: View {
     @State private var priorities: [String: Priority] = [:]
     @State private var isLoadingPriorities = false
 
+    @State private var oldestCachedAt: Date?
+    private let pageSize = 15
+    @State private var displayLimit = 15
+    @State private var lastRefreshDate: Date?
+    private let refreshCooldown: TimeInterval = 10
+
     private var allIssues: [GitHubIssue] {
         issuesByRepo.values.flatMap { $0 }
     }
@@ -162,6 +168,12 @@ struct IssueListView: View {
 
                 Divider()
 
+                if let oldestCachedAt {
+                    CacheAgeLabel(date: oldestCachedAt)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 4)
+                }
+
                 Group {
                     if isLoading && issuesByRepo.isEmpty && drafts.isEmpty {
                         ProgressView("Loading issues...")
@@ -278,6 +290,10 @@ struct IssueListView: View {
                 }
             }
             .task { await loadAll() }
+            .onChange(of: section) { _, _ in displayLimit = pageSize }
+            .onChange(of: selectedRepoIds) { _, _ in displayLimit = pageSize }
+            .onChange(of: sortOrder) { _, _ in displayLimit = pageSize }
+            .onChange(of: mineOnly) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
     }
@@ -286,6 +302,8 @@ struct IssueListView: View {
 
     @ViewBuilder
     private var issuesList: some View {
+        let allFiltered = filteredIssues
+        let visibleIssues = Array(allFiltered.prefix(displayLimit))
         List {
             if let actionError {
                 Label(actionError, systemImage: "exclamationmark.triangle")
@@ -293,7 +311,7 @@ struct IssueListView: View {
                     .font(.subheadline)
                     .lineLimit(3)
             }
-            ForEach(filteredIssues, id: \.htmlUrl) { issue in
+            ForEach(visibleIssues, id: \.htmlUrl) { issue in
                 let color = repoIndex(for: issue).map { RepoColors.color(for: $0) } ?? .secondary
                 let repo = repoFor(issue: issue)
                 let running = repo.map { isRunning(issue, in: $0.fullName) } ?? false
@@ -338,8 +356,18 @@ struct IssueListView: View {
                     }
                 }
             }
+
+            if allFiltered.count > displayLimit {
+                Button {
+                    displayLimit += pageSize
+                } label: {
+                    Text("Load More (\(allFiltered.count - displayLimit) remaining)")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+            }
         }
-        .refreshable { await loadAll(refresh: true) }
+        .refreshable { await refreshWithCooldown() }
     }
 
     @ViewBuilder
@@ -382,7 +410,7 @@ struct IssueListView: View {
                     }
                 }
             }
-            .refreshable { await loadAll(refresh: true) }
+            .refreshable { await refreshWithCooldown() }
         }
     }
 
@@ -457,20 +485,26 @@ struct IssueListView: View {
                 failures.append("user profile (\(error.localizedDescription))")
             }
 
-            await withTaskGroup(of: (String, String, [GitHubIssue]?, Error?).self) { group in
+            var cachedDates: [Date] = []
+            let isoFormatter = ISO8601DateFormatter()
+
+            await withTaskGroup(of: (String, String, [GitHubIssue]?, String?, Error?).self) { group in
                 for repo in repos {
                     group.addTask {
                         do {
                             let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.issues, nil)
+                            return (repo.fullName, repo.name, response.issues, response.cachedAt, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil, error)
+                            return (repo.fullName, repo.name, nil, nil, error)
                         }
                     }
                 }
-                for await (fullName, name, issues, error) in group {
+                for await (fullName, name, issues, cachedAt, error) in group {
                     if let issues {
                         issuesByRepo[fullName] = issues
+                        if let cachedAt, let date = isoFormatter.date(from: cachedAt) {
+                            cachedDates.append(date)
+                        }
                     } else if let error {
                         failures.append("\(name) (\(error.localizedDescription))")
                     } else {
@@ -478,6 +512,7 @@ struct IssueListView: View {
                     }
                 }
             }
+            oldestCachedAt = cachedDates.min()
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }
@@ -521,6 +556,14 @@ struct IssueListView: View {
         priorities = newPriorities
         isLoadingPriorities = false
         return priorityErrors
+    }
+
+    private func refreshWithCooldown() async {
+        if let last = lastRefreshDate, Date().timeIntervalSince(last) < refreshCooldown {
+            return
+        }
+        lastRefreshDate = Date()
+        await loadAll(refresh: true)
     }
 }
 

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -10,9 +10,11 @@ struct LaunchView: View {
     let issueTitle: String
     let comments: [GitHubComment]
     let referencedFiles: [String]
+    let repoLocalPath: String?
 
     @State private var branchName: String
-    @State private var workspaceMode = "worktree"
+    @State private var workspaceMode: String
+    @State private var showCloneWarning: Bool
     @State private var selectedCommentIndices: Set<Int> = []
     @State private var selectedFilePaths: Set<String> = []
     @State private var preamble = ""
@@ -21,13 +23,14 @@ struct LaunchView: View {
     @State private var launchedPort: Int?
     @State private var launchedDeployment: ActiveDeployment?
 
-    init(owner: String, repo: String, issueNumber: Int, issueTitle: String, comments: [GitHubComment], referencedFiles: [String]) {
+    init(owner: String, repo: String, issueNumber: Int, issueTitle: String, comments: [GitHubComment], referencedFiles: [String], repoLocalPath: String? = nil) {
         self.owner = owner
         self.repo = repo
         self.issueNumber = issueNumber
         self.issueTitle = issueTitle
         self.comments = comments
         self.referencedFiles = referencedFiles
+        self.repoLocalPath = repoLocalPath
 
         let slug = issueTitle
             .lowercased()
@@ -35,6 +38,9 @@ struct LaunchView: View {
             .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
             .prefix(40)
         _branchName = State(initialValue: "issue-\(issueNumber)-\(slug)")
+        let needsClone = repoLocalPath == nil || repoLocalPath?.isEmpty == true
+        _workspaceMode = State(initialValue: needsClone ? "clone" : "worktree")
+        _showCloneWarning = State(initialValue: needsClone)
     }
 
     var body: some View {
@@ -51,6 +57,14 @@ struct LaunchView: View {
                     }
                 }
 
+                if showCloneWarning {
+                    Section {
+                        Label("This repository has no local clone. A fresh clone will be created.", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                            .font(.subheadline)
+                    }
+                }
+
                 Section("Workspace Mode") {
                     Picker("Mode", selection: $workspaceMode) {
                         Text("Worktree").tag("worktree")
@@ -58,6 +72,7 @@ struct LaunchView: View {
                         Text("Clone").tag("clone")
                     }
                     .pickerStyle(.segmented)
+                    .disabled(showCloneWarning)
                     .accessibilityIdentifier("workspace-mode-picker")
                 }
 
@@ -143,6 +158,21 @@ struct LaunchView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") { dismiss() }
+                }
+            }
+            .task {
+                if repoLocalPath == nil {
+                    do {
+                        let repos = try await api.repos()
+                        if let match = repos.first(where: { $0.owner == owner && $0.name == repo }) {
+                            let needsClone = match.localPath == nil || match.localPath?.isEmpty == true
+                            showCloneWarning = needsClone
+                            workspaceMode = needsClone ? "clone" : "worktree"
+                        }
+                    } catch {
+                        // Could not verify clone status — unlock the picker so user can choose
+                        showCloneWarning = false
+                    }
                 }
             }
             .fullScreenCover(item: $launchedDeployment) { deployment in

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -20,6 +20,12 @@ struct PRListView: View {
     @State private var actionError: String?
     @State private var errorDismissTask: Task<Void, Never>?
 
+    @State private var oldestCachedAt: Date?
+    private let pageSize = 15
+    @State private var displayLimit = 15
+    @State private var lastRefreshDate: Date?
+    private let refreshCooldown: TimeInterval = 10
+
     private var allPulls: [GitHubPull] {
         pullsByRepo.values.flatMap { $0 }
     }
@@ -100,6 +106,12 @@ struct PRListView: View {
 
                 Divider()
 
+                if let oldestCachedAt {
+                    CacheAgeLabel(date: oldestCachedAt)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 4)
+                }
+
                 Group {
                     if isLoading && pullsByRepo.isEmpty {
                         ProgressView("Loading pull requests...")
@@ -168,6 +180,10 @@ struct PRListView: View {
                 }
             }
             .task { await loadAll() }
+            .onChange(of: section) { _, _ in displayLimit = pageSize }
+            .onChange(of: selectedRepoIds) { _, _ in displayLimit = pageSize }
+            .onChange(of: sortOrder) { _, _ in displayLimit = pageSize }
+            .onChange(of: mineOnly) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
     }
@@ -176,6 +192,8 @@ struct PRListView: View {
 
     @ViewBuilder
     private var pullsList: some View {
+        let allFiltered = filteredPulls
+        let visiblePulls = Array(allFiltered.prefix(displayLimit))
         List {
             if let actionError {
                 Label(actionError, systemImage: "exclamationmark.triangle")
@@ -183,7 +201,7 @@ struct PRListView: View {
                     .font(.subheadline)
                     .lineLimit(3)
             }
-            ForEach(filteredPulls, id: \.htmlUrl) { pull in
+            ForEach(visiblePulls, id: \.htmlUrl) { pull in
                 let color = repoIndex(for: pull).map { RepoColors.color(for: $0) } ?? .secondary
                 let repo = repoFor(pull: pull)
 
@@ -209,8 +227,18 @@ struct PRListView: View {
                     }
                 }
             }
+
+            if allFiltered.count > displayLimit {
+                Button {
+                    displayLimit += pageSize
+                } label: {
+                    Text("Load More (\(allFiltered.count - displayLimit) remaining)")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+            }
         }
-        .refreshable { await loadAll(refresh: true) }
+        .refreshable { await refreshWithCooldown() }
     }
 
     // MARK: - Actions
@@ -250,20 +278,26 @@ struct PRListView: View {
                 failures.append("user profile (\(error.localizedDescription))")
             }
 
-            await withTaskGroup(of: (String, String, [GitHubPull]?, Error?).self) { group in
+            var cachedDates: [Date] = []
+            let isoFormatter = ISO8601DateFormatter()
+
+            await withTaskGroup(of: (String, String, [GitHubPull]?, String?, Error?).self) { group in
                 for repo in repos {
                     group.addTask {
                         do {
                             let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.pulls, nil)
+                            return (repo.fullName, repo.name, response.pulls, response.cachedAt, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil, error)
+                            return (repo.fullName, repo.name, nil, nil, error)
                         }
                     }
                 }
-                for await (fullName, name, pulls, error) in group {
+                for await (fullName, name, pulls, cachedAt, error) in group {
                     if let pulls {
                         pullsByRepo[fullName] = pulls
+                        if let cachedAt, let date = isoFormatter.date(from: cachedAt) {
+                            cachedDates.append(date)
+                        }
                     } else if let error {
                         failures.append("\(name) (\(error.localizedDescription))")
                     } else {
@@ -271,6 +305,7 @@ struct PRListView: View {
                     }
                 }
             }
+            oldestCachedAt = cachedDates.min()
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }
@@ -278,6 +313,14 @@ struct PRListView: View {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func refreshWithCooldown() async {
+        if let last = lastRefreshDate, Date().timeIntervalSince(last) < refreshCooldown {
+            return
+        }
+        lastRefreshDate = Date()
+        await loadAll(refresh: true)
     }
 }
 

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @State private var showAddRepo = false
     @State private var repos: [Repo] = []
     @State private var serverHealth: ServerHealth?
+    @State private var currentUsername: String?
     @State private var isLoadingRepos = false
     @State private var isLoadingHealth = false
     @State private var reposError: String?
@@ -109,6 +110,10 @@ struct SettingsView: View {
                 }
             }
 
+            if let username = currentUsername {
+                LabeledContent("User", value: username)
+            }
+
             if let health = serverHealth {
                 LabeledContent("Version", value: health.version)
             } else if let error = healthError {
@@ -190,7 +195,17 @@ struct SettingsView: View {
     private func loadData() async {
         async let healthTask: () = loadHealth()
         async let reposTask: () = loadRepos()
-        _ = await (healthTask, reposTask)
+        async let userTask: () = loadUser()
+        _ = await (healthTask, reposTask, userTask)
+    }
+
+    private func loadUser() async {
+        do {
+            let user = try await api.currentUser()
+            currentUsername = user.login
+        } catch {
+            // Non-fatal — just don't show the username
+        }
     }
 
     private func loadHealth() async {

--- a/ios/IssueCTL/Views/Shared/CacheAgeLabel.swift
+++ b/ios/IssueCTL/Views/Shared/CacheAgeLabel.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct CacheAgeLabel: View {
+    let date: Date
+
+    private static let formatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    private var timeAgo: String {
+        Self.formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 60)) { _ in
+            HStack(spacing: 4) {
+                Image(systemName: "clock")
+                    .font(.caption2)
+                Text("Cached \(timeAgo)")
+                    .font(.caption2)
+            }
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Draft assign-to-repo**: repo picker, dynamic label toggles, create button with error feedback and retry
- **Cache age label**: shared `CacheAgeLabel` component with `TimelineView` for auto-updating relative timestamps on Issues and PRs tabs
- **Pagination**: 15-item pages with "Load More" button for Issues and PRs lists
- **Refresh cooldown**: 10-second throttle on pull-to-refresh to prevent API hammering
- **Clone prompt**: detect repos without local path, show warning and lock picker to clone mode; unlock on API failure so user isn't stuck
- **Settings username**: display current GitHub user from API

## Review fixes included
- `defer` for `isLoadingLabels` to prevent stuck spinner on race condition
- `.disabled(showCloneWarning)` on entire segmented picker (per-item `.disabled` is a SwiftUI no-op)
- `workspaceMode` reset to "worktree" when API reveals repo has local path
- Staleness guard on label loading (rapid repo switching)
- Static `RelativeDateTimeFormatter` to avoid per-render allocations
- Error feedback with retry for repo/label loading failures
- Unlock picker on network failure in clone detection

## Test plan
- [x] Build succeeds on iOS simulator (iPhone 17 Pro)
- [x] Settings tab shows "User: neonwatty" field
- [x] Draft detail view shows "Assign to Repository" section with repo picker
- [x] Selecting a repo loads labels dynamically with colored badges
- [x] "Create Issue in {repo}" button appears when repo selected
- [x] Cache age label absent for fresh data (correct behavior)
- [x] Workspace mode picker disabled when clone warning shown
- [x] All TypeScript packages pass typecheck
- [x] Pre-commit hooks (typecheck + lint) pass