### PR TITLE
Accept paired iPhones in preview smoke preflight

### DIFF
--- a/scripts/ios-preview-device-smoke.sh
+++ b/scripts/ios-preview-device-smoke.sh
@@ -48,10 +48,8 @@ echo "Keep the iPhone unlocked and awake until the UI test starts."
 
 ready_deadline=$((SECONDS + IOS_DEVICE_READY_TIMEOUT))
 while true; do
-  if xcrun devicectl list devices 2>/dev/null | grep -F "$device_id" | grep -q "connected"; then
-    if xcrun devicectl device info details --device "$device_id" --quiet --timeout 10 >/dev/null 2>&1; then
-      break
-    fi
+  if xcrun devicectl device info details --device "$device_id" --quiet --timeout 10 >/dev/null 2>&1; then
+    break
   fi
 
   if [ "$SECONDS" -ge "$ready_deadline" ]; then


### PR DESCRIPTION
## Summary
- treat successful `devicectl device info details` as the physical-device readiness signal
- avoid requiring `devicectl list devices` to report the literal state `connected`, since this machine reports the paired iPhone as `available (paired)` while still being runnable

## Verification
- `bash -n scripts/ios-preview-device-smoke.sh`
- `git diff --check -- scripts/ios-preview-device-smoke.sh`
- `IOS_DEVICE_ID=D7045658-5C05-5166-B20F-1E01DEC05DB1 pnpm ios:preview-device-smoke:fast`
- pre-commit typecheck/lint passed; lint reported existing warnings only
- pre-push typecheck passed
