### PR TITLE
refactor(ios): extract shared list infrastructure (#290)

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
+		0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */; };
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
@@ -17,6 +18,7 @@
 		327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D2FEDC36ACDF7207272AE3 /* ParseView.swift */; };
 		332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
 		34F18449E8DBA4A039C94A44 /* APIClient+Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */; };
+		3719E03E98785A8075A6F871 /* ErrorAutoDismissModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458A6E2819377536E7EDF138 /* ErrorAutoDismissModifier.swift */; };
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
 		42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */; };
 		435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3403F8C644518F599E01A976 /* ReassignSheet.swift */; };
@@ -30,6 +32,7 @@
 		57F286E2B3615BA000C1987C /* EdgeCaseModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CF16B90E6F234095B67412 /* EdgeCaseModelTests.swift */; };
 		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
 		59D20056C3E281403735631D /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7701223E13D43C4F74244B0 /* Repo.swift */; };
+		5AA1967A4E7CC1D191C872DF /* LoadMoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4497D324AB6CE09260737497 /* LoadMoreButton.swift */; };
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
 		62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */; };
 		65142BB24364562CB5305E0F /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472896A74FFDCC9B621A984E /* PRListView.swift */; };
@@ -109,7 +112,10 @@
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		3F39642CB180355E5C62A75E /* ImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightbox.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
+		41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoFilterHelpers.swift; sourceTree = "<group>"; };
 		4403330B1342AA7C19FA797D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		4497D324AB6CE09260737497 /* LoadMoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMoreButton.swift; sourceTree = "<group>"; };
+		458A6E2819377536E7EDF138 /* ErrorAutoDismissModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAutoDismissModifier.swift; sourceTree = "<group>"; };
 		45D2FEDC36ACDF7207272AE3 /* ParseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseView.swift; sourceTree = "<group>"; };
 		472896A74FFDCC9B621A984E /* PRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentSheet.swift; sourceTree = "<group>"; };
@@ -344,11 +350,13 @@
 			children = (
 				2841D89323711B68449BB980 /* CacheAgeLabel.swift */,
 				4403330B1342AA7C19FA797D /* Constants.swift */,
+				458A6E2819377536E7EDF138 /* ErrorAutoDismissModifier.swift */,
 				894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */,
 				3F39642CB180355E5C62A75E /* ImageLightbox.swift */,
 				CCED89BF4650BDFC4262B48D /* InteractivePopDisabler.swift */,
 				FE149A3F324BCC15AB57153E /* LabelPicker.swift */,
 				C1EDD5BE2AB56ED93A092C0C /* MarkdownView.swift */,
+				4497D324AB6CE09260737497 /* LoadMoreButton.swift */,
 				F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */,
 				6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
@@ -361,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				736AD6AF28A44D0CEF44377B /* BranchNameHelper.swift */,
+				41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -527,6 +536,7 @@
 				9318F86221EE651B485C689D /* EditCommentSheet.swift in Sources */,
 				E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */,
 				8F6B1136F0F654026188BFF6 /* EditRepoSheet.swift in Sources */,
+				3719E03E98785A8075A6F871 /* ErrorAutoDismissModifier.swift in Sources */,
 				51D419285114BB9B1F7B6D5A /* GitHubAccessibleRepo.swift in Sources */,
 				1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */,
 				C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */,
@@ -543,6 +553,7 @@
 				D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */,
 				E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */,
 				C02C3F84D16B27F60A6622E0 /* MarkdownView.swift in Sources */,
+				5AA1967A4E7CC1D191C872DF /* LoadMoreButton.swift in Sources */,
 				2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */,
 				62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */,
 				8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */,
@@ -557,6 +568,7 @@
 				435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */,
 				59D20056C3E281403735631D /* Repo.swift in Sources */,
 				BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */,
+				0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */,
 				332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */,
 				49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */,
 				E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */,

--- a/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
+++ b/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Filter items from a [repoFullName: [Item]] dictionary by selected repos and current user.
+func filterItemsByRepo<Item>(
+    _ itemsByRepo: [String: [Item]],
+    repos: [Repo],
+    selectedRepoIds: Set<Int>,
+    mineOnly: Bool,
+    currentUserLogin: String?,
+    userLogin: (Item) -> String?
+) -> [Item] {
+    var items: [Item]
+    if selectedRepoIds.isEmpty {
+        items = itemsByRepo.values.flatMap { $0 }
+    } else {
+        let selectedNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
+        items = itemsByRepo
+            .filter { selectedNames.contains($0.key) }
+            .values.flatMap { $0 }
+    }
+    if mineOnly, let login = currentUserLogin {
+        items = items.filter { userLogin($0) == login }
+    }
+    return items
+}
+
+/// Look up the Repo that owns an item by matching its URL in the itemsByRepo dictionary.
+func repoForItem<Item>(
+    _ item: Item,
+    in itemsByRepo: [String: [Item]],
+    repos: [Repo],
+    htmlUrl: (Item) -> String
+) -> Repo? {
+    let url = htmlUrl(item)
+    for (repoFullName, items) in itemsByRepo {
+        if items.contains(where: { htmlUrl($0) == url }) {
+            return repos.first(where: { $0.fullName == repoFullName })
+        }
+    }
+    return nil
+}
+
+/// Look up the index of the Repo that owns an item (for color assignment).
+func repoIndexForItem<Item>(
+    _ item: Item,
+    in itemsByRepo: [String: [Item]],
+    repos: [Repo],
+    htmlUrl: (Item) -> String
+) -> Int? {
+    guard let repo = repoForItem(item, in: itemsByRepo, repos: repos, htmlUrl: htmlUrl) else {
+        return nil
+    }
+    return repos.firstIndex(where: { $0.id == repo.id })
+}

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -33,7 +33,6 @@ struct IssueListView: View {
     @State private var deleteDraftTarget: String?
 
     @State private var actionError: String?
-    @State private var errorDismissTask: Task<Void, Never>?
 
     // Priority data keyed by "owner/repo#number"
     @State private var priorities: [String: Priority] = [:]
@@ -45,10 +44,6 @@ struct IssueListView: View {
     @State private var searchText = ""
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
-
-    private var allIssues: [GitHubIssue] {
-        issuesByRepo.values.flatMap { $0 }
-    }
 
     // Maps repo full name to set of running issue numbers for that repo.
     // Keyed by repo to avoid cross-repo collisions (issue #5 in repo A vs repo B).
@@ -64,21 +59,15 @@ struct IssueListView: View {
         runningIssuesByRepo[repoFullName]?.contains(issue.number) ?? false
     }
 
-    // Issues filtered by selected repos and "mine" toggle (before section/sort filtering)
     private var repoFilteredIssues: [GitHubIssue] {
-        var items: [GitHubIssue]
-        if selectedRepoIds.isEmpty {
-            items = allIssues
-        } else {
-            let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
-            items = issuesByRepo
-                .filter { selectedRepoNames.contains($0.key) }
-                .values.flatMap { $0 }
-        }
-        if mineOnly, let login = currentUserLogin {
-            items = items.filter { $0.user?.login == login }
-        }
-        return items
+        filterItemsByRepo(
+            issuesByRepo,
+            repos: repos,
+            selectedRepoIds: selectedRepoIds,
+            mineOnly: mineOnly,
+            currentUserLogin: currentUserLogin,
+            userLogin: { $0.user?.login }
+        )
     }
 
     private var filteredIssues: [GitHubIssue] {
@@ -157,21 +146,11 @@ struct IssueListView: View {
     }
 
     private func repoIndex(for issue: GitHubIssue) -> Int? {
-        for (repoFullName, issues) in issuesByRepo {
-            if issues.contains(where: { $0.htmlUrl == issue.htmlUrl }) {
-                return repos.firstIndex(where: { $0.fullName == repoFullName })
-            }
-        }
-        return nil
+        repoIndexForItem(issue, in: issuesByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
     }
 
     private func repoFor(issue: GitHubIssue) -> Repo? {
-        for (repoFullName, issues) in issuesByRepo {
-            if issues.contains(where: { $0.htmlUrl == issue.htmlUrl }) {
-                return repos.first(where: { $0.fullName == repoFullName })
-            }
-        }
-        return nil
+        repoForItem(issue, in: issuesByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
     }
 
     var body: some View {
@@ -308,17 +287,7 @@ struct IssueListView: View {
                     }
                 }
             }
-            .onChange(of: actionError) { _, newValue in
-                errorDismissTask?.cancel()
-                if newValue != nil {
-                    errorDismissTask = Task {
-                        try? await Task.sleep(for: .seconds(5))
-                        if !Task.isCancelled {
-                            actionError = nil
-                        }
-                    }
-                }
-            }
+            .autoDismissError($actionError)
             .task { await loadAll() }
             .onAppear {
                 if let s = IssueSection(rawValue: storedSection) { section = s }
@@ -408,15 +377,7 @@ struct IssueListView: View {
                 }
             }
 
-            if allFiltered.count > displayLimit {
-                Button {
-                    displayLimit += pageSize
-                } label: {
-                    Text("Load More (\(allFiltered.count - displayLimit) remaining)")
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity)
-                }
-            }
+            LoadMoreButton(totalCount: allFiltered.count, displayLimit: $displayLimit, pageSize: pageSize)
         }
         .refreshable { await refreshWithCooldown() }
     }
@@ -424,11 +385,15 @@ struct IssueListView: View {
     @ViewBuilder
     private var draftsList: some View {
         if filteredDrafts.isEmpty {
-            ContentUnavailableView(
-                "No Drafts",
-                systemImage: "doc.text",
-                description: Text("Tap + to create a draft.")
-            )
+            ScrollView {
+                ContentUnavailableView(
+                    "No Drafts",
+                    systemImage: "doc.text",
+                    description: Text("Tap + to create a draft.")
+                )
+                .frame(maxHeight: .infinity)
+            }
+            .refreshable { await refreshWithCooldown() }
         } else {
             List {
                 ForEach(filteredDrafts) { draft in

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -21,7 +21,6 @@ struct PRListView: View {
     @State private var showMergeConfirm = false
     @State private var swipeTarget: (owner: String, repo: String, number: Int)?
     @State private var actionError: String?
-    @State private var errorDismissTask: Task<Void, Never>?
 
     @State private var oldestCachedAt: Date?
     private let pageSize = 15
@@ -30,25 +29,15 @@ struct PRListView: View {
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
-    private var allPulls: [GitHubPull] {
-        pullsByRepo.values.flatMap { $0 }
-    }
-
-    // Pulls filtered by selected repos and "mine" toggle (before section/sort filtering)
     private var repoFilteredPulls: [GitHubPull] {
-        var items: [GitHubPull]
-        if selectedRepoIds.isEmpty {
-            items = allPulls
-        } else {
-            let selectedRepoNames = Set(repos.filter { selectedRepoIds.contains($0.id) }.map(\.fullName))
-            items = pullsByRepo
-                .filter { selectedRepoNames.contains($0.key) }
-                .values.flatMap { $0 }
-        }
-        if mineOnly, let login = currentUserLogin {
-            items = items.filter { $0.user?.login == login }
-        }
-        return items
+        filterItemsByRepo(
+            pullsByRepo,
+            repos: repos,
+            selectedRepoIds: selectedRepoIds,
+            mineOnly: mineOnly,
+            currentUserLogin: currentUserLogin,
+            userLogin: { $0.user?.login }
+        )
     }
 
     private var filteredPulls: [GitHubPull] {
@@ -86,21 +75,11 @@ struct PRListView: View {
     }
 
     private func repoIndex(for pull: GitHubPull) -> Int? {
-        for (repoFullName, pulls) in pullsByRepo {
-            if pulls.contains(where: { $0.htmlUrl == pull.htmlUrl }) {
-                return repos.firstIndex(where: { $0.fullName == repoFullName })
-            }
-        }
-        return nil
+        repoIndexForItem(pull, in: pullsByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
     }
 
     private func repoFor(pull: GitHubPull) -> Repo? {
-        for (repoFullName, pulls) in pullsByRepo {
-            if pulls.contains(where: { $0.htmlUrl == pull.htmlUrl }) {
-                return repos.first(where: { $0.fullName == repoFullName })
-            }
-        }
-        return nil
+        repoForItem(pull, in: pullsByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
     }
 
     var body: some View {
@@ -129,19 +108,27 @@ struct PRListView: View {
                         ProgressView("Loading pull requests...")
                             .frame(maxHeight: .infinity)
                     } else if let errorMessage {
-                        ContentUnavailableView {
-                            Label("Error", systemImage: "exclamationmark.triangle")
-                        } description: {
-                            Text(errorMessage)
-                        } actions: {
-                            Button("Retry") { Task { await loadAll() } }
+                        ScrollView {
+                            ContentUnavailableView {
+                                Label("Error", systemImage: "exclamationmark.triangle")
+                            } description: {
+                                Text(errorMessage)
+                            } actions: {
+                                Button("Retry") { Task { await loadAll() } }
+                            }
+                            .frame(maxHeight: .infinity)
                         }
+                        .refreshable { await refreshWithCooldown() }
                     } else if filteredPulls.isEmpty {
-                        ContentUnavailableView(
-                            "No Pull Requests",
-                            systemImage: "arrow.triangle.merge",
-                            description: Text("No \(section.rawValue) pull requests.")
-                        )
+                        ScrollView {
+                            ContentUnavailableView(
+                                "No Pull Requests",
+                                systemImage: "arrow.triangle.merge",
+                                description: Text("No \(section.rawValue) pull requests.")
+                            )
+                            .frame(maxHeight: .infinity)
+                        }
+                        .refreshable { await refreshWithCooldown() }
                     } else {
                         pullsList
                     }
@@ -180,17 +167,7 @@ struct PRListView: View {
                     }
                 }
             }
-            .onChange(of: actionError) { _, newValue in
-                errorDismissTask?.cancel()
-                if newValue != nil {
-                    errorDismissTask = Task {
-                        try? await Task.sleep(for: .seconds(5))
-                        if !Task.isCancelled {
-                            actionError = nil
-                        }
-                    }
-                }
-            }
+            .autoDismissError($actionError)
             .task { await loadAll() }
             .onAppear {
                 if let s = PRSection(rawValue: storedSection) { section = s }
@@ -256,15 +233,7 @@ struct PRListView: View {
                 }
             }
 
-            if allFiltered.count > displayLimit {
-                Button {
-                    displayLimit += pageSize
-                } label: {
-                    Text("Load More (\(allFiltered.count - displayLimit) remaining)")
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity)
-                }
-            }
+            LoadMoreButton(totalCount: allFiltered.count, displayLimit: $displayLimit, pageSize: pageSize)
         }
         .refreshable { await refreshWithCooldown() }
     }
@@ -349,7 +318,7 @@ struct PRListView: View {
     }
 
     private func refreshWithCooldown() async {
-        if let last = lastRefreshDate, Date().timeIntervalSince(last) < refreshCooldown {
+        guard shouldAllowRefresh(lastRefreshDate: lastRefreshDate, cooldown: refreshCooldown) else {
             return
         }
         lastRefreshDate = Date()

--- a/ios/IssueCTL/Views/Shared/ErrorAutoDismissModifier.swift
+++ b/ios/IssueCTL/Views/Shared/ErrorAutoDismissModifier.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ErrorAutoDismissModifier: ViewModifier {
+    @Binding var error: String?
+    var delay: Duration = .seconds(5)
+
+    @State private var dismissTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: error) { _, newValue in
+                dismissTask?.cancel()
+                if newValue != nil {
+                    dismissTask = Task {
+                        try? await Task.sleep(for: delay)
+                        if !Task.isCancelled {
+                            error = nil
+                        }
+                    }
+                }
+            }
+            .onDisappear {
+                dismissTask?.cancel()
+            }
+    }
+}
+
+extension View {
+    func autoDismissError(_ error: Binding<String?>, after delay: Duration = .seconds(5)) -> some View {
+        modifier(ErrorAutoDismissModifier(error: error, delay: delay))
+    }
+}

--- a/ios/IssueCTL/Views/Shared/LoadMoreButton.swift
+++ b/ios/IssueCTL/Views/Shared/LoadMoreButton.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct LoadMoreButton: View {
+    let totalCount: Int
+    @Binding var displayLimit: Int
+    let pageSize: Int
+
+    var body: some View {
+        if totalCount > displayLimit {
+            Button {
+                displayLimit += pageSize
+            } label: {
+                Text("Load More (\(totalCount - displayLimit) remaining)")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+}

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -158,4 +158,134 @@ final class ViewLogicTests: XCTestCase {
         // In this case "Load More" would not be shown
         XCTAssertTrue(displayLimit >= totalItems, "All items are now visible")
     }
+
+    // MARK: - Repo Filter Helpers
+
+    private struct FakeItem {
+        let htmlUrl: String
+        let userLogin: String?
+    }
+
+    private func makeRepos() -> [Repo] {
+        [
+            Repo(id: 1, owner: "org", name: "alpha", localPath: nil, branchPattern: nil, createdAt: ""),
+            Repo(id: 2, owner: "org", name: "beta", localPath: nil, branchPattern: nil, createdAt: ""),
+        ]
+    }
+
+    func testFilterItemsByRepoNoSelection() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: "alice")],
+            "org/beta": [FakeItem(htmlUrl: "b1", userLogin: "bob")],
+        ]
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [], mineOnly: false, currentUserLogin: nil, userLogin: { $0.userLogin })
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testFilterItemsByRepoWithSelection() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: "alice")],
+            "org/beta": [FakeItem(htmlUrl: "b1", userLogin: "bob")],
+        ]
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [1], mineOnly: false, currentUserLogin: nil, userLogin: { $0.userLogin })
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.htmlUrl, "a1")
+    }
+
+    func testFilterItemsByRepoMineOnly() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [
+                FakeItem(htmlUrl: "a1", userLogin: "alice"),
+                FakeItem(htmlUrl: "a2", userLogin: "bob"),
+            ],
+        ]
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [], mineOnly: true, currentUserLogin: "alice", userLogin: { $0.userLogin })
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.htmlUrl, "a1")
+    }
+
+    func testFilterItemsByRepoEmpty() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [:]
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [], mineOnly: false, currentUserLogin: nil, userLogin: { $0.userLogin })
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testRepoForItemFound() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: nil)],
+            "org/beta": [FakeItem(htmlUrl: "b1", userLogin: nil)],
+        ]
+        let target = FakeItem(htmlUrl: "b1", userLogin: nil)
+        let repo = repoForItem(target, in: items, repos: repos, htmlUrl: { $0.htmlUrl })
+        XCTAssertEqual(repo?.name, "beta")
+    }
+
+    func testRepoForItemNotFound() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: nil)],
+        ]
+        let target = FakeItem(htmlUrl: "missing", userLogin: nil)
+        let repo = repoForItem(target, in: items, repos: repos, htmlUrl: { $0.htmlUrl })
+        XCTAssertNil(repo)
+    }
+
+    func testRepoIndexForItemFound() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: nil)],
+            "org/beta": [FakeItem(htmlUrl: "b1", userLogin: nil)],
+        ]
+        let target = FakeItem(htmlUrl: "b1", userLogin: nil)
+        let idx = repoIndexForItem(target, in: items, repos: repos, htmlUrl: { $0.htmlUrl })
+        XCTAssertEqual(idx, 1)
+    }
+
+    func testRepoIndexForItemNotFound() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [:]
+        let target = FakeItem(htmlUrl: "nope", userLogin: nil)
+        let idx = repoIndexForItem(target, in: items, repos: repos, htmlUrl: { $0.htmlUrl })
+        XCTAssertNil(idx)
+    }
+
+    func testFilterItemsByRepoMineOnlyWithNilLogin() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: "alice")],
+        ]
+        // mineOnly is true but login is nil — filter is a no-op, all items returned
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [], mineOnly: true, currentUserLogin: nil, userLogin: { $0.userLogin })
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testFilterItemsByRepoSelectionAndMineOnly() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [
+                FakeItem(htmlUrl: "a1", userLogin: "alice"),
+                FakeItem(htmlUrl: "a2", userLogin: "bob"),
+            ],
+            "org/beta": [FakeItem(htmlUrl: "b1", userLogin: "alice")],
+        ]
+        // Select only repo 1 (alpha) AND filter to alice
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [1], mineOnly: true, currentUserLogin: "alice", userLogin: { $0.userLogin })
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.htmlUrl, "a1")
+    }
+
+    func testFilterItemsByRepoStaleSelectionId() {
+        let repos = makeRepos()
+        let items: [String: [FakeItem]] = [
+            "org/alpha": [FakeItem(htmlUrl: "a1", userLogin: nil)],
+        ]
+        // selectedRepoIds contains an ID not in repos — returns empty
+        let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [999], mineOnly: false, currentUserLogin: nil, userLogin: { $0.userLogin })
+        XCTAssertTrue(result.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- Extract 3 shared components from IssueListView (617→579 lines) and PRListView (349→317 lines) to eliminate ~265 lines of duplication
- **LoadMoreButton**: reusable pagination button view
- **ErrorAutoDismissModifier**: `.autoDismissError()` ViewModifier with proper onDisappear cleanup
- **RepoFilterHelpers**: generic `filterItemsByRepo`, `repoForItem`, `repoIndexForItem` functions
- Fix 4 bugs caused by copy-paste divergence: PRListView inlined refresh cooldown, missing ScrollView+refreshable on error/empty/drafts states
- Add 11 tests for RepoFilterHelpers (184 total tests passing)

Closes #290

## Test plan
- [x] `xcodebuildmcp simulator build` — clean build
- [x] `xcodebuildmcp simulator test` — 184/184 pass
- [x] PR review toolkit (6 agents) — 0 critical, 0 important findings
- [ ] Manual: verify Issues list pagination, pull-to-refresh on error/empty/drafts states, PR list merge swipe, "mine" filter