### PR TITLE
Clarify agent harness defaults in settings

### DIFF
--- a/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/AdvancedSettingsView.swift
@@ -77,36 +77,24 @@ struct AdvancedSettingsView: View {
                 }
 
                 Section {
-                    Picker("Default Launch Agent", selection: $launchAgent) {
+                    Picker("Default Agent", selection: $launchAgent) {
                         ForEach(LaunchAgent.allCases) { agent in
                             Text(agent.displayName).tag(agent)
                         }
                     }
                     .pickerStyle(.segmented)
-                } header: {
-                    Text("Launch Agent")
-                } footer: {
-                    Text("Default agent used when launching a new terminal session.")
-                }
 
-                Section {
-                    TextField("Extra arguments", text: $claudeExtraArgs)
+                    TextField("Claude Code extra args", text: $claudeExtraArgs)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+
+                    TextField("Codex extra args", text: $codexExtraArgs)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
                 } header: {
-                    Text("Claude CLI")
+                    Text("Agent Harness")
                 } footer: {
-                    Text("Additional arguments passed to Claude Code on launch.")
-                }
-
-                Section {
-                    TextField("Extra arguments", text: $codexExtraArgs)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                } header: {
-                    Text("Codex CLI")
-                } footer: {
-                    Text("Additional arguments passed to Codex on launch.")
+                    Text("Choose the default agent for new launches and set harness-specific CLI arguments. The launch sheet can still override the agent for one session.")
                 }
 
                 Section {
@@ -161,7 +149,7 @@ struct AdvancedSettingsView: View {
                 }
             }
         }
-        .navigationTitle("Advanced Settings")
+        .navigationTitle("Agent Harness & Defaults")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -174,7 +174,7 @@ struct SettingsView: View {
     private var managementSection: some View {
         Section("Management") {
             NavigationLink(value: SettingsDestination.advancedSettings) {
-                Label("Advanced Settings", systemImage: "slider.horizontal.3")
+                Label("Agent Harness & Defaults", systemImage: "terminal")
             }
             NavigationLink(value: SettingsDestination.worktrees) {
                 Label("Worktrees", systemImage: "arrow.triangle.branch")

--- a/packages/web/components/settings/SettingsForm.module.css
+++ b/packages/web/components/settings/SettingsForm.module.css
@@ -45,11 +45,6 @@
   min-height: 44px;
 }
 
-.select {
-  composes: input;
-  appearance: auto;
-}
-
 .input:focus {
   outline: none;
   border-color: var(--paper-accent);
@@ -61,7 +56,6 @@
   }
 
   .input,
-  .select,
   .inputReadonly {
     max-width: none;
   }
@@ -78,6 +72,62 @@
   font-size: 11px;
   color: var(--paper-ink-muted);
   margin-top: 4px;
+}
+
+.helpBlock {
+  max-width: 560px;
+  margin: -8px 0 14px;
+  color: var(--paper-ink-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.agentOptions {
+  display: grid;
+  gap: 8px;
+  max-width: 560px;
+  margin-bottom: 16px;
+}
+
+.agentOption {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  cursor: pointer;
+}
+
+.agentOptionSelected {
+  background: var(--paper-accent-soft);
+  border-color: var(--paper-accent);
+}
+
+.agentOptionDisabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.agentRadio {
+  margin-top: 2px;
+  accent-color: var(--paper-accent);
+}
+
+.agentLabel {
+  display: block;
+  color: var(--paper-ink);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.agentDetail {
+  display: block;
+  margin-top: 2px;
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .saveRow {

--- a/packages/web/components/settings/SettingsForm.tsx
+++ b/packages/web/components/settings/SettingsForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { updateSettings } from "@/lib/actions/settings";
 import { useToast } from "@/components/ui/ToastProvider";
 import { Button } from "@/components/paper";
+import { cn } from "@/lib/cn";
 import * as validation from "@issuectl/core/validation";
 import type { SettingKey } from "@issuectl/core";
 import { LAUNCH_AGENTS, launchAgentCommand, launchAgentLabel, normalizeLaunchAgent, type LaunchAgent } from "@/components/launch/agent";
@@ -13,6 +14,11 @@ import styles from "./SettingsForm.module.css";
 // toast is the global + screen-reader path, but after clicking the
 // user's eyes are on the button, not the toast region.
 const SAVED_FLASH_MS = 2500;
+
+const AGENT_DETAILS: Record<LaunchAgent, string> = {
+  claude: "Use Claude Code by default for new agent sessions.",
+  codex: "Use Codex by default for new agent sessions.",
+};
 
 type Props = {
   branchPattern: string;
@@ -198,30 +204,47 @@ export function SettingsForm({
               enterKeyHint="done"
             />
           </div>
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="sf-launch-agent">Launch Agent</label>
-            <select
-              id="sf-launch-agent"
-              className={styles.select}
-              value={values.launch_agent}
-              onChange={(e) => handleChange("launch_agent", normalizeLaunchAgent(e.target.value))}
-              disabled={isPending}
-            >
-              {LAUNCH_AGENTS.map((agent) => (
-                <option key={agent} value={agent}>
-                  {launchAgentLabel(agent)}
-                </option>
-              ))}
-            </select>
-          </div>
         </div>
       </section>
 
       <section className={styles.section}>
-        <div className={styles.sectionTitle}>Claude</div>
+        <div className={styles.sectionTitle}>Agent Harness</div>
+        <div className={styles.helpBlock}>
+          Choose the default agentic harness for launches. You can still override
+          the agent from the launch dialog for a single session.
+        </div>
+        <div className={styles.agentOptions} role="radiogroup" aria-labelledby="sf-launch-agent-label">
+          <div id="sf-launch-agent-label" className={styles.label}>Default Agent</div>
+          {LAUNCH_AGENTS.map((agent) => {
+            const isSelected = values.launch_agent === agent;
+            return (
+              <label
+                key={agent}
+                className={cn(
+                  styles.agentOption,
+                  isSelected && styles.agentOptionSelected,
+                  isPending && styles.agentOptionDisabled,
+                )}
+              >
+                <input
+                  type="radio"
+                  name="sf-launch-agent"
+                  className={styles.agentRadio}
+                  checked={isSelected}
+                  disabled={isPending}
+                  onChange={() => handleChange("launch_agent", agent)}
+                />
+                <span>
+                  <span className={styles.agentLabel}>{launchAgentLabel(agent)}</span>
+                  <span className={styles.agentDetail}>{AGENT_DETAILS[agent]}</span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
         <div className={styles.row}>
           <div className={styles.field}>
-            <label className={styles.label} htmlFor="sf-claude-args">Extra Args</label>
+            <label className={styles.label} htmlFor="sf-claude-args">Claude Extra Args</label>
             <input
               id="sf-claude-args"
               className={styles.input}
@@ -236,7 +259,8 @@ export function SettingsForm({
               enterKeyHint="done"
             />
             <div className={styles.help}>
-              Passed verbatim after <code>claude</code> at launch. Leave empty for defaults.
+              Passed verbatim after <code>{launchAgentCommand("claude")}</code> when launching Claude Code.
+              Leave empty for defaults.
             </div>
             {claudeArgsValidation.errors.length > 0 && (
               <div className={styles.fieldError} role="alert">
@@ -270,7 +294,8 @@ export function SettingsForm({
               enterKeyHint="done"
             />
             <div className={styles.help}>
-              Passed verbatim after <code>{launchAgentCommand("codex")}</code> at launch. Leave empty for defaults.
+              Passed verbatim after <code>{launchAgentCommand("codex")}</code> when launching Codex.
+              Leave empty for defaults.
             </div>
             {codexArgsValidation.errors.length > 0 && (
               <div className={styles.fieldError} role="alert">


### PR DESCRIPTION
## Summary
- Add a dedicated Agent Harness section in web settings with radio-style default agent selection
- Group Claude Code and Codex CLI flags under the harness settings
- Rename the iOS settings entry and advanced screen to make agent harness defaults easier to find

## Verification
- pnpm --filter @issuectl/web test -- lib/actions/settings.test.ts
- pnpm --filter @issuectl/web lint
- pnpm --filter @issuectl/core build
- pnpm --filter @issuectl/web typecheck
- xcodebuild -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator' build
- commit/push hooks ran full typecheck and lint

Closes #376