### PR TITLE
Fix mobile terminal sizing

### DIFF
--- a/packages/core/src/launch/ttyd.test.ts
+++ b/packages/core/src/launch/ttyd.test.ts
@@ -420,9 +420,11 @@ describe("spawnTtyd", () => {
     )!;
     expect(tmuxCall).toBeDefined();
     const tmuxArgs = tmuxCall[1] as string[];
-    expect(tmuxArgs.slice(0, 4)).toEqual(["new-session", "-d", "-s", "issuectl-myrepo-42"]);
+    expect(tmuxArgs.slice(0, 8)).toEqual([
+      "new-session", "-d", "-x", "40", "-y", "24", "-s", "issuectl-myrepo-42",
+    ]);
     // The shell command passed to tmux redirects the context into the agent
-    const tmuxCmd = tmuxArgs[4];
+    const tmuxCmd = tmuxArgs[8];
     expect(tmuxCmd).toContain("bash -lic");
     expect(tmuxCmd).toContain("/home/user/project");
     expect(tmuxCmd).toContain("/tmp/ctx.md");
@@ -464,7 +466,7 @@ describe("spawnTtyd", () => {
 
     const tmuxCmd = execFileSyncSpy.mock.calls.find(
       (c: unknown[]) => c[0] === "tmux" && (c[1] as string[])[0] === "new-session",
-    )![1][4] as string;
+    )![1][8] as string;
     expect(tmuxCmd).toContain("codex --sandbox danger-full-access --ask-for-approval never");
     expect(tmuxCmd).toContain("$(cat ");
     expect(tmuxCmd).toContain("/tmp/ctx.md");
@@ -510,7 +512,7 @@ describe("spawnTtyd", () => {
     // once when wrapping in bash -lic, so the quote escaping is doubled.
     const tmuxCmd = execFileSyncSpy.mock.calls.find(
       (c: unknown[]) => c[0] === "tmux" && (c[1] as string[])[0] === "new-session",
-    )![1][4] as string;
+    )![1][8] as string;
     expect(tmuxCmd).toContain("it");
     expect(tmuxCmd).toContain("s a project");
     killSpy.mockRestore();

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -30,6 +30,9 @@ function shellEscape(s: string): string {
 
 const TMUX_TIMEOUT_MS = 10_000;
 const TMUX_SESSION_RE = /^[a-zA-Z0-9_-]+$/;
+// Detached tmux sessions otherwise start at 80 columns, wider than phones.
+const TMUX_INITIAL_COLUMNS = 40;
+const TMUX_INITIAL_ROWS = 24;
 
 /**
  * Build a tmux-safe session name from repo + issue number. Dots, colons,
@@ -260,7 +263,10 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
   // This is step 1 of 2 — ttyd will then serve `tmux attach` so
   // every WebSocket client shares the same terminal view.
   execFileSync("tmux", [
-    "new-session", "-d", "-s", sessionName,
+    "new-session", "-d",
+    "-x", String(TMUX_INITIAL_COLUMNS),
+    "-y", String(TMUX_INITIAL_ROWS),
+    "-s", sessionName,
     `bash -lic ${shellEscape(innerCommand)}`,
   ], { timeout: TMUX_TIMEOUT_MS });
 

--- a/packages/web/components/terminal/TerminalPanel.module.css
+++ b/packages/web/components/terminal/TerminalPanel.module.css
@@ -26,6 +26,7 @@
   right: 0;
   bottom: 0;
   width: 100%;
+  max-width: 100vw;
   background: var(--paper-bg);
   box-shadow: var(--paper-shadow-drawer);
   transform: translateX(100%);
@@ -33,6 +34,7 @@
   z-index: 1001;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 @media (min-width: 1200px) {
@@ -55,6 +57,11 @@
 }
 
 @media (max-width: 767px) {
+  .panel {
+    width: 100vw;
+    width: 100dvw;
+  }
+
   .header {
     gap: 8px;
     padding-right: 12px;
@@ -189,6 +196,9 @@
   flex: 1;
   border: none;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  display: block;
   background: #1a1b26;
 }
 


### PR DESCRIPTION
## Summary
- start new tmux-backed terminal sessions at a phone-safe 40x24 size
- constrain the terminal drawer and iframe to the mobile viewport
- update ttyd launch tests for the tmux sizing args

## Verification
- pnpm --filter @issuectl/core test -- src/launch/ttyd.test.ts
- pnpm --filter @issuectl/web lint
- pnpm --filter @issuectl/core build
- pnpm --filter @issuectl/web typecheck

Closes #369