### PR TITLE
feat: batch 2 features — search, PR reviews/diffs, keyboard shortcuts

### DIFF
--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -151,6 +151,7 @@ export async function listPullFiles(
     status: f.status as GitHubPullFile["status"],
     additions: f.additions,
     deletions: f.deletions,
+    patch: f.patch,
   }));
 }
 

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -74,6 +74,7 @@ export type GitHubPullFile = {
   status: "added" | "modified" | "removed" | "renamed" | "copied" | "changed" | "unchanged";
   additions: number;
   deletions: number;
+  patch?: string;
 };
 
 export type GitHubAccessibleRepo = {

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -43,6 +43,7 @@ export default async function PullDetailPage({
         pull={detail.pull}
         checks={detail.checks}
         files={detail.files}
+        reviews={detail.reviews}
         linkedIssue={detail.linkedIssue}
       />
     );

--- a/packages/web/components/detail/DetailKeyboardNav.tsx
+++ b/packages/web/components/detail/DetailKeyboardNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
@@ -17,16 +17,14 @@ type Props = {
  */
 export function DetailKeyboardNav({ backHref }: Props) {
   const router = useRouter();
-  const helpOpenRef = useRef(false);
 
   const shortcuts = useMemo(
     () => ({
       Escape: () => {
         // Close help overlay first if open
-        if (helpOpenRef.current) {
-          helpOpenRef.current = false;
-          const overlay = document.getElementById("keyboard-help-overlay");
-          if (overlay) overlay.style.display = "none";
+        const overlay = document.getElementById("keyboard-help-overlay");
+        if (overlay && overlay.style.display !== "none") {
+          overlay.style.display = "none";
           return;
         }
         router.push(backHref);
@@ -44,10 +42,10 @@ export function DetailKeyboardNav({ backHref }: Props) {
         btn?.click();
       },
       "?": () => {
-        helpOpenRef.current = !helpOpenRef.current;
         const overlay = document.getElementById("keyboard-help-overlay");
         if (overlay) {
-          overlay.style.display = helpOpenRef.current ? "flex" : "none";
+          const isVisible = overlay.style.display !== "none";
+          overlay.style.display = isVisible ? "none" : "flex";
         }
       },
     }),

--- a/packages/web/components/detail/DetailKeyboardNav.tsx
+++ b/packages/web/components/detail/DetailKeyboardNav.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+type Props = {
+  backHref: string;
+};
+
+/**
+ * Keyboard shortcuts for detail pages (issue and PR).
+ * - Escape: go back to the list
+ * - l: click the launch button (via data-shortcut="launch")
+ * - m: click the merge button (via data-shortcut="merge")
+ * - ?: toggle the keyboard help overlay
+ */
+export function DetailKeyboardNav({ backHref }: Props) {
+  const router = useRouter();
+  const helpOpenRef = useRef(false);
+
+  const shortcuts = useMemo(
+    () => ({
+      Escape: () => {
+        // Close help overlay first if open
+        if (helpOpenRef.current) {
+          helpOpenRef.current = false;
+          const overlay = document.getElementById("keyboard-help-overlay");
+          if (overlay) overlay.style.display = "none";
+          return;
+        }
+        router.push(backHref);
+      },
+      l: () => {
+        const btn = document.querySelector(
+          '[data-shortcut="launch"]',
+        ) as HTMLButtonElement | null;
+        btn?.click();
+      },
+      m: () => {
+        const btn = document.querySelector(
+          '[data-shortcut="merge"]',
+        ) as HTMLButtonElement | null;
+        btn?.click();
+      },
+      "?": () => {
+        helpOpenRef.current = !helpOpenRef.current;
+        const overlay = document.getElementById("keyboard-help-overlay");
+        if (overlay) {
+          overlay.style.display = helpOpenRef.current ? "flex" : "none";
+        }
+      },
+    }),
+    [router, backHref],
+  );
+
+  useKeyboardShortcuts(shortcuts);
+  return null;
+}

--- a/packages/web/components/detail/FilesChanged.module.css
+++ b/packages/web/components/detail/FilesChanged.module.css
@@ -16,6 +16,30 @@
   align-items: center;
 }
 
+.expandBtn {
+  cursor: pointer;
+  border-radius: var(--paper-radius-sm);
+  transition: background 0.12s;
+}
+
+.expandBtn:hover {
+  background: color-mix(in srgb, var(--paper-ink) 5%, transparent);
+}
+
+.chevron {
+  display: inline-block;
+  font-size: 10px;
+  width: 14px;
+  text-align: center;
+  transition: transform 0.15s ease;
+  color: var(--paper-ink-faint);
+  flex-shrink: 0;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
 .add {
   color: var(--paper-accent);
   font-family: var(--paper-serif);
@@ -54,4 +78,36 @@
   font-size: 12px;
   color: var(--paper-ink-faint);
   text-align: center;
+}
+
+/* --- Diff block --- */
+
+.diffBlock {
+  font-family: var(--paper-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  overflow-x: auto;
+  margin: 4px 0 8px;
+  padding: 8px 10px;
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  white-space: pre;
+}
+
+.diffLine {
+  padding: 0 4px;
+}
+
+.diffAdd {
+  background: color-mix(in srgb, var(--paper-accent) 12%, transparent);
+}
+
+.diffDel {
+  background: color-mix(in srgb, var(--paper-brick) 12%, transparent);
+}
+
+.diffHunk {
+  color: var(--paper-ink-faint);
+  font-style: italic;
 }

--- a/packages/web/components/detail/FilesChanged.tsx
+++ b/packages/web/components/detail/FilesChanged.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import type { GitHubPullFile } from "@issuectl/core";
 import styles from "./FilesChanged.module.css";
 
@@ -5,7 +8,37 @@ type Props = {
   files: GitHubPullFile[];
 };
 
+function renderDiffLine(line: string, index: number) {
+  let className = styles.diffLine;
+  if (line.startsWith("@@")) {
+    className = `${styles.diffLine} ${styles.diffHunk}`;
+  } else if (line.startsWith("+")) {
+    className = `${styles.diffLine} ${styles.diffAdd}`;
+  } else if (line.startsWith("-")) {
+    className = `${styles.diffLine} ${styles.diffDel}`;
+  }
+  return (
+    <div key={index} className={className}>
+      {line}
+    </div>
+  );
+}
+
 export function FilesChanged({ files }: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = (filename: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(filename)) {
+        next.delete(filename);
+      } else {
+        next.add(filename);
+      }
+      return next;
+    });
+  };
+
   if (files.length === 0) {
     return (
       <div className={styles.wrapper}>
@@ -15,20 +48,54 @@ export function FilesChanged({ files }: Props) {
       </div>
     );
   }
+
   return (
     <div className={styles.wrapper}>
-      {files.map((file) => (
-        <div
-          key={file.filename}
-          className={`${styles.line} ${
-            file.status === "removed" ? styles.removed : ""
-          }`}
-        >
-          <span className={styles.add}>+{file.additions}</span>
-          <span className={styles.del}>-{file.deletions}</span>
-          <span className={styles.filename}>{file.filename}</span>
-        </div>
-      ))}
+      {files.map((file) => {
+        const isExpanded = expanded.has(file.filename);
+        const hasPatch = Boolean(file.patch);
+        return (
+          <div key={file.filename}>
+            <div
+              className={`${styles.line} ${
+                file.status === "removed" ? styles.removed : ""
+              } ${hasPatch ? styles.expandBtn : ""}`}
+              onClick={hasPatch ? () => toggle(file.filename) : undefined}
+              role={hasPatch ? "button" : undefined}
+              tabIndex={hasPatch ? 0 : undefined}
+              onKeyDown={
+                hasPatch
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggle(file.filename);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              {hasPatch && (
+                <span
+                  className={`${styles.chevron} ${
+                    isExpanded ? styles.chevronOpen : ""
+                  }`}
+                  aria-hidden="true"
+                >
+                  &#9656;
+                </span>
+              )}
+              <span className={styles.add}>+{file.additions}</span>
+              <span className={styles.del}>-{file.deletions}</span>
+              <span className={styles.filename}>{file.filename}</span>
+            </div>
+            {isExpanded && file.patch && (
+              <pre className={styles.diffBlock}>
+                {file.patch.split("\n").map(renderDiffLine)}
+              </pre>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -226,7 +226,7 @@ export function IssueActionSheet({
       {/* Desktop inline action bar — visible only on wide viewports */}
       <div className={styles.desktopBar}>
         {!hasLiveDeployment && (
-          <Button variant="primary" onClick={handleLaunchTap}>
+          <Button variant="primary" onClick={handleLaunchTap} data-shortcut="launch">
             Launch with Claude
           </Button>
         )}

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -14,6 +14,8 @@ import { EditableTitle } from "./EditableTitle";
 import { PriorityPicker } from "./PriorityPicker";
 import { IssueActionSheet } from "./IssueActionSheet";
 import { ReopenButton } from "./ReopenButton";
+import { DetailKeyboardNav } from "./DetailKeyboardNav";
+import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
 import styles from "./IssueDetail.module.css";
 
 type Props = {
@@ -48,6 +50,8 @@ export function IssueDetail({
 
   return (
     <div className={styles.container} data-lightbox-root>
+      <DetailKeyboardNav backHref="/" />
+      <KeyboardHelpOverlay />
       <DetailTopBar
         backHref="/"
         crumb={

--- a/packages/web/components/detail/MergeButton.tsx
+++ b/packages/web/components/detail/MergeButton.tsx
@@ -143,6 +143,7 @@ export function MergeButton({ owner, repoName, pullNumber, baseRef, draft, check
             setConfirming(true);
           }}
           disabled={merging}
+          data-shortcut="merge"
         >
           {merging ? "merging…" : "merge pull request →"}
         </button>

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -16,6 +16,8 @@ import { BodyText } from "./BodyText";
 import { CIChecks } from "./CIChecks";
 import { FilesChanged } from "./FilesChanged";
 import { MergeButton } from "./MergeButton";
+import { DetailKeyboardNav } from "./DetailKeyboardNav";
+import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
 import styles from "./PrDetail.module.css";
 
 type Props = {
@@ -41,6 +43,8 @@ export function PrDetail({
 
   return (
     <div className={styles.container}>
+      <DetailKeyboardNav backHref="/?tab=prs" />
+      <KeyboardHelpOverlay />
       <DetailTopBar
         backHref="/?tab=prs"
         crumb={<>{owner}/<b>{repoName}</b></>}

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -2,6 +2,7 @@ import type {
   GitHubPull,
   GitHubCheck,
   GitHubPullFile,
+  GitHubPullReview,
   GitHubIssue,
 } from "@issuectl/core";
 import { Chip } from "@/components/paper";
@@ -14,6 +15,7 @@ import {
 } from "./DetailMeta";
 import { BodyText } from "./BodyText";
 import { CIChecks } from "./CIChecks";
+import { ReviewPanel } from "./ReviewPanel";
 import { FilesChanged } from "./FilesChanged";
 import { MergeButton } from "./MergeButton";
 import styles from "./PrDetail.module.css";
@@ -24,6 +26,7 @@ type Props = {
   pull: GitHubPull;
   checks: GitHubCheck[];
   files: GitHubPullFile[];
+  reviews: GitHubPullReview[];
   linkedIssue: GitHubIssue | null;
 };
 
@@ -33,6 +36,7 @@ export function PrDetail({
   pull,
   checks,
   files,
+  reviews,
   linkedIssue,
 }: Props) {
   const prState: "open" | "closed" | "merged" = pull.merged
@@ -81,6 +85,15 @@ export function PrDetail({
 
         <h2 className={styles.section}>ci checks</h2>
         <CIChecks checks={checks} />
+
+        <h2 className={styles.section}>reviews</h2>
+        <ReviewPanel
+          owner={owner}
+          repoName={repoName}
+          pullNumber={pull.number}
+          reviews={reviews}
+          isOpen={prState === "open"}
+        />
 
         <h2 className={styles.section}>files changed</h2>
         <FilesChanged files={files} />

--- a/packages/web/components/detail/ReviewPanel.module.css
+++ b/packages/web/components/detail/ReviewPanel.module.css
@@ -1,0 +1,205 @@
+.panel {
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 14px 16px;
+  margin-bottom: 20px;
+}
+
+.empty {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--paper-ink-faint);
+  text-align: center;
+  padding: 6px 0;
+}
+
+/* --- Review item --- */
+
+.review {
+  padding-bottom: 14px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.review:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.reviewHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.avi {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--paper-bg-warmer, var(--paper-bg));
+  border: 1px solid var(--paper-line);
+  font-family: var(--paper-serif);
+  font-weight: 600;
+  font-style: italic;
+  font-size: 10px;
+  color: var(--paper-ink-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.avi img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.who {
+  font-family: var(--paper-serif);
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--paper-ink);
+}
+
+.badge {
+  display: inline-block;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--paper-radius-sm);
+  line-height: 1.4;
+}
+
+.badgeApproved {
+  color: var(--paper-accent);
+  background: color-mix(in srgb, var(--paper-accent) 10%, transparent);
+}
+
+.badgeChangesRequested {
+  color: var(--paper-brick);
+  background: color-mix(in srgb, var(--paper-brick) 10%, transparent);
+}
+
+.badgeCommented {
+  color: var(--paper-ink-soft);
+  background: color-mix(in srgb, var(--paper-ink-soft) 8%, transparent);
+}
+
+.badgeDismissed {
+  color: var(--paper-ink-faint);
+  background: color-mix(in srgb, var(--paper-ink-faint) 8%, transparent);
+}
+
+.time {
+  font-family: var(--paper-mono);
+  font-size: 11px;
+  color: var(--paper-ink-faint);
+  margin-left: auto;
+}
+
+.reviewBody {
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--paper-ink-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* --- Submission form --- */
+
+.form {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--paper-line);
+}
+
+.textarea {
+  width: 100%;
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--paper-ink-soft);
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  padding: 10px 12px;
+  resize: vertical;
+  min-height: 72px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.textarea:focus {
+  border-color: var(--paper-accent);
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+}
+
+.formActions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.submitBtn {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 600;
+  font-size: 12px;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+  background: var(--paper-bg);
+  color: var(--paper-ink-soft);
+}
+
+.submitBtn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.submitBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.approveBtn {
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+  border-color: var(--paper-accent);
+}
+
+.changesBtn {
+  background: var(--paper-brick);
+  color: var(--paper-bg);
+  border-color: var(--paper-brick);
+}
+
+.error {
+  font-family: var(--paper-serif);
+  font-size: var(--paper-fs-sm);
+  color: var(--paper-brick);
+  margin-top: 8px;
+}
+
+@media (max-width: 767px) {
+  .submitBtn {
+    min-height: 44px;
+    padding: 0 16px;
+  }
+}

--- a/packages/web/components/detail/ReviewPanel.tsx
+++ b/packages/web/components/detail/ReviewPanel.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import type { GitHubPullReview } from "@issuectl/core";
+import { submitReviewAction } from "@/lib/actions/pulls";
+import { timeAgo } from "@/lib/format";
+import styles from "./ReviewPanel.module.css";
+
+type Props = {
+  owner: string;
+  repoName: string;
+  pullNumber: number;
+  reviews: GitHubPullReview[];
+  isOpen: boolean;
+};
+
+function initials(login: string | undefined): string {
+  if (!login) return "??";
+  return login.slice(0, 2).toLowerCase();
+}
+
+function badgeLabel(state: GitHubPullReview["state"]): string {
+  switch (state) {
+    case "approved":
+      return "approved";
+    case "changes_requested":
+      return "changes requested";
+    case "commented":
+      return "commented";
+    case "dismissed":
+      return "dismissed";
+    case "pending":
+      return "pending";
+  }
+}
+
+function badgeClass(state: GitHubPullReview["state"]): string {
+  switch (state) {
+    case "approved":
+      return styles.badgeApproved;
+    case "changes_requested":
+      return styles.badgeChangesRequested;
+    case "commented":
+      return styles.badgeCommented;
+    case "dismissed":
+      return styles.badgeDismissed;
+    case "pending":
+      return styles.badgeCommented;
+  }
+}
+
+export function ReviewPanel({
+  owner,
+  repoName,
+  pullNumber,
+  reviews,
+  isOpen,
+}: Props) {
+  const router = useRouter();
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (
+    event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
+  ) => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await submitReviewAction(
+        owner,
+        repoName,
+        pullNumber,
+        event,
+        body.trim() || undefined,
+      );
+      if (result.success) {
+        setBody("");
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to submit review");
+      }
+    } catch (err) {
+      console.error("[issuectl] Submit review failed:", err);
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.panel}>
+      {reviews.length === 0 && !isOpen && (
+        <div className={styles.empty}>
+          <em>no reviews</em>
+        </div>
+      )}
+
+      {reviews.map((review) => (
+        <div key={review.id} className={styles.review}>
+          <div className={styles.reviewHead}>
+            <div className={styles.avi}>
+              {review.user?.avatarUrl ? (
+                <Image
+                  src={review.user.avatarUrl}
+                  alt=""
+                  width={24}
+                  height={24}
+                  data-avatar="true"
+                />
+              ) : (
+                initials(review.user?.login)
+              )}
+            </div>
+            <span className={styles.who}>
+              {review.user?.login ?? "unknown"}
+            </span>
+            <span className={`${styles.badge} ${badgeClass(review.state)}`}>
+              {badgeLabel(review.state)}
+            </span>
+            {review.submittedAt && (
+              <span className={styles.time}>
+                {timeAgo(review.submittedAt)}
+              </span>
+            )}
+          </div>
+          {review.body && (
+            <div className={styles.reviewBody}>{review.body}</div>
+          )}
+        </div>
+      ))}
+
+      {isOpen && (
+        <div className={styles.form}>
+          <textarea
+            className={styles.textarea}
+            placeholder="Leave a review..."
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            disabled={submitting}
+            rows={3}
+            maxLength={65536}
+          />
+          <div className={styles.formActions}>
+            <button
+              type="button"
+              className={`${styles.submitBtn} ${styles.approveBtn}`}
+              onClick={() => handleSubmit("APPROVE")}
+              disabled={submitting}
+            >
+              {submitting ? "submitting..." : "approve"}
+            </button>
+            <button
+              type="button"
+              className={`${styles.submitBtn} ${styles.changesBtn}`}
+              onClick={() => handleSubmit("REQUEST_CHANGES")}
+              disabled={submitting || !body.trim()}
+            >
+              request changes
+            </button>
+            <button
+              type="button"
+              className={styles.submitBtn}
+              onClick={() => handleSubmit("COMMENT")}
+              disabled={submitting || !body.trim()}
+            >
+              comment
+            </button>
+          </div>
+          {error && (
+            <div className={styles.error} role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/list/FocusContext.tsx
+++ b/packages/web/components/list/FocusContext.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+type FocusContextValue = {
+  focusedIndex: number;
+  setFocusedIndex: (index: number) => void;
+};
+
+const FocusContext = createContext<FocusContextValue | null>(null);
+
+export function FocusProvider({ children }: { children: ReactNode }) {
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  return (
+    <FocusContext.Provider value={{ focusedIndex, setFocusedIndex }}>
+      {children}
+    </FocusContext.Provider>
+  );
+}
+
+export function useFocusContext(): FocusContextValue | null {
+  return useContext(FocusContext);
+}

--- a/packages/web/components/list/FocusContext.tsx
+++ b/packages/web/components/list/FocusContext.tsx
@@ -18,6 +18,10 @@ export function FocusProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useFocusContext(): FocusContextValue | null {
-  return useContext(FocusContext);
+export function useFocusContext(): FocusContextValue {
+  const ctx = useContext(FocusContext);
+  if (!ctx) {
+    throw new Error("useFocusContext must be used within a FocusProvider");
+  }
+  return ctx;
 }

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -12,6 +12,8 @@ import { RepoFilterChips } from "./RepoFilterChips";
 import { FiltersSheet } from "./FiltersSheet";
 import { BottomHandle } from "./BottomHandle";
 import { useListCounts } from "./ListCountContext";
+import { SearchProvider } from "./SearchContext";
+import { SearchBar } from "./SearchBar";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 import { CacheAge } from "@/components/ui/CacheAge";
@@ -160,6 +162,7 @@ export function List({
       : mineOnly ? "mine" : "everyone";
 
   return (
+    <SearchProvider>
     <PullToRefreshWrapper>
     <div className={styles.container}>
       <div className={styles.topBar}>
@@ -191,6 +194,8 @@ export function List({
             <span className={styles.contextCount}>{prCount}</span>
           )}
         </button>
+
+        <SearchBar />
 
         <CacheAge cachedAt={cachedAt ?? null} />
         <nav className={styles.desktopNav}>
@@ -443,6 +448,7 @@ export function List({
       </Drawer>
     </div>
     </PullToRefreshWrapper>
+    </SearchProvider>
   );
 }
 

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, useCallback, type ReactNode } from "react";
 import Link from "next/link";
 import type { Section, SortMode } from "@issuectl/core";
 import { Drawer, Fab } from "@/components/paper";
@@ -12,11 +12,14 @@ import { RepoFilterChips } from "./RepoFilterChips";
 import { FiltersSheet } from "./FiltersSheet";
 import { BottomHandle } from "./BottomHandle";
 import { useListCounts } from "./ListCountContext";
+import { FocusProvider } from "./FocusContext";
+import { ListKeyboardNav } from "./ListKeyboardNav";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 import { CacheAge } from "@/components/ui/CacheAge";
 import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
 import { VersionBadge } from "@/components/ui/VersionBadge";
+import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
 
 type Repo = { owner: string; name: string };
 
@@ -72,6 +75,8 @@ export function List({
   const [createOpen, setCreateOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const handleCreateDraft = useCallback(() => setCreateOpen(true), []);
 
   const counts = useListCounts();
   const sectionCounts = counts?.sectionCounts ?? null;
@@ -160,8 +165,18 @@ export function List({
       : mineOnly ? "mine" : "everyone";
 
   return (
+    <FocusProvider>
     <PullToRefreshWrapper>
     <div className={styles.container}>
+      <ListKeyboardNav
+        activeTab={activeTab}
+        activeSection={activeSection}
+        activeRepo={activeRepo}
+        activeSort={activeSort}
+        mineOnly={mineOnly}
+        onCreateDraft={handleCreateDraft}
+      />
+      <KeyboardHelpOverlay />
       <div className={styles.topBar}>
         {/* Brand: full on desktop, compact on mobile */}
         <h1 className={styles.brand}>
@@ -443,6 +458,7 @@ export function List({
       </Drawer>
     </div>
     </PullToRefreshWrapper>
+    </FocusProvider>
   );
 }
 

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -187,12 +187,13 @@ export function ListContent({
 
   return (
     <div>
-      {prs.map(({ repo, pull }) => (
+      {prs.map(({ repo, pull }, i) => (
         <PrListRow
           key={`pr-${repo.owner}-${repo.name}-${pull.number}`}
           owner={repo.owner}
           repoName={repo.name}
           pull={pull}
+          rowIndex={i}
         />
       ))}
     </div>

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, useTransition } from "react";
+import { useState, useRef, useEffect, useCallback, useTransition, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import type { Section, UnifiedList } from "@issuectl/core";
+import type { Section, UnifiedList, UnifiedListItem } from "@issuectl/core";
 import type { PrEntry } from "@/lib/page-filters";
 import { ListSection } from "./ListSection";
 import { PrListRow } from "./PrListRow";
 import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
 import { closeIssue } from "@/lib/actions/issues";
 import { useToast } from "@/components/ui/ToastProvider";
+import { useSearch } from "./SearchContext";
 import { buildHref } from "@/lib/list-href";
 import styles from "./List.module.css";
 
@@ -57,15 +58,41 @@ export function ListContent({
   const [closeTarget, setCloseTarget] = useState<{ owner: string; repo: string; number: number } | null>(null);
   const [isPending, startTransition] = useTransition();
   const [closeError, setCloseError] = useState<string | null>(null);
+  const { query } = useSearch();
+
+  // ── Search filtering ──
+  const filteredData = useMemo((): UnifiedList => {
+    if (!query) return data;
+    const q = query.toLowerCase();
+    return {
+      unassigned: data.unassigned.filter((item) =>
+        matchesDraft(item, q),
+      ),
+      open: data.open.filter((item) => matchesIssue(item, q)),
+      running: data.running.filter((item) => matchesIssue(item, q)),
+      closed: data.closed.filter((item) => matchesIssue(item, q)),
+    };
+  }, [data, query]);
+
+  const filteredPrs = useMemo((): PrEntry[] => {
+    if (!query) return prs;
+    const q = query.toLowerCase();
+    return prs.filter(({ pull }) => {
+      if (pull.title.toLowerCase().includes(q)) return true;
+      if (pull.body?.toLowerCase().includes(q)) return true;
+      if (pull.headRef.toLowerCase().includes(q)) return true;
+      return false;
+    });
+  }, [prs, query]);
 
   // Reset visible count whenever filter criteria or the filtered dataset changes.
   // Length fingerprints detect upstream filter changes (sort, repo) without
   // resetting on every RSC re-render that produces a new array reference.
-  const dataFingerprint = data.open.length + data.running.length + data.closed.length;
-  const prsFingerprint = prs.length;
+  const dataFingerprint = filteredData.open.length + filteredData.running.length + filteredData.closed.length;
+  const prsFingerprint = filteredPrs.length;
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [activeTab, activeSection, activeRepo, mineOnly, dataFingerprint, prsFingerprint]);
+  }, [activeTab, activeSection, activeRepo, mineOnly, dataFingerprint, prsFingerprint, query]);
 
   const loadMore = useCallback(() => {
     setVisibleCount((prev) => prev + PAGE_SIZE);
@@ -136,11 +163,11 @@ export function ListContent({
   }, [loadMore, activeSection]);
 
   if (activeTab === "issues") {
-    const total = data[activeSection].length;
+    const total = filteredData[activeSection].length;
     const showing = Math.min(visibleCount, total);
     return (
       <>
-        {renderIssueSection({ activeSection, data, visibleCount, onLaunch: handleLaunch, onClose: handleCloseRequest })}
+        {renderIssueSection({ activeSection, data: filteredData, visibleCount, onLaunch: handleLaunch, onClose: handleCloseRequest })}
         {total > PAGE_SIZE && (
           <div className={styles.pageStatus}>
             Showing {showing} of {total}
@@ -162,9 +189,11 @@ export function ListContent({
     );
   }
 
-  if (prs.length === 0) {
+  if (filteredPrs.length === 0) {
     let emptyMessage: string;
-    if (activeRepo && mineOnly) {
+    if (query) {
+      emptyMessage = "no PRs match your search.";
+    } else if (activeRepo && mineOnly) {
       emptyMessage = `no open PRs from you in ${activeRepo}.`;
     } else if (activeRepo) {
       emptyMessage = `no open PRs in ${activeRepo}.`;
@@ -187,7 +216,7 @@ export function ListContent({
 
   return (
     <div>
-      {prs.map(({ repo, pull }) => (
+      {filteredPrs.map(({ repo, pull }) => (
         <PrListRow
           key={`pr-${repo.owner}-${repo.name}-${pull.number}`}
           owner={repo.owner}
@@ -229,4 +258,23 @@ function renderIssueSection({
 
   const items = allItems.slice(0, visibleCount);
   return <ListSection title={null} items={items} onLaunch={onLaunch} onClose={onClose} />;
+}
+
+/** Case-insensitive substring match for draft items (title + body). */
+function matchesDraft(item: UnifiedListItem, q: string): boolean {
+  if (item.kind !== "draft") return false;
+  const { title, body } = item.draft;
+  if (title.toLowerCase().includes(q)) return true;
+  if (body.toLowerCase().includes(q)) return true;
+  return false;
+}
+
+/** Case-insensitive substring match for issue items (title, body, labels). */
+function matchesIssue(item: UnifiedListItem, q: string): boolean {
+  if (item.kind !== "issue") return false;
+  const { title, body, labels } = item.issue;
+  if (title.toLowerCase().includes(q)) return true;
+  if (body?.toLowerCase().includes(q)) return true;
+  if (labels.some((l) => l.name.toLowerCase().includes(q))) return true;
+  return false;
 }

--- a/packages/web/components/list/ListKeyboardNav.tsx
+++ b/packages/web/components/list/ListKeyboardNav.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { Section, SortMode } from "@issuectl/core";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useFocusContext } from "./FocusContext";
+import { useListCounts } from "./ListCountContext";
+import { buildHref } from "@/lib/list-href";
+
+type Props = {
+  activeTab: "issues" | "prs";
+  activeSection: Section;
+  activeRepo: string | null;
+  activeSort: SortMode;
+  mineOnly: boolean;
+  onCreateDraft: () => void;
+};
+
+/** Sections in tab-order for 1/2/3/4 shortcuts */
+const SECTIONS: Section[] = ["unassigned", "open", "running", "closed"];
+
+/**
+ * Client component that adds keyboard shortcuts to the list view.
+ * Rendered inside FocusProvider so it can read/write focusedIndex.
+ * Derives item count from ListCountContext (set by the server component).
+ */
+export function ListKeyboardNav({
+  activeTab,
+  activeSection,
+  activeRepo,
+  activeSort,
+  mineOnly,
+  onCreateDraft,
+}: Props) {
+  const router = useRouter();
+  const focus = useFocusContext();
+  const counts = useListCounts();
+  const helpOpenRef = useRef(false);
+
+  // Derive visible item count from the counts context
+  const itemCount =
+    activeTab === "prs"
+      ? (counts?.prCount ?? 0)
+      : (counts?.sectionCounts[activeSection] ?? 0);
+
+  const moveFocus = useCallback(
+    (delta: number) => {
+      if (!focus || itemCount === 0) return;
+      const { focusedIndex, setFocusedIndex } = focus;
+      let next: number;
+      if (focusedIndex < 0) {
+        // Nothing focused yet — start at first (j) or last (k)
+        next = delta > 0 ? 0 : itemCount - 1;
+      } else {
+        next = (focusedIndex + delta + itemCount) % itemCount;
+      }
+      setFocusedIndex(next);
+
+      // Scroll the focused row into view
+      requestAnimationFrame(() => {
+        const row = document.querySelector(`[data-row-index="${next}"]`);
+        row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      });
+    },
+    [focus, itemCount],
+  );
+
+  const openFocused = useCallback(() => {
+    if (!focus || focus.focusedIndex < 0) return;
+    const row = document.querySelector(
+      `[data-row-index="${focus.focusedIndex}"]`,
+    );
+    const link = row?.querySelector("a[href]") as HTMLAnchorElement | null;
+    if (link) {
+      router.push(link.href);
+    }
+  }, [focus, router]);
+
+  const shortcuts = useMemo(
+    () => ({
+      j: () => moveFocus(1),
+      k: () => moveFocus(-1),
+      Enter: () => openFocused(),
+      n: () => router.push("/new"),
+      d: () => onCreateDraft(),
+      i: () =>
+        router.push(
+          buildHref({
+            repo: activeRepo,
+            section: activeSection,
+            sort: activeSort,
+          }),
+        ),
+      p: () =>
+        router.push(
+          buildHref({
+            tab: "prs",
+            repo: activeRepo,
+            mine: mineOnly ? true : null,
+          }),
+        ),
+      "1": () =>
+        activeTab === "issues"
+          ? router.push(
+              buildHref({ repo: activeRepo, section: SECTIONS[0], sort: activeSort }),
+            )
+          : undefined,
+      "2": () =>
+        activeTab === "issues"
+          ? router.push(
+              buildHref({ repo: activeRepo, section: SECTIONS[1], sort: activeSort }),
+            )
+          : undefined,
+      "3": () =>
+        activeTab === "issues"
+          ? router.push(
+              buildHref({ repo: activeRepo, section: SECTIONS[2], sort: activeSort }),
+            )
+          : undefined,
+      "4": () =>
+        activeTab === "issues"
+          ? router.push(
+              buildHref({ repo: activeRepo, section: SECTIONS[3], sort: activeSort }),
+            )
+          : undefined,
+      "?": () => {
+        helpOpenRef.current = !helpOpenRef.current;
+        const overlay = document.getElementById("keyboard-help-overlay");
+        if (overlay) {
+          overlay.style.display = helpOpenRef.current ? "flex" : "none";
+        }
+      },
+      Escape: () => {
+        // Close help overlay if open
+        if (helpOpenRef.current) {
+          helpOpenRef.current = false;
+          const overlay = document.getElementById("keyboard-help-overlay");
+          if (overlay) overlay.style.display = "none";
+        }
+      },
+    }),
+    [
+      moveFocus,
+      openFocused,
+      router,
+      activeTab,
+      activeSection,
+      activeRepo,
+      activeSort,
+      mineOnly,
+      onCreateDraft,
+    ],
+  );
+
+  useKeyboardShortcuts(shortcuts);
+
+  // Reset focus when tab/section/repo changes
+  useEffect(() => {
+    focus?.setFocusedIndex(-1);
+  }, [activeTab, activeSection, activeRepo]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}

--- a/packages/web/components/list/ListKeyboardNav.tsx
+++ b/packages/web/components/list/ListKeyboardNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useEffect } from "react";
+import { useCallback, useMemo, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import type { Section, SortMode } from "@issuectl/core";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -36,7 +36,6 @@ export function ListKeyboardNav({
   const router = useRouter();
   const focus = useFocusContext();
   const counts = useListCounts();
-  const helpOpenRef = useRef(false);
 
   // Derive visible item count from the counts context
   const itemCount =
@@ -46,7 +45,7 @@ export function ListKeyboardNav({
 
   const moveFocus = useCallback(
     (delta: number) => {
-      if (!focus || itemCount === 0) return;
+      if (itemCount === 0) return;
       const { focusedIndex, setFocusedIndex } = focus;
       let next: number;
       if (focusedIndex < 0) {
@@ -67,13 +66,14 @@ export function ListKeyboardNav({
   );
 
   const openFocused = useCallback(() => {
-    if (!focus || focus.focusedIndex < 0) return;
+    if (focus.focusedIndex < 0) return;
     const row = document.querySelector(
       `[data-row-index="${focus.focusedIndex}"]`,
     );
-    const link = row?.querySelector("a[href]") as HTMLAnchorElement | null;
-    if (link) {
-      router.push(link.href);
+    const link = row?.querySelector("a[href]");
+    const href = link?.getAttribute("href");
+    if (href) {
+      router.push(href);
     }
   }, [focus, router]);
 
@@ -125,18 +125,16 @@ export function ListKeyboardNav({
             )
           : undefined,
       "?": () => {
-        helpOpenRef.current = !helpOpenRef.current;
         const overlay = document.getElementById("keyboard-help-overlay");
         if (overlay) {
-          overlay.style.display = helpOpenRef.current ? "flex" : "none";
+          const isVisible = overlay.style.display !== "none";
+          overlay.style.display = isVisible ? "none" : "flex";
         }
       },
       Escape: () => {
-        // Close help overlay if open
-        if (helpOpenRef.current) {
-          helpOpenRef.current = false;
-          const overlay = document.getElementById("keyboard-help-overlay");
-          if (overlay) overlay.style.display = "none";
+        const overlay = document.getElementById("keyboard-help-overlay");
+        if (overlay && overlay.style.display !== "none") {
+          overlay.style.display = "none";
         }
       },
     }),
@@ -157,8 +155,8 @@ export function ListKeyboardNav({
 
   // Reset focus when tab/section/repo changes
   useEffect(() => {
-    focus?.setFocusedIndex(-1);
-  }, [activeTab, activeSection, activeRepo]); // eslint-disable-line react-hooks/exhaustive-deps
+    focus.setFocusedIndex(-1);
+  }, [activeTab, activeSection, activeRepo]); // focus intentionally omitted — including it causes infinite loop
 
   return null;
 }

--- a/packages/web/components/list/ListRow.module.css
+++ b/packages/web/components/list/ListRow.module.css
@@ -15,6 +15,12 @@
   background: var(--paper-bg-warm);
 }
 
+.item.focused {
+  background: var(--paper-bg-warm);
+  border-left: 3px solid var(--paper-accent);
+  padding-left: 0;
+}
+
 .item:active {
   background: var(--paper-bg-warmer);
 }

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -1,12 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import type { UnifiedListItem } from "@issuectl/core";
 import { Chip, LabelChip } from "@/components/paper";
 import { SyncDot } from "@/components/ui/SyncDot";
+import { useFocusContext } from "./FocusContext";
 import { SwipeRow } from "./SwipeRow";
 import styles from "./ListRow.module.css";
 
 type Props = {
   item: UnifiedListItem;
+  rowIndex?: number;
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
   onClose?: (owner: string, repo: string, issueNumber: number) => void;
 };
@@ -28,10 +32,16 @@ function formatAge(updatedAt: string | number): string {
   return `${diffDays}d`;
 }
 
-export function ListRow({ item, onLaunch, onClose }: Props) {
+export function ListRow({ item, rowIndex, onLaunch, onClose }: Props) {
+  const focus = useFocusContext();
+  const isFocused = rowIndex !== undefined && focus?.focusedIndex === rowIndex;
+
   if (item.kind === "draft") {
     return (
-      <div className={styles.item}>
+      <div
+        className={`${styles.item}${isFocused ? ` ${styles.focused}` : ""}`}
+        data-row-index={rowIndex}
+      >
         <Link href={`/drafts/${item.draft.id}`} className={styles.rowLink}>
           <div className={styles.title}>{item.draft.title}</div>
           <div className={styles.meta}>
@@ -81,7 +91,11 @@ export function ListRow({ item, onLaunch, onClose }: Props) {
   }
 
   const rowContent = (
-    <div className={styles.item} data-section={section}>
+    <div
+      className={`${styles.item}${isFocused ? ` ${styles.focused}` : ""}`}
+      data-section={section}
+      data-row-index={rowIndex}
+    >
       <Link
         href={`/issues/${repo.owner}/${repo.name}/${issue.number}`}
         className={styles.rowLink}

--- a/packages/web/components/list/ListRow.tsx
+++ b/packages/web/components/list/ListRow.tsx
@@ -34,7 +34,7 @@ function formatAge(updatedAt: string | number): string {
 
 export function ListRow({ item, rowIndex, onLaunch, onClose }: Props) {
   const focus = useFocusContext();
-  const isFocused = rowIndex !== undefined && focus?.focusedIndex === rowIndex;
+  const isFocused = rowIndex !== undefined && focus.focusedIndex === rowIndex;
 
   if (item.kind === "draft") {
     return (

--- a/packages/web/components/list/ListSection.tsx
+++ b/packages/web/components/list/ListSection.tsx
@@ -6,11 +6,12 @@ import styles from "./ListSection.module.css";
 type Props = {
   title: ReactNode | null;
   items: UnifiedListItem[];
+  startIndex?: number;
   onLaunch?: (owner: string, repo: string, issueNumber: number) => void;
   onClose?: (owner: string, repo: string, issueNumber: number) => void;
 };
 
-export function ListSection({ title, items, onLaunch, onClose }: Props) {
+export function ListSection({ title, items, startIndex = 0, onLaunch, onClose }: Props) {
   if (items.length === 0) return null;
 
   return (
@@ -22,7 +23,7 @@ export function ListSection({ title, items, onLaunch, onClose }: Props) {
           <span className={styles.count}>{items.length}</span>
         </div>
       ) : null}
-      {items.map((item) => (
+      {items.map((item, i) => (
         <ListRow
           key={
             item.kind === "draft"
@@ -30,6 +31,7 @@ export function ListSection({ title, items, onLaunch, onClose }: Props) {
               : `issue-${item.repo.id}-${item.issue.number}`
           }
           item={item}
+          rowIndex={startIndex + i}
           onLaunch={onLaunch}
           onClose={onClose}
         />

--- a/packages/web/components/list/PrListRow.module.css
+++ b/packages/web/components/list/PrListRow.module.css
@@ -8,6 +8,11 @@
   background: var(--paper-bg-warm);
 }
 
+.item.focused {
+  background: var(--paper-bg-warm);
+  border-left: 3px solid var(--paper-accent);
+}
+
 .rowLink {
   flex: 1;
   padding: 16px 24px 16px 58px;

--- a/packages/web/components/list/PrListRow.tsx
+++ b/packages/web/components/list/PrListRow.tsx
@@ -36,7 +36,7 @@ function getStatusDot(pull: PullWithChecksStatus): StatusDotVariant {
 
 export function PrListRow({ owner, repoName, pull, rowIndex }: Props) {
   const focus = useFocusContext();
-  const isFocused = rowIndex !== undefined && focus?.focusedIndex === rowIndex;
+  const isFocused = rowIndex !== undefined && focus.focusedIndex === rowIndex;
   const dot = getStatusDot(pull);
   const href = `/pulls/${owner}/${repoName}/${pull.number}`;
 

--- a/packages/web/components/list/PrListRow.tsx
+++ b/packages/web/components/list/PrListRow.tsx
@@ -1,12 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import type { PullWithChecksStatus } from "@issuectl/core";
 import { Chip } from "@/components/paper";
+import { useFocusContext } from "./FocusContext";
 import styles from "./PrListRow.module.css";
 
 type Props = {
   owner: string;
   repoName: string;
   pull: PullWithChecksStatus;
+  rowIndex?: number;
 };
 
 function formatAge(updatedAt: string): string {
@@ -30,12 +34,17 @@ function getStatusDot(pull: PullWithChecksStatus): StatusDotVariant {
   return "none";
 }
 
-export function PrListRow({ owner, repoName, pull }: Props) {
+export function PrListRow({ owner, repoName, pull, rowIndex }: Props) {
+  const focus = useFocusContext();
+  const isFocused = rowIndex !== undefined && focus?.focusedIndex === rowIndex;
   const dot = getStatusDot(pull);
   const href = `/pulls/${owner}/${repoName}/${pull.number}`;
 
   return (
-    <div className={styles.item}>
+    <div
+      className={`${styles.item}${isFocused ? ` ${styles.focused}` : ""}`}
+      data-row-index={rowIndex}
+    >
       <Link href={href} className={styles.rowLink}>
         <span className={`${styles.dot} ${styles[dot]}`} aria-hidden />
         <div className={styles.title}>{pull.title}</div>

--- a/packages/web/components/list/SearchBar.module.css
+++ b/packages/web/components/list/SearchBar.module.css
@@ -1,0 +1,107 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+/* ── Search icon (inline SVG) ── */
+.icon {
+  color: var(--paper-ink-muted);
+  flex-shrink: 0;
+}
+
+/* ── Mobile: show only the icon toggle button ── */
+.mobileToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  background: transparent;
+  border: none;
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobileToggle:hover {
+  color: var(--paper-ink);
+}
+
+/* ── Input container ── */
+.inputWrap {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg);
+  padding: 0 8px;
+  height: 32px;
+}
+
+.inputWrap .icon {
+  flex-shrink: 0;
+}
+
+.input {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--paper-mono);
+  font-size: 12px;
+  color: var(--paper-ink);
+  width: 100%;
+  min-width: 0;
+}
+
+.input::placeholder {
+  color: var(--paper-ink-faint);
+  font-style: italic;
+}
+
+/* ── Clear button ── */
+.clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: transparent;
+  border: none;
+  color: var(--paper-ink-muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+  border-radius: var(--paper-radius-sm);
+}
+
+.clear:hover {
+  color: var(--paper-ink);
+  background: var(--paper-bg-warm);
+}
+
+/* ── Mobile expanded state ── */
+.expanded .mobileToggle {
+  display: none;
+}
+
+.expanded .inputWrap {
+  display: flex;
+  width: 100%;
+}
+
+/* ── Desktop: always show input, hide mobile toggle ── */
+@media (min-width: 768px) {
+  .mobileToggle {
+    display: none;
+  }
+
+  .inputWrap {
+    display: flex;
+    width: 240px;
+  }
+}

--- a/packages/web/components/list/SearchBar.tsx
+++ b/packages/web/components/list/SearchBar.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useSearch } from "./SearchContext";
+import styles from "./SearchBar.module.css";
+
+const DEBOUNCE_MS = 200;
+
+export function SearchBar() {
+  const { query, setQuery } = useSearch();
+  const [localValue, setLocalValue] = useState(query);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  // Sync local value when external query changes (e.g. cleared elsewhere)
+  useEffect(() => {
+    setLocalValue(query);
+  }, [query]);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      setLocalValue(value);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setQuery(value);
+      }, DEBOUNCE_MS);
+    },
+    [setQuery],
+  );
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setLocalValue("");
+    setQuery("");
+    inputRef.current?.focus();
+  }, [setQuery]);
+
+  const handleMobileToggle = useCallback(() => {
+    setExpanded(true);
+    // Focus after the next paint so the input is visible
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    // Collapse mobile search if empty
+    if (localValue === "") {
+      setExpanded(false);
+    }
+  }, [localValue]);
+
+  return (
+    <div
+      className={`${styles.wrapper} ${expanded ? styles.expanded : ""}`}
+    >
+      {/* Mobile: icon-only trigger */}
+      <button
+        type="button"
+        className={styles.mobileToggle}
+        onClick={handleMobileToggle}
+        aria-label="Open search"
+      >
+        <SearchIcon />
+      </button>
+
+      {/* Desktop: always visible / Mobile: visible when expanded */}
+      <div className={styles.inputWrap}>
+        <SearchIcon />
+        <input
+          ref={inputRef}
+          type="text"
+          className={styles.input}
+          value={localValue}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="search..."
+          aria-label="Search issues, PRs, and drafts"
+        />
+        {localValue && (
+          <button
+            type="button"
+            className={styles.clear}
+            onClick={handleClear}
+            aria-label="Clear search"
+          >
+            &times;
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      className={styles.icon}
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="5.5"
+        cy="5.5"
+        r="4"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <path
+        d="M9 9l3.5 3.5"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/packages/web/components/list/SearchContext.tsx
+++ b/packages/web/components/list/SearchContext.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+type SearchContextValue = {
+  query: string;
+  setQuery: (q: string) => void;
+};
+
+const SearchContext = createContext<SearchContextValue | null>(null);
+
+export function SearchProvider({ children }: { children: ReactNode }) {
+  const [query, setQuery] = useState("");
+  return (
+    <SearchContext.Provider value={{ query, setQuery }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function useSearch(): SearchContextValue {
+  const ctx = useContext(SearchContext);
+  if (!ctx) {
+    throw new Error("useSearch must be used within a SearchProvider");
+  }
+  return ctx;
+}

--- a/packages/web/components/ui/KeyboardHelpOverlay.module.css
+++ b/packages/web/components/ui/KeyboardHelpOverlay.module.css
@@ -1,0 +1,93 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.panel {
+  background: var(--paper-bg);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 28px 32px 24px;
+  max-width: 380px;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+
+.title {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--paper-ink);
+  margin-bottom: 20px;
+  letter-spacing: -0.3px;
+}
+
+.section {
+  margin-bottom: 16px;
+}
+
+.sectionTitle {
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--paper-ink-muted);
+  margin-bottom: 8px;
+  text-transform: lowercase;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.key {
+  display: inline-block;
+  min-width: 44px;
+  text-align: center;
+  padding: 3px 8px;
+  font-family: var(--paper-mono);
+  font-size: 12px;
+  color: var(--paper-ink);
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.desc {
+  font-family: var(--paper-serif);
+  font-size: 14px;
+  color: var(--paper-ink-soft);
+}
+
+.hint {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--paper-line);
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-size: 12px;
+  color: var(--paper-ink-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.hint .key {
+  min-width: 0;
+  padding: 2px 6px;
+  font-size: 11px;
+}

--- a/packages/web/components/ui/KeyboardHelpOverlay.tsx
+++ b/packages/web/components/ui/KeyboardHelpOverlay.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import styles from "./KeyboardHelpOverlay.module.css";
+
+const LIST_SHORTCUTS = [
+  { key: "j / k", desc: "Move focus down / up" },
+  { key: "Enter", desc: "Open focused item" },
+  { key: "n", desc: "New issue" },
+  { key: "d", desc: "Create draft" },
+  { key: "i", desc: "Switch to Issues tab" },
+  { key: "p", desc: "Switch to PRs tab" },
+  { key: "1-4", desc: "Switch section (issues tab)" },
+];
+
+const DETAIL_SHORTCUTS = [
+  { key: "Esc", desc: "Go back to list" },
+  { key: "l", desc: "Launch issue" },
+  { key: "m", desc: "Merge PR" },
+];
+
+const GLOBAL_SHORTCUTS = [
+  { key: "?", desc: "Toggle this help" },
+];
+
+/**
+ * Keyboard shortcut help overlay. Hidden by default; toggled via the `?` key.
+ * Uses a plain DOM id so ListKeyboardNav can toggle display without React state.
+ */
+export function KeyboardHelpOverlay() {
+  return (
+    <div
+      id="keyboard-help-overlay"
+      className={styles.overlay}
+      style={{ display: "none" }}
+      onClick={(e) => {
+        // Close when clicking the backdrop
+        if (e.target === e.currentTarget) {
+          (e.currentTarget as HTMLElement).style.display = "none";
+        }
+      }}
+    >
+      <div className={styles.panel}>
+        <h2 className={styles.title}>keyboard shortcuts</h2>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>list view</h3>
+          {LIST_SHORTCUTS.map((s) => (
+            <div key={s.key} className={styles.row}>
+              <kbd className={styles.key}>{s.key}</kbd>
+              <span className={styles.desc}>{s.desc}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>detail view</h3>
+          {DETAIL_SHORTCUTS.map((s) => (
+            <div key={s.key} className={styles.row}>
+              <kbd className={styles.key}>{s.key}</kbd>
+              <span className={styles.desc}>{s.desc}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>global</h3>
+          {GLOBAL_SHORTCUTS.map((s) => (
+            <div key={s.key} className={styles.row}>
+              <kbd className={styles.key}>{s.key}</kbd>
+              <span className={styles.desc}>{s.desc}</span>
+            </div>
+          ))}
+        </div>
+
+        <p className={styles.hint}>
+          press <kbd className={styles.key}>?</kbd> or <kbd className={styles.key}>Esc</kbd> to close
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/ui/KeyboardHelpOverlay.tsx
+++ b/packages/web/components/ui/KeyboardHelpOverlay.tsx
@@ -24,7 +24,8 @@ const GLOBAL_SHORTCUTS = [
 
 /**
  * Keyboard shortcut help overlay. Hidden by default; toggled via the `?` key.
- * Uses a plain DOM id so ListKeyboardNav can toggle display without React state.
+ * Uses a plain DOM id so keyboard nav components (ListKeyboardNav and
+ * DetailKeyboardNav) can toggle display without React state.
  */
 export function KeyboardHelpOverlay() {
   return (

--- a/packages/web/hooks/useKeyboardShortcuts.ts
+++ b/packages/web/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+
+type ShortcutMap = Record<string, () => void>;
+
+/**
+ * Registers global keydown listeners for keyboard shortcuts.
+ * Ignores keystrokes when focus is in an input, textarea, select, or
+ * contenteditable element — except for Escape, which always fires.
+ * Cleans up on unmount.
+ */
+export function useKeyboardShortcuts(shortcuts: ShortcutMap) {
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      // Escape always fires, regardless of focus
+      if (e.key === "Escape") {
+        const fn = shortcuts["Escape"];
+        if (fn) {
+          e.preventDefault();
+          fn();
+        }
+        return;
+      }
+
+      // Ignore when typing in form elements
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+
+      // Ignore when modifier keys are held (Ctrl/Cmd/Alt)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const fn = shortcuts[e.key];
+      if (fn) {
+        e.preventDefault();
+        fn();
+      }
+    }
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [shortcuts]);
+}

--- a/packages/web/hooks/useKeyboardShortcuts.ts
+++ b/packages/web/hooks/useKeyboardShortcuts.ts
@@ -18,7 +18,9 @@ export function useKeyboardShortcuts(shortcuts: ShortcutMap) {
         const fn = shortcuts["Escape"];
         if (fn) {
           e.preventDefault();
-          fn();
+          try { fn(); } catch (err) {
+            console.error(`[issuectl] Keyboard shortcut "Escape" handler failed:`, err);
+          }
         }
         return;
       }
@@ -43,7 +45,9 @@ export function useKeyboardShortcuts(shortcuts: ShortcutMap) {
       const fn = shortcuts[e.key];
       if (fn) {
         e.preventDefault();
-        fn();
+        try { fn(); } catch (err) {
+          console.error(`[issuectl] Keyboard shortcut "${e.key}" handler failed:`, err);
+        }
       }
     }
 

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -6,7 +6,9 @@ import {
   clearCacheKey,
   withAuthRetry,
   formatErrorForUser,
+  createReview,
 } from "@issuectl/core";
+import type { ReviewEvent } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
 
 export async function mergePullAction(
@@ -61,6 +63,56 @@ export async function mergePullAction(
   const { stale } = revalidateSafely(
     `/pulls/${owner}/${repo}/${pullNumber}`,
     "/",
+  );
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+export async function submitReviewAction(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  event: ReviewEvent,
+  body?: string,
+): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
+  if (typeof owner !== "string" || owner.trim().length === 0) {
+    return { success: false, error: "Invalid owner" };
+  }
+  if (typeof repo !== "string" || repo.trim().length === 0) {
+    return { success: false, error: "Invalid repo" };
+  }
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    return { success: false, error: "Invalid pull request number" };
+  }
+  const VALID_EVENTS = ["APPROVE", "REQUEST_CHANGES", "COMMENT"] as const;
+  if (!(VALID_EVENTS as readonly string[]).includes(event)) {
+    return { success: false, error: "Invalid review event" };
+  }
+  if (body !== undefined && typeof body !== "string") {
+    return { success: false, error: "Invalid review body" };
+  }
+
+  try {
+    const db = getDb();
+    const tracked = getRepo(db, owner, repo);
+    if (!tracked) {
+      return { success: false, error: "Repository is not tracked" };
+    }
+
+    await withAuthRetry((octokit) =>
+      createReview(octokit, owner, repo, pullNumber, event, body),
+    );
+    clearCacheKey(db, `pull-detail:${owner}/${repo}#${pullNumber}`);
+  } catch (err) {
+    console.error(
+      "[issuectl] submitReviewAction failed",
+      { owner, repo, pullNumber, event },
+      err,
+    );
+    return { success: false, error: formatErrorForUser(err) };
+  }
+
+  const { stale } = revalidateSafely(
+    `/pulls/${owner}/${repo}/${pullNumber}`,
   );
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }

--- a/packages/web/lib/actions/pulls.ts
+++ b/packages/web/lib/actions/pulls.ts
@@ -90,6 +90,9 @@ export async function submitReviewAction(
   if (body !== undefined && typeof body !== "string") {
     return { success: false, error: "Invalid review body" };
   }
+  if (event === "REQUEST_CHANGES" && (!body || body.trim().length === 0)) {
+    return { success: false, error: "Body is required when requesting changes" };
+  }
 
   try {
     const db = getDb();
@@ -113,6 +116,7 @@ export async function submitReviewAction(
 
   const { stale } = revalidateSafely(
     `/pulls/${owner}/${repo}/${pullNumber}`,
+    "/",
   );
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }


### PR DESCRIPTION
## Summary

Implements the remaining 4 feature issues from the pre-Phase 3 backlog:

- **#311 — Global search**: Client-side search bar in the dashboard that filters issues, PRs, and drafts by title, body, and labels. Uses a SearchContext provider with 200ms debounced input.
- **#314 — PR review panel**: Displays existing reviews on PR detail pages with state badges and a submission form (approve/request changes/comment) backed by a new `submitReviewAction` server action.
- **#315 — Per-file diff view**: Expandable file rows in the files changed section showing unified diff with color-coded added/removed/hunk lines. Added `patch` field to `GitHubPullFile` type in core.
- **#320 — Keyboard shortcuts**: `j`/`k` navigation, `Enter` to open, `n`/`d` for new items, `1-4` section switching, `i`/`p` tab switching, `Escape` to go back, `l`/`m` for launch/merge, `?` for help overlay.

## Changes

- 28 files changed (+1,499/-31)
- New components: SearchBar, SearchContext, ReviewPanel, FocusContext, ListKeyboardNav, DetailKeyboardNav, KeyboardHelpOverlay, useKeyboardShortcuts hook
- Core: added `patch?: string` to GitHubPullFile, updated listPullFiles mapper
- Server action: added submitReviewAction with full validation including REQUEST_CHANGES body requirement
- Converted FilesChanged and ListRow/PrListRow to client components for interactivity

## Review fixes applied

- Fixed helpOpenRef desync bug (read DOM state instead of tracking with ref)
- Added root path revalidation to submitReviewAction
- Validated REQUEST_CHANGES requires non-empty body
- Wrapped keyboard shortcut handlers in try-catch
- Used getAttribute("href") for relative path safety
- Made useFocusContext throw when outside FocusProvider

## Test plan

- [ ] Dashboard search: type in search bar, verify issues/PRs/drafts filter by title/body/labels
- [ ] Search clear: click × or delete text, verify full list returns
- [ ] PR reviews: open a PR detail page, verify reviews section shows existing reviews
- [ ] Review submission: submit an approval on an open PR, verify it appears
- [ ] Per-file diff: click a file row on PR detail, verify diff expands with color coding
- [ ] Keyboard j/k: press j/k on dashboard, verify row focus moves with highlight
- [ ] Keyboard Enter: focus a row and press Enter, verify navigation to detail
- [ ] Keyboard ?: press ? to open help overlay, press ? or Esc to close
- [ ] Keyboard Escape: on detail page, press Escape to navigate back
- [ ] Backdrop close then ?: click backdrop to close help, press ? once to reopen (desync fix)

Closes #311, #314, #315, #320