### PR TITLE
Fix iOS date parsing and offline issue actions

### DIFF
--- a/ios/IssueCTL/Models/Deployment.swift
+++ b/ios/IssueCTL/Models/Deployment.swift
@@ -32,7 +32,7 @@ struct Deployment: Codable, Identifiable, Sendable {
     var isActive: Bool { state == .active && endedAt == nil }
 
     var launchedDate: Date? {
-        sharedISO8601Formatter.date(from: launchedAt)
+        parseIssueCTLDate(launchedAt)
     }
 
     var runningDuration: String {
@@ -64,7 +64,7 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
     let repoName: String
 
     var launchedDate: Date? {
-        sharedISO8601Formatter.date(from: launchedAt)
+        parseIssueCTLDate(launchedAt)
     }
 
     var runningDuration: String {

--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -8,6 +8,17 @@ nonisolated(unsafe) let sharedISO8601Formatter: ISO8601DateFormatter = {
     return f
 }()
 
+nonisolated(unsafe) private let sharedISO8601FormatterWithoutFractionalSeconds: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+}()
+
+func parseIssueCTLDate(_ value: String) -> Date? {
+    sharedISO8601Formatter.date(from: value)
+        ?? sharedISO8601FormatterWithoutFractionalSeconds.date(from: value)
+}
+
 struct GitHubUser: Codable, Sendable {
     let login: String
     let avatarUrl: String
@@ -42,7 +53,7 @@ struct GitHubIssue: Codable, Identifiable, Sendable {
     var isOpen: Bool { state == "open" }
 
     var updatedDate: Date? {
-        sharedISO8601Formatter.date(from: updatedAt)
+        parseIssueCTLDate(updatedAt)
     }
 
     var timeAgo: String {

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -67,7 +67,7 @@ struct SessionListView: View {
                         port: port,
                         onEnd: {
                             terminalTarget = nil
-                            Task { await endSession(deployment) }
+                            deployments.removeAll { $0.id == deployment.id }
                         }
                     )
                 }

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -2,26 +2,22 @@
 
 import { useState, useEffect, useRef, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import type {
-  GitHubIssue,
-  GitHubComment,
-  Deployment,
-} from "@issuectl/core";
-import { Sheet, Button } from "@/components/paper";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import type { GitHubIssue, GitHubComment, Deployment } from "@issuectl/core";
 import { CloseIssueModal } from "@/components/ui/CloseIssueModal";
 import { BottomHandle } from "@/components/list/BottomHandle";
 import { LaunchModal } from "@/components/launch/LaunchModal";
+import { IssueActionsMenu } from "./IssueActionsMenu";
+import { IssueDesktopActions } from "./IssueDesktopActions";
+import { IssueReassignSheet } from "./IssueReassignSheet";
 import { closeIssue, reassignIssueAction } from "@/lib/actions/issues";
 import { endSession } from "@/lib/actions/launch";
 import { getComments } from "@/lib/actions/comments";
 import { listReposAction } from "@/lib/actions/drafts";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
+import { tryOrQueue } from "@/lib/tryOrQueue";
 import { useOfflineAware } from "@/hooks/useOfflineAware";
 import { useStaleTab } from "@/hooks/useStaleTab";
-import styles from "./ActionSheet.module.css";
-import assignStyles from "../list/AssignSheet.module.css";
 
 type Repo = { id: number; owner: string; name: string };
 
@@ -57,7 +53,6 @@ export function IssueActionSheet({
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  // Re-assign state
   const [reassignSheetOpen, setReassignSheetOpen] = useState(false);
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loadingRepos, setLoadingRepos] = useState(false);
@@ -139,7 +134,7 @@ export function IssueActionSheet({
       try {
         // End active terminal session before closing the issue
         const liveDeployment = deployments.find((d) => d.endedAt === null);
-        if (liveDeployment) {
+        if (liveDeployment && !isOffline) {
           const endResult = await endSession(liveDeployment.id, owner, repo, number);
           if (!endResult.success) {
             console.warn(
@@ -152,14 +147,25 @@ export function IssueActionSheet({
             );
           }
         }
-        const result = await closeIssue(owner, repo, number, comment || undefined);
-        if (!result.success) {
+        const result = await tryOrQueue(
+          "closeIssue",
+          { owner, repo, issueNumber: number, comment: comment || undefined },
+          () => closeIssue(owner, repo, number, comment || undefined),
+        );
+        if (result.outcome === "queued") {
+          setConfirmClose(false);
+          showToast("Issue close queued — will sync when online", "warning");
+          router.replace("/");
+          return;
+        }
+        if (result.outcome === "error") {
           setError(result.error);
           return;
         }
         setConfirmClose(false);
+        const data = result.data as { cacheStale?: boolean };
         showToast(
-          result.cacheStale
+          data.cacheStale
             ? "Issue closed — reload if the list looks stale"
             : "Issue closed",
           "success",
@@ -179,8 +185,6 @@ export function IssueActionSheet({
 
   function handleRepoSelect(targetRepo: Repo) {
     setSelectedRepo(targetRepo);
-    // Generate idempotency key once per intent so retries reuse
-    // the same key and don't create duplicate issues.
     setReassignKey(newIdempotencyKey());
   }
 
@@ -224,65 +228,26 @@ export function IssueActionSheet({
     }
   }
 
-  const otherRepos = repos.filter((r) => r.id !== repoId);
-
   return (
     <>
-      <BottomHandle
-        onTrigger={() => setSheetOpen(true)}
-        label="Actions"
+      <BottomHandle onTrigger={() => setSheetOpen(true)} label="Actions" />
+
+      <IssueDesktopActions
+        hasLiveDeployment={hasLiveDeployment}
+        onLaunch={handleLaunchTap}
+        onReassign={handleReassignTap}
+        onCloseIssue={handleCloseTap}
       />
 
-      {/* Desktop inline action bar — visible only on wide viewports */}
-      <div className={styles.desktopBar}>
-        {!hasLiveDeployment && (
-          <Button variant="primary" onClick={handleLaunchTap}>
-            Launch with Claude
-          </Button>
-        )}
-        <Button variant="ghost" onClick={handleReassignTap}>
-          Re-assign
-        </Button>
-        <Button variant="ghost" onClick={handleCloseTap}>
-          Close issue
-        </Button>
-      </div>
-
-      <Sheet
+      <IssueActionsMenu
         open={sheetOpen}
         onClose={() => setSheetOpen(false)}
-        title="issue actions"
-      >
-        {!hasLiveDeployment && (
-          <button className={styles.item} onClick={handleLaunchTap}>
-            <span className={styles.icon}>
-              <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
-                <path d="M8 2Q8.7 7 15 8Q8.7 9 8 15Q7.3 9 1 8Q7.3 7 8 2Z" fill="currentColor" />
-                <path d="M14 2Q14.3 4.5 17 5Q14.3 5.3 14 8Q13.7 5.3 11 5Q13.7 4.7 14 2Z" fill="currentColor" opacity="0.5" />
-              </svg>
-            </span>
-            Launch with Claude
-          </button>
-        )}
-        <button
-          className={`${styles.item} ${isOffline ? styles.disabled : ""}`}
-          onClick={isOffline ? undefined : handleReassignTap}
-          disabled={isOffline}
-        >
-          <span className={styles.icon}>&harr;</span>
-          Re-assign to repo
-          {isOffline && <span className={styles.offlineHint}>Requires connection</span>}
-        </button>
-        <button
-          className={`${styles.item} ${styles.danger} ${isOffline ? styles.disabled : ""}`}
-          onClick={isOffline ? undefined : handleCloseTap}
-          disabled={isOffline}
-        >
-          <span className={styles.icon}>&bull;</span>
-          Close issue
-          {isOffline && <span className={styles.offlineHint}>Requires connection</span>}
-        </button>
-      </Sheet>
+        hasLiveDeployment={hasLiveDeployment}
+        isOffline={isOffline}
+        onLaunch={handleLaunchTap}
+        onReassign={handleReassignTap}
+        onCloseIssue={handleCloseTap}
+      />
 
       {launchOpen && (
         <LaunchModal
@@ -307,66 +272,25 @@ export function IssueActionSheet({
         />
       )}
 
-      <Sheet
+      <IssueReassignSheet
         open={reassignSheetOpen}
         onClose={() => setReassignSheetOpen(false)}
-        title="re-assign to repo"
-        description={
-          <em>
-            #{number} &mdash; currently on {owner}/{repo}
-          </em>
-        }
-      >
-        <div className={assignStyles.body}>
-          {loadingRepos && (
-            <div className={assignStyles.loading}>loading repos…</div>
-          )}
-          {reassignError && !selectedRepo && (
-            <div className={assignStyles.error}>{reassignError}</div>
-          )}
-          {!loadingRepos && otherRepos.length === 0 && !reassignError && (
-            <div className={assignStyles.empty}>
-              <em>no other repos available</em>
-            </div>
-          )}
-          {otherRepos.map((r) => (
-            <button
-              key={r.id}
-              className={assignStyles.row}
-              onClick={() => handleRepoSelect(r)}
-              disabled={reassigning}
-            >
-              <div className={assignStyles.repoName}>{r.name}</div>
-              <div className={assignStyles.repoOwner}>{r.owner}</div>
-            </button>
-          ))}
-          <div className={assignStyles.footer}>
-            <Button
-              variant="ghost"
-              onClick={() => setReassignSheetOpen(false)}
-              disabled={reassigning}
-            >
-              cancel
-            </Button>
-          </div>
-        </div>
-      </Sheet>
-
-      {selectedRepo && (
-        <ConfirmDialog
-          title="Re-assign Issue"
-          message={`Move issue #${number} from ${owner}/${repo} to ${selectedRepo.owner}/${selectedRepo.name}? The old issue will be closed with a cross-reference.`}
-          confirmLabel="Re-assign"
-          confirmVariant="default"
-          onConfirm={handleReassignConfirm}
-          onCancel={() => {
-            setSelectedRepo(null);
-            setReassignError(null);
-          }}
-          isPending={reassigning}
-          error={reassignError ?? undefined}
-        />
-      )}
+        owner={owner}
+        repo={repo}
+        repoId={repoId}
+        number={number}
+        repos={repos}
+        loadingRepos={loadingRepos}
+        selectedRepo={selectedRepo}
+        reassigning={reassigning}
+        reassignError={reassignError}
+        onSelectRepo={handleRepoSelect}
+        onConfirm={handleReassignConfirm}
+        onCancelSelection={() => {
+          setSelectedRepo(null);
+          setReassignError(null);
+        }}
+      />
     </>
   );
 }

--- a/packages/web/components/detail/IssueActionsMenu.tsx
+++ b/packages/web/components/detail/IssueActionsMenu.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Sheet } from "@/components/paper";
+import styles from "./ActionSheet.module.css";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  hasLiveDeployment: boolean;
+  isOffline: boolean;
+  onLaunch: () => void;
+  onReassign: () => void;
+  onCloseIssue: () => void;
+};
+
+export function IssueActionsMenu({
+  open,
+  onClose,
+  hasLiveDeployment,
+  isOffline,
+  onLaunch,
+  onReassign,
+  onCloseIssue,
+}: Props) {
+  return (
+    <Sheet open={open} onClose={onClose} title="issue actions">
+      {!hasLiveDeployment && (
+        <button className={styles.item} onClick={onLaunch}>
+          <span className={styles.icon}>
+            <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+              <path d="M8 2Q8.7 7 15 8Q8.7 9 8 15Q7.3 9 1 8Q7.3 7 8 2Z" fill="currentColor" />
+              <path d="M14 2Q14.3 4.5 17 5Q14.3 5.3 14 8Q13.7 5.3 11 5Q13.7 4.7 14 2Z" fill="currentColor" opacity="0.5" />
+            </svg>
+          </span>
+          Launch with Claude
+        </button>
+      )}
+      <button
+        className={`${styles.item} ${isOffline ? styles.disabled : ""}`}
+        onClick={isOffline ? undefined : onReassign}
+        disabled={isOffline}
+      >
+        <span className={styles.icon}>&harr;</span>
+        Re-assign to repo
+        {isOffline && <span className={styles.offlineHint}>Requires connection</span>}
+      </button>
+      <button
+        className={`${styles.item} ${styles.danger}`}
+        onClick={onCloseIssue}
+      >
+        <span className={styles.icon}>&bull;</span>
+        Close issue
+        {isOffline && <span className={styles.offlineHint}>Queues until online</span>}
+      </button>
+    </Sheet>
+  );
+}

--- a/packages/web/components/detail/IssueDesktopActions.tsx
+++ b/packages/web/components/detail/IssueDesktopActions.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/paper";
+import styles from "./ActionSheet.module.css";
+
+type Props = {
+  hasLiveDeployment: boolean;
+  onLaunch: () => void;
+  onReassign: () => void;
+  onCloseIssue: () => void;
+};
+
+export function IssueDesktopActions({
+  hasLiveDeployment,
+  onLaunch,
+  onReassign,
+  onCloseIssue,
+}: Props) {
+  return (
+    <div className={styles.desktopBar}>
+      {!hasLiveDeployment && (
+        <Button variant="primary" onClick={onLaunch}>
+          Launch with Claude
+        </Button>
+      )}
+      <Button variant="ghost" onClick={onReassign}>
+        Re-assign
+      </Button>
+      <Button variant="ghost" onClick={onCloseIssue}>
+        Close issue
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/components/detail/IssueReassignSheet.tsx
+++ b/packages/web/components/detail/IssueReassignSheet.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Sheet, Button } from "@/components/paper";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import assignStyles from "../list/AssignSheet.module.css";
+
+type Repo = { id: number; owner: string; name: string };
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  owner: string;
+  repo: string;
+  repoId: number;
+  number: number;
+  repos: Repo[];
+  loadingRepos: boolean;
+  selectedRepo: Repo | null;
+  reassigning: boolean;
+  reassignError: string | null;
+  onSelectRepo: (repo: Repo) => void;
+  onConfirm: () => void;
+  onCancelSelection: () => void;
+};
+
+export function IssueReassignSheet({
+  open,
+  onClose,
+  owner,
+  repo,
+  repoId,
+  number,
+  repos,
+  loadingRepos,
+  selectedRepo,
+  reassigning,
+  reassignError,
+  onSelectRepo,
+  onConfirm,
+  onCancelSelection,
+}: Props) {
+  const otherRepos = repos.filter((r) => r.id !== repoId);
+
+  return (
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title="re-assign to repo"
+        description={
+          <em>
+            #{number} &mdash; currently on {owner}/{repo}
+          </em>
+        }
+      >
+        <div className={assignStyles.body}>
+          {loadingRepos && (
+            <div className={assignStyles.loading}>loading repos…</div>
+          )}
+          {reassignError && !selectedRepo && (
+            <div className={assignStyles.error}>{reassignError}</div>
+          )}
+          {!loadingRepos && otherRepos.length === 0 && !reassignError && (
+            <div className={assignStyles.empty}>
+              <em>no other repos available</em>
+            </div>
+          )}
+          {otherRepos.map((targetRepo) => (
+            <button
+              key={targetRepo.id}
+              className={assignStyles.row}
+              onClick={() => onSelectRepo(targetRepo)}
+              disabled={reassigning}
+            >
+              <div className={assignStyles.repoName}>{targetRepo.name}</div>
+              <div className={assignStyles.repoOwner}>{targetRepo.owner}</div>
+            </button>
+          ))}
+          <div className={assignStyles.footer}>
+            <Button variant="ghost" onClick={onClose} disabled={reassigning}>
+              cancel
+            </Button>
+          </div>
+        </div>
+      </Sheet>
+
+      {selectedRepo && (
+        <ConfirmDialog
+          title="Re-assign Issue"
+          message={`Move issue #${number} from ${owner}/${repo} to ${selectedRepo.owner}/${selectedRepo.name}? The old issue will be closed with a cross-reference.`}
+          confirmLabel="Re-assign"
+          confirmVariant="default"
+          onConfirm={onConfirm}
+          onCancel={onCancelSelection}
+          isPending={reassigning}
+          error={reassignError ?? undefined}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/components/detail/PriorityPicker.tsx
+++ b/packages/web/components/detail/PriorityPicker.tsx
@@ -3,7 +3,9 @@
 import { useState } from "react";
 import type { Priority } from "@issuectl/core";
 import { Sheet } from "@/components/paper";
+import { useToast } from "@/components/ui/ToastProvider";
 import { setPriorityAction } from "@/lib/actions/priority";
+import { tryOrQueue } from "@/lib/tryOrQueue";
 import styles from "./PriorityPicker.module.css";
 
 type PriorityOption = {
@@ -36,6 +38,7 @@ type Props = {
 };
 
 export function PriorityPicker({ repoId, issueNumber, currentPriority }: Props) {
+  const { showToast } = useToast();
   const [open, setOpen] = useState(false);
   const [priority, setPriority] = useState<Priority>(currentPriority);
   const [setting, setSetting] = useState<Priority | null>(null);
@@ -45,12 +48,20 @@ export function PriorityPicker({ repoId, issueNumber, currentPriority }: Props) 
     setSetting(next);
     setError(null);
     try {
-      const result = await setPriorityAction(repoId, issueNumber, next);
-      if (result.success) {
+      const result = await tryOrQueue(
+        "setPriority",
+        { repoId, issueNumber, priority: next },
+        () => setPriorityAction(repoId, issueNumber, next),
+      );
+      if (result.outcome === "queued") {
+        setPriority(next);
+        setOpen(false);
+        showToast("Priority change queued — will sync when online", "warning");
+      } else if (result.outcome === "succeeded") {
         setPriority(next);
         setOpen(false);
       } else {
-        setError(result.error ?? "Failed to update priority");
+        setError(result.error);
       }
     } catch {
       setError("Failed to update priority");

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import type { GitHubLabel } from "@issuectl/core";
 import { toggleLabel } from "@/lib/actions/issues";
 import { tryOrQueue } from "@/lib/tryOrQueue";
@@ -28,6 +29,7 @@ export function LabelManager({
   currentLabels,
   availableLabels,
 }: Props) {
+  const router = useRouter();
   const { showToast } = useToast();
   const [isPending, startTransition] = useTransition();
   const [syncVisible, setSyncVisible] = useState(false);
@@ -77,6 +79,7 @@ export function LabelManager({
         }
 
         showToast("Labels updated", "success");
+        router.refresh();
       } catch (err) {
         console.error("[issuectl] toggleLabel threw:", err);
         setError(err instanceof Error ? err.message : "Failed to update label");

--- a/packages/web/components/ui/OfflineIndicator.tsx
+++ b/packages/web/components/ui/OfflineIndicator.tsx
@@ -64,7 +64,11 @@ export function OfflineIndicator() {
       const { enqueue, remove: removeOp } = await import("@/lib/offline-queue");
       try {
         await removeOp(op.id);
-        await enqueue(op.action as "assignDraft" | "addComment" | "toggleLabel", op.params, op.nonce);
+        await enqueue(
+          op.action as "assignDraft" | "addComment" | "toggleLabel" | "closeIssue" | "setPriority",
+          op.params,
+          op.nonce,
+        );
         refreshQueue();
         showToast("Operation re-queued for sync", "success");
       } catch (err) {
@@ -124,7 +128,7 @@ export function OfflineIndicator() {
               {hasQueue && ` · ${pendingCount} operation${pendingCount > 1 ? "s" : ""} queued`}
             </span>
             <span className={styles.textCompact}>
-              Offline{hasQueue && ` �� ${pendingCount} queued`}
+              Offline{hasQueue && ` - ${pendingCount} queued`}
             </span>
           </div>
           {dropdownOpen && (

--- a/packages/web/components/ui/QueueDropdown.tsx
+++ b/packages/web/components/ui/QueueDropdown.tsx
@@ -19,6 +19,10 @@ function describeOp(op: QueuedOperation): string {
       const verb = (p.action as string) === "add" ? "Add" : "Remove";
       return `${verb} label "${p.label as string}" on ${p.owner as string}/${p.repo as string}#${p.issueNumber as number}`;
     }
+    case "closeIssue":
+      return `Close ${p.owner as string}/${p.repo as string}#${p.issueNumber as number}`;
+    case "setPriority":
+      return `Set priority to "${p.priority as string}" on issue #${p.issueNumber as number}`;
     default:
       return op.action;
   }

--- a/packages/web/hooks/useSyncOnReconnect.ts
+++ b/packages/web/hooks/useSyncOnReconnect.ts
@@ -5,7 +5,8 @@ import { checkHealth, replayQueue } from "@/lib/sync";
 import { listPending, type QueuedOperation } from "@/lib/offline-queue";
 import { assignDraftAction } from "@/lib/actions/drafts";
 import { addComment } from "@/lib/actions/comments";
-import { toggleLabel } from "@/lib/actions/issues";
+import { closeIssue, toggleLabel } from "@/lib/actions/issues";
+import { setPriorityAction } from "@/lib/actions/priority";
 import { refreshAction } from "@/lib/actions/refresh";
 
 type ActionResult = { success: boolean; error?: string };
@@ -35,6 +36,19 @@ async function executeOperation(op: QueuedOperation): Promise<ActionResult> {
         label: p.label as string,
         action: p.action as "add" | "remove",
       });
+    case "closeIssue":
+      return closeIssue(
+        p.owner as string,
+        p.repo as string,
+        p.issueNumber as number,
+        p.comment as string | undefined,
+      );
+    case "setPriority":
+      return setPriorityAction(
+        p.repoId as number,
+        p.issueNumber as number,
+        p.priority as "low" | "normal" | "high",
+      );
     default:
       return { success: false, error: `Unknown action: ${op.action}` };
   }

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -3,7 +3,6 @@
 import {
   getDb,
   getRepo,
-  getRepoById,
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,

--- a/packages/web/lib/offline-queue.test.ts
+++ b/packages/web/lib/offline-queue.test.ts
@@ -9,7 +9,6 @@ import {
   markPending,
   remove,
   clearAll,
-  type QueuedOperation,
 } from "./offline-queue";
 
 beforeEach(async () => {
@@ -43,6 +42,14 @@ describe("offline-queue", () => {
     expect(pending).toHaveLength(2);
     expect(pending[0].action).toBe("addComment");
     expect(pending[1].action).toBe("toggleLabel");
+  });
+
+  it("supports replayable issue actions", async () => {
+    await enqueue("closeIssue", { owner: "acme", repo: "api", issueNumber: 47 }, "n1");
+    await enqueue("setPriority", { repoId: 1, issueNumber: 47, priority: "high" }, "n2");
+
+    const pending = await listPending();
+    expect(pending.map((op) => op.action)).toEqual(["closeIssue", "setPriority"]);
   });
 
   it("marks an operation as syncing", async () => {

--- a/packages/web/lib/offline-queue.ts
+++ b/packages/web/lib/offline-queue.ts
@@ -1,4 +1,9 @@
-export type QueueableAction = "assignDraft" | "addComment" | "toggleLabel";
+export type QueueableAction =
+  | "assignDraft"
+  | "addComment"
+  | "toggleLabel"
+  | "closeIssue"
+  | "setPriority";
 
 export type QueuedOperation = {
   id: string;


### PR DESCRIPTION
## Summary
- Fix iOS ISO 8601 parsing for timestamps without fractional seconds
- Avoid double-ending iOS terminal sessions from active sessions
- Refresh labels after web label updates and fix compact offline banner text
- Add offline replay support for closing issues and setting priority
- Split issue action sheet into smaller components

## Verification
- pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/web test
- pnpm --filter @issuectl/web lint
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath /tmp/issuectl-derived