### PR TITLE
test(ios): cover draft creation workflow

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -442,6 +442,7 @@ struct IssueListView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(draft.title)
                                 .font(.body)
+                                .accessibilityIdentifier("draft-row-\(draft.id)-title")
                             if let body = draft.body, !body.isEmpty {
                                 Text(body)
                                     .font(.caption)

--- a/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
+++ b/ios/IssueCTL/Views/Issues/QuickCreateSheet.swift
@@ -149,6 +149,7 @@ struct QuickCreateSheet: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
+                        .accessibilityIdentifier("quick-create-more-options")
                     }
 
                     if let errorMessage {
@@ -243,6 +244,7 @@ struct QuickCreateSheet: View {
                         .foregroundStyle(selectedRepoId == repo.id ? IssueCTLColors.action : .primary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("quick-create-repo-\(repo.id)-button")
                 }
 
                 Menu {
@@ -250,11 +252,13 @@ struct QuickCreateSheet: View {
                         Button(repo.fullName) {
                             selectedRepoId = repo.id
                         }
+                        .accessibilityIdentifier("quick-create-repo-\(repo.id)-option")
                     }
                     Divider()
                     Button("Local Draft") {
                         selectedRepoId = nil
                     }
+                    .accessibilityIdentifier("quick-create-local-draft-option")
                 } label: {
                     Text("More")
                         .font(.body)
@@ -263,6 +267,7 @@ struct QuickCreateSheet: View {
                         .background(Color(.tertiarySystemGroupedBackground), in: Capsule())
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier("quick-create-repo-more-button")
             }
         }
     }

--- a/ios/IssueCTL/Views/Shared/SectionTabs.swift
+++ b/ios/IssueCTL/Views/Shared/SectionTabs.swift
@@ -29,6 +29,7 @@ struct SectionTabs<Section: Hashable & CaseIterable & RawRepresentable>: View wh
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(selected == section ? .primary : .secondary)
+                    .accessibilityIdentifier("section-tab-\(section.rawValue)")
                 }
             }
             .padding(.horizontal)

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -64,6 +64,37 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    func testCreateDraftIssueFromThumbReachEntryPoint() {
+        let app = launchApp()
+
+        assertElement("today-create-issue-button", existsIn: app, timeout: 8)
+        element("today-create-issue-button", in: app).tap()
+
+        assertElement("issue-title-field", existsIn: app, timeout: 3)
+        element("quick-create-repo-more-button", in: app).tap()
+        app.buttons["quick-create-local-draft-option"].tap()
+
+        element("issue-title-field", in: app).tap()
+        app.typeText("Test draft issue from automation")
+
+        element("issue-body-editor", in: app).tap()
+        app.typeText("This is a test draft created via workflow automation.")
+
+        element("quick-create-more-options", in: app).tap()
+        app.buttons["High"].tap()
+
+        element("submit-issue-button", in: app).tap()
+        waitForNonexistence("issue-title-field", in: app)
+
+        app.buttons["issues-tab"].tap()
+        assertElement("section-tab-drafts", existsIn: app, timeout: 8)
+        element("section-tab-drafts", in: app).tap()
+        assertElement("draft-row-draft-ui-1", existsIn: app, timeout: 8)
+        let draftTitle = element("draft-row-draft-ui-1-title", in: app)
+        XCTAssertEqual(draftTitle.label, "Test draft issue from automation")
+    }
+
+    @MainActor
     func testTodayActiveSessionsThumbButtonOpensSessions() {
         server.seedActiveDeployment()
         let app = launchApp()
@@ -254,6 +285,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
     private let listener: NWListener
     private let queue = DispatchQueue(label: "MockIssueCTLServer")
     private var activeDeployments: [[String: Any]] = []
+    private var drafts: [[String: Any]] = []
     var failUserProfile = false
 
     init() throws {
@@ -332,6 +364,8 @@ private final class MockIssueCTLServer: @unchecked Sendable {
             body = ["repos": [repo]]
         case ("GET", "/api/v1/deployments"):
             body = ["deployments": activeDeployments]
+        case ("GET", "/api/v1/drafts"):
+            body = ["drafts": drafts]
         case ("GET", "/api/v1/issues/org/alpha"):
             body = ["issues": [issue(number: 101), issue(number: 102)], "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/101"):
@@ -370,6 +404,7 @@ private final class MockIssueCTLServer: @unchecked Sendable {
             activateDeployment(issueNumber: 102)
             body = ["success": true, "deployment_id": 9002, "ttyd_port": 19002, "error": NSNull(), "label_warning": NSNull()]
         case ("POST", "/api/v1/drafts"):
+            createDraft(from: request)
             body = ["success": true, "id": "draft-ui-1", "error": NSNull()]
         case ("POST", "/api/v1/drafts/draft-ui-1/assign"):
             body = [
@@ -431,6 +466,30 @@ private final class MockIssueCTLServer: @unchecked Sendable {
             "closed_at": NSNull(),
             "html_url": "https://github.com/org/alpha/issues/\(number)",
         ]
+    }
+
+    private func createDraft(from request: String) {
+        let payload = jsonBody(from: request)
+        drafts = [
+            [
+                "id": "draft-ui-1",
+                "title": payload["title"] as? String ?? "Untitled draft",
+                "body": payload["body"] as? String ?? NSNull(),
+                "priority": payload["priority"] as? String ?? "normal",
+                "created_at": 1_777_440_000,
+            ]
+        ]
+    }
+
+    private func jsonBody(from request: String) -> [String: Any] {
+        guard
+            let body = request.components(separatedBy: "\r\n\r\n").last,
+            let data = body.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return [:]
+        }
+        return json
     }
 
     private var pulls: [[String: Any]] {

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -332,16 +332,51 @@ private final class MockIssueCTLServer: @unchecked Sendable {
 
     private func handle(_ connection: NWConnection) {
         connection.start(queue: queue)
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
-            guard let self, let data, let request = String(data: data, encoding: .utf8) else {
+        receiveRequest(on: connection, buffer: Data())
+    }
+
+    private func receiveRequest(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, _ in
+            guard let self else {
                 connection.cancel()
                 return
             }
-            let response = self.response(for: request)
-            connection.send(content: response, completion: .contentProcessed { _ in
-                connection.cancel()
-            })
+
+            var nextBuffer = buffer
+            if let data {
+                nextBuffer.append(data)
+            }
+
+            if self.hasCompleteHTTPRequest(nextBuffer) || isComplete {
+                guard let request = String(data: nextBuffer, encoding: .utf8) else {
+                    connection.cancel()
+                    return
+                }
+                let response = self.response(for: request)
+                connection.send(content: response, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+                return
+            }
+
+            self.receiveRequest(on: connection, buffer: nextBuffer)
         }
+    }
+
+    private func hasCompleteHTTPRequest(_ data: Data) -> Bool {
+        guard let request = String(data: data, encoding: .utf8) else { return false }
+        guard let headerRange = request.range(of: "\r\n\r\n") else { return false }
+        let headers = String(request[..<headerRange.lowerBound])
+        let contentLength = headers
+            .components(separatedBy: "\r\n")
+            .first { $0.lowercased().hasPrefix("content-length:") }
+            .flatMap { line -> Int? in
+                let value = line.split(separator: ":", maxSplits: 1).dropFirst().first?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return value.flatMap(Int.init)
+            } ?? 0
+        let bodyStart = request.distance(from: request.startIndex, to: headerRange.upperBound)
+        return data.count >= bodyStart + contentLength
     }
 
     private func response(for request: String) -> Data {

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -36,6 +36,7 @@ FAST_TESTS=(
 
 FULL_TESTS=(
   "IssueCTLUITests/IssueCTLUITests/testCommandCenterActionsAreReachableFromTabs"
+  "IssueCTLUITests/IssueCTLUITests/testCreateDraftIssueFromThumbReachEntryPoint"
   "IssueCTLUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs"
   "IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"


### PR DESCRIPTION
## Summary
- add stable accessibility identifiers for the quick create repo picker and shared section tabs
- add an iOS UI smoke test for creating a local draft issue from the thumb-reach entry point
- teach the mock API server to persist draft creation and include the workflow in the full smoke profile

## Testing
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL-UISmoke -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:IssueCTLUITests/IssueCTLUITests/testCreateDraftIssueFromThumbReachEntryPoint
- pnpm ios:ui-smoke:full
- git commit hooks: typecheck and lint (existing lint warnings only)
- git push hook: typecheck