### PR TITLE
Add iOS terminal text size controls

### DIFF
--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -6,14 +6,14 @@ struct TerminalView: View {
     let deployment: ActiveDeployment
     let port: Int
     let onEnd: () -> Void
-    private let terminalFontSize = 24
-    private let terminalPageZoom = 1.35
+    private let terminalPageZoom = TerminalDisplaySettings.defaultPageZoom
 
     @Environment(\.dismiss) private var dismiss
     @State private var showEndConfirm = false
     @State private var loadError: String?
     @State private var currentPort: Int
     @State private var terminalToken: String?
+    @State private var terminalFontSize = TerminalDisplaySettings.defaultFontSize
     @State private var isRespawning = false
     @State private var isEndingSession = false
     @State private var endSessionError: String?
@@ -84,6 +84,32 @@ struct TerminalView: View {
                         Text(deployment.runningDuration)
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                        Menu {
+                            Button {
+                                terminalFontSize = TerminalDisplaySettings.decreased(from: terminalFontSize)
+                            } label: {
+                                Label("Smaller Text", systemImage: "minus.magnifyingglass")
+                            }
+                            .disabled(terminalFontSize <= TerminalDisplaySettings.minimumFontSize)
+
+                            Button {
+                                terminalFontSize = TerminalDisplaySettings.defaultFontSize
+                            } label: {
+                                Label("Default Text Size", systemImage: "textformat")
+                            }
+
+                            Button {
+                                terminalFontSize = TerminalDisplaySettings.increased(from: terminalFontSize)
+                            } label: {
+                                Label("Larger Text", systemImage: "plus.magnifyingglass")
+                            }
+                            .disabled(terminalFontSize >= TerminalDisplaySettings.maximumFontSize)
+                        } label: {
+                            Image(systemName: "textformat.size")
+                        }
+                        .accessibilityLabel("Terminal text size")
+                        .accessibilityIdentifier("terminal-text-size-menu")
+
                         Button(role: .destructive) {
                             showEndConfirm = true
                         } label: {
@@ -187,6 +213,26 @@ struct TerminalView: View {
             loadError = error.localizedDescription
         }
         isRespawning = false
+    }
+}
+
+struct TerminalDisplaySettings {
+    static let minimumFontSize = 22
+    static let maximumFontSize = 34
+    static let defaultFontSize = 28
+    static let step = 2
+    static let defaultPageZoom = 1.45
+
+    static func clampedFontSize(_ value: Int) -> Int {
+        min(max(value, minimumFontSize), maximumFontSize)
+    }
+
+    static func increased(from value: Int) -> Int {
+        clampedFontSize(value + step)
+    }
+
+    static func decreased(from value: Int) -> Int {
+        clampedFontSize(value - step)
     }
 }
 

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -393,4 +393,37 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertNil(runningDeployment(for: issue, in: "org/alpha", deployments: deployments))
         XCTAssertNil(runningDeployment(owner: "org", repo: "alpha", number: 42, deployments: deployments))
     }
+
+    // MARK: - Terminal Display Settings
+
+    func testTerminalFontSizeClampsToSupportedRange() {
+        XCTAssertEqual(
+            TerminalDisplaySettings.clampedFontSize(TerminalDisplaySettings.minimumFontSize - 10),
+            TerminalDisplaySettings.minimumFontSize
+        )
+        XCTAssertEqual(
+            TerminalDisplaySettings.clampedFontSize(TerminalDisplaySettings.maximumFontSize + 10),
+            TerminalDisplaySettings.maximumFontSize
+        )
+        XCTAssertEqual(TerminalDisplaySettings.clampedFontSize(28), 28)
+    }
+
+    func testTerminalFontSizeIncreaseAndDecreaseRespectBounds() {
+        XCTAssertEqual(
+            TerminalDisplaySettings.increased(from: TerminalDisplaySettings.maximumFontSize),
+            TerminalDisplaySettings.maximumFontSize
+        )
+        XCTAssertEqual(
+            TerminalDisplaySettings.decreased(from: TerminalDisplaySettings.minimumFontSize),
+            TerminalDisplaySettings.minimumFontSize
+        )
+        XCTAssertEqual(
+            TerminalDisplaySettings.increased(from: TerminalDisplaySettings.defaultFontSize),
+            TerminalDisplaySettings.defaultFontSize + TerminalDisplaySettings.step
+        )
+        XCTAssertEqual(
+            TerminalDisplaySettings.decreased(from: TerminalDisplaySettings.defaultFontSize),
+            TerminalDisplaySettings.defaultFontSize - TerminalDisplaySettings.step
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Raises the default terminal display size and page zoom for better iPhone readability
- Adds a terminal toolbar menu for smaller/default/larger text size controls
- Adds view-logic tests for terminal font-size clamping and step behavior

## Validation
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' (191 tests, 0 failures)
- xcodebuild build/run on iPhone 17 Pro simulator
- git diff --check

Note: manual terminal entry was blocked by the local Active Sessions API returning HTTP 500 during the smoke pass.