### PR TITLE
fix(ios): simplify session thumb actions

### DIFF
--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -108,13 +108,14 @@ struct SessionListView: View {
                             }
                             .padding(.horizontal, 16)
                             .padding(.top, 16)
-                            .padding(.bottom, 16)
+                            .padding(.bottom, 116)
                         }
                         .refreshable { await load(refresh: true) }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-
+            }
+            .safeAreaInset(edge: .bottom) {
                 sessionThumbBar
             }
             .navigationTitle("Active Sessions")

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -14,6 +14,7 @@ struct SessionRowView: View {
                     .frame(width: 8, height: 8)
                 Text(deployment.repoFullName)
                     .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.primary)
                 Text("#\(deployment.issueNumber)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -42,20 +43,21 @@ struct SessionRowView: View {
             }
 
             HStack(spacing: 8) {
-                Button(action: onOpen) {
-                    Label(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal", systemImage: "terminal")
-                        .font(.subheadline.weight(.bold))
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(IssueCTLColors.action)
-                .disabled(deployment.ttydPort == nil)
-                .accessibilityIdentifier("session-reenter-terminal-\(deployment.id)")
+                Label(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal", systemImage: "terminal")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, minHeight: 40)
+                    .background(IssueCTLColors.action.opacity(deployment.ttydPort == nil ? 0.45 : 1), in: RoundedRectangle(cornerRadius: 12))
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal")
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityIdentifier("session-reenter-terminal-\(deployment.id)")
 
                 Button(action: onControls) {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 36, height: 36)
+                        .frame(width: 44, height: 40)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.bordered)
                 .disabled(isEnding)
@@ -68,6 +70,12 @@ struct SessionRowView: View {
         .overlay {
             RoundedRectangle(cornerRadius: 18)
                 .stroke(Color.green.opacity(0.22), lineWidth: 1)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if deployment.ttydPort != nil {
+                onOpen()
+            }
         }
     }
 

--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -215,46 +215,6 @@ struct AttentionChip: Identifiable {
     }
 }
 
-struct SessionDock: View {
-    let deployments: [ActiveDeployment]
-    let action: () -> Void
-
-    var body: some View {
-        if !deployments.isEmpty {
-            HStack(spacing: 10) {
-                Circle()
-                    .fill(.green)
-                    .frame(width: 8, height: 8)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("\(deployments.count) session\(deployments.count == 1 ? "" : "s") running")
-                        .font(.caption.weight(.semibold))
-                    Text(summary)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 8)
-                Button("Resume", action: action)
-                    .font(.caption.weight(.bold))
-                    .buttonStyle(.borderedProminent)
-                    .tint(IssueCTLColors.action)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
-            .overlay {
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.green.opacity(0.28), lineWidth: 1)
-            }
-            .padding(.horizontal, 14)
-        }
-    }
-
-    private var summary: String {
-        deployments.prefix(2).map { "#\($0.issueNumber) \($0.runningDuration)" }.joined(separator: " - ")
-    }
-}
-
 struct ThumbActionBar<Primary: View, Secondary: View>: View {
     @ViewBuilder var primary: () -> Primary
     @ViewBuilder var secondary: () -> Secondary

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -90,8 +90,7 @@ struct TodayView: View {
                 }
 
                 content
-            }
-            .safeAreaInset(edge: .bottom) {
+
                 todayBottomActions
             }
             .navigationBarHidden(true)
@@ -134,21 +133,29 @@ struct TodayView: View {
     }
 
     private var todayBottomActions: some View {
-        VStack(spacing: 8) {
-            SessionDock(deployments: activeDeployments, action: onShowSessions)
-            ThumbActionBar {
-                Button {
-                    showCreateSheet = true
-                } label: {
-                    Label("Create Issue", systemImage: "plus")
-                        .font(.subheadline.weight(.bold))
-                        .frame(maxWidth: .infinity)
+        ThumbActionBar {
+            Button {
+                showCreateSheet = true
+            } label: {
+                Label("Create Issue", systemImage: "plus")
+                    .font(.subheadline.weight(.bold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action)
+            .contentShape(Rectangle())
+            .accessibilityIdentifier("today-create-issue-button")
+        } secondary: {
+            HStack(spacing: 8) {
+                if !activeDeployments.isEmpty {
+                    ThumbIconButton(
+                        systemName: "terminal",
+                        accessibilityLabel: "\(activeDeployments.count) active sessions",
+                        accessibilityIdentifier: "today-active-sessions-button",
+                        action: onShowSessions
+                    )
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(IssueCTLColors.action)
-                .contentShape(Rectangle())
-                .accessibilityIdentifier("today-create-issue-button")
-            } secondary: {
+
                 ThumbIconButton(
                     systemName: "magnifyingglass",
                     accessibilityLabel: "Search",

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -58,6 +58,17 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("sessions-refresh-button", existsIn: app)
     }
 
+    func testTodayActiveSessionsThumbButtonOpensSessions() {
+        server.seedActiveDeployment()
+        let app = launchApp()
+
+        assertElement("today-active-sessions-button", existsIn: app, timeout: 8)
+        element("today-active-sessions-button", in: app).tap()
+
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9001", existsIn: app)
+    }
+
     func testLaunchingIssueCanBeReenteredFromActiveSessions() {
         let app = launchApp()
 
@@ -178,6 +189,10 @@ private final class MockIssueCTLServer: @unchecked Sendable {
 
     func stop() {
         listener.cancel()
+    }
+
+    func seedActiveDeployment() {
+        activeDeployments = [deployment]
     }
 
     private func handle(_ connection: NWConnection) {


### PR DESCRIPTION
## Summary
- replace the stacked Today session dock with a single thumb-bar terminal action when sessions are active
- keep Create Issue as the primary thumb action while preserving quick access to Active Sessions and Search
- make Active Sessions rows re-enter from the full card and reserve bottom scroll space for the thumb bar
- add UI coverage for the Today active-session thumb action

## Verification
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' -only-testing:IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions -only-testing:IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions
- build_run_sim with real server env and manual screenshot inspection
- temporary real sessions created for visual/manual pass, then ended; /api/v1/deployments returned []
- git diff --check
