### PR TITLE
Add iOS Today search

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */; };
 		FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4010BC691DB71B872353344A /* SessionListView.swift */; };
 		FE0B5C2B67B34C029C49FD12 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72E02E2D87749738F2DB8BC /* TodayView.swift */; };
+		FE7C48D6D112493DA287E086 /* TodaySearchSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20D8DA49803407D8C47855E /* TodaySearchSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,6 +158,7 @@
 		AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+AdvancedSettings.swift"; sourceTree = "<group>"; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAccessibleRepo.swift; sourceTree = "<group>"; };
+		B20D8DA49803407D8C47855E /* TodaySearchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaySearchSheet.swift; sourceTree = "<group>"; };
 		B7701223E13D43C4F74244B0 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
 		BC00C899D2ADA14475787AE7 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerHealth.swift; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 		9277C6A223C54C5FA343C53F /* Today */ = {
 			isa = PBXGroup;
 			children = (
+				B20D8DA49803407D8C47855E /* TodaySearchSheet.swift */,
 				F72E02E2D87749738F2DB8BC /* TodayView.swift */,
 			);
 			path = Today;
@@ -644,6 +647,7 @@
 				89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */,
 				6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */,
 				C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */,
+				FE7C48D6D112493DA287E086 /* TodaySearchSheet.swift in Sources */,
 				FE0B5C2B67B34C029C49FD12 /* TodayView.swift in Sources */,
 				42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */,
 			);

--- a/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
+++ b/ios/IssueCTL/Helpers/RepoFilterHelpers.swift
@@ -81,6 +81,29 @@ func todayReviewPulls(_ pulls: [GitHubPull]) -> [GitHubPull] {
         .sorted { todayPullSortIndex($0) < todayPullSortIndex($1) }
 }
 
+func todayMatchesSearchQuery(
+    query: String,
+    title: String,
+    body: String?,
+    repoFullName: String?,
+    number: Int
+) -> Bool {
+    let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !normalizedQuery.isEmpty else { return true }
+
+    let searchableText = [
+        title,
+        body ?? "",
+        repoFullName ?? "",
+        "#\(number)",
+        "\(number)",
+    ]
+    .joined(separator: " ")
+    .lowercased()
+
+    return searchableText.contains(normalizedQuery)
+}
+
 func todayPullSortIndex(_ pull: GitHubPull) -> Int {
     switch pull.checksStatus {
     case "failure": 0

--- a/ios/IssueCTL/Views/Today/TodaySearchSheet.swift
+++ b/ios/IssueCTL/Views/Today/TodaySearchSheet.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+
+struct TodaySearchSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var isSearchFocused: Bool
+
+    let repos: [Repo]
+    let issuesByRepo: [String: [GitHubIssue]]
+    let pullsByRepo: [String: [GitHubPull]]
+    let onSelect: (TodayDestination) -> Void
+
+    @State private var query = ""
+
+    private var issueResults: [TodayIssueSearchResult] {
+        issuesByRepo.flatMap { repoFullName, issues in
+            issues.compactMap { issue in
+                guard todayMatchesSearchQuery(
+                    query: query,
+                    title: issue.title,
+                    body: issue.body,
+                    repoFullName: repoFullName,
+                    number: issue.number
+                ) else { return nil }
+                return TodayIssueSearchResult(issue: issue, repo: repo(for: repoFullName))
+            }
+        }
+        .sorted { $0.issue.updatedAt > $1.issue.updatedAt }
+    }
+
+    private var pullResults: [TodayPullSearchResult] {
+        pullsByRepo.flatMap { repoFullName, pulls in
+            pulls.compactMap { pull in
+                guard todayMatchesSearchQuery(
+                    query: query,
+                    title: pull.title,
+                    body: pull.body,
+                    repoFullName: repoFullName,
+                    number: pull.number
+                ) else { return nil }
+                return TodayPullSearchResult(pull: pull, repo: repo(for: repoFullName))
+            }
+        }
+        .sorted { $0.pull.updatedAt > $1.pull.updatedAt }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                searchField
+
+                if issueResults.isEmpty && pullResults.isEmpty {
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "magnifyingglass",
+                        description: Text("No issues or pull requests match this search.")
+                    )
+                    .frame(maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 16) {
+                            if !issueResults.isEmpty {
+                                resultSection(title: "Issues") {
+                                    ForEach(issueResults.prefix(12)) { result in
+                                        issueResultRow(result)
+                                    }
+                                }
+                            }
+
+                            if !pullResults.isEmpty {
+                                resultSection(title: "Pull Requests") {
+                                    ForEach(pullResults.prefix(12)) { result in
+                                        pullResultRow(result)
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 24)
+                    }
+                }
+            }
+            .padding(.top, 12)
+            .navigationTitle("Search")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("today-search-cancel-button")
+                }
+            }
+        }
+        .task { isSearchFocused = true }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search issues and PRs", text: $query)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused($isSearchFocused)
+                .accessibilityIdentifier("today-search-field")
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+                .accessibilityIdentifier("today-search-clear-button")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private func resultSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            VStack(spacing: 8) {
+                content()
+            }
+        }
+    }
+
+    private func issueResultRow(_ result: TodayIssueSearchResult) -> some View {
+        Button {
+            guard let repo = result.repo else { return }
+            onSelect(.issue(owner: repo.owner, repo: repo.name, number: result.issue.number))
+        } label: {
+            TodaySearchRow(
+                icon: "circle",
+                iconColor: repoColor(for: result.repo),
+                kicker: "\(result.repo?.fullName ?? "Unknown repo") - Issue #\(result.issue.number)",
+                title: result.issue.title,
+                detail: result.issue.timeAgo
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(result.repo == nil)
+        .accessibilityIdentifier("today-search-issue-\(result.issue.number)")
+    }
+
+    private func pullResultRow(_ result: TodayPullSearchResult) -> some View {
+        Button {
+            guard let repo = result.repo else { return }
+            onSelect(.pull(owner: repo.owner, repo: repo.name, number: result.pull.number))
+        } label: {
+            TodaySearchRow(
+                icon: "arrow.triangle.merge",
+                iconColor: IssueCTLColors.action,
+                kicker: "\(result.repo?.fullName ?? "Unknown repo") - PR #\(result.pull.number)",
+                title: result.pull.title,
+                detail: relativeTime(for: result.pull.updatedAt)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(result.repo == nil)
+        .accessibilityIdentifier("today-search-pr-\(result.pull.number)")
+    }
+
+    private func repo(for fullName: String) -> Repo? {
+        repos.first { $0.fullName == fullName }
+    }
+
+    private func repoColor(for repo: Repo?) -> Color {
+        guard let repo, let index = repos.firstIndex(where: { $0.id == repo.id }) else { return .secondary }
+        return RepoColors.color(for: index)
+    }
+
+    private func relativeTime(for timestamp: String) -> String {
+        guard let date = parseIssueCTLDate(timestamp) else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+private struct TodaySearchRow: View {
+    let icon: String
+    let iconColor: Color
+    let kicker: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(iconColor)
+                .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(kicker)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                if !detail.isEmpty {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(12)
+        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+        }
+    }
+}
+
+private struct TodayIssueSearchResult: Identifiable {
+    let issue: GitHubIssue
+    let repo: Repo?
+
+    var id: String {
+        "\(repo?.fullName ?? "unknown")-issue-\(issue.number)"
+    }
+}
+
+private struct TodayPullSearchResult: Identifiable {
+    let pull: GitHubPull
+    let repo: Repo?
+
+    var id: String {
+        "\(repo?.fullName ?? "unknown")-pull-\(pull.number)"
+    }
+}

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -19,6 +19,8 @@ struct TodayView: View {
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var showCreateSheet = false
+    @State private var showSearchSheet = false
+    @State private var pendingSearchDestination: TodayDestination?
     @State private var actionError: String?
     @State private var navigationPath = NavigationPath()
 
@@ -76,7 +78,9 @@ struct TodayView: View {
                         systemName: "magnifyingglass",
                         accessibilityLabel: "Search",
                         accessibilityIdentifier: "today-search-button"
-                    ) {}
+                    ) {
+                        showSearchSheet = true
+                    }
                     IconChromeButton(
                         systemName: "gearshape",
                         accessibilityLabel: "Settings",
@@ -104,6 +108,24 @@ struct TodayView: View {
                     if let warning { actionError = warning }
                     Task { await load(refresh: true) }
                 })
+            }
+            .sheet(isPresented: $showSearchSheet, onDismiss: {
+                if let destination = pendingSearchDestination {
+                    navigationPath.append(destination)
+                    pendingSearchDestination = nil
+                }
+            }) {
+                TodaySearchSheet(
+                    repos: repos,
+                    issuesByRepo: issuesByRepo,
+                    pullsByRepo: pullsByRepo,
+                    onSelect: { destination in
+                        pendingSearchDestination = destination
+                        showSearchSheet = false
+                    }
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .autoDismissError($actionError)
             .task { await load() }
@@ -392,7 +414,7 @@ struct TodayView: View {
 
 }
 
-private enum TodayDestination: Hashable {
+enum TodayDestination: Hashable {
     case issue(owner: String, repo: String, number: Int)
     case pull(owner: String, repo: String, number: Int)
 }

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -420,6 +420,54 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertEqual(todayReviewPulls(pulls).map(\.number), [3, 2])
     }
 
+    func testTodaySearchMatchesTitleBodyRepoAndNumber() {
+        XCTAssertTrue(todayMatchesSearchQuery(
+            query: "login",
+            title: "Fix login bug",
+            body: nil,
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+        XCTAssertTrue(todayMatchesSearchQuery(
+            query: "oauth",
+            title: "Fix login bug",
+            body: "Handle OAuth redirect failures",
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+        XCTAssertTrue(todayMatchesSearchQuery(
+            query: "org/alpha",
+            title: "Fix login bug",
+            body: nil,
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+        XCTAssertTrue(todayMatchesSearchQuery(
+            query: "#42",
+            title: "Fix login bug",
+            body: nil,
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+        XCTAssertFalse(todayMatchesSearchQuery(
+            query: "billing",
+            title: "Fix login bug",
+            body: nil,
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+    }
+
+    func testTodaySearchEmptyQueryShowsDefaultResults() {
+        XCTAssertTrue(todayMatchesSearchQuery(
+            query: "  ",
+            title: "Fix login bug",
+            body: nil,
+            repoFullName: "org/alpha",
+            number: 42
+        ))
+    }
+
     // MARK: - Running Deployment Helpers
 
     func testRunningDeploymentMatchesActiveIssueSessionByRepoAndIssue() {

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -24,6 +24,13 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("today-metric-prs", existsIn: app)
         assertElement("today-metric-issues", existsIn: app)
 
+        element("today-search-button", in: app).tap()
+        assertElement("today-search-field", existsIn: app, timeout: 3)
+        assertElement("today-search-issue-101", existsIn: app)
+        assertElement("today-search-pr-7", existsIn: app)
+        app.buttons["today-search-cancel-button"].tap()
+        waitForNonexistence("today-search-field", in: app)
+
         element("today-create-issue-button", in: app).tap()
         assertElement("issue-title-field", existsIn: app, timeout: 3)
         app.buttons["cancel-button"].tap()


### PR DESCRIPTION
## Summary
- make the Today search icon open a compact search sheet
- search across loaded issues and pull requests by title, body, repo, and number
- navigate search results directly into issue or PR detail
- add helper and UI regression coverage for the Today search flow

## Testing
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440"
- manual simulator: opened Today search sheet from the custom top bar and verified dark-mode layout/empty state
- pre-commit/pre-push typecheck hooks passed; lint hook completed with existing warnings only
