### PR TITLE
Revamp iOS command center UX

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */; };
+		10B14C8F5BB6411AB48FB37A /* CommandCenterComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D6C8B9D3F84B69988A9F55 /* CommandCenterComponents.swift */; };
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
@@ -80,6 +81,7 @@
 		F8AA4C4B8F453C5ED17CA45C /* APIClient+Drafts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D7802FFDD0F6D445452B3 /* APIClient+Drafts.swift */; };
 		FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */; };
 		FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4010BC691DB71B872353344A /* SessionListView.swift */; };
+		FE0B5C2B67B34C029C49FD12 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72E02E2D87749738F2DB8BC /* TodayView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -140,6 +142,7 @@
 		9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepoSheet.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
+		A9D6C8B9D3F84B69988A9F55 /* CommandCenterComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterComponents.swift; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+AdvancedSettings.swift"; sourceTree = "<group>"; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -161,6 +164,7 @@
 		F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRepoSheet.swift; sourceTree = "<group>"; };
 		F3CF16B90E6F234095B67412 /* EdgeCaseModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseModelTests.swift; sourceTree = "<group>"; };
 		F63680089A3314AB67CE5883 /* ViewLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLogicTests.swift; sourceTree = "<group>"; };
+		F72E02E2D87749738F2DB8BC /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTabs.swift; sourceTree = "<group>"; };
 		F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MineFilterChip.swift; sourceTree = "<group>"; };
 		FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
@@ -209,6 +213,7 @@
 				653A328D4F0E8EA06901C71E /* Settings */,
 				E81A7D2E7B5E3CA762AC518E /* Shared */,
 				2FA8C48F01DE69137521E3BC /* Terminal */,
+				9277C6A223C54C5FA343C53F /* Today */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -332,6 +337,14 @@
 			path = Launch;
 			sourceTree = "<group>";
 		};
+		9277C6A223C54C5FA343C53F /* Today */ = {
+			isa = PBXGroup;
+			children = (
+				F72E02E2D87749738F2DB8BC /* TodayView.swift */,
+			);
+			path = Today;
+			sourceTree = "<group>";
+		};
 		D5E657213913F2B68B41C505 /* IssueCTL */ = {
 			isa = PBXGroup;
 			children = (
@@ -349,6 +362,7 @@
 			isa = PBXGroup;
 			children = (
 				2841D89323711B68449BB980 /* CacheAgeLabel.swift */,
+				A9D6C8B9D3F84B69988A9F55 /* CommandCenterComponents.swift */,
 				4403330B1342AA7C19FA797D /* Constants.swift */,
 				458A6E2819377536E7EDF138 /* ErrorAutoDismissModifier.swift */,
 				894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */,
@@ -529,6 +543,7 @@
 				AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */,
 				C188EF4912DB0E5917317C07 /* CommentSheet.swift in Sources */,
 				661BA5DB6B1BC46ADC8289D5 /* CommentView.swift in Sources */,
+				10B14C8F5BB6411AB48FB37A /* CommandCenterComponents.swift in Sources */,
 				4451AE4574EA7D0F86AEE021 /* Constants.swift in Sources */,
 				A18D8982D49319C633EE661A /* ContentView.swift in Sources */,
 				48B3B409AB2457A29BE870C7 /* Deployment.swift in Sources */,
@@ -577,6 +592,7 @@
 				89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */,
 				6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */,
 				C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */,
+				FE0B5C2B67B34C029C49FD12 /* TodayView.swift in Sources */,
 				42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -3,26 +3,36 @@ import SwiftUI
 struct ContentView: View {
     @Environment(APIClient.self) private var api
     @Environment(NetworkMonitor.self) private var network
+    @State private var selectedTab: AppTab = .today
+    @State private var showSettings = false
 
     var body: some View {
         if api.isConfigured {
-            TabView {
-                Tab("Issues", systemImage: "list.bullet") {
+            TabView(selection: $selectedTab) {
+                Tab("Today", systemImage: "waveform.path.ecg", value: AppTab.today) {
+                    TodayView(
+                        onShowSettings: { showSettings = true },
+                        onShowIssues: { selectedTab = .issues },
+                        onShowPullRequests: { selectedTab = .pullRequests },
+                        onShowSessions: { selectedTab = .active }
+                    )
+                }
+                .accessibilityIdentifier("today-tab")
+                Tab("Issues", systemImage: "list.bullet", value: AppTab.issues) {
                     IssueListView()
                 }
                 .accessibilityIdentifier("issues-tab")
-                Tab("PRs", systemImage: "arrow.triangle.merge") {
+                Tab("PRs", systemImage: "arrow.triangle.merge", value: AppTab.pullRequests) {
                     PRListView()
                 }
                 .accessibilityIdentifier("prs-tab")
-                Tab("Active", systemImage: "play.circle") {
+                Tab("Active", systemImage: "terminal", value: AppTab.active) {
                     SessionListView()
                 }
                 .accessibilityIdentifier("active-tab")
-                Tab("Settings", systemImage: "gearshape") {
-                    SettingsView()
-                }
-                .accessibilityIdentifier("settings-tab")
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
             }
             .overlay(alignment: .top) {
                 OfflineBanner()
@@ -32,4 +42,11 @@ struct ContentView: View {
             OnboardingView()
         }
     }
+}
+
+private enum AppTab: Hashable {
+    case today
+    case issues
+    case pullRequests
+    case active
 }

--- a/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
+++ b/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
@@ -52,3 +52,35 @@ func repoIndexForItem<Item>(
     }
     return repos.firstIndex(where: { $0.id == repo.id })
 }
+
+extension GitHubPull {
+    var needsReviewAttention: Bool {
+        isOpen && (checksStatus == "failure" || checksStatus == "pending")
+    }
+}
+
+func runningDeployment(
+    for issue: GitHubIssue,
+    in repoFullName: String,
+    deployments: [ActiveDeployment]
+) -> ActiveDeployment? {
+    deployments.first {
+        $0.isActive &&
+        $0.repoFullName == repoFullName &&
+        $0.issueNumber == issue.number
+    }
+}
+
+func runningDeployment(
+    owner: String,
+    repo: String,
+    number: Int,
+    deployments: [ActiveDeployment]
+) -> ActiveDeployment? {
+    deployments.first {
+        $0.isActive &&
+        $0.owner == owner &&
+        $0.repoName == repo &&
+        $0.issueNumber == number
+    }
+}

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -76,84 +76,6 @@ struct IssueDetailView: View {
         }
         .navigationTitle("#\(number)")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            if let detail {
-                ToolbarItem(placement: .topBarTrailing) {
-                    if let url = URL(string: detail.issue.htmlUrl) {
-                        ShareLink(item: url) {
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        Button {
-                            if let url = URL(string: detail.issue.htmlUrl) {
-                                openURL(url)
-                            }
-                        } label: {
-                            Label("Open on GitHub", systemImage: "safari")
-                        }
-                        Divider()
-                        Button {
-                            activeDetailSheet = .edit(detail)
-                        } label: {
-                            Label("Edit Issue", systemImage: "pencil")
-                        }
-                        Button {
-                            activeDetailSheet = .labels(detail)
-                        } label: {
-                            Label("Manage Labels", systemImage: "tag")
-                        }
-                        Button {
-                            activeDetailSheet = .assignees(detail)
-                        } label: {
-                            Label("Manage Assignees", systemImage: "person.badge.plus")
-                        }
-                        Divider()
-                        Menu {
-                            ForEach(Priority.allCases, id: \.self) { priority in
-                                Button {
-                                    let previousPriority = currentPriority
-                                    currentPriority = priority
-                                    Task { await confirmPriority(priority, rollbackTo: previousPriority) }
-                                } label: {
-                                    HStack {
-                                        Text(priority.rawValue.capitalized)
-                                        if priority == currentPriority {
-                                            Image(systemName: "checkmark")
-                                        }
-                                    }
-                                }
-                            }
-                        } label: {
-                            Label("Priority", systemImage: "arrow.up.arrow.down")
-                        }
-                        Divider()
-                        Button {
-                            activeDetailSheet = .reassign(detail)
-                        } label: {
-                            Label("Reassign to Repo…", systemImage: "arrow.triangle.swap")
-                        }
-                        Button {
-                            if let deployment = activeDeployment(from: detail) {
-                                openTerminal(deployment)
-                            } else {
-                                activeDetailSheet = .launch(detail)
-                            }
-                        } label: {
-                            if activeDeployment(from: detail) != nil {
-                                Label("Open Terminal", systemImage: "terminal")
-                            } else {
-                                Label("Launch", systemImage: "play.fill")
-                            }
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                    }
-                }
-            }
-        }
         .navigationDestination(for: PRDestination.self) { dest in
             PRDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
         }
@@ -175,6 +97,8 @@ struct IssueDetailView: View {
                     comments: detail.comments,
                     referencedFiles: detail.referencedFiles
                 )
+                .presentationDetents([.fraction(0.66), .large])
+                .presentationDragIndicator(.visible)
             case .edit(let detail):
                 EditIssueSheet(
                     owner: owner, repo: repo, number: number,
@@ -426,16 +350,61 @@ struct IssueDetailView: View {
     @ViewBuilder
     private func actionBar(for issue: GitHubIssue) -> some View {
         if issue.isOpen {
-            HStack(spacing: 16) {
+            ThumbActionBar {
                 if let detail, let deployment = activeDeployment(from: detail) {
                     Button {
                         openTerminal(deployment)
                     } label: {
-                        Label("Terminal", systemImage: "terminal")
+                        Label(deployment.ttydPort == nil ? "Terminal Starting" : "Re-enter Terminal", systemImage: "terminal")
+                            .font(.subheadline.weight(.bold))
+                            .frame(maxWidth: .infinity)
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(IssueCTLColors.action)
                     .disabled(deployment.ttydPort == nil)
+                } else if let detail {
+                    Button {
+                        activeDetailSheet = .launch(detail)
+                    } label: {
+                        Label("Launch Claude", systemImage: "play.fill")
+                            .font(.subheadline.weight(.bold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(IssueCTLColors.action)
                 }
+            } secondary: {
+                issueActionsMenu
+            }
+            .padding(.bottom, 4)
+        } else {
+            ThumbActionBar {
+                Button {
+                    activeConfirmation = .reopenIssue
+                } label: {
+                    HStack {
+                        if isReopening {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Label("Reopen", systemImage: "arrow.uturn.backward.circle")
+                        }
+                    }
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .disabled(isReopening)
+            } secondary: {
+                issueActionsMenu
+            }
+            .padding(.bottom, 4)
+        }
+    }
 
+    private var issueActionsMenu: some View {
+        Menu {
+            if let detail {
                 Button {
                     activeDetailSheet = .comment
                 } label: {
@@ -443,40 +412,80 @@ struct IssueDetailView: View {
                 }
 
                 Button {
-                    activeConfirmation = .closeIssue
+                    activeDetailSheet = .edit(detail)
                 } label: {
-                    if isClosing {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Label("Close", systemImage: "xmark.circle")
-                    }
+                    Label("Edit Issue", systemImage: "pencil")
                 }
-                .tint(.red)
-                .disabled(isClosing)
-            }
-            .labelStyle(.titleAndIcon)
-            .font(.caption)
-            .padding()
-            .background(.bar)
-        } else {
-            HStack {
+
                 Button {
-                    activeConfirmation = .reopenIssue
+                    activeDetailSheet = .labels(detail)
                 } label: {
-                    if isReopening {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Label("Reopen", systemImage: "arrow.uturn.backward.circle")
-                    }
+                    Label("Manage Labels", systemImage: "tag")
                 }
-                .tint(.green)
-                .disabled(isReopening)
+
+                Button {
+                    activeDetailSheet = .assignees(detail)
+                } label: {
+                    Label("Manage Assignees", systemImage: "person.badge.plus")
+                }
+
+                Divider()
+
+                Menu {
+                    ForEach(Priority.allCases, id: \.self) { priority in
+                        Button {
+                            let previousPriority = currentPriority
+                            currentPriority = priority
+                            Task { await confirmPriority(priority, rollbackTo: previousPriority) }
+                        } label: {
+                            HStack {
+                                Text(priority.rawValue.capitalized)
+                                if priority == currentPriority {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Label("Priority", systemImage: "arrow.up.arrow.down")
+                }
+
+                Button {
+                    activeDetailSheet = .reassign(detail)
+                } label: {
+                    Label("Reassign to Repo", systemImage: "arrow.triangle.swap")
+                }
+
+                Divider()
+
+                Button {
+                    if let url = URL(string: detail.issue.htmlUrl) {
+                        openURL(url)
+                    }
+                } label: {
+                    Label("Open on GitHub", systemImage: "safari")
+                }
+
+                if detail.issue.isOpen {
+                    Button(role: .destructive) {
+                        activeConfirmation = .closeIssue
+                    } label: {
+                        if isClosing {
+                            Label("Closing", systemImage: "hourglass")
+                        } else {
+                            Label("Close Issue", systemImage: "xmark.circle")
+                        }
+                    }
+                    .disabled(isClosing)
+                }
             }
-            .labelStyle(.titleAndIcon)
-            .font(.caption)
-            .padding()
-            .background(.bar)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(width: 44, height: 36)
         }
+        .buttonStyle(.bordered)
+        .accessibilityLabel("Issue actions")
     }
 
     // MARK: - Confirmation Dialog Helpers

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -17,6 +17,7 @@ struct IssueListView: View {
     @SceneStorage("issues.mineOnly") private var storedMineOnly = false
     @State private var showCreateSheet = false
     @State private var showParseSheet = false
+    @State private var showFiltersSheet = false
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var navigationPath = NavigationPath()
@@ -47,24 +48,7 @@ struct IssueListView: View {
     private let refreshCooldown: TimeInterval = 10
 
     private func isRunning(_ issue: GitHubIssue, in repoFullName: String) -> Bool {
-        runningDeployment(for: issue, in: repoFullName) != nil
-    }
-
-    private func runningDeployment(for issue: GitHubIssue, in repoFullName: String) -> ActiveDeployment? {
-        activeDeployments.first {
-            $0.isActive &&
-            $0.repoFullName == repoFullName &&
-            $0.issueNumber == issue.number
-        }
-    }
-
-    private func runningDeployment(owner: String, repo: String, number: Int) -> ActiveDeployment? {
-        activeDeployments.first {
-            $0.isActive &&
-            $0.owner == owner &&
-            $0.repoName == repo &&
-            $0.issueNumber == number
-        }
+        runningDeployment(for: issue, in: repoFullName, deployments: activeDeployments) != nil
     }
 
     private var repoFilteredIssues: [GitHubIssue] {
@@ -167,13 +151,6 @@ struct IssueListView: View {
                 SectionTabs(selected: $section, counts: sectionCounts)
                     .padding(.vertical, 8)
 
-                HStack(spacing: 0) {
-                    RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil, isDisabled: userFetchFailed)
-                        .padding(.trailing, 16)
-                }
-                .padding(.bottom, 8)
-
                 Divider()
 
                 if let oldestCachedAt {
@@ -216,39 +193,6 @@ struct IssueListView: View {
                 }
             }
             .navigationTitle("Issues")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        Picker("Sort", selection: $sortOrder) {
-                            Label("Updated", systemImage: "clock").tag(SortOrder.updated)
-                            Label("Created", systemImage: "calendar").tag(SortOrder.created)
-                            Label("Priority", systemImage: "arrow.up.arrow.down").tag(SortOrder.priority)
-                        }
-                    } label: {
-                        Image(systemName: "arrow.up.arrow.down")
-                    }
-                    .accessibilityIdentifier("sort-menu")
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        Button {
-                            showCreateSheet = true
-                        } label: {
-                            Label("Quick Create", systemImage: "plus")
-                        }
-                        .accessibilityIdentifier("quick-create-button")
-                        Button {
-                            showParseSheet = true
-                        } label: {
-                            Label("Parse with AI", systemImage: "text.viewfinder")
-                        }
-                        .accessibilityIdentifier("parse-ai-button")
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .accessibilityIdentifier("create-menu")
-                }
-            }
             .navigationDestination(for: IssueDestination.self) { dest in
                 IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
@@ -264,6 +208,23 @@ struct IssueListView: View {
             .sheet(isPresented: $showParseSheet) {
                 ParseView()
             }
+            .sheet(isPresented: $showFiltersSheet) {
+                IssueFilterSheet(
+                    repos: repos,
+                    selectedRepoIds: $selectedRepoIds,
+                    section: $section,
+                    sortOrder: $sortOrder,
+                    mineOnly: $mineOnly,
+                    mineFilterEnabled: currentUserLogin != nil && !userFetchFailed,
+                    sectionCounts: sectionCounts,
+                    onParseWithAI: {
+                        showFiltersSheet = false
+                        showParseSheet = true
+                    }
+                )
+                .presentationDetents([.fraction(0.66), .large])
+                .presentationDragIndicator(.visible)
+            }
             .sheet(item: $launchTarget) { target in
                 LaunchView(
                     owner: target.owner,
@@ -273,6 +234,8 @@ struct IssueListView: View {
                     comments: target.comments,
                     referencedFiles: target.referencedFiles
                 )
+                .presentationDetents([.fraction(0.66), .large])
+                .presentationDragIndicator(.visible)
             }
             .fullScreenCover(item: $terminalTarget) { deployment in
                 if let port = deployment.ttydPort {
@@ -330,8 +293,36 @@ struct IssueListView: View {
             }
             .onChange(of: searchText) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
+            .safeAreaInset(edge: .bottom) {
+                issueThumbBar
+            }
         }
         .searchable(text: $searchText, prompt: "Search issues")
+    }
+
+    private var issueThumbBar: some View {
+        ThumbActionBar {
+            Button {
+                showCreateSheet = true
+            } label: {
+                Label("Create Issue", systemImage: "plus")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action)
+        } secondary: {
+            Button {
+                showFiltersSheet = true
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 44, height: 36)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Issue filters")
+        }
+        .padding(.bottom, 4)
     }
 
     // MARK: - Lists
@@ -363,7 +354,7 @@ struct IssueListView: View {
                     .accessibilityIdentifier("issue-row-\(issue.number)")
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         if issue.isOpen {
-                            if let deployment = runningDeployment(for: issue, in: repo.fullName) {
+                            if let deployment = runningDeployment(for: issue, in: repo.fullName, deployments: activeDeployments) {
                                 Button {
                                     if deployment.ttydPort != nil {
                                         terminalTarget = deployment
@@ -476,7 +467,7 @@ struct IssueListView: View {
             }
         }
 
-        if let deployment = runningDeployment(owner: owner, repo: repo, number: number) {
+        if let deployment = runningDeployment(owner: owner, repo: repo, number: number, deployments: activeDeployments) {
             if deployment.ttydPort != nil {
                 terminalTarget = deployment
             } else {
@@ -692,5 +683,152 @@ struct DraftDestination: Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(draft.id)
+    }
+}
+
+private struct IssueFilterSheet: View {
+    let repos: [Repo]
+    @Binding var selectedRepoIds: Set<Int>
+    @Binding var section: IssueSection
+    @Binding var sortOrder: SortOrder
+    @Binding var mineOnly: Bool
+
+    let mineFilterEnabled: Bool
+    let sectionCounts: [IssueSection: Int]
+    let onParseWithAI: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Filter & Sort")
+                            .font(.title2.weight(.bold))
+                        Text("\(sectionCounts[section] ?? 0) \(section.rawValue) items")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    sheetCard(title: "Status") {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                            ForEach(IssueSection.allCases, id: \.self) { option in
+                                filterOption(
+                                    title: option.rawValue.capitalized,
+                                    subtitle: "\(sectionCounts[option] ?? 0) items",
+                                    isSelected: section == option
+                                ) {
+                                    section = option
+                                }
+                            }
+                        }
+                    }
+
+                    sheetCard(title: "Repository") {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                            Button {
+                                selectedRepoIds.removeAll()
+                            } label: {
+                                optionContent(title: "All Repos", subtitle: "\(repos.count) configured", isSelected: selectedRepoIds.isEmpty)
+                            }
+                            .buttonStyle(.plain)
+
+                            ForEach(repos) { repo in
+                                let isSelected = selectedRepoIds.contains(repo.id)
+                                Button {
+                                    if isSelected {
+                                        selectedRepoIds.remove(repo.id)
+                                    } else {
+                                        selectedRepoIds.insert(repo.id)
+                                    }
+                                } label: {
+                                    optionContent(title: repo.name, subtitle: repo.owner, isSelected: isSelected)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+
+                    sheetCard(title: "Sort") {
+                        Picker("Sort", selection: $sortOrder) {
+                            Label("Priority", systemImage: "arrow.up.arrow.down").tag(SortOrder.priority)
+                            Label("Updated", systemImage: "clock").tag(SortOrder.updated)
+                            Label("Created", systemImage: "calendar").tag(SortOrder.created)
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    VStack(spacing: 0) {
+                        Toggle(isOn: $mineOnly) {
+                            Label("Mine Only", systemImage: "person.crop.circle")
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .disabled(!mineFilterEnabled)
+                        .padding(12)
+
+                        Divider()
+
+                        Button(action: onParseWithAI) {
+                            HStack(spacing: 12) {
+                                Image(systemName: "text.viewfinder")
+                                    .frame(width: 24)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Parse with AI")
+                                        .font(.subheadline.weight(.semibold))
+                                    Text("Create a structured draft from rough notes.")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.caption.weight(.bold))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .padding(12)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private func sheetCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+        .padding(12)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func filterOption(title: String, subtitle: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            optionContent(title: title, subtitle: subtitle, isSelected: isSelected)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func optionContent(title: String, subtitle: String, isSelected: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
+        .padding(10)
+        .background(isSelected ? IssueCTLColors.action.opacity(0.14) : Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSelected ? IssueCTLColors.action.opacity(0.55) : Color.clear, lineWidth: 1)
+        }
     }
 }

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -15,6 +15,7 @@ struct QuickCreateSheet: View {
     @State private var priority: Priority = .normal
     @State private var isSubmitting = false
     @State private var errorMessage: String?
+    @State private var showMoreOptions = false
 
     // Labels
     @State private var availableLabels: [GitHubLabel] = []
@@ -35,111 +36,155 @@ struct QuickCreateSheet: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section("Title") {
-                    TextField("Issue title", text: $title)
-                        .font(.body)
-                        .accessibilityIdentifier("issue-title-field")
-                }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Create Issue")
+                            .font(.title2.weight(.bold))
+                        Text("Fast capture first. Add metadata only when needed.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.top, 4)
 
-                Section("Description") {
-                    TextEditor(text: $bodyText)
-                        .font(.body)
-                        .frame(minHeight: 100)
-                        .accessibilityIdentifier("issue-body-editor")
-                        .overlay(alignment: .topLeading) {
-                            if bodyText.isEmpty {
-                                Text("Optional description...")
-                                    .foregroundStyle(.tertiary)
-                                    .font(.body)
-                                    .padding(.top, 8)
-                                    .padding(.leading, 5)
-                                    .allowsHitTesting(false)
-                            }
-                        }
-                    if let repo = selectedRepo {
-                        ImageAttachmentButton(owner: repo.owner, repo: repo.name) { markdown in
-                            if bodyText.isEmpty {
-                                bodyText = markdown
-                            } else {
-                                bodyText += "\n\n\(markdown)"
-                            }
+                    sheetCard {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("Repository")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            repoSelector
                         }
                     }
-                }
 
-                Section("Repository") {
-                    Picker("Repo", selection: $selectedRepoId) {
-                        Text("None (local draft)").tag(nil as Int?)
-                        ForEach(Array(repos.enumerated()), id: \.element.id) { index, repo in
-                            HStack(spacing: 6) {
-                                Circle()
-                                    .fill(RepoColors.color(for: index))
-                                    .frame(width: 8, height: 8)
-                                Text(repo.fullName)
-                            }
-                            .tag(repo.id as Int?)
+                    sheetCard {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Title")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            TextField("Issue title", text: $title)
+                                .font(.body)
+                                .textInputAutocapitalization(.sentences)
+                                .accessibilityIdentifier("issue-title-field")
                         }
                     }
-                    .accessibilityIdentifier("repo-picker")
-                }
 
-                if let repo = selectedRepo {
-                    Section("Labels") {
-                        if let labelError = labelLoadError {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Label(labelError, systemImage: "exclamationmark.triangle")
-                                    .foregroundStyle(.orange)
-                                    .font(.callout)
-                                Button("Retry") {
-                                    Task { await loadLabels(owner: repo.owner, repo: repo.name) }
+                    sheetCard {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Details")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            TextEditor(text: $bodyText)
+                                .font(.body)
+                                .frame(minHeight: 92)
+                                .accessibilityIdentifier("issue-body-editor")
+                                .overlay(alignment: .topLeading) {
+                                    if bodyText.isEmpty {
+                                        Text("Describe the issue")
+                                            .foregroundStyle(.tertiary)
+                                            .font(.body)
+                                            .padding(.top, 8)
+                                            .padding(.leading, 5)
+                                            .allowsHitTesting(false)
+                                    }
                                 }
-                                .font(.callout)
+                        }
+                    }
+
+                    sheetCard {
+                        DisclosureGroup(isExpanded: $showMoreOptions) {
+                            VStack(alignment: .leading, spacing: 16) {
+                                if let repo = selectedRepo {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Labels")
+                                            .font(.caption.weight(.semibold))
+                                            .foregroundStyle(.secondary)
+                                        if let labelError = labelLoadError {
+                                            VStack(alignment: .leading, spacing: 8) {
+                                                Label(labelError, systemImage: "exclamationmark.triangle")
+                                                    .foregroundStyle(.orange)
+                                                    .font(.callout)
+                                                Button("Retry") {
+                                                    Task { await loadLabels(owner: repo.owner, repo: repo.name) }
+                                                }
+                                                .font(.callout)
+                                            }
+                                        } else {
+                                            LabelPicker(
+                                                labels: availableLabels,
+                                                selectedLabels: $selectedLabels,
+                                                isLoading: isLoadingLabels
+                                            )
+                                        }
+                                    }
+
+                                    ImageAttachmentButton(owner: repo.owner, repo: repo.name) { markdown in
+                                        if bodyText.isEmpty {
+                                            bodyText = markdown
+                                        } else {
+                                            bodyText += "\n\n\(markdown)"
+                                        }
+                                    }
+                                }
+
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("Priority")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                    Picker("Priority", selection: $priority) {
+                                        Text("Low").tag(Priority.low)
+                                        Text("Normal").tag(Priority.normal)
+                                        Text("High").tag(Priority.high)
+                                    }
+                                    .pickerStyle(.segmented)
+                                    .accessibilityIdentifier("priority-picker")
+                                }
                             }
-                        } else {
-                            LabelPicker(
-                                labels: availableLabels,
-                                selectedLabels: $selectedLabels,
-                                isLoading: isLoadingLabels
-                            )
+                            .padding(.top, 12)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("More Options")
+                                    .font(.subheadline.weight(.semibold))
+                                Text("Labels, attachments, priority, and local drafts.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
-                }
 
-                Section("Priority") {
-                    Picker("Priority", selection: $priority) {
-                        Text("Low").tag(Priority.low)
-                        Text("Normal").tag(Priority.normal)
-                        Text("High").tag(Priority.high)
-                    }
-                    .pickerStyle(.segmented)
-                    .accessibilityIdentifier("priority-picker")
-                }
-
-                if let errorMessage {
-                    Section {
+                    if let errorMessage {
                         Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.subheadline)
                             .foregroundStyle(.red)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.red.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))
                     }
                 }
-
-                Section {
-                    Button {
-                        Task { await submit() }
-                    } label: {
-                        if isSubmitting {
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                        } else {
-                            Text(buttonLabel)
-                                .frame(maxWidth: .infinity)
-                        }
-                    }
-                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
-                    .accessibilityIdentifier("submit-issue-button")
-                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 18)
             }
-            .navigationTitle("Quick Create")
+            .safeAreaInset(edge: .bottom) {
+                Button {
+                    Task { await submit() }
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text(buttonLabel)
+                            .font(.subheadline.weight(.bold))
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(IssueCTLColors.action)
+                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                .accessibilityIdentifier("submit-issue-button")
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .background(.bar)
+            }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -147,15 +192,86 @@ struct QuickCreateSheet: View {
                         .accessibilityIdentifier("cancel-button")
                 }
             }
+            .onAppear {
+                if selectedRepoId == nil {
+                    selectedRepoId = repos.first?.id
+                }
+            }
             .onChange(of: selectedRepoId) { _, newValue in
                 selectedLabels = []
                 availableLabels = []
                 labelLoadError = nil
-                if let repoId = newValue, let repo = repos.first(where: { $0.id == repoId }) {
+                if showMoreOptions, let repoId = newValue, let repo = repos.first(where: { $0.id == repoId }) {
                     Task { await loadLabels(owner: repo.owner, repo: repo.name) }
                 }
             }
+            .onChange(of: showMoreOptions) { _, isExpanded in
+                guard isExpanded, availableLabels.isEmpty, labelLoadError == nil, let repo = selectedRepo else { return }
+                Task { await loadLabels(owner: repo.owner, repo: repo.name) }
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
+    }
+
+    @ViewBuilder
+    private var repoSelector: some View {
+        if repos.isEmpty {
+            Text("Local draft")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        } else {
+            HStack(spacing: 8) {
+                ForEach(Array(repos.prefix(2).enumerated()), id: \.element.id) { index, repo in
+                    Button {
+                        selectedRepoId = repo.id
+                    } label: {
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(RepoColors.color(for: index))
+                                .frame(width: 8, height: 8)
+                            Text(repo.name)
+                                .lineLimit(1)
+                        }
+                        .font(.body)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 8)
+                        .background(
+                            selectedRepoId == repo.id ? IssueCTLColors.action.opacity(0.16) : Color(.tertiarySystemGroupedBackground),
+                            in: Capsule()
+                        )
+                        .foregroundStyle(selectedRepoId == repo.id ? IssueCTLColors.action : .primary)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Menu {
+                    ForEach(repos.dropFirst(2), id: \.id) { repo in
+                        Button(repo.fullName) {
+                            selectedRepoId = repo.id
+                        }
+                    }
+                    Divider()
+                    Button("Local Draft") {
+                        selectedRepoId = nil
+                    }
+                } label: {
+                    Text("More")
+                        .font(.body)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 8)
+                        .background(Color(.tertiarySystemGroupedBackground), in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func sheetCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
     }
 
     private func loadLabels(owner: String, repo: String) async {
@@ -202,7 +318,7 @@ struct QuickCreateSheet: View {
                 }
                 if let warning = assignResponse.cleanupWarning {
                     // Issue was created on GitHub but draft cleanup failed on server.
-                    // Dismiss the sheet — the issue exists — and surface the warning
+                    // Dismiss the sheet; the issue exists. Surface the warning
                     // via the parent's action-error banner (auto-dismisses after 5s).
                     isSubmitting = false
                     onSuccess("Issue created. Note: \(warning)")
@@ -211,7 +327,7 @@ struct QuickCreateSheet: View {
                 }
                 if let warning = assignResponse.labelsWarning {
                     // Issue was created on GitHub but labels could not be applied.
-                    // Dismiss the sheet — the issue exists — and surface the warning
+                    // Dismiss the sheet; the issue exists. Surface the warning
                     // via the parent's action-error banner (auto-dismisses after 5s).
                     isSubmitting = false
                     onSuccess("Issue created. Note: \(warning)")

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -28,6 +28,7 @@ struct LaunchView: View {
     @State private var shouldDismissAfterTerminalClose = false
     @State private var dirtyWorktree = false
     @State private var isResettingWorktree = false
+    @State private var showAdvancedOptions = false
 
     init(owner: String, repo: String, issueNumber: Int, issueTitle: String, comments: [GitHubComment], referencedFiles: [String], repoLocalPath: String? = nil) {
         self.owner = owner
@@ -97,14 +98,37 @@ struct LaunchView: View {
     private var launchForm: some View {
         Form {
             Section {
-                HStack {
-                    Text("#\(issueNumber)")
-                        .font(.subheadline)
+                VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Launch Claude Code")
+                            .font(.title2.weight(.bold))
+                        Text("#\(issueNumber) \(issueTitle)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
+                    if let existingDeployment {
+                        Button {
+                            openExistingTerminal(existingDeployment)
+                        } label: {
+                            Label("Re-enter Running Terminal", systemImage: "terminal")
+                                .font(.subheadline.weight(.bold))
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(IssueCTLColors.action)
+                        .disabled(existingDeployment.ttydPort == nil)
+                    } else {
+                        launchButton
+                    }
+
+                    Text(recommendedSummary)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(issueTitle)
-                        .font(.subheadline)
-                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+                .padding(.vertical, 4)
             }
 
             if showCloneWarning {
@@ -112,6 +136,30 @@ struct LaunchView: View {
                     Label("This repository has no local clone. A fresh clone will be created.", systemImage: "exclamationmark.triangle")
                         .foregroundStyle(.orange)
                         .font(.subheadline)
+                }
+            }
+
+            if let existingDeployment {
+                Section {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Claude Code is already running for this issue.", systemImage: "terminal")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.blue)
+
+                        HStack(spacing: 12) {
+                            Text(existingDeployment.runningDuration)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            Spacer()
+
+                            if existingDeployment.ttydPort == nil {
+                                Text("Terminal starting")
+                                    .font(.caption.weight(.medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -147,100 +195,20 @@ struct LaunchView: View {
                 }
             }
 
-            if let existingDeployment {
-                Section {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Label("Claude Code is already running for this issue.", systemImage: "terminal")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(.blue)
-
-                        HStack(spacing: 12) {
-                            Button {
-                                openExistingTerminal(existingDeployment)
-                            } label: {
-                                Label("Open Existing Terminal", systemImage: "terminal")
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(existingDeployment.ttydPort == nil)
-
-                            Text(existingDeployment.runningDuration)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        if existingDeployment.ttydPort == nil {
-                            Text("The session is active, but the terminal is not ready yet.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+            Section {
+                DisclosureGroup(isExpanded: $showAdvancedOptions) {
+                    VStack(alignment: .leading, spacing: 18) {
+                        workspaceOptions
+                        branchOptions
+                        commentOptions
+                        fileOptions
+                        preambleOptions
                     }
+                    .padding(.top, 8)
+                } label: {
+                    Label("Advanced Options", systemImage: "slider.horizontal.3")
+                        .font(.subheadline.weight(.medium))
                 }
-            }
-
-            Section("Workspace Mode") {
-                Picker("Mode", selection: $workspaceMode) {
-                    Text("Worktree").tag(WorkspaceMode.worktree)
-                    Text("Existing").tag(WorkspaceMode.existing)
-                    Text("Clone").tag(WorkspaceMode.clone)
-                }
-                .pickerStyle(.segmented)
-                .disabled(showCloneWarning)
-                .accessibilityIdentifier("workspace-mode-picker")
-            }
-
-            Section("Branch Name") {
-                TextField("Branch name", text: $branchName)
-                    .autocapitalization(.none)
-                    .font(.body.monospaced())
-            }
-
-            if !comments.isEmpty {
-                Section("Include Comments") {
-                    ForEach(Array(comments.enumerated()), id: \.offset) { index, comment in
-                        Toggle(isOn: Binding(
-                            get: { selectedCommentIndices.contains(index) },
-                            set: { isOn in
-                                if isOn { selectedCommentIndices.insert(index) }
-                                else { selectedCommentIndices.remove(index) }
-                            }
-                        )) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                if let user = comment.user {
-                                    Text(user.login)
-                                        .font(.caption.weight(.medium))
-                                }
-                                Text(comment.body)
-                                    .font(.caption)
-                                    .lineLimit(2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
-            }
-
-            if !referencedFiles.isEmpty {
-                Section("Include Files") {
-                    ForEach(referencedFiles, id: \.self) { filePath in
-                        Toggle(isOn: Binding(
-                            get: { selectedFilePaths.contains(filePath) },
-                            set: { isOn in
-                                if isOn { selectedFilePaths.insert(filePath) }
-                                else { selectedFilePaths.remove(filePath) }
-                            }
-                        )) {
-                            Text(filePath)
-                                .font(.caption.monospaced())
-                                .lineLimit(1)
-                        }
-                    }
-                }
-            }
-
-            Section("Preamble (optional)") {
-                TextEditor(text: $preamble)
-                    .frame(minHeight: 80)
-                    .font(.body)
             }
 
             if let errorMessage {
@@ -249,26 +217,8 @@ struct LaunchView: View {
                         .foregroundStyle(.red)
                 }
             }
-
-            Section {
-                Button {
-                    Task { await launchSession() }
-                } label: {
-                    if isLaunching || isCheckingActiveSession {
-                        ProgressView()
-                            .frame(maxWidth: .infinity)
-                    } else if existingDeployment != nil {
-                        Label("Session Already Running", systemImage: "terminal")
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        Label("Launch Claude Code", systemImage: "play.fill")
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-                .disabled(branchName.isEmpty || isLaunching || isCheckingActiveSession || existingDeployment != nil)
-            }
         }
-        .navigationTitle("Launch Session")
+        .navigationTitle("Launch")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -303,6 +253,136 @@ struct LaunchView: View {
                     dirtyWorktree = true
                 }
             }
+        }
+    }
+
+    private var launchButton: some View {
+        Button {
+            Task { await launchSession() }
+        } label: {
+            if isLaunching || isCheckingActiveSession {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            } else {
+                Label("Launch with Recommended Settings", systemImage: "play.fill")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(IssueCTLColors.action)
+        .disabled(branchName.isEmpty || isLaunching || isCheckingActiveSession)
+    }
+
+    private var recommendedSummary: String {
+        let mode: String
+        switch workspaceMode {
+        case .worktree:
+            mode = "new worktree"
+        case .existing:
+            mode = "existing checkout"
+        case .clone:
+            mode = "fresh clone"
+        }
+        return "\(mode.capitalized) workspace - \(branchName.isEmpty ? "generated branch" : branchName)"
+    }
+
+    private var workspaceOptions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Workspace Mode")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Picker("Mode", selection: $workspaceMode) {
+                Text("Worktree").tag(WorkspaceMode.worktree)
+                Text("Existing").tag(WorkspaceMode.existing)
+                Text("Clone").tag(WorkspaceMode.clone)
+            }
+            .pickerStyle(.segmented)
+            .disabled(showCloneWarning)
+            .accessibilityIdentifier("workspace-mode-picker")
+        }
+    }
+
+    private var branchOptions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Branch Name")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextField("Branch name", text: $branchName)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .font(.body.monospaced())
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    @ViewBuilder
+    private var commentOptions: some View {
+        if !comments.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Include Comments")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(Array(comments.enumerated()), id: \.offset) { index, comment in
+                    Toggle(isOn: Binding(
+                        get: { selectedCommentIndices.contains(index) },
+                        set: { isOn in
+                            if isOn { selectedCommentIndices.insert(index) }
+                            else { selectedCommentIndices.remove(index) }
+                        }
+                    )) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            if let user = comment.user {
+                                Text(user.login)
+                                    .font(.caption.weight(.medium))
+                            }
+                            Text(comment.body)
+                                .font(.caption)
+                                .lineLimit(2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var fileOptions: some View {
+        if !referencedFiles.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Include Files")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(referencedFiles, id: \.self) { filePath in
+                    Toggle(isOn: Binding(
+                        get: { selectedFilePaths.contains(filePath) },
+                        set: { isOn in
+                            if isOn { selectedFilePaths.insert(filePath) }
+                            else { selectedFilePaths.remove(filePath) }
+                        }
+                    )) {
+                        Text(filePath)
+                            .font(.caption.monospaced())
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    private var preambleOptions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preamble")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextEditor(text: $preamble)
+                .frame(minHeight: 80)
+                .font(.body)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(.separator), lineWidth: 0.5)
+                )
         }
     }
 

--- a/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -59,34 +59,12 @@ struct PRDetailView: View {
                     }
                     .refreshable { await load(refresh: true) }
 
-                    if detail.pull.isOpen && !detail.pull.merged {
-                        actionBar
-                    }
+                    actionBar(for: detail.pull)
                 }
             }
         }
         .navigationTitle("#\(number)")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            if let detail {
-                ToolbarItem(placement: .topBarTrailing) {
-                    if let url = URL(string: detail.pull.htmlUrl) {
-                        ShareLink(item: url) {
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        if let url = URL(string: detail.pull.htmlUrl) {
-                            openURL(url)
-                        }
-                    } label: {
-                        Image(systemName: "safari")
-                    }
-                }
-            }
-        }
         .task { await load() }
         .onAppear {
             actionError = nil
@@ -287,49 +265,82 @@ struct PRDetailView: View {
 
     // MARK: - Action Bar
 
-    private var actionBar: some View {
-        HStack(spacing: 16) {
-            Button {
-                Task { await approve() }
-            } label: {
-                if isApproving {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Label("Approve", systemImage: "checkmark.circle")
+    private func actionBar(for pull: GitHubPull) -> some View {
+        ThumbActionBar {
+            if pull.isOpen && !pull.merged {
+                Button {
+                    showMergeConfirm = true
+                } label: {
+                    if isMerging {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Label("Merge", systemImage: "arrow.triangle.merge")
+                            .font(.subheadline.weight(.bold))
+                            .frame(maxWidth: .infinity)
+                    }
                 }
-            }
-            .tint(.green)
-            .disabled(isApproving)
-
-            Button {
-                showRequestChanges = true
-            } label: {
-                Label("Changes", systemImage: "xmark.circle")
-            }
-            .tint(.red)
-
-            Button {
-                showCommentSheet = true
-            } label: {
-                Label("Comment", systemImage: "bubble.left")
-            }
-
-            Button {
-                showMergeConfirm = true
-            } label: {
-                if isMerging {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Label("Merge", systemImage: "arrow.triangle.merge")
+                .buttonStyle(.borderedProminent)
+                .tint(IssueCTLColors.action)
+                .disabled(isMerging)
+            } else {
+                Button {
+                    if let url = URL(string: pull.htmlUrl) {
+                        openURL(url)
+                    }
+                } label: {
+                    Label("Open GitHub", systemImage: "safari")
+                        .font(.subheadline.weight(.bold))
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.borderedProminent)
+                .tint(IssueCTLColors.action)
             }
-            .tint(.purple)
-            .disabled(isMerging)
+        } secondary: {
+            Menu {
+                if pull.isOpen && !pull.merged {
+                    Button {
+                        Task { await approve() }
+                    } label: {
+                        if isApproving {
+                            Label("Approving", systemImage: "hourglass")
+                        } else {
+                            Label("Approve", systemImage: "checkmark.circle")
+                        }
+                    }
+                    .disabled(isApproving)
+
+                    Button {
+                        showRequestChanges = true
+                    } label: {
+                        Label("Request Changes", systemImage: "xmark.circle")
+                    }
+                }
+
+                Button {
+                    showCommentSheet = true
+                } label: {
+                    Label("Comment", systemImage: "bubble.left")
+                }
+
+                Divider()
+
+                if let detail, let url = URL(string: detail.pull.htmlUrl) {
+                    Button {
+                        openURL(url)
+                    } label: {
+                        Label("Open on GitHub", systemImage: "safari")
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 44, height: 36)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Pull request actions")
         }
-        .labelStyle(.titleAndIcon)
-        .font(.caption)
-        .padding()
-        .background(.bar)
+        .padding(.bottom, 4)
     }
 
     // MARK: - Loading

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -6,16 +6,19 @@ struct PRListView: View {
     @State private var pullsByRepo: [String: [GitHubPull]] = [:]
     @State private var isLoading = true
     @State private var errorMessage: String?
-    @State private var section: PRSection = .open
+    @State private var section: PRSection = .review
     @State private var selectedRepoIds: Set<Int> = []
     @State private var sortOrder: SortOrder = .updated
     @State private var mineOnly = false
-    @SceneStorage("prs.section") private var storedSection = PRSection.open.rawValue
+    @SceneStorage("prs.section") private var storedSection = PRSection.review.rawValue
     @SceneStorage("prs.sortOrder") private var storedSortOrder = SortOrder.updated.rawValue
     @SceneStorage("prs.mineOnly") private var storedMineOnly = false
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var navigationPath = NavigationPath()
+    @State private var showQuickActionsSheet = false
+    @State private var showCreateSheet = false
+    @State private var showFiltersSheet = false
 
     // Swipe state
     @State private var showMergeConfirm = false
@@ -44,8 +47,10 @@ struct PRListView: View {
         var items = repoFilteredPulls
 
         switch section {
+        case .review: items = items.filter(\.needsReviewAttention)
         case .open: items = items.filter { $0.isOpen }
-        case .closed: items = items.filter { !$0.isOpen }
+        case .merged: items = items.filter { !$0.isOpen && $0.merged }
+        case .closed: items = items.filter { !$0.isOpen && !$0.merged }
         }
 
         if !searchText.isEmpty {
@@ -69,8 +74,10 @@ struct PRListView: View {
     private var sectionCounts: [PRSection: Int] {
         let items = repoFilteredPulls
         return [
+            .review: items.filter(\.needsReviewAttention).count,
             .open: items.filter(\.isOpen).count,
-            .closed: items.filter { !$0.isOpen }.count,
+            .merged: items.filter { !$0.isOpen && $0.merged }.count,
+            .closed: items.filter { !$0.isOpen && !$0.merged }.count,
         ]
     }
 
@@ -87,13 +94,6 @@ struct PRListView: View {
             VStack(spacing: 0) {
                 SectionTabs(selected: $section, counts: sectionCounts)
                     .padding(.vertical, 8)
-
-                HStack(spacing: 0) {
-                    RepoFilterChips(repos: repos, selectedRepoIds: $selectedRepoIds)
-                    MineFilterChip(isOn: $mineOnly, isAvailable: currentUserLogin != nil, isDisabled: userFetchFailed)
-                        .padding(.trailing, 16)
-                }
-                .padding(.bottom, 8)
 
                 Divider()
 
@@ -135,18 +135,6 @@ struct PRListView: View {
                 }
             }
             .navigationTitle("Pull Requests")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        Picker("Sort", selection: $sortOrder) {
-                            Label("Updated", systemImage: "clock").tag(SortOrder.updated)
-                            Label("Created", systemImage: "calendar").tag(SortOrder.created)
-                        }
-                    } label: {
-                        Image(systemName: "arrow.up.arrow.down")
-                    }
-                }
-            }
             .navigationDestination(for: PRDestination.self) { dest in
                 PRDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
@@ -166,6 +154,61 @@ struct PRListView: View {
                         Task { await mergePull(owner: target.owner, repo: target.repo, number: target.number, strategy: "rebase") }
                     }
                 }
+            }
+            .sheet(isPresented: $showQuickActionsSheet) {
+                PRQuickActionsSheet(
+                    mineOnly: $mineOnly,
+                    mineFilterEnabled: currentUserLogin != nil && !userFetchFailed,
+                    reviewCount: sectionCounts[.review] ?? 0,
+                    openCount: sectionCounts[.open] ?? 0,
+                    mergedCount: sectionCounts[.merged] ?? 0,
+                    closedCount: sectionCounts[.closed] ?? 0,
+                    onCreateIssue: {
+                        showQuickActionsSheet = false
+                        showCreateSheet = true
+                    },
+                    onShowReview: {
+                        section = .review
+                        showQuickActionsSheet = false
+                    },
+                    onShowOpen: {
+                        section = .open
+                        showQuickActionsSheet = false
+                    },
+                    onShowMerged: {
+                        section = .merged
+                        showQuickActionsSheet = false
+                    },
+                    onShowClosed: {
+                        section = .closed
+                        showQuickActionsSheet = false
+                    },
+                    onRefresh: {
+                        showQuickActionsSheet = false
+                        Task { await refreshWithCooldown() }
+                    }
+                )
+                .presentationDetents([.height(360), .medium])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $showCreateSheet) {
+                QuickCreateSheet(repos: repos, onSuccess: { warning in
+                    if let warning { actionError = warning }
+                    Task { await loadAll(refresh: true) }
+                })
+            }
+            .sheet(isPresented: $showFiltersSheet) {
+                PRFilterSheet(
+                    repos: repos,
+                    selectedRepoIds: $selectedRepoIds,
+                    section: $section,
+                    sortOrder: $sortOrder,
+                    mineOnly: $mineOnly,
+                    mineFilterEnabled: currentUserLogin != nil && !userFetchFailed,
+                    sectionCounts: sectionCounts
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .autoDismissError($actionError)
             .task { await loadAll() }
@@ -189,8 +232,36 @@ struct PRListView: View {
             }
             .onChange(of: searchText) { _, _ in displayLimit = pageSize }
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
+            .safeAreaInset(edge: .bottom) {
+                pullRequestThumbBar
+            }
         }
         .searchable(text: $searchText, prompt: "Search pull requests")
+    }
+
+    private var pullRequestThumbBar: some View {
+        ThumbActionBar {
+            Button {
+                showQuickActionsSheet = true
+            } label: {
+                Label("Quick Actions", systemImage: "bolt.fill")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action)
+        } secondary: {
+            Button {
+                showFiltersSheet = true
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 44, height: 36)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Pull request filters")
+        }
+        .padding(.bottom, 4)
     }
 
     // MARK: - List
@@ -330,4 +401,261 @@ struct PRDestination: Hashable {
     let owner: String
     let repo: String
     let number: Int
+}
+
+private struct PRQuickActionsSheet: View {
+    @Binding var mineOnly: Bool
+
+    let mineFilterEnabled: Bool
+    let reviewCount: Int
+    let openCount: Int
+    let mergedCount: Int
+    let closedCount: Int
+    let onCreateIssue: () -> Void
+    let onShowReview: () -> Void
+    let onShowOpen: () -> Void
+    let onShowMerged: () -> Void
+    let onShowClosed: () -> Void
+    let onRefresh: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Quick Actions")
+                        .font(.title2.weight(.bold))
+                    Text("\(reviewCount) need review, \(openCount) open")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(spacing: 0) {
+                    sheetAction(
+                        title: "Create Issue",
+                        subtitle: "Capture follow-up work from PR review.",
+                        systemImage: "plus.circle",
+                        action: onCreateIssue
+                    )
+
+                    Divider()
+
+                    sheetAction(
+                        title: "Refresh Pull Requests",
+                        subtitle: "Fetch the latest PR state.",
+                        systemImage: "arrow.clockwise",
+                        action: onRefresh
+                    )
+                }
+                .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+                VStack(spacing: 0) {
+                    sheetAction(
+                        title: "Review Queue",
+                        subtitle: "\(reviewCount) PRs need attention",
+                        systemImage: "exclamationmark.bubble",
+                        action: onShowReview
+                    )
+
+                    Divider()
+
+                    sheetAction(
+                        title: "Open PRs",
+                        subtitle: "\(openCount) currently open",
+                        systemImage: "arrow.triangle.merge",
+                        action: onShowOpen
+                    )
+
+                    Divider()
+
+                    sheetAction(
+                        title: "Merged PRs",
+                        subtitle: "\(mergedCount) merged",
+                        systemImage: "checkmark.seal",
+                        action: onShowMerged
+                    )
+
+                    Divider()
+
+                    sheetAction(
+                        title: "Closed PRs",
+                        subtitle: "\(closedCount) closed without merge",
+                        systemImage: "checkmark.circle",
+                        action: onShowClosed
+                    )
+
+                    Divider()
+
+                    Toggle(isOn: $mineOnly) {
+                        HStack(spacing: 12) {
+                            Image(systemName: "person.crop.circle")
+                                .frame(width: 26)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Mine Only")
+                                    .font(.subheadline.weight(.semibold))
+                                Text(mineFilterEnabled ? "Assigned to your GitHub login." : "User profile unavailable.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .disabled(!mineFilterEnabled)
+                    .padding(12)
+                }
+                .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+        }
+    }
+
+    private func sheetAction(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct PRFilterSheet: View {
+    let repos: [Repo]
+    @Binding var selectedRepoIds: Set<Int>
+    @Binding var section: PRSection
+    @Binding var sortOrder: SortOrder
+    @Binding var mineOnly: Bool
+
+    let mineFilterEnabled: Bool
+    let sectionCounts: [PRSection: Int]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Filter & Sort")
+                            .font(.title2.weight(.bold))
+                        Text("\(sectionCounts[section] ?? 0) \(section.rawValue) PRs")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    sheetCard(title: "Status") {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                            ForEach(PRSection.allCases, id: \.self) { option in
+                                filterOption(
+                                    title: option.rawValue.capitalized,
+                                    subtitle: "\(sectionCounts[option] ?? 0) PRs",
+                                    isSelected: section == option
+                                ) {
+                                    section = option
+                                }
+                            }
+                        }
+                    }
+
+                    sheetCard(title: "Repository") {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                            Button {
+                                selectedRepoIds.removeAll()
+                            } label: {
+                                optionContent(title: "All Repos", subtitle: "\(repos.count) configured", isSelected: selectedRepoIds.isEmpty)
+                            }
+                            .buttonStyle(.plain)
+
+                            ForEach(repos) { repo in
+                                let isSelected = selectedRepoIds.contains(repo.id)
+                                Button {
+                                    if isSelected {
+                                        selectedRepoIds.remove(repo.id)
+                                    } else {
+                                        selectedRepoIds.insert(repo.id)
+                                    }
+                                } label: {
+                                    optionContent(title: repo.name, subtitle: repo.owner, isSelected: isSelected)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+
+                    sheetCard(title: "Sort") {
+                        Picker("Sort", selection: $sortOrder) {
+                            Label("Updated", systemImage: "clock").tag(SortOrder.updated)
+                            Label("Created", systemImage: "calendar").tag(SortOrder.created)
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    Toggle(isOn: $mineOnly) {
+                        Label("Mine Only", systemImage: "person.crop.circle")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .disabled(!mineFilterEnabled)
+                    .padding(12)
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private func sheetCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+        .padding(12)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func filterOption(title: String, subtitle: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            optionContent(title: title, subtitle: subtitle, isSelected: isSelected)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func optionContent(title: String, subtitle: String, isSelected: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
+        .padding(10)
+        .background(isSelected ? IssueCTLColors.action.opacity(0.14) : Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSelected ? IssueCTLColors.action.opacity(0.55) : Color.clear, lineWidth: 1)
+        }
+    }
 }

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -2,10 +2,14 @@ import SwiftUI
 
 struct SessionListView: View {
     @Environment(APIClient.self) private var api
+    @State private var repos: [Repo] = []
     @State private var deployments: [ActiveDeployment] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var actionError: String?
     @State private var terminalTarget: ActiveDeployment?
+    @State private var sessionControlsTarget: ActiveDeployment?
+    @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
     @State private var navigationPath = NavigationPath()
 
@@ -13,52 +17,71 @@ struct SessionListView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            Group {
-                if isLoading && deployments.isEmpty {
-                    ProgressView("Loading sessions...")
-                } else if let errorMessage {
-                    ContentUnavailableView {
-                        Label("Error", systemImage: "exclamationmark.triangle")
-                    } description: {
-                        Text(errorMessage)
-                    } actions: {
-                        Button("Retry") { Task { await load() } }
-                    }
-                } else if deployments.isEmpty {
-                    ContentUnavailableView(
-                        "No Active Sessions",
-                        systemImage: "play.circle",
-                        description: Text("Launch a Claude Code session from an issue to see it here.")
-                    )
-                } else {
-                    List {
-                        ForEach(deployments) { deployment in
-                            SessionRowView(deployment: deployment)
-                                .accessibilityIdentifier("session-row-\(deployment.id)")
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    if deployment.ttydPort != nil {
-                                        terminalTarget = deployment
-                                    }
-                                }
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button(role: .destructive) {
-                                        Task { await endSession(deployment) }
-                                    } label: {
-                                        Label("End", systemImage: "stop.circle")
-                                    }
-                                    .disabled(endingDeploymentId == deployment.id)
-                                }
+            VStack(spacing: 0) {
+                Group {
+                    if isLoading && deployments.isEmpty {
+                        ProgressView("Loading sessions...")
+                    } else if let errorMessage {
+                        ContentUnavailableView {
+                            Label("Error", systemImage: "exclamationmark.triangle")
+                        } description: {
+                            Text(errorMessage)
+                        } actions: {
+                            Button("Retry") { Task { await load() } }
                         }
+                    } else if deployments.isEmpty {
+                        ContentUnavailableView(
+                            "No Active Sessions",
+                            systemImage: "play.circle",
+                            description: Text("Launch a Claude Code session from an issue to see it here.")
+                        )
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: 12) {
+                                if let actionError {
+                                    Label(actionError, systemImage: "exclamationmark.triangle")
+                                        .foregroundStyle(.red)
+                                        .font(.subheadline)
+                                        .lineLimit(3)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+
+                                ForEach(deployments) { deployment in
+                                    SessionRowView(
+                                        deployment: deployment,
+                                        isEnding: endingDeploymentId == deployment.id,
+                                        onOpen: {
+                                            if deployment.ttydPort != nil {
+                                                terminalTarget = deployment
+                                            }
+                                        },
+                                        onControls: {
+                                            sessionControlsTarget = deployment
+                                        }
+                                    )
+                                    .accessibilityIdentifier("session-row-\(deployment.id)")
+                                }
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.top, 16)
+                            .padding(.bottom, 16)
+                        }
+                        .refreshable { await load(refresh: true) }
                     }
-                    .refreshable { await load() }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                sessionThumbBar
             }
             .navigationTitle("Active Sessions")
+            .navigationDestination(for: IssueDestination.self) { dest in
+                IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
+            }
             .task { await load() }
             .onReceive(refreshTimer) { _ in
                 Task { await load() }
             }
+            .autoDismissError($actionError)
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
             .fullScreenCover(item: $terminalTarget) { deployment in
                 if let port = deployment.ttydPort {
@@ -72,15 +95,80 @@ struct SessionListView: View {
                     )
                 }
             }
+            .sheet(item: $sessionControlsTarget) { deployment in
+                SessionControlsSheet(
+                    deployment: deployment,
+                    isEnding: endingDeploymentId == deployment.id,
+                    onOpenTerminal: {
+                        sessionControlsTarget = nil
+                        if deployment.ttydPort != nil {
+                            terminalTarget = deployment
+                        }
+                    },
+                    onViewIssue: {
+                        sessionControlsTarget = nil
+                        navigationPath.append(IssueDestination(
+                            owner: deployment.owner,
+                            repo: deployment.repoName,
+                            number: deployment.issueNumber
+                        ))
+                    },
+                    onEnd: {
+                        Task {
+                            await endSession(deployment)
+                            sessionControlsTarget = nil
+                        }
+                    }
+                )
+                .presentationDetents([.height(330), .medium])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $showCreateSheet) {
+                QuickCreateSheet(repos: repos, onSuccess: { warning in
+                    if let warning { actionError = warning }
+                    Task { await load(refresh: true) }
+                })
+            }
         }
     }
 
-    private func load() async {
+    private var sessionThumbBar: some View {
+        ThumbActionBar {
+            Button {
+                showCreateSheet = true
+            } label: {
+                Label("Create Issue", systemImage: "plus")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action)
+        } secondary: {
+            EmptyView()
+        }
+        .padding(.bottom, 14)
+    }
+
+    private func load(refresh: Bool = false) async {
         if deployments.isEmpty { isLoading = true }
         errorMessage = nil
+        if refresh { actionError = nil }
         do {
-            let response = try await api.activeDeployments()
+            async let deploymentsResult = api.activeDeployments()
+            async let reposResult: Result<[Repo], Error> = {
+                do { return .success(try await api.repos()) }
+                catch { return .failure(error) }
+            }()
+            let response = try await deploymentsResult
             deployments = response.deployments
+            switch await reposResult {
+            case .success(let loadedRepos):
+                repos = loadedRepos
+            case .failure(let error):
+                if repos.isEmpty {
+                    actionError = "Failed to load repos for create: \(error.localizedDescription)"
+                }
+            }
         } catch {
             if deployments.isEmpty {
                 errorMessage = error.localizedDescription
@@ -103,5 +191,101 @@ struct SessionListView: View {
             errorMessage = error.localizedDescription
         }
         endingDeploymentId = nil
+    }
+}
+
+private struct SessionControlsSheet: View {
+    let deployment: ActiveDeployment
+    let isEnding: Bool
+    let onOpenTerminal: () -> Void
+    let onViewIssue: () -> Void
+    let onEnd: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("#\(deployment.issueNumber) Session")
+                    .font(.title2.weight(.bold))
+                Text(deployment.repoFullName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(spacing: 0) {
+                sheetAction(
+                    title: "Open Terminal",
+                    subtitle: deployment.ttydPort.map { "Port \($0)" } ?? "Terminal is still preparing.",
+                    systemImage: "terminal",
+                    isDisabled: deployment.ttydPort == nil,
+                    action: onOpenTerminal
+                )
+
+                Divider()
+
+                sheetAction(
+                    title: "View Issue",
+                    subtitle: "Jump to #\(deployment.issueNumber) without losing this session.",
+                    systemImage: "number",
+                    action: onViewIssue
+                )
+
+                Divider()
+
+                Button(role: .destructive, action: onEnd) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "stop.circle")
+                            .frame(width: 26)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(isEnding ? "Ending Session" : "End Session")
+                                .font(.subheadline.weight(.semibold))
+                            Text("Stop ttyd and mark deployment ended.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if isEnding {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+                    .padding(12)
+                }
+                .disabled(isEnding)
+            }
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+    }
+
+    private func sheetAction(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.55 : 1)
     }
 }

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -2,9 +2,12 @@ import SwiftUI
 
 struct SessionRowView: View {
     let deployment: ActiveDeployment
+    var isEnding = false
+    var onOpen: () -> Void = {}
+    var onControls: () -> Void = {}
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 6) {
                 Circle()
                     .fill(.green)
@@ -14,26 +17,75 @@ struct SessionRowView: View {
                 Text("#\(deployment.issueNumber)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Text("Running")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.green.opacity(0.14), in: Capsule())
+            }
+
+            Label(deployment.branchName, systemImage: "arrow.triangle.branch")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            HStack(spacing: 10) {
+                sessionMetric(value: deployment.runningDuration, label: "Duration", systemImage: "clock")
+
+                if let port = deployment.ttydPort {
+                    sessionMetric(value: "\(port)", label: "Terminal", systemImage: "terminal")
+                } else {
+                    sessionMetric(value: "Starting", label: "Terminal", systemImage: "terminal")
+                }
             }
 
             HStack(spacing: 8) {
-                Label(deployment.branchName, systemImage: "arrow.triangle.branch")
-                    .font(.caption.monospaced())
-                    .lineLimit(1)
-
-                Spacer()
-
-                Label(deployment.runningDuration, systemImage: "clock")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if deployment.ttydPort != nil {
-                    Label("Open", systemImage: "terminal")
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.blue)
+                Button(action: onOpen) {
+                    Label(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal", systemImage: "terminal")
+                        .font(.subheadline.weight(.bold))
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.borderedProminent)
+                .tint(IssueCTLColors.action)
+                .disabled(deployment.ttydPort == nil)
+
+                Button(action: onControls) {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isEnding)
+                .accessibilityLabel("Session controls")
             }
         }
-        .padding(.vertical, 4)
+        .padding(14)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.green.opacity(0.22), lineWidth: 1)
+        }
+    }
+
+    private func sessionMetric(value: String, label: String, systemImage: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+enum IssueCTLColors {
+    static let action = Color(hex: "e87125") ?? .orange
+}
+
+struct AppTopBar<Trailing: View>: View {
+    let title: String
+    let subtitle: String?
+    @ViewBuilder var trailing: () -> Trailing
+
+    var body: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.title2.weight(.bold))
+                if let subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            trailing()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 8)
+    }
+}
+
+struct IconChromeButton: View {
+    let systemName: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 16, weight: .medium))
+                .frame(width: 36, height: 36)
+                .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(systemName)
+    }
+}
+
+struct StatusMetricCard: View {
+    let value: String
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(value)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.primary)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+            .padding(10)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct AttentionRow: View {
+    let color: Color
+    let kicker: String
+    let title: String
+    let chips: [AttentionChip]
+    var isAttention = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: 10) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(color)
+                    .frame(width: 8, height: 42)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(kicker)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        ForEach(chips) { chip in
+                            Text(chip.title)
+                                .font(.caption2.weight(.medium))
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .foregroundStyle(chip.foreground)
+                                .background(chip.background, in: Capsule())
+                        }
+                    }
+                }
+
+                Spacer(minLength: 6)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 18)
+                    .fill(Color(.secondarySystemGroupedBackground))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 18)
+                            .stroke(isAttention ? IssueCTLColors.action.opacity(0.55) : Color.clear, lineWidth: 1)
+                    }
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct AttentionChip: Identifiable {
+    let id = UUID()
+    let title: String
+    let foreground: Color
+    let background: Color
+
+    static func neutral(_ title: String) -> AttentionChip {
+        AttentionChip(title: title, foreground: .secondary, background: Color.secondary.opacity(0.12))
+    }
+
+    static func green(_ title: String) -> AttentionChip {
+        AttentionChip(title: title, foreground: .green, background: Color.green.opacity(0.14))
+    }
+
+    static func red(_ title: String) -> AttentionChip {
+        AttentionChip(title: title, foreground: .red, background: Color.red.opacity(0.14))
+    }
+
+    static func blue(_ title: String) -> AttentionChip {
+        AttentionChip(title: title, foreground: .blue, background: Color.blue.opacity(0.14))
+    }
+
+    static func orange(_ title: String) -> AttentionChip {
+        AttentionChip(title: title, foreground: IssueCTLColors.action, background: IssueCTLColors.action.opacity(0.14))
+    }
+}
+
+struct SessionDock: View {
+    let deployments: [ActiveDeployment]
+    let action: () -> Void
+
+    var body: some View {
+        if !deployments.isEmpty {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 8, height: 8)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(deployments.count) session\(deployments.count == 1 ? "" : "s") running")
+                        .font(.caption.weight(.semibold))
+                    Text(summary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                Button("Resume", action: action)
+                    .font(.caption.weight(.bold))
+                    .buttonStyle(.borderedProminent)
+                    .tint(IssueCTLColors.action)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+            .overlay {
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color.green.opacity(0.28), lineWidth: 1)
+            }
+            .padding(.horizontal, 14)
+        }
+    }
+
+    private var summary: String {
+        deployments.prefix(2).map { "#\($0.issueNumber) \($0.runningDuration)" }.joined(separator: " - ")
+    }
+}
+
+struct ThumbActionBar<Primary: View, Secondary: View>: View {
+    @ViewBuilder var primary: () -> Primary
+    @ViewBuilder var secondary: () -> Secondary
+
+    var body: some View {
+        HStack(spacing: 8) {
+            primary()
+                .frame(maxWidth: .infinity)
+            secondary()
+        }
+        .padding(8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        }
+        .padding(.horizontal, 14)
+    }
+}
+
+struct OfflineStatusBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wifi.exclamationmark")
+            Text(message)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .font(.caption.weight(.medium))
+        .foregroundStyle(.red)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(Color.red.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.red.opacity(0.25), lineWidth: 1)
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Shared/SectionTabs.swift
+++ b/ios/IssueCTL/Views/Shared/SectionTabs.swift
@@ -41,7 +41,7 @@ enum IssueSection: String, CaseIterable {
 }
 
 enum PRSection: String, CaseIterable {
-    case open, closed
+    case review, open, merged, closed
 }
 
 enum SortOrder: String, CaseIterable {

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+struct TodayView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+
+    let onShowSettings: () -> Void
+    let onShowIssues: () -> Void
+    let onShowPullRequests: () -> Void
+    let onShowSessions: () -> Void
+
+    @State private var repos: [Repo] = []
+    @State private var issuesByRepo: [String: [GitHubIssue]] = [:]
+    @State private var pullsByRepo: [String: [GitHubPull]] = [:]
+    @State private var activeDeployments: [ActiveDeployment] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var oldestCachedAt: Date?
+    @State private var currentUserLogin: String?
+    @State private var userFetchFailed = false
+    @State private var showCreateSheet = false
+    @State private var actionError: String?
+    @State private var navigationPath = NavigationPath()
+
+    private var allIssues: [GitHubIssue] {
+        issuesByRepo.values.flatMap { $0 }
+    }
+
+    private var allPulls: [GitHubPull] {
+        pullsByRepo.values.flatMap { $0 }
+    }
+
+    private var assignedIssues: [GitHubIssue] {
+        let openIssues = allIssues.filter(\.isOpen)
+        guard let currentUserLogin else { return openIssues }
+        return openIssues.filter { issue in
+            (issue.assignees ?? []).contains { $0.login == currentUserLogin }
+        }
+    }
+
+    private var issueMetricLabel: String {
+        currentUserLogin == nil || userFetchFailed ? "open issues" : "assigned issues"
+    }
+
+    private var attentionSubtitle: String {
+        let count = attentionItems.count
+        return "\(count) item\(count == 1 ? "" : "s") need attention"
+    }
+
+    private var reviewPulls: [GitHubPull] {
+        allPulls
+            .filter(\.isOpen)
+            .sorted { pullSortIndex($0) < pullSortIndex($1) }
+    }
+
+    private var attentionItems: [TodayAttentionItem] {
+        var items: [TodayAttentionItem] = []
+
+        if let pull = reviewPulls.first {
+            items.append(.pull(
+                pull,
+                repo: repoFor(pull: pull),
+                isAttention: pull.checksStatus == "failure"
+            ))
+        }
+
+        for issue in assignedIssues.prefix(3) {
+            items.append(.issue(
+                issue,
+                repo: repoFor(issue: issue),
+                isAttention: issue.labels.contains { $0.name.lowercased().contains("block") }
+            ))
+        }
+
+        return Array(items.prefix(4))
+    }
+
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            ZStack(alignment: .bottom) {
+                VStack(spacing: 0) {
+                    AppTopBar(title: "Today", subtitle: attentionSubtitle) {
+                        IconChromeButton(systemName: "magnifyingglass") {}
+                        IconChromeButton(systemName: "gearshape") { onShowSettings() }
+                    }
+
+                    content
+                }
+
+                VStack(spacing: 8) {
+                    SessionDock(deployments: activeDeployments, action: onShowSessions)
+                    Button {
+                        showCreateSheet = true
+                    } label: {
+                        Text("Create Issue")
+                            .font(.subheadline.weight(.bold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(IssueCTLColors.action)
+                    .padding(.horizontal, 22)
+                }
+                .padding(.bottom, 8)
+            }
+            .navigationBarHidden(true)
+            .navigationDestination(for: TodayDestination.self) { destination in
+                switch destination {
+                case .issue(let owner, let repo, let number):
+                    IssueDetailView(owner: owner, repo: repo, number: number)
+                case .pull(let owner, let repo, let number):
+                    PRDetailView(owner: owner, repo: repo, number: number)
+                }
+            }
+            .sheet(isPresented: $showCreateSheet) {
+                QuickCreateSheet(repos: repos, onSuccess: { warning in
+                    if let warning { actionError = warning }
+                    Task { await load(refresh: true) }
+                })
+            }
+            .autoDismissError($actionError)
+            .task { await load() }
+            .refreshable { await load(refresh: true) }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading && repos.isEmpty {
+            ProgressView("Loading today...")
+                .frame(maxHeight: .infinity)
+        } else if let errorMessage {
+            ContentUnavailableView {
+                Label("Error", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(errorMessage)
+            } actions: {
+                Button("Retry") { Task { await load(refresh: true) } }
+            }
+            .frame(maxHeight: .infinity)
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if !network.isConnected {
+                        OfflineStatusBanner(message: cacheMessage)
+                    }
+
+                    metrics
+
+                    HStack {
+                        Text("Needs Attention")
+                            .font(.headline)
+                        Spacer()
+                        Button("Refresh") { Task { await load(refresh: true) } }
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(IssueCTLColors.action)
+                    }
+                    .padding(.top, 4)
+
+                    if attentionItems.isEmpty {
+                        ContentUnavailableView(
+                            "No Attention Items",
+                            systemImage: "checkmark.circle",
+                            description: Text("Nothing urgent is waiting right now.")
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 28)
+                    } else {
+                        VStack(spacing: 10) {
+                            ForEach(attentionItems) { item in
+                                attentionRow(for: item)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, activeDeployments.isEmpty ? 96 : 154)
+            }
+        }
+    }
+
+    private var metrics: some View {
+        HStack(spacing: 8) {
+            StatusMetricCard(value: "\(activeDeployments.count)", label: "running sessions", action: onShowSessions)
+            StatusMetricCard(value: "\(reviewPulls.count)", label: "PRs need review", action: onShowPullRequests)
+            StatusMetricCard(value: "\(assignedIssues.count)", label: issueMetricLabel, action: onShowIssues)
+        }
+    }
+
+    private func attentionRow(for item: TodayAttentionItem) -> some View {
+        switch item {
+        case .issue(let issue, let repo, let isAttention):
+            return AttentionRow(
+                color: repoColor(for: repo),
+                kicker: "\(repo?.fullName ?? "Unknown repo") - Issue #\(issue.number)",
+                title: issue.title,
+                chips: issueChips(for: issue),
+                isAttention: isAttention,
+                action: {
+                    if let repo {
+                        navigationPath.append(TodayDestination.issue(owner: repo.owner, repo: repo.name, number: issue.number))
+                    }
+                }
+            )
+        case .pull(let pull, let repo, let isAttention):
+            return AttentionRow(
+                color: IssueCTLColors.action,
+                kicker: "\(repo?.fullName ?? "Unknown repo") - PR #\(pull.number)",
+                title: pull.title,
+                chips: pullChips(for: pull),
+                isAttention: isAttention,
+                action: {
+                    if let repo {
+                        navigationPath.append(TodayDestination.pull(owner: repo.owner, repo: repo.name, number: pull.number))
+                    }
+                }
+            )
+        }
+    }
+
+    private func issueChips(for issue: GitHubIssue) -> [AttentionChip] {
+        var chips: [AttentionChip] = []
+        if issue.labels.contains(where: { $0.name.lowercased().contains("block") }) {
+            chips.append(.orange("Blocked"))
+        } else {
+            chips.append(.green("Ready to start"))
+        }
+        if let assignees = issue.assignees, !assignees.isEmpty {
+            if let currentUserLogin, assignees.contains(where: { $0.login == currentUserLogin }) {
+                chips.append(.neutral("Assigned to you"))
+            } else {
+                chips.append(.neutral("Assigned"))
+            }
+        }
+        return chips
+    }
+
+    private func pullChips(for pull: GitHubPull) -> [AttentionChip] {
+        var chips: [AttentionChip] = []
+        switch pull.checksStatus {
+        case "failure": chips.append(.red("Checks failing"))
+        case "success": chips.append(.green("Checks pass"))
+        case "pending": chips.append(.orange("Checks pending"))
+        default: break
+        }
+        chips.append(.blue("Review requested"))
+        return chips
+    }
+
+    private var cacheMessage: String {
+        if let oldestCachedAt {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+            return "Offline - showing cached data from \(formatter.localizedString(for: oldestCachedAt, relativeTo: Date()))"
+        }
+        return "Offline - showing cached data"
+    }
+
+    private func load(refresh: Bool = false) async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            repos = try await api.repos()
+
+            async let deploymentsResult: Result<ActiveDeploymentsResponse, Error> = {
+                do { return .success(try await api.activeDeployments()) }
+                catch { return .failure(error) }
+            }()
+            async let userResult: Result<UserResponse, Error> = {
+                do { return .success(try await api.currentUser()) }
+                catch { return .failure(error) }
+            }()
+
+            let repoSnapshot = repos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
+            async let issueResults = loadIssues(for: repoSnapshot, refresh: refresh)
+            async let pullResults = loadPulls(for: repoSnapshot, refresh: refresh)
+
+            switch await deploymentsResult {
+            case .success(let response): activeDeployments = response.deployments
+            case .failure: activeDeployments = []
+            }
+            switch await userResult {
+            case .success(let user):
+                currentUserLogin = user.login
+                userFetchFailed = false
+            case .failure:
+                currentUserLogin = nil
+                userFetchFailed = true
+            }
+
+            let loadedIssues = await issueResults
+            let loadedPulls = await pullResults
+            issuesByRepo = loadedIssues.items
+            pullsByRepo = loadedPulls.items
+            oldestCachedAt = (loadedIssues.cachedDates + loadedPulls.cachedDates).min()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func loadIssues(
+        for repos: [(fullName: String, owner: String, name: String)],
+        refresh: Bool
+    ) async -> (items: [String: [GitHubIssue]], cachedDates: [Date]) {
+        await withTaskGroup(of: (String, [GitHubIssue]?, String?).self) { group in
+            for repo in repos {
+                group.addTask { [api] in
+                    do {
+                        let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
+                        return (repo.fullName, response.issues, response.cachedAt)
+                    } catch {
+                        return (repo.fullName, nil, nil)
+                    }
+                }
+            }
+
+            var items: [String: [GitHubIssue]] = [:]
+            var cachedDates: [Date] = []
+            for await (fullName, issues, cachedAt) in group {
+                if let issues { items[fullName] = issues }
+                if let cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                    cachedDates.append(date)
+                }
+            }
+            return (items, cachedDates)
+        }
+    }
+
+    private func loadPulls(
+        for repos: [(fullName: String, owner: String, name: String)],
+        refresh: Bool
+    ) async -> (items: [String: [GitHubPull]], cachedDates: [Date]) {
+        await withTaskGroup(of: (String, [GitHubPull]?, String?).self) { group in
+            for repo in repos {
+                group.addTask { [api] in
+                    do {
+                        let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
+                        return (repo.fullName, response.pulls, response.cachedAt)
+                    } catch {
+                        return (repo.fullName, nil, nil)
+                    }
+                }
+            }
+
+            var items: [String: [GitHubPull]] = [:]
+            var cachedDates: [Date] = []
+            for await (fullName, pulls, cachedAt) in group {
+                if let pulls { items[fullName] = pulls }
+                if let cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                    cachedDates.append(date)
+                }
+            }
+            return (items, cachedDates)
+        }
+    }
+
+    private func repoFor(issue: GitHubIssue) -> Repo? {
+        repoForItem(issue, in: issuesByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
+    }
+
+    private func repoFor(pull: GitHubPull) -> Repo? {
+        repoForItem(pull, in: pullsByRepo, repos: repos, htmlUrl: { $0.htmlUrl })
+    }
+
+    private func repoColor(for repo: Repo?) -> Color {
+        guard let repo, let index = repos.firstIndex(where: { $0.id == repo.id }) else { return .secondary }
+        return RepoColors.color(for: index)
+    }
+
+    private func pullSortIndex(_ pull: GitHubPull) -> Int {
+        switch pull.checksStatus {
+        case "failure": 0
+        case "pending": 1
+        default: 2
+        }
+    }
+}
+
+private enum TodayDestination: Hashable {
+    case issue(owner: String, repo: String, number: Int)
+    case pull(owner: String, repo: String, number: Int)
+}
+
+private enum TodayAttentionItem: Identifiable {
+    case issue(GitHubIssue, repo: Repo?, isAttention: Bool)
+    case pull(GitHubPull, repo: Repo?, isAttention: Bool)
+
+    var id: String {
+        switch self {
+        case .issue(let issue, _, _): "issue-\(issue.id)"
+        case .pull(let pull, _, _): "pull-\(pull.id)"
+        }
+    }
+}

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -173,6 +173,72 @@ final class ViewLogicTests: XCTestCase {
         ]
     }
 
+    private func makePull(number: Int = 1, state: String = "open", merged: Bool = false, checksStatus: String? = nil) -> GitHubPull {
+        GitHubPull(
+            number: number,
+            title: "PR \(number)",
+            body: nil,
+            state: state,
+            draft: false,
+            merged: merged,
+            user: nil,
+            headRef: "feature",
+            baseRef: "main",
+            additions: 1,
+            deletions: 1,
+            changedFiles: 1,
+            createdAt: "2026-04-27T08:00:00Z",
+            updatedAt: "2026-04-27T09:00:00Z",
+            mergedAt: merged ? "2026-04-27T10:00:00Z" : nil,
+            closedAt: state == "closed" ? "2026-04-27T10:00:00Z" : nil,
+            htmlUrl: "https://github.com/org/alpha/pull/\(number)",
+            checksStatus: checksStatus
+        )
+    }
+
+    private func makeIssue(number: Int = 1, state: String = "open") -> GitHubIssue {
+        GitHubIssue(
+            number: number,
+            title: "Issue \(number)",
+            body: nil,
+            state: state,
+            labels: [],
+            assignees: nil,
+            user: nil,
+            commentCount: 0,
+            createdAt: "2026-04-27T08:00:00Z",
+            updatedAt: "2026-04-27T09:00:00Z",
+            closedAt: state == "closed" ? "2026-04-27T10:00:00Z" : nil,
+            htmlUrl: "https://github.com/org/alpha/issues/\(number)"
+        )
+    }
+
+    private func makeDeployment(
+        id: Int = 1,
+        owner: String = "org",
+        repo: String = "alpha",
+        issueNumber: Int = 1,
+        state: DeploymentState = .active,
+        endedAt: String? = nil
+    ) -> ActiveDeployment {
+        ActiveDeployment(
+            id: id,
+            repoId: 1,
+            issueNumber: issueNumber,
+            branchName: "issue-\(issueNumber)",
+            workspaceMode: .worktree,
+            workspacePath: "/tmp/repo",
+            linkedPrNumber: nil,
+            state: state,
+            launchedAt: "2026-04-27T08:00:00Z",
+            endedAt: endedAt,
+            ttydPort: 7681,
+            ttydPid: 123,
+            owner: owner,
+            repoName: repo
+        )
+    }
+
     func testFilterItemsByRepoNoSelection() {
         let repos = makeRepos()
         let items: [String: [FakeItem]] = [
@@ -287,5 +353,44 @@ final class ViewLogicTests: XCTestCase {
         // selectedRepoIds contains an ID not in repos — returns empty
         let result = filterItemsByRepo(items, repos: repos, selectedRepoIds: [999], mineOnly: false, currentUserLogin: nil, userLogin: { $0.userLogin })
         XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - PR Review Helpers
+
+    func testPullNeedsReviewAttentionForFailingOrPendingOpenPulls() {
+        XCTAssertTrue(makePull(checksStatus: "failure").needsReviewAttention)
+        XCTAssertTrue(makePull(checksStatus: "pending").needsReviewAttention)
+    }
+
+    func testPullNeedsReviewAttentionIgnoresPassingMissingAndClosedPulls() {
+        XCTAssertFalse(makePull(checksStatus: "success").needsReviewAttention)
+        XCTAssertFalse(makePull(checksStatus: nil).needsReviewAttention)
+        XCTAssertFalse(makePull(state: "closed", checksStatus: "failure").needsReviewAttention)
+    }
+
+    // MARK: - Running Deployment Helpers
+
+    func testRunningDeploymentMatchesActiveIssueSessionByRepoAndIssue() {
+        let issue = makeIssue(number: 42)
+        let deployments = [
+            makeDeployment(id: 1, repo: "beta", issueNumber: 42),
+            makeDeployment(id: 2, repo: "alpha", issueNumber: 42),
+        ]
+
+        let result = runningDeployment(for: issue, in: "org/alpha", deployments: deployments)
+
+        XCTAssertEqual(result?.id, 2)
+    }
+
+    func testRunningDeploymentIgnoresEndedAndMismatchedSessions() {
+        let issue = makeIssue(number: 42)
+        let deployments = [
+            makeDeployment(id: 1, repo: "alpha", issueNumber: 42, state: .ended, endedAt: "2026-04-27T10:00:00Z"),
+            makeDeployment(id: 2, repo: "alpha", issueNumber: 99),
+            makeDeployment(id: 3, repo: "beta", issueNumber: 42),
+        ]
+
+        XCTAssertNil(runningDeployment(for: issue, in: "org/alpha", deployments: deployments))
+        XCTAssertNil(runningDeployment(owner: "org", repo: "alpha", number: 42, deployments: deployments))
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Today command-center tab with attention metrics, active-session dock, and thumb-reachable create flow
- Moves Issues, PRs, Active Sessions, detail actions, and Launch into bottom-sheet/thumb-action UX patterns based on the mockup
- Adds shared helpers and tests for PR review attention and active session matching

## Validation
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' (189 tests, 0 failures)
- xcodebuild build -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator'
- git diff --check
- Manual simulator smoke: Today, Create Issue sheet, Issues filters, PR filters/actions, Launch sheet, Active Sessions, Session Controls