### PR TITLE
Improve mobile issue detail navigation performance

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -27,6 +27,24 @@ struct IssueDetailView: View {
     @State private var isLoadingPriority = false
     @State private var staleHint: String?
     @State private var staleHintDismissTask: Task<Void, Never>?
+    @State private var hasLoadedFullDetail = false
+
+    init(owner: String, repo: String, number: Int, initialIssue: GitHubIssue? = nil) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        if let initialIssue {
+            _detail = State(initialValue: IssueDetailResponse(
+                issue: initialIssue,
+                comments: [],
+                deployments: [],
+                linkedPRs: [],
+                referencedFiles: [],
+                fromCache: true
+            ))
+            _isLoading = State(initialValue: false)
+        }
+    }
 
     var body: some View {
         Group {
@@ -261,7 +279,20 @@ struct IssueDetailView: View {
             )
 
             if issue.isOpen {
-                if let deployment = activeDeployment(from: detail) {
+                if !hasLoadedFullDetail {
+                    SessionStatusCard(
+                        title: "Loading Actions",
+                        subtitle: "Checking session and launch context.",
+                        status: "Loading",
+                        systemImage: "hourglass",
+                        tint: .orange,
+                        primaryTitle: nil,
+                        primarySystemImage: "hourglass",
+                        primaryAccessibilityIdentifier: nil,
+                        primaryAction: {}
+                    )
+                    .accessibilityIdentifier("issue-detail-actions-loading-card")
+                } else if let deployment = activeDeployment(from: detail) {
                     SessionStatusCard(
                         title: deployment.ttydPort == nil ? "Session Starting" : "Session Active",
                         subtitle: "\(deployment.branchName) - \(deployment.runningDuration)",
@@ -560,6 +591,7 @@ struct IssueDetailView: View {
                 catch { return .failure(error) }
             }()
             detail = try await detailResult
+            hasLoadedFullDetail = true
 
             // Supplementary fetches — failures are non-fatal but surfaced
             var failures: [String] = []

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -270,7 +270,12 @@ struct IssueListView: View {
                 }
             }
             .navigationDestination(for: IssueDestination.self) { dest in
-                IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
+                IssueDetailView(
+                    owner: dest.owner,
+                    repo: dest.repo,
+                    number: dest.number,
+                    initialIssue: dest.initialIssue
+                )
             }
             .navigationDestination(for: DraftDestination.self) { dest in
                 DraftDetailView(draft: dest.draft, onSaved: { Task { await loadAll(refresh: true) } })
@@ -494,7 +499,8 @@ struct IssueListView: View {
                     NavigationLink(value: IssueDestination(
                         owner: repo.owner,
                         repo: repo.name,
-                        number: issue.number
+                        number: issue.number,
+                        initialIssue: issue
                     )) {
                         IssueRowView(issue: issue, repoColor: color, isRunning: running)
                     }
@@ -906,6 +912,26 @@ struct IssueDestination: Hashable {
     let owner: String
     let repo: String
     let number: Int
+    let initialIssue: GitHubIssue?
+
+    init(owner: String, repo: String, number: Int, initialIssue: GitHubIssue? = nil) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.initialIssue = initialIssue
+    }
+
+    static func == (lhs: IssueDestination, rhs: IssueDestination) -> Bool {
+        lhs.owner == rhs.owner &&
+            lhs.repo == rhs.repo &&
+            lhs.number == rhs.number
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(owner)
+        hasher.combine(repo)
+        hasher.combine(number)
+    }
 }
 
 struct LaunchTarget: Identifiable, Sendable {


### PR DESCRIPTION
## Summary
- warm-start iOS issue detail screens from the already loaded issue list row
- keep launch/session actions gated until the full detail payload arrives
- preserve the existing API refresh path for comments, linked PRs, deployments, and priority

## Testing
- xcodebuild -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator' build

Closes #370