### PR TITLE
fix: batch 4 — CI alignment, comment race, list UX, iOS data integrity & security

### DIFF
--- a/ios/IssueCTL/Services/KeychainService.swift
+++ b/ios/IssueCTL/Services/KeychainService.swift
@@ -40,7 +40,6 @@ enum KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
@@ -58,7 +57,6 @@ enum KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
         SecItemDelete(query as CFDictionary)
     }

--- a/ios/IssueCTL/Services/KeychainService.swift
+++ b/ios/IssueCTL/Services/KeychainService.swift
@@ -40,6 +40,7 @@ enum KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
@@ -57,6 +58,7 @@ enum KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
         ]
         SecItemDelete(query as CFDictionary)
     }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -250,7 +250,10 @@ struct IssueListView: View {
                 DraftDetailView(draft: dest.draft, onSaved: { Task { await loadAll(refresh: true) } })
             }
             .sheet(isPresented: $showCreateSheet) {
-                QuickCreateSheet(repos: repos, onSuccess: { Task { await loadAll(refresh: true) } })
+                QuickCreateSheet(repos: repos, onSuccess: { warning in
+                    if let warning { actionError = warning }
+                    Task { await loadAll(refresh: true) }
+                })
             }
             .sheet(isPresented: $showParseSheet) {
                 ParseView()
@@ -506,9 +509,14 @@ struct IssueListView: View {
                 failures.append("user profile (\(error.localizedDescription))")
             }
 
-            let repoResults = await withTaskGroup(of: (String, String, [GitHubIssue]?, String?, Error?).self) { group in
-                for repo in repos {
-                    group.addTask {
+            // Snapshot repos to a local Sendable value so child tasks don't
+            // capture main-actor state. Each child returns its result; the
+            // sequential `for await` loop collects them without data races.
+            let repoSnapshot = repos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
+            var repoResults: [(String, String, [GitHubIssue]?, String?, Error?)] = []
+            await withTaskGroup(of: (String, String, [GitHubIssue]?, String?, Error?).self) { group in
+                for repo in repoSnapshot {
+                    group.addTask { [api] in
                         do {
                             let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
                             return (repo.fullName, repo.name, response.issues, response.cachedAt, nil)
@@ -517,11 +525,9 @@ struct IssueListView: View {
                         }
                     }
                 }
-                var collected: [(String, String, [GitHubIssue]?, String?, Error?)] = []
                 for await result in group {
-                    collected.append(result)
+                    repoResults.append(result)
                 }
-                return collected
             }
             var cachedDates: [Date] = []
             for (fullName, name, issues, cachedAt, error) in repoResults {
@@ -555,11 +561,15 @@ struct IssueListView: View {
 
     private func loadPriorities() async -> [String] {
         isLoadingPriorities = true
-        let priorityResults = await withTaskGroup(of: ([(String, Priority)], String?).self) { group in
-            let uniqueRepos = Set(repos.map { ($0.owner, $0.name) }.map { "\($0.0)/\($0.1)" })
-            for repoFullName in uniqueRepos {
-                guard let repo = repos.first(where: { $0.fullName == repoFullName }) else { continue }
-                group.addTask {
+        // Snapshot repos into a local Sendable value so child tasks don't
+        // capture main-actor state. Collect results via sequential `for await`.
+        let repoSnapshot = repos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
+        let uniqueFullNames = Set(repoSnapshot.map(\.fullName))
+        var priorityResults: [([(String, Priority)], String?)] = []
+        await withTaskGroup(of: ([(String, Priority)], String?).self) { group in
+            for fullName in uniqueFullNames {
+                guard let repo = repoSnapshot.first(where: { $0.fullName == fullName }) else { continue }
+                group.addTask { [api] in
                     do {
                         let items = try await api.listPriorities(owner: repo.owner, repo: repo.name)
                         return (items.map { ("\(repo.owner)/\(repo.name)#\($0.issueNumber)", $0.priority) }, nil)
@@ -568,11 +578,9 @@ struct IssueListView: View {
                     }
                 }
             }
-            var collected: [([(String, Priority)], String?)] = []
             for await result in group {
-                collected.append(result)
+                priorityResults.append(result)
             }
-            return collected
         }
         var newPriorities: [String: Priority] = [:]
         var priorityErrors: [String] = []

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -5,7 +5,9 @@ struct QuickCreateSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let repos: [Repo]
-    let onSuccess: () -> Void
+    /// Called on success. The optional string carries a non-fatal warning
+    /// (e.g. "labels could not be applied") that the parent should surface briefly.
+    let onSuccess: (_ warning: String?) -> Void
 
     @State private var title = ""
     @State private var bodyText = ""
@@ -200,22 +202,25 @@ struct QuickCreateSheet: View {
                 }
                 if let warning = assignResponse.cleanupWarning {
                     // Issue was created on GitHub but draft cleanup failed on server.
-                    // Show warning and refresh, but don't auto-dismiss so user sees it.
-                    errorMessage = "Issue created. Note: \(warning)"
+                    // Dismiss the sheet — the issue exists — and surface the warning
+                    // via the parent's action-error banner (auto-dismisses after 5s).
                     isSubmitting = false
-                    onSuccess()
+                    onSuccess("Issue created. Note: \(warning)")
+                    dismiss()
                     return
                 }
                 if let warning = assignResponse.labelsWarning {
                     // Issue was created on GitHub but labels could not be applied.
-                    errorMessage = "Issue created. Note: \(warning)"
+                    // Dismiss the sheet — the issue exists — and surface the warning
+                    // via the parent's action-error banner (auto-dismisses after 5s).
                     isSubmitting = false
-                    onSuccess()
+                    onSuccess("Issue created. Note: \(warning)")
+                    dismiss()
                     return
                 }
             }
 
-            onSuccess()
+            onSuccess(nil)
             dismiss()
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -174,7 +174,7 @@ struct TerminalWebView: UIViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.isOpaque = false
         webView.backgroundColor = .black
-        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.bounces = false
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
         return webView

--- a/packages/web/components/detail/CIChecks.tsx
+++ b/packages/web/components/detail/CIChecks.tsx
@@ -10,7 +10,12 @@ type DotKind = "success" | "failure" | "pending" | "neutral";
 function dotKind(check: GitHubCheck): DotKind {
   if (check.status !== "completed") return "pending";
   if (check.conclusion === "success") return "success";
-  if (check.conclusion === "failure" || check.conclusion === "timed_out") {
+  if (
+    check.conclusion === "failure" ||
+    check.conclusion === "cancelled" ||
+    check.conclusion === "timed_out" ||
+    check.conclusion === "action_required"
+  ) {
     return "failure";
   }
   return "neutral";

--- a/packages/web/components/detail/CommentSection.tsx
+++ b/packages/web/components/detail/CommentSection.tsx
@@ -18,14 +18,25 @@ export function CommentSection({ initialComments, currentUser, owner, repo, issu
   const prevCountRef = useRef(initialComments.length);
 
   // When server-rendered comments update (e.g. from router.refresh()),
-  // clear pending optimistic comments — the server data is authoritative.
+  // remove only the specific confirmed optimistic comments — not all of them.
+  // We match each server body to at most one pending comment so that rapid
+  // double-posts of the same text don't lose the second optimistic entry.
   useEffect(() => {
     if (initialComments.length > prevCountRef.current) {
-      const serverBodies = new Set(initialComments.map(c => c.body));
-      setPendingComments(prev => prev.filter(p => !serverBodies.has(p.body)));
+      const newServerBodies = initialComments
+        .slice(prevCountRef.current)
+        .map(c => c.body);
+      setPendingComments(prev => {
+        const remaining = [...prev];
+        for (const body of newServerBodies) {
+          const idx = remaining.findIndex(p => p.body === body);
+          if (idx !== -1) remaining.splice(idx, 1);
+        }
+        return remaining;
+      });
     }
     prevCountRef.current = initialComments.length;
-  }, [initialComments.length]);
+  }, [initialComments]);
 
   const allComments = [...initialComments, ...pendingComments];
 

--- a/packages/web/components/detail/LightboxBodyText.tsx
+++ b/packages/web/components/detail/LightboxBodyText.tsx
@@ -12,7 +12,7 @@ const AVATAR_MAX_SIZE = 100; // pixels — GitHub avatars are typically 20–46p
 function isAvatarImage(el: HTMLImageElement): boolean {
   if (el.hasAttribute("data-avatar")) return true;
   if (AVATAR_URL_PATTERN.test(el.src)) return true;
-  // Check natural dimensions for already-loaded small square images
+  // Check natural dimensions for already-loaded small images
   if (
     el.naturalWidth > 0 &&
     el.naturalWidth <= AVATAR_MAX_SIZE &&

--- a/packages/web/components/detail/LightboxBodyText.tsx
+++ b/packages/web/components/detail/LightboxBodyText.tsx
@@ -5,6 +5,25 @@ import type { Components } from "react-markdown";
 import { BodyText } from "./BodyText";
 import { useLightbox } from "./ImageLightbox";
 
+const AVATAR_URL_PATTERN = /avatars\.githubusercontent\.com/;
+const AVATAR_MAX_SIZE = 100; // pixels — GitHub avatars are typically 20–46px
+
+/** Detect avatar images by data attribute, URL pattern, or rendered size. */
+function isAvatarImage(el: HTMLImageElement): boolean {
+  if (el.hasAttribute("data-avatar")) return true;
+  if (AVATAR_URL_PATTERN.test(el.src)) return true;
+  // Check natural dimensions for already-loaded small square images
+  if (
+    el.naturalWidth > 0 &&
+    el.naturalWidth <= AVATAR_MAX_SIZE &&
+    el.naturalHeight > 0 &&
+    el.naturalHeight <= AVATAR_MAX_SIZE
+  ) {
+    return true;
+  }
+  return false;
+}
+
 type Props = {
   body: string | null | undefined;
   className?: string;
@@ -28,7 +47,7 @@ export function LightboxBodyText({ body, className }: Props) {
       const page = containerRef.current.closest("[data-lightbox-root]");
       const root = page ?? document;
       const imgs = Array.from(root.querySelectorAll("img"))
-        .filter((el) => !el.hasAttribute("data-avatar"))
+        .filter((el) => !isAvatarImage(el))
         .map((el) => el.src)
         .filter((s) => s);
       lightbox.open(src, imgs.length > 0 ? imgs : [src]);

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -110,11 +110,13 @@ export function LaunchModal({
     return () => { cancelled = true; };
   }, [owner, repo, issue.number, workspaceMode]);
 
+  const allCommentIndices = comments.map((_, i) => i);
   const isDirty =
     branchName !== initialBranch ||
     workspaceMode !== initialMode ||
     preamble.trim().length > 0 ||
-    selectedComments.length !== comments.length ||
+    selectedComments.length !== allCommentIndices.length ||
+    [...selectedComments].sort((a, b) => a - b).some((v, i) => v !== allCommentIndices[i]) ||
     selectedFiles.length !== referencedFiles.length ||
     selectedFiles.some((f) => !referencedFiles.includes(f));
 

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -59,11 +59,13 @@ export function ListContent({
   const [closeError, setCloseError] = useState<string | null>(null);
 
   // Reset visible count whenever filter criteria or the filtered dataset changes.
-  // `data` and `prs` capture search-term and repo/status filter changes that the
-  // discrete props (activeRepo, mineOnly) don't cover.
+  // Length fingerprints detect upstream filter changes (sort, repo) without
+  // resetting on every RSC re-render that produces a new array reference.
+  const dataFingerprint = data.open.length + data.running.length + data.closed.length;
+  const prsFingerprint = prs.length;
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [activeTab, activeSection, activeRepo, mineOnly, data, prs]);
+  }, [activeTab, activeSection, activeRepo, mineOnly, dataFingerprint, prsFingerprint]);
 
   const loadMore = useCallback(() => {
     setVisibleCount((prev) => prev + PAGE_SIZE);

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -58,9 +58,12 @@ export function ListContent({
   const [isPending, startTransition] = useTransition();
   const [closeError, setCloseError] = useState<string | null>(null);
 
+  // Reset visible count whenever filter criteria or the filtered dataset changes.
+  // `data` and `prs` capture search-term and repo/status filter changes that the
+  // discrete props (activeRepo, mineOnly) don't cover.
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [activeTab, activeSection, activeRepo, mineOnly]);
+  }, [activeTab, activeSection, activeRepo, mineOnly, data, prs]);
 
   const loadMore = useCallback(() => {
     setVisibleCount((prev) => prev + PAGE_SIZE);

--- a/packages/web/components/list/SwipeRow.tsx
+++ b/packages/web/components/list/SwipeRow.tsx
@@ -3,7 +3,10 @@
 import { useRef, useState, useCallback, type ReactNode } from "react";
 import styles from "./SwipeRow.module.css";
 
-const SWIPE_THRESHOLD = 60;
+const SWIPE_THRESHOLD = 100;
+
+/** Horizontal distance must exceed vertical distance by this ratio to count. */
+const DIRECTION_RATIO = 1.5;
 
 type SwipeState = "idle" | "left" | "right";
 
@@ -17,41 +20,56 @@ type Props = {
 export function SwipeRow({ children, onLaunch, onClose, disabled }: Props) {
   const [swiped, setSwiped] = useState<SwipeState>("idle");
   const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
       if (disabled) return;
       startX.current = e.touches[0].clientX;
+      startY.current = e.touches[0].clientY;
     },
     [disabled],
   );
 
   const handleTouchEnd = useCallback(
     (e: React.TouchEvent) => {
-      if (startX.current === null) return;
+      if (startX.current === null || startY.current === null) return;
       const touch = e.changedTouches[0];
       if (!touch) {
         startX.current = null;
+        startY.current = null;
         return;
       }
-      const delta = touch.clientX - startX.current;
-      if (delta > SWIPE_THRESHOLD && onClose) {
+      const deltaX = touch.clientX - startX.current;
+      const deltaY = touch.clientY - startY.current;
+      const absDX = Math.abs(deltaX);
+      const absDY = Math.abs(deltaY);
+
+      // Only recognise the gesture as a horizontal swipe when the horizontal
+      // distance clearly dominates the vertical distance. This prevents
+      // accidental swipe actions during normal vertical scrolling.
+      const isHorizontalSwipe =
+        absDX >= SWIPE_THRESHOLD && absDX > absDY * DIRECTION_RATIO;
+
+      if (isHorizontalSwipe && deltaX > 0 && onClose) {
         // Swiped right — reveal close on left
         setSwiped("right");
-      } else if (delta < -SWIPE_THRESHOLD && onLaunch) {
+      } else if (isHorizontalSwipe && deltaX < 0 && onLaunch) {
         // Swiped left — reveal launch on right
         setSwiped("left");
-      } else if (Math.abs(delta) > SWIPE_THRESHOLD) {
+      } else if (isHorizontalSwipe) {
         // Swipe in a direction with no handler — dismiss
         setSwiped("idle");
       }
       startX.current = null;
+      startY.current = null;
     },
     [onLaunch, onClose],
   );
 
   const handleTouchCancel = useCallback(() => {
     startX.current = null;
+    startY.current = null;
   }, []);
 
   const dismiss = useCallback(() => setSwiped("idle"), []);

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -32,6 +32,11 @@ export function OpenTerminalButton({
   const [activePort, setActivePort] = useState(ttydPort);
   const router = useRouter();
 
+  // Sync activePort when the server re-renders with a new ttydPort
+  useEffect(() => {
+    setActivePort(ttydPort);
+  }, [ttydPort]);
+
   useEffect(() => {
     if (isPending) return;
 
@@ -55,7 +60,7 @@ export function OpenTerminalButton({
     setError(null);
     startTransition(async () => {
       const result = await ensureTtyd(deploymentId);
-      if (!("port" in result) || result.port == null) {
+      if (!("port" in result) || result.port === null || result.port === undefined) {
         if ("error" in result && result.error) setError(result.error);
         router.refresh();
         return;

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -29,6 +29,7 @@ export function OpenTerminalButton({
   const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [activePort, setActivePort] = useState(ttydPort);
   const router = useRouter();
 
   useEffect(() => {
@@ -54,11 +55,14 @@ export function OpenTerminalButton({
     setError(null);
     startTransition(async () => {
       const result = await ensureTtyd(deploymentId);
-      if (!("port" in result)) {
-        if (result.error) setError(result.error);
+      if (!("port" in result) || result.port == null) {
+        if ("error" in result && result.error) setError(result.error);
         router.refresh();
         return;
       }
+      // Use the fresh port from ensureTtyd — the RSC-rendered ttydPort
+      // may be stale if ttyd was respawned on a different port.
+      setActivePort(result.port);
       setOpen(true);
     });
   }
@@ -72,7 +76,7 @@ export function OpenTerminalButton({
       <TerminalPanel
         open={open}
         onClose={() => setOpen(false)}
-        ttydPort={ttydPort}
+        ttydPort={activePort}
         deploymentId={deploymentId}
         owner={owner}
         repo={repo}


### PR DESCRIPTION
## Summary
Final batch of audit fixes (issues #299–#306), batch 4 of 4.

**Web — PR & CI detail:**
- CIChecks: align `cancelled`, `action_required`, `timed_out` conclusions as failures (matching MergeButton and core rollup)
- OpenTerminalButton: use fresh port from `ensureTtyd` instead of stale RSC-rendered prop; sync on re-render

**Web — Comments & lightbox:**
- CommentSection: fix optimistic cleanup race — match one server comment to one pending entry (prevents double-post loss)
- LightboxBodyText: multi-signal avatar detection (data-attr, URL pattern, natural dimensions) to exclude avatars from lightbox
- LaunchModal: isDirty now compares actual selected indices, not just length

**Web — List views:**
- ListContent: reset visibleCount on filter change using length fingerprints (avoids reset on every RSC re-render)
- SwipeRow: raise threshold from 60→100px and require 1.5x horizontal dominance to prevent accidental triggers during scroll

**iOS — List data integrity:**
- IssueListView: fix Swift 6 data race — snapshot repos into Sendable tuples before task group
- QuickCreateSheet: dismiss sheet on warning and surface via parent banner

**iOS — Security & terminal:**
- KeychainService: add `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` to save (load/delete use default query for backward compat)
- TerminalView: `bounces = false` instead of `isScrollEnabled = false` to preserve xterm.js scrollback

## Test plan
- [x] `pnpm turbo typecheck` — 4/4 pass
- [x] `pnpm turbo test` — 184 tests pass
- [x] iOS build clean (iPhone 17 Pro simulator)
- [x] PR review toolkit (6 agents) — all Critical/Important findings fixed