### PR TITLE
test: harden iOS smoke issue section selection

### DIFF
--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -109,7 +109,12 @@ final class IssueCTLUITests: XCTestCase {
     ) {
         assertElement("issue-title-field", existsIn: app, timeout: 3)
         element("quick-create-repo-more-button", in: app).tap()
-        app.buttons["quick-create-local-draft-option"].tap()
+        let localDraftButton = app.buttons["quick-create-local-draft-button"]
+        if localDraftButton.waitForExistence(timeout: 3) {
+            localDraftButton.tap()
+        } else {
+            app.buttons["quick-create-local-draft-option"].tap()
+        }
 
         element("issue-title-field", in: app).tap()
         app.typeText(title)
@@ -255,13 +260,15 @@ final class IssueCTLUITests: XCTestCase {
     private func openIssuesSection(in app: XCUIApplication) {
         if element("issues-tab", in: app).waitForExistence(timeout: 5) {
             element("issues-tab", in: app).tap()
-        } else {
-            assertElement("section-tab-open", existsIn: app, timeout: 5)
         }
 
-        if element("section-tab-open", in: app).waitForExistence(timeout: 5) {
-            element("section-tab-open", in: app).tap()
+        let openSection = element("section-tab-open", in: app)
+        if !openSection.waitForExistence(timeout: 8), app.scrollViews.firstMatch.exists {
+            app.scrollViews.firstMatch.swipeRight()
         }
+
+        XCTAssertTrue(openSection.waitForExistence(timeout: 8), "Missing section-tab-open\n\(app.debugDescription)")
+        openSection.tap()
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- harden the iOS UI smoke helper that opens the Issues/Open section
- use the current quick-create local draft identifier, with fallback for the older identifier
- avoid treating an already-selected Issues tab as a failure when the section control is still settling
- add a short horizontal scroll recovery before asserting the Open section exists

## Context
The previous #349 run exposed a smoke-test reliability issue after `testCreateMinimalDraftIssueFromThumbReachEntryPoint`: the following launch/re-entry workflow could start with Issues already selected, but `section-tab-open` was not ready within the old 5s path. A local rerun also exposed a stale test identifier for the local draft button.

This PR is a reliability fix for iOS UI smoke coverage, not a CI speed experiment.

## Validation
- `IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-ui-smoke.sh`
- local result: 2 UI tests passed, 55s script elapsed, XCTest 50.590s
