### PR TITLE
Fix web and iOS audit gaps

### DIFF
--- a/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
+++ b/ios/IssueCTL/Services/APIClient+AdvancedSettings.swift
@@ -73,20 +73,21 @@ struct WorktreeResetRequest: Encodable, Sendable {
 // MARK: - EnsureTtyd types
 
 enum EnsureTtydResult: Sendable {
-    case available(port: Int, respawned: Bool)
+    case available(port: Int, terminalToken: String, respawned: Bool)
     case unavailable(error: String?)
 }
 
 extension EnsureTtydResult: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case port, respawned, alive, error
+        case port, terminalToken, respawned, alive, error
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         if let port = try c.decodeIfPresent(Int.self, forKey: .port) {
+            let terminalToken = try c.decode(String.self, forKey: .terminalToken)
             let respawned = try c.decodeIfPresent(Bool.self, forKey: .respawned) ?? false
-            self = .available(port: port, respawned: respawned)
+            self = .available(port: port, terminalToken: terminalToken, respawned: respawned)
         } else {
             let error = try c.decodeIfPresent(String.self, forKey: .error)
             self = .unavailable(error: error)

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -26,6 +26,7 @@ struct IssueListView: View {
     @State private var showReopenConfirm = false
     @State private var swipeTarget: (owner: String, repo: String, number: Int)?
     @State private var launchTarget: LaunchTarget?
+    @State private var loadingLaunchTargetId: String?
 
     // Draft swipe state
     @State private var showDeleteDraftConfirm = false
@@ -282,8 +283,8 @@ struct IssueListView: View {
                     repo: target.repo,
                     issueNumber: target.number,
                     issueTitle: target.title,
-                    comments: [],
-                    referencedFiles: []
+                    comments: target.comments,
+                    referencedFiles: target.referencedFiles
                 )
             }
             .confirmationDialog("Close Issue", isPresented: $showCloseConfirm, titleVisibility: .visible) {
@@ -373,9 +374,15 @@ struct IssueListView: View {
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if issue.isOpen {
                             Button {
-                                launchTarget = LaunchTarget(owner: repo.owner, repo: repo.name, number: issue.number, title: issue.title)
+                                Task {
+                                    await prepareLaunch(owner: repo.owner, repo: repo.name, number: issue.number, title: issue.title)
+                                }
                             } label: {
-                                Label("Launch", systemImage: "play.fill")
+                                if loadingLaunchTargetId == "\(repo.owner)/\(repo.name)#\(issue.number)" {
+                                    Label("Loading", systemImage: "hourglass")
+                                } else {
+                                    Label("Launch", systemImage: "play.fill")
+                                }
                             }
                             .tint(.green)
                         } else {
@@ -459,6 +466,31 @@ struct IssueListView: View {
     }
 
     // MARK: - Actions
+
+    private func prepareLaunch(owner: String, repo: String, number: Int, title: String) async {
+        let targetId = "\(owner)/\(repo)#\(number)"
+        loadingLaunchTargetId = targetId
+        actionError = nil
+        defer {
+            if loadingLaunchTargetId == targetId {
+                loadingLaunchTargetId = nil
+            }
+        }
+
+        do {
+            let detail = try await api.issueDetail(owner: owner, repo: repo, number: number)
+            launchTarget = LaunchTarget(
+                owner: owner,
+                repo: repo,
+                number: number,
+                title: title,
+                comments: detail.comments,
+                referencedFiles: detail.referencedFiles
+            )
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
 
     private func updateIssueState(owner: String, repo: String, number: Int, state: String) async {
         actionError = nil
@@ -550,9 +582,10 @@ struct IssueListView: View {
                 }
             }
             var cachedDates: [Date] = []
+            var nextIssuesByRepo: [String: [GitHubIssue]] = [:]
             for (fullName, name, issues, cachedAt, error) in repoResults {
                 if let issues {
-                    issuesByRepo[fullName] = issues
+                    nextIssuesByRepo[fullName] = issues
                     if let cachedAt, let date = sharedISO8601Formatter.date(from: cachedAt) {
                         cachedDates.append(date)
                     }
@@ -562,6 +595,7 @@ struct IssueListView: View {
                     failures.append(name)
                 }
             }
+            issuesByRepo = nextIssuesByRepo
             oldestCachedAt = cachedDates.min()
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
@@ -581,14 +615,14 @@ struct IssueListView: View {
 
     private func loadPriorities() async -> [String] {
         isLoadingPriorities = true
-        // Snapshot repos into a local Sendable value so child tasks don't
-        // capture main-actor state. Collect results via sequential `for await`.
-        let repoSnapshot = repos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
-        let uniqueFullNames = Set(repoSnapshot.map(\.fullName))
+        // Snapshot repos into a local Sendable value keyed by fullName so
+        // child tasks don't capture main-actor state and duplicates are skipped.
+        let repoByName: [String: (owner: String, name: String)] = repos.reduce(into: [:]) {
+            $0[$1.fullName] = (owner: $1.owner, name: $1.name)
+        }
         var priorityResults: [([(String, Priority)], String?)] = []
         await withTaskGroup(of: ([(String, Priority)], String?).self) { group in
-            for fullName in uniqueFullNames {
-                guard let repo = repoSnapshot.first(where: { $0.fullName == fullName }) else { continue }
+            for (_, repo) in repoByName {
                 group.addTask { [api] in
                     do {
                         let items = try await api.listPriorities(owner: repo.owner, repo: repo.name)
@@ -635,6 +669,8 @@ struct LaunchTarget: Identifiable, Sendable {
     let repo: String
     let number: Int
     let title: String
+    let comments: [GitHubComment]
+    let referencedFiles: [String]
 
     var id: String { "\(owner)/\(repo)#\(number)" }
 }

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -324,9 +324,10 @@ struct PRListView: View {
                 return collected
             }
             var cachedDates: [Date] = []
+            var nextPullsByRepo: [String: [GitHubPull]] = [:]
             for (fullName, name, pulls, cachedAt, error) in repoResults {
                 if let pulls {
-                    pullsByRepo[fullName] = pulls
+                    nextPullsByRepo[fullName] = pulls
                     if let cachedAt, let date = sharedISO8601Formatter.date(from: cachedAt) {
                         cachedDates.append(date)
                     }
@@ -336,6 +337,7 @@ struct PRListView: View {
                     failures.append(name)
                 }
             }
+            pullsByRepo = nextPullsByRepo
             oldestCachedAt = cachedDates.min()
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -11,6 +11,7 @@ struct TerminalView: View {
     @State private var showEndConfirm = false
     @State private var loadError: String?
     @State private var currentPort: Int
+    @State private var terminalToken: String?
     @State private var isRespawning = false
     @State private var isEndingSession = false
     @State private var endSessionError: String?
@@ -25,7 +26,14 @@ struct TerminalView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if let url = terminalURL {
+                if terminalToken == nil && loadError == nil {
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text("Connecting terminal…")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let url = terminalURL {
                     if isRespawning {
                         VStack(spacing: 12) {
                             ProgressView()
@@ -113,11 +121,19 @@ struct TerminalView: View {
                     Text(endSessionError)
                 }
             }
+            .task {
+                if terminalToken == nil && !isRespawning {
+                    await attemptRespawn()
+                }
+            }
         }
     }
 
     private var terminalURL: URL? {
-        URL(string: "\(api.serverURL)/api/terminal/\(currentPort)/")
+        guard let terminalToken else { return nil }
+        var components = URLComponents(string: "\(api.serverURL)/api/terminal/\(currentPort)/")
+        components?.queryItems = [URLQueryItem(name: "terminalToken", value: terminalToken)]
+        return components?.url
     }
 
     private func endSession() async {
@@ -148,8 +164,9 @@ struct TerminalView: View {
         do {
             let result = try await api.ensureTtyd(deploymentId: deployment.id)
             switch result {
-            case .available(let port, _):
+            case .available(let port, let token, _):
                 currentPort = port
+                terminalToken = token
             case .unavailable(let error):
                 loadError = error ?? "Session has ended"
             }

--- a/packages/web/app/api/terminal/[port]/[...path]/route.ts
+++ b/packages/web/app/api/terminal/[port]/[...path]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidTerminalPort, proxyHttpRequest } from "@/lib/terminal-proxy";
+import { validateTerminalToken } from "@/lib/terminal-auth";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ port: string; path: string[] }> },
 ): Promise<NextResponse> {
   const { port: portStr, path } = await params;
@@ -12,6 +13,9 @@ export async function GET(
 
   if (!isValidTerminalPort(port)) {
     return new NextResponse("Not Found", { status: 404 });
+  }
+  if (!validateTerminalToken(request.nextUrl.searchParams.get("terminalToken"), port)) {
+    return new NextResponse("Unauthorized", { status: 401 });
   }
 
   if (path.some((seg) => seg === ".." || seg === ".")) {
@@ -35,3 +39,5 @@ export async function GET(
     return new NextResponse("Proxy error", { status: 502 });
   }
 }
+
+export const HEAD = GET;

--- a/packages/web/app/api/terminal/[port]/route.ts
+++ b/packages/web/app/api/terminal/[port]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidTerminalPort, proxyHttpRequest, rewriteHtml } from "@/lib/terminal-proxy";
+import { validateTerminalToken } from "@/lib/terminal-auth";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ port: string }> },
 ): Promise<NextResponse> {
   const { port: portStr } = await params;
@@ -13,13 +14,17 @@ export async function GET(
   if (!isValidTerminalPort(port)) {
     return new NextResponse("Not Found", { status: 404 });
   }
+  const terminalToken = request.nextUrl.searchParams.get("terminalToken");
+  if (!validateTerminalToken(terminalToken, port)) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
 
   try {
     const upstream = await proxyHttpRequest(port, "/");
     const contentType = upstream.headers["content-type"] ?? "";
 
     if (contentType.includes("text/html")) {
-      const rewritten = rewriteHtml(upstream.body.toString("utf-8"), port);
+      const rewritten = rewriteHtml(upstream.body.toString("utf-8"), port, terminalToken ?? undefined);
       return new NextResponse(rewritten, {
         status: upstream.status,
         headers: { "content-type": contentType },
@@ -39,3 +44,5 @@ export async function GET(
     return new NextResponse("Proxy error", { status: 502 });
   }
 }
+
+export const HEAD = GET;

--- a/packages/web/components/detail/IssueActionSheet.tsx
+++ b/packages/web/components/detail/IssueActionSheet.tsx
@@ -137,7 +137,7 @@ export function IssueActionSheet({
         if (result.outcome === "queued") {
           setConfirmClose(false);
           showToast("Issue close queued — will sync when online", "warning");
-          router.replace("/");
+          router.replace("/?section=closed");
           return;
         }
         if (result.outcome === "error") {
@@ -152,7 +152,7 @@ export function IssueActionSheet({
             : "Issue closed",
           "success",
         );
-        router.replace("/");
+        router.replace("/?section=closed");
       } catch (err) {
         console.error("[issuectl] Close issue failed:", err);
         setError("Something went wrong while closing the issue. Please try again.");

--- a/packages/web/components/list/CreateDraftSheet.tsx
+++ b/packages/web/components/list/CreateDraftSheet.tsx
@@ -51,6 +51,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
     Promise.all([listReposAction(), getDefaultRepoIdAction()])
       .then(([repoList, defaultId]) => {
         setRepos(repoList);
+        setShowRepos(repoList.length > 0);
         if (defaultId !== null && repoList.some((r) => r.id === defaultId)) {
           setSelectedRepoIds(new Set([defaultId]));
           setDefaultRepoId(defaultId);
@@ -259,6 +260,7 @@ export function CreateDraftSheet({ open, onClose }: Props) {
               onClick={() => setShowRepos(!showRepos)}
               disabled={saving}
               aria-expanded={showRepos}
+              aria-label="Choose repositories"
             >
               <span className={styles.repoSummary}>
                 {selectedRepoIds.size === 0

--- a/packages/web/components/list/List.tsx
+++ b/packages/web/components/list/List.tsx
@@ -223,7 +223,7 @@ export function List({
         <button
           className={styles.sheetMenuBtn}
           onClick={() => setFiltersOpen(true)}
-          aria-label="Filters and navigation"
+          aria-label="Open navigation"
         >
           <svg
             width="18"
@@ -245,7 +245,7 @@ export function List({
         <button
           className={styles.menuBtn}
           onClick={() => setDrawerOpen(true)}
-          aria-label="Open navigation"
+          aria-label="Open drawer"
         >
           <svg
             width="20"

--- a/packages/web/components/list/ListContent.tsx
+++ b/packages/web/components/list/ListContent.tsx
@@ -160,7 +160,7 @@ export function ListContent({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [loadMore, activeSection]);
+  }, [loadMore, activeTab, activeSection]);
 
   if (activeTab === "issues") {
     const total = filteredData[activeSection].length;
@@ -214,9 +214,13 @@ export function ListContent({
     );
   }
 
+  const total = filteredPrs.length;
+  const showing = Math.min(visibleCount, total);
+  const visiblePrs = filteredPrs.slice(0, visibleCount);
+
   return (
     <div>
-      {filteredPrs.map(({ repo, pull }, i) => (
+      {visiblePrs.map(({ repo, pull }, i) => (
         <PrListRow
           key={`pr-${repo.owner}-${repo.name}-${pull.number}`}
           owner={repo.owner}
@@ -225,6 +229,14 @@ export function ListContent({
           rowIndex={i}
         />
       ))}
+      {total > PAGE_SIZE && (
+        <div className={styles.pageStatus}>
+          Showing {showing} of {total}
+        </div>
+      )}
+      {visibleCount < total && (
+        <div ref={sentinelRef} className={styles.sentinel} />
+      )}
     </div>
   );
 }

--- a/packages/web/components/paper/Sheet.tsx
+++ b/packages/web/components/paper/Sheet.tsx
@@ -328,6 +328,7 @@ export function Sheet({ open, onClose, title, description, children }: Props) {
       <div
         className={styles.scrim}
         data-closing={closing || undefined}
+        onMouseDown={onClose}
         onClick={onClose}
         aria-hidden="true"
         style={scrimStyle}

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -30,6 +30,7 @@ export function OpenTerminalButton({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const [activePort, setActivePort] = useState(ttydPort);
+  const [terminalToken, setTerminalToken] = useState<string | null>(null);
   const router = useRouter();
 
   // Sync activePort when the server re-renders with a new ttydPort
@@ -68,6 +69,7 @@ export function OpenTerminalButton({
       // Use the fresh port from ensureTtyd — the RSC-rendered ttydPort
       // may be stale if ttyd was respawned on a different port.
       setActivePort(result.port);
+      setTerminalToken(result.terminalToken);
       setOpen(true);
     });
   }
@@ -82,6 +84,7 @@ export function OpenTerminalButton({
         open={open}
         onClose={() => setOpen(false)}
         ttydPort={activePort}
+        terminalToken={terminalToken}
         deploymentId={deploymentId}
         owner={owner}
         repo={repo}

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -18,6 +18,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   ttydPort: number;
+  terminalToken: string | null;
   deploymentId: number;
   owner: string;
   repo: string;
@@ -29,6 +30,7 @@ export function TerminalPanel({
   open,
   onClose,
   ttydPort,
+  terminalToken,
   deploymentId,
   owner,
   repo,
@@ -74,8 +76,12 @@ export function TerminalPanel({
   }, [open, connectionStatus]);
 
   function handleIframeLoad() {
+    if (!terminalToken) {
+      setConnectionStatus("error");
+      return;
+    }
     // iframe onLoad fires even for HTTP error pages — verify the endpoint is healthy
-    fetch(`/api/terminal/${ttydPort}/`, { method: "HEAD" })
+    fetch(`/api/terminal/${ttydPort}/?terminalToken=${encodeURIComponent(terminalToken)}`, { method: "HEAD" })
       .then((res) => {
         setConnectionStatus(res.ok ? "connected" : "error");
       })
@@ -166,7 +172,11 @@ export function TerminalPanel({
           key={iframeKey}
           ref={iframeRef}
           className={styles.terminalFrame}
-          src={`/api/terminal/${ttydPort}/`}
+          src={
+            terminalToken
+              ? `/api/terminal/${ttydPort}/?terminalToken=${encodeURIComponent(terminalToken)}`
+              : "about:blank"
+          }
           title={`Terminal — Issue #${issueNumber}`}
           onLoad={handleIframeLoad}
           onError={handleIframeError}

--- a/packages/web/e2e/terminal-persistence.spec.ts
+++ b/packages/web/e2e/terminal-persistence.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
-import { initSchema, runMigrations, tmuxSessionName } from "@issuectl/core";
+import { generateApiToken, initSchema, runMigrations, tmuxSessionName } from "@issuectl/core";
 
 /**
  * E2E test: terminal session persistence across panel close and navigation.
@@ -183,6 +183,7 @@ function createTestDb(dbPath: string, ttydPid: number): void {
     ] as const) {
       insertSetting.run(key, value);
     }
+    generateApiToken(db);
 
     // Repo
     db.prepare("INSERT OR IGNORE INTO repos (owner, name) VALUES (?, ?)").run(

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -11,6 +11,7 @@ const getDb = vi.hoisted(() => vi.fn());
 const getDeploymentById = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
+const getSetting = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const coreEndDeployment = vi.hoisted(() => vi.fn());
 const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
@@ -24,6 +25,7 @@ vi.mock("@issuectl/core", () => ({
   getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
   getRepo: (...args: unknown[]) => getRepo(...args),
   getRepoById: (...args: unknown[]) => getRepoById(...args),
+  getSetting: (...args: unknown[]) => getSetting(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   endDeployment: (...args: unknown[]) => coreEndDeployment(...args),
   cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
@@ -84,6 +86,7 @@ beforeEach(() => {
   getDeploymentById.mockReset();
   getRepo.mockReset();
   getRepoById.mockReset();
+  getSetting.mockReset();
   killTtyd.mockReset();
   coreEndDeployment.mockReset();
   cleanupStaleContextFiles.mockReset();
@@ -104,6 +107,7 @@ beforeEach(() => {
   getDeploymentById.mockReturnValue(makeDeployment(42));
   getRepo.mockReturnValue(makeRepoRecord());
   getRepoById.mockReturnValue(makeRepoRecord());
+  getSetting.mockReturnValue("test-api-token");
   coreEndDeployment.mockReturnValue(undefined);
   cleanupStaleContextFiles.mockReturnValue(Promise.resolve());
 });
@@ -233,7 +237,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ port: 7700 });
+    expect(result).toEqual({ port: 7700, terminalToken: expect.any(String) });
     expect(respawnTtyd).not.toHaveBeenCalled();
   });
 
@@ -245,7 +249,7 @@ describe("ensureTtyd", () => {
 
     const result = await ensureTtyd(1);
 
-    expect(result).toEqual({ port: 7700, respawned: true });
+    expect(result).toEqual({ port: 7700, terminalToken: expect.any(String), respawned: true });
     expect(respawnTtyd).toHaveBeenCalledWith(7700, "issuectl-repo-7");
   });
 

--- a/packages/web/lib/ensure-ttyd.ts
+++ b/packages/web/lib/ensure-ttyd.ts
@@ -10,9 +10,10 @@ import {
   updateTtydInfo,
   formatErrorForUser,
 } from "@issuectl/core";
+import { createTerminalToken } from "./terminal-auth";
 
 export type EnsureTtydResult =
-  | { port: number; respawned?: true; alive?: never; error?: never }
+  | { port: number; terminalToken: string; respawned?: true; alive?: never; error?: never }
   | { alive: false; error?: string; port?: never };
 
 export async function ensureTtydForDeployment(
@@ -33,7 +34,9 @@ export async function ensureTtydForDeployment(
     const port = deployment.ttydPort;
 
     if (isTtydAlive(deployment.ttydPid)) {
-      return { port };
+      const terminalToken = createTerminalToken(deploymentId, port);
+      if (!terminalToken) return { alive: false, error: "Terminal auth token could not be created" };
+      return { port, terminalToken };
     }
 
     const repo = getRepoById(db, deployment.repoId);
@@ -49,7 +52,9 @@ export async function ensureTtydForDeployment(
 
     const { pid } = await respawnTtyd(port, sessionName);
     updateTtydInfo(db, deploymentId, port, pid);
-    return { port, respawned: true };
+    const terminalToken = createTerminalToken(deploymentId, port);
+    if (!terminalToken) return { alive: false, error: "Terminal auth token could not be created" };
+    return { port, terminalToken, respawned: true };
   } catch (err) {
     console.error("[issuectl] ensureTtydForDeployment failed:", deploymentId, err);
     return { alive: false, error: formatErrorForUser(err) };

--- a/packages/web/lib/terminal-auth.test.ts
+++ b/packages/web/lib/terminal-auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetDb = vi.hoisted(() => vi.fn(() => "fake-db"));
+const mockGetSetting = vi.hoisted(() => vi.fn(() => "test-secret"));
+const mockGetDeploymentById = vi.hoisted(() => vi.fn());
+const mockGetActiveDeploymentByPort = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: mockGetDb,
+  getSetting: mockGetSetting,
+  getDeploymentById: mockGetDeploymentById,
+  getActiveDeploymentByPort: mockGetActiveDeploymentByPort,
+}));
+
+import { createTerminalToken, validateTerminalToken } from "./terminal-auth.js";
+
+describe("terminal auth tokens", () => {
+  beforeEach(() => {
+    mockGetDb.mockReturnValue("fake-db");
+    mockGetSetting.mockReturnValue("test-secret");
+    mockGetDeploymentById.mockReturnValue({
+      id: 7,
+      endedAt: null,
+      ttydPort: 7700,
+    });
+    mockGetActiveDeploymentByPort.mockReturnValue({ id: 7 });
+  });
+
+  it("creates and validates a deployment-bound terminal token", () => {
+    const token = createTerminalToken(7, 7700);
+
+    expect(token).toEqual(expect.any(String));
+    expect(validateTerminalToken(token, 7700)).toBe(true);
+  });
+
+  it("rejects a token for a different port", () => {
+    const token = createTerminalToken(7, 7700);
+
+    expect(validateTerminalToken(token, 7701)).toBe(false);
+  });
+
+  it("rejects a tampered token", () => {
+    const token = createTerminalToken(7, 7700);
+    const tampered = `${token}x`;
+
+    expect(validateTerminalToken(tampered, 7700)).toBe(false);
+  });
+
+  it("rejects a token when the deployment is no longer active", () => {
+    const token = createTerminalToken(7, 7700);
+    mockGetDeploymentById.mockReturnValue({ id: 7, endedAt: "2026-04-28", ttydPort: 7700 });
+
+    expect(validateTerminalToken(token, 7700)).toBe(false);
+  });
+});

--- a/packages/web/lib/terminal-auth.ts
+++ b/packages/web/lib/terminal-auth.ts
@@ -1,0 +1,104 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+  getActiveDeploymentByPort,
+  getDb,
+  getDeploymentById,
+  getSetting,
+} from "@issuectl/core";
+import log from "./logger";
+
+const TOKEN_TTL_MS = 10 * 60 * 1000;
+
+type TerminalTokenPayload = {
+  deploymentId: number;
+  port: number;
+  exp: number;
+};
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function base64UrlDecode(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+function sign(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("base64url");
+}
+
+function getTerminalSecret(): string | null {
+  const db = getDb();
+  return getSetting(db, "api_token") ?? null;
+}
+
+export function createTerminalToken(deploymentId: number, port: number): string | null {
+  try {
+    const secret = getTerminalSecret();
+    if (!secret) return null;
+    const payload: TerminalTokenPayload = {
+      deploymentId,
+      port,
+      exp: Date.now() + TOKEN_TTL_MS,
+    };
+    const encoded = base64UrlEncode(JSON.stringify(payload));
+    return `${encoded}.${sign(encoded, secret)}`;
+  } catch (err) {
+    log.error({ err, msg: "terminal_token_create_failed", deploymentId, port });
+    return null;
+  }
+}
+
+function parseToken(token: string): TerminalTokenPayload | null {
+  const [encoded, signature, extra] = token.split(".");
+  if (!encoded || !signature || extra !== undefined) return null;
+
+  const secret = getTerminalSecret();
+  if (!secret) return null;
+
+  const expected = sign(encoded, secret);
+  const actualBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+  if (
+    actualBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(actualBuffer, expectedBuffer)
+  ) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(base64UrlDecode(encoded)) as Partial<TerminalTokenPayload>;
+    if (
+      !Number.isInteger(payload.deploymentId) ||
+      !Number.isInteger(payload.port) ||
+      !Number.isFinite(payload.exp)
+    ) {
+      return null;
+    }
+    return payload as TerminalTokenPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function validateTerminalToken(token: string | null | undefined, port: number): boolean {
+  if (!token) return false;
+  try {
+    const payload = parseToken(token);
+    if (!payload || payload.port !== port || payload.exp < Date.now()) {
+      return false;
+    }
+
+    const db = getDb();
+    const deployment = getDeploymentById(db, payload.deploymentId);
+    if (!deployment || deployment.endedAt !== null || deployment.ttydPort !== port) {
+      return false;
+    }
+
+    const activeByPort = getActiveDeploymentByPort(db, port);
+    return activeByPort?.id === deployment.id;
+  } catch (err) {
+    log.error({ err, msg: "terminal_token_validate_failed", port });
+    return false;
+  }
+}

--- a/packages/web/lib/terminal-proxy.test.ts
+++ b/packages/web/lib/terminal-proxy.test.ts
@@ -6,6 +6,8 @@ const mockGetDb = vi.hoisted(() => vi.fn(() => "fake-db"));
 vi.mock("@issuectl/core", () => ({
   getDb: mockGetDb,
   getActiveDeploymentByPort: mockGetActiveDeploymentByPort,
+  getDeploymentById: vi.fn(),
+  getSetting: vi.fn(),
 }));
 
 import { isValidTerminalPort, rewriteHtml } from "./terminal-proxy.js";
@@ -72,5 +74,17 @@ describe("rewriteHtml", () => {
     const input = "<link href='/style.css'>";
     const result = rewriteHtml(input, 7700);
     expect(result).toBe("<link href='/api/terminal/7700/style.css'>");
+  });
+
+  it("adds terminalToken to rewritten asset URLs", () => {
+    const input = '<script src="/auth_token.js"></script>';
+    const result = rewriteHtml(input, 7701, "abc123");
+    expect(result).toContain('/api/terminal/7701/auth_token.js?terminalToken=abc123');
+  });
+
+  it("injects a WebSocket token patch when terminalToken is present", () => {
+    const result = rewriteHtml("<html><head></head><body></body></html>", 7701, "abc123");
+    expect(result).toContain("window.WebSocket=AuthWebSocket");
+    expect(result).toContain("abc123");
   });
 });

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -14,6 +14,7 @@ import {
 } from "@issuectl/core";
 import log from "./logger";
 import { registerPort, unregisterPort, recordPtyOutput } from "./idle-registry";
+import { validateTerminalToken } from "./terminal-auth";
 
 const PORT_MIN = 7700;
 const PORT_MAX = 7799;
@@ -171,11 +172,31 @@ export async function proxyHttpRequest(
  * `/auth_token.js`, etc. that need to become
  * `/api/terminal/{port}/token`, etc.
  */
-export function rewriteHtml(html: string, port: number): string {
+export function rewriteHtml(html: string, port: number, terminalToken?: string): string {
   const prefix = `/api/terminal/${port}`;
-  return html
+  const token = terminalToken;
+  const encodedToken = token ? encodeURIComponent(token) : "";
+  const tokenQuery = encodedToken ? `?terminalToken=${encodedToken}` : "";
+  const wsPatch = terminalToken
+    ? `<script>(()=>{const token=${JSON.stringify(token)};const port=${JSON.stringify(port)};const Native=window.WebSocket;function AuthWebSocket(url,protocols){try{const u=new URL(url,window.location.href);if(u.origin===window.location.origin&&u.pathname.startsWith("/api/terminal/"+port+"/")&&!u.searchParams.has("terminalToken")){u.searchParams.set("terminalToken",token);url=u.toString();}}catch{}return protocols===undefined?new Native(url):new Native(url,protocols)}AuthWebSocket.prototype=Native.prototype;Object.setPrototypeOf(AuthWebSocket,Native);window.WebSocket=AuthWebSocket;})();</script>`
+    : "";
+  const rewritten = html
     .replace(/(href|src|action)="\/(?!\/)/g, `$1="${prefix}/`)
     .replace(/(href|src|action)='\/(?!\/)/g, `$1='${prefix}/`);
+  const withToken = tokenQuery
+    ? rewritten.replace(
+        /(href|src|action)=(["'])(\/api\/terminal\/\d+\/[^"']*?)(["'])/g,
+        (_match, attr: string, quote: string, url: string, endQuote: string) => {
+          if (url.includes("terminalToken=")) return `${attr}=${quote}${url}${endQuote}`;
+          const separator = url.includes("?") ? "&" : "?";
+          return `${attr}=${quote}${url}${separator}terminalToken=${encodedToken}${endQuote}`;
+        },
+      )
+    : rewritten;
+  if (!wsPatch) return withToken;
+  return withToken.includes("</head>")
+    ? withToken.replace("</head>", `${wsPatch}</head>`)
+    : `${wsPatch}${withToken}`;
 }
 
 const wss = new WebSocketServer({ noServer: true });
@@ -264,6 +285,13 @@ export async function handleUpgrade(
   head: Buffer,
   port: number,
 ): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (!validateTerminalToken(url.searchParams.get("terminalToken"), port)) {
+    socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
   if (!isValidTerminalPort(port)) {
     socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
     socket.destroy();

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -7,6 +7,7 @@ import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./
 import { startIdleChecker, stopIdleChecker } from "./lib/idle-checker";
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
+const SENSITIVE_QUERY_PARAMS = new Set(["terminalToken"]);
 
 const dev = process.argv.includes("--dev");
 const port = Number(process.env.PORT ?? 3847);
@@ -38,7 +39,8 @@ if (process.env.ISSUECTL_TUNNEL_URL) {
 
 function logRequest(req: IncomingMessage, res: ServerResponse): void {
   const start = Date.now();
-  const { method, url } = req;
+  const { method } = req;
+  const url = redactSensitiveUrl(req.url, req.headers.host);
 
   // `close` fires on every response (including aborted ones), unlike
   // `finish` which only fires when the response was fully sent.
@@ -52,6 +54,23 @@ function logRequest(req: IncomingMessage, res: ServerResponse): void {
       aborted: !res.writableFinished,
     });
   });
+}
+
+function redactSensitiveUrl(rawUrl: string | undefined, host: string | undefined): string | undefined {
+  if (!rawUrl) return rawUrl;
+  try {
+    const parsed = new URL(rawUrl, `http://${host ?? "localhost"}`);
+    let redacted = false;
+    for (const param of SENSITIVE_QUERY_PARAMS) {
+      if (parsed.searchParams.has(param)) {
+        parsed.searchParams.set(param, "[redacted]");
+        redacted = true;
+      }
+    }
+    return redacted ? `${parsed.pathname}${parsed.search}` : rawUrl;
+  } catch {
+    return rawUrl.replace(/([?&]terminalToken=)[^&]*/g, "$1[redacted]");
+  }
 }
 
 const server = createServer((req, res) => {
@@ -76,7 +95,11 @@ const server = createServer((req, res) => {
   }
 
   handle(req, res).catch((err) => {
-    log.error({ err, msg: "next_request_handler_error", url: req.url });
+    log.error({
+      err,
+      msg: "next_request_handler_error",
+      url: redactSensitiveUrl(req.url, req.headers.host),
+    });
     if (!res.headersSent) {
       res.writeHead(500, { "Content-Type": "text/plain" });
     }


### PR DESCRIPTION
## Summary
- add deployment-bound terminal auth tokens for web terminal HTTP routes, WebSocket upgrades, rewritten ttyd assets, and iOS terminal loading
- redact terminal auth tokens from server request/error logs
- fix web audit gaps around repo selection, mobile navigation locators, sheet dismissal, close routing, and PR pagination
- fix iOS stale issue/PR list state and populate launch context from fetched issue detail
- add/update focused unit and E2E coverage for terminal auth/proxy/launch behavior

## Verification
- pnpm typecheck
- pnpm lint (passes with existing warning-only output)
- pnpm --filter @issuectl/web test -- lib/terminal-auth.test.ts lib/terminal-proxy.test.ts lib/actions/launch.test.ts
- pnpm --filter @issuectl/web exec playwright test e2e/terminal-persistence.spec.ts
- prior full pass: pnpm test; pnpm --filter @issuectl/web test:e2e; xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16'
