### PR TITLE
fix: batch 3 — P2 bugs, launch flow, settings, and iOS detail polish

### DIFF
--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -202,11 +202,12 @@ struct DraftDetailView: View {
         ) {
             Button("Save and Close") {
                 Task {
-                    await autoSave()
-                    dismiss()
+                    let saved = await autoSave()
+                    if saved { dismiss() }
                 }
             }
             Button("Discard Changes", role: .destructive) {
+                hasChanges = false
                 dismiss()
             }
             Button("Cancel", role: .cancel) {}
@@ -268,19 +269,23 @@ struct DraftDetailView: View {
         isAssigning = false
     }
 
+    /// Builds an update body containing only the fields that differ from the original draft.
+    private func buildUpdateBody() -> UpdateDraftRequestBody {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return UpdateDraftRequestBody(
+            title: trimmedTitle != draft.title ? trimmedTitle : nil,
+            body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
+            priority: priority != (draft.priority ?? .normal) ? priority : nil
+        )
+    }
+
     private func save() async {
         isSaving = true
         errorMessage = nil
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
-            let updateBody = UpdateDraftRequestBody(
-                title: trimmedTitle != draft.title ? trimmedTitle : nil,
-                body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
-                priority: priority != (draft.priority ?? .normal) ? priority : nil
-            )
-            let response = try await api.updateDraft(id: draft.id, body: updateBody)
+            let response = try await api.updateDraft(id: draft.id, body: buildUpdateBody())
             if response.success {
                 onSaved()
                 dismiss()
@@ -293,25 +298,27 @@ struct DraftDetailView: View {
         isSaving = false
     }
 
-    private func autoSave() async {
-        guard hasChanges else { return }
+    @discardableResult
+    private func autoSave() async -> Bool {
+        guard hasChanges else { return true }
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty else { return }
-        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return false }
 
         do {
-            let updateBody = UpdateDraftRequestBody(
-                title: trimmedTitle != draft.title ? trimmedTitle : nil,
-                body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
-                priority: priority != (draft.priority ?? .normal) ? priority : nil
-            )
-            let response = try await api.updateDraft(id: draft.id, body: updateBody)
+            let response = try await api.updateDraft(id: draft.id, body: buildUpdateBody())
             if response.success {
                 hasChanges = false
                 onSaved()
+                return true
+            } else {
+                print("[IssueCTL] autoSave server error for draft \(draft.id): \(response.error ?? "unknown")")
+                errorMessage = response.error ?? "Auto-save failed"
+                return false
             }
         } catch {
-            // Auto-save is best-effort; errors are silently ignored
+            print("[IssueCTL] autoSave failed for draft \(draft.id): \(error.localizedDescription)")
+            errorMessage = "Auto-save failed: \(error.localizedDescription)"
+            return false
         }
     }
 }

--- a/ios/IssueCTL/Views/Issues/DraftDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/DraftDetailView.swift
@@ -13,6 +13,7 @@ struct DraftDetailView: View {
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var hasChanges = false
+    @State private var showDiscardConfirm = false
 
     @State private var repos: [Repo] = []
     @State private var selectedRepoId: Int?
@@ -148,7 +149,20 @@ struct DraftDetailView: View {
         }
         .navigationTitle("Edit Draft")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    if hasChanges {
+                        showDiscardConfirm = true
+                    } else {
+                        dismiss()
+                    }
+                } label: {
+                    Text("Back")
+                }
+                .accessibilityIdentifier("draft-back-button")
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     Task { await save() }
@@ -175,6 +189,27 @@ struct DraftDetailView: View {
                 availableLabels = []
                 selectedLabels = []
             }
+        }
+        .onDisappear {
+            if hasChanges {
+                Task { await autoSave() }
+            }
+        }
+        .confirmationDialog(
+            "You have unsaved changes",
+            isPresented: $showDiscardConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Save and Close") {
+                Task {
+                    await autoSave()
+                    dismiss()
+                }
+            }
+            Button("Discard Changes", role: .destructive) {
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
         }
     }
 
@@ -256,5 +291,27 @@ struct DraftDetailView: View {
             errorMessage = error.localizedDescription
         }
         isSaving = false
+    }
+
+    private func autoSave() async {
+        guard hasChanges else { return }
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+        let trimmedBody = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            let updateBody = UpdateDraftRequestBody(
+                title: trimmedTitle != draft.title ? trimmedTitle : nil,
+                body: trimmedBody != (draft.body ?? "") ? trimmedBody : nil,
+                priority: priority != (draft.priority ?? .normal) ? priority : nil
+            )
+            let response = try await api.updateDraft(id: draft.id, body: updateBody)
+            if response.success {
+                hasChanges = false
+                onSaved()
+            }
+        } catch {
+            // Auto-save is best-effort; errors are silently ignored
+        }
     }
 }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct IssueDetailView: View {
     @Environment(APIClient.self) private var api
+    @Environment(\.openURL) private var openURL
     let owner: String
     let repo: String
     let number: Int
@@ -77,7 +78,22 @@ struct IssueDetailView: View {
         .toolbar {
             if let detail {
                 ToolbarItem(placement: .topBarTrailing) {
+                    if let url = URL(string: detail.issue.htmlUrl) {
+                        ShareLink(item: url) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     Menu {
+                        Button {
+                            if let url = URL(string: detail.issue.htmlUrl) {
+                                openURL(url)
+                            }
+                        } label: {
+                            Label("Open on GitHub", systemImage: "safari")
+                        }
+                        Divider()
                         Button {
                             activeDetailSheet = .edit(detail)
                         } label: {
@@ -128,6 +144,9 @@ struct IssueDetailView: View {
                     }
                 }
             }
+        }
+        .navigationDestination(for: PRDestination.self) { dest in
+            PRDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
         }
         .sheet(item: $activeDetailSheet) { sheet in
             switch sheet {
@@ -282,19 +301,21 @@ struct IssueDetailView: View {
                 .font(.headline)
 
             ForEach(prs) { pr in
-                HStack(spacing: 6) {
-                    Image(systemName: pr.isOpen ? "arrow.triangle.merge" : (pr.merged ? "checkmark.circle.fill" : "xmark.circle"))
-                        .foregroundStyle(pr.isOpen ? .green : (pr.merged ? .purple : .red))
-                    Text("#\(pr.number)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Text(pr.title)
-                        .font(.subheadline)
-                        .lineLimit(1)
-                    Spacer()
-                    Text(pr.diffSummary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                NavigationLink(value: PRDestination(owner: owner, repo: repo, number: pr.number)) {
+                    HStack(spacing: 6) {
+                        Image(systemName: pr.isOpen ? "arrow.triangle.merge" : (pr.merged ? "checkmark.circle.fill" : "xmark.circle"))
+                            .foregroundStyle(pr.isOpen ? .green : (pr.merged ? .purple : .red))
+                        Text("#\(pr.number)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text(pr.title)
+                            .font(.subheadline)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(pr.diffSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 .padding(.vertical, 2)
             }

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -291,6 +291,11 @@ struct LaunchView: View {
         errorMessage = nil
         withAnimation { showProgress = true }
 
+        defer {
+            isLaunching = false
+            withAnimation { showProgress = false }
+        }
+
         do {
             let body = LaunchRequestBody(
                 branchName: branchName,
@@ -321,13 +326,9 @@ struct LaunchView: View {
                 )
             } else {
                 errorMessage = response.error ?? "Launch failed"
-                withAnimation { showProgress = false }
             }
         } catch {
             errorMessage = error.localizedDescription
-            withAnimation { showProgress = false }
         }
-
-        isLaunching = false
     }
 }

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -293,7 +293,9 @@ struct LaunchView: View {
 
         defer {
             isLaunching = false
-            withAnimation { showProgress = false }
+            if launchedDeployment == nil {
+                withAnimation { showProgress = false }
+            }
         }
 
         do {

--- a/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PRDetailView: View {
     @Environment(APIClient.self) private var api
+    @Environment(\.openURL) private var openURL
     let owner: String
     let repo: String
     let number: Int
@@ -66,6 +67,26 @@ struct PRDetailView: View {
         }
         .navigationTitle("#\(number)")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if let detail {
+                ToolbarItem(placement: .topBarTrailing) {
+                    if let url = URL(string: detail.pull.htmlUrl) {
+                        ShareLink(item: url) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        if let url = URL(string: detail.pull.htmlUrl) {
+                            openURL(url)
+                        }
+                    } label: {
+                        Image(systemName: "safari")
+                    }
+                }
+            }
+        }
         .task { await load() }
         .onAppear {
             actionError = nil

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -123,6 +123,8 @@ struct TerminalView: View {
     private func endSession() async {
         isEndingSession = true
         endSessionError = nil
+        defer { isEndingSession = false }
+
         do {
             let response = try await api.endSession(
                 deploymentId: deployment.id,
@@ -138,7 +140,6 @@ struct TerminalView: View {
         } catch {
             endSessionError = error.localizedDescription
         }
-        isEndingSession = false
     }
 
     private func attemptRespawn() async {

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -12,6 +12,8 @@ struct TerminalView: View {
     @State private var loadError: String?
     @State private var currentPort: Int
     @State private var isRespawning = false
+    @State private var isEndingSession = false
+    @State private var endSessionError: String?
 
     init(deployment: ActiveDeployment, port: Int, onEnd: @escaping () -> Void) {
         self.deployment = deployment
@@ -82,7 +84,33 @@ struct TerminalView: View {
                 titleVisibility: .visible
             ) {
                 Button("End Session", role: .destructive) {
-                    onEnd()
+                    Task { await endSession() }
+                }
+            }
+            .overlay {
+                if isEndingSession {
+                    ZStack {
+                        Color.black.opacity(0.3)
+                            .ignoresSafeArea()
+                        VStack(spacing: 12) {
+                            ProgressView()
+                            Text("Ending session…")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(24)
+                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                    }
+                }
+            }
+            .alert("Failed to End Session", isPresented: Binding(
+                get: { endSessionError != nil },
+                set: { if !$0 { endSessionError = nil } }
+            )) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                if let endSessionError {
+                    Text(endSessionError)
                 }
             }
         }
@@ -90,6 +118,27 @@ struct TerminalView: View {
 
     private var terminalURL: URL? {
         URL(string: "\(api.serverURL)/api/terminal/\(currentPort)/")
+    }
+
+    private func endSession() async {
+        isEndingSession = true
+        endSessionError = nil
+        do {
+            let response = try await api.endSession(
+                deploymentId: deployment.id,
+                owner: deployment.owner,
+                repo: deployment.repoName,
+                issueNumber: deployment.issueNumber
+            )
+            if response.success {
+                onEnd()
+            } else {
+                endSessionError = response.error ?? "Failed to end session"
+            }
+        } catch {
+            endSessionError = error.localizedDescription
+        }
+        isEndingSession = false
     }
 
     private func attemptRespawn() async {

--- a/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/launch/[owner]/[repo]/[number]/page.tsx
@@ -99,7 +99,10 @@ export default async function LaunchProgressPage({
           {owner}/{repo} · #{issueNumber}
         </p>
         <LaunchProgress deployment={deployment} counts={counts} />
-        <LaunchProgressPoller active={deployment.endedAt === null} />
+        <LaunchProgressPoller
+          active={deployment.endedAt === null}
+          stateFingerprint={`${deployment.state}:${deployment.ttydPort ?? "none"}`}
+        />
       </div>
     </div>
   );

--- a/packages/web/components/detail/CommentItem.tsx
+++ b/packages/web/components/detail/CommentItem.tsx
@@ -34,11 +34,18 @@ export function CommentItem({ comment, currentUser, owner, repo, issueNumber }: 
   const [displayBody, setDisplayBody] = useState(comment.body);
   const [editBody, setEditBody] = useState(comment.body);
   const [saving, setSaving] = useState(false);
+  // Tracks whether displayBody holds an optimistic value that should not
+  // be overwritten by a concurrent server refresh (comment.body change).
+  const [optimistic, setOptimistic] = useState(false);
 
-  // Sync displayBody when the server data changes (e.g. after router.refresh())
+  // Sync displayBody when the server data changes (e.g. after router.refresh()),
+  // but skip while an optimistic update is in flight to avoid clobbering the
+  // value the user just saved with a stale server response.
   useEffect(() => {
-    setDisplayBody(comment.body);
-  }, [comment.body]);
+    if (!optimistic) {
+      setDisplayBody(comment.body);
+    }
+  }, [comment.body, optimistic]);
 
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleted, setDeleted] = useState(false);
@@ -67,25 +74,31 @@ export function CommentItem({ comment, currentUser, owner, repo, issueNumber }: 
     setSaving(true);
     const originalBody = displayBody;
 
-    // Optimistic: show new body immediately; rolled back in the error handler below
+    // Optimistic: show new body immediately; rolled back in the error handler below.
+    // Set the optimistic flag so the server-sync effect doesn't clobber this value.
+    setOptimistic(true);
     setDisplayBody(editBody);
     setMode("normal");
 
     try {
       const result = await editComment(owner, repo, issueNumber, comment.id, editBody);
       if (!result.success) {
+        setOptimistic(false);
         setDisplayBody(originalBody);
         setMode("editing");
         showToast(result.error, "error");
         return;
       }
       router.refresh();
+      // Clear optimistic flag after refresh so the next server data wins
+      setOptimistic(false);
       showToast(
         result.cacheStale ? "Comment updated — reload if the page looks stale" : "Comment updated",
         "success",
       );
     } catch (err) {
       console.error("[issuectl] Edit comment failed unexpectedly:", err);
+      setOptimistic(false);
       setDisplayBody(originalBody);
       setMode("editing");
       showToast("Failed to edit comment", "error");

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useEffect, useRef, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type {
   GitHubIssue,
@@ -69,8 +69,16 @@ export function IssueActionSheet({
   const { isOffline } = useOfflineAware();
   const searchParams = useSearchParams();
 
+  // Keep a ref to hasLiveDeployment so the mount-only effect below always
+  // reads the latest value without needing it in the dependency array
+  // (which would re-trigger the effect on every render where it changes).
+  const hasLiveDeploymentRef = useRef(hasLiveDeployment);
   useEffect(() => {
-    if (searchParams.get("launch") === "true" && !hasLiveDeployment) {
+    hasLiveDeploymentRef.current = hasLiveDeployment;
+  }, [hasLiveDeployment]);
+
+  useEffect(() => {
+    if (searchParams.get("launch") === "true" && !hasLiveDeploymentRef.current) {
       handleLaunchTap();
       const url = new URL(window.location.href);
       url.searchParams.delete("launch");

--- a/packages/web/components/detail/PriorityPicker.tsx
+++ b/packages/web/components/detail/PriorityPicker.tsx
@@ -67,6 +67,8 @@ export function PriorityPicker({ repoId, issueNumber, currentPriority }: Props) 
           e.stopPropagation();
           setOpen(true);
         }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >
         priority: {priority}
       </button>

--- a/packages/web/components/launch/EndSessionButton.module.css
+++ b/packages/web/components/launch/EndSessionButton.module.css
@@ -1,0 +1,11 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.error {
+  font-size: var(--paper-fs-xs);
+  color: var(--paper-brick);
+  font-family: var(--paper-sans);
+}

--- a/packages/web/components/launch/EndSessionButton.tsx
+++ b/packages/web/components/launch/EndSessionButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";
@@ -14,20 +14,42 @@ type Props = {
 
 export function EndSessionButton({ deploymentId, owner, repo, issueNumber }: Props) {
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   function handleEnd() {
+    setError(null);
     startTransition(async () => {
-      const result = await endSession(deploymentId, owner, repo, issueNumber);
-      if (result.success) {
-        router.refresh();
+      try {
+        const result = await endSession(deploymentId, owner, repo, issueNumber);
+        if (result.success) {
+          router.refresh();
+        } else {
+          setError(result.error ?? "Failed to end session");
+        }
+      } catch {
+        setError("Failed to end session — please try again");
       }
     });
   }
 
   return (
-    <Button variant="ghost" onClick={handleEnd} disabled={isPending}>
-      {isPending ? "Ending..." : "End Session"}
-    </Button>
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      <Button variant="ghost" onClick={handleEnd} disabled={isPending}>
+        {isPending ? "Ending..." : "End Session"}
+      </Button>
+      {error && (
+        <span
+          role="alert"
+          style={{
+            fontSize: "var(--paper-fs-xs)",
+            color: "var(--paper-brick)",
+            fontFamily: "var(--paper-sans)",
+          }}
+        >
+          {error}
+        </span>
+      )}
+    </span>
   );
 }

--- a/packages/web/components/launch/EndSessionButton.tsx
+++ b/packages/web/components/launch/EndSessionButton.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/paper";
 import { endSession } from "@/lib/actions/launch";
+import styles from "./EndSessionButton.module.css";
 
 type Props = {
   deploymentId: number;
@@ -27,26 +28,20 @@ export function EndSessionButton({ deploymentId, owner, repo, issueNumber }: Pro
         } else {
           setError(result.error ?? "Failed to end session");
         }
-      } catch {
+      } catch (err) {
+        console.error("[issuectl] EndSessionButton: endSession threw:", err);
         setError("Failed to end session — please try again");
       }
     });
   }
 
   return (
-    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+    <span className={styles.wrapper}>
       <Button variant="ghost" onClick={handleEnd} disabled={isPending}>
         {isPending ? "Ending..." : "End Session"}
       </Button>
       {error && (
-        <span
-          role="alert"
-          style={{
-            fontSize: "var(--paper-fs-xs)",
-            color: "var(--paper-brick)",
-            fontFamily: "var(--paper-sans)",
-          }}
-        >
+        <span role="alert" className={styles.error}>
           {error}
         </span>
       )}

--- a/packages/web/components/launch/LaunchProgress.module.css
+++ b/packages/web/components/launch/LaunchProgress.module.css
@@ -40,6 +40,18 @@
   animation: spin 0.8s linear infinite;
 }
 
+.numPending {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px dashed var(--paper-line);
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -67,6 +79,13 @@
   font-size: 13px;
   font-weight: 500;
   color: var(--paper-accent);
+  margin-bottom: 2px;
+}
+
+.labelPending {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--paper-ink-muted);
   margin-bottom: 2px;
 }
 

--- a/packages/web/components/launch/LaunchProgress.tsx
+++ b/packages/web/components/launch/LaunchProgress.tsx
@@ -2,11 +2,13 @@ import type { Deployment } from "@issuectl/core";
 import { LIFECYCLE_LABEL } from "@issuectl/core";
 import styles from "./LaunchProgress.module.css";
 
+type StepStatus = "done" | "active" | "pending";
+
 type Step = {
   label: string;
   detail: string;
   highlightDetail?: boolean;
-  status: "done" | "active";
+  status: StepStatus;
 };
 
 type Props = {
@@ -14,12 +16,27 @@ type Props = {
   counts?: { commentCount: number; fileCount: number };
 };
 
-export function LaunchProgress({ deployment, counts }: Props) {
+/**
+ * Derive step statuses from real deployment data.
+ *
+ * Timeline:  pending → active (ttydPort set) → endedAt set
+ *
+ * Steps advance based on these transitions:
+ * 1. Context assembled: done once the deployment row exists (always true here)
+ * 2. Deployment created: done once the deployment row exists
+ * 3. Branch checked out: done once state is "active"
+ * 4. Lifecycle label applied: done once state is "active"
+ * 5. Session status: active while running, done when ended
+ */
+function deriveSteps(deployment: Deployment, counts: Props["counts"]): Step[] {
+  const isActive = deployment.state === "active";
   const ended = deployment.endedAt !== null;
+
   const contextDetail = counts
     ? `issue + ${counts.commentCount} comment${counts.commentCount !== 1 ? "s" : ""} + ${counts.fileCount} referenced file${counts.fileCount !== 1 ? "s" : ""}`
     : "issue + selected comments + referenced files";
-  const steps: Step[] = [
+
+  return [
     {
       label: "Assembled issue context",
       detail: contextDetail,
@@ -34,38 +51,52 @@ export function LaunchProgress({ deployment, counts }: Props) {
       label: "Checked out branch",
       detail: deployment.branchName,
       highlightDetail: true,
-      status: "done",
+      status: isActive || ended ? "done" : "active",
     },
     {
       label: "Applied lifecycle label",
       detail: LIFECYCLE_LABEL.deployed,
-      status: "done",
+      status: isActive || ended ? "done" : "pending",
     },
     {
       label: ended ? "Session ended" : "Claude Code running",
       detail: deployment.workspacePath,
       highlightDetail: true,
-      status: ended ? "done" : "active",
+      status: ended ? "done" : isActive ? "active" : "pending",
     },
   ];
+}
+
+const statusClassName: Record<StepStatus, string> = {
+  done: styles.numDone,
+  active: styles.numActive,
+  pending: styles.numPending,
+};
+
+const labelClassName: Record<StepStatus, string> = {
+  done: styles.label,
+  active: styles.labelActive,
+  pending: styles.labelPending,
+};
+
+const statusIcon: Record<StepStatus, string> = {
+  done: "\u2713",
+  active: "",
+  pending: "",
+};
+
+export function LaunchProgress({ deployment, counts }: Props) {
+  const steps = deriveSteps(deployment, counts);
 
   return (
     <div className={styles.steps} role="status" aria-live="polite">
       {steps.map((step) => (
         <div key={step.label} className={styles.step}>
-          <div
-            className={
-              step.status === "done" ? styles.numDone : styles.numActive
-            }
-          >
-            {step.status === "done" ? "\u2713" : ""}
+          <div className={statusClassName[step.status]}>
+            {statusIcon[step.status]}
           </div>
           <div className={styles.content}>
-            <div
-              className={
-                step.status === "active" ? styles.labelActive : styles.label
-              }
-            >
+            <div className={labelClassName[step.status]}>
               {step.label}
             </div>
             <div className={styles.detail}>

--- a/packages/web/components/launch/LaunchProgressPoller.module.css
+++ b/packages/web/components/launch/LaunchProgressPoller.module.css
@@ -1,0 +1,27 @@
+.stallWarning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 20px;
+  padding: 12px 14px;
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-butter) 15%, var(--paper-bg));
+  border: 1px solid var(--paper-butter);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-ink-soft);
+  line-height: 1.45;
+}
+
+.stallIcon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--paper-butter);
+  color: var(--paper-ink);
+}

--- a/packages/web/components/launch/LaunchProgressPoller.tsx
+++ b/packages/web/components/launch/LaunchProgressPoller.tsx
@@ -17,12 +17,9 @@ type Props = {
 // Drives a parent Server Component re-fetch via router.refresh() while the
 // deployment is active — the RSC equivalent of a polling fetch. Pauses on
 // visibilitychange so a backgrounded tab doesn't keep firing GitHub-backed
-// refreshes (battery, API quota). Browsers throttle hidden-tab timers, but
-// not aggressively enough to skip this.
-//
-// Improvements over the original:
-// - Concurrency guard: overlapping router.refresh() calls cannot pile up
-// - Stall detection: warns the user if no state change in 5 minutes
+// refreshes (battery, API quota). A concurrency guard prevents overlapping
+// refresh calls from piling up, and a stall timer warns the user if no
+// deployment state change occurs within STALL_TIMEOUT_MS.
 export function LaunchProgressPoller({ active, stateFingerprint }: Props) {
   const router = useRouter();
   const isRefreshing = useRef(false);
@@ -40,13 +37,10 @@ export function LaunchProgressPoller({ active, stateFingerprint }: Props) {
   const safeRefresh = useCallback(() => {
     if (isRefreshing.current) return;
     isRefreshing.current = true;
-    // router.refresh() returns void but behaves as an async operation
-    // internally. Use startTransition-style scheduling: mark done on the
-    // next microtask so the flag clears after React processes the update.
     router.refresh();
-    // Clear the guard after a short delay — router.refresh() doesn't
-    // return a promise, so we use a conservative timeout that's shorter
-    // than the poll interval to avoid skipping cycles.
+    // router.refresh() doesn't return a promise, so clear the guard
+    // after a short delay that's shorter than the poll interval to
+    // avoid skipping cycles.
     setTimeout(() => {
       isRefreshing.current = false;
     }, 2000);

--- a/packages/web/components/launch/LaunchProgressPoller.tsx
+++ b/packages/web/components/launch/LaunchProgressPoller.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import styles from "./LaunchProgressPoller.module.css";
 
 const POLL_INTERVAL_MS = 5000;
+const STALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 type Props = {
   active: boolean;
+  /** Opaque fingerprint of the current deployment state (e.g. state + ttydPort).
+   *  When this changes, the stall timer resets. */
+  stateFingerprint?: string;
 };
 
 // Drives a parent Server Component re-fetch via router.refresh() while the
@@ -14,8 +19,38 @@ type Props = {
 // visibilitychange so a backgrounded tab doesn't keep firing GitHub-backed
 // refreshes (battery, API quota). Browsers throttle hidden-tab timers, but
 // not aggressively enough to skip this.
-export function LaunchProgressPoller({ active }: Props) {
+//
+// Improvements over the original:
+// - Concurrency guard: overlapping router.refresh() calls cannot pile up
+// - Stall detection: warns the user if no state change in 5 minutes
+export function LaunchProgressPoller({ active, stateFingerprint }: Props) {
   const router = useRouter();
+  const isRefreshing = useRef(false);
+  const [stalled, setStalled] = useState(false);
+
+  // Reset stall timer whenever the server-rendered state changes
+  const lastFingerprint = useRef(stateFingerprint);
+  useEffect(() => {
+    if (stateFingerprint !== lastFingerprint.current) {
+      lastFingerprint.current = stateFingerprint;
+      setStalled(false);
+    }
+  }, [stateFingerprint]);
+
+  const safeRefresh = useCallback(() => {
+    if (isRefreshing.current) return;
+    isRefreshing.current = true;
+    // router.refresh() returns void but behaves as an async operation
+    // internally. Use startTransition-style scheduling: mark done on the
+    // next microtask so the flag clears after React processes the update.
+    router.refresh();
+    // Clear the guard after a short delay — router.refresh() doesn't
+    // return a promise, so we use a conservative timeout that's shorter
+    // than the poll interval to avoid skipping cycles.
+    setTimeout(() => {
+      isRefreshing.current = false;
+    }, 2000);
+  }, [router]);
 
   useEffect(() => {
     if (!active) return;
@@ -24,9 +59,7 @@ export function LaunchProgressPoller({ active }: Props) {
 
     const start = () => {
       if (timer) return;
-      timer = setInterval(() => {
-        router.refresh();
-      }, POLL_INTERVAL_MS);
+      timer = setInterval(safeRefresh, POLL_INTERVAL_MS);
     };
 
     const stop = () => {
@@ -48,7 +81,28 @@ export function LaunchProgressPoller({ active }: Props) {
       stop();
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [active, router]);
+  }, [active, safeRefresh]);
 
-  return null;
+  // Stall detection: if active and no fingerprint change for STALL_TIMEOUT_MS
+  useEffect(() => {
+    if (!active || stalled) return;
+
+    const stallTimer = setTimeout(() => {
+      setStalled(true);
+    }, STALL_TIMEOUT_MS);
+
+    return () => clearTimeout(stallTimer);
+  }, [active, stalled, stateFingerprint]);
+
+  if (!stalled) return null;
+
+  return (
+    <div className={styles.stallWarning} role="alert">
+      <span className={styles.stallIcon}>!</span>
+      <span>
+        Launch may be stalled — no progress detected for 5 minutes.
+        Try refreshing the page or check the terminal logs.
+      </span>
+    </div>
+  );
 }

--- a/packages/web/components/onboarding/WelcomeScreen.tsx
+++ b/packages/web/components/onboarding/WelcomeScreen.tsx
@@ -40,7 +40,8 @@ export function WelcomeScreen() {
       }
 
       router.refresh();
-    } catch {
+    } catch (err) {
+      console.error("[issuectl] WelcomeScreen: addRepo failed:", err);
       setError("Something went wrong. Check your connection and try again.");
     } finally {
       setSubmitting(false);

--- a/packages/web/components/onboarding/WelcomeScreen.tsx
+++ b/packages/web/components/onboarding/WelcomeScreen.tsx
@@ -35,7 +35,8 @@ export function WelcomeScreen() {
 
       if (result.warning) {
         setWarning(result.warning);
-        return;
+        // Repo was added successfully despite the warning — still
+        // refresh so the user proceeds past the welcome screen.
       }
 
       router.refresh();

--- a/packages/web/components/parse/ParseResults.tsx
+++ b/packages/web/components/parse/ParseResults.tsx
@@ -49,12 +49,14 @@ export function ParseResults({ results, onReset }: Props) {
             </span>
             <div className={styles.resultSpacer} />
             {r.success && r.issueNumber !== undefined ? (
-              <Link
-                href={`/${r.owner}/${r.repo}/issues/${r.issueNumber}`}
+              <a
+                href={`https://github.com/${r.owner}/${r.repo}/issues/${r.issueNumber}`}
                 className={styles.resultLink}
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 #{r.issueNumber}
-              </Link>
+              </a>
             ) : r.success && r.draftId ? (
               <Link
                 href={`/drafts/${r.draftId}`}

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -43,6 +43,13 @@ export function SettingsForm({
     idle_grace_period: idleGracePeriod,
     idle_threshold: idleThreshold,
   });
+  const [originals, setOriginals] = useState<FormValues>({
+    branch_pattern: branchPattern,
+    cache_ttl: cacheTTL,
+    claude_extra_args: claudeExtraArgs,
+    idle_grace_period: idleGracePeriod,
+    idle_threshold: idleThreshold,
+  });
   const [error, setError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -54,14 +61,6 @@ export function SettingsForm({
       if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
     };
   }, []);
-
-  const originals: FormValues = {
-    branch_pattern: branchPattern,
-    cache_ttl: cacheTTL,
-    claude_extra_args: claudeExtraArgs,
-    idle_grace_period: idleGracePeriod,
-    idle_threshold: idleThreshold,
-  };
 
   const isDirty = (Object.keys(originals) as (keyof FormValues)[]).some(
     (k) => values[k] !== originals[k],
@@ -115,6 +114,10 @@ export function SettingsForm({
         setError(result.error ?? "Failed to save settings");
         return;
       }
+
+      // Reset the baseline so hasChanges correctly reflects the saved
+      // state — without this, subsequent edits always appear dirty.
+      setOriginals({ ...values });
 
       if (result.cacheStale) {
         showToast("Settings saved — reload to see updates", "success");

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -36,20 +36,15 @@ export function SettingsForm({
   idleGracePeriod,
   idleThreshold,
 }: Props) {
-  const [values, setValues] = useState<FormValues>({
+  const initialValues: FormValues = {
     branch_pattern: branchPattern,
     cache_ttl: cacheTTL,
     claude_extra_args: claudeExtraArgs,
     idle_grace_period: idleGracePeriod,
     idle_threshold: idleThreshold,
-  });
-  const [originals, setOriginals] = useState<FormValues>({
-    branch_pattern: branchPattern,
-    cache_ttl: cacheTTL,
-    claude_extra_args: claudeExtraArgs,
-    idle_grace_period: idleGracePeriod,
-    idle_threshold: idleThreshold,
-  });
+  };
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [originals, setOriginals] = useState<FormValues>(initialValues);
   const [error, setError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -115,7 +110,7 @@ export function SettingsForm({
         return;
       }
 
-      // Reset the baseline so hasChanges correctly reflects the saved
+      // Reset the baseline so isDirty correctly reflects the saved
       // state — without this, subsequent edits always appear dirty.
       setOriginals({ ...values });
 

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -29,6 +29,7 @@ import { revalidateSafely } from "@/lib/revalidate";
 // case and prevents a paste-bomb from burning the LLM budget.
 const MAX_PARSE_INPUT = 8192;
 const MAX_BATCH_SIZE = 25;
+const MAX_TITLE = 256;
 
 type ParseActionResult =
   | { success: true; data: { parsed: ParsedIssuesResponse } }
@@ -126,6 +127,16 @@ export async function batchCreateIssues(
           id: issue.id,
           success: false as const,
           error: "Title is required",
+          owner: issue.owner,
+          repo: issue.repo,
+        };
+      }
+
+      if (issue.title.trim().length > MAX_TITLE) {
+        return {
+          id: issue.id,
+          success: false as const,
+          error: `Title must be ${MAX_TITLE} characters or fewer`,
           owner: issue.owner,
           repo: issue.repo,
         };

--- a/packages/web/lib/actions/refresh.ts
+++ b/packages/web/lib/actions/refresh.ts
@@ -4,6 +4,11 @@ import { getDb, clearCache, clearCacheKey, dbExists } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
 const REFRESH_COOLDOWN_MS = 10_000;
+// NOTE: `lastRefreshAt` is process-local module state. In a multi-process
+// deployment (e.g. Node cluster mode, multiple serverless instances) each
+// process maintains its own timestamp, so the cooldown is per-process, not
+// global. This is acceptable for the single-process `issuectl web` server.
+// If multi-process support is needed, move the timestamp to the DB.
 let lastRefreshAt = 0;
 
 export async function refreshAction(): Promise<{
@@ -36,6 +41,7 @@ export async function refreshAction(): Promise<{
 }
 
 const ISSUE_REFRESH_COOLDOWN_MS = 5_000;
+// Same process-local caveat as `lastRefreshAt` above.
 let lastIssueRefreshAt = 0;
 
 /**


### PR DESCRIPTION
## Summary
Fixes P2 findings from the cross-platform audit (issues #299–#306), batch 3 of 4.

**Web — Launch flow:**
- LaunchProgress: real step statuses (pending/active/done) derived from deployment state instead of hardcoded "done"
- LaunchProgressPoller: concurrency guard prevents overlapping `router.refresh()`, 5-minute stall detection warns users
- EndSessionButton: error feedback with `role="alert"`, CSS Module extraction

**Web — Issue detail:**
- IssueActionSheet: fix stale closure over `hasLiveDeployment` using ref pattern
- PriorityPicker: add `aria-haspopup`/`aria-expanded` attributes
- CommentItem: optimistic flag prevents server refresh from clobbering just-saved edit
- refresh.ts: document process-local module state caveat

**Web — Settings/Parse:**
- WelcomeScreen: warning no longer blocks `router.refresh()` (user could get stuck)
- ParseResults: link to GitHub URL instead of broken internal route
- SettingsForm: baseline reset after save so isDirty clears correctly
- parse.ts: MAX_TITLE=256 validation in `batchCreateIssues`

**iOS — Detail polish:**
- IssueDetailView: share button, "Open on GitHub", tappable linked PRs
- PRDetailView: share button, "Open on GitHub" toolbar button
- LaunchView: defer only resets showProgress on failure (prevents flash)

**iOS — Draft/Terminal:**
- DraftDetailView: unsaved-changes guard with Save/Discard/Cancel dialog, auto-save on disappear
- TerminalView: actual API call on "End Session" with loading overlay and error alert

## Test plan
- [x] `pnpm turbo typecheck` — 4/4 pass
- [x] `pnpm turbo test` — 184 tests pass
- [x] iOS build clean (iPhone 17 Pro simulator)
- [x] PR review toolkit (6 agents) — all Critical/Important findings fixed