### PR TITLE
fix(ios): retry port binding in MockServer to avoid TIME_WAIT collisions

### DIFF
--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -32,10 +32,21 @@ final class MockIssueCTLServer: @unchecked Sendable {
     private var nextCommentId: Int = 1001
 
     init() throws {
-        let port = NWEndpoint.Port(rawValue: UInt16.random(in: 49_152...65_000))!
-        listener = try NWListener(using: .tcp, on: port)
-        baseURL = URL(string: "http://127.0.0.1:\(port.rawValue)")!
-        repos = [defaultRepo]
+        var lastError: Error?
+        for _ in 0..<5 {
+            let port = NWEndpoint.Port(rawValue: UInt16.random(in: 49_152...65_000))!
+            do {
+                let attempt = try NWListener(using: .tcp, on: port)
+                listener = attempt
+                baseURL = URL(string: "http://127.0.0.1:\(port.rawValue)")!
+                repos = [defaultRepo]
+                return
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? NSError(domain: "MockIssueCTLServer", code: 1,
+                                   userInfo: [NSLocalizedDescriptionKey: "No available port after 5 attempts"])
     }
 
     func start() throws {


### PR DESCRIPTION
## Summary
- MockServer `init()` now retries up to 5 random ports if binding fails
- Fixes `POSIX error 48: Address already in use` when running all XCUITest classes back-to-back on a physical device
- The previous test class's NWListener may still hold the port in TIME_WAIT state

## Test plan
- [x] 21/21 XCUITests pass on physical iPhone 16e (iOS 26.4.2)
- [x] 21/21 XCUITests pass on simulator (CI)