### PR TITLE
feat: CI status indicators on iOS PR list

### DIFF
--- a/ios/IssueCTL/Models/PullRequest.swift
+++ b/ios/IssueCTL/Models/PullRequest.swift
@@ -17,6 +17,7 @@ struct GitHubPull: Codable, Identifiable, Sendable {
     let mergedAt: String?
     let closedAt: String?
     let htmlUrl: String
+    let checksStatus: String?
 
     var id: Int { number }
 

--- a/ios/IssueCTL/Views/PullRequests/PRRowView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRRowView.swift
@@ -23,6 +23,8 @@ struct PRRowView: View {
                 HStack(spacing: 8) {
                     PRStateBadge(pull: pull)
 
+                    ChecksStatusDot(status: pull.checksStatus)
+
                     Text(pull.diffSummary)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -74,6 +76,37 @@ struct PRStateBadge: View {
         .background(color.opacity(0.15))
         .foregroundStyle(color)
         .clipShape(Capsule())
+    }
+}
+
+struct ChecksStatusDot: View {
+    let status: String?
+
+    private var color: Color {
+        switch status {
+        case "success": return .green
+        case "failure": return .red
+        case "pending": return .yellow
+        default: return .gray
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch status {
+        case "success": return "CI passing"
+        case "failure": return "CI failing"
+        case "pending": return "CI pending"
+        default: return "CI status unknown"
+        }
+    }
+
+    var body: some View {
+        if status != nil {
+            Image(systemName: "circle.fill")
+                .font(.system(size: 7))
+                .foregroundStyle(color)
+                .accessibilityLabel(accessibilityLabel)
+        }
     }
 }
 

--- a/packages/core/src/data/pulls.ts
+++ b/packages/core/src/data/pulls.ts
@@ -1,7 +1,7 @@
 import type { Octokit } from "@octokit/rest";
 import type Database from "better-sqlite3";
 import type { GitHubPull, GitHubCheck, GitHubIssue, GitHubPullFile, GitHubPullReview } from "../github/types.js";
-import { listPulls, getPull, getPullChecks, listPullFiles, listReviews } from "../github/pulls.js";
+import { listPulls, getPull, getPullChecks, listPullFiles, listReviews, getChecksRollupForRef, type ChecksRollupStatus } from "../github/pulls.js";
 import { getIssue } from "../github/issues.js";
 import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
 
@@ -47,6 +47,75 @@ export async function getPulls(
   const pulls = await listPulls(octokit, owner, repo, "open");
   setCached(db, cacheKey, pulls);
   return { pulls, fromCache: false, cachedAt: new Date() };
+}
+
+export type PullWithChecksStatus = GitHubPull & { checksStatus: ChecksRollupStatus };
+
+/**
+ * Fetches the PR list and enriches each PR with a checksStatus rollup.
+ * Check statuses are fetched concurrently (capped at 5 in-flight).
+ * The enriched result is cached separately from the plain pulls list.
+ */
+export async function getPullsWithChecks(
+  db: Database.Database,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  options?: { forceRefresh?: boolean },
+): Promise<{
+  pulls: PullWithChecksStatus[];
+  fromCache: boolean;
+  cachedAt: Date | null;
+}> {
+  const cacheKey = `pulls-with-checks:${owner}/${repo}`;
+  const ttl = getCacheTtl(db);
+
+  if (!options?.forceRefresh) {
+    const cached = getCached<PullWithChecksStatus[]>(db, cacheKey);
+    if (cached) {
+      if (!isFresh(cached.fetchedAt, ttl)) {
+        // Background revalidation
+        fetchPullsWithChecks(octokit, owner, repo).then((data) => {
+          setCached(db, cacheKey, data);
+        }).catch((err) => {
+          console.warn(`[issuectl] Background revalidation failed for ${cacheKey}:`, err);
+        });
+      }
+      return { pulls: cached.data, fromCache: true, cachedAt: cached.fetchedAt };
+    }
+  }
+
+  const pulls = await fetchPullsWithChecks(octokit, owner, repo);
+  setCached(db, cacheKey, pulls);
+  return { pulls, fromCache: false, cachedAt: new Date() };
+}
+
+async function fetchPullsWithChecks(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<PullWithChecksStatus[]> {
+  const pulls = await listPulls(octokit, owner, repo, "open");
+
+  // Fetch check rollups concurrently with a concurrency cap of 5
+  const CONCURRENCY = 5;
+  const results: PullWithChecksStatus[] = [];
+  for (let i = 0; i < pulls.length; i += CONCURRENCY) {
+    const batch = pulls.slice(i, i + CONCURRENCY);
+    const enriched = await Promise.all(
+      batch.map(async (pull) => {
+        let checksStatus: ChecksRollupStatus = null;
+        try {
+          checksStatus = await getChecksRollupForRef(octokit, owner, repo, pull.headRef);
+        } catch {
+          // If checks fetch fails, leave as null rather than failing the whole list
+        }
+        return { ...pull, checksStatus };
+      }),
+    );
+    results.push(...enriched);
+  }
+  return results;
 }
 
 async function fetchPullDetail(

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -92,6 +92,46 @@ export async function getPullChecks(
   }));
 }
 
+export type ChecksRollupStatus = "success" | "failure" | "pending" | null;
+
+/**
+ * Returns a single rollup status for a given ref by inspecting check runs.
+ * - "failure" if any check has conclusion failure/cancelled/timed_out
+ * - "pending" if any check is not yet completed
+ * - "success" if all checks completed with success/neutral/skipped
+ * - null if there are no checks
+ */
+export async function getChecksRollupForRef(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+): Promise<ChecksRollupStatus> {
+  const { data } = await octokit.rest.checks.listForRef({
+    owner,
+    repo,
+    ref,
+    per_page: 100,
+  });
+
+  const runs = data.check_runs;
+  if (runs.length === 0) return null;
+
+  let hasPending = false;
+  for (const run of runs) {
+    if (run.status !== "completed") {
+      hasPending = true;
+      continue;
+    }
+    const c = run.conclusion;
+    if (c === "failure" || c === "cancelled" || c === "timed_out" || c === "action_required") {
+      return "failure";
+    }
+  }
+
+  return hasPending ? "pending" : "success";
+}
+
 export async function listPullFiles(
   octokit: Octokit,
   owner: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,7 @@ export {
 } from "./data/issues.js";
 export {
   getPulls,
+  getPullsWithChecks,
   getPullDetail,
 } from "./data/pulls.js";
 export {
@@ -150,6 +151,7 @@ export {
   createPullComment,
   type ReviewEvent,
   type MergeMethod,
+  type ChecksRollupStatus,
 } from "./github/pulls.js";
 export { getDashboardData } from "./data/repos.js";
 export {

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
-import { getDb, getRepo, getPulls, withAuthRetry } from "@issuectl/core";
+import { getDb, getRepo, getPulls, getPullsWithChecks, withAuthRetry } from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
@@ -20,9 +20,15 @@ export async function GET(
     }
 
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
-    const result = await withAuthRetry((octokit) =>
-      getPulls(db, octokit, owner, repo, { forceRefresh }),
-    );
+    const includeChecks = request.nextUrl.searchParams.get("checks") !== "false";
+
+    const result = includeChecks
+      ? await withAuthRetry((octokit) =>
+          getPullsWithChecks(db, octokit, owner, repo, { forceRefresh }),
+        )
+      : await withAuthRetry((octokit) =>
+          getPulls(db, octokit, owner, repo, { forceRefresh }),
+        );
     return NextResponse.json(result);
   } catch (err) {
     console.error(`[issuectl] GET /api/v1/pulls/${owner}/${repo} failed:`, err);


### PR DESCRIPTION
## Summary
- Add `getChecksRollupForRef()` to core — fetches check runs and returns a single rollup status (success/failure/pending/null)
- Add `getPullsWithChecks()` data function with concurrency-capped (5) parallel enrichment and separate cache key
- Update PR list API route to include check status by default (opt-out via `?checks=false`)
- Add `checksStatus` field to iOS `GitHubPull` model
- Add `ChecksStatusDot` SwiftUI view — colored dot (green/red/yellow/gray) on each PR row

## Test plan
- [x] TypeScript typecheck passes (all 3 packages)
- [x] iOS simulator build succeeds
- [x] ESLint: no new errors