### PR TITLE
Improve iOS command center actions

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -44,6 +44,7 @@ struct IssueListView: View {
     private let pageSize = 15
     @State private var displayLimit = 15
     @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
@@ -298,6 +299,7 @@ struct IssueListView: View {
             }
         }
         .searchable(text: $searchText, prompt: "Search issues")
+        .searchFocused($isSearchFocused)
     }
 
     private var issueThumbBar: some View {
@@ -313,16 +315,29 @@ struct IssueListView: View {
             .tint(IssueCTLColors.action)
             .accessibilityIdentifier("issues-create-issue-button")
         } secondary: {
-            Button {
-                showFiltersSheet = true
-            } label: {
-                Image(systemName: "line.3.horizontal.decrease")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 44, height: 36)
+            HStack(spacing: 8) {
+                Button {
+                    isSearchFocused = true
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Search issues")
+                .accessibilityIdentifier("issues-search-button")
+
+                Button {
+                    showFiltersSheet = true
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Issue filters")
+                .accessibilityIdentifier("issues-filter-button")
             }
-            .buttonStyle(.bordered)
-            .accessibilityLabel("Issue filters")
-            .accessibilityIdentifier("issues-filter-button")
         }
         .padding(.bottom, 4)
     }

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -29,6 +29,7 @@ struct PRListView: View {
     private let pageSize = 15
     @State private var displayLimit = 15
     @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
 
@@ -237,31 +238,56 @@ struct PRListView: View {
             }
         }
         .searchable(text: $searchText, prompt: "Search pull requests")
+        .searchFocused($isSearchFocused)
     }
 
     private var pullRequestThumbBar: some View {
         ThumbActionBar {
             Button {
-                showQuickActionsSheet = true
+                showCreateSheet = true
             } label: {
-                Label("Quick Actions", systemImage: "bolt.fill")
+                Label("Create Issue", systemImage: "plus")
                     .font(.subheadline.weight(.bold))
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
             .tint(IssueCTLColors.action)
-            .accessibilityIdentifier("prs-quick-actions-button")
+            .accessibilityIdentifier("prs-create-issue-button")
         } secondary: {
-            Button {
-                showFiltersSheet = true
-            } label: {
-                Image(systemName: "line.3.horizontal.decrease")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 44, height: 36)
+            HStack(spacing: 8) {
+                Button {
+                    isSearchFocused = true
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Search pull requests")
+                .accessibilityIdentifier("prs-search-button")
+
+                Button {
+                    showFiltersSheet = true
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Pull request filters")
+                .accessibilityIdentifier("prs-filter-button")
+
+                Button {
+                    showQuickActionsSheet = true
+                } label: {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Pull request quick actions")
+                .accessibilityIdentifier("prs-quick-actions-button")
             }
-            .buttonStyle(.bordered)
-            .accessibilityLabel("Pull request filters")
-            .accessibilityIdentifier("prs-filter-button")
         }
         .padding(.bottom, 4)
     }

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -12,8 +12,35 @@ struct SessionListView: View {
     @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
     @State private var navigationPath = NavigationPath()
+    @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
+
+    private var filteredDeployments: [ActiveDeployment] {
+        guard !searchText.isEmpty else { return deployments }
+        let query = searchText.lowercased()
+        return deployments.filter { deployment in
+            [
+                deployment.repoFullName,
+                "#\(deployment.issueNumber)",
+                deployment.branchName,
+                deployment.ttydPort.map(String.init) ?? "starting",
+            ]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+            .contains(query)
+        }
+    }
+
+    private var readyCount: Int {
+        deployments.filter { $0.ttydPort != nil }.count
+    }
+
+    private var startingCount: Int {
+        deployments.count - readyCount
+    }
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -38,6 +65,15 @@ struct SessionListView: View {
                     } else {
                         ScrollView {
                             LazyVStack(spacing: 12) {
+                                ActiveSessionsHeader(
+                                    totalCount: deployments.count,
+                                    readyCount: readyCount,
+                                    startingCount: startingCount,
+                                    onRefresh: {
+                                        Task { await load(refresh: true) }
+                                    }
+                                )
+
                                 if let actionError {
                                     Label(actionError, systemImage: "exclamationmark.triangle")
                                         .foregroundStyle(.red)
@@ -46,7 +82,16 @@ struct SessionListView: View {
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                 }
 
-                                ForEach(deployments) { deployment in
+                                if filteredDeployments.isEmpty {
+                                    ContentUnavailableView(
+                                        "No Matching Sessions",
+                                        systemImage: "magnifyingglass",
+                                        description: Text("Try another repo, issue number, branch, or port.")
+                                    )
+                                    .padding(.top, 18)
+                                }
+
+                                ForEach(filteredDeployments) { deployment in
                                     SessionRowView(
                                         deployment: deployment,
                                         isEnding: endingDeploymentId == deployment.id,
@@ -73,6 +118,8 @@ struct SessionListView: View {
                 sessionThumbBar
             }
             .navigationTitle("Active Sessions")
+            .searchable(text: $searchText, prompt: "Search sessions")
+            .searchFocused($isSearchFocused)
             .navigationDestination(for: IssueDestination.self) { dest in
                 IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
@@ -144,7 +191,29 @@ struct SessionListView: View {
             .tint(IssueCTLColors.action)
             .accessibilityIdentifier("sessions-create-issue-button")
         } secondary: {
-            EmptyView()
+            HStack(spacing: 8) {
+                Button {
+                    isSearchFocused = true
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Search sessions")
+                .accessibilityIdentifier("sessions-search-button")
+
+                Button {
+                    Task { await load(refresh: true) }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Refresh sessions")
+                .accessibilityIdentifier("sessions-refresh-button")
+            }
         }
         .padding(.bottom, 14)
     }
@@ -191,6 +260,71 @@ struct SessionListView: View {
             errorMessage = error.localizedDescription
         }
         endingDeploymentId = nil
+    }
+}
+
+private struct ActiveSessionsHeader: View {
+    let totalCount: Int
+    let readyCount: Int
+    let startingCount: Int
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(totalCount) running")
+                        .font(.title3.weight(.bold))
+                    Text("Re-enter terminals without losing active Claude Code work.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 8)
+
+                Button(action: onRefresh) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Refresh sessions")
+                .accessibilityIdentifier("sessions-header-refresh-button")
+            }
+
+            HStack(spacing: 10) {
+                metric(value: "\(readyCount)", label: "ready", systemImage: "terminal")
+                metric(value: "\(startingCount)", label: "starting", systemImage: "hourglass")
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+        }
+        .accessibilityIdentifier("sessions-command-header")
+    }
+
+    private func metric(value: String, label: String, systemImage: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.caption.weight(.semibold))
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(IssueCTLColors.elevatedBackground, in: RoundedRectangle(cornerRadius: 12))
     }
 }
 

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -136,18 +136,30 @@ struct TodayView: View {
     private var todayBottomActions: some View {
         VStack(spacing: 8) {
             SessionDock(deployments: activeDeployments, action: onShowSessions)
-            Button {
-                showCreateSheet = true
-            } label: {
-                Text("Create Issue")
-                    .font(.subheadline.weight(.bold))
-                    .frame(maxWidth: .infinity)
+            ThumbActionBar {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    Label("Create Issue", systemImage: "plus")
+                        .font(.subheadline.weight(.bold))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(IssueCTLColors.action)
+                .contentShape(Rectangle())
+                .accessibilityIdentifier("today-create-issue-button")
+            } secondary: {
+                Button {
+                    showSearchSheet = true
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Search")
+                .accessibilityIdentifier("today-bottom-search-button")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(IssueCTLColors.action)
-            .contentShape(Rectangle())
-            .padding(.horizontal, 22)
-            .accessibilityIdentifier("today-create-issue-button")
         }
         .padding(.bottom, 8)
     }

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -38,14 +38,19 @@ final class IssueCTLUITests: XCTestCase {
 
         app.buttons["issues-tab"].tap()
         assertElement("issues-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("issues-search-button", existsIn: app)
         assertElement("issues-filter-button", existsIn: app)
 
         app.buttons["prs-tab"].tap()
+        assertElement("prs-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("prs-search-button", existsIn: app)
         assertElement("prs-quick-actions-button", existsIn: app, timeout: 5)
         assertElement("prs-filter-button", existsIn: app)
 
         app.buttons["active-tab"].tap()
         assertElement("sessions-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("sessions-search-button", existsIn: app)
+        assertElement("sessions-refresh-button", existsIn: app)
     }
 
     func testLaunchingIssueCanBeReenteredFromActiveSessions() {
@@ -66,6 +71,7 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
 
         app.buttons["active-tab"].tap()
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
         element("session-reenter-terminal-9001", in: app).tap()
 


### PR DESCRIPTION
## Summary
- add thumb-reachable search affordances across the iOS command tabs
- make PRs expose direct Create Issue while keeping quick actions available
- turn Active Sessions into a searchable command hub with running/ready/starting summary and refresh controls

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440'
- git diff --check

## Notes
- Pre-push hook skipped the web build because dev server :3847 is running and ran typecheck only, as designed.