### PR TITLE
Default new issues to the last used repo

### DIFF
--- a/packages/web/app/new/default-repo.test.ts
+++ b/packages/web/app/new/default-repo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Repo } from "@issuectl/core";
+import { getDefaultRepoOption, parseDefaultRepoId } from "./default-repo";
+
+const repos: Repo[] = [
+  {
+    id: 2,
+    owner: "acme",
+    name: "second",
+    localPath: null,
+    branchPattern: null,
+    createdAt: "2026-01-02 00:00:00",
+  },
+  {
+    id: 1,
+    owner: "acme",
+    name: "first",
+    localPath: null,
+    branchPattern: null,
+    createdAt: "2026-01-01 00:00:00",
+  },
+];
+
+describe("new issue default repo selection", () => {
+  it("uses the stored repo id when it matches a tracked repo", () => {
+    expect(getDefaultRepoOption(repos, 1)).toEqual({
+      owner: "acme",
+      repo: "first",
+    });
+  });
+
+  it("falls back to the first repo when the stored id is missing", () => {
+    expect(getDefaultRepoOption(repos, 999)).toEqual({
+      owner: "acme",
+      repo: "second",
+    });
+  });
+
+  it("parses only positive integer default repo ids", () => {
+    expect(parseDefaultRepoId("42")).toBe(42);
+    expect(parseDefaultRepoId("")).toBeNull();
+    expect(parseDefaultRepoId("1.5")).toBeNull();
+    expect(parseDefaultRepoId("-1")).toBeNull();
+    expect(parseDefaultRepoId(undefined)).toBeNull();
+  });
+});

--- a/packages/web/app/new/default-repo.ts
+++ b/packages/web/app/new/default-repo.ts
@@ -1,0 +1,20 @@
+import type { Repo } from "@issuectl/core";
+import type { RepoOption } from "@/lib/types";
+
+export function parseDefaultRepoId(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function getDefaultRepoOption(
+  repos: Repo[],
+  defaultRepoId: number | null,
+): RepoOption {
+  const repo =
+    defaultRepoId !== null
+      ? repos.find((candidate) => candidate.id === defaultRepoId)
+      : undefined;
+  const selected = repo ?? repos[0];
+  return { owner: selected.owner, repo: selected.name };
+}

--- a/packages/web/app/new/page.tsx
+++ b/packages/web/app/new/page.tsx
@@ -3,6 +3,7 @@ import {
   dbExists,
   getDb,
   getOctokit,
+  getSetting,
   listRepos,
   listLabels,
 } from "@issuectl/core";
@@ -10,6 +11,7 @@ import type { GitHubLabel } from "@issuectl/core";
 import type { RepoOption } from "@/lib/types";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { NewIssuePage } from "./NewIssuePage";
+import { getDefaultRepoOption, parseDefaultRepoId } from "./default-repo";
 import type { Metadata } from "next";
 import styles from "./page.module.css";
 
@@ -51,6 +53,10 @@ export default async function NewIssueRoute() {
   }
 
   const repos: RepoOption[] = dbRepos.map((r) => ({ owner: r.owner, repo: r.name }));
+  const defaultRepo = getDefaultRepoOption(
+    dbRepos,
+    parseDefaultRepoId(getSetting(db, "default_repo_id")),
+  );
   const labelsPerRepo: Record<string, GitHubLabel[]> = {};
   let loadError: string | undefined;
 
@@ -82,7 +88,7 @@ export default async function NewIssueRoute() {
   return (
     <NewIssuePage
       repos={repos}
-      defaultRepo={repos[0]}
+      defaultRepo={defaultRepo}
       labelsPerRepo={labelsPerRepo}
       initError={loadError}
     />

--- a/packages/web/lib/actions/issues.test.ts
+++ b/packages/web/lib/actions/issues.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+  getDb: vi.fn(() => ({})),
+  getRepo: vi.fn(),
+  setSetting: vi.fn(),
+  createIssue: vi.fn(),
+  clearCacheKey: vi.fn(),
+  withAuthRetry: vi.fn((fn: (octokit: unknown) => Promise<unknown>) => fn({})),
+  withIdempotency: vi.fn(
+    (_db: unknown, _action: string, _key: string, fn: () => Promise<unknown>) =>
+      fn(),
+  ),
+}));
+
+vi.mock("@issuectl/core", async () => {
+  const real = await vi.importActual<typeof import("@issuectl/core")>(
+    "@issuectl/core",
+  );
+  return {
+    ...real,
+    getDb: coreMocks.getDb,
+    getRepo: coreMocks.getRepo,
+    setSetting: coreMocks.setSetting,
+    createIssue: coreMocks.createIssue,
+    clearCacheKey: coreMocks.clearCacheKey,
+    withAuthRetry: coreMocks.withAuthRetry,
+    withIdempotency: coreMocks.withIdempotency,
+  };
+});
+
+vi.mock("@/lib/revalidate", () => ({
+  revalidateSafely: () => ({ stale: false }),
+}));
+
+const { createIssue } = await import("./issues");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  coreMocks.getDb.mockReturnValue({});
+  coreMocks.setSetting.mockReset();
+  coreMocks.getRepo.mockReturnValue({
+    id: 7,
+    owner: "acme",
+    name: "api",
+    localPath: null,
+    branchPattern: null,
+    createdAt: "2026-01-01 00:00:00",
+  });
+  coreMocks.createIssue.mockResolvedValue({ number: 123 });
+});
+
+describe("createIssue action", () => {
+  it("stores the created issue repo as the next default repo", async () => {
+    const result = await createIssue({
+      owner: "acme",
+      repo: "api",
+      title: "Fix cache invalidation",
+    });
+
+    expect(result).toEqual({ success: true, issueNumber: 123 });
+    expect(coreMocks.setSetting).toHaveBeenCalledWith(
+      {},
+      "default_repo_id",
+      "7",
+    );
+  });
+
+  it("does not update the default repo when the repo is not tracked", async () => {
+    coreMocks.getRepo.mockReturnValue(undefined);
+
+    const result = await createIssue({
+      owner: "acme",
+      repo: "missing",
+      title: "Fix cache invalidation",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Repository is not tracked",
+    });
+    expect(coreMocks.createIssue).not.toHaveBeenCalled();
+    expect(coreMocks.setSetting).not.toHaveBeenCalled();
+  });
+
+  it("still succeeds if persisting the default repo fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    coreMocks.setSetting.mockImplementation(() => {
+      throw new Error("db busy");
+    });
+
+    const result = await createIssue({
+      owner: "acme",
+      repo: "api",
+      title: "Fix cache invalidation",
+    });
+
+    expect(result).toEqual({ success: true, issueNumber: 123 });
+    warn.mockRestore();
+  });
+});

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -3,6 +3,7 @@
 import {
   getDb,
   getRepo,
+  setSetting,
   createIssue as coreCreateIssue,
   updateIssue as coreUpdateIssue,
   closeIssue as coreCloseIssue,
@@ -56,7 +57,8 @@ export async function createIssue(data: {
   let issueNumber: number;
   try {
     const db = getDb();
-    if (!getRepo(db, owner, repo)) {
+    const trackedRepo = getRepo(db, owner, repo);
+    if (!trackedRepo) {
       return { success: false, error: "Repository is not tracked" };
     }
     const runCreate = async () => {
@@ -74,6 +76,15 @@ export async function createIssue(data: {
       ? await withIdempotency(db, "create-issue", idempotencyKey, runCreate)
       : await runCreate();
     issueNumber = result.number;
+    try {
+      setSetting(db, "default_repo_id", String(trackedRepo.id));
+    } catch (err) {
+      console.warn(
+        "[issuectl] Failed to update default repo after issue creation",
+        { owner, repo },
+        err,
+      );
+    }
   } catch (err) {
     if (err instanceof DuplicateInFlightError) {
       return {


### PR DESCRIPTION
## Summary
- use the stored default repo id when opening the full new issue page
- persist the repo after a direct issue creation succeeds
- add focused tests for default repo selection and persistence

## Tests
- pnpm --filter @issuectl/core build
- pnpm --filter @issuectl/web test -- app/new/default-repo.test.ts lib/actions/issues.test.ts
- pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/web lint

Closes #377