### PR TITLE
test(ios): cover running issue terminal reentry

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -41,6 +41,4 @@ jobs:
             | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Run focused UI smoke tests
-        env:
-          IOS_DESTINATION: platform=iOS Simulator,name=iPhone 16
         run: ./scripts/ios-ui-smoke.sh

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,8 +22,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 16.3
-        run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+      - name: Select Xcode with iOS Simulator runtime
+        run: |
+          for developer_dir in \
+            /Applications/Xcode_16.4.app/Contents/Developer \
+            /Applications/Xcode_16.3.app/Contents/Developer \
+            /Applications/Xcode.app/Contents/Developer
+          do
+            if [ ! -d "$developer_dir" ]; then
+              continue
+            fi
+
+            sudo xcode-select -s "$developer_dir"
+            if xcrun simctl list runtimes available | grep -q 'iOS'; then
+              echo "Selected $developer_dir"
+              exit 0
+            fi
+          done
+
+          echo "No Xcode installation with an available iOS Simulator runtime found" >&2
+          exit 70
 
       - name: Show build environment
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'ios/**'
+      - 'scripts/ios-ui-smoke.sh'
+      - 'package.json'
+      - '.husky/pre-push'
       - '.github/workflows/ios.yml'
 
 concurrency:
@@ -13,9 +16,9 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: Build + UI Smoke
     runs-on: macos-15
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -36,3 +39,8 @@ jobs:
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Run focused UI smoke tests
+        env:
+          IOS_DESTINATION: platform=iOS Simulator,name=iPhone 16
+        run: ./scripts/ios-ui-smoke.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,3 +12,7 @@ if echo "$changed_files" | grep -qvE '\.(md|html|txt|json|yaml|yml)$|^docs/|^\.h
     pnpm turbo build
   fi
 fi
+
+if [ "${RUN_IOS_UI_SMOKE:-0}" = "1" ] && echo "$changed_files" | grep -qE '^ios/|^scripts/ios-ui-smoke\.sh$|^\.github/workflows/ios\.yml$'; then
+  pnpm ios:ui-smoke
+fi

--- a/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL-UISmoke.xcscheme
+++ b/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL-UISmoke.xcscheme
@@ -21,6 +21,20 @@
                ReferencedContainer = "container:IssueCTL.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A00000000000000000000005"
+               BuildableName = "IssueCTLUITests.xctest"
+               BlueprintName = "IssueCTLUITests"
+               ReferencedContainer = "container:IssueCTL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL-UISmoke.xcscheme
+++ b/ios/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTL-UISmoke.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "791AFA96580A5FB3D384B678"
+               BuildableName = "IssueCTL.app"
+               BlueprintName = "IssueCTL"
+               ReferencedContainer = "container:IssueCTL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "791AFA96580A5FB3D384B678"
+            BuildableName = "IssueCTL.app"
+            BlueprintName = "IssueCTL"
+            ReferencedContainer = "container:IssueCTL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A00000000000000000000005"
+               BuildableName = "IssueCTLUITests.xctest"
+               BlueprintName = "IssueCTLUITests"
+               ReferencedContainer = "container:IssueCTL.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "791AFA96580A5FB3D384B678"
+            BuildableName = "IssueCTL.app"
+            BlueprintName = "IssueCTL"
+            ReferencedContainer = "container:IssueCTL.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "791AFA96580A5FB3D384B678"
+            BuildableName = "IssueCTL.app"
+            BlueprintName = "IssueCTL"
+            ReferencedContainer = "container:IssueCTL.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -94,6 +94,24 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testRunningIssueDetailShowsReentryInsteadOfLaunch() {
+        server.seedActiveDeployment()
+        let app = launchApp()
+
+        app.buttons["issues-tab"].tap()
+        let runningSegment = app.buttons.containing(NSPredicate(format: "label == %@", "Running, 1")).firstMatch
+        XCTAssertTrue(runningSegment.waitForExistence(timeout: 5), app.debugDescription)
+        runningSegment.tap()
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        element("issue-row-101", in: app).tap()
+
+        assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
+        XCTAssertFalse(element("issue-detail-launch-button", in: app).exists, app.debugDescription)
+
+        element("issue-detail-reenter-terminal-button", in: app).tap()
+        XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testUserProfileFailureDoesNotBlockPrimaryLists() {
         server.failUserProfile = true
         let app = launchApp()

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -15,6 +15,7 @@ final class IssueCTLUITests: XCTestCase {
         server = nil
     }
 
+    @MainActor
     func testCommandCenterActionsAreReachableFromTabs() {
         let app = launchApp()
 
@@ -57,6 +58,7 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("sessions-refresh-button", existsIn: app)
     }
 
+    @MainActor
     func testTodayActiveSessionsThumbButtonOpensSessions() {
         server.seedActiveDeployment()
         let app = launchApp()
@@ -68,6 +70,7 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("session-reenter-terminal-9001", existsIn: app)
     }
 
+    @MainActor
     func testLaunchingIssueCanBeReenteredFromActiveSessions() {
         let app = launchApp()
 
@@ -93,6 +96,7 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    @MainActor
     func testRunningIssueDetailShowsReentryInsteadOfLaunch() {
         server.seedActiveDeployment()
         let app = launchApp()
@@ -111,6 +115,7 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    @MainActor
     func testUserProfileFailureDoesNotBlockPrimaryLists() {
         server.failUserProfile = true
         let app = launchApp()
@@ -124,6 +129,7 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "user profile")).firstMatch.exists)
     }
 
+    @MainActor
     private func launchApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["ISSUECTL_SERVER_URL"] = server.baseURL.absoluteString
@@ -133,10 +139,12 @@ final class IssueCTLUITests: XCTestCase {
         return app
     }
 
+    @MainActor
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
         app.descendants(matching: .any)[identifier]
     }
 
+    @MainActor
     private func assertElement(
         _ identifier: String,
         existsIn app: XCUIApplication,
@@ -149,6 +157,7 @@ final class IssueCTLUITests: XCTestCase {
         XCTAssertTrue(exists, "Missing \(identifier)\n\(app.debugDescription)", file: file, line: line)
     }
 
+    @MainActor
     private func waitForNonexistence(
         _ identifier: String,
         in app: XCUIApplication,

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -1,7 +1,6 @@
 import Network
 import XCTest
 
-@MainActor
 final class IssueCTLUITests: XCTestCase {
     private var server: MockIssueCTLServer!
 

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -40,6 +40,11 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("issue-title-field", existsIn: app, timeout: 3)
         app.buttons["cancel-button"].tap()
         waitForNonexistence("issue-title-field", in: app)
+    }
+
+    @MainActor
+    func testListToolbarActionsAreReachableFromTabs() {
+        let app = launchApp()
 
         app.buttons["issues-tab"].tap()
         assertElement("issues-create-issue-button", existsIn: app, timeout: 5)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "turbo typecheck",
     "lint": "turbo lint",
     "test": "turbo test",
+    "ios:ui-smoke": "./scripts/ios-ui-smoke.sh",
     "dev": "turbo dev",
     "prepare": "husky"
   },

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -17,6 +17,12 @@ else
       | sed -n 's/.*id:\([^,}]*\).*/\1/p'
   )"
   if [ -z "$destination_id" ]; then
+    destination_id="$(
+      xcrun simctl list devices available 2>/dev/null \
+        | awk -F '[()]' '/iPhone/ { print $2; exit }'
+    )"
+  fi
+  if [ -z "$destination_id" ]; then
     echo "No available iPhone simulator destination found for $SCHEME" >&2
     exit 70
   fi

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -7,10 +7,25 @@ cd "$ROOT_DIR"
 PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
 SCHEME="${IOS_SCHEME:-IssueCTL-UISmoke}"
 CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
-DESTINATION="${IOS_DESTINATION:-platform=iOS Simulator,name=iPhone 16}"
+
+if [ -n "${IOS_DESTINATION:-}" ]; then
+  DESTINATION="$IOS_DESTINATION"
+else
+  destination_id="$(
+    xcodebuild -project "$PROJECT" -scheme "$SCHEME" -showdestinations 2>/dev/null \
+      | awk '/platform:iOS Simulator/ && /name:iPhone/ { print; exit }' \
+      | sed -n 's/.*id:\([^,}]*\).*/\1/p'
+  )"
+  if [ -z "$destination_id" ]; then
+    echo "No available iPhone simulator destination found for $SCHEME" >&2
+    exit 70
+  fi
+  DESTINATION="platform=iOS Simulator,id=$destination_id"
+fi
 
 TESTS=(
   "IssueCTLUITests/IssueCTLUITests/testCommandCenterActionsAreReachableFromTabs"
+  "IssueCTLUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs"
   "IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
   "IssueCTLUITests/IssueCTLUITests/testRunningIssueDetailShowsReentryInsteadOfLaunch"

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
-SCHEME="${IOS_SCHEME:-IssueCTL}"
+SCHEME="${IOS_SCHEME:-IssueCTL-UISmoke}"
 CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
 DESTINATION="${IOS_DESTINATION:-platform=iOS Simulator,name=iPhone 16}"
 

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
+SCHEME="${IOS_SCHEME:-IssueCTL}"
+CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
+DESTINATION="${IOS_DESTINATION:-platform=iOS Simulator,name=iPhone 16}"
+
+TESTS=(
+  "IssueCTLUITests/IssueCTLUITests/testCommandCenterActionsAreReachableFromTabs"
+  "IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
+  "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
+  "IssueCTLUITests/IssueCTLUITests/testRunningIssueDetailShowsReentryInsteadOfLaunch"
+)
+
+args=(
+  test
+  -project "$PROJECT"
+  -scheme "$SCHEME"
+  -destination "$DESTINATION"
+  -configuration "$CONFIGURATION"
+  CODE_SIGNING_ALLOWED=NO
+)
+
+for test_id in "${TESTS[@]}"; do
+  args+=("-only-testing:$test_id")
+done
+
+echo "Running focused iOS UI smoke tests on: $DESTINATION"
+
+if command -v xcpretty >/dev/null 2>&1; then
+  set -o pipefail
+  xcodebuild "${args[@]}" | xcpretty
+else
+  xcodebuild "${args[@]}"
+fi


### PR DESCRIPTION
## Summary
- add UI regression coverage for an already-running issue detail
- verify the detail action swaps to re-enter terminal and does not expose launch
- verify the running terminal still opens from that state

## Validation
- xcodebuild UI focused suite: 4 passed, 0 failed
- pre-push hook typecheck passed
- pre-push hook lint passed with existing warnings