### PR TITLE
Bound iOS preview device smoke runs

### DIFF
--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -7,6 +7,20 @@ IssueCTL has two installable iOS app variants:
 
 The preview app is intended for development, physical-device smoke tests, and feature validation without overwriting the production app on the same iPhone.
 
+## App Lanes
+
+Use `IssueCTL Preview` as the active development lane. It is the app to run from feature branches, local simulator testing, and physical-device smoke tests.
+
+Keep `IssueCTL` as the stable production lane. Update it from trusted integration points such as `main`, tags, or release branches.
+
+A third `IssueCTL Dev` app is not needed yet. Add one only if we need three simultaneous installed states on the same phone, for example:
+
+- production: stable daily-use app
+- preview: release candidate or branch under review
+- development: local experimental build with intentionally unstable services/data
+
+Until that need is real, a third target would add signing, scheme, URL, keychain, and CI surface area without changing the main workflow.
+
 ## Local Smoke Tests
 
 Run the preview smoke suite on an available simulator:
@@ -28,6 +42,18 @@ IOS_DEVICE_ID=<device-udid> pnpm ios:preview-device-smoke:fast
 ```
 
 Use the CoreDevice identifier from `pnpm ios:list-devices` for `IOS_DEVICE_ID`. In practice this can differ from the lower-level hardware id shown by some Xcode destination output.
+
+The physical-device wrapper checks that the iPhone is visible through CoreDevice before launching Xcode. Keep the iPhone unlocked and awake until the test runner starts. By default, physical runs time out instead of waiting indefinitely:
+
+- `fast`: 420 seconds
+- `pr`: 600 seconds
+- `full`: 900 seconds
+
+Override the timeout when needed:
+
+```bash
+IOS_DEVICE_ID=<device-udid> IOS_UI_SMOKE_TIMEOUT=1200 pnpm ios:preview-device-smoke:full
+```
 
 You can also pass a full Xcode destination:
 

--- a/scripts/ios-preview-device-smoke.sh
+++ b/scripts/ios-preview-device-smoke.sh
@@ -4,16 +4,71 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+device_id="${IOS_DEVICE_ID:-}"
+
 if [ -z "${IOS_DESTINATION:-}" ]; then
-  if [ -z "${IOS_DEVICE_ID:-}" ]; then
+  if [ -z "$device_id" ]; then
     echo "Set IOS_DEVICE_ID=<device-udid> or IOS_DESTINATION='platform=iOS,id=<device-udid>'." >&2
+    echo "Run 'pnpm ios:list-devices' to find the CoreDevice identifier." >&2
     exit 64
   fi
-  export IOS_DESTINATION="platform=iOS,id=${IOS_DEVICE_ID}"
+  export IOS_DESTINATION="platform=iOS,id=${device_id}"
+else
+  device_id="$(printf '%s\n' "$IOS_DESTINATION" | sed -n 's/.*id=\([^,]*\).*/\1/p')"
 fi
 
 export IOS_SCHEME="${IOS_SCHEME:-IssueCTLPreview-UISmoke}"
 export IOS_CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
 export IOS_UI_SMOKE_PROFILE="${IOS_UI_SMOKE_PROFILE:-fast}"
+export IOS_DEVICE_READY_TIMEOUT="${IOS_DEVICE_READY_TIMEOUT:-45}"
+
+case "$IOS_UI_SMOKE_PROFILE" in
+  fast)
+    export IOS_UI_SMOKE_TIMEOUT="${IOS_UI_SMOKE_TIMEOUT:-420}"
+    ;;
+  pr)
+    export IOS_UI_SMOKE_TIMEOUT="${IOS_UI_SMOKE_TIMEOUT:-600}"
+    ;;
+  full)
+    export IOS_UI_SMOKE_TIMEOUT="${IOS_UI_SMOKE_TIMEOUT:-900}"
+    ;;
+  *)
+    # Let ios-ui-smoke.sh report the unsupported profile with the canonical error.
+    export IOS_UI_SMOKE_TIMEOUT="${IOS_UI_SMOKE_TIMEOUT:-600}"
+    ;;
+esac
+
+if [ -z "$device_id" ]; then
+  echo "IOS_DESTINATION must include an id=... device identifier for physical preview smoke tests." >&2
+  exit 64
+fi
+
+echo "Checking physical iOS device readiness for: $device_id"
+echo "Keep the iPhone unlocked and awake until the UI test starts."
+
+ready_deadline=$((SECONDS + IOS_DEVICE_READY_TIMEOUT))
+while true; do
+  if xcrun devicectl list devices 2>/dev/null | grep -F "$device_id" | grep -q "connected"; then
+    if xcrun devicectl device info details --device "$device_id" --quiet --timeout 10 >/dev/null 2>&1; then
+      break
+    fi
+  fi
+
+  if [ "$SECONDS" -ge "$ready_deadline" ]; then
+    cat >&2 <<EOF
+Device '$device_id' was not ready within ${IOS_DEVICE_READY_TIMEOUT}s.
+
+Make sure the iPhone is:
+- connected to this Mac
+- trusted by this Mac
+- unlocked and awake
+
+Run 'pnpm ios:list-devices' to verify the CoreDevice identifier, then retry.
+EOF
+    exit 69
+  fi
+
+  sleep 3
+done
 
 exec ./scripts/ios-ui-smoke.sh

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -98,6 +98,9 @@ if [ -n "$sim_id" ]; then
 fi
 
 echo "Running $PROFILE iOS UI smoke tests on: $DESTINATION"
+if [ -n "${IOS_UI_SMOKE_TIMEOUT:-}" ]; then
+  echo "Timeout: ${IOS_UI_SMOKE_TIMEOUT}s"
+fi
 printf 'Selected tests:\n'
 printf '  %s\n' "${TESTS[@]}"
 printf 'Started at: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
@@ -108,9 +111,36 @@ finish() {
 }
 trap finish EXIT
 
-if command -v xcpretty >/dev/null 2>&1; then
-  set -o pipefail
-  xcodebuild "${args[@]}" | xcpretty
+run_xcodebuild() {
+  if command -v xcpretty >/dev/null 2>&1; then
+    set -o pipefail
+    xcodebuild "${args[@]}" | xcpretty
+  else
+    xcodebuild "${args[@]}"
+  fi
+}
+
+if [ -n "${IOS_UI_SMOKE_TIMEOUT:-}" ]; then
+  run_xcodebuild &
+  xcodebuild_pid=$!
+  deadline=$((SECONDS + IOS_UI_SMOKE_TIMEOUT))
+
+  while kill -0 "$xcodebuild_pid" 2>/dev/null; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Timed out after ${IOS_UI_SMOKE_TIMEOUT}s waiting for iOS UI smoke tests to finish." >&2
+      echo "If this was a physical-device run, unlock the iPhone, keep it awake, and retry." >&2
+      pkill -TERM -P "$xcodebuild_pid" 2>/dev/null || true
+      kill -TERM "$xcodebuild_pid" 2>/dev/null || true
+      sleep 2
+      pkill -KILL -P "$xcodebuild_pid" 2>/dev/null || true
+      kill -KILL "$xcodebuild_pid" 2>/dev/null || true
+      wait "$xcodebuild_pid" 2>/dev/null || true
+      exit 124
+    fi
+    sleep 2
+  done
+
+  wait "$xcodebuild_pid"
 else
-  xcodebuild "${args[@]}"
+  run_xcodebuild
 fi


### PR DESCRIPTION
## Summary
- add a physical-device readiness preflight to the preview smoke wrapper
- add bounded timeouts for preview device UI smoke profiles so locked phones do not leave push/test runs waiting indefinitely
- document preview as the active development lane and defer a third development app target until there is a real three-lane need

## Verification
- `bash -n scripts/ios-preview-device-smoke.sh`
- `bash -n scripts/ios-ui-smoke.sh`
- `./scripts/ios-preview-device-smoke.sh` exits 64 with setup guidance when no destination is provided
- `IOS_DEVICE_ID=not-a-real-device IOS_DEVICE_READY_TIMEOUT=1 ./scripts/ios-preview-device-smoke.sh` exits 69 with readiness guidance
- `pnpm ios:preview-smoke:fast`
- pre-commit typecheck/lint passed; lint reported existing warnings only
- pre-push typecheck passed
