### PR TITLE
refactor(ios): type-safe enums for Priority, WorkspaceMode, DeploymentState

### DIFF
--- a/ios/IssueCTL/Models/Deployment.swift
+++ b/ios/IssueCTL/Models/Deployment.swift
@@ -1,20 +1,35 @@
 import Foundation
 
+// MARK: - Enums
+
+enum WorkspaceMode: String, Codable, CaseIterable, Sendable {
+    case clone
+    case worktree
+    case existing
+}
+
+enum DeploymentState: String, Codable, Sendable {
+    case active
+    case ended
+}
+
+// MARK: - Models
+
 struct Deployment: Codable, Identifiable, Sendable {
     let id: Int
     let repoId: Int
     let issueNumber: Int
     let branchName: String
-    let workspaceMode: String
+    let workspaceMode: WorkspaceMode
     let workspacePath: String
     let linkedPrNumber: Int?
-    let state: String
+    let state: DeploymentState
     let launchedAt: String
     let endedAt: String?
     let ttydPort: Int?
     let ttydPid: Int?
 
-    var isActive: Bool { state == "active" && endedAt == nil }
+    var isActive: Bool { state == .active && endedAt == nil }
 
     var launchedDate: Date? {
         ISO8601DateFormatter().date(from: launchedAt)
@@ -37,10 +52,10 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
     let repoId: Int
     let issueNumber: Int
     let branchName: String
-    let workspaceMode: String
+    let workspaceMode: WorkspaceMode
     let workspacePath: String
     let linkedPrNumber: Int?
-    let state: String
+    let state: DeploymentState
     let launchedAt: String
     let endedAt: String?
     let ttydPort: Int?
@@ -72,7 +87,7 @@ struct ActiveDeploymentsResponse: Codable, Sendable {
 
 struct LaunchRequestBody: Encodable, Sendable {
     let branchName: String
-    let workspaceMode: String
+    let workspaceMode: WorkspaceMode
     let selectedCommentIndices: [Int]
     let selectedFilePaths: [String]
     let preamble: String?

--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -99,7 +99,7 @@ struct Draft: Codable, Identifiable, Sendable {
     let id: String
     let title: String
     let body: String?
-    let priority: String?
+    let priority: Priority?
     let createdAt: Double // unix timestamp from server
 }
 
@@ -110,7 +110,7 @@ struct DraftsResponse: Codable, Sendable {
 struct CreateDraftRequestBody: Encodable, Sendable {
     let title: String
     let body: String?
-    let priority: String?
+    let priority: Priority?
 }
 
 struct CreateDraftResponse: Codable, Sendable {

--- a/ios/IssueCTL/Services/APIClient+Drafts.swift
+++ b/ios/IssueCTL/Services/APIClient+Drafts.swift
@@ -5,7 +5,7 @@ import Foundation
 struct UpdateDraftRequestBody: Encodable, Sendable {
     let title: String?
     let body: String?
-    let priority: String?
+    let priority: Priority?
 }
 
 struct UpdateDraftResponse: Codable, Sendable {

--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -9,7 +9,7 @@ struct DraftDetailView: View {
 
     @State private var title: String
     @State private var bodyText: String
-    @State private var priority: String
+    @State private var priority: Priority
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var hasChanges = false
@@ -28,7 +28,7 @@ struct DraftDetailView: View {
         self.onSaved = onSaved
         _title = State(initialValue: draft.title)
         _bodyText = State(initialValue: draft.body ?? "")
-        _priority = State(initialValue: draft.priority ?? "normal")
+        _priority = State(initialValue: draft.priority ?? .normal)
     }
 
     private var canSave: Bool {
@@ -64,9 +64,9 @@ struct DraftDetailView: View {
 
             Section("Priority") {
                 Picker("Priority", selection: $priority) {
-                    Text("Low").tag("low")
-                    Text("Normal").tag("normal")
-                    Text("High").tag("high")
+                    Text("Low").tag(Priority.low)
+                    Text("Normal").tag(Priority.normal)
+                    Text("High").tag(Priority.high)
                 }
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("priority-picker")
@@ -183,7 +183,7 @@ struct DraftDetailView: View {
         let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
         let titleChanged = trimmedTitle != draft.title
         let bodyChanged = trimmedBody != (draft.body ?? "")
-        let priorityChanged = priority != (draft.priority ?? "normal")
+        let priorityChanged = priority != (draft.priority ?? .normal)
         hasChanges = titleChanged || bodyChanged || priorityChanged
     }
 
@@ -243,7 +243,7 @@ struct DraftDetailView: View {
             let updateBody = UpdateDraftRequestBody(
                 title: trimmedTitle != draft.title ? trimmedTitle : nil,
                 body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
-                priority: priority != (draft.priority ?? "normal") ? priority : nil
+                priority: priority != (draft.priority ?? .normal) ? priority : nil
             )
             let response = try await api.updateDraft(id: draft.id, body: updateBody)
             if response.success {

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -338,7 +338,7 @@ struct IssueDetailView: View {
                     Text(deployment.branchName)
                         .font(.subheadline)
                     Spacer()
-                    Text(deployment.state)
+                    Text(deployment.state.rawValue)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -391,10 +391,10 @@ struct IssueListView: View {
                                     .foregroundStyle(.secondary)
                                     .lineLimit(2)
                             }
-                            if let priority = draft.priority, priority != "normal" {
-                                Text(priority.capitalized)
+                            if let priority = draft.priority, priority != .normal {
+                                Text(priority.rawValue.capitalized)
                                     .font(.caption2)
-                                    .foregroundStyle(priority == "high" ? .red : .secondary)
+                                    .foregroundStyle(priority == .high ? .red : .secondary)
                             }
                         }
                         .padding(.vertical, 2)

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -10,7 +10,7 @@ struct QuickCreateSheet: View {
     @State private var title = ""
     @State private var bodyText = ""
     @State private var selectedRepoId: Int?
-    @State private var priority: String = "normal"
+    @State private var priority: Priority = .normal
     @State private var isSubmitting = false
     @State private var errorMessage: String?
 
@@ -106,9 +106,9 @@ struct QuickCreateSheet: View {
 
                 Section("Priority") {
                     Picker("Priority", selection: $priority) {
-                        Text("Low").tag("low")
-                        Text("Normal").tag("normal")
-                        Text("High").tag("high")
+                        Text("Low").tag(Priority.low)
+                        Text("Normal").tag(Priority.normal)
+                        Text("High").tag(Priority.high)
                     }
                     .pickerStyle(.segmented)
                     .accessibilityIdentifier("priority-picker")

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -13,7 +13,7 @@ struct LaunchView: View {
     let repoLocalPath: String?
 
     @State private var branchName: String
-    @State private var workspaceMode: String
+    @State private var workspaceMode: WorkspaceMode
     @State private var showCloneWarning: Bool
     @State private var selectedCommentIndices: Set<Int> = []
     @State private var selectedFilePaths: Set<String> = []
@@ -39,7 +39,7 @@ struct LaunchView: View {
             .prefix(40)
         _branchName = State(initialValue: "issue-\(issueNumber)-\(slug)")
         let needsClone = repoLocalPath == nil || repoLocalPath?.isEmpty == true
-        _workspaceMode = State(initialValue: needsClone ? "clone" : "worktree")
+        _workspaceMode = State(initialValue: needsClone ? .clone : .worktree)
         _showCloneWarning = State(initialValue: needsClone)
     }
 
@@ -67,9 +67,9 @@ struct LaunchView: View {
 
                 Section("Workspace Mode") {
                     Picker("Mode", selection: $workspaceMode) {
-                        Text("Worktree").tag("worktree")
-                        Text("Existing").tag("existing")
-                        Text("Clone").tag("clone")
+                        Text("Worktree").tag(WorkspaceMode.worktree)
+                        Text("Existing").tag(WorkspaceMode.existing)
+                        Text("Clone").tag(WorkspaceMode.clone)
                     }
                     .pickerStyle(.segmented)
                     .disabled(showCloneWarning)
@@ -167,7 +167,7 @@ struct LaunchView: View {
                         if let match = repos.first(where: { $0.owner == owner && $0.name == repo }) {
                             let needsClone = match.localPath == nil || match.localPath?.isEmpty == true
                             showCloneWarning = needsClone
-                            workspaceMode = needsClone ? "clone" : "worktree"
+                            workspaceMode = needsClone ? .clone : .worktree
                         }
                     } catch {
                         // Could not verify clone status — unlock the picker so user can choose
@@ -217,7 +217,7 @@ struct LaunchView: View {
                     workspaceMode: workspaceMode,
                     workspacePath: "",
                     linkedPrNumber: nil,
-                    state: "active",
+                    state: .active,
                     launchedAt: ISO8601DateFormatter().string(from: Date()),
                     endedAt: nil,
                     ttydPort: port,


### PR DESCRIPTION
## Summary
- Add `WorkspaceMode` enum (`clone`, `worktree`, `existing`) replacing raw strings in LaunchView and Deployment models
- Add `DeploymentState` enum replacing `state == "active"` string comparisons
- Use existing `Priority` enum in Draft model, DraftDetailView, QuickCreateSheet, and IssueListView
- All Codable with `rawValue: String` for seamless JSON encoding/decoding

## Test plan
- [x] iOS simulator build succeeds with zero errors
- [x] All string literal usages verified replaced via grep
- [x] Picker tags, comparisons, and display text all use enum values