### PR TITLE
Polish iOS dark mode surfaces

### DIFF
--- a/ios/IssueCTL/Views/Issues/ParseView.swift
+++ b/ios/IssueCTL/Views/Issues/ParseView.swift
@@ -58,11 +58,11 @@ struct ParseView: View {
                 TextEditor(text: $input)
                     .frame(minHeight: 200)
                     .padding(8)
-                    .background(Color(.systemGray6))
+                    .background(IssueCTLColors.elevatedBackground)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .strokeBorder(Color.secondary.opacity(0.2))
+                            .strokeBorder(IssueCTLColors.hairline)
                     )
 
                 Text("\(input.count) / 8192")
@@ -84,8 +84,12 @@ struct ParseView: View {
                         .buttonStyle(.bordered)
                 }
                 .padding()
-                .background(Color(.systemGray6))
+                .background(IssueCTLColors.elevatedBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+                }
             }
 
             if let errorMessage {
@@ -219,8 +223,12 @@ struct ParseView: View {
                     }
                 }
                 .padding()
-                .background(Color(.systemGray6))
+                .background(IssueCTLColors.elevatedBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+                }
             }
 
             Spacer()

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -1,7 +1,30 @@
 import SwiftUI
+import UIKit
 
 enum IssueCTLColors {
-    static let action = Color(hex: "e87125") ?? .orange
+    static var action: Color {
+        Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 1.00, green: 0.56, blue: 0.22, alpha: 1.00)
+                : UIColor(red: 0.91, green: 0.44, blue: 0.15, alpha: 1.00)
+        })
+    }
+
+    static var cardBackground: Color {
+        Color(.secondarySystemGroupedBackground)
+    }
+
+    static var elevatedBackground: Color {
+        Color(.tertiarySystemGroupedBackground)
+    }
+
+    static var hairline: Color {
+        Color(.separator).opacity(0.65)
+    }
+
+    static var materialStroke: Color {
+        Color(.separator).opacity(0.45)
+    }
 }
 
 struct AppTopBar<Trailing: View>: View {
@@ -39,8 +62,13 @@ struct IconChromeButton: View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.primary)
                 .frame(width: 36, height: 36)
-                .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+                .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 12))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+                }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel ?? systemName)
@@ -68,7 +96,11 @@ struct StatusMetricCard: View {
             }
             .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
             .padding(10)
-            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+            .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 16))
+            .overlay {
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+            }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier ?? "")
@@ -119,10 +151,10 @@ struct AttentionRow: View {
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 18)
-                    .fill(Color(.secondarySystemGroupedBackground))
+                    .fill(IssueCTLColors.cardBackground)
                     .overlay {
                         RoundedRectangle(cornerRadius: 18)
-                            .stroke(isAttention ? IssueCTLColors.action.opacity(0.55) : Color.clear, lineWidth: 1)
+                            .stroke(isAttention ? IssueCTLColors.action.opacity(0.65) : IssueCTLColors.hairline, lineWidth: 1)
                     }
             )
         }
@@ -211,7 +243,7 @@ struct ThumbActionBar<Primary: View, Secondary: View>: View {
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
         .overlay {
             RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                .stroke(IssueCTLColors.materialStroke, lineWidth: 1)
         }
         .padding(.horizontal, 14)
     }
@@ -223,12 +255,13 @@ struct OfflineStatusBanner: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "wifi.exclamationmark")
+                .foregroundStyle(.red)
             Text(message)
                 .lineLimit(2)
             Spacer(minLength: 0)
         }
         .font(.caption.weight(.medium))
-        .foregroundStyle(.red)
+        .foregroundStyle(.primary)
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
         .background(Color.red.opacity(0.10), in: RoundedRectangle(cornerRadius: 14))

--- a/ios/IssueCTL/Views/Shared/LabelPicker.swift
+++ b/ios/IssueCTL/Views/Shared/LabelPicker.swift
@@ -61,11 +61,11 @@ private struct LabelChip: View {
             .padding(.vertical, 6)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(isSelected ? labelColor.opacity(0.2) : Color(.systemGray6))
+                    .fill(isSelected ? labelColor.opacity(0.2) : IssueCTLColors.elevatedBackground)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(isSelected ? labelColor : Color.clear, lineWidth: 1.5)
+                    .strokeBorder(isSelected ? labelColor : IssueCTLColors.hairline, lineWidth: isSelected ? 1.5 : 0.5)
             )
         }
         .buttonStyle(.plain)

--- a/ios/IssueCTL/Views/Shared/MarkdownView.swift
+++ b/ios/IssueCTL/Views/Shared/MarkdownView.swift
@@ -19,8 +19,12 @@ struct MarkdownView: View {
                         .font(.body.monospaced())
                         .padding(10)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color(.secondarySystemBackground))
+                        .background(IssueCTLColors.elevatedBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+                        }
                         .textSelection(.enabled)
                 } else {
                     markdownText(block.text)


### PR DESCRIPTION
## Summary
- add dynamic iOS surface tokens for command-center chrome, cards, hairlines, and the orange action color
- apply those surfaces to command center metrics, attention rows, top icon buttons, and thumb bars
- improve dark-mode contrast for parse sheet panels, label chips, markdown code blocks, and offline status copy

Closes #292

## Test Plan
- xcrun simctl ui 3078C4C7-E3E0-448A-B6AB-8AFE7A39F440 appearance dark
- build/run IssueCTL on iPhone 17 Pro simulator and inspect Today error state screenshot in dark appearance
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440"
- git diff --check
- pre-commit typecheck/lint hooks (warnings only, existing)
