### PR TITLE
ci: disable coverage for iOS smoke tests

### DIFF
--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -71,6 +71,7 @@ args=(
   -scheme "$SCHEME"
   -destination "$DESTINATION"
   -configuration "$CONFIGURATION"
+  -enableCodeCoverage NO
   CODE_SIGNING_ALLOWED=NO
 )
 


### PR DESCRIPTION
## Summary
- disable Xcode code coverage collection in the iOS UI smoke script
- keep the existing PR/full smoke test selection unchanged

## Why
The latest green PR smoke run spent 188s in the Xcode test operation while the selected UI tests accounted for 92s. The smoke workflow does not consume coverage artifacts, so this isolates whether coverage collection is contributing meaningful overhead.

## Validation
- `IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-ui-smoke.sh`
- local result before commit: 2 UI tests passed, 56s script elapsed, XCTest 51.302s
- accidental post-push local rerun also reached completed Xcode test operation in 53.302s

## Measurement Plan
Compare this PR iOS check duration against #349 green run:
- #349 iOS job: 4m06s
- #349 smoke script elapsed: 214s
- #349 XCTest operation: 188.184s
- #349 selected UI tests: 92.392s
