### PR TITLE
Add iOS UI automation for command center flows

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A00000000000000000000001 /* IssueCTLUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000003 /* IssueCTLUITests.swift */; };
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */; };
@@ -85,6 +86,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		A00000000000000000000008 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EF5E413184FCD5C1D397759F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 791AFA96580A5FB3D384B678;
+			remoteInfo = IssueCTL;
+		};
 		CC2BD2F35AE9F4F4FD860CF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EF5E413184FCD5C1D397759F /* Project object */;
@@ -96,6 +104,8 @@
 
 /* Begin PBXFileReference section */
 		0075145AA41F584D8D58036B /* IssueCTLTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00000000000000000000002 /* IssueCTLUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00000000000000000000003 /* IssueCTLUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLUITests.swift; sourceTree = "<group>"; };
 		0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoFilterChips.swift; sourceTree = "<group>"; };
 		093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
@@ -315,8 +325,17 @@
 			children = (
 				AB6764D0DF2A55EB3796889D /* IssueCTL.app */,
 				0075145AA41F584D8D58036B /* IssueCTLTests.xctest */,
+				A00000000000000000000002 /* IssueCTLUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A00000000000000000000004 /* IssueCTLUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000003 /* IssueCTLUITests.swift */,
+			);
+			path = IssueCTLUITests;
 			sourceTree = "<group>";
 		};
 		91076B7D050263F986B5E4E9 = {
@@ -324,6 +343,7 @@
 			children = (
 				D5E657213913F2B68B41C505 /* IssueCTL */,
 				679803C9E7560FAB9A36EE85 /* IssueCTLTests */,
+				A00000000000000000000004 /* IssueCTLUITests */,
 				7B6751999C63C970469632F3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -413,6 +433,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		A00000000000000000000005 /* IssueCTLUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A0000000000000000000000B /* Build configuration list for PBXNativeTarget "IssueCTLUITests" */;
+			buildPhases = (
+				A00000000000000000000006 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A00000000000000000000007 /* PBXTargetDependency */,
+			);
+			name = IssueCTLUITests;
+			packageProductDependencies = (
+			);
+			productName = IssueCTLUITests;
+			productReference = A00000000000000000000002 /* IssueCTLUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		74A5540D3FF8CC05F0E56974 /* IssueCTLTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 188108183A585BD066C9C064 /* Build configuration list for PBXNativeTarget "IssueCTLTests" */;
@@ -462,6 +500,11 @@
 						DevelopmentTeam = B3A6AN2HA4;
 						ProvisioningStyle = Automatic;
 					};
+					A00000000000000000000005 = {
+						CreatedOnToolsVersion = 26.4.1;
+						DevelopmentTeam = B3A6AN2HA4;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = DA7D0782F66BD4E6E2A975A4 /* Build configuration list for PBXProject "IssueCTL" */;
@@ -480,6 +523,7 @@
 			targets = (
 				791AFA96580A5FB3D384B678 /* IssueCTL */,
 				74A5540D3FF8CC05F0E56974 /* IssueCTLTests */,
+				A00000000000000000000005 /* IssueCTLUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -508,6 +552,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A00000000000000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A00000000000000000000001 /* IssueCTLUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0CFDDAD5B48B63CD070021C8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -600,6 +652,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		A00000000000000000000007 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 791AFA96580A5FB3D384B678 /* IssueCTL */;
+			targetProxy = A00000000000000000000008 /* PBXContainerItemProxy */;
+		};
 		B0357ED7EF8E8EA8C2BBE9A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 791AFA96580A5FB3D384B678 /* IssueCTL */;
@@ -608,6 +665,48 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		A00000000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.issuectl.ios.uitests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = IssueCTL;
+			};
+			name = Debug;
+		};
+		A0000000000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.issuectl.ios.uitests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = IssueCTL;
+			};
+			name = Release;
+		};
 		3EAB58CA558187F39D825331 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -828,6 +927,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A0000000000000000000000B /* Build configuration list for PBXNativeTarget "IssueCTLUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A00000000000000000000009 /* Debug */,
+				A0000000000000000000000A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		188108183A585BD066C9C064 /* Build configuration list for PBXNativeTarget "IssueCTLTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL.xcscheme
+++ b/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL.xcscheme
@@ -51,6 +51,17 @@
                ReferencedContainer = "container:IssueCTL.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A00000000000000000000005"
+               BuildableName = "IssueCTLUITests.xctest"
+               BlueprintName = "IssueCTLUITests"
+               ReferencedContainer = "container:IssueCTL.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -325,7 +325,6 @@ struct IssueListView: View {
             .accessibilityIdentifier("issues-filter-button")
         }
         .padding(.bottom, 4)
-        .accessibilityIdentifier("issues-thumb-bar")
     }
 
     // MARK: - Lists

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -264,7 +264,6 @@ struct PRListView: View {
             .accessibilityIdentifier("prs-filter-button")
         }
         .padding(.bottom, 4)
-        .accessibilityIdentifier("prs-thumb-bar")
     }
 
     // MARK: - List

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -59,7 +59,6 @@ struct SessionListView: View {
                                             sessionControlsTarget = deployment
                                         }
                                     )
-                                    .accessibilityIdentifier("session-row-\(deployment.id)")
                                 }
                             }
                             .padding(.horizontal, 16)
@@ -148,7 +147,6 @@ struct SessionListView: View {
             EmptyView()
         }
         .padding(.bottom, 14)
-        .accessibilityIdentifier("sessions-thumb-bar")
     }
 
     private func load(refresh: Bool = false) async {

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -1,0 +1,315 @@
+import Network
+import XCTest
+
+@MainActor
+final class IssueCTLUITests: XCTestCase {
+    private var server: MockIssueCTLServer!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        server = try MockIssueCTLServer()
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        server.stop()
+        server = nil
+    }
+
+    func testCommandCenterActionsAreReachableFromTabs() {
+        let app = launchApp()
+
+        assertElement("today-create-issue-button", existsIn: app, timeout: 8)
+        assertElement("today-metric-sessions", existsIn: app)
+        assertElement("today-metric-prs", existsIn: app)
+        assertElement("today-metric-issues", existsIn: app)
+
+        element("today-create-issue-button", in: app).tap()
+        assertElement("issue-title-field", existsIn: app, timeout: 3)
+        app.buttons["cancel-button"].tap()
+        waitForNonexistence("issue-title-field", in: app)
+
+        app.buttons["issues-tab"].tap()
+        assertElement("issues-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("issues-filter-button", existsIn: app)
+
+        app.buttons["prs-tab"].tap()
+        assertElement("prs-quick-actions-button", existsIn: app, timeout: 5)
+        assertElement("prs-filter-button", existsIn: app)
+
+        app.buttons["active-tab"].tap()
+        assertElement("sessions-create-issue-button", existsIn: app, timeout: 5)
+    }
+
+    func testLaunchingIssueCanBeReenteredFromActiveSessions() {
+        let app = launchApp()
+
+        app.buttons["issues-tab"].tap()
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        element("issue-row-101", in: app).tap()
+
+        assertElement("issue-detail-launch-button", existsIn: app, timeout: 5)
+        element("issue-detail-launch-button", in: app).tap()
+
+        assertElement("launch-recommended-button", existsIn: app, timeout: 5)
+        element("launch-recommended-button", in: app).tap()
+
+        XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 8), app.debugDescription)
+        app.buttons["terminal-done-button"].tap()
+
+        app.buttons["active-tab"].tap()
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+        element("session-reenter-terminal-9001", in: app).tap()
+
+        XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    private func launchApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["ISSUECTL_SERVER_URL"] = server.baseURL.absoluteString
+        app.launchEnvironment["ISSUECTL_API_TOKEN"] = "ui-test-token"
+        app.launchEnvironment["ISSUECTL_UI_TESTING"] = "1"
+        app.launch()
+        return app
+    }
+
+    private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)[identifier]
+    }
+
+    private func assertElement(
+        _ identifier: String,
+        existsIn app: XCUIApplication,
+        timeout: TimeInterval = 1,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let target = element(identifier, in: app)
+        let exists = timeout > 0 ? target.waitForExistence(timeout: timeout) : target.exists
+        XCTAssertTrue(exists, "Missing \(identifier)\n\(app.debugDescription)", file: file, line: line)
+    }
+
+    private func waitForNonexistence(
+        _ identifier: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 3,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element(identifier, in: app))
+        let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(result, .completed, "\(identifier) did not disappear\n\(app.debugDescription)", file: file, line: line)
+    }
+}
+
+private final class MockIssueCTLServer: @unchecked Sendable {
+    let baseURL: URL
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "MockIssueCTLServer")
+    private var activeDeployments: [[String: Any]] = []
+
+    init() throws {
+        let port = NWEndpoint.Port(rawValue: UInt16.random(in: 49_152...65_000))!
+        listener = try NWListener(using: .tcp, on: port)
+        baseURL = URL(string: "http://127.0.0.1:\(port.rawValue)")!
+    }
+
+    func start() throws {
+        let ready = XCTestExpectation(description: "mock server started")
+        let failure = FailureBox()
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                ready.fulfill()
+            case .failed(let error):
+                failure.error = error
+                ready.fulfill()
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+        listener.start(queue: queue)
+
+        let result = XCTWaiter.wait(for: [ready], timeout: 2)
+        if result != .completed {
+            throw NSError(domain: "MockIssueCTLServer", code: 2)
+        }
+        if let failedError = failure.error {
+            throw failedError
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            guard let self, let data, let request = String(data: data, encoding: .utf8) else {
+                connection.cancel()
+                return
+            }
+            let response = self.response(for: request)
+            connection.send(content: response, completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        }
+    }
+
+    private func response(for request: String) -> Data {
+        let firstLine = request.split(separator: "\r\n", maxSplits: 1).first ?? ""
+        let parts = firstLine.split(separator: " ")
+        let method = parts.indices.contains(0) ? String(parts[0]) : "GET"
+        let rawPath = parts.indices.contains(1) ? String(parts[1]) : "/"
+        let path = rawPath.split(separator: "?", maxSplits: 1).first.map(String.init) ?? rawPath
+
+        let body: Any
+        switch (method, path) {
+        case ("GET", "/api/v1/health"):
+            body = ["ok": true, "version": "ui-test", "timestamp": isoDate]
+        case ("GET", "/api/v1/user"):
+            body = ["login": "alice"]
+        case ("GET", "/api/v1/repos"):
+            body = ["repos": [repo]]
+        case ("GET", "/api/v1/deployments"):
+            body = ["deployments": activeDeployments]
+        case ("GET", "/api/v1/issues/org/alpha"):
+            body = ["issues": [issue], "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/issues/org/alpha/101"):
+            body = [
+                "issue": issue,
+                "comments": [],
+                "deployments": [],
+                "linkedPRs": [],
+                "referencedFiles": [],
+                "fromCache": false,
+            ]
+        case ("GET", "/api/v1/issues/org/alpha/priorities"):
+            body = ["priorities": [["repo_id": 1, "issue_number": 101, "priority": "high", "updated_at": 1_777_440_000]]]
+        case ("GET", "/api/v1/issues/org/alpha/101/priority"):
+            body = ["priority": "high"]
+        case ("GET", "/api/v1/pulls/org/alpha"):
+            body = ["pulls": pulls, "from_cache": false, "cached_at": NSNull()]
+        case ("POST", "/api/v1/launch/org/alpha/101"):
+            activeDeployments = [deployment]
+            body = ["success": true, "deployment_id": 9001, "ttyd_port": 19001, "error": NSNull(), "label_warning": NSNull()]
+        case ("POST", "/api/v1/drafts"):
+            body = ["success": true, "id": "draft-ui-1", "error": NSNull()]
+        case ("POST", "/api/v1/drafts/draft-ui-1/assign"):
+            body = [
+                "success": true,
+                "issue_number": 202,
+                "issue_url": "https://github.com/org/alpha/issues/202",
+                "cleanup_warning": NSNull(),
+                "labels_warning": NSNull(),
+                "error": NSNull(),
+            ]
+        default:
+            return http(status: 404, json: ["error": "Unhandled \(method) \(path)"])
+        }
+
+        return http(status: 200, json: body)
+    }
+
+    private func http(status: Int, json: Any) -> Data {
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        let reason = status == 200 ? "OK" : "Not Found"
+        let header = """
+        HTTP/1.1 \(status) \(reason)\r
+        Content-Type: application/json\r
+        Content-Length: \(data.count)\r
+        Connection: close\r
+        \r
+
+        """
+        return Data(header.utf8) + data
+    }
+
+    private var isoDate: String { "2026-04-29T08:00:00Z" }
+
+    private var repo: [String: Any] {
+        [
+            "id": 1,
+            "owner": "org",
+            "name": "alpha",
+            "local_path": "/tmp/alpha",
+            "branch_pattern": NSNull(),
+            "created_at": isoDate,
+        ]
+    }
+
+    private var issue: [String: Any] {
+        [
+            "number": 101,
+            "title": "Improve launch handoff",
+            "body": "Keep the terminal reachable after leaving detail.",
+            "state": "open",
+            "labels": [["name": "bug", "color": "d73a4a", "description": NSNull()]],
+            "assignees": [["login": "alice", "avatar_url": ""]],
+            "user": ["login": "alice", "avatar_url": ""],
+            "comment_count": 0,
+            "created_at": isoDate,
+            "updated_at": isoDate,
+            "closed_at": NSNull(),
+            "html_url": "https://github.com/org/alpha/issues/101",
+        ]
+    }
+
+    private var pulls: [[String: Any]] {
+        [
+            pull(number: 7, title: "Pending review work", checksStatus: "pending"),
+            pull(number: 8, title: "Passing background work", checksStatus: "success"),
+        ]
+    }
+
+    private func pull(number: Int, title: String, checksStatus: String) -> [String: Any] {
+        [
+            "number": number,
+            "title": title,
+            "body": NSNull(),
+            "state": "open",
+            "draft": false,
+            "merged": false,
+            "user": ["login": "alice", "avatar_url": ""],
+            "head_ref": "feature-\(number)",
+            "base_ref": "main",
+            "additions": 3,
+            "deletions": 1,
+            "changed_files": 2,
+            "created_at": isoDate,
+            "updated_at": isoDate,
+            "merged_at": NSNull(),
+            "closed_at": NSNull(),
+            "html_url": "https://github.com/org/alpha/pull/\(number)",
+            "checks_status": checksStatus,
+        ]
+    }
+
+    private var deployment: [String: Any] {
+        [
+            "id": 9001,
+            "repo_id": 1,
+            "issue_number": 101,
+            "branch_name": "issue-101-improve-launch-handoff",
+            "workspace_mode": "worktree",
+            "workspace_path": "/tmp/alpha-worktree",
+            "linked_pr_number": NSNull(),
+            "state": "active",
+            "launched_at": isoDate,
+            "ended_at": NSNull(),
+            "ttyd_port": 19001,
+            "ttyd_pid": 12345,
+            "owner": "org",
+            "repo_name": "alpha",
+        ]
+    }
+}
+
+private final class FailureBox: @unchecked Sendable {
+    var error: NWError?
+}


### PR DESCRIPTION
## Summary
- add an iOS UI test target to the shared IssueCTL scheme
- cover command center create/filter controls across Today, Issues, PRs, and Active tabs
- cover launching an issue, leaving the terminal, and re-entering it from Active Sessions
- remove masking accessibility identifiers from thumb bar/session row containers so child controls are reachable in XCTest

## Test Plan
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440"
- git diff --check
- pre-commit typecheck/lint hooks (warnings only, existing)
