### PR TITLE
fix(ios): fix decoding errors, blank sheets, and harden sheet presentation

### DIFF
--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -65,11 +65,6 @@ struct IssueDetailResponse: Codable, Sendable {
     let linkedPRs: [GitHubPull]
     let referencedFiles: [String]
     let fromCache: Bool
-
-    private enum CodingKeys: String, CodingKey {
-        case issue, comments, deployments, referencedFiles, fromCache
-        case linkedPRs = "linkedPrs"
-    }
 }
 
 struct IssueStateRequestBody: Encodable, Sendable {

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -18,7 +18,7 @@ struct IssueDetailView: View {
     @State private var showReopenConfirm = false
     @State private var actionError: String?
 
-    // State for comment edit/delete actions
+    // Comment actions and error display
     @State private var editingComment: GitHubComment?
     @State private var deletingComment: GitHubComment?
     @State private var isDeletingComment = false

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -9,7 +9,7 @@ struct IssueDetailView: View {
     @State private var detail: IssueDetailResponse?
     @State private var isLoading = true
     @State private var errorMessage: String?
-    @State private var showLaunchSheet = false
+    @State private var activeDetailSheet: DetailSheet?
     @State private var isClosing = false
     @State private var isReopening = false
     @State private var showCommentSheet = false
@@ -18,10 +18,7 @@ struct IssueDetailView: View {
     @State private var showReopenConfirm = false
     @State private var actionError: String?
 
-    // State for issue editing, label management, and comment edit/delete actions
-    @State private var showEditSheet = false
-    @State private var showLabelSheet = false
-    @State private var showAssigneeSheet = false
+    // State for comment edit/delete actions
     @State private var editingComment: GitHubComment?
     @State private var deletingComment: GitHubComment?
     @State private var isDeletingComment = false
@@ -31,7 +28,6 @@ struct IssueDetailView: View {
     // Priority state
     @State private var currentPriority: Priority = .normal
     @State private var isLoadingPriority = false
-    @State private var showReassignSheet = false
     @State private var staleHint: String?
     @State private var staleHintDismissTask: Task<Void, Never>?
 
@@ -84,21 +80,21 @@ struct IssueDetailView: View {
         .navigationTitle("#\(number)")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if detail != nil {
+            if let detail {
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         Button {
-                            showEditSheet = true
+                            activeDetailSheet = .edit(detail)
                         } label: {
                             Label("Edit Issue", systemImage: "pencil")
                         }
                         Button {
-                            showLabelSheet = true
+                            activeDetailSheet = .labels(detail)
                         } label: {
                             Label("Manage Labels", systemImage: "tag")
                         }
                         Button {
-                            showAssigneeSheet = true
+                            activeDetailSheet = .assignees(detail)
                         } label: {
                             Label("Manage Assignees", systemImage: "person.badge.plus")
                         }
@@ -123,12 +119,12 @@ struct IssueDetailView: View {
                         }
                         Divider()
                         Button {
-                            showReassignSheet = true
+                            activeDetailSheet = .reassign(detail)
                         } label: {
                             Label("Reassign to Repo…", systemImage: "arrow.triangle.swap")
                         }
                         Button {
-                            showLaunchSheet = true
+                            activeDetailSheet = .launch(detail)
                         } label: {
                             Label("Launch", systemImage: "play.fill")
                         }
@@ -138,18 +134,16 @@ struct IssueDetailView: View {
                 }
             }
         }
-        .sheet(isPresented: $showReassignSheet) {
-            if let detail {
+        .sheet(item: $activeDetailSheet) { sheet in
+            switch sheet {
+            case .reassign(let detail):
                 ReassignSheet(
                     owner: owner, repo: repo, number: number,
                     issueTitle: detail.issue.title
-                ) { newOwner, newRepo, newNumber in
+                ) { _, _, _ in
                     Task { await load(refresh: true) }
                 }
-            }
-        }
-        .sheet(isPresented: $showLaunchSheet) {
-            if let detail {
+            case .launch(let detail):
                 LaunchView(
                     owner: owner,
                     repo: repo,
@@ -157,6 +151,25 @@ struct IssueDetailView: View {
                     issueTitle: detail.issue.title,
                     comments: detail.comments,
                     referencedFiles: detail.referencedFiles
+                )
+            case .edit(let detail):
+                EditIssueSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentTitle: detail.issue.title,
+                    currentBody: detail.issue.body,
+                    onSuccess: { Task { await load(refresh: true) } }
+                )
+            case .labels(let detail):
+                LabelManagementSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentLabels: detail.issue.labels,
+                    onSuccess: { Task { await load(refresh: true) } }
+                )
+            case .assignees(let detail):
+                AssigneeSheet(
+                    owner: owner, repo: repo, number: number,
+                    currentAssignees: (detail.issue.assignees ?? []).map(\.login),
+                    onUpdate: { _ in Task { await load(refresh: true) } }
                 )
             }
         }
@@ -171,34 +184,6 @@ struct IssueDetailView: View {
                 owner: owner, repo: repo, number: number,
                 onSuccess: { Task { await load(refresh: true) } }
             )
-        }
-        .sheet(isPresented: $showEditSheet) {
-            if let detail {
-                EditIssueSheet(
-                    owner: owner, repo: repo, number: number,
-                    currentTitle: detail.issue.title,
-                    currentBody: detail.issue.body,
-                    onSuccess: { Task { await load(refresh: true) } }
-                )
-            }
-        }
-        .sheet(isPresented: $showLabelSheet) {
-            if let detail {
-                LabelManagementSheet(
-                    owner: owner, repo: repo, number: number,
-                    currentLabels: detail.issue.labels,
-                    onSuccess: { Task { await load(refresh: true) } }
-                )
-            }
-        }
-        .sheet(isPresented: $showAssigneeSheet) {
-            if let detail {
-                AssigneeSheet(
-                    owner: owner, repo: repo, number: number,
-                    currentAssignees: (detail.issue.assignees ?? []).map(\.login),
-                    onUpdate: { _ in Task { await load(refresh: true) } }
-                )
-            }
         }
         .sheet(item: $editingComment) { comment in
             EditCommentSheet(
@@ -660,6 +645,24 @@ struct PriorityBadge: View {
         case .high: "arrow.up"
         case .normal: "minus"
         case .low: "arrow.down"
+        }
+    }
+}
+
+enum DetailSheet: Identifiable, Sendable {
+    case reassign(IssueDetailResponse)
+    case launch(IssueDetailResponse)
+    case edit(IssueDetailResponse)
+    case labels(IssueDetailResponse)
+    case assignees(IssueDetailResponse)
+
+    var id: String {
+        switch self {
+        case .reassign: "reassign"
+        case .launch: "launch"
+        case .edit: "edit"
+        case .labels: "labels"
+        case .assignees: "assignees"
         }
     }
 }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -25,8 +25,7 @@ struct IssueListView: View {
     @State private var showCloseConfirm = false
     @State private var showReopenConfirm = false
     @State private var swipeTarget: (owner: String, repo: String, number: Int)?
-    @State private var showLaunchSheet = false
-    @State private var launchTarget: (owner: String, repo: String, number: Int, title: String)?
+    @State private var launchTarget: LaunchTarget?
 
     // Draft swipe state
     @State private var showDeleteDraftConfirm = false
@@ -256,17 +255,15 @@ struct IssueListView: View {
             .sheet(isPresented: $showParseSheet) {
                 ParseView()
             }
-            .sheet(isPresented: $showLaunchSheet) {
-                if let target = launchTarget {
-                    LaunchView(
-                        owner: target.owner,
-                        repo: target.repo,
-                        issueNumber: target.number,
-                        issueTitle: target.title,
-                        comments: [],
-                        referencedFiles: []
-                    )
-                }
+            .sheet(item: $launchTarget) { target in
+                LaunchView(
+                    owner: target.owner,
+                    repo: target.repo,
+                    issueNumber: target.number,
+                    issueTitle: target.title,
+                    comments: [],
+                    referencedFiles: []
+                )
             }
             .confirmationDialog("Close Issue", isPresented: $showCloseConfirm, titleVisibility: .visible) {
                 Button("Close", role: .destructive) {
@@ -353,8 +350,7 @@ struct IssueListView: View {
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if issue.isOpen {
                             Button {
-                                launchTarget = (repo.owner, repo.name, issue.number, issue.title)
-                                showLaunchSheet = true
+                                launchTarget = LaunchTarget(owner: repo.owner, repo: repo.name, number: issue.number, title: issue.title)
                             } label: {
                                 Label("Launch", systemImage: "play.fill")
                             }
@@ -596,6 +592,15 @@ struct IssueDestination: Hashable {
     let owner: String
     let repo: String
     let number: Int
+}
+
+struct LaunchTarget: Identifiable {
+    let owner: String
+    let repo: String
+    let number: Int
+    let title: String
+
+    var id: String { "\(owner)/\(repo)#\(number)" }
 }
 
 struct DraftDestination: Hashable {

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -594,7 +594,7 @@ struct IssueDestination: Hashable {
     let number: Int
 }
 
-struct LaunchTarget: Identifiable {
+struct LaunchTarget: Identifiable, Sendable {
     let owner: String
     let repo: String
     let number: Int

--- a/ios/IssueCTLTests/ModelDecodingTests.swift
+++ b/ios/IssueCTLTests/ModelDecodingTests.swift
@@ -274,7 +274,7 @@ final class ModelDecodingTests: XCTestCase {
                 }
             ],
             "deployments": [],
-            "linked_prs": [],
+            "linkedPRs": [],
             "referenced_files": ["src/main.ts", "README.md"],
             "from_cache": false
         }


### PR DESCRIPTION
## Summary

- Remove `CodingKeys` from `IssueDetailResponse` that caused decoding failures — the server sends `linkedPRs` (camelCase), but the old CodingKeys mapped to `linkedPrs` (lowercase 'r'), which didn't match
- Replace `.sheet(isPresented:)` + separate tuple state with `.sheet(item:)` + `LaunchTarget` struct in `IssueListView` to prevent blank launch sheets caused by SwiftUI state race
- Consolidate 5 detail-dependent sheets in `IssueDetailView` into a single `.sheet(item:)` with a `DetailSheet` enum, capturing data at tap time
- Fix test JSON fixture to use `linkedPRs` (matching actual server wire format) instead of `linked_prs` (which `convertFromSnakeCase` maps to `linkedPrs`, not `linkedPRs`)
- Add `Sendable` conformance to `LaunchTarget` for consistency with model types

## Test plan

- [x] All 173 iOS unit tests pass
- [x] iOS simulator build succeeds
- [x] Swipe-to-launch presents launch sheet with correct content (no blank sheet)
- [x] Issue detail view loads and decodes correctly (no "data couldn't be read" error)
- [x] Multiple concurrent Claude Code sessions survive navigation
- [x] PR review toolkit run (all 6 agents) — 0 critical, 0 important issues