### PR TITLE
fix(ios): pull-to-refresh on empty and error states

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -420,6 +420,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					791AFA96580A5FB3D384B678 = {
+						DevelopmentTeam = B3A6AN2HA4;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = DA7D0782F66BD4E6E2A975A4 /* Build configuration list for PBXProject "IssueCTL" */;
@@ -626,6 +630,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3A6AN2HA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -729,6 +735,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3A6AN2HA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -182,21 +182,29 @@ struct IssueListView: View {
                         ProgressView("Loading issues...")
                             .frame(maxHeight: .infinity)
                     } else if let errorMessage {
-                        ContentUnavailableView {
-                            Label("Error", systemImage: "exclamationmark.triangle")
-                        } description: {
-                            Text(errorMessage)
-                        } actions: {
-                            Button("Retry") { Task { await loadAll() } }
+                        ScrollView {
+                            ContentUnavailableView {
+                                Label("Error", systemImage: "exclamationmark.triangle")
+                            } description: {
+                                Text(errorMessage)
+                            } actions: {
+                                Button("Retry") { Task { await loadAll() } }
+                            }
+                            .frame(maxHeight: .infinity)
                         }
+                        .refreshable { await refreshWithCooldown() }
                     } else if section == .drafts {
                         draftsList
                     } else if filteredIssues.isEmpty {
-                        ContentUnavailableView(
-                            "No Issues",
-                            systemImage: "checkmark.circle",
-                            description: Text("No \(section.rawValue) issues.")
-                        )
+                        ScrollView {
+                            ContentUnavailableView(
+                                "No Issues",
+                                systemImage: "checkmark.circle",
+                                description: Text("No \(section.rawValue) issues.")
+                            )
+                            .frame(maxHeight: .infinity)
+                        }
+                        .refreshable { await refreshWithCooldown() }
                     } else {
                         issuesList
                     }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -19,6 +19,8 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         GENERATE_INFOPLIST_FILE: true
         PRODUCT_BUNDLE_IDENTIFIER: com.issuectl.ios
+        DEVELOPMENT_TEAM: B3A6AN2HA4
+        CODE_SIGN_STYLE: Automatic
     scheme:
       testTargets:
         - IssueCTLTests


### PR DESCRIPTION
## Summary
- Wrap empty-state and error-state `ContentUnavailableView`s in `ScrollView` with `.refreshable` so pull-to-refresh works in all issue list states, not just when issues are loaded
- Add `DEVELOPMENT_TEAM` and `CODE_SIGN_STYLE` to `project.yml` for physical device builds

## Test plan
- [ ] Open app with no tracked repos — pull-to-refresh gesture should appear on "No Issues" screen
- [ ] Disconnect from server — error state should support pull-to-refresh
- [ ] Normal issue list pull-to-refresh continues to work as before