### PR TITLE
ci: avoid duplicate iOS simulator build

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -61,16 +61,6 @@ jobs:
           xcodebuild -version
           swift --version
 
-      - name: Build for iOS Simulator
-        run: |
-          xcodebuild build \
-            -project ios/IssueCTL.xcodeproj \
-            -scheme IssueCTL \
-            -destination 'generic/platform=iOS Simulator' \
-            -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO \
-            | xcpretty && exit ${PIPESTATUS[0]}
-
       - name: Run UI smoke workflow suite
         run: |
           profile="full"


### PR DESCRIPTION
## Summary
- remove the standalone generic iOS simulator build step from the iOS workflow
- rely on `scripts/ios-ui-smoke.sh` / `xcodebuild test` to build and run the selected UI smoke profile once

## Why
The prior run for #345 still spent most of its time outside the selected test bodies. The workflow first ran `xcodebuild build`, then the smoke script invoked `xcodebuild test`, which rebuilt/linked app and UI test targets again. This PR measures whether removing the explicit pre-build reduces PR iOS wall time.

## Validation
- Workflow-only change; GitHub Actions is the validation target.
- Compare iOS `Build + UI Smoke` against #345: 5m46s job wall time, smoke script elapsed 290s, selected XCTest runtime 108.281s.
