### PR TITLE
Fix physical iPhone setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cross-repo GitHub issue command center with Claude Code launch integration.
 pnpm install
 pnpm turbo build
 issuectl init        # First-time setup (creates DB)
-issuectl web         # Start dashboard (localhost:3847)
+issuectl web         # Start dashboard and print iOS setup link/QR
 ```
 
 ## What it does

--- a/docs/workflows/ios-user-workflows.md
+++ b/docs/workflows/ios-user-workflows.md
@@ -3,9 +3,11 @@
 > Executable playbooks for QA-testing the issuectl iOS app via Claude Code + `xcodebuildmcp ui-automation`. Each workflow is self-contained and describes the preconditions, steps, and expected outcomes.
 
 **Prerequisites for all workflows:**
-- iOS app built and running on simulator (`xcodebuildmcp simulator build-and-run`)
-- `issuectl web` running on localhost:3847
+- iOS app built and running on simulator (`xcodebuildmcp simulator build-and-run`) or a physical iPhone
+- `issuectl web` running on port 3847
 - At least one GitHub repo accessible via `gh auth token`
+
+When testing on a physical iPhone, use the LAN URL printed by `issuectl web`, for example `http://192.0.2.10:3847`. Do not use `localhost`, because that points at the phone, not the Mac. `issuectl web` also prints the current mobile API token, an `issuectl://setup?...` deep link, and a QR code that configures the iOS app automatically.
 
 **Automation commands used:**
 ```
@@ -49,13 +51,15 @@ CI runs the full profile in `.github/workflows/ios.yml` on iOS, smoke-script, pr
 |------|--------|--------|
 | 1 | Screenshot to confirm onboarding screen visible | See "Server URL" and "API Token" fields |
 | 2 | Tap the Server URL field | Field is focused |
-| 3 | Type `http://localhost:3847` | URL appears in field |
+| 3 | Type `http://localhost:3847` on simulator, or the LAN URL from `issuectl web` on a physical iPhone | URL appears in field |
 | 4 | Tap the API Token field | Field is focused (SecureField) |
 | 5 | Type the API token from `issuectl web` output | Dots appear in field |
 | 6 | Tap "Connect" button | Loading indicator, then transition to main TabView |
 | 7 | Screenshot to confirm main app loaded | See Issues tab with tab bar at bottom |
 
-**Recovery:** If connect fails, verify `issuectl web` is running and the token matches `SELECT value FROM settings WHERE key = 'api_token'`.
+**Shortcut:** On a physical iPhone, scan the QR code printed by `issuectl web` or open the printed `issuectl://setup?...` link. The app should save the server URL and token, then transition to the main TabView.
+
+**Recovery:** If connect fails, verify `issuectl web` is running, the phone and Mac are on the same network, the server URL is not `localhost` on a physical iPhone, and the token matches `SELECT value FROM settings WHERE key = 'api_token'`.
 
 ---
 

--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		87D4FB7DE2798776F76673E2 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364C3F577D49589A381F15B4 /* SessionRowView.swift */; };
 		8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */; };
+		8EC2C0978BFF48C89133D579 /* SetupLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A4FD89B5D744B09BD11089 /* SetupLink.swift */; };
 		8F6B1136F0F654026188BFF6 /* EditRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */; };
 		90BE1758390002096CF585BA /* APIClient+AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC76CB48493EFBDF4AABEF73 /* APIClient+AdvancedSettings.swift */; };
 		916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */; };
@@ -125,6 +126,7 @@
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		3F39642CB180355E5C62A75E /* ImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightbox.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
+		40A4FD89B5D744B09BD11089 /* SetupLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupLink.swift; sourceTree = "<group>"; };
 		41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoFilterHelpers.swift; sourceTree = "<group>"; };
 		4403330B1342AA7C19FA797D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		4497D324AB6CE09260737497 /* LoadMoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMoreButton.swift; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
 				FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */,
+				40A4FD89B5D744B09BD11089 /* SetupLink.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -643,6 +646,7 @@
 				49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */,
 				E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */,
 				493AD60F477A0039E95E5D02 /* ServerHealth.swift in Sources */,
+				8EC2C0978BFF48C89133D579 /* SetupLink.swift in Sources */,
 				FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */,
 				89A326731AF767A4A3FE92EC /* SessionRowView.swift in Sources */,
 				6929F40E6CD23E9A083F4B83 /* SettingsView.swift in Sources */,
@@ -803,7 +807,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IssueCTL/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -908,7 +913,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IssueCTL/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -7,39 +7,45 @@ struct ContentView: View {
     @State private var showSettings = false
 
     var body: some View {
-        if api.isConfigured {
-            TabView(selection: $selectedTab) {
-                Tab("Today", systemImage: "waveform.path.ecg", value: AppTab.today) {
-                    TodayView(
-                        onShowSettings: { showSettings = true },
-                        onShowIssues: { selectedTab = .issues },
-                        onShowPullRequests: { selectedTab = .pullRequests },
-                        onShowSessions: { selectedTab = .active }
-                    )
+        Group {
+            if api.isConfigured {
+                TabView(selection: $selectedTab) {
+                    Tab("Today", systemImage: "waveform.path.ecg", value: AppTab.today) {
+                        TodayView(
+                            onShowSettings: { showSettings = true },
+                            onShowIssues: { selectedTab = .issues },
+                            onShowPullRequests: { selectedTab = .pullRequests },
+                            onShowSessions: { selectedTab = .active }
+                        )
+                    }
+                    .accessibilityIdentifier("today-tab")
+                    Tab("Issues", systemImage: "list.bullet", value: AppTab.issues) {
+                        IssueListView()
+                    }
+                    .accessibilityIdentifier("issues-tab")
+                    Tab("PRs", systemImage: "arrow.triangle.merge", value: AppTab.pullRequests) {
+                        PRListView()
+                    }
+                    .accessibilityIdentifier("prs-tab")
+                    Tab("Active", systemImage: "terminal", value: AppTab.active) {
+                        SessionListView()
+                    }
+                    .accessibilityIdentifier("active-tab")
                 }
-                .accessibilityIdentifier("today-tab")
-                Tab("Issues", systemImage: "list.bullet", value: AppTab.issues) {
-                    IssueListView()
+                .sheet(isPresented: $showSettings) {
+                    SettingsView()
                 }
-                .accessibilityIdentifier("issues-tab")
-                Tab("PRs", systemImage: "arrow.triangle.merge", value: AppTab.pullRequests) {
-                    PRListView()
+                .overlay(alignment: .top) {
+                    OfflineBanner()
                 }
-                .accessibilityIdentifier("prs-tab")
-                Tab("Active", systemImage: "terminal", value: AppTab.active) {
-                    SessionListView()
-                }
-                .accessibilityIdentifier("active-tab")
+                .animation(.easeInOut(duration: 0.3), value: network.isConnected)
+            } else {
+                OnboardingView()
             }
-            .sheet(isPresented: $showSettings) {
-                SettingsView()
-            }
-            .overlay(alignment: .top) {
-                OfflineBanner()
-            }
-            .animation(.easeInOut(duration: 0.3), value: network.isConnected)
-        } else {
-            OnboardingView()
+        }
+        .onOpenURL { url in
+            guard let setup = SetupLink(url: url) else { return }
+            try? api.configure(url: setup.serverURL, token: setup.token)
         }
     }
 }

--- a/ios/IssueCTL/Info.plist
+++ b/ios/IssueCTL/Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.issuectl.ios.setup</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>issuectl</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>IssueCTL connects to the issuectl server running on your Mac.</string>
+</dict>
+</plist>

--- a/ios/IssueCTL/Services/SetupLink.swift
+++ b/ios/IssueCTL/Services/SetupLink.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct SetupLink: Equatable, Sendable {
+    let serverURL: String
+    let token: String
+
+    init?(url: URL) {
+        guard url.scheme == "issuectl", url.host == "setup" else {
+            return nil
+        }
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let serverURL = components.queryItems?.first(where: { $0.name == "serverURL" })?.value,
+              let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
+              !serverURL.isEmpty,
+              !token.isEmpty else {
+            return nil
+        }
+
+        self.serverURL = serverURL
+        self.token = token
+    }
+}

--- a/ios/IssueCTL/Views/Onboarding/OnboardingView.swift
+++ b/ios/IssueCTL/Views/Onboarding/OnboardingView.swift
@@ -12,7 +12,7 @@ struct OnboardingView: View {
         NavigationStack {
             Form {
                 Section {
-                    Text("Connect to your issuectl server running on your Mac.")
+                    Text("Connect to your issuectl server running on your Mac. On a physical iPhone, use your Mac's Wi-Fi IP address instead of localhost.")
                         .foregroundStyle(.secondary)
                 }
 
@@ -39,7 +39,7 @@ struct OnboardingView: View {
                         .buttonStyle(.plain)
                     }
 
-                    Text("Run `issuectl init` on your Mac to generate a token.")
+                    Text("Run `issuectl web` on your Mac and use the iOS server URL and API token shown there.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -90,6 +90,12 @@ struct OnboardingView: View {
             return
         }
 
+        if isLocalhost(parsed.host) {
+            errorMessage = "Use your Mac's Wi-Fi IP address, not localhost, when running on a physical iPhone."
+            isChecking = false
+            return
+        }
+
         let token = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
@@ -100,11 +106,49 @@ struct OnboardingView: View {
             // Success — persist and switch to main UI
             try api.configure(url: url, token: token)
         } catch {
-            errorMessage = error.localizedDescription
+            errorMessage = onboardingErrorMessage(for: error, serverURL: url)
         }
 
         isChecking = false
     }
+}
+
+func isLocalhost(_ host: String?) -> Bool {
+    guard let host = host?.lowercased() else { return false }
+    return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func onboardingErrorMessage(for error: Error, serverURL: String) -> String {
+    if let apiError = error as? APIError {
+        switch apiError {
+        case .unauthorized:
+            return "Invalid or stale API token. Copy the iOS API token from `issuectl web` and try again."
+        case .notConfigured:
+            return "Server URL not configured."
+        case .invalidPath, .invalidResponse:
+            return "The server responded in an unexpected format. Check that this URL points to issuectl."
+        case .serverError(let code, let message):
+            return "Server error (\(code)): \(message)"
+        }
+    }
+
+    let nsError = error as NSError
+    if nsError.domain == NSURLErrorDomain {
+        switch nsError.code {
+        case NSURLErrorCannotConnectToHost,
+             NSURLErrorCannotFindHost,
+             NSURLErrorTimedOut,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorNotConnectedToInternet:
+            return "Could not reach \(serverURL). Make sure issuectl web is running, both devices are on the same network, and Local Network access is allowed."
+        case NSURLErrorAppTransportSecurityRequiresSecureConnection:
+            return "iOS blocked this connection. Rebuild the app with local-network access enabled or use an HTTPS server URL."
+        default:
+            break
+        }
+    }
+
+    return error.localizedDescription
 }
 
 private struct APITokenField: UIViewRepresentable {

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -3,6 +3,40 @@ import XCTest
 
 final class ViewLogicTests: XCTestCase {
 
+    // MARK: - iOS Setup Links
+
+    func testSetupLinkParsesServerURLAndToken() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl://setup?serverURL=http%3A%2F%2F192.0.2.10%3A3847&token=abc123"))
+        let setup = try XCTUnwrap(SetupLink(url: url))
+
+        XCTAssertEqual(setup.serverURL, "http://192.0.2.10:3847")
+        XCTAssertEqual(setup.token, "abc123")
+    }
+
+    func testSetupLinkRejectsWrongScheme() throws {
+        let url = try XCTUnwrap(URL(string: "https://setup?serverURL=http%3A%2F%2F192.0.2.10%3A3847&token=abc123"))
+        XCTAssertNil(SetupLink(url: url))
+    }
+
+    func testLocalhostDetectionForPhysicalDeviceSetup() {
+        XCTAssertTrue(isLocalhost("localhost"))
+        XCTAssertTrue(isLocalhost("127.0.0.1"))
+        XCTAssertTrue(isLocalhost("::1"))
+        XCTAssertFalse(isLocalhost("192.0.2.10"))
+    }
+
+    func testUnauthorizedOnboardingErrorIsActionable() {
+        let message = onboardingErrorMessage(for: APIError.unauthorized, serverURL: "http://192.0.2.10:3847")
+        XCTAssertTrue(message.contains("Invalid or stale API token"))
+    }
+
+    func testNetworkOnboardingErrorMentionsReachability() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        let message = onboardingErrorMessage(for: error, serverURL: "http://192.0.2.10:3847")
+        XCTAssertTrue(message.contains("Could not reach"))
+        XCTAssertTrue(message.contains("Local Network access"))
+    }
+
     // MARK: - Branch Name Generation
 
     func testBasicSlugGeneration() {

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -259,16 +259,14 @@ final class IssueCTLUITests: XCTestCase {
 
     @MainActor
     private func openIssuesSection(in app: XCUIApplication) {
-        if element("issues-tab", in: app).waitForExistence(timeout: 5) {
-            element("issues-tab", in: app).tap()
-        }
+        tapElement("issues-tab", in: app, timeout: 20)
 
         let openSection = element("section-tab-open", in: app)
-        if !openSection.waitForExistence(timeout: 8), app.scrollViews.firstMatch.exists {
+        if !openSection.waitForExistence(timeout: 20), app.scrollViews.firstMatch.exists {
             app.scrollViews.firstMatch.swipeRight()
         }
 
-        XCTAssertTrue(openSection.waitForExistence(timeout: 8), "Missing section-tab-open\n\(app.debugDescription)")
+        XCTAssertTrue(openSection.waitForExistence(timeout: 20), "Missing section-tab-open\n\(app.debugDescription)")
         openSection.tap()
     }
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -10,6 +10,23 @@ targets:
     supportedDestinations: [iOS]
     sources:
       - path: IssueCTL
+    info:
+      path: IssueCTL/Info.plist
+      properties:
+        CFBundleURLTypes:
+          - CFBundleURLName: com.issuectl.ios.setup
+            CFBundleURLSchemes:
+              - issuectl
+        UIApplicationSupportsIndirectInputEvents: true
+        UILaunchScreen: {}
+        UIRequiresFullScreen: true
+        "UISupportedInterfaceOrientations~iphone":
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
+        NSLocalNetworkUsageDescription: "IssueCTL connects to the issuectl server running on your Mac."
     settings:
       base:
         SWIFT_VERSION: "6.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@inquirer/prompts": "^7.5.0",
     "@issuectl/core": "workspace:*",
+    "@types/qrcode-terminal": "^0.12.2",
     "chalk": "^5.4.1",
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "qrcode-terminal": "^0.12.0"
   }
 }

--- a/packages/cli/src/commands/web.ts
+++ b/packages/cli/src/commands/web.ts
@@ -1,9 +1,12 @@
 import { execFile, spawn } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import qrcode from "qrcode-terminal";
 import * as log from "../utils/logger.js";
 import { requireDb } from "../utils/db.js";
 import { requireAuth } from "../utils/auth.js";
+import { buildIosSetupUrl, detectLanIp } from "../utils/mobile-setup.js";
+import { generateApiToken } from "@issuectl/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -15,13 +18,29 @@ function getWebPackagePath(): string {
 export async function webCommand(options: { port: string }): Promise<void> {
   const port = options.port;
 
-  requireDb();
+  const db = requireDb();
   await requireAuth();
 
   const webPath = getWebPackagePath();
   const serverPath = resolve(webPath, "server.ts");
+  const token = generateApiToken(db);
+  const lanIp = detectLanIp();
 
   log.info(`Starting dashboard on http://localhost:${port}`);
+  if (lanIp) {
+    const iosServerUrl = `http://${lanIp}:${port}`;
+    const setupUrl = buildIosSetupUrl(iosServerUrl, token);
+    log.info(`iOS server URL: ${iosServerUrl}`);
+    log.info(`iOS API token: ${token}`);
+    log.info(`iOS setup link: ${setupUrl}`);
+    log.info("Scan this QR code with your iPhone Camera to configure the iOS app:");
+    qrcode.generate(setupUrl, { small: true }, (qr) => {
+      console.error(qr);
+    });
+  } else {
+    log.warn("Could not detect a LAN IP for iOS setup. Use your Mac's Wi-Fi IP address.");
+    log.info(`iOS API token: ${token}`);
+  }
 
   const child = spawn("node", ["--import", "tsx", serverPath, "--dev"], {
     cwd: webPath,

--- a/packages/cli/src/utils/mobile-setup.ts
+++ b/packages/cli/src/utils/mobile-setup.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+
+export function detectLanIp(): string | null {
+  for (const addrs of Object.values(os.networkInterfaces())) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family === "IPv4" && !addr.internal && !addr.address.startsWith("169.254.")) {
+        return addr.address;
+      }
+    }
+  }
+  return null;
+}
+
+export function buildIosSetupUrl(serverUrl: string, token: string): string {
+  const params = new URLSearchParams({
+    serverURL: serverUrl,
+    token,
+  });
+  return `issuectl://setup?${params.toString()}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,12 +65,18 @@ importers:
       '@issuectl/core':
         specifier: workspace:*
         version: link:../core
+      '@types/qrcode-terminal':
+        specifier: ^0.12.2
+        version: 0.12.2
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
 
   packages/core:
     dependencies:
@@ -1325,6 +1331,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/qrcode-terminal@0.12.2':
+    resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3064,6 +3073,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4852,6 +4865,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/qrcode-terminal@0.12.2': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -6699,6 +6714,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qrcode-terminal@0.12.0: {}
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary
- print LAN iOS setup URL, API token, deep link, and QR code from `issuectl web`
- add iOS URL scheme/local-network plist setup and deep-link handling
- improve onboarding guidance/errors for physical iPhone connections
- document simulator vs physical iPhone setup flow

## Verification
- `pnpm --filter @issuectl/cli typecheck`
- `pnpm --filter @issuectl/cli build`
- `pnpm --filter @issuectl/cli lint`
- `pnpm turbo typecheck lint test build`
- `xcodebuild -project ios/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build`\n- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests`\n- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -skip-testing:IssueCTLUITests`\n- `pnpm ios:ui-smoke:fast`\n- `pnpm ios:ui-smoke:full`\n- installed/launched on physical iPhone and confirmed authenticated API requests returned 200\n\n## Notes\n- No private LAN URL, setup link, or API token is committed; setup values are generated and printed at runtime.