### PR TITLE
feat: batch 1 feature issues (#312, #313, #316, #317, #318)

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -41,6 +41,7 @@ struct IssueListView: View {
     @State private var oldestCachedAt: Date?
     private let pageSize = 15
     @State private var displayLimit = 15
+    @State private var searchText = ""
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
@@ -98,6 +99,14 @@ struct IssueListView: View {
         case .closed: items = items.filter { !$0.isOpen }
         }
 
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            items = items.filter { issue in
+                issue.title.lowercased().contains(query) ||
+                (issue.body ?? "").lowercased().contains(query)
+            }
+        }
+
         switch sortOrder {
         case .updated: items.sort { $0.updatedAt > $1.updatedAt }
         case .created: items.sort { $0.createdAt > $1.createdAt }
@@ -135,6 +144,15 @@ struct IssueListView: View {
             .unassigned: unassigned.count,
             .closed: closed.count,
         ]
+    }
+
+    private var filteredDrafts: [Draft] {
+        guard !searchText.isEmpty else { return drafts }
+        let query = searchText.lowercased()
+        return drafts.filter { draft in
+            draft.title.lowercased().contains(query) ||
+            (draft.body ?? "").lowercased().contains(query)
+        }
     }
 
     private func repoIndex(for issue: GitHubIssue) -> Int? {
@@ -319,8 +337,10 @@ struct IssueListView: View {
                 displayLimit = pageSize
                 storedMineOnly = new
             }
+            .onChange(of: searchText) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
+        .searchable(text: $searchText, prompt: "Search issues")
     }
 
     // MARK: - Lists
@@ -396,7 +416,7 @@ struct IssueListView: View {
 
     @ViewBuilder
     private var draftsList: some View {
-        if drafts.isEmpty {
+        if filteredDrafts.isEmpty {
             ContentUnavailableView(
                 "No Drafts",
                 systemImage: "doc.text",
@@ -404,7 +424,7 @@ struct IssueListView: View {
             )
         } else {
             List {
-                ForEach(drafts) { draft in
+                ForEach(filteredDrafts) { draft in
                     NavigationLink(value: DraftDestination(draft: draft)) {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(draft.title)

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -26,6 +26,7 @@ struct PRListView: View {
     @State private var oldestCachedAt: Date?
     private let pageSize = 15
     @State private var displayLimit = 15
+    @State private var searchText = ""
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
@@ -56,6 +57,14 @@ struct PRListView: View {
         switch section {
         case .open: items = items.filter { $0.isOpen }
         case .closed: items = items.filter { !$0.isOpen }
+        }
+
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            items = items.filter { pull in
+                pull.title.lowercased().contains(query) ||
+                (pull.body ?? "").lowercased().contains(query)
+            }
         }
 
         switch sortOrder {
@@ -201,8 +210,10 @@ struct PRListView: View {
                 displayLimit = pageSize
                 storedMineOnly = new
             }
+            .onChange(of: searchText) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
         }
+        .searchable(text: $searchText, prompt: "Search pull requests")
     }
 
     // MARK: - List

--- a/packages/web/components/detail/AutoLaunchTrigger.tsx
+++ b/packages/web/components/detail/AutoLaunchTrigger.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+type Props = {
+  hasLiveDeployment: boolean;
+  onTrigger: () => void;
+};
+
+/**
+ * Reads `?launch=true` from the URL and fires `onTrigger` on mount.
+ *
+ * Extracted into its own component so it can be wrapped in a dedicated
+ * `<Suspense>` boundary — `useSearchParams()` de-opts SSR for the entire
+ * route unless the caller is independently suspendable.
+ */
+export function AutoLaunchTrigger({ hasLiveDeployment, onTrigger }: Props) {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("launch") === "true" && !hasLiveDeployment) {
+      onTrigger();
+      const url = new URL(window.location.href);
+      url.searchParams.delete("launch");
+      window.history.replaceState({}, "", url.toString());
+    }
+    // Only run on mount — hasLiveDeployment and onTrigger are read from
+    // the initial render; subsequent changes are intentionally ignored.
+  }, []); // mount-only
+
+  return null;
+}

--- a/packages/web/components/detail/AutoLaunchTrigger.tsx
+++ b/packages/web/components/detail/AutoLaunchTrigger.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 
 type Props = {
@@ -9,24 +9,30 @@ type Props = {
 };
 
 /**
- * Reads `?launch=true` from the URL and fires `onTrigger` on mount.
+ * Reads `?launch=true` from the URL and fires `onTrigger` on mount
+ * when there is no live deployment.
  *
  * Extracted into its own component so it can be wrapped in a dedicated
- * `<Suspense>` boundary — `useSearchParams()` de-opts SSR for the entire
- * route unless the caller is independently suspendable.
+ * `<Suspense>` boundary — `useSearchParams()` forces the entire route
+ * into dynamic rendering unless the caller is independently suspendable.
  */
 export function AutoLaunchTrigger({ hasLiveDeployment, onTrigger }: Props) {
   const searchParams = useSearchParams();
 
+  // Keep refs so the mount-only effect always reads the latest values
+  // without re-triggering (guards against concurrent-render staleness).
+  const hasLiveRef = useRef(hasLiveDeployment);
+  useEffect(() => { hasLiveRef.current = hasLiveDeployment; }, [hasLiveDeployment]);
+  const onTriggerRef = useRef(onTrigger);
+  useEffect(() => { onTriggerRef.current = onTrigger; }, [onTrigger]);
+
   useEffect(() => {
-    if (searchParams.get("launch") === "true" && !hasLiveDeployment) {
-      onTrigger();
+    if (searchParams.get("launch") === "true" && !hasLiveRef.current) {
+      onTriggerRef.current();
       const url = new URL(window.location.href);
       url.searchParams.delete("launch");
       window.history.replaceState({}, "", url.toString());
     }
-    // Only run on mount — hasLiveDeployment and onTrigger are read from
-    // the initial render; subsequent changes are intentionally ignored.
   }, []); // mount-only
 
   return null;

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef, useTransition } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState, useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import type {
   GitHubIssue,
   GitHubComment,
@@ -20,6 +20,7 @@ import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
 import { useOfflineAware } from "@/hooks/useOfflineAware";
 import { useStaleTab } from "@/hooks/useStaleTab";
+import { AutoLaunchTrigger } from "./AutoLaunchTrigger";
 import styles from "./ActionSheet.module.css";
 import assignStyles from "../list/AssignSheet.module.css";
 
@@ -67,24 +68,6 @@ export function IssueActionSheet({
   const [reassignKey, setReassignKey] = useState<string | null>(null);
 
   const { isOffline } = useOfflineAware();
-  const searchParams = useSearchParams();
-
-  // Keep a ref to hasLiveDeployment so the mount-only effect below always
-  // reads the latest value without needing it in the dependency array
-  // (which would re-trigger the effect on every render where it changes).
-  const hasLiveDeploymentRef = useRef(hasLiveDeployment);
-  useEffect(() => {
-    hasLiveDeploymentRef.current = hasLiveDeployment;
-  }, [hasLiveDeployment]);
-
-  useEffect(() => {
-    if (searchParams.get("launch") === "true" && !hasLiveDeploymentRef.current) {
-      handleLaunchTap();
-      const url = new URL(window.location.href);
-      url.searchParams.delete("launch");
-      window.history.replaceState({}, "", url.toString());
-    }
-  }, []); // only run on mount
 
   useStaleTab();
 
@@ -232,6 +215,13 @@ export function IssueActionSheet({
         onTrigger={() => setSheetOpen(true)}
         label="Actions"
       />
+
+      <Suspense fallback={null}>
+        <AutoLaunchTrigger
+          hasLiveDeployment={hasLiveDeployment}
+          onTrigger={handleLaunchTap}
+        />
+      </Suspense>
 
       {/* Desktop inline action bar — visible only on wide viewports */}
       <div className={styles.desktopBar}>

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -13,6 +13,7 @@ import { EditableBody } from "./EditableBody";
 import { EditableTitle } from "./EditableTitle";
 import { PriorityPicker } from "./PriorityPicker";
 import { IssueActionSheet } from "./IssueActionSheet";
+import { ReopenButton } from "./ReopenButton";
 import styles from "./IssueDetail.module.css";
 
 type Props = {
@@ -85,7 +86,9 @@ export function IssueDetail({
           />
         </DetailMeta>
 
-        {issue.state !== "closed" && (
+        {issue.state === "closed" ? (
+          <ReopenButton owner={owner} repo={repoName} issueNumber={issue.number} />
+        ) : (
           <Suspense fallback={null}>
             <IssueActionSheet
               owner={owner}

--- a/packages/web/components/detail/MergeButton.tsx
+++ b/packages/web/components/detail/MergeButton.tsx
@@ -57,13 +57,19 @@ export function MergeButton({ owner, repoName, pullNumber, baseRef, draft, check
     setConfirming(false);
     setMerging(true);
     setMergeError(null);
-    const result = await mergePullAction(owner, repoName, pullNumber, strategy);
-    setMerging(false);
-    if (result.success) {
-      setMerged(true);
-      router.refresh();
-    } else {
-      setMergeError(result.error ?? "Merge failed");
+    try {
+      const result = await mergePullAction(owner, repoName, pullNumber, strategy);
+      if (result.success) {
+        setMerged(true);
+        router.refresh();
+      } else {
+        setMergeError(result.error ?? "Merge failed");
+      }
+    } catch (err) {
+      console.error("[issuectl] Merge pull request failed:", err);
+      setMergeError("Something went wrong while merging. Please try again.");
+    } finally {
+      setMerging(false);
     }
   };
 

--- a/packages/web/components/detail/MergeButton.tsx
+++ b/packages/web/components/detail/MergeButton.tsx
@@ -51,12 +51,13 @@ export function MergeButton({ owner, repoName, pullNumber, baseRef, draft, check
   const [merging, setMerging] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
   const [merged, setMerged] = useState(false);
+  const [strategy, setStrategy] = useState<"merge" | "squash" | "rebase">("merge");
 
   const handleConfirm = async () => {
     setConfirming(false);
     setMerging(true);
     setMergeError(null);
-    const result = await mergePullAction(owner, repoName, pullNumber);
+    const result = await mergePullAction(owner, repoName, pullNumber, strategy);
     setMerging(false);
     if (result.success) {
       setMerged(true);
@@ -107,6 +108,16 @@ export function MergeButton({ owner, repoName, pullNumber, baseRef, draft, check
           <span className={styles.confirmLabel}>
             merge into <b>{baseRef}</b>?
           </span>
+          <select
+            className={styles.strategySelect}
+            value={strategy}
+            onChange={(e) => setStrategy(e.target.value as "merge" | "squash" | "rebase")}
+            disabled={merging}
+          >
+            <option value="merge">Merge commit</option>
+            <option value="squash">Squash and merge</option>
+            <option value="rebase">Rebase and merge</option>
+          </select>
           <button className={styles.confirmBtn} onClick={handleConfirm} disabled={merging}>
             {merging ? "merging…" : "yes, merge →"}
           </button>

--- a/packages/web/components/detail/PrDetail.module.css
+++ b/packages/web/components/detail/PrDetail.module.css
@@ -113,6 +113,23 @@
   border-color: var(--paper-ink-muted);
 }
 
+.strategySelect {
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  padding: 6px 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg);
+  color: var(--paper-ink);
+  cursor: pointer;
+  min-height: 32px;
+}
+
+.strategySelect:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .mergeError {
   font-family: var(--paper-serif);
   font-size: var(--paper-fs-sm);

--- a/packages/web/components/detail/ReopenButton.module.css
+++ b/packages/web/components/detail/ReopenButton.module.css
@@ -1,5 +1,5 @@
 .error {
-  color: var(--color-danger);
-  margin-top: var(--space-xs);
-  font-size: var(--font-sm);
+  color: var(--paper-brick);
+  margin-top: 8px;
+  font-size: var(--paper-fs-sm);
 }

--- a/packages/web/components/detail/ReopenButton.module.css
+++ b/packages/web/components/detail/ReopenButton.module.css
@@ -1,0 +1,5 @@
+.error {
+  color: var(--color-danger);
+  margin-top: var(--space-xs);
+  font-size: var(--font-sm);
+}

--- a/packages/web/components/detail/ReopenButton.tsx
+++ b/packages/web/components/detail/ReopenButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/paper";
+import { reopenIssue } from "@/lib/actions/issues";
+import { useToast } from "@/components/ui/ToastProvider";
+import styles from "./ReopenButton.module.css";
+
+type Props = {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export function ReopenButton({ owner, repo, issueNumber }: Props) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleReopen() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const result = await reopenIssue(owner, repo, issueNumber);
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+        showToast(
+          result.cacheStale
+            ? "Issue reopened — reload if the page looks stale"
+            : "Issue reopened",
+          "success",
+        );
+        router.refresh();
+      } catch (err) {
+        console.error("[issuectl] Reopen issue failed:", err);
+        setError("Something went wrong while reopening the issue. Please try again.");
+      }
+    });
+  }
+
+  return (
+    <div>
+      <Button variant="primary" onClick={handleReopen} disabled={isPending}>
+        {isPending ? "Reopening..." : "Reopen Issue"}
+      </Button>
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/launch/LaunchModal.tsx
+++ b/packages/web/components/launch/LaunchModal.tsx
@@ -13,6 +13,7 @@ import { launchIssue } from "@/lib/actions/launch";
 import { DEFAULT_BRANCH_PATTERN } from "@/lib/constants";
 import { Button } from "@/components/paper";
 import { Modal } from "@/components/ui/Modal";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
 import { checkWorktreeStatusAction } from "@/lib/actions/worktrees";
@@ -72,6 +73,7 @@ export function LaunchModal({
     path: string;
   } | null>(null);
   const [forceResume, setForceResume] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
   const [initialBranch] = useState(defaultBranch);
   const [initialMode] = useState<WorkspaceMode>(
@@ -142,9 +144,21 @@ export function LaunchModal({
 
   const handleClose = useCallback(() => {
     if (isPending) return;
-    if (isDirty && !window.confirm("Discard launch configuration?")) return;
+    if (isDirty) {
+      setShowDiscardConfirm(true);
+      return;
+    }
     onClose();
   }, [isPending, isDirty, onClose]);
+
+  const handleDiscardConfirm = useCallback(() => {
+    setShowDiscardConfirm(false);
+    onClose();
+  }, [onClose]);
+
+  const handleDiscardCancel = useCallback(() => {
+    setShowDiscardConfirm(false);
+  }, []);
 
   function handleLaunch() {
     setError(null);
@@ -194,82 +208,94 @@ export function LaunchModal({
   }
 
   return (
-    <Modal
-      title="Launch to Claude Code"
-      width={620}
-      onClose={handleClose}
-      disabled={isPending}
-      footer={
-        <>
-          <Button variant="ghost" onClick={handleClose} disabled={isPending}>
-            Cancel
-          </Button>
-          <Button
-            variant="accent"
-            onClick={handleLaunch}
-            disabled={isPending || !branchName.trim()}
-          >
-            {isPending
-              ? workspaceMode === "clone"
-                ? "Cloning repo & launching\u2026"
-                : workspaceMode === "worktree"
-                  ? "Preparing worktree & launching\u2026"
-                  : "Launching\u2026"
-              : "Launch"}
-          </Button>
-        </>
-      }
-    >
-      <div className={styles.issueSummary}>
-        <span className={styles.issueDot} />
-        <div>
-          <div className={styles.issueTitle}>
-            #{issue.number} &middot; {issue.title}
-          </div>
-          <div className={styles.issueRepo}>
-            {owner}/{repo}
+    <>
+      <Modal
+        title="Launch to Claude Code"
+        width={620}
+        onClose={handleClose}
+        disabled={isPending}
+        footer={
+          <>
+            <Button variant="ghost" onClick={handleClose} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="accent"
+              onClick={handleLaunch}
+              disabled={isPending || !branchName.trim()}
+            >
+              {isPending
+                ? workspaceMode === "clone"
+                  ? "Cloning repo & launching\u2026"
+                  : workspaceMode === "worktree"
+                    ? "Preparing worktree & launching\u2026"
+                    : "Launching\u2026"
+                : "Launch"}
+            </Button>
+          </>
+        }
+      >
+        <div className={styles.issueSummary}>
+          <span className={styles.issueDot} />
+          <div>
+            <div className={styles.issueTitle}>
+              #{issue.number} &middot; {issue.title}
+            </div>
+            <div className={styles.issueRepo}>
+              {owner}/{repo}
+            </div>
           </div>
         </div>
-      </div>
 
-      {dirtyWorktree?.dirty && !forceResume && (
-        <DirtyWorktreeBanner
-          owner={owner}
+        {dirtyWorktree?.dirty && !forceResume && (
+          <DirtyWorktreeBanner
+            owner={owner}
+            repo={repo}
+            issueNumber={issue.number}
+            worktreePath={dirtyWorktree.path}
+            onDiscard={() => setDirtyWorktree(null)}
+            onResume={() => setForceResume(true)}
+          />
+        )}
+
+        <BranchInput value={branchName} onChange={setBranchName} />
+
+        <WorkspaceModeSelector
+          value={workspaceMode}
+          onChange={setWorkspaceMode}
+          repoLocalPath={repoLocalPath}
           repo={repo}
           issueNumber={issue.number}
-          worktreePath={dirtyWorktree.path}
-          onDiscard={() => setDirtyWorktree(null)}
-          onResume={() => setForceResume(true)}
+        />
+
+        <ContextToggles
+          comments={comments}
+          referencedFiles={referencedFiles}
+          selectedComments={selectedComments}
+          selectedFiles={selectedFiles}
+          onToggleComment={toggleComment}
+          onToggleFile={toggleFile}
+          onAddFile={addFile}
+        />
+
+        <PreambleInput value={preamble} onChange={setPreamble} />
+
+        {error && (
+          <div className={styles.error} role="alert">
+            {error}
+          </div>
+        )}
+      </Modal>
+      {showDiscardConfirm && (
+        <ConfirmDialog
+          title="Discard Changes"
+          message="Discard launch configuration?"
+          confirmLabel="Discard"
+          confirmVariant="danger"
+          onConfirm={handleDiscardConfirm}
+          onCancel={handleDiscardCancel}
         />
       )}
-
-      <BranchInput value={branchName} onChange={setBranchName} />
-
-      <WorkspaceModeSelector
-        value={workspaceMode}
-        onChange={setWorkspaceMode}
-        repoLocalPath={repoLocalPath}
-        repo={repo}
-        issueNumber={issue.number}
-      />
-
-      <ContextToggles
-        comments={comments}
-        referencedFiles={referencedFiles}
-        selectedComments={selectedComments}
-        selectedFiles={selectedFiles}
-        onToggleComment={toggleComment}
-        onToggleFile={toggleFile}
-        onAddFile={addFile}
-      />
-
-      <PreambleInput value={preamble} onChange={setPreamble} />
-
-      {error && (
-        <div className={styles.error} role="alert">
-          {error}
-        </div>
-      )}
-    </Modal>
+    </>
   );
 }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -7,6 +7,7 @@ import {
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,
+  reopenIssue as coreReopenIssue,
   reassignIssue as coreReassignIssue,
   addLabel as coreAddLabel,
   removeLabel as coreRemoveLabel,
@@ -181,6 +182,33 @@ export async function closeIssue(
     clearCacheKey(db, `issues:${owner}/${repo}`);
   } catch (err) {
     console.error("[issuectl] Failed to close issue:", err);
+    return { success: false, error: formatErrorForUser(err) };
+  }
+  const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+export async function reopenIssue(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<{ success: true; cacheStale?: true } | { success: false; error: string }> {
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0) {
+    return { success: false, error: "Valid owner, repo, and issue number are required" };
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
+    await withAuthRetry((octokit) =>
+      coreReopenIssue(octokit, owner, repo, number),
+    );
+    clearCacheKey(db, `issue-detail:${owner}/${repo}#${number}`);
+    clearCacheKey(db, `issues:${owner}/${repo}`);
+  } catch (err) {
+    console.error("[issuectl] Failed to reopen issue:", err);
     return { success: false, error: formatErrorForUser(err) };
   }
   const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -13,6 +13,7 @@ export async function mergePullAction(
   owner: string,
   repo: string,
   pullNumber: number,
+  mergeMethod?: "merge" | "squash" | "rebase",
 ): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
   if (typeof owner !== "string" || owner.trim().length === 0) {
     return { success: false, error: "Invalid owner" };
@@ -36,6 +37,7 @@ export async function mergePullAction(
         owner,
         repo,
         pull_number: pullNumber,
+        ...(mergeMethod ? { merge_method: mergeMethod } : {}),
       }),
     );
     // Clear the PR detail cache so the re-rendered page shows merged state

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -24,14 +24,18 @@ export async function mergePullAction(
   if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
     return { success: false, error: "Invalid pull request number" };
   }
-
-  const db = getDb();
-  const tracked = getRepo(db, owner, repo);
-  if (!tracked) {
-    return { success: false, error: "Repository is not tracked" };
+  const VALID_MERGE_METHODS = ["merge", "squash", "rebase"] as const;
+  if (mergeMethod !== undefined && !(VALID_MERGE_METHODS as readonly string[]).includes(mergeMethod)) {
+    return { success: false, error: "Invalid merge method" };
   }
 
   try {
+    const db = getDb();
+    const tracked = getRepo(db, owner, repo);
+    if (!tracked) {
+      return { success: false, error: "Repository is not tracked" };
+    }
+
     await withAuthRetry((octokit) =>
       octokit.rest.pulls.merge({
         owner,


### PR DESCRIPTION
## Summary
- **#316** — Extract useSearchParams into AutoLaunchTrigger with dedicated Suspense boundary to prevent SSR de-opt
- **#312** — Add Reopen Issue button for closed issues (new reopenIssue server action + ReopenButton component)
- **#313** — Add merge strategy dropdown (squash/rebase/merge) to MergeButton with server-side validation
- **#317** — Replace window.confirm with accessible ConfirmDialog in LaunchModal
- **#318** — Add .searchable() to iOS IssueListView and PRListView (filters by title/body)
- **#319** — Closed as already implemented (swipe actions exist on all iOS list rows)

## Review fixes applied
- Fix ReopenButton.module.css to use --paper-* design tokens
- Validate mergeMethod param in mergePullAction server action
- Move getDb() inside try-catch in mergePullAction
- Add try-catch + finally to MergeButton.handleConfirm
- Restore ref-based guard in AutoLaunchTrigger to prevent stale closure

## Test plan
- [ ] Typecheck passes (npx turbo typecheck)
- [ ] iOS build succeeds (xcodebuild -scheme IssueCTL)
- [ ] Closed issue detail page shows Reopen Issue button
- [ ] PR detail page shows merge strategy dropdown (squash/rebase/merge)
- [ ] Launch modal dirty-state guard shows accessible ConfirmDialog instead of browser alert
- [ ] iOS issue list search filters by title and body
- [ ] iOS PR list search filters by title and body

Closes #312, closes #313, closes #316, closes #317, closes #318