### PR TITLE
Gate iOS smoke in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - '.github/**/*.md'
       - 'ios/**'
       - '.github/workflows/ios.yml'
+  merge_group:
+    branches: [main]
 
 jobs:
   typecheck:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -34,8 +34,45 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine iOS smoke relevance
+        id: ios_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run_smoke=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            base_ref="origin/${{ github.base_ref }}"
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            changed_files="$(git diff --name-only "$base_ref"...HEAD)"
+          elif [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            if git rev-parse --verify HEAD^1 >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only HEAD^1 HEAD)"
+            else
+              changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+            fi
+          else
+            changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+          fi
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -E -q '^(ios/|scripts/ios-ui-smoke\.sh$|package\.json$|\.husky/pre-push$|\.github/workflows/ios\.yml$)'; then
+            echo "run_smoke=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_smoke=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Select Xcode with iOS Simulator runtime
+        if: steps.ios_changes.outputs.run_smoke == 'true'
         run: |
           for developer_dir in \
             /Applications/Xcode_16.4.app/Contents/Developer \
@@ -57,11 +94,13 @@ jobs:
           exit 70
 
       - name: Show build environment
+        if: steps.ios_changes.outputs.run_smoke == 'true'
         run: |
           xcodebuild -version
           swift --version
 
       - name: Run UI smoke workflow suite
+        if: steps.ios_changes.outputs.run_smoke == 'true'
         run: |
           profile="full"
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
@@ -72,3 +111,7 @@ jobs:
           fi
 
           IOS_UI_SMOKE_PROFILE="$profile" ./scripts/ios-ui-smoke.sh
+
+      - name: Skip UI smoke workflow suite
+        if: steps.ios_changes.outputs.run_smoke != 'true'
+        run: echo "No iOS-relevant changes detected; required iOS check passes without running simulator smoke."

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -236,6 +236,7 @@ final class IssueCTLUITests: XCTestCase {
         app.launchEnvironment["ISSUECTL_SERVER_URL"] = server.baseURL.absoluteString
         app.launchEnvironment["ISSUECTL_API_TOKEN"] = "ui-test-token"
         app.launchEnvironment["ISSUECTL_UI_TESTING"] = "1"
+        app.terminate()
         app.launch()
         return app
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "ios:ui-smoke": "./scripts/ios-ui-smoke.sh",
     "ios:ui-smoke:fast": "IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-ui-smoke.sh",
     "ios:ui-smoke:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh",
-    "test:merge-queue": "echo merge queue required checks test",
     "dev": "turbo dev",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ios:ui-smoke": "./scripts/ios-ui-smoke.sh",
     "ios:ui-smoke:fast": "IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-ui-smoke.sh",
     "ios:ui-smoke:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh",
+    "test:merge-queue": "echo merge queue required checks test",
     "dev": "turbo dev",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- add merge_group triggering to the main CI workflow so required CI checks report on queue refs
- keep the required iOS Build + UI Smoke check reporting on merge-group refs, but skip expensive simulator smoke when no iOS-relevant files changed
- stabilize iOS UI smoke by terminating any previous app process before each UI test launch

## Verification
- ruby YAML parse for .github/workflows/ios.yml and .github/workflows/ci.yml
- git diff --check
- IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh

## Notes
- This PR started as a temporary merge queue test, but now carries the actual queue/iOS fixes. The temporary package.json script was removed from the final diff.