### PR TITLE
ci: trim PR iOS smoke to launch workflow

### DIFF
--- a/ios/IssueCTLTests/APIClientTests.swift
+++ b/ios/IssueCTLTests/APIClientTests.swift
@@ -108,6 +108,30 @@ final class TestableAPIClient {
         return try decoder.decode(ActiveDeploymentsResponse.self, from: data)
     }
 
+    func createDraft(body: CreateDraftRequestBody) async throws -> CreateDraftResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/drafts", method: "POST", body: bodyData)
+        return try decoder.decode(CreateDraftResponse.self, from: data)
+    }
+
+    func requestBodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        stream.open()
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: 4096)
+            if read > 0 {
+                data.append(buffer, count: read)
+            }
+        }
+        buffer.deallocate()
+        stream.close()
+        return data
+    }
+
     private struct ErrorBody: Codable {
         let error: String
     }
@@ -499,6 +523,40 @@ final class APIClientTests: XCTestCase {
         let launchResponse = try decoder.decode(LaunchResponse.self, from: data)
         XCTAssertTrue(launchResponse.success)
         XCTAssertEqual(launchResponse.deploymentId, 1)
+    }
+
+    @MainActor
+    func testCreateDraftEndpointAndBodyEncoding() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/drafts"))
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = self.client.requestBodyData(from: request)
+            XCTAssertNotNil(bodyData)
+            if let bodyData {
+                let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+                XCTAssertEqual(json?["title"] as? String, "CI draft")
+                XCTAssertEqual(json?["body"] as? String, "Created from unit coverage")
+                XCTAssertEqual(json?["priority"] as? String, "high")
+            }
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {"success": true, "id": "draft-unit-1", "error": null}
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        let body = CreateDraftRequestBody(
+            title: "CI draft",
+            body: "Created from unit coverage",
+            priority: .high
+        )
+        let response = try await client.createDraft(body: body)
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.id, "draft-unit-1")
+        XCTAssertNil(response.error)
     }
 
     // MARK: - Base URL configuration

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -35,7 +35,6 @@ FAST_TESTS=(
 )
 
 PR_TESTS=(
-  "IssueCTLUITests/IssueCTLUITests/testCreateMinimalDraftIssueFromThumbReachEntryPoint"
   "IssueCTLUITests/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
 )
 


### PR DESCRIPTION
## Summary
- run only the launch/re-entry workflow in the PR iOS UI smoke profile
- preserve draft creation API coverage with a fast unit test for `createDraft` endpoint, method, body encoding, and response decoding
- keep detailed draft creation in the full iOS UI smoke profile

## Why
After #346, the PR smoke profile still spent most time in simulator/XCTest overhead. The draft UI path is covered in the full profile and its request contract is better covered by a unit test, so PR smoke can focus on the highest-risk mobile workflow: launching and re-entering a running terminal session.

## Local validation
- `IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-ui-smoke.sh` passed: 1 UI test, 24.976s XCTest runtime, 32s script elapsed
- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,name=iPhone 17" -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:IssueCTLTests/APIClientTests/testCreateDraftEndpointAndBodyEncoding` passed

## Measurement baseline
- #346 iOS job wall: 5m27s
- #346 smoke script elapsed: 275s
- #346 selected XCTest runtime: 86.720s for 2 UI tests
