### PR TITLE
fix(ios): move Add Repository button inline for discoverability

### DIFF
--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -25,16 +25,6 @@ struct SettingsView: View {
                 disconnectSection
             }
             .navigationTitle("Settings")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showAddRepo = true
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .accessibilityLabel("Add repository")
-                }
-            }
             .navigationDestination(for: SettingsDestination.self) { dest in
                 switch dest {
                 case .advancedSettings:
@@ -155,6 +145,12 @@ struct SettingsView: View {
                     .tint(.primary)
                 }
                 .onDelete(perform: deleteRepos)
+
+                Button {
+                    showAddRepo = true
+                } label: {
+                    Label("Add Repository", systemImage: "plus.circle")
+                }
             }
         } header: {
             HStack {


### PR DESCRIPTION
## Summary
- Replace the toolbar "+" icon with an inline "Add Repository" row at the bottom of the Repositories section in Settings
- Matches standard iOS settings patterns (e.g., "Add Account" in Mail)
- Found during manual simulator testing — the toolbar icon was easy to miss

## Test plan
- [x] Verified on simulator: inline button visible, triggers AddRepoSheet
- [x] Toolbar "+" removed, no duplicate entry points
- [x] Typecheck passes