### PR TITLE
Fix iOS terminal re-entry and duplicate launch handling

### DIFF
--- a/ios/IssueCTL/Models/Deployment.swift
+++ b/ios/IssueCTL/Models/Deployment.swift
@@ -63,6 +63,8 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
     let owner: String
     let repoName: String
 
+    var isActive: Bool { state == .active && endedAt == nil }
+
     var launchedDate: Date? {
         parseIssueCTLDate(launchedAt)
     }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -11,6 +11,7 @@ struct IssueDetailView: View {
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var activeDetailSheet: DetailSheet?
+    @State private var terminalTarget: ActiveDeployment?
     @State private var isClosing = false
     @State private var isReopening = false
     @State private var activeConfirmation: ActiveConfirmation?
@@ -135,9 +136,17 @@ struct IssueDetailView: View {
                             Label("Reassign to Repo…", systemImage: "arrow.triangle.swap")
                         }
                         Button {
-                            activeDetailSheet = .launch(detail)
+                            if let deployment = activeDeployment(from: detail) {
+                                openTerminal(deployment)
+                            } else {
+                                activeDetailSheet = .launch(detail)
+                            }
                         } label: {
-                            Label("Launch", systemImage: "play.fill")
+                            if activeDeployment(from: detail) != nil {
+                                Label("Open Terminal", systemImage: "terminal")
+                            } else {
+                                Label("Launch", systemImage: "play.fill")
+                            }
                         }
                     } label: {
                         Image(systemName: "ellipsis.circle")
@@ -200,6 +209,18 @@ struct IssueDetailView: View {
                     owner: owner, repo: repo, number: number,
                     commentId: comment.id, currentBody: comment.body,
                     onSuccess: { Task { await load(refresh: true) } }
+                )
+            }
+        }
+        .fullScreenCover(item: $terminalTarget) { deployment in
+            if let port = deployment.ttydPort {
+                TerminalView(
+                    deployment: deployment,
+                    port: port,
+                    onEnd: {
+                        terminalTarget = nil
+                        Task { await load(refresh: true) }
+                    }
                 )
             }
         }
@@ -330,20 +351,39 @@ struct IssueDetailView: View {
                 .font(.headline)
 
             ForEach(deployments) { deployment in
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(deployment.isActive ? .green : .secondary)
-                        .frame(width: 8, height: 8)
-                    Text(deployment.branchName)
-                        .font(.subheadline)
-                    Spacer()
-                    Text(deployment.state.rawValue)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                if deployment.isActive, deployment.ttydPort != nil {
+                    Button {
+                        openTerminal(activeDeployment(from: deployment))
+                    } label: {
+                        deploymentRow(deployment, showsTerminal: true)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    deploymentRow(deployment, showsTerminal: false)
                 }
-                .padding(.vertical, 2)
             }
         }
+    }
+
+    private func deploymentRow(_ deployment: Deployment, showsTerminal: Bool) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(deployment.isActive ? .green : .secondary)
+                .frame(width: 8, height: 8)
+            Text(deployment.branchName)
+                .font(.subheadline)
+            Spacer()
+            if showsTerminal {
+                Label("Open", systemImage: "terminal")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.blue)
+            } else {
+                Text(deployment.state.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder
@@ -387,6 +427,15 @@ struct IssueDetailView: View {
     private func actionBar(for issue: GitHubIssue) -> some View {
         if issue.isOpen {
             HStack(spacing: 16) {
+                if let detail, let deployment = activeDeployment(from: detail) {
+                    Button {
+                        openTerminal(deployment)
+                    } label: {
+                        Label("Terminal", systemImage: "terminal")
+                    }
+                    .disabled(deployment.ttydPort == nil)
+                }
+
                 Button {
                     activeDetailSheet = .comment
                 } label: {
@@ -505,6 +554,37 @@ struct IssueDetailView: View {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func activeDeployment(from detail: IssueDetailResponse) -> ActiveDeployment? {
+        detail.deployments.first(where: { $0.isActive }).map(activeDeployment(from:))
+    }
+
+    private func activeDeployment(from deployment: Deployment) -> ActiveDeployment {
+        ActiveDeployment(
+            id: deployment.id,
+            repoId: deployment.repoId,
+            issueNumber: deployment.issueNumber,
+            branchName: deployment.branchName,
+            workspaceMode: deployment.workspaceMode,
+            workspacePath: deployment.workspacePath,
+            linkedPrNumber: deployment.linkedPrNumber,
+            state: deployment.state,
+            launchedAt: deployment.launchedAt,
+            endedAt: deployment.endedAt,
+            ttydPort: deployment.ttydPort,
+            ttydPid: deployment.ttydPid,
+            owner: owner,
+            repoName: repo
+        )
+    }
+
+    private func openTerminal(_ deployment: ActiveDeployment) {
+        guard deployment.ttydPort != nil else {
+            actionError = "Session is running, but its terminal is not ready yet."
+            return
+        }
+        terminalTarget = deployment
     }
 
     private func confirmPriority(_ priority: Priority, rollbackTo previous: Priority) async {

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -26,6 +26,7 @@ struct IssueListView: View {
     @State private var showReopenConfirm = false
     @State private var swipeTarget: (owner: String, repo: String, number: Int)?
     @State private var launchTarget: LaunchTarget?
+    @State private var terminalTarget: ActiveDeployment?
     @State private var loadingLaunchTargetId: String?
 
     // Draft swipe state
@@ -45,18 +46,25 @@ struct IssueListView: View {
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
-    // Maps repo full name to set of running issue numbers for that repo.
-    // Keyed by repo to avoid cross-repo collisions (issue #5 in repo A vs repo B).
-    private var runningIssuesByRepo: [String: Set<Int>] {
-        var map: [String: Set<Int>] = [:]
-        for deployment in activeDeployments {
-            map[deployment.repoFullName, default: []].insert(deployment.issueNumber)
-        }
-        return map
+    private func isRunning(_ issue: GitHubIssue, in repoFullName: String) -> Bool {
+        runningDeployment(for: issue, in: repoFullName) != nil
     }
 
-    private func isRunning(_ issue: GitHubIssue, in repoFullName: String) -> Bool {
-        runningIssuesByRepo[repoFullName]?.contains(issue.number) ?? false
+    private func runningDeployment(for issue: GitHubIssue, in repoFullName: String) -> ActiveDeployment? {
+        activeDeployments.first {
+            $0.isActive &&
+            $0.repoFullName == repoFullName &&
+            $0.issueNumber == issue.number
+        }
+    }
+
+    private func runningDeployment(owner: String, repo: String, number: Int) -> ActiveDeployment? {
+        activeDeployments.first {
+            $0.isActive &&
+            $0.owner == owner &&
+            $0.repoName == repo &&
+            $0.issueNumber == number
+        }
     }
 
     private var repoFilteredIssues: [GitHubIssue] {
@@ -266,6 +274,19 @@ struct IssueListView: View {
                     referencedFiles: target.referencedFiles
                 )
             }
+            .fullScreenCover(item: $terminalTarget) { deployment in
+                if let port = deployment.ttydPort {
+                    TerminalView(
+                        deployment: deployment,
+                        port: port,
+                        onEnd: {
+                            terminalTarget = nil
+                            activeDeployments.removeAll { $0.id == deployment.id }
+                            Task { await loadAll(refresh: true) }
+                        }
+                    )
+                }
+            }
             .confirmationDialog("Close Issue", isPresented: $showCloseConfirm, titleVisibility: .visible) {
                 Button("Close", role: .destructive) {
                     if let target = swipeTarget {
@@ -342,18 +363,31 @@ struct IssueListView: View {
                     .accessibilityIdentifier("issue-row-\(issue.number)")
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if issue.isOpen {
-                            Button {
-                                Task {
-                                    await prepareLaunch(owner: repo.owner, repo: repo.name, number: issue.number, title: issue.title)
+                            if let deployment = runningDeployment(for: issue, in: repo.fullName) {
+                                Button {
+                                    if deployment.ttydPort != nil {
+                                        terminalTarget = deployment
+                                    } else {
+                                        actionError = "Session is running, but its terminal is not ready yet."
+                                    }
+                                } label: {
+                                    Label("Terminal", systemImage: "terminal")
                                 }
-                            } label: {
-                                if loadingLaunchTargetId == "\(repo.owner)/\(repo.name)#\(issue.number)" {
-                                    Label("Loading", systemImage: "hourglass")
-                                } else {
-                                    Label("Launch", systemImage: "play.fill")
+                                .tint(.blue)
+                            } else {
+                                Button {
+                                    Task {
+                                        await prepareLaunch(owner: repo.owner, repo: repo.name, number: issue.number, title: issue.title)
+                                    }
+                                } label: {
+                                    if loadingLaunchTargetId == "\(repo.owner)/\(repo.name)#\(issue.number)" {
+                                        Label("Loading", systemImage: "hourglass")
+                                    } else {
+                                        Label("Launch", systemImage: "play.fill")
+                                    }
                                 }
+                                .tint(.green)
                             }
-                            .tint(.green)
                         } else {
                             Button {
                                 swipeTarget = (repo.owner, repo.name, issue.number)
@@ -440,6 +474,15 @@ struct IssueListView: View {
             if loadingLaunchTargetId == targetId {
                 loadingLaunchTargetId = nil
             }
+        }
+
+        if let deployment = runningDeployment(owner: owner, repo: repo, number: number) {
+            if deployment.ttydPort != nil {
+                terminalTarget = deployment
+            } else {
+                actionError = "Session is running, but its terminal is not ready yet."
+            }
+            return
         }
 
         do {

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -23,6 +23,9 @@ struct LaunchView: View {
     @State private var errorMessage: String?
     @State private var launchedPort: Int?
     @State private var launchedDeployment: ActiveDeployment?
+    @State private var existingDeployment: ActiveDeployment?
+    @State private var isCheckingActiveSession = false
+    @State private var shouldDismissAfterTerminalClose = false
     @State private var dirtyWorktree = false
     @State private var isResettingWorktree = false
 
@@ -58,7 +61,15 @@ struct LaunchView: View {
                 launchForm
             }
         }
-        .fullScreenCover(item: $launchedDeployment) { deployment in
+        .fullScreenCover(
+            item: $launchedDeployment,
+            onDismiss: {
+                if shouldDismissAfterTerminalClose {
+                    shouldDismissAfterTerminalClose = false
+                    dismiss()
+                }
+            }
+        ) { deployment in
             if let port = launchedPort {
                 TerminalView(
                     deployment: deployment,
@@ -131,6 +142,36 @@ struct LaunchView: View {
                                 Text("Resume with Changes")
                             }
                             .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
+            }
+
+            if let existingDeployment {
+                Section {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Claude Code is already running for this issue.", systemImage: "terminal")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.blue)
+
+                        HStack(spacing: 12) {
+                            Button {
+                                openExistingTerminal(existingDeployment)
+                            } label: {
+                                Label("Open Existing Terminal", systemImage: "terminal")
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(existingDeployment.ttydPort == nil)
+
+                            Text(existingDeployment.runningDuration)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if existingDeployment.ttydPort == nil {
+                            Text("The session is active, but the terminal is not ready yet.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
@@ -213,15 +254,18 @@ struct LaunchView: View {
                 Button {
                     Task { await launchSession() }
                 } label: {
-                    if isLaunching {
+                    if isLaunching || isCheckingActiveSession {
                         ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else if existingDeployment != nil {
+                        Label("Session Already Running", systemImage: "terminal")
                             .frame(maxWidth: .infinity)
                     } else {
                         Label("Launch Claude Code", systemImage: "play.fill")
                             .frame(maxWidth: .infinity)
                     }
                 }
-                .disabled(branchName.isEmpty || isLaunching)
+                .disabled(branchName.isEmpty || isLaunching || isCheckingActiveSession || existingDeployment != nil)
             }
         }
         .navigationTitle("Launch Session")
@@ -232,6 +276,7 @@ struct LaunchView: View {
             }
         }
         .task {
+            await loadExistingDeployment()
             if repoLocalPath == nil {
                 do {
                     let repos = try await api.repos()
@@ -286,10 +331,39 @@ struct LaunchView: View {
         await performLaunch(forceResume: nil)
     }
 
+    private func loadExistingDeployment() async {
+        isCheckingActiveSession = true
+        defer { isCheckingActiveSession = false }
+        do {
+            existingDeployment = try await findExistingDeployment()
+        } catch {
+            existingDeployment = nil
+        }
+    }
+
+    private func findExistingDeployment() async throws -> ActiveDeployment? {
+        let response = try await api.activeDeployments()
+        return response.deployments.first {
+            $0.isActive &&
+            $0.owner == owner &&
+            $0.repoName == repo &&
+            $0.issueNumber == issueNumber
+        }
+    }
+
+    private func openExistingTerminal(_ deployment: ActiveDeployment) {
+        guard let port = deployment.ttydPort else {
+            errorMessage = "Session is running, but its terminal is not ready yet."
+            return
+        }
+        shouldDismissAfterTerminalClose = true
+        launchedPort = port
+        launchedDeployment = deployment
+    }
+
     private func performLaunch(forceResume: Bool?) async {
         isLaunching = true
         errorMessage = nil
-        withAnimation { showProgress = true }
 
         defer {
             isLaunching = false
@@ -299,6 +373,14 @@ struct LaunchView: View {
         }
 
         do {
+            if let existing = try await findExistingDeployment() {
+                existingDeployment = existing
+                openExistingTerminal(existing)
+                return
+            }
+
+            withAnimation { showProgress = true }
+
             let body = LaunchRequestBody(
                 branchName: branchName,
                 workspaceMode: workspaceMode,
@@ -312,8 +394,9 @@ struct LaunchView: View {
                 owner: owner, repo: repo, number: issueNumber, body: body
             )
             if response.success, let deploymentId = response.deploymentId, let port = response.ttydPort {
+                shouldDismissAfterTerminalClose = true
                 launchedPort = port
-                launchedDeployment = ActiveDeployment(
+                let deployment = ActiveDeployment(
                     id: deploymentId,
                     repoId: 0,
                     issueNumber: issueNumber,
@@ -326,6 +409,8 @@ struct LaunchView: View {
                     endedAt: nil, ttydPort: port, ttydPid: nil,
                     owner: owner, repoName: repo
                 )
+                existingDeployment = deployment
+                launchedDeployment = deployment
             } else {
                 errorMessage = response.error ?? "Launch failed"
             }

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -26,6 +26,12 @@ struct SessionRowView: View {
                 Label(deployment.runningDuration, systemImage: "clock")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if deployment.ttydPort != nil {
+                    Label("Open", systemImage: "terminal")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.blue)
+                }
             }
         }
         .padding(.vertical, 4)

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -6,6 +6,8 @@ struct TerminalView: View {
     let deployment: ActiveDeployment
     let port: Int
     let onEnd: () -> Void
+    private let terminalFontSize = 24
+    private let terminalPageZoom = 1.35
 
     @Environment(\.dismiss) private var dismiss
     @State private var showEndConfirm = false
@@ -52,7 +54,12 @@ struct TerminalView: View {
                             }
                         }
                     } else {
-                        TerminalWebView(url: url, loadError: $loadError)
+                        TerminalWebView(
+                            url: url,
+                            loadError: $loadError,
+                            fontSize: terminalFontSize,
+                            pageZoom: terminalPageZoom
+                        )
                             .ignoresSafeArea(edges: .bottom)
                     }
                 } else {
@@ -132,7 +139,13 @@ struct TerminalView: View {
     private var terminalURL: URL? {
         guard let terminalToken else { return nil }
         var components = URLComponents(string: "\(api.serverURL)/api/terminal/\(currentPort)/")
-        components?.queryItems = [URLQueryItem(name: "terminalToken", value: terminalToken)]
+        components?.queryItems = [
+            URLQueryItem(name: "terminalToken", value: terminalToken),
+            URLQueryItem(name: "fontSize", value: "\(terminalFontSize)"),
+            URLQueryItem(name: "lineHeight", value: "1.25"),
+            URLQueryItem(name: "disableResizeOverlay", value: "true"),
+            URLQueryItem(name: "rendererType", value: "canvas"),
+        ]
         return components?.url
     }
 
@@ -180,9 +193,11 @@ struct TerminalView: View {
 struct TerminalWebView: UIViewRepresentable {
     let url: URL
     @Binding var loadError: String?
+    let fontSize: Int
+    let pageZoom: CGFloat
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(loadError: $loadError)
+        Coordinator(loadError: $loadError, fontSize: fontSize)
     }
 
     func makeUIView(context: Context) -> WKWebView {
@@ -193,25 +208,33 @@ struct TerminalWebView: UIViewRepresentable {
         webView.backgroundColor = .black
         webView.scrollView.bounces = false
         webView.navigationDelegate = context.coordinator
+        webView.pageZoom = pageZoom
         webView.load(URLRequest(url: url))
         return webView
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.fontSize = fontSize
+        webView.pageZoom = pageZoom
         if webView.url != url {
             webView.load(URLRequest(url: url))
+        } else {
+            context.coordinator.applyTerminalSizing(to: webView)
         }
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         @Binding var loadError: String?
+        var fontSize: Int
 
-        init(loadError: Binding<String?>) {
+        init(loadError: Binding<String?>, fontSize: Int) {
             _loadError = loadError
+            self.fontSize = fontSize
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             loadError = nil
+            applyTerminalSizing(to: webView)
         }
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
@@ -220,6 +243,46 @@ struct TerminalWebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
             loadError = error.localizedDescription
+        }
+
+        func applyTerminalSizing(to webView: WKWebView) {
+            let script = """
+            (() => {
+                const id = "issuectl-terminal-font-size";
+                let style = document.getElementById(id);
+                if (!style) {
+                    style = document.createElement("style");
+                    style.id = id;
+                    document.head.appendChild(style);
+                }
+                style.textContent = `
+                    :root {
+                        --issuectl-terminal-font-size: \(fontSize)px;
+                    }
+                    body,
+                    .terminal,
+                    .xterm,
+                    .xterm-viewport,
+                    .xterm-screen,
+                    .xterm-rows,
+                    .xterm-char-measure-element {
+                        font-size: var(--issuectl-terminal-font-size) !important;
+                        line-height: 1.2 !important;
+                    }
+                `;
+                const terminal = window.term || window.terminal || window.xterm;
+                if (terminal && terminal.options) {
+                    terminal.options.fontSize = \(fontSize);
+                    terminal.options.lineHeight = 1.2;
+                    if (typeof terminal.refresh === "function") {
+                        terminal.refresh(0, terminal.rows || 0);
+                    }
+                }
+                window.dispatchEvent(new Event("resize"));
+                setTimeout(() => window.dispatchEvent(new Event("resize")), 150);
+            })();
+            """
+            webView.evaluateJavaScript(script)
         }
     }
 }

--- a/ios/IssueCTLTests/EnumTests.swift
+++ b/ios/IssueCTLTests/EnumTests.swift
@@ -229,6 +229,24 @@ final class EnumTests: XCTestCase {
         let deployment = try decoder.decode(ActiveDeployment.self, from: json)
         XCTAssertEqual(deployment.state, .active)
         XCTAssertEqual(deployment.workspaceMode, .clone)
+        XCTAssertTrue(deployment.isActive)
+    }
+
+    func testActiveDeploymentActiveButEndedAtPresent() throws {
+        let json = """
+        {
+            "id": 1, "repo_id": 1, "issue_number": 1,
+            "branch_name": "b", "workspace_mode": "clone",
+            "workspace_path": "/tmp", "linked_pr_number": null,
+            "state": "active",
+            "launched_at": "2026-04-27T08:00:00Z", "ended_at": "2026-04-27T09:00:00Z",
+            "ttyd_port": 7682, "ttyd_pid": 100,
+            "owner": "org", "repo_name": "app"
+        }
+        """.data(using: .utf8)!
+
+        let deployment = try decoder.decode(ActiveDeployment.self, from: json)
+        XCTAssertFalse(deployment.isActive)
     }
 
     func testPriorityInDraft() throws {


### PR DESCRIPTION
## Summary
- increase iOS ttyd terminal readability with client font options, line height, and web view zoom
- add terminal re-entry from running issues, issue detail deployments, and active session rows
- block duplicate Claude Code launches and dismiss the launch sheet after terminal close

## Testing
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\n- Manual simulator: launched #793 and #792 from Issues, terminal opened for each, Done returned to issue/index without a stale launch sheet, Running count went 6 -> 8\n- Cleanup: ended the two test deployments, removed in-progress/deployed labels, and verified #792/#793 were back to open bug issues