### PR TITLE
Add iOS command center UI hooks and Today tests

### DIFF
--- a/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
+++ b/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
@@ -59,6 +59,36 @@ extension GitHubPull {
     }
 }
 
+func todayIssueMetricLabel(currentUserLogin: String?, userFetchFailed: Bool) -> String {
+    currentUserLogin == nil || userFetchFailed ? "open issues" : "assigned issues"
+}
+
+func todayAssignedIssues(_ issues: [GitHubIssue], currentUserLogin: String?) -> [GitHubIssue] {
+    let openIssues = issues.filter(\.isOpen)
+    guard let currentUserLogin else { return openIssues }
+    return openIssues.filter { issue in
+        (issue.assignees ?? []).contains { $0.login == currentUserLogin }
+    }
+}
+
+func todayAttentionSubtitle(count: Int) -> String {
+    count == 1 ? "1 item needs attention" : "\(count) items need attention"
+}
+
+func todayReviewPulls(_ pulls: [GitHubPull]) -> [GitHubPull] {
+    pulls
+        .filter(\.needsReviewAttention)
+        .sorted { todayPullSortIndex($0) < todayPullSortIndex($1) }
+}
+
+func todayPullSortIndex(_ pull: GitHubPull) -> Int {
+    switch pull.checksStatus {
+    case "failure": 0
+    case "pending": 1
+    default: 2
+    }
+}
+
 func runningDeployment(
     for issue: GitHubIssue,
     in repoFullName: String,

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -362,6 +362,7 @@ struct IssueDetailView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(IssueCTLColors.action)
                     .disabled(deployment.ttydPort == nil)
+                    .accessibilityIdentifier("issue-detail-reenter-terminal-button")
                 } else if let detail {
                     Button {
                         activeDetailSheet = .launch(detail)
@@ -372,6 +373,7 @@ struct IssueDetailView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(IssueCTLColors.action)
+                    .accessibilityIdentifier("issue-detail-launch-button")
                 }
             } secondary: {
                 issueActionsMenu
@@ -395,6 +397,7 @@ struct IssueDetailView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(.green)
                 .disabled(isReopening)
+                .accessibilityIdentifier("issue-detail-reopen-button")
             } secondary: {
                 issueActionsMenu
             }
@@ -486,6 +489,7 @@ struct IssueDetailView: View {
         }
         .buttonStyle(.bordered)
         .accessibilityLabel("Issue actions")
+        .accessibilityIdentifier("issue-detail-actions-menu")
     }
 
     // MARK: - Confirmation Dialog Helpers

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -311,6 +311,7 @@ struct IssueListView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(IssueCTLColors.action)
+            .accessibilityIdentifier("issues-create-issue-button")
         } secondary: {
             Button {
                 showFiltersSheet = true
@@ -321,8 +322,10 @@ struct IssueListView: View {
             }
             .buttonStyle(.bordered)
             .accessibilityLabel("Issue filters")
+            .accessibilityIdentifier("issues-filter-button")
         }
         .padding(.bottom, 4)
+        .accessibilityIdentifier("issues-thumb-bar")
     }
 
     // MARK: - Lists

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -119,6 +119,7 @@ struct LaunchView: View {
                         .buttonStyle(.borderedProminent)
                         .tint(IssueCTLColors.action)
                         .disabled(existingDeployment.ttydPort == nil)
+                        .accessibilityIdentifier("launch-reenter-terminal-button")
                     } else {
                         launchButton
                     }
@@ -209,6 +210,7 @@ struct LaunchView: View {
                     Label("Advanced Options", systemImage: "slider.horizontal.3")
                         .font(.subheadline.weight(.medium))
                 }
+                .accessibilityIdentifier("launch-advanced-options")
             }
 
             if let errorMessage {
@@ -223,6 +225,7 @@ struct LaunchView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button("Cancel") { dismiss() }
+                    .accessibilityIdentifier("launch-cancel-button")
             }
         }
         .task {
@@ -272,6 +275,7 @@ struct LaunchView: View {
         .buttonStyle(.borderedProminent)
         .tint(IssueCTLColors.action)
         .disabled(branchName.isEmpty || isLaunching || isCheckingActiveSession)
+        .accessibilityIdentifier("launch-recommended-button")
     }
 
     private var recommendedSummary: String {

--- a/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -283,6 +283,7 @@ struct PRDetailView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(IssueCTLColors.action)
                 .disabled(isMerging)
+                .accessibilityIdentifier("pr-detail-merge-button")
             } else {
                 Button {
                     if let url = URL(string: pull.htmlUrl) {
@@ -295,6 +296,7 @@ struct PRDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(IssueCTLColors.action)
+                .accessibilityIdentifier("pr-detail-open-github-button")
             }
         } secondary: {
             Menu {
@@ -339,6 +341,7 @@ struct PRDetailView: View {
             }
             .buttonStyle(.bordered)
             .accessibilityLabel("Pull request actions")
+            .accessibilityIdentifier("pr-detail-actions-menu")
         }
         .padding(.bottom, 4)
     }

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -250,6 +250,7 @@ struct PRListView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(IssueCTLColors.action)
+            .accessibilityIdentifier("prs-quick-actions-button")
         } secondary: {
             Button {
                 showFiltersSheet = true
@@ -260,8 +261,10 @@ struct PRListView: View {
             }
             .buttonStyle(.bordered)
             .accessibilityLabel("Pull request filters")
+            .accessibilityIdentifier("prs-filter-button")
         }
         .padding(.bottom, 4)
+        .accessibilityIdentifier("prs-thumb-bar")
     }
 
     // MARK: - List

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -143,10 +143,12 @@ struct SessionListView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(IssueCTLColors.action)
+            .accessibilityIdentifier("sessions-create-issue-button")
         } secondary: {
             EmptyView()
         }
         .padding(.bottom, 14)
+        .accessibilityIdentifier("sessions-thumb-bar")
     }
 
     private func load(refresh: Bool = false) async {

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -50,6 +50,7 @@ struct SessionRowView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(IssueCTLColors.action)
                 .disabled(deployment.ttydPort == nil)
+                .accessibilityIdentifier("session-reenter-terminal-\(deployment.id)")
 
                 Button(action: onControls) {
                     Image(systemName: "ellipsis")
@@ -59,6 +60,7 @@ struct SessionRowView: View {
                 .buttonStyle(.bordered)
                 .disabled(isEnding)
                 .accessibilityLabel("Session controls")
+                .accessibilityIdentifier("session-controls-\(deployment.id)")
             }
         }
         .padding(14)

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -31,6 +31,8 @@ struct AppTopBar<Trailing: View>: View {
 
 struct IconChromeButton: View {
     let systemName: String
+    var accessibilityLabel: String?
+    var accessibilityIdentifier: String?
     let action: () -> Void
 
     var body: some View {
@@ -41,13 +43,15 @@ struct IconChromeButton: View {
                 .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(systemName)
+        .accessibilityLabel(accessibilityLabel ?? systemName)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 }
 
 struct StatusMetricCard: View {
     let value: String
     let label: String
+    var accessibilityIdentifier: String?
     let action: () -> Void
 
     var body: some View {
@@ -67,6 +71,7 @@ struct StatusMetricCard: View {
             .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 }
 

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -31,26 +31,19 @@ struct TodayView: View {
     }
 
     private var assignedIssues: [GitHubIssue] {
-        let openIssues = allIssues.filter(\.isOpen)
-        guard let currentUserLogin else { return openIssues }
-        return openIssues.filter { issue in
-            (issue.assignees ?? []).contains { $0.login == currentUserLogin }
-        }
+        todayAssignedIssues(allIssues, currentUserLogin: currentUserLogin)
     }
 
     private var issueMetricLabel: String {
-        currentUserLogin == nil || userFetchFailed ? "open issues" : "assigned issues"
+        todayIssueMetricLabel(currentUserLogin: currentUserLogin, userFetchFailed: userFetchFailed)
     }
 
     private var attentionSubtitle: String {
-        let count = attentionItems.count
-        return "\(count) item\(count == 1 ? "" : "s") need attention"
+        todayAttentionSubtitle(count: attentionItems.count)
     }
 
     private var reviewPulls: [GitHubPull] {
-        allPulls
-            .filter(\.isOpen)
-            .sorted { pullSortIndex($0) < pullSortIndex($1) }
+        todayReviewPulls(allPulls)
     }
 
     private var attentionItems: [TodayAttentionItem] {
@@ -80,8 +73,17 @@ struct TodayView: View {
             ZStack(alignment: .bottom) {
                 VStack(spacing: 0) {
                     AppTopBar(title: "Today", subtitle: attentionSubtitle) {
-                        IconChromeButton(systemName: "magnifyingglass") {}
-                        IconChromeButton(systemName: "gearshape") { onShowSettings() }
+                        IconChromeButton(
+                            systemName: "magnifyingglass",
+                            accessibilityLabel: "Search",
+                            accessibilityIdentifier: "today-search-button"
+                        ) {}
+                        IconChromeButton(
+                            systemName: "gearshape",
+                            accessibilityLabel: "Settings",
+                            accessibilityIdentifier: "today-settings-button",
+                            action: onShowSettings
+                        )
                     }
 
                     content
@@ -99,6 +101,7 @@ struct TodayView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(IssueCTLColors.action)
                     .padding(.horizontal, 22)
+                    .accessibilityIdentifier("today-create-issue-button")
                 }
                 .padding(.bottom, 8)
             }
@@ -153,6 +156,7 @@ struct TodayView: View {
                         Button("Refresh") { Task { await load(refresh: true) } }
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(IssueCTLColors.action)
+                            .accessibilityIdentifier("today-refresh-button")
                     }
                     .padding(.top, 4)
 
@@ -180,9 +184,24 @@ struct TodayView: View {
 
     private var metrics: some View {
         HStack(spacing: 8) {
-            StatusMetricCard(value: "\(activeDeployments.count)", label: "running sessions", action: onShowSessions)
-            StatusMetricCard(value: "\(reviewPulls.count)", label: "PRs need review", action: onShowPullRequests)
-            StatusMetricCard(value: "\(assignedIssues.count)", label: issueMetricLabel, action: onShowIssues)
+            StatusMetricCard(
+                value: "\(activeDeployments.count)",
+                label: "running sessions",
+                accessibilityIdentifier: "today-metric-sessions",
+                action: onShowSessions
+            )
+            StatusMetricCard(
+                value: "\(reviewPulls.count)",
+                label: "PRs need review",
+                accessibilityIdentifier: "today-metric-prs",
+                action: onShowPullRequests
+            )
+            StatusMetricCard(
+                value: "\(assignedIssues.count)",
+                label: issueMetricLabel,
+                accessibilityIdentifier: "today-metric-issues",
+                action: onShowIssues
+            )
         }
     }
 
@@ -367,13 +386,6 @@ struct TodayView: View {
         return RepoColors.color(for: index)
     }
 
-    private func pullSortIndex(_ pull: GitHubPull) -> Int {
-        switch pull.checksStatus {
-        case "failure": 0
-        case "pending": 1
-        default: 2
-        }
-    }
 }
 
 private enum TodayDestination: Hashable {

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -196,14 +196,18 @@ final class ViewLogicTests: XCTestCase {
         )
     }
 
-    private func makeIssue(number: Int = 1, state: String = "open") -> GitHubIssue {
+    private func makeIssue(
+        number: Int = 1,
+        state: String = "open",
+        assignees: [GitHubUser]? = nil
+    ) -> GitHubIssue {
         GitHubIssue(
             number: number,
             title: "Issue \(number)",
             body: nil,
             state: state,
             labels: [],
-            assignees: nil,
+            assignees: assignees,
             user: nil,
             commentCount: 0,
             createdAt: "2026-04-27T08:00:00Z",
@@ -366,6 +370,54 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertFalse(makePull(checksStatus: "success").needsReviewAttention)
         XCTAssertFalse(makePull(checksStatus: nil).needsReviewAttention)
         XCTAssertFalse(makePull(state: "closed", checksStatus: "failure").needsReviewAttention)
+    }
+
+    // MARK: - Today Helpers
+
+    func testTodayIssueMetricLabelFallsBackWhenUserUnavailable() {
+        XCTAssertEqual(todayIssueMetricLabel(currentUserLogin: nil, userFetchFailed: false), "open issues")
+        XCTAssertEqual(todayIssueMetricLabel(currentUserLogin: "alice", userFetchFailed: true), "open issues")
+        XCTAssertEqual(todayIssueMetricLabel(currentUserLogin: "alice", userFetchFailed: false), "assigned issues")
+    }
+
+    func testTodayAssignedIssuesFallsBackToOpenIssuesWhenNoLogin() {
+        let issues = [
+            makeIssue(number: 1, state: "open"),
+            makeIssue(number: 2, state: "closed"),
+            makeIssue(number: 3, state: "open"),
+        ]
+
+        XCTAssertEqual(todayAssignedIssues(issues, currentUserLogin: nil).map(\.number), [1, 3])
+    }
+
+    func testTodayAssignedIssuesFiltersToCurrentUser() {
+        let alice = GitHubUser(login: "alice", avatarUrl: "")
+        let bob = GitHubUser(login: "bob", avatarUrl: "")
+        let issues = [
+            makeIssue(number: 1, assignees: [alice]),
+            makeIssue(number: 2, assignees: [bob]),
+            makeIssue(number: 3, state: "closed", assignees: [alice]),
+            makeIssue(number: 4, assignees: nil),
+        ]
+
+        XCTAssertEqual(todayAssignedIssues(issues, currentUserLogin: "alice").map(\.number), [1])
+    }
+
+    func testTodayAttentionSubtitlePluralizes() {
+        XCTAssertEqual(todayAttentionSubtitle(count: 0), "0 items need attention")
+        XCTAssertEqual(todayAttentionSubtitle(count: 1), "1 item needs attention")
+        XCTAssertEqual(todayAttentionSubtitle(count: 2), "2 items need attention")
+    }
+
+    func testTodayReviewPullsIncludesOnlyFailingOrPendingOpenPullsSorted() {
+        let pulls = [
+            makePull(number: 1, checksStatus: "success"),
+            makePull(number: 2, checksStatus: "pending"),
+            makePull(number: 3, checksStatus: "failure"),
+            makePull(number: 4, state: "closed", checksStatus: "failure"),
+        ]
+
+        XCTAssertEqual(todayReviewPulls(pulls).map(\.number), [3, 2])
     }
 
     // MARK: - Running Deployment Helpers


### PR DESCRIPTION
## Summary
- add stable accessibility identifiers to iOS command center, thumb-bar, launch, issue, PR, and session actions
- extract Today helper logic for assigned issues, review PRs, metric labels, and attention subtitles
- fix Today review metric to count only failing/pending open PRs and correct singular subtitle copy

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440'
- git diff --check