### PR TITLE
Fix iOS launch reentry state after returning to issue

### DIFF
--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -12,6 +12,7 @@ struct IssueDetailView: View {
     @State private var errorMessage: String?
     @State private var activeDetailSheet: DetailSheet?
     @State private var terminalTarget: ActiveDeployment?
+    @State private var liveDeployment: ActiveDeployment?
     @State private var isClosing = false
     @State private var isReopening = false
     @State private var activeConfirmation: ActiveConfirmation?
@@ -104,7 +105,9 @@ struct IssueDetailView: View {
                     issueTitle: detail.issue.title,
                     comments: detail.comments,
                     referencedFiles: detail.referencedFiles
-                )
+                ) { deployment in
+                    liveDeployment = deployment
+                }
                 .presentationDetents([.fraction(0.66), .large])
                 .presentationDragIndicator(.visible)
             case .edit(let detail):
@@ -551,6 +554,10 @@ struct IssueDetailView: View {
         actionError = nil
         do {
             async let detailResult = api.issueDetail(owner: owner, repo: repo, number: number, refresh: refresh)
+            async let deploymentsResult: Result<ActiveDeploymentsResponse, Error> = {
+                do { return .success(try await api.activeDeployments()) }
+                catch { return .failure(error) }
+            }()
             async let userResult: Result<UserResponse, Error> = {
                 do { return .success(try await api.currentUser()) }
                 catch { return .failure(error) }
@@ -563,6 +570,12 @@ struct IssueDetailView: View {
 
             // Supplementary fetches — failures are non-fatal but surfaced
             var failures: [String] = []
+            switch await deploymentsResult {
+            case .success(let response):
+                liveDeployment = response.deployments.first(where: isMatchingActiveDeployment)
+            case .failure:
+                break
+            }
             switch await userResult {
             case .success(let user): currentUserLogin = user.login
             case .failure: currentUserLogin = nil
@@ -583,7 +596,17 @@ struct IssueDetailView: View {
     }
 
     private func activeDeployment(from detail: IssueDetailResponse) -> ActiveDeployment? {
-        detail.deployments.first(where: { $0.isActive }).map(activeDeployment(from:))
+        if let liveDeployment, isMatchingActiveDeployment(liveDeployment) {
+            return liveDeployment
+        }
+        return detail.deployments.first(where: { $0.isActive }).map(activeDeployment(from:))
+    }
+
+    private func isMatchingActiveDeployment(_ deployment: ActiveDeployment) -> Bool {
+        deployment.isActive &&
+        deployment.owner == owner &&
+        deployment.repoName == repo &&
+        deployment.issueNumber == number
     }
 
     private func activeDeployment(from deployment: Deployment) -> ActiveDeployment {

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -307,7 +307,10 @@ struct IssueListView: View {
                     issueTitle: target.title,
                     comments: target.comments,
                     referencedFiles: target.referencedFiles
-                )
+                ) { deployment in
+                    activeDeployments.removeAll { $0.id == deployment.id }
+                    activeDeployments.append(deployment)
+                }
                 .presentationDetents([.fraction(0.66), .large])
                 .presentationDragIndicator(.visible)
             }

--- a/ios/IssueCTL/Views/Launch/LaunchView.swift
+++ b/ios/IssueCTL/Views/Launch/LaunchView.swift
@@ -11,6 +11,7 @@ struct LaunchView: View {
     let comments: [GitHubComment]
     let referencedFiles: [String]
     let repoLocalPath: String?
+    let onSessionAvailable: (ActiveDeployment) -> Void
 
     @State private var branchName: String
     @State private var workspaceMode: WorkspaceMode
@@ -32,7 +33,16 @@ struct LaunchView: View {
     @State private var isResettingWorktree = false
     @State private var showAdvancedOptions = false
 
-    init(owner: String, repo: String, issueNumber: Int, issueTitle: String, comments: [GitHubComment], referencedFiles: [String], repoLocalPath: String? = nil) {
+    init(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        issueTitle: String,
+        comments: [GitHubComment],
+        referencedFiles: [String],
+        repoLocalPath: String? = nil,
+        onSessionAvailable: @escaping (ActiveDeployment) -> Void = { _ in }
+    ) {
         self.owner = owner
         self.repo = repo
         self.issueNumber = issueNumber
@@ -40,6 +50,7 @@ struct LaunchView: View {
         self.comments = comments
         self.referencedFiles = referencedFiles
         self.repoLocalPath = repoLocalPath
+        self.onSessionAvailable = onSessionAvailable
 
         _branchName = State(initialValue: generateBranchName(issueNumber: issueNumber, issueTitle: issueTitle))
         let needsClone = repoLocalPath == nil || repoLocalPath?.isEmpty == true
@@ -596,6 +607,9 @@ struct LaunchView: View {
         defer { isCheckingActiveSession = false }
         do {
             existingDeployment = try await findExistingDeployment()
+            if let existingDeployment {
+                onSessionAvailable(existingDeployment)
+            }
         } catch {
             existingDeployment = nil
         }
@@ -635,6 +649,7 @@ struct LaunchView: View {
         do {
             if let existing = try await findExistingDeployment() {
                 existingDeployment = existing
+                onSessionAvailable(existing)
                 openExistingTerminal(existing)
                 return
             }
@@ -671,6 +686,7 @@ struct LaunchView: View {
                     owner: owner, repoName: repo
                 )
                 existingDeployment = deployment
+                onSessionAvailable(deployment)
                 launchedDeployment = deployment
             } else {
                 errorMessage = response.error ?? "Launch failed"

--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -14,6 +14,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
     var failUserProfile = false
     var failRepos = false
     var failDeployments = false
+    var issueDetailDeploymentsLagBehindLaunch = false
 
     // Settings controls.
     var defaultLaunchAgent = "claude"
@@ -563,7 +564,10 @@ final class MockIssueCTLServer: @unchecked Sendable {
     }
 
     func deployments(for issueNumber: Int) -> [[String: Any]] {
-        activeDeployments.filter { $0["issue_number"] as? Int == issueNumber }
+        if issueDetailDeploymentsLagBehindLaunch {
+            return []
+        }
+        return activeDeployments.filter { $0["issue_number"] as? Int == issueNumber }
     }
 
     // MARK: - Mutation helpers

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -252,6 +252,28 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    func testReturningToIssueAfterLaunchUsesLiveDeploymentState() {
+        server.issueDetailDeploymentsLagBehindLaunch = true
+        let app = launchApp(server: server)
+
+        openIssuesSection(in: app)
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        element("issue-row-101", in: app).tap()
+
+        assertElement("issue-detail-launch-button", existsIn: app, timeout: 5)
+        element("issue-detail-launch-button", in: app).tap()
+
+        assertElement("launch-recommended-button", existsIn: app, timeout: 5)
+        element("launch-recommended-button", in: app).tap()
+
+        XCTAssertTrue(app.buttons["terminal-done-button"].waitForExistence(timeout: 8), app.debugDescription)
+        app.buttons["terminal-done-button"].tap()
+
+        assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
+        XCTAssertFalse(element("issue-detail-launch-button", in: app).exists, app.debugDescription)
+    }
+
+    @MainActor
     func testCodexLaunchSelectionIsSentToServer() {
         server.defaultLaunchAgent = "codex"
         let app = launchApp(server: server)


### PR DESCRIPTION
## Summary
- track live active deployment state on iOS issue detail pages
- notify issue detail/list callers when LaunchView finds or creates a running session
- add a UI regression test for stale issue-detail deployment payloads

## Tests
- `xcodebuild -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "generic/platform=iOS Simulator" build`
- `xcodebuild -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "id=8C27AB74-4C3D-4E95-8D5F-837BC8FE4CEF" -only-testing:IssueCTLUITests/IssueCTLUITests/testReturningToIssueAfterLaunchUsesLiveDeploymentState test`

Closes #372