### PR TITLE
Ignore optional iOS user profile failures

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -554,7 +554,7 @@ struct IssueDetailView: View {
             var failures: [String] = []
             switch await userResult {
             case .success(let user): currentUserLogin = user.login
-            case .failure(let error): failures.append("user profile (\(error.localizedDescription))")
+            case .failure: currentUserLogin = nil
             }
             switch await priorityResult {
             case .success(let priority): currentPriority = priority

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -568,7 +568,7 @@ struct IssueListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                failures.append("user profile (\(error.localizedDescription))")
+                currentUserLogin = nil
             }
 
             // Snapshot repos to a local Sendable value so child tasks don't

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -362,7 +362,7 @@ struct PRListView: View {
                 userFetchFailed = false
             } catch {
                 userFetchFailed = true
-                failures.append("user profile (\(error.localizedDescription))")
+                currentUserLogin = nil
             }
 
             let repoResults = await withTaskGroup(of: (String, String, [GitHubPull]?, String?, Error?).self) { group in

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -83,6 +83,19 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testUserProfileFailureDoesNotBlockPrimaryLists() {
+        server.failUserProfile = true
+        let app = launchApp()
+
+        app.buttons["issues-tab"].tap()
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        XCTAssertFalse(app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "user profile")).firstMatch.exists)
+
+        app.buttons["prs-tab"].tap()
+        assertElement("pr-row-7", existsIn: app, timeout: 8)
+        XCTAssertFalse(app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "user profile")).firstMatch.exists)
+    }
+
     private func launchApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["ISSUECTL_SERVER_URL"] = server.baseURL.absoluteString
@@ -127,6 +140,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
     private let listener: NWListener
     private let queue = DispatchQueue(label: "MockIssueCTLServer")
     private var activeDeployments: [[String: Any]] = []
+    var failUserProfile = false
 
     init() throws {
         let port = NWEndpoint.Port(rawValue: UInt16.random(in: 49_152...65_000))!
@@ -192,6 +206,9 @@ private final class MockIssueCTLServer: @unchecked Sendable {
         case ("GET", "/api/v1/health"):
             body = ["ok": true, "version": "ui-test", "timestamp": isoDate]
         case ("GET", "/api/v1/user"):
+            if failUserProfile {
+                return http(status: 500, json: ["error": "user profile unavailable"])
+            }
             body = ["login": "alice"]
         case ("GET", "/api/v1/repos"):
             body = ["repos": [repo]]


### PR DESCRIPTION
## Summary
- stop surfacing optional current-user lookup failures as primary list/detail errors
- fall back to non-personalized Issues/PRs/Issue Detail behavior when /api/v1/user fails
- add UI coverage proving Issues and PRs still load when user profile returns 500

## Verification
- /api/v1/user currently returns 500 locally
- /api/v1/deployments and /api/v1/repos return 200 locally
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLUITests/IssueCTLUITests
- git diff --check