### PR TITLE
ci: fix auto-merge workflow repo context

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -66,7 +66,7 @@ jobs:
               ;;
           esac
 
-          pr_json="$(gh pr view "$pr_target" --json id,state,isDraft,mergeStateStatus,headRepository,url)"
+          pr_json="$(gh pr view "$pr_target" --repo "$REPOSITORY" --json id,state,isDraft,mergeStateStatus,headRepository,url)"
 
           state="$(jq -r '.state' <<<"$pr_json")"
           if [ "$state" != "OPEN" ]; then


### PR DESCRIPTION
## Summary
- pass an explicit repo to `gh pr view` so workflow_dispatch works without a checkout

## Testing
- git diff --check