### PR TITLE
Polish iOS command center controls

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -316,27 +316,21 @@ struct IssueListView: View {
             .accessibilityIdentifier("issues-create-issue-button")
         } secondary: {
             HStack(spacing: 8) {
-                Button {
+                ThumbIconButton(
+                    systemName: "magnifyingglass",
+                    accessibilityLabel: "Search issues",
+                    accessibilityIdentifier: "issues-search-button"
+                ) {
                     isSearchFocused = true
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Search issues")
-                .accessibilityIdentifier("issues-search-button")
 
-                Button {
+                ThumbIconButton(
+                    systemName: "line.3.horizontal.decrease",
+                    accessibilityLabel: "Issue filters",
+                    accessibilityIdentifier: "issues-filter-button"
+                ) {
                     showFiltersSheet = true
-                } label: {
-                    Image(systemName: "line.3.horizontal.decrease")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Issue filters")
-                .accessibilityIdentifier("issues-filter-button")
             }
         }
         .padding(.bottom, 4)

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -255,38 +255,29 @@ struct PRListView: View {
             .accessibilityIdentifier("prs-create-issue-button")
         } secondary: {
             HStack(spacing: 8) {
-                Button {
+                ThumbIconButton(
+                    systemName: "magnifyingglass",
+                    accessibilityLabel: "Search pull requests",
+                    accessibilityIdentifier: "prs-search-button"
+                ) {
                     isSearchFocused = true
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Search pull requests")
-                .accessibilityIdentifier("prs-search-button")
 
-                Button {
+                ThumbIconButton(
+                    systemName: "line.3.horizontal.decrease",
+                    accessibilityLabel: "Pull request filters",
+                    accessibilityIdentifier: "prs-filter-button"
+                ) {
                     showFiltersSheet = true
-                } label: {
-                    Image(systemName: "line.3.horizontal.decrease")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Pull request filters")
-                .accessibilityIdentifier("prs-filter-button")
 
-                Button {
+                ThumbIconButton(
+                    systemName: "bolt.fill",
+                    accessibilityLabel: "Pull request quick actions",
+                    accessibilityIdentifier: "prs-quick-actions-button"
+                ) {
                     showQuickActionsSheet = true
-                } label: {
-                    Image(systemName: "bolt.fill")
-                        .font(.system(size: 15, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Pull request quick actions")
-                .accessibilityIdentifier("prs-quick-actions-button")
             }
         }
         .padding(.bottom, 4)

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -192,27 +192,21 @@ struct SessionListView: View {
             .accessibilityIdentifier("sessions-create-issue-button")
         } secondary: {
             HStack(spacing: 8) {
-                Button {
+                ThumbIconButton(
+                    systemName: "magnifyingglass",
+                    accessibilityLabel: "Search sessions",
+                    accessibilityIdentifier: "sessions-search-button"
+                ) {
                     isSearchFocused = true
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Search sessions")
-                .accessibilityIdentifier("sessions-search-button")
 
-                Button {
+                ThumbIconButton(
+                    systemName: "arrow.clockwise",
+                    accessibilityLabel: "Refresh sessions",
+                    accessibilityIdentifier: "sessions-refresh-button"
+                ) {
                     Task { await load(refresh: true) }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Refresh sessions")
-                .accessibilityIdentifier("sessions-refresh-button")
             }
         }
         .padding(.bottom, 14)

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
     @State private var showDisconnectConfirm = false
     @State private var showAddRepo = false
     @State private var repos: [Repo] = []
@@ -25,6 +26,15 @@ struct SettingsView: View {
                 disconnectSection
             }
             .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .accessibilityIdentifier("settings-done-button")
+                }
+            }
             .navigationDestination(for: SettingsDestination.self) { dest in
                 switch dest {
                 case .advancedSettings:

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -78,6 +78,30 @@ struct IconChromeButton: View {
     }
 }
 
+struct ThumbIconButton: View {
+    let systemName: String
+    let accessibilityLabel: String
+    var accessibilityIdentifier: String?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(IssueCTLColors.action)
+                .frame(width: 44, height: 36)
+                .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(IssueCTLColors.materialStroke, lineWidth: 1)
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
+    }
+}
+
 struct StatusMetricCard: View {
     let value: String
     let label: String

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -149,16 +149,13 @@ struct TodayView: View {
                 .contentShape(Rectangle())
                 .accessibilityIdentifier("today-create-issue-button")
             } secondary: {
-                Button {
+                ThumbIconButton(
+                    systemName: "magnifyingglass",
+                    accessibilityLabel: "Search",
+                    accessibilityIdentifier: "today-bottom-search-button"
+                ) {
                     showSearchSheet = true
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 44, height: 36)
                 }
-                .buttonStyle(.bordered)
-                .accessibilityLabel("Search")
-                .accessibilityIdentifier("today-bottom-search-button")
             }
         }
         .padding(.bottom, 8)

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -24,6 +24,11 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("today-metric-prs", existsIn: app)
         assertElement("today-metric-issues", existsIn: app)
 
+        element("today-settings-button", in: app).tap()
+        assertElement("settings-done-button", existsIn: app, timeout: 3)
+        app.buttons["settings-done-button"].tap()
+        waitForNonexistence("settings-done-button", in: app)
+
         element("today-search-button", in: app).tap()
         assertElement("today-search-field", existsIn: app, timeout: 3)
         assertElement("today-search-issue-101", existsIn: app)


### PR DESCRIPTION
## Summary
- add a visible Done action to Settings so the sheet has an explicit exit
- replace thumb-bar secondary bordered buttons with compact fixed-width icon controls
- keep PR Create Issue on one line on iPhone-width screens
- add UI test coverage for opening and dismissing Settings

## Manual simulator pass
- Today: search sheet, live filtering, create sheet, settings sheet
- Issues: list rendering and detail navigation
- PRs: bottom Create Issue no longer wraps with search/filter/quick-actions icons
- Active: command bar renders; local API currently returns 500 for /api/v1/deployments, confirmed with direct curl

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLUITests/IssueCTLUITests
- git diff --check