### PR TITLE
ci: speed up iOS Xcode selection

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -47,13 +47,11 @@ jobs:
             fi
 
             sudo xcode-select -s "$developer_dir"
-            if xcrun simctl list runtimes available | grep -q 'iOS'; then
-              echo "Selected $developer_dir"
-              exit 0
-            fi
+            echo "Selected $developer_dir"
+            exit 0
           done
 
-          echo "No Xcode installation with an available iOS Simulator runtime found" >&2
+          echo "No Xcode installation found" >&2
           exit 70
 
       - name: Show build environment


### PR DESCRIPTION
## Summary
- stop probing `xcrun simctl list runtimes available` during Xcode selection
- keep the existing preferred Xcode order and let the smoke step validate simulator availability through `xcodebuild test`

## Why
The #346 run spent 41s in `Select Xcode with iOS Simulator runtime` before the smoke script started. That step launches CoreSimulator just to check runtime availability. Since the runner image is pinned to `macos-15` and the smoke step already fails clearly if no iOS runtime is available, this PR measures whether skipping that probe reduces job wall time.

## Measurement baseline
- #346 iOS job wall: 5m27s
- #346 smoke script elapsed: 275s
- #346 selected XCTest runtime: 86.720s
