### PR TITLE
ci: speed up PR iOS smoke draft coverage

### DIFF
--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -64,34 +64,75 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
-    func testCreateDraftIssueFromThumbReachEntryPoint() {
+    func testCreateMinimalDraftIssueFromThumbReachEntryPoint() {
+        let draftTitle = "CI draft"
         let app = launchApp()
 
         assertElement("today-create-issue-button", existsIn: app, timeout: 8)
         element("today-create-issue-button", in: app).tap()
 
+        createLocalDraft(title: draftTitle, body: nil, priority: nil, in: app)
+
+        openDraftsSection(in: app)
+        assertElement("draft-row-draft-ui-1", existsIn: app, timeout: 8)
+        XCTAssertEqual(element("draft-row-draft-ui-1-title", in: app).label, draftTitle)
+        openIssuesSection(in: app)
+    }
+
+    @MainActor
+    func testCreateDetailedDraftIssueFromThumbReachEntryPoint() {
+        let draftTitle = "Test draft issue from automation"
+        let app = launchApp()
+
+        assertElement("today-create-issue-button", existsIn: app, timeout: 8)
+        element("today-create-issue-button", in: app).tap()
+
+        createLocalDraft(
+            title: draftTitle,
+            body: "This is a test draft created via workflow automation.",
+            priority: "High",
+            in: app
+        )
+
+        openDraftsSection(in: app)
+        assertElement("draft-row-draft-ui-1", existsIn: app, timeout: 8)
+        XCTAssertEqual(element("draft-row-draft-ui-1-title", in: app).label, draftTitle)
+        openIssuesSection(in: app)
+    }
+
+    @MainActor
+    private func createLocalDraft(
+        title: String,
+        body: String?,
+        priority: String?,
+        in app: XCUIApplication
+    ) {
         assertElement("issue-title-field", existsIn: app, timeout: 3)
         element("quick-create-repo-more-button", in: app).tap()
         app.buttons["quick-create-local-draft-option"].tap()
 
         element("issue-title-field", in: app).tap()
-        app.typeText("Test draft issue from automation")
+        app.typeText(title)
 
-        element("issue-body-editor", in: app).tap()
-        app.typeText("This is a test draft created via workflow automation.")
+        if let body {
+            element("issue-body-editor", in: app).tap()
+            app.typeText(body)
+        }
 
-        element("quick-create-more-options", in: app).tap()
-        app.buttons["High"].tap()
+        if let priority {
+            element("quick-create-more-options", in: app).tap()
+            app.buttons[priority].tap()
+        }
 
         element("submit-issue-button", in: app).tap()
         waitForNonexistence("issue-title-field", in: app)
+    }
 
+    @MainActor
+    private func openDraftsSection(in app: XCUIApplication) {
         tapElement("issues-tab", in: app)
         assertElement("section-tab-drafts", existsIn: app, timeout: 8)
         element("section-tab-drafts", in: app).tap()
-        assertElement("draft-row-draft-ui-1", existsIn: app, timeout: 8)
-        let draftTitle = element("draft-row-draft-ui-1-title", in: app)
-        XCTAssertEqual(draftTitle.label, "Test draft issue from automation")
     }
 
     @MainActor

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -35,13 +35,13 @@ FAST_TESTS=(
 )
 
 PR_TESTS=(
-  "IssueCTLUITests/IssueCTLUITests/testCreateDraftIssueFromThumbReachEntryPoint"
+  "IssueCTLUITests/IssueCTLUITests/testCreateMinimalDraftIssueFromThumbReachEntryPoint"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
 )
 
 FULL_TESTS=(
   "IssueCTLUITests/IssueCTLUITests/testCommandCenterActionsAreReachableFromTabs"
-  "IssueCTLUITests/IssueCTLUITests/testCreateDraftIssueFromThumbReachEntryPoint"
+  "IssueCTLUITests/IssueCTLUITests/testCreateDetailedDraftIssueFromThumbReachEntryPoint"
   "IssueCTLUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs"
   "IssueCTLUITests/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
@@ -81,6 +81,13 @@ done
 echo "Running $PROFILE iOS UI smoke tests on: $DESTINATION"
 printf 'Selected tests:\n'
 printf '  %s\n' "${TESTS[@]}"
+printf 'Started at: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+started_at="$SECONDS"
+finish() {
+  printf 'Finished at: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf 'Elapsed seconds: %s\n' "$((SECONDS - started_at))"
+}
+trap finish EXIT
 
 if command -v xcpretty >/dev/null 2>&1; then
   set -o pipefail


### PR DESCRIPTION
## Summary
- split the draft-creation UI smoke coverage into a minimal PR path and a detailed full-profile path
- keep the slower body/priority draft workflow in the full iOS smoke profile
- add start/finish/elapsed timing logs to the iOS smoke script for easier CI measurement

## Local validation
- `IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-ui-smoke.sh` passed: selected XCTest runtime 43.998s, script elapsed 49s, wall 49.582s
- `IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh` passed: 7 tests, selected XCTest runtime 151.296s, script elapsed 155s, wall 155.47s

## Measurement target
- compare PR iOS smoke wall time against the prior best green run around 5m55s after PR #344
