### PR TITLE
feat(ios): close parity gaps with web dashboard

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
 		CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */; };
+		D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */; };
 		DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75027D57516F296784BEDA4B /* PRRowView.swift */; };
 		E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2D036E0950B774A3A43 /* LaunchView.swift */; };
 		E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
@@ -128,6 +129,7 @@
 		F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTabs.swift; sourceTree = "<group>"; };
 		F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MineFilterChip.swift; sourceTree = "<group>"; };
 		FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchProgressView.swift; sourceTree = "<group>"; };
 		FD234C4632456D401809E8A5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FE149A3F324BCC15AB57153E /* LabelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPicker.swift; sourceTree = "<group>"; };
 		FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequest.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 		91959DC1A8A25C554BECF0FA /* Launch */ = {
 			isa = PBXGroup;
 			children = (
+				FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */,
 				13EBC2D036E0950B774A3A43 /* LaunchView.swift */,
 			);
 			path = Launch;
@@ -412,6 +415,7 @@
 				F17CDC8FC484D666EB0B35C0 /* KeychainService.swift in Sources */,
 				BB243C0355BC2828C525684A /* LabelManagementSheet.swift in Sources */,
 				581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */,
+				D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
 				2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */,
 				62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */,

--- a/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
+++ b/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
@@ -101,9 +101,13 @@ extension APIClient {
     // MARK: Worktree Status
 
     func checkWorktreeStatus(owner: String, repo: String, issueNumber: Int) async throws -> WorktreeStatusResponse {
-        let (data, _) = try await request(
-            path: "/api/v1/worktrees/status?owner=\(owner)&repo=\(repo)&issueNumber=\(issueNumber)"
-        )
+        var components = URLComponents(string: "/api/v1/worktrees/status")!
+        components.queryItems = [
+            URLQueryItem(name: "owner", value: owner),
+            URLQueryItem(name: "repo", value: repo),
+            URLQueryItem(name: "issueNumber", value: String(issueNumber)),
+        ]
+        let (data, _) = try await request(path: components.string!)
         return try decoder.decode(WorktreeStatusResponse.self, from: data)
     }
 

--- a/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
+++ b/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
@@ -6,16 +6,6 @@ struct SettingsResponse: Codable, Sendable {
     let settings: [String: String]
 }
 
-struct SettingsUpdateRequest: Encodable, Sendable {
-    let updates: [String: String]
-
-    func encode(to encoder: Encoder) throws {
-        // Encode as flat key-value (not nested under "updates")
-        var container = encoder.singleValueContainer()
-        try container.encode(updates)
-    }
-}
-
 // MARK: - Worktree types
 
 struct WorktreeInfo: Codable, Identifiable, Sendable {
@@ -64,9 +54,75 @@ struct ReassignResponse: Codable, Sendable {
     let error: String?
 }
 
+// MARK: - Worktree status types
+
+struct WorktreeStatusResponse: Codable, Sendable {
+    let exists: Bool
+    let dirty: Bool
+    let path: String
+
+    var isDirty: Bool { exists && dirty }
+}
+
+struct WorktreeResetRequest: Encodable, Sendable {
+    let owner: String
+    let repo: String
+    let issueNumber: Int
+}
+
+// MARK: - EnsureTtyd types
+
+enum EnsureTtydResult: Sendable {
+    case available(port: Int, respawned: Bool)
+    case unavailable(error: String?)
+}
+
+extension EnsureTtydResult: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case port, respawned, alive, error
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        if let port = try c.decodeIfPresent(Int.self, forKey: .port) {
+            let respawned = try c.decodeIfPresent(Bool.self, forKey: .respawned) ?? false
+            self = .available(port: port, respawned: respawned)
+        } else {
+            let error = try c.decodeIfPresent(String.self, forKey: .error)
+            self = .unavailable(error: error)
+        }
+    }
+}
+
 // MARK: - APIClient extensions
 
 extension APIClient {
+
+    // MARK: Worktree Status
+
+    func checkWorktreeStatus(owner: String, repo: String, issueNumber: Int) async throws -> WorktreeStatusResponse {
+        let (data, _) = try await request(
+            path: "/api/v1/worktrees/status?owner=\(owner)&repo=\(repo)&issueNumber=\(issueNumber)"
+        )
+        return try decoder.decode(WorktreeStatusResponse.self, from: data)
+    }
+
+    func resetWorktree(owner: String, repo: String, issueNumber: Int) async throws -> SuccessResponse {
+        let body = WorktreeResetRequest(owner: owner, repo: repo, issueNumber: issueNumber)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/worktrees/reset", method: "POST", body: bodyData)
+        return try decoder.decode(SuccessResponse.self, from: data)
+    }
+
+    // MARK: EnsureTtyd
+
+    func ensureTtyd(deploymentId: Int) async throws -> EnsureTtydResult {
+        let (data, _) = try await request(
+            path: "/api/v1/deployments/\(deploymentId)/ensure-ttyd",
+            method: "POST"
+        )
+        return try decoder.decode(EnsureTtydResult.self, from: data)
+    }
 
     // MARK: Settings
 

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -55,7 +55,10 @@ final class APIClient {
             throw APIError.notConfigured
         }
 
-        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
+        guard let url = URL(string: path, relativeTo: base) else {
+            throw APIError.notConfigured
+        }
+        var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
         urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -56,7 +56,7 @@ final class APIClient {
         }
 
         guard let url = URL(string: path, relativeTo: base) else {
-            throw APIError.notConfigured
+            throw APIError.invalidPath(path)
         }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
@@ -92,7 +92,10 @@ final class APIClient {
         guard let base = URL(string: url) else {
             throw APIError.notConfigured
         }
-        var urlRequest = URLRequest(url: base.appendingPathComponent("/api/v1/health"))
+        guard let healthURL = URL(string: "/api/v1/health", relativeTo: base) else {
+            throw APIError.invalidPath("/api/v1/health")
+        }
+        var urlRequest = URLRequest(url: healthURL)
         urlRequest.httpMethod = "GET"
         urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -225,6 +228,7 @@ final class APIClient {
 
 enum APIError: LocalizedError {
     case notConfigured
+    case invalidPath(String)
     case unauthorized
     case invalidResponse
     case serverError(Int, String)
@@ -232,6 +236,7 @@ enum APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .notConfigured: "Server URL not configured"
+        case .invalidPath(let path): "Invalid API path: \(path)"
         case .unauthorized: "Invalid API token"
         case .invalidResponse: "Invalid server response"
         case .serverError(let code, let message): "Server error (\(code)): \(message)"

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -18,7 +18,7 @@ struct IssueDetailView: View {
     @State private var showReopenConfirm = false
     @State private var actionError: String?
 
-    // Detail actions state (#263, #264, #265)
+    // State for issue editing, label management, and comment edit/delete actions
     @State private var showEditSheet = false
     @State private var showLabelSheet = false
     @State private var showAssigneeSheet = false
@@ -32,6 +32,8 @@ struct IssueDetailView: View {
     @State private var currentPriority: Priority = .normal
     @State private var isLoadingPriority = false
     @State private var showReassignSheet = false
+    @State private var staleHint: String?
+    @State private var staleHintDismissTask: Task<Void, Never>?
 
     var body: some View {
         Group {
@@ -47,6 +49,16 @@ struct IssueDetailView: View {
                 }
             } else if let detail {
                 VStack(spacing: 0) {
+                    if let staleHint {
+                        Label(staleHint, systemImage: "arrow.clockwise")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal)
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity)
+                            .background(.ultraThinMaterial)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                    }
                     ScrollView {
                         VStack(alignment: .leading, spacing: 20) {
                             headerSection(detail.issue)
@@ -230,6 +242,8 @@ struct IssueDetailView: View {
         .onAppear {
             actionError = nil
         }
+        .animation(.easeInOut(duration: 0.25), value: staleHint != nil)
+        .onDisappear { staleHintDismissTask?.cancel() }
     }
 
     // MARK: - Sections
@@ -495,6 +509,7 @@ struct IssueDetailView: View {
             let response = try await api.updateIssueState(owner: owner, repo: repo, number: number, body: body)
             if response.success {
                 await load(refresh: true)
+                showStaleHint("Issue closed — pull to refresh if stale")
             } else {
                 actionError = response.error ?? "Failed to close issue"
             }
@@ -512,6 +527,7 @@ struct IssueDetailView: View {
             let response = try await api.updateIssueState(owner: owner, repo: repo, number: number, body: body)
             if response.success {
                 await load(refresh: true)
+                showStaleHint("Issue reopened — pull to refresh if stale")
             } else {
                 actionError = response.error ?? "Failed to reopen issue"
             }
@@ -532,6 +548,7 @@ struct IssueDetailView: View {
             )
             if response.success {
                 await load(refresh: true)
+                showStaleHint("Comment deleted — pull to refresh if stale")
             } else {
                 actionError = response.error ?? "Failed to delete comment"
             }
@@ -540,6 +557,15 @@ struct IssueDetailView: View {
         }
         isDeletingComment = false
         deletingComment = nil
+    }
+
+    private func showStaleHint(_ message: String) {
+        staleHintDismissTask?.cancel()
+        staleHint = message
+        staleHintDismissTask = Task {
+            try? await Task.sleep(for: .seconds(3))
+            if !Task.isCancelled { staleHint = nil }
+        }
     }
 }
 

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -11,9 +11,12 @@ struct IssueListView: View {
     @State private var section: IssueSection = .open
     @State private var selectedRepoIds: Set<Int> = []
     @State private var sortOrder: SortOrder = .updated
+    @State private var mineOnly = false
+    @SceneStorage("issues.section") private var storedSection = IssueSection.open.rawValue
+    @SceneStorage("issues.sortOrder") private var storedSortOrder = SortOrder.updated.rawValue
+    @SceneStorage("issues.mineOnly") private var storedMineOnly = false
     @State private var showCreateSheet = false
     @State private var showParseSheet = false
-    @State private var mineOnly = false
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var navigationPath = NavigationPath()
@@ -290,10 +293,24 @@ struct IssueListView: View {
                 }
             }
             .task { await loadAll() }
-            .onChange(of: section) { _, _ in displayLimit = pageSize }
+            .onAppear {
+                if let s = IssueSection(rawValue: storedSection) { section = s }
+                if let s = SortOrder(rawValue: storedSortOrder) { sortOrder = s }
+                mineOnly = storedMineOnly
+            }
+            .onChange(of: section) { _, new in
+                displayLimit = pageSize
+                storedSection = new.rawValue
+            }
             .onChange(of: selectedRepoIds) { _, _ in displayLimit = pageSize }
-            .onChange(of: sortOrder) { _, _ in displayLimit = pageSize }
-            .onChange(of: mineOnly) { _, _ in displayLimit = pageSize }
+            .onChange(of: sortOrder) { _, new in
+                displayLimit = pageSize
+                storedSortOrder = new.rawValue
+            }
+            .onChange(of: mineOnly) { _, new in
+                displayLimit = pageSize
+                storedMineOnly = new
+            }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
     }

--- a/ios/IssueCTL/Views/Launch/LaunchProgressView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchProgressView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct LaunchProgressView: View {
+    let owner: String
+    let repo: String
+    let issueNumber: Int
+    let branchName: String
+
+    @State private var currentStep = 0
+    private let steps: [(label: String, detail: String)] = [
+        ("Assembled issue context", "Gathering comments and referenced files"),
+        ("Checked deployment history", "Verifying no conflicting sessions"),
+        ("Checked out branch", ""),
+        ("Applied lifecycle label", "Marking issue as in-progress"),
+        ("Claude Code running", "Launching terminal session"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(owner)/\(repo) #\(issueNumber)")
+                .font(.headline)
+                .padding(.bottom, 24)
+
+            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                HStack(alignment: .top, spacing: 12) {
+                    stepIndicator(for: index)
+                        .frame(width: 24, height: 24)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(step.label)
+                            .font(.subheadline.weight(index <= currentStep ? .medium : .regular))
+                            .foregroundStyle(index <= currentStep ? .primary : .secondary)
+
+                        if index == 2 {
+                            Text(branchName)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.blue)
+                        } else if !step.detail.isEmpty {
+                            Text(step.detail)
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.bottom, index < steps.count - 1 ? 16 : 0)
+                }
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            await animateSteps()
+        }
+    }
+
+    @ViewBuilder
+    private func stepIndicator(for index: Int) -> some View {
+        if index < currentStep {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .transition(.scale.combined(with: .opacity))
+        } else if index == currentStep {
+            ProgressView()
+                .scaleEffect(0.7)
+                .transition(.opacity)
+        } else {
+            Circle()
+                .strokeBorder(.quaternary, lineWidth: 1.5)
+        }
+    }
+
+    private func animateSteps() async {
+        for i in 0..<steps.count {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                currentStep = i
+            }
+            if i < steps.count - 1 {
+                do {
+                    try await Task.sleep(for: .milliseconds(800))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -70,6 +70,19 @@ struct LaunchView: View {
                     port: port,
                     onEnd: { dismiss() }
                 )
+            } else {
+                NavigationStack {
+                    ContentUnavailableView {
+                        Label("Terminal Error", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text("Terminal port was not assigned.")
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button("Dismiss") { dismiss() }
+                        }
+                    }
+                }
             }
         }
     }

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -19,9 +19,12 @@ struct LaunchView: View {
     @State private var selectedFilePaths: Set<String> = []
     @State private var preamble = ""
     @State private var isLaunching = false
+    @State private var showProgress = false
     @State private var errorMessage: String?
     @State private var launchedPort: Int?
     @State private var launchedDeployment: ActiveDeployment?
+    @State private var dirtyWorktree = false
+    @State private var isResettingWorktree = false
 
     init(owner: String, repo: String, issueNumber: Int, issueTitle: String, comments: [GitHubComment], referencedFiles: [String], repoLocalPath: String? = nil) {
         self.owner = owner
@@ -45,151 +48,239 @@ struct LaunchView: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    HStack {
-                        Text("#\(issueNumber)")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text(issueTitle)
-                            .font(.subheadline)
-                            .lineLimit(2)
-                    }
-                }
+            if showProgress {
+                LaunchProgressView(
+                    owner: owner,
+                    repo: repo,
+                    issueNumber: issueNumber,
+                    branchName: branchName
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.systemGroupedBackground))
+                .navigationTitle("Launching…")
+                .navigationBarTitleDisplayMode(.inline)
+            } else {
+                launchForm
+            }
+        }
+        .fullScreenCover(item: $launchedDeployment) { deployment in
+            if let port = launchedPort {
+                TerminalView(
+                    deployment: deployment,
+                    port: port,
+                    onEnd: { dismiss() }
+                )
+            }
+        }
+    }
 
-                if showCloneWarning {
-                    Section {
-                        Label("This repository has no local clone. A fresh clone will be created.", systemImage: "exclamationmark.triangle")
+    @ViewBuilder
+    private var launchForm: some View {
+        Form {
+            Section {
+                HStack {
+                    Text("#\(issueNumber)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(issueTitle)
+                        .font(.subheadline)
+                        .lineLimit(2)
+                }
+            }
+
+            if showCloneWarning {
+                Section {
+                    Label("This repository has no local clone. A fresh clone will be created.", systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                        .font(.subheadline)
+                }
+            }
+
+            if dirtyWorktree {
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Previous session left uncommitted changes", systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
-                            .font(.subheadline)
+                            .font(.subheadline.weight(.medium))
+
+                        HStack(spacing: 12) {
+                            Button(role: .destructive) {
+                                Task { await resetDirtyWorktree() }
+                            } label: {
+                                if isResettingWorktree {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Text("Discard & Start Fresh")
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(isResettingWorktree)
+
+                            Button {
+                                launchWithForceResume()
+                            } label: {
+                                Text("Resume with Changes")
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
                     }
                 }
+            }
 
-                Section("Workspace Mode") {
-                    Picker("Mode", selection: $workspaceMode) {
-                        Text("Worktree").tag("worktree")
-                        Text("Existing").tag("existing")
-                        Text("Clone").tag("clone")
-                    }
-                    .pickerStyle(.segmented)
-                    .disabled(showCloneWarning)
-                    .accessibilityIdentifier("workspace-mode-picker")
+            Section("Workspace Mode") {
+                Picker("Mode", selection: $workspaceMode) {
+                    Text("Worktree").tag("worktree")
+                    Text("Existing").tag("existing")
+                    Text("Clone").tag("clone")
                 }
+                .pickerStyle(.segmented)
+                .disabled(showCloneWarning)
+                .accessibilityIdentifier("workspace-mode-picker")
+            }
 
-                Section("Branch Name") {
-                    TextField("Branch name", text: $branchName)
-                        .autocapitalization(.none)
-                        .font(.body.monospaced())
-                }
+            Section("Branch Name") {
+                TextField("Branch name", text: $branchName)
+                    .autocapitalization(.none)
+                    .font(.body.monospaced())
+            }
 
-                if !comments.isEmpty {
-                    Section("Include Comments") {
-                        ForEach(Array(comments.enumerated()), id: \.offset) { index, comment in
-                            Toggle(isOn: Binding(
-                                get: { selectedCommentIndices.contains(index) },
-                                set: { isOn in
-                                    if isOn { selectedCommentIndices.insert(index) }
-                                    else { selectedCommentIndices.remove(index) }
+            if !comments.isEmpty {
+                Section("Include Comments") {
+                    ForEach(Array(comments.enumerated()), id: \.offset) { index, comment in
+                        Toggle(isOn: Binding(
+                            get: { selectedCommentIndices.contains(index) },
+                            set: { isOn in
+                                if isOn { selectedCommentIndices.insert(index) }
+                                else { selectedCommentIndices.remove(index) }
+                            }
+                        )) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                if let user = comment.user {
+                                    Text(user.login)
+                                        .font(.caption.weight(.medium))
                                 }
-                            )) {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    if let user = comment.user {
-                                        Text(user.login)
-                                            .font(.caption.weight(.medium))
-                                    }
-                                    Text(comment.body)
-                                        .font(.caption)
-                                        .lineLimit(2)
-                                        .foregroundStyle(.secondary)
-                                }
+                                Text(comment.body)
+                                    .font(.caption)
+                                    .lineLimit(2)
+                                    .foregroundStyle(.secondary)
                             }
                         }
                     }
                 }
+            }
 
-                if !referencedFiles.isEmpty {
-                    Section("Include Files") {
-                        ForEach(referencedFiles, id: \.self) { filePath in
-                            Toggle(isOn: Binding(
-                                get: { selectedFilePaths.contains(filePath) },
-                                set: { isOn in
-                                    if isOn { selectedFilePaths.insert(filePath) }
-                                    else { selectedFilePaths.remove(filePath) }
-                                }
-                            )) {
-                                Text(filePath)
-                                    .font(.caption.monospaced())
-                                    .lineLimit(1)
+            if !referencedFiles.isEmpty {
+                Section("Include Files") {
+                    ForEach(referencedFiles, id: \.self) { filePath in
+                        Toggle(isOn: Binding(
+                            get: { selectedFilePaths.contains(filePath) },
+                            set: { isOn in
+                                if isOn { selectedFilePaths.insert(filePath) }
+                                else { selectedFilePaths.remove(filePath) }
                             }
+                        )) {
+                            Text(filePath)
+                                .font(.caption.monospaced())
+                                .lineLimit(1)
                         }
                     }
                 }
+            }
 
-                Section("Preamble (optional)") {
-                    TextEditor(text: $preamble)
-                        .frame(minHeight: 80)
-                        .font(.body)
-                }
+            Section("Preamble (optional)") {
+                TextEditor(text: $preamble)
+                    .frame(minHeight: 80)
+                    .font(.body)
+            }
 
-                if let errorMessage {
-                    Section {
-                        Label(errorMessage, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                    }
-                }
-
+            if let errorMessage {
                 Section {
-                    Button {
-                        Task { await launchSession() }
-                    } label: {
-                        if isLaunching {
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                        } else {
-                            Label("Launch Claude Code", systemImage: "play.fill")
-                                .frame(maxWidth: .infinity)
-                        }
-                    }
-                    .disabled(branchName.isEmpty || isLaunching)
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
                 }
             }
-            .navigationTitle("Launch Session")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
-                }
-            }
-            .task {
-                if repoLocalPath == nil {
-                    do {
-                        let repos = try await api.repos()
-                        if let match = repos.first(where: { $0.owner == owner && $0.name == repo }) {
-                            let needsClone = match.localPath == nil || match.localPath?.isEmpty == true
-                            showCloneWarning = needsClone
-                            workspaceMode = needsClone ? "clone" : "worktree"
-                        }
-                    } catch {
-                        // Could not verify clone status — unlock the picker so user can choose
-                        showCloneWarning = false
+
+            Section {
+                Button {
+                    Task { await launchSession() }
+                } label: {
+                    if isLaunching {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Label("Launch Claude Code", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity)
                     }
                 }
+                .disabled(branchName.isEmpty || isLaunching)
             }
-            .fullScreenCover(item: $launchedDeployment) { deployment in
-                if let port = launchedPort {
-                    TerminalView(
-                        deployment: deployment,
-                        port: port,
-                        onEnd: { dismiss() }
+        }
+        .navigationTitle("Launch Session")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+        }
+        .task {
+            if repoLocalPath == nil {
+                do {
+                    let repos = try await api.repos()
+                    if let match = repos.first(where: { $0.owner == owner && $0.name == repo }) {
+                        let needsClone = match.localPath == nil || match.localPath?.isEmpty == true
+                        showCloneWarning = needsClone
+                        workspaceMode = needsClone ? "clone" : "worktree"
+                    }
+                } catch {
+                    // Network failure — leave showCloneWarning at its init value
+                }
+            }
+            if workspaceMode == "worktree" {
+                do {
+                    let status = try await api.checkWorktreeStatus(
+                        owner: owner, repo: repo, issueNumber: issueNumber
                     )
+                    if status.isDirty {
+                        dirtyWorktree = true
+                    }
+                } catch {
+                    // Assume dirty when check fails — safer than losing uncommitted work
+                    dirtyWorktree = true
                 }
             }
         }
     }
 
+    private func resetDirtyWorktree() async {
+        isResettingWorktree = true
+        do {
+            let response = try await api.resetWorktree(
+                owner: owner, repo: repo, issueNumber: issueNumber
+            )
+            if response.success {
+                dirtyWorktree = false
+            } else {
+                errorMessage = response.error ?? "Failed to reset worktree"
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isResettingWorktree = false
+    }
+
+    private func launchWithForceResume() {
+        Task { await performLaunch(forceResume: true) }
+    }
+
     private func launchSession() async {
+        await performLaunch(forceResume: nil)
+    }
+
+    private func performLaunch(forceResume: Bool?) async {
         isLaunching = true
         errorMessage = nil
+        withAnimation { showProgress = true }
 
         do {
             let body = LaunchRequestBody(
@@ -198,38 +289,29 @@ struct LaunchView: View {
                 selectedCommentIndices: Array(selectedCommentIndices).sorted(),
                 selectedFilePaths: Array(selectedFilePaths),
                 preamble: preamble.isEmpty ? nil : preamble,
-                forceResume: nil,
+                forceResume: forceResume,
                 idempotencyKey: UUID().uuidString
             )
             let response = try await api.launch(
-                owner: owner,
-                repo: repo,
-                number: issueNumber,
-                body: body
+                owner: owner, repo: repo, number: issueNumber, body: body
             )
             if response.success, let deploymentId = response.deploymentId, let port = response.ttydPort {
                 launchedPort = port
                 launchedDeployment = ActiveDeployment(
-                    id: deploymentId,
-                    repoId: 0,
-                    issueNumber: issueNumber,
-                    branchName: branchName,
-                    workspaceMode: workspaceMode,
-                    workspacePath: "",
-                    linkedPrNumber: nil,
-                    state: "active",
+                    id: deploymentId, repoId: 0, issueNumber: issueNumber,
+                    branchName: branchName, workspaceMode: workspaceMode,
+                    workspacePath: "", linkedPrNumber: nil, state: "active",
                     launchedAt: ISO8601DateFormatter().string(from: Date()),
-                    endedAt: nil,
-                    ttydPort: port,
-                    ttydPid: nil,
-                    owner: owner,
-                    repoName: repo
+                    endedAt: nil, ttydPort: port, ttydPid: nil,
+                    owner: owner, repoName: repo
                 )
             } else {
                 errorMessage = response.error ?? "Launch failed"
+                withAnimation { showProgress = false }
             }
         } catch {
             errorMessage = error.localizedDescription
+            withAnimation { showProgress = false }
         }
 
         isLaunching = false

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -10,6 +10,9 @@ struct PRListView: View {
     @State private var selectedRepoIds: Set<Int> = []
     @State private var sortOrder: SortOrder = .updated
     @State private var mineOnly = false
+    @SceneStorage("prs.section") private var storedSection = PRSection.open.rawValue
+    @SceneStorage("prs.sortOrder") private var storedSortOrder = SortOrder.updated.rawValue
+    @SceneStorage("prs.mineOnly") private var storedMineOnly = false
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var navigationPath = NavigationPath()
@@ -180,10 +183,24 @@ struct PRListView: View {
                 }
             }
             .task { await loadAll() }
-            .onChange(of: section) { _, _ in displayLimit = pageSize }
+            .onAppear {
+                if let s = PRSection(rawValue: storedSection) { section = s }
+                if let s = SortOrder(rawValue: storedSortOrder) { sortOrder = s }
+                mineOnly = storedMineOnly
+            }
+            .onChange(of: section) { _, new in
+                displayLimit = pageSize
+                storedSection = new.rawValue
+            }
             .onChange(of: selectedRepoIds) { _, _ in displayLimit = pageSize }
-            .onChange(of: sortOrder) { _, _ in displayLimit = pageSize }
-            .onChange(of: mineOnly) { _, _ in displayLimit = pageSize }
+            .onChange(of: sortOrder) { _, new in
+                displayLimit = pageSize
+                storedSortOrder = new.rawValue
+            }
+            .onChange(of: mineOnly) { _, new in
+                displayLimit = pageSize
+                storedMineOnly = new
+            }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
     }

--- a/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
@@ -15,14 +15,23 @@ struct AdvancedSettingsView: View {
     @State private var idleThreshold = ""
     @State private var branchPattern = ""
     @State private var worktreeDir = ""
+    @State private var defaultRepoId = ""
+    @State private var repos: [Repo] = []
+
+    private var editableFields: [(key: String, value: String)] {
+        [
+            ("cache_ttl", cacheTTL),
+            ("claude_extra_args", claudeExtraArgs),
+            ("idle_grace_period", idleGracePeriod),
+            ("idle_threshold", idleThreshold),
+            ("branch_pattern", branchPattern),
+            ("worktree_dir", worktreeDir),
+            ("default_repo_id", defaultRepoId),
+        ]
+    }
 
     private var hasChanges: Bool {
-        cacheTTL != (settings["cache_ttl"] ?? "") ||
-        claudeExtraArgs != (settings["claude_extra_args"] ?? "") ||
-        idleGracePeriod != (settings["idle_grace_period"] ?? "") ||
-        idleThreshold != (settings["idle_threshold"] ?? "") ||
-        branchPattern != (settings["branch_pattern"] ?? "") ||
-        worktreeDir != (settings["worktree_dir"] ?? "")
+        editableFields.contains { $0.value != (settings[$0.key] ?? "") }
     }
 
     var body: some View {
@@ -96,6 +105,19 @@ struct AdvancedSettingsView: View {
                     Text("Directory where git worktrees are created.")
                 }
 
+                Section {
+                    Picker("Default Repository", selection: $defaultRepoId) {
+                        Text("None").tag("")
+                        ForEach(repos) { repo in
+                            Text(repo.fullName).tag(String(repo.id))
+                        }
+                    }
+                } header: {
+                    Text("Default Repository")
+                } footer: {
+                    Text("Pre-selected repository when creating new drafts.")
+                }
+
                 if let saveError {
                     Section {
                         Label(saveError, systemImage: "exclamationmark.triangle.fill")
@@ -125,13 +147,17 @@ struct AdvancedSettingsView: View {
         isLoading = true
         errorMessage = nil
         do {
-            settings = try await api.getSettings()
+            async let settingsFetch = api.getSettings()
+            async let reposFetch = api.repos()
+            settings = try await settingsFetch
+            repos = try await reposFetch
             cacheTTL = settings["cache_ttl"] ?? ""
             claudeExtraArgs = settings["claude_extra_args"] ?? ""
             idleGracePeriod = settings["idle_grace_period"] ?? ""
             idleThreshold = settings["idle_threshold"] ?? ""
             branchPattern = settings["branch_pattern"] ?? ""
             worktreeDir = settings["worktree_dir"] ?? ""
+            defaultRepoId = settings["default_repo_id"] ?? ""
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -143,13 +169,10 @@ struct AdvancedSettingsView: View {
         saveError = nil
         defer { isSaving = false }
 
-        var updates: [String: String] = [:]
-        if cacheTTL != (settings["cache_ttl"] ?? "") { updates["cache_ttl"] = cacheTTL }
-        if claudeExtraArgs != (settings["claude_extra_args"] ?? "") { updates["claude_extra_args"] = claudeExtraArgs }
-        if idleGracePeriod != (settings["idle_grace_period"] ?? "") { updates["idle_grace_period"] = idleGracePeriod }
-        if idleThreshold != (settings["idle_threshold"] ?? "") { updates["idle_threshold"] = idleThreshold }
-        if branchPattern != (settings["branch_pattern"] ?? "") { updates["branch_pattern"] = branchPattern }
-        if worktreeDir != (settings["worktree_dir"] ?? "") { updates["worktree_dir"] = worktreeDir }
+        let updates = Dictionary(
+            uniqueKeysWithValues: editableFields.filter { $0.value != (settings[$0.key] ?? "") }
+                .map { ($0.key, $0.value) }
+        )
 
         guard !updates.isEmpty else { return }
 

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -10,18 +10,36 @@ struct TerminalView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showEndConfirm = false
     @State private var loadError: String?
+    @State private var currentPort: Int
+    @State private var isRespawning = false
+
+    init(deployment: ActiveDeployment, port: Int, onEnd: @escaping () -> Void) {
+        self.deployment = deployment
+        self.port = port
+        self.onEnd = onEnd
+        _currentPort = State(initialValue: port)
+    }
 
     var body: some View {
         NavigationStack {
             Group {
                 if let url = terminalURL {
-                    if let loadError {
+                    if isRespawning {
+                        VStack(spacing: 12) {
+                            ProgressView()
+                            Text("Reconnecting terminal…")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if let loadError {
                         ContentUnavailableView {
                             Label("Terminal Connection Failed", systemImage: "wifi.exclamationmark")
                         } description: {
                             Text(loadError)
                         } actions: {
-                            Button("Retry") { self.loadError = nil }
+                            Button("Retry") {
+                                Task { await attemptRespawn() }
+                            }
                         }
                     } else {
                         TerminalWebView(url: url, loadError: $loadError)
@@ -71,7 +89,24 @@ struct TerminalView: View {
     }
 
     private var terminalURL: URL? {
-        URL(string: "\(api.serverURL)/api/terminal/\(port)/")
+        URL(string: "\(api.serverURL)/api/terminal/\(currentPort)/")
+    }
+
+    private func attemptRespawn() async {
+        isRespawning = true
+        loadError = nil
+        do {
+            let result = try await api.ensureTtyd(deploymentId: deployment.id)
+            switch result {
+            case .available(let port, _):
+                currentPort = port
+            case .unavailable(let error):
+                loadError = error ?? "Session has ended"
+            }
+        } catch {
+            loadError = error.localizedDescription
+        }
+        isRespawning = false
     }
 }
 

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -2,10 +2,12 @@ import { randomBytes } from "node:crypto";
 import type Database from "better-sqlite3";
 import type { Setting, SettingKey } from "../types.js";
 
+export const DEFAULT_WORKTREE_DIR = "~/.issuectl/worktrees/";
+
 const DEFAULT_SETTINGS: Setting[] = [
   { key: "branch_pattern", value: "issue-{number}-{slug}" },
   { key: "cache_ttl", value: "300" },
-  { key: "worktree_dir", value: "~/.issuectl/worktrees/" },
+  { key: "worktree_dir", value: DEFAULT_WORKTREE_DIR },
   { key: "claude_extra_args", value: "--dangerously-skip-permissions" },
   { key: "idle_grace_period", value: "300" },
   { key: "idle_threshold", value: "300" },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   getSettings,
   seedDefaults,
   generateApiToken,
+  DEFAULT_WORKTREE_DIR,
 } from "./db/settings.js";
 export {
   createDraft,
@@ -175,6 +176,7 @@ export {
 // Launch flow
 export {
   executeLaunch,
+  expandHome,
   type LaunchOptions,
   type LaunchResult,
   type LaunchContext,

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -49,7 +49,7 @@ export interface LaunchResult {
   labelWarning?: string;
 }
 
-function expandHome(p: string): string {
+export function expandHome(p: string): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "/";
   if (p === "~") return home;
   if (p.startsWith("~/")) return home + p.slice(1);

--- a/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
@@ -15,7 +15,7 @@ export async function POST(
   const { id: idStr } = await params;
   const deploymentId = parseInt(idStr, 10);
   if (Number.isNaN(deploymentId) || deploymentId <= 0) {
-    return NextResponse.json({ alive: false }, { status: 400 });
+    return NextResponse.json({ alive: false, error: "Invalid deployment ID" }, { status: 400 });
   }
 
   const result = await ensureTtydForDeployment(deploymentId);

--- a/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { ensureTtydForDeployment } from "@/lib/ensure-ttyd";
+import log from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id: idStr } = await params;
+  const deploymentId = parseInt(idStr, 10);
+  if (Number.isNaN(deploymentId) || deploymentId <= 0) {
+    return NextResponse.json({ alive: false }, { status: 400 });
+  }
+
+  const result = await ensureTtydForDeployment(deploymentId);
+  if ("respawned" in result && result.respawned) {
+    log.info({ msg: "ttyd_respawned", deploymentId, port: result.port });
+  }
+  if (result.alive === false && result.error) {
+    log.error({ msg: "ensure_ttyd_failed", deploymentId, error: result.error });
+  }
+  return NextResponse.json(result);
+}

--- a/packages/web/app/api/v1/worktrees/reset/route.ts
+++ b/packages/web/app/api/v1/worktrees/reset/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolve, join } from "node:path";
+import { requireAuth } from "@/lib/api-auth";
+import {
+  getDb,
+  getRepo,
+  expandHome,
+  formatErrorForUser,
+  resetWorktree as coreResetWorktree,
+} from "@issuectl/core";
+import { getWorktreeDir } from "@/lib/worktree-dir";
+import log from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+type ResetBody = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let body: ResetBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { owner, repo, issueNumber } = body;
+  if (!owner || !repo || !Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json(
+      { success: false, error: "Invalid parameters" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const repoRecord = getRepo(db, owner, repo);
+    if (!repoRecord) {
+      return NextResponse.json(
+        { success: false, error: "Repository not found" },
+        { status: 404 },
+      );
+    }
+
+    const repoLocalPath = repoRecord.localPath;
+    if (!repoLocalPath) {
+      return NextResponse.json(
+        { success: false, error: "Repository has no local path" },
+        { status: 400 },
+      );
+    }
+
+    const worktreeDir = getWorktreeDir();
+    const worktreeName = `${repoRecord.name}-issue-${issueNumber}`;
+    const worktreePath = join(worktreeDir, worktreeName);
+
+    const resolved = resolve(worktreePath);
+    if (!resolved.startsWith(resolve(worktreeDir))) {
+      return NextResponse.json(
+        { success: false, error: "Invalid worktree path" },
+        { status: 400 },
+      );
+    }
+
+    await coreResetWorktree(resolved, expandHome(repoLocalPath));
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_worktree_reset_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/worktrees/status/route.ts
+++ b/packages/web/app/api/v1/worktrees/status/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import { getDb, getRepo, checkWorktreeStatus, formatErrorForUser } from "@issuectl/core";
+import { getWorktreeDir } from "@/lib/worktree-dir";
+import log from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { searchParams } = new URL(request.url);
+  const owner = searchParams.get("owner");
+  const repo = searchParams.get("repo");
+  const issueNumberStr = searchParams.get("issueNumber");
+
+  if (!owner || !repo || !issueNumberStr) {
+    return NextResponse.json(
+      { error: "owner, repo, and issueNumber are required" },
+      { status: 400 },
+    );
+  }
+
+  const issueNumber = parseInt(issueNumberStr, 10);
+  if (Number.isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json(
+      { error: "Invalid issue number" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const repoRecord = getRepo(db, owner, repo);
+    if (!repoRecord) {
+      return NextResponse.json({ exists: false, dirty: false, path: "" });
+    }
+
+    const worktreeDir = getWorktreeDir();
+    const status = await checkWorktreeStatus(
+      worktreeDir,
+      repoRecord.name,
+      issueNumber,
+    );
+    return NextResponse.json(status);
+  } catch (err) {
+    log.error({ err, msg: "api_worktree_status_failed", owner, repo, issueNumber });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -256,7 +256,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false });
+    expect(result).toEqual({ alive: false, error: "Terminal session has ended" });
     expect(respawnTtyd).not.toHaveBeenCalled();
     expect(coreEndDeployment).toHaveBeenCalled();
   });
@@ -266,7 +266,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false });
+    expect(result).toEqual({ alive: false, error: "Deployment not found or already ended" });
   });
 
   it("returns alive false when deployment has no ttydPid", async () => {
@@ -274,7 +274,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false });
+    expect(result).toEqual({ alive: false, error: "No terminal process configured" });
   });
 
   it("calls updateTtydInfo with new PID after respawn", async () => {
@@ -307,7 +307,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ alive: false });
+    expect(result).toEqual({ alive: false, error: "Repository not found" });
     expect(isTmuxSessionAlive).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -8,11 +8,8 @@ import {
   executeLaunch,
   endDeployment as coreEndDeployment,
   killTtyd,
-  isTtydAlive,
   isTmuxSessionAlive,
-  respawnTtyd,
   tmuxSessionName,
-  updateTtydInfo,
   withAuthRetry,
   withIdempotency,
   DuplicateInFlightError,
@@ -247,51 +244,7 @@ export async function checkSessionAlive(
   }
 }
 
-type EnsureTtydResult =
-  | { port: number; respawned?: true; alive?: never }
-  | { alive: false; error?: string };
-
-export async function ensureTtyd(
-  deploymentId: number,
-): Promise<EnsureTtydResult> {
-  if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
-    return { alive: false };
-  }
-  try {
-    const db = getDb();
-    const deployment = getDeploymentById(db, deploymentId);
-    if (!deployment || deployment.endedAt !== null) {
-      return { alive: false };
-    }
-    if (!deployment.ttydPid || deployment.ttydPort === null) {
-      return { alive: false };
-    }
-    const port = deployment.ttydPort;
-
-    // ttyd is still running — return immediately
-    if (isTtydAlive(deployment.ttydPid)) {
-      return { port };
-    }
-
-    // ttyd is dead — check if the tmux session is still alive
-    const repo = getRepoById(db, deployment.repoId);
-    if (!repo) {
-      return { alive: false };
-    }
-
-    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
-    if (!isTmuxSessionAlive(sessionName)) {
-      // Both dead — session is truly over
-      coreEndDeployment(db, deploymentId);
-      return { alive: false };
-    }
-
-    // Tmux alive, ttyd dead — respawn ttyd
-    const { pid } = await respawnTtyd(port, sessionName);
-    updateTtydInfo(db, deploymentId, port, pid);
-    return { port, respawned: true };
-  } catch (err) {
-    console.error("[issuectl] ensureTtyd failed:", err);
-    return { alive: false, error: formatErrorForUser(err) };
-  }
+export async function ensureTtyd(deploymentId: number) {
+  const { ensureTtydForDeployment } = await import("@/lib/ensure-ttyd");
+  return ensureTtydForDeployment(deploymentId);
 }

--- a/packages/web/lib/ensure-ttyd.ts
+++ b/packages/web/lib/ensure-ttyd.ts
@@ -51,6 +51,7 @@ export async function ensureTtydForDeployment(
     updateTtydInfo(db, deploymentId, port, pid);
     return { port, respawned: true };
   } catch (err) {
+    console.error("[issuectl] ensureTtydForDeployment failed:", deploymentId, err);
     return { alive: false, error: formatErrorForUser(err) };
   }
 }

--- a/packages/web/lib/ensure-ttyd.ts
+++ b/packages/web/lib/ensure-ttyd.ts
@@ -1,0 +1,56 @@
+import {
+  getDb,
+  getRepoById,
+  getDeploymentById,
+  endDeployment,
+  isTtydAlive,
+  isTmuxSessionAlive,
+  respawnTtyd,
+  tmuxSessionName,
+  updateTtydInfo,
+  formatErrorForUser,
+} from "@issuectl/core";
+
+export type EnsureTtydResult =
+  | { port: number; respawned?: true; alive?: never; error?: never }
+  | { alive: false; error?: string; port?: never };
+
+export async function ensureTtydForDeployment(
+  deploymentId: number,
+): Promise<EnsureTtydResult> {
+  if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
+    return { alive: false, error: "Invalid deployment ID" };
+  }
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    if (!deployment || deployment.endedAt !== null) {
+      return { alive: false, error: "Deployment not found or already ended" };
+    }
+    if (!deployment.ttydPid || deployment.ttydPort === null) {
+      return { alive: false, error: "No terminal process configured" };
+    }
+    const port = deployment.ttydPort;
+
+    if (isTtydAlive(deployment.ttydPid)) {
+      return { port };
+    }
+
+    const repo = getRepoById(db, deployment.repoId);
+    if (!repo) {
+      return { alive: false, error: "Repository not found" };
+    }
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (!isTmuxSessionAlive(sessionName)) {
+      endDeployment(db, deploymentId);
+      return { alive: false, error: "Terminal session has ended" };
+    }
+
+    const { pid } = await respawnTtyd(port, sessionName);
+    updateTtydInfo(db, deploymentId, port, pid);
+    return { port, respawned: true };
+  } catch (err) {
+    return { alive: false, error: formatErrorForUser(err) };
+  }
+}

--- a/packages/web/lib/worktree-dir.ts
+++ b/packages/web/lib/worktree-dir.ts
@@ -1,0 +1,7 @@
+import { getDb, getSetting, expandHome, DEFAULT_WORKTREE_DIR } from "@issuectl/core";
+
+export function getWorktreeDir(): string {
+  const db = getDb();
+  const configured = getSetting(db, "worktree_dir");
+  return expandHome(configured ?? DEFAULT_WORKTREE_DIR);
+}


### PR DESCRIPTION
## Summary
- **Feature parity**: dirty-worktree detection with discard/resume flow, launch progress animation, stale-data hints after mutations, filter persistence via `@SceneStorage`, cache-age labels, pull-to-refresh on PR list
- **Bug fixes**: critical URL encoding bug (`appendPathComponent` → `URL(string:relativeTo:)`), silent worktree-status failure (fail-safe assumes dirty), `.fullScreenCover` placement bug, task cancellation leak in `IssueDetailView`, query parameter injection in `checkWorktreeStatus`
- **Code quality**: extract shared `ensure-ttyd.ts` and `worktree-dir.ts` utilities, replace all-optional `EnsureTtydResponse` with proper Swift enum + custom `Decodable`, deduplicate settings comparisons, extract `LaunchView` form into `@ViewBuilder`, add `invalidPath` error case to `APIError`, structured logging in API routes
- **Tests**: fix 4 `ensureTtyd` test expectations to match new error message contract

## Test plan
- [x] `pnpm turbo typecheck` — all packages pass
- [x] `pnpm turbo build` — production build succeeds
- [x] iOS simulator build succeeds
- [x] 19/19 tests pass in `launch.test.ts`
- [ ] Launch session flow: create → progress animation → terminal opens
- [ ] Dirty worktree: "Discard & Start Fresh" resets, "Resume with Changes" continues
- [ ] Filters persist across app restarts (section, sort order, mine-only)
- [ ] Pull-to-refresh works on issue and PR lists
- [ ] Cache-age labels show on list views
- [ ] Stale hints appear after close/reopen/delete actions, auto-dismiss after 3s
- [ ] Terminal reconnect works via `ensureTtyd` enum result