### PR TITLE
Fix iOS launch session state refresh

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -79,7 +79,9 @@ struct IssueDetailView: View {
         .navigationDestination(for: PRDestination.self) { dest in
             PRDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
         }
-        .sheet(item: $activeDetailSheet) { sheet in
+        .sheet(item: $activeDetailSheet, onDismiss: {
+            Task { await load(refresh: true) }
+        }) { sheet in
             switch sheet {
             case .reassign(let detail):
                 ReassignSheet(

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -69,6 +69,8 @@ struct IconChromeButton: View {
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
                 }
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel ?? systemName)

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -70,40 +70,25 @@ struct TodayView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            ZStack(alignment: .bottom) {
-                VStack(spacing: 0) {
-                    AppTopBar(title: "Today", subtitle: attentionSubtitle) {
-                        IconChromeButton(
-                            systemName: "magnifyingglass",
-                            accessibilityLabel: "Search",
-                            accessibilityIdentifier: "today-search-button"
-                        ) {}
-                        IconChromeButton(
-                            systemName: "gearshape",
-                            accessibilityLabel: "Settings",
-                            accessibilityIdentifier: "today-settings-button",
-                            action: onShowSettings
-                        )
-                    }
-
-                    content
+            VStack(spacing: 0) {
+                AppTopBar(title: "Today", subtitle: attentionSubtitle) {
+                    IconChromeButton(
+                        systemName: "magnifyingglass",
+                        accessibilityLabel: "Search",
+                        accessibilityIdentifier: "today-search-button"
+                    ) {}
+                    IconChromeButton(
+                        systemName: "gearshape",
+                        accessibilityLabel: "Settings",
+                        accessibilityIdentifier: "today-settings-button",
+                        action: onShowSettings
+                    )
                 }
 
-                VStack(spacing: 8) {
-                    SessionDock(deployments: activeDeployments, action: onShowSessions)
-                    Button {
-                        showCreateSheet = true
-                    } label: {
-                        Text("Create Issue")
-                            .font(.subheadline.weight(.bold))
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(IssueCTLColors.action)
-                    .padding(.horizontal, 22)
-                    .accessibilityIdentifier("today-create-issue-button")
-                }
-                .padding(.bottom, 8)
+                content
+            }
+            .safeAreaInset(edge: .bottom) {
+                todayBottomActions
             }
             .navigationBarHidden(true)
             .navigationDestination(for: TodayDestination.self) { destination in
@@ -124,6 +109,25 @@ struct TodayView: View {
             .task { await load() }
             .refreshable { await load(refresh: true) }
         }
+    }
+
+    private var todayBottomActions: some View {
+        VStack(spacing: 8) {
+            SessionDock(deployments: activeDeployments, action: onShowSessions)
+            Button {
+                showCreateSheet = true
+            } label: {
+                Text("Create Issue")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action)
+            .contentShape(Rectangle())
+            .padding(.horizontal, 22)
+            .accessibilityIdentifier("today-create-issue-button")
+        }
+        .padding(.bottom, 8)
     }
 
     @ViewBuilder
@@ -177,7 +181,7 @@ struct TodayView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-                .padding(.bottom, activeDeployments.isEmpty ? 96 : 154)
+                .padding(.bottom, 16)
             }
         }
     }

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -56,6 +56,7 @@ final class IssueCTLUITests: XCTestCase {
 
         XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 8), app.debugDescription)
         app.buttons["terminal-done-button"].tap()
+        assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
 
         app.buttons["active-tab"].tap()
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
@@ -184,7 +185,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
             body = [
                 "issue": issue,
                 "comments": [],
-                "deployments": [],
+                "deployments": activeDeployments,
                 "linkedPRs": [],
                 "referencedFiles": [],
                 "fromCache": false,


### PR DESCRIPTION
## Summary
- refresh issue detail after launch/action sheets dismiss so running sessions replace Launch Claude with Re-enter Terminal
- move Today bottom actions into a safe-area inset to keep Create Issue and the session dock reachable without overlaying content
- expand command-center icon hit targets to 44x44
- add UI regression coverage for returning from terminal to issue detail

## Testing
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440"
- manual simulator: launched Claude for issue #879, returned from terminal, verified issue detail shows Re-enter Terminal instead of Launch Claude
- manual simulator: opened Active Sessions, used View Issue path, confirmed session remained running, then ended the test session
- pre-commit/pre-push typecheck hooks passed; lint hook completed with existing warnings only
