### PR TITLE
test(ios): cover multiple session reentry

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -58,5 +58,5 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty && exit ${PIPESTATUS[0]}
 
-      - name: Run focused UI smoke tests
-        run: ./scripts/ios-ui-smoke.sh
+      - name: Run full UI smoke workflow suite
+        run: IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,5 +14,5 @@ if echo "$changed_files" | grep -qvE '\.(md|html|txt|json|yaml|yml)$|^docs/|^\.h
 fi
 
 if [ "${RUN_IOS_UI_SMOKE:-0}" = "1" ] && echo "$changed_files" | grep -qE '^ios/|^scripts/ios-ui-smoke\.sh$|^\.github/workflows/ios\.yml$'; then
-  pnpm ios:ui-smoke
+  pnpm ios:ui-smoke:fast
 fi

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -138,11 +138,16 @@ struct IssueDetailView: View {
                 )
             }
         }
-        .fullScreenCover(item: $terminalTarget) { deployment in
+        .fullScreenCover(item: $terminalTarget, onDismiss: {
+            terminalTarget = nil
+        }) { deployment in
             if let port = deployment.ttydPort {
                 TerminalView(
                     deployment: deployment,
                     port: port,
+                    onClose: {
+                        terminalTarget = nil
+                    },
                     onEnd: {
                         terminalTarget = nil
                         Task { await load(refresh: true) }

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -238,11 +238,16 @@ struct IssueListView: View {
                 .presentationDetents([.fraction(0.66), .large])
                 .presentationDragIndicator(.visible)
             }
-            .fullScreenCover(item: $terminalTarget) { deployment in
+            .fullScreenCover(item: $terminalTarget, onDismiss: {
+                terminalTarget = nil
+            }) { deployment in
                 if let port = deployment.ttydPort {
                     TerminalView(
                         deployment: deployment,
                         port: port,
+                        onClose: {
+                            terminalTarget = nil
+                        },
                         onEnd: {
                             terminalTarget = nil
                             activeDeployments.removeAll { $0.id == deployment.id }

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -75,6 +75,9 @@ struct LaunchView: View {
                 TerminalView(
                     deployment: deployment,
                     port: port,
+                    onClose: {
+                        launchedDeployment = nil
+                    },
                     onEnd: { dismiss() }
                 )
             } else {

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -7,7 +7,7 @@ struct SessionListView: View {
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var actionError: String?
-    @State private var terminalTarget: ActiveDeployment?
+    @State private var terminalPresentation: TerminalPresentation?
     @State private var sessionControlsTarget: ActiveDeployment?
     @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
@@ -96,9 +96,7 @@ struct SessionListView: View {
                                         deployment: deployment,
                                         isEnding: endingDeploymentId == deployment.id,
                                         onOpen: {
-                                            if deployment.ttydPort != nil {
-                                                terminalTarget = deployment
-                                            }
+                                            openTerminal(deployment)
                                         },
                                         onControls: {
                                             sessionControlsTarget = deployment
@@ -130,13 +128,17 @@ struct SessionListView: View {
             }
             .autoDismissError($actionError)
             .interactivePopDisabled(isAtRoot: navigationPath.isEmpty)
-            .fullScreenCover(item: $terminalTarget) { deployment in
+            .fullScreenCover(item: $terminalPresentation) { presentation in
+                let deployment = presentation.deployment
                 if let port = deployment.ttydPort {
                     TerminalView(
                         deployment: deployment,
                         port: port,
+                        onClose: {
+                            terminalPresentation = nil
+                        },
                         onEnd: {
-                            terminalTarget = nil
+                            terminalPresentation = nil
                             deployments.removeAll { $0.id == deployment.id }
                         }
                     )
@@ -148,9 +150,7 @@ struct SessionListView: View {
                     isEnding: endingDeploymentId == deployment.id,
                     onOpenTerminal: {
                         sessionControlsTarget = nil
-                        if deployment.ttydPort != nil {
-                            terminalTarget = deployment
-                        }
+                        openTerminal(deployment)
                     },
                     onViewIssue: {
                         sessionControlsTarget = nil
@@ -213,6 +213,11 @@ struct SessionListView: View {
         .padding(.bottom, 14)
     }
 
+    private func openTerminal(_ deployment: ActiveDeployment) {
+        guard deployment.ttydPort != nil else { return }
+        terminalPresentation = TerminalPresentation(deployment: deployment)
+    }
+
     private func load(refresh: Bool = false) async {
         if deployments.isEmpty { isLoading = true }
         errorMessage = nil
@@ -256,6 +261,11 @@ struct SessionListView: View {
         }
         endingDeploymentId = nil
     }
+}
+
+private struct TerminalPresentation: Identifiable {
+    let id = UUID()
+    let deployment: ActiveDeployment
 }
 
 private struct ActiveSessionsHeader: View {

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -43,15 +43,18 @@ struct SessionRowView: View {
             }
 
             HStack(spacing: 8) {
-                Label(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal", systemImage: "terminal")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity, minHeight: 40)
-                    .background(IssueCTLColors.action.opacity(deployment.ttydPort == nil ? 0.45 : 1), in: RoundedRectangle(cornerRadius: 12))
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal")
-                    .accessibilityAddTraits(.isButton)
-                    .accessibilityIdentifier("session-reenter-terminal-\(deployment.id)")
+                Button(action: onOpen) {
+                    Label(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal", systemImage: "terminal")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity, minHeight: 40)
+                        .background(IssueCTLColors.action.opacity(deployment.ttydPort == nil ? 0.45 : 1), in: RoundedRectangle(cornerRadius: 12))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(deployment.ttydPort == nil || isEnding)
+                .accessibilityLabel(deployment.ttydPort == nil ? "Preparing" : "Re-enter Terminal")
+                .accessibilityIdentifier("session-reenter-terminal-\(deployment.id)")
 
                 Button(action: onControls) {
                     Image(systemName: "ellipsis")

--- a/ios/IssueCTL/Views/Terminal/TerminalView.swift
+++ b/ios/IssueCTL/Views/Terminal/TerminalView.swift
@@ -5,6 +5,7 @@ struct TerminalView: View {
     @Environment(APIClient.self) private var api
     let deployment: ActiveDeployment
     let port: Int
+    let onClose: () -> Void
     let onEnd: () -> Void
     private let terminalPageZoom = TerminalDisplaySettings.defaultPageZoom
 
@@ -18,9 +19,10 @@ struct TerminalView: View {
     @State private var isEndingSession = false
     @State private var endSessionError: String?
 
-    init(deployment: ActiveDeployment, port: Int, onEnd: @escaping () -> Void) {
+    init(deployment: ActiveDeployment, port: Int, onClose: @escaping () -> Void = {}, onEnd: @escaping () -> Void) {
         self.deployment = deployment
         self.port = port
+        self.onClose = onClose
         self.onEnd = onEnd
         _currentPort = State(initialValue: port)
     }
@@ -76,7 +78,10 @@ struct TerminalView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Done") { dismiss() }
+                    Button("Done") {
+                        onClose()
+                        dismiss()
+                    }
                         .accessibilityIdentifier("terminal-done-button")
                 }
                 ToolbarItem(placement: .topBarTrailing) {

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -20,14 +20,14 @@ final class IssueCTLUITests: XCTestCase {
         let app = launchApp()
 
         assertElement("today-create-issue-button", existsIn: app, timeout: 8)
-        assertElement("today-metric-sessions", existsIn: app)
-        assertElement("today-metric-prs", existsIn: app)
-        assertElement("today-metric-issues", existsIn: app)
+        assertElement("today-metric-sessions", existsIn: app, timeout: 5)
+        assertElement("today-metric-prs", existsIn: app, timeout: 5)
+        assertElement("today-metric-issues", existsIn: app, timeout: 5)
 
         element("today-settings-button", in: app).tap()
         assertElement("settings-done-button", existsIn: app, timeout: 3)
         app.buttons["settings-done-button"].tap()
-        waitForNonexistence("settings-done-button", in: app)
+        waitForButtonNonexistence("settings-done-button", in: app)
 
         element("today-search-button", in: app).tap()
         assertElement("today-search-field", existsIn: app, timeout: 3)
@@ -102,6 +102,24 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    func testMultipleLaunchedIssueSessionsRemainAvailableFromActiveSessions() {
+        let app = launchApp()
+
+        app.buttons["issues-tab"].tap()
+        launchIssueSession(101, in: app)
+        backToIssueList(in: app, expectingIssue: 102)
+
+        launchIssueSession(102, in: app)
+
+        app.buttons["active-tab"].tap()
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9002", existsIn: app, timeout: 5)
+        XCTAssertTrue(element("session-reenter-terminal-9001", in: app).isEnabled)
+        XCTAssertTrue(element("session-reenter-terminal-9002", in: app).isEnabled)
+    }
+
+    @MainActor
     func testRunningIssueDetailShowsReentryInsteadOfLaunch() {
         server.seedActiveDeployment()
         let app = launchApp()
@@ -145,6 +163,45 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    private func launchIssueSession(_ number: Int, in app: XCUIApplication) {
+        assertElement("issue-row-\(number)", existsIn: app, timeout: 8)
+        element("issue-row-\(number)", in: app).tap()
+
+        assertElement("issue-detail-launch-button", existsIn: app, timeout: 5)
+        element("issue-detail-launch-button", in: app).tap()
+
+        assertElement("launch-recommended-button", existsIn: app, timeout: 5)
+        element("launch-recommended-button", in: app).tap()
+
+        XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 8), app.debugDescription)
+        app.buttons["terminal-done-button"].tap()
+        assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
+    }
+
+    @MainActor
+    private func backToIssueList(in app: XCUIApplication, expectingIssue number: Int) {
+        if !element("issue-row-\(number)", in: app).exists {
+            app.navigationBars.buttons.firstMatch.tap()
+        }
+        assertElement("issue-row-\(number)", existsIn: app, timeout: 5)
+    }
+
+    @MainActor
+    private func openSessionTerminal(_ deploymentId: Int, in app: XCUIApplication) {
+        let identifier = "session-reenter-terminal-\(deploymentId)"
+        let target = element(identifier, in: app)
+        XCTAssertTrue(target.waitForExistence(timeout: 5), "Missing \(identifier)\n\(app.debugDescription)")
+
+        if !target.isHittable, app.scrollViews.firstMatch.exists {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+
+        XCTAssertTrue(target.waitForExistence(timeout: 5), "Missing \(identifier) after scroll\n\(app.debugDescription)")
+        XCTAssertTrue(target.isHittable, "\(identifier) is not hittable\n\(app.debugDescription)")
+        target.tap()
+    }
+
+    @MainActor
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
         app.descendants(matching: .any)[identifier]
     }
@@ -166,7 +223,7 @@ final class IssueCTLUITests: XCTestCase {
     private func waitForNonexistence(
         _ identifier: String,
         in app: XCUIApplication,
-        timeout: TimeInterval = 3,
+        timeout: TimeInterval = 8,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
@@ -175,6 +232,21 @@ final class IssueCTLUITests: XCTestCase {
         let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
         XCTAssertEqual(result, .completed, "\(identifier) did not disappear\n\(app.debugDescription)", file: file, line: line)
     }
+
+    @MainActor
+    private func waitForButtonNonexistence(
+        _ identifier: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 8,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: app.buttons[identifier])
+        let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(result, .completed, "\(identifier) button did not disappear\n\(app.debugDescription)", file: file, line: line)
+    }
+
 }
 
 private final class MockIssueCTLServer: @unchecked Sendable {
@@ -261,25 +333,42 @@ private final class MockIssueCTLServer: @unchecked Sendable {
         case ("GET", "/api/v1/deployments"):
             body = ["deployments": activeDeployments]
         case ("GET", "/api/v1/issues/org/alpha"):
-            body = ["issues": [issue], "from_cache": false, "cached_at": NSNull()]
+            body = ["issues": [issue(number: 101), issue(number: 102)], "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/101"):
             body = [
-                "issue": issue,
+                "issue": issue(number: 101),
                 "comments": [],
-                "deployments": activeDeployments,
+                "deployments": deployments(for: 101),
+                "linkedPRs": [],
+                "referencedFiles": [],
+                "fromCache": false,
+            ]
+        case ("GET", "/api/v1/issues/org/alpha/102"):
+            body = [
+                "issue": issue(number: 102),
+                "comments": [],
+                "deployments": deployments(for: 102),
                 "linkedPRs": [],
                 "referencedFiles": [],
                 "fromCache": false,
             ]
         case ("GET", "/api/v1/issues/org/alpha/priorities"):
-            body = ["priorities": [["repo_id": 1, "issue_number": 101, "priority": "high", "updated_at": 1_777_440_000]]]
+            body = ["priorities": [
+                ["repo_id": 1, "issue_number": 101, "priority": "high", "updated_at": 1_777_440_000],
+                ["repo_id": 1, "issue_number": 102, "priority": "normal", "updated_at": 1_777_440_000],
+            ]]
         case ("GET", "/api/v1/issues/org/alpha/101/priority"):
             body = ["priority": "high"]
+        case ("GET", "/api/v1/issues/org/alpha/102/priority"):
+            body = ["priority": "normal"]
         case ("GET", "/api/v1/pulls/org/alpha"):
             body = ["pulls": pulls, "from_cache": false, "cached_at": NSNull()]
         case ("POST", "/api/v1/launch/org/alpha/101"):
-            activeDeployments = [deployment]
+            activateDeployment(issueNumber: 101)
             body = ["success": true, "deployment_id": 9001, "ttyd_port": 19001, "error": NSNull(), "label_warning": NSNull()]
+        case ("POST", "/api/v1/launch/org/alpha/102"):
+            activateDeployment(issueNumber: 102)
+            body = ["success": true, "deployment_id": 9002, "ttyd_port": 19002, "error": NSNull(), "label_warning": NSNull()]
         case ("POST", "/api/v1/drafts"):
             body = ["success": true, "id": "draft-ui-1", "error": NSNull()]
         case ("POST", "/api/v1/drafts/draft-ui-1/assign"):
@@ -325,11 +414,13 @@ private final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
-    private var issue: [String: Any] {
-        [
-            "number": 101,
-            "title": "Improve launch handoff",
-            "body": "Keep the terminal reachable after leaving detail.",
+    private func issue(number: Int) -> [String: Any] {
+        return [
+            "number": number,
+            "title": number == 101 ? "Improve launch handoff" : "Persist multiple sessions",
+            "body": number == 101
+                ? "Keep the terminal reachable after leaving detail."
+                : "Keep independent terminals reachable after launching more than one issue.",
             "state": "open",
             "labels": [["name": "bug", "color": "d73a4a", "description": NSNull()]],
             "assignees": [["login": "alice", "avatar_url": ""]],
@@ -338,7 +429,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
             "created_at": isoDate,
             "updated_at": isoDate,
             "closed_at": NSNull(),
-            "html_url": "https://github.com/org/alpha/issues/101",
+            "html_url": "https://github.com/org/alpha/issues/\(number)",
         ]
     }
 
@@ -350,7 +441,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
     }
 
     private func pull(number: Int, title: String, checksStatus: String) -> [String: Any] {
-        [
+        return [
             "number": number,
             "title": title,
             "body": NSNull(),
@@ -373,22 +464,38 @@ private final class MockIssueCTLServer: @unchecked Sendable {
     }
 
     private var deployment: [String: Any] {
-        [
-            "id": 9001,
+        deployment(issueNumber: 101)
+    }
+
+    private func deployment(issueNumber: Int) -> [String: Any] {
+        let id = issueNumber == 101 ? 9001 : 9002
+        return [
+            "id": id,
             "repo_id": 1,
-            "issue_number": 101,
-            "branch_name": "issue-101-improve-launch-handoff",
+            "issue_number": issueNumber,
+            "branch_name": issueNumber == 101
+                ? "issue-101-improve-launch-handoff"
+                : "issue-102-persist-multiple-sessions",
             "workspace_mode": "worktree",
-            "workspace_path": "/tmp/alpha-worktree",
+            "workspace_path": "/tmp/alpha-worktree-\(issueNumber)",
             "linked_pr_number": NSNull(),
             "state": "active",
             "launched_at": isoDate,
             "ended_at": NSNull(),
-            "ttyd_port": 19001,
-            "ttyd_pid": 12345,
+            "ttyd_port": issueNumber == 101 ? 19001 : 19002,
+            "ttyd_pid": issueNumber == 101 ? 12345 : 12346,
             "owner": "org",
             "repo_name": "alpha",
         ]
+    }
+
+    private func activateDeployment(issueNumber: Int) {
+        activeDeployments.removeAll { $0["issue_number"] as? Int == issueNumber }
+        activeDeployments.append(deployment(issueNumber: issueNumber))
+    }
+
+    private func deployments(for issueNumber: Int) -> [[String: Any]] {
+        activeDeployments.filter { $0["issue_number"] as? Int == issueNumber }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "turbo lint",
     "test": "turbo test",
     "ios:ui-smoke": "./scripts/ios-ui-smoke.sh",
+    "ios:ui-smoke:fast": "IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-ui-smoke.sh",
+    "ios:ui-smoke:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh",
     "dev": "turbo dev",
     "prepare": "husky"
   },

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
 SCHEME="${IOS_SCHEME:-IssueCTL-UISmoke}"
 CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
+PROFILE="${IOS_UI_SMOKE_PROFILE:-full}"
 
 if [ -n "${IOS_DESTINATION:-}" ]; then
   DESTINATION="$IOS_DESTINATION"
@@ -29,13 +30,31 @@ else
   DESTINATION="platform=iOS Simulator,id=$destination_id"
 fi
 
-TESTS=(
+FAST_TESTS=(
+  "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
+)
+
+FULL_TESTS=(
   "IssueCTLUITests/IssueCTLUITests/testCommandCenterActionsAreReachableFromTabs"
   "IssueCTLUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs"
   "IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
+  "IssueCTLUITests/IssueCTLUITests/testMultipleLaunchedIssueSessionsRemainAvailableFromActiveSessions"
   "IssueCTLUITests/IssueCTLUITests/testRunningIssueDetailShowsReentryInsteadOfLaunch"
 )
+
+case "$PROFILE" in
+  fast)
+    TESTS=("${FAST_TESTS[@]}")
+    ;;
+  full)
+    TESTS=("${FULL_TESTS[@]}")
+    ;;
+  *)
+    echo "Unknown IOS_UI_SMOKE_PROFILE '$PROFILE'. Expected 'fast' or 'full'." >&2
+    exit 64
+    ;;
+esac
 
 args=(
   test
@@ -50,7 +69,9 @@ for test_id in "${TESTS[@]}"; do
   args+=("-only-testing:$test_id")
 done
 
-echo "Running focused iOS UI smoke tests on: $DESTINATION"
+echo "Running $PROFILE iOS UI smoke tests on: $DESTINATION"
+printf 'Selected tests:\n'
+printf '  %s\n' "${TESTS[@]}"
 
 if command -v xcpretty >/dev/null 2>&1; then
   set -o pipefail


### PR DESCRIPTION
## Summary
- add mocked iOS UI smoke coverage for launching two issue sessions
- verify both running sessions remain reachable from Active after returning through the issue list
- extend the UI mock server with a second issue, deployment, and active deployment state

## Validation
- ./scripts/ios-ui-smoke.sh (6 tests, 0 failures)