### PR TITLE
feat(ios): badge active session thumb action

### DIFF
--- a/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
+++ b/ios/IssueCTL/Views/Shared/CommandCenterComponents.swift
@@ -82,19 +82,39 @@ struct ThumbIconButton: View {
     let systemName: String
     let accessibilityLabel: String
     var accessibilityIdentifier: String?
+    var badge: String?
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(IssueCTLColors.action)
-                .frame(width: 44, height: 36)
-                .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 14)
-                        .stroke(IssueCTLColors.materialStroke, lineWidth: 1)
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: systemName)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(IssueCTLColors.action)
+                    .frame(width: 44, height: 36)
+                    .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(IssueCTLColors.materialStroke, lineWidth: 1)
+                    }
+
+                if let badge {
+                    Text(badge)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .frame(minWidth: 16, minHeight: 16)
+                        .padding(.horizontal, 3)
+                        .background(Color.green, in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .stroke(Color(.systemBackground), lineWidth: 1.5)
+                        }
+                        .offset(x: 5, y: -5)
+                        .accessibilityHidden(true)
                 }
+            }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -152,6 +152,7 @@ struct TodayView: View {
                         systemName: "terminal",
                         accessibilityLabel: "\(activeDeployments.count) active sessions",
                         accessibilityIdentifier: "today-active-sessions-button",
+                        badge: activeSessionBadge,
                         action: onShowSessions
                     )
                 }
@@ -166,6 +167,10 @@ struct TodayView: View {
             }
         }
         .padding(.bottom, 8)
+    }
+
+    private var activeSessionBadge: String {
+        activeDeployments.count > 99 ? "99+" : "\(activeDeployments.count)"
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- add optional badges to thumb icon buttons
- show active session count on Today's terminal thumb action
- keep the visual badge hidden from accessibility so the button label remains the single source of truth

## Verification
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,id=3078C4C7-E3E0-448A-B6AB-8AFE7A39F440' -only-testing:IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions
- git diff --check
