### PR TITLE
ci: pin iOS smoke simulator architecture

### DIFF
--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -27,7 +27,7 @@ else
     echo "No available iPhone simulator destination found for $SCHEME" >&2
     exit 70
   fi
-  DESTINATION="platform=iOS Simulator,id=$destination_id"
+  DESTINATION="platform=iOS Simulator,id=$destination_id,arch=arm64"
 fi
 
 FAST_TESTS=(


### PR DESCRIPTION
## Summary
- pin the auto-selected iOS Simulator destination to arm64 in the smoke script
- leave custom IOS_DESTINATION values unchanged
- keep the existing PR/full smoke test selection unchanged

## Why
CI logs currently show Xcode warning that the selected simulator ID matches both arm64 and x86_64 destinations. This PR measures whether removing that ambiguity improves iOS smoke timing.

## Validation
- `IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-ui-smoke.sh`
- local result: 2 UI tests passed, 56s script elapsed, XCTest 50.395s
- local run no longer emitted the multiple matching destinations warning

## Measurement Plan
Compare this PR iOS check duration against #349 green run:
- #349 iOS job: 4m06s
- #349 smoke script elapsed: 214s
- #349 XCTest operation: 188.184s
- #349 selected UI tests: 92.392s
