### PR TITLE
Support iOS preview setup links

### DIFF
--- a/ios/IssueCTL/Services/SetupLink.swift
+++ b/ios/IssueCTL/Services/SetupLink.swift
@@ -5,7 +5,7 @@ struct SetupLink: Equatable, Sendable {
     let token: String
 
     init?(url: URL) {
-        guard url.scheme == "issuectl", url.host == "setup" else {
+        guard ["issuectl", "issuectl-preview"].contains(url.scheme), url.host == "setup" else {
             return nil
         }
 

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -13,6 +13,14 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertEqual(setup.token, "abc123")
     }
 
+    func testPreviewSetupLinkParsesServerURLAndToken() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl-preview://setup?serverURL=http%3A%2F%2F192.0.2.10%3A3847&token=abc123"))
+        let setup = try XCTUnwrap(SetupLink(url: url))
+
+        XCTAssertEqual(setup.serverURL, "http://192.0.2.10:3847")
+        XCTAssertEqual(setup.token, "abc123")
+    }
+
     func testSetupLinkRejectsWrongScheme() throws {
         let url = try XCTUnwrap(URL(string: "https://setup?serverURL=http%3A%2F%2F192.0.2.10%3A3847&token=abc123"))
         XCTAssertNil(SetupLink(url: url))

--- a/ios/IssueCTLUITests/DraftWorkflowTests.swift
+++ b/ios/IssueCTLUITests/DraftWorkflowTests.swift
@@ -38,7 +38,7 @@ final class DraftWorkflowTests: XCTestCase {
         waitForNonexistence("issue-title-field", in: app)
 
         // Navigate to drafts.
-        tapElement("issues-tab", in: app)
+        tapMainTab("issues-tab", label: "Issues", in: app)
         assertElement("section-tab-drafts", existsIn: app, timeout: 8)
         element("section-tab-drafts", in: app).tap()
 

--- a/ios/IssueCTLUITests/Helpers/TestHelpers.swift
+++ b/ios/IssueCTLUITests/Helpers/TestHelpers.swift
@@ -30,6 +30,43 @@ func tapElement(
 }
 
 @MainActor
+func tapMainTab(
+    _ identifier: String,
+    label: String,
+    in app: XCUIApplication,
+    timeout: TimeInterval = 8,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let identifiedTab = element(identifier, in: app)
+    if identifiedTab.exists {
+        identifiedTab.tap()
+        return
+    }
+
+    let labeledTab = app.tabBars.buttons[label]
+    if labeledTab.exists {
+        labeledTab.tap()
+        return
+    }
+
+    let identifierProbe = min(timeout, 2)
+    if identifiedTab.waitForExistence(timeout: identifierProbe) {
+        identifiedTab.tap()
+        return
+    }
+
+    let remainingTimeout = max(timeout - identifierProbe, 0)
+    XCTAssertTrue(
+        labeledTab.waitForExistence(timeout: remainingTimeout),
+        "Missing \(identifier) or tab labeled \(label)\n\(app.debugDescription)",
+        file: file,
+        line: line
+    )
+    labeledTab.tap()
+}
+
+@MainActor
 func assertElement(
     _ identifier: String,
     existsIn app: XCUIApplication,
@@ -73,7 +110,7 @@ func waitForButtonNonexistence(
 @MainActor
 func openIssuesSection(in app: XCUIApplication) {
     dismissRestoredModal(in: app)
-    tapElement("issues-tab", in: app, timeout: 20)
+    tapMainTab("issues-tab", label: "Issues", in: app, timeout: 20)
     let openSection = element("section-tab-open", in: app)
     if !openSection.waitForExistence(timeout: 20), app.scrollViews.firstMatch.exists {
         app.scrollViews.firstMatch.swipeRight()

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -45,18 +45,18 @@ final class IssueCTLUITests: XCTestCase {
     func testListToolbarActionsAreReachableFromTabs() {
         let app = launchApp(server: server)
 
-        tapElement("issues-tab", in: app)
+        tapMainTab("issues-tab", label: "Issues", in: app)
         assertElement("issues-create-issue-button", existsIn: app, timeout: 5)
         assertElement("issues-search-button", existsIn: app)
         assertElement("issues-filter-button", existsIn: app)
 
-        tapElement("prs-tab", in: app)
+        tapMainTab("prs-tab", label: "PRs", in: app)
         assertElement("prs-create-issue-button", existsIn: app, timeout: 5)
         assertElement("prs-search-button", existsIn: app)
         assertElement("prs-quick-actions-button", existsIn: app, timeout: 5)
         assertElement("prs-filter-button", existsIn: app)
 
-        tapElement("active-tab", in: app)
+        tapMainTab("active-tab", label: "Active", in: app)
         assertElement("sessions-create-issue-button", existsIn: app, timeout: 5)
         assertElement("sessions-search-button", existsIn: app)
         assertElement("sessions-refresh-button", existsIn: app)
@@ -134,7 +134,7 @@ final class IssueCTLUITests: XCTestCase {
 
     @MainActor
     private func openDraftsSection(in app: XCUIApplication) {
-        tapElement("issues-tab", in: app)
+        tapMainTab("issues-tab", label: "Issues", in: app)
         assertElement("section-tab-drafts", existsIn: app, timeout: 8)
         element("section-tab-drafts", in: app).tap()
     }
@@ -169,7 +169,7 @@ final class IssueCTLUITests: XCTestCase {
         app.buttons["terminal-done-button"].tap()
         assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
 
-        tapElement("active-tab", in: app)
+        tapMainTab("active-tab", label: "Active", in: app)
         assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
         element("session-reenter-terminal-9001", in: app).tap()
@@ -208,7 +208,7 @@ final class IssueCTLUITests: XCTestCase {
 
         launchIssueSession(102, in: app)
 
-        tapElement("active-tab", in: app)
+        tapMainTab("active-tab", label: "Active", in: app)
         assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9002", existsIn: app, timeout: 5)
@@ -244,7 +244,7 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("issue-row-101", existsIn: app, timeout: 8)
         XCTAssertFalse(app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "user profile")).firstMatch.exists)
 
-        tapElement("prs-tab", in: app)
+        tapMainTab("prs-tab", label: "PRs", in: app)
         assertElement("pr-row-7", existsIn: app, timeout: 8)
         XCTAssertFalse(app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "user profile")).firstMatch.exists)
     }

--- a/ios/IssueCTLUITests/PRBrowseTests.swift
+++ b/ios/IssueCTLUITests/PRBrowseTests.swift
@@ -18,7 +18,7 @@ final class PRBrowseTests: XCTestCase {
     func testPRListShowsOpenPRsWithCheckStatus() {
         let app = launchApp(server: server)
 
-        tapElement("prs-tab", in: app)
+        tapMainTab("prs-tab", label: "PRs", in: app)
         // PR #7 has checksStatus "pending" → visible in default "review" section.
         assertElement("pr-row-7", existsIn: app, timeout: 8)
 
@@ -31,7 +31,7 @@ final class PRBrowseTests: XCTestCase {
     func testPRDetailShowsChecksAndBranchInfo() {
         let app = launchApp(server: server)
 
-        tapElement("prs-tab", in: app)
+        tapMainTab("prs-tab", label: "PRs", in: app)
         assertElement("pr-row-7", existsIn: app, timeout: 8)
         element("pr-row-7", in: app).tap()
 
@@ -47,7 +47,7 @@ final class PRBrowseTests: XCTestCase {
     func testPRFilterAndSearchButtons() {
         let app = launchApp(server: server)
 
-        tapElement("prs-tab", in: app)
+        tapMainTab("prs-tab", label: "PRs", in: app)
         assertElement("prs-filter-button", existsIn: app, timeout: 5)
         assertElement("prs-search-button", existsIn: app, timeout: 3)
         assertElement("prs-quick-actions-button", existsIn: app, timeout: 3)

--- a/ios/IssueCTLUITests/SessionManagementTests.swift
+++ b/ios/IssueCTLUITests/SessionManagementTests.swift
@@ -20,7 +20,7 @@ final class SessionManagementTests: XCTestCase {
         server.seedActiveDeployment()
         let app = launchApp(server: server)
 
-        tapElement("active-tab", in: app)
+        tapMainTab("active-tab", label: "Active", in: app)
         assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
 

--- a/packages/cli/src/commands/web.ts
+++ b/packages/cli/src/commands/web.ts
@@ -30,9 +30,11 @@ export async function webCommand(options: { port: string }): Promise<void> {
   if (lanIp) {
     const iosServerUrl = `http://${lanIp}:${port}`;
     const setupUrl = buildIosSetupUrl(iosServerUrl, token);
+    const previewSetupUrl = buildIosSetupUrl(iosServerUrl, token, "issuectl-preview");
     log.info(`iOS server URL: ${iosServerUrl}`);
     log.info(`iOS API token: ${token}`);
     log.info(`iOS setup link: ${setupUrl}`);
+    log.info(`iOS preview setup link: ${previewSetupUrl}`);
     log.info("Scan this QR code with your iPhone Camera to configure the iOS app:");
     qrcode.generate(setupUrl, { small: true }, (qr) => {
       console.error(qr);

--- a/packages/cli/src/utils/mobile-setup.ts
+++ b/packages/cli/src/utils/mobile-setup.ts
@@ -12,10 +12,14 @@ export function detectLanIp(): string | null {
   return null;
 }
 
-export function buildIosSetupUrl(serverUrl: string, token: string): string {
+export function buildIosSetupUrl(
+  serverUrl: string,
+  token: string,
+  scheme = "issuectl",
+): string {
   const params = new URLSearchParams({
     serverURL: serverUrl,
     token,
   });
-  return `issuectl://setup?${params.toString()}`;
+  return `${scheme}://setup?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- allow the iOS setup parser to accept `issuectl-preview://setup` links
- add coverage for preview setup links
- have `issuectl web` print a preview setup link alongside the production setup link

## Verification
- `pnpm --filter @issuectl/cli typecheck`
- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug -only-testing:IssueCTLTests/ViewLogicTests/testSetupLinkParsesServerURLAndToken -only-testing:IssueCTLTests/ViewLogicTests/testPreviewSetupLinkParsesServerURLAndToken`
- built and installed `IssueCTL` and `IssueCTLPreview` on physical iPhone
- launched both apps with `ISSUECTL_SERVER_URL=http://192.168.1.32:3847` and current `ISSUECTL_API_TOKEN`
