### PR TITLE
Add iOS offline cache and notification settings

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0DA7B2AAB4F3504E9AB370FC /* SessionManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEF9A9D19EA4BD4284C8F00 /* SessionManagementTests.swift */; };
 		0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */; };
 		14B82C6AF822FB1BDF280402 /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
+		16F841C2C2ACBFE1AC1D4AA6 /* OfflineCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */; };
 		1947E5288D6AB12AE79684BB /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		19E9D441250270BCDD06172B /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A4F0FF399CC75CAB4F1A1C /* Issue.swift */; };
 		1C5028D29E4612025EE76D36 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6C0859937F6A85F709D99 /* Deployment.swift */; };
@@ -58,7 +59,9 @@
 		5029F9DC560599B76834000C /* APIClient+Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */; };
 		51D419285114BB9B1F7B6D5A /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */; };
 		5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */; };
+		54C6FF5A24ED1F784D022F19 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */; };
 		554B56D3274A1BC49D0B3939 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
+		55AEB0B56C5CDDF6FD4B7B0F /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */; };
 		55CF2EB4B12805D948B4F57C /* APIClientExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E30AE4ECDAC300ED2EE8F2 /* APIClientExtensionTests.swift */; };
 		57F286E2B3615BA000C1987C /* EdgeCaseModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CF16B90E6F234095B67412 /* EdgeCaseModelTests.swift */; };
 		581A38A699B1591C0D6C6EB9 /* LabelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE149A3F324BCC15AB57153E /* LabelPicker.swift */; };
@@ -103,6 +106,7 @@
 		9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
 		9F4A5C1ED1DFDCBC5EA8D823 /* InteractivePopDisabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCED89BF4650BDFC4262B48D /* InteractivePopDisabler.swift */; };
 		9FC4A8A601C39FEEDE496822 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA58C21063864ADB4BAC822 /* TodayView.swift */; };
+		A0D87C6AEC928127B7E8C4B2 /* OfflineCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */; };
 		A18D8982D49319C633EE661A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C1581E55A12781F1E76A1 /* ContentView.swift */; };
 		A2F5F2C02EF56C3F98D596E8 /* EditRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */; };
 		A3CBDBDDDEF8192FEB9DCBC0 /* APIClient+Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */; };
@@ -119,6 +123,7 @@
 		B4D3E5DC8306990F763058B6 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */; };
 		B576EDE5BCC90B29FD377101 /* DraftWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FAC416FAB2ACA469E0EC6F /* DraftWorkflowTests.swift */; };
 		B5F6E35A791604A67AB43860 /* PRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767FFF9158E604C69C4007DB /* PRDetailView.swift */; };
+		B6466C355DE3B70971FA8D7D /* NotificationSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */; };
 		B7BC266681BEE18B94DA1223 /* BranchNameHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736AD6AF28A44D0CEF44377B /* BranchNameHelper.swift */; };
 		B909D1854C184F5A61EB5091 /* IssueCTLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E1C810B3BD014B117301B /* IssueCTLApp.swift */; };
 		BA44F3237CDB6B67654C5933 /* BranchNameHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736AD6AF28A44D0CEF44377B /* BranchNameHelper.swift */; };
@@ -141,6 +146,7 @@
 		D1B085BF32A2BA054762456F /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC00C899D2ADA14475787AE7 /* APIClientTests.swift */; };
 		D52DC5DDE3BE88CF966B0675 /* IssueCTLUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FC68F504BF4FA08B86548 /* IssueCTLUITests.swift */; };
 		D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */; };
+		D9D891AEA02391C6479319B5 /* NotificationSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */; };
 		DBAAAF7B3925847446CC5E39 /* ModelDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */; };
 		DBE64FF10CF36A1BE16B7C3E /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EDD5BE2AB56ED93A092C0C /* MarkdownView.swift */; };
 		DF9D730DC11003377B8A76D6 /* AddRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */; };
@@ -218,6 +224,7 @@
 		2D10373E745B3E9EC223B684 /* IssueCTLPreview.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTLPreview.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Priority.swift"; sourceTree = "<group>"; };
 		3403F8C644518F599E01A976 /* ReassignSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReassignSheet.swift; sourceTree = "<group>"; };
+		344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCacheStore.swift; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		39EDF1F24285C1D3795B24B1 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
@@ -238,6 +245,7 @@
 		5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSheet.swift; sourceTree = "<group>"; };
 		5CEF9A9D19EA4BD4284C8F00 /* SessionManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagementTests.swift; sourceTree = "<group>"; };
 		5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
+		61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsStore.swift; sourceTree = "<group>"; };
 		62E30AE4ECDAC300ED2EE8F2 /* APIClientExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientExtensionTests.swift; sourceTree = "<group>"; };
 		6BE8B812763DC773F8484C7D /* ParseResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultRow.swift; sourceTree = "<group>"; };
 		6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailActionTests.swift; sourceTree = "<group>"; };
@@ -253,6 +261,7 @@
 		80A4F0FF399CC75CAB4F1A1C /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		80B19DB112594A978EE5AF5B /* EditCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommentSheet.swift; sourceTree = "<group>"; };
 		864FC68F504BF4FA08B86548 /* IssueCTLUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLUITests.swift; sourceTree = "<group>"; };
+		87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentButton.swift; sourceTree = "<group>"; };
 		9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepoSheet.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
@@ -357,6 +366,8 @@
 				A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */,
 				7A6FD670361C44AE6DB85ECE /* KeychainService.swift */,
 				FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */,
+				61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */,
+				344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */,
 				BC1D044DCA62B13F4196F816 /* SetupLink.swift */,
 			);
 			path = Services;
@@ -384,6 +395,7 @@
 				F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */,
 				6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */,
 				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
+				87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */,
 				093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */,
 				723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */,
 			);
@@ -810,6 +822,9 @@
 				2AB481A4FEF6B8AE429E279C /* MineFilterChip.swift in Sources */,
 				62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */,
 				8E89CDCD892A094F7485DB40 /* NetworkMonitor.swift in Sources */,
+				D9D891AEA02391C6479319B5 /* NotificationSettingsStore.swift in Sources */,
+				55AEB0B56C5CDDF6FD4B7B0F /* NotificationSettingsView.swift in Sources */,
+				16F841C2C2ACBFE1AC1D4AA6 /* OfflineCacheStore.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,
 				65142BB24364562CB5305E0F /* PRListView.swift in Sources */,
@@ -888,6 +903,9 @@
 				F7DAA0E5DD04C7761ED3B88F /* MineFilterChip.swift in Sources */,
 				1CCC0B31BDA3E181A6E15A9D /* NetworkErrorBanner.swift in Sources */,
 				F9A25EFC79F8804268FD9457 /* NetworkMonitor.swift in Sources */,
+				B6466C355DE3B70971FA8D7D /* NotificationSettingsStore.swift in Sources */,
+				54C6FF5A24ED1F784D022F19 /* NotificationSettingsView.swift in Sources */,
+				A0D87C6AEC928127B7E8C4B2 /* OfflineCacheStore.swift in Sources */,
 				227F5D726370EBF5F1C55F98 /* OnboardingView.swift in Sources */,
 				B5F6E35A791604A67AB43860 /* PRDetailView.swift in Sources */,
 				29142761332EA217923C5D78 /* PRListView.swift in Sources */,

--- a/ios/IssueCTL/App/IssueCTLApp.swift
+++ b/ios/IssueCTL/App/IssueCTLApp.swift
@@ -4,12 +4,14 @@ import SwiftUI
 struct IssueCTLApp: App {
     @State private var apiClient = APIClient()
     @State private var networkMonitor = NetworkMonitor()
+    @State private var notificationSettings = NotificationSettingsStore()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(apiClient)
                 .environment(networkMonitor)
+                .environment(notificationSettings)
         }
     }
 }

--- a/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
+++ b/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
@@ -69,8 +69,17 @@ extension APIClient {
 
     /// Fetch the authenticated GitHub user login.
     func currentUser() async throws -> UserResponse {
-        let (data, _) = try await request(path: "/api/v1/user")
-        return try decoder.decode(UserResponse.self, from: data)
+        do {
+            let (data, _) = try await request(path: "/api/v1/user")
+            let response = try decoder.decode(UserResponse.self, from: data)
+            offlineCache.save(response, for: "current-user", serverURL: serverURL)
+            return response
+        } catch {
+            if let cached = offlineCache.load(UserResponse.self, for: "current-user", serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     /// Parse natural language text into structured issues via Claude.

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -4,6 +4,7 @@ import Foundation
 final class APIClient {
     private(set) var serverURL: String = ""
     private(set) var apiToken: String = ""
+    let offlineCache = OfflineCacheStore()
     var isConfigured: Bool {
         !serverURL.isEmpty && !apiToken.isEmpty
     }
@@ -109,42 +110,99 @@ final class APIClient {
     }
 
     func repos() async throws -> [Repo] {
-        let (data, _) = try await request(path: "/api/v1/repos")
-        let response = try decoder.decode(ReposResponse.self, from: data)
-        return response.repos
+        do {
+            let (data, _) = try await request(path: "/api/v1/repos")
+            let response = try decoder.decode(ReposResponse.self, from: data)
+            offlineCache.save(response.repos, for: "repos", serverURL: serverURL)
+            return response.repos
+        } catch {
+            if let cached = offlineCache.load([Repo].self, for: "repos", serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     func issues(owner: String, repo: String, refresh: Bool = false) async throws -> IssuesResponse {
         var path = "/api/v1/issues/\(owner)/\(repo)"
         if refresh { path += "?refresh=true" }
-        let (data, _) = try await request(path: path)
-        return try decoder.decode(IssuesResponse.self, from: data)
+        let cacheKey = "issues.\(owner).\(repo)"
+        do {
+            let (data, _) = try await request(path: path)
+            let response = try decoder.decode(IssuesResponse.self, from: data)
+            offlineCache.save(response.issues, for: cacheKey, serverURL: serverURL, cachedAt: response.cachedAt)
+            return response
+        } catch {
+            if let cached = offlineCache.load([GitHubIssue].self, for: cacheKey, serverURL: serverURL) {
+                return IssuesResponse(issues: cached.value, fromCache: true, cachedAt: cached.cachedAt)
+            }
+            throw error
+        }
     }
 
     func issueDetail(owner: String, repo: String, number: Int, refresh: Bool = false) async throws -> IssueDetailResponse {
         var path = "/api/v1/issues/\(owner)/\(repo)/\(number)"
         if refresh { path += "?refresh=true" }
-        let (data, _) = try await request(path: path)
-        return try decoder.decode(IssueDetailResponse.self, from: data)
+        let cacheKey = "issue-detail.\(owner).\(repo).\(number)"
+        do {
+            let (data, _) = try await request(path: path)
+            let response = try decoder.decode(IssueDetailResponse.self, from: data)
+            offlineCache.save(response, for: cacheKey, serverURL: serverURL)
+            return response
+        } catch {
+            if let cached = offlineCache.load(IssueDetailResponse.self, for: cacheKey, serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     func pulls(owner: String, repo: String, refresh: Bool = false) async throws -> PullsResponse {
         var path = "/api/v1/pulls/\(owner)/\(repo)"
         if refresh { path += "?refresh=true" }
-        let (data, _) = try await request(path: path)
-        return try decoder.decode(PullsResponse.self, from: data)
+        let cacheKey = "pulls.\(owner).\(repo)"
+        do {
+            let (data, _) = try await request(path: path)
+            let response = try decoder.decode(PullsResponse.self, from: data)
+            offlineCache.save(response.pulls, for: cacheKey, serverURL: serverURL, cachedAt: response.cachedAt)
+            return response
+        } catch {
+            if let cached = offlineCache.load([GitHubPull].self, for: cacheKey, serverURL: serverURL) {
+                return PullsResponse(pulls: cached.value, fromCache: true, cachedAt: cached.cachedAt)
+            }
+            throw error
+        }
     }
 
     func pullDetail(owner: String, repo: String, number: Int, refresh: Bool = false) async throws -> PullDetailResponse {
         var path = "/api/v1/pulls/\(owner)/\(repo)/\(number)"
         if refresh { path += "?refresh=true" }
-        let (data, _) = try await request(path: path)
-        return try decoder.decode(PullDetailResponse.self, from: data)
+        let cacheKey = "pull-detail.\(owner).\(repo).\(number)"
+        do {
+            let (data, _) = try await request(path: path)
+            let response = try decoder.decode(PullDetailResponse.self, from: data)
+            offlineCache.save(response, for: cacheKey, serverURL: serverURL, cachedAt: response.cachedAt)
+            return response
+        } catch {
+            if let cached = offlineCache.load(PullDetailResponse.self, for: cacheKey, serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     func activeDeployments() async throws -> ActiveDeploymentsResponse {
-        let (data, _) = try await request(path: "/api/v1/deployments")
-        return try decoder.decode(ActiveDeploymentsResponse.self, from: data)
+        do {
+            let (data, _) = try await request(path: "/api/v1/deployments")
+            let response = try decoder.decode(ActiveDeploymentsResponse.self, from: data)
+            offlineCache.save(response, for: "deployments", serverURL: serverURL)
+            return response
+        } catch {
+            if let cached = offlineCache.load(ActiveDeploymentsResponse.self, for: "deployments", serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     func launch(owner: String, repo: String, number: Int, body: LaunchRequestBody) async throws -> LaunchResponse {
@@ -193,8 +251,17 @@ final class APIClient {
     // MARK: - Drafts
 
     func listDrafts() async throws -> DraftsResponse {
-        let (data, _) = try await request(path: "/api/v1/drafts")
-        return try decoder.decode(DraftsResponse.self, from: data)
+        do {
+            let (data, _) = try await request(path: "/api/v1/drafts")
+            let response = try decoder.decode(DraftsResponse.self, from: data)
+            offlineCache.save(response, for: "drafts", serverURL: serverURL)
+            return response
+        } catch {
+            if let cached = offlineCache.load(DraftsResponse.self, for: "drafts", serverURL: serverURL) {
+                return cached.value
+            }
+            throw error
+        }
     }
 
     func createDraft(body: CreateDraftRequestBody) async throws -> CreateDraftResponse {

--- a/ios/IssueCTL/Services/NotificationSettingsStore.swift
+++ b/ios/IssueCTL/Services/NotificationSettingsStore.swift
@@ -1,0 +1,78 @@
+import Foundation
+import UIKit
+@preconcurrency import UserNotifications
+
+struct NotificationPreferences: Codable, Equatable, Sendable {
+    var idleTerminals: Bool
+    var newIssues: Bool
+    var mergedPullRequests: Bool
+
+    static let defaults = NotificationPreferences(
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true
+    )
+}
+
+@Observable @MainActor
+final class NotificationSettingsStore {
+    private let defaults: UserDefaults
+    private let defaultsKey = "issuectl.notification-preferences"
+
+    private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    var preferences: NotificationPreferences {
+        didSet {
+            savePreferences()
+        }
+    }
+
+    var hasEnabledNotificationTypes: Bool {
+        preferences.idleTerminals || preferences.newIssues || preferences.mergedPullRequests
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: defaultsKey),
+           let decoded = try? JSONDecoder().decode(NotificationPreferences.self, from: data) {
+            self.preferences = decoded
+        } else {
+            self.preferences = .defaults
+        }
+    }
+
+    func refreshAuthorizationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+    }
+
+    func requestAuthorization() async -> Bool {
+        do {
+            let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+            await refreshAuthorizationStatus()
+            if granted {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+            return granted
+        } catch {
+            await refreshAuthorizationStatus()
+            return false
+        }
+    }
+
+    func setIdleTerminals(_ isEnabled: Bool) {
+        preferences.idleTerminals = isEnabled
+    }
+
+    func setNewIssues(_ isEnabled: Bool) {
+        preferences.newIssues = isEnabled
+    }
+
+    func setMergedPullRequests(_ isEnabled: Bool) {
+        preferences.mergedPullRequests = isEnabled
+    }
+
+    private func savePreferences() {
+        guard let data = try? JSONEncoder().encode(preferences) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+}

--- a/ios/IssueCTL/Services/OfflineCacheStore.swift
+++ b/ios/IssueCTL/Services/OfflineCacheStore.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct OfflineCacheEntry<Value: Codable>: Codable {
+    let value: Value
+    let cachedAt: String
+}
+
+struct OfflineCacheStore {
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func save<Value: Codable>(_ value: Value, for key: String, serverURL: String, cachedAt: String? = nil) {
+        let entry = OfflineCacheEntry(value: value, cachedAt: cachedAt ?? currentTimestamp())
+        guard let data = try? encoder.encode(entry) else { return }
+        defaults.set(data, forKey: storageKey(key, serverURL: serverURL))
+    }
+
+    func load<Value: Codable>(_ type: Value.Type, for key: String, serverURL: String) -> OfflineCacheEntry<Value>? {
+        guard let data = defaults.data(forKey: storageKey(key, serverURL: serverURL)) else { return nil }
+        return try? decoder.decode(OfflineCacheEntry<Value>.self, from: data)
+    }
+
+    func remove(for key: String, serverURL: String) {
+        defaults.removeObject(forKey: storageKey(key, serverURL: serverURL))
+    }
+
+    private func storageKey(_ key: String, serverURL: String) -> String {
+        "issuectl.offline.\(sanitize(serverURL)).\(sanitize(key))"
+    }
+
+    private func sanitize(_ value: String) -> String {
+        value
+            .lowercased()
+            .map { character in
+                character.isLetter || character.isNumber ? character : "_"
+            }
+            .reduce(into: "") { $0.append($1) }
+    }
+
+    private func currentTimestamp() -> String {
+        sharedISO8601Formatter.string(from: Date())
+    }
+}

--- a/ios/IssueCTL/Views/Settings/NotificationSettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/NotificationSettingsView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import UserNotifications
+
+struct NotificationSettingsView: View {
+    @Environment(NotificationSettingsStore.self) private var notificationSettings
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var isRequestingAuthorization = false
+
+    var body: some View {
+        Form {
+            authorizationSection
+
+            Section {
+                Toggle(isOn: Binding(
+                    get: { notificationSettings.preferences.idleTerminals },
+                    set: { notificationSettings.setIdleTerminals($0) }
+                )) {
+                    Label("Idle Terminals", systemImage: "terminal")
+                }
+                .accessibilityIdentifier("notifications-idle-terminals-toggle")
+
+                Toggle(isOn: Binding(
+                    get: { notificationSettings.preferences.newIssues },
+                    set: { notificationSettings.setNewIssues($0) }
+                )) {
+                    Label("New Issues", systemImage: "number")
+                }
+                .accessibilityIdentifier("notifications-new-issues-toggle")
+
+                Toggle(isOn: Binding(
+                    get: { notificationSettings.preferences.mergedPullRequests },
+                    set: { notificationSettings.setMergedPullRequests($0) }
+                )) {
+                    Label("Merged Pull Requests", systemImage: "arrow.triangle.merge")
+                }
+                .accessibilityIdentifier("notifications-merged-prs-toggle")
+            } header: {
+                Text("Notify Me About")
+            } footer: {
+                Text("These preferences control which iOS push categories IssueCTL should register for when notifications are allowed.")
+            }
+        }
+        .navigationTitle("Notifications")
+        .task {
+            await notificationSettings.refreshAuthorizationStatus()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            Task { await notificationSettings.refreshAuthorizationStatus() }
+        }
+    }
+
+    private var authorizationSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Image(systemName: authorizationIcon)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(authorizationTint)
+                    .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(authorizationTitle)
+                        .font(.subheadline.weight(.semibold))
+                    Text(authorizationSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .combine)
+
+            if notificationSettings.authorizationStatus == .notDetermined {
+                Button {
+                    Task { await requestAuthorization() }
+                } label: {
+                    HStack {
+                        Text(isRequestingAuthorization ? "Requesting..." : "Enable Notifications")
+                        Spacer()
+                        if isRequestingAuthorization {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+                }
+                .disabled(isRequestingAuthorization)
+                .accessibilityIdentifier("notifications-enable-button")
+            }
+        }
+    }
+
+    private var authorizationTitle: String {
+        switch notificationSettings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            "Notifications Enabled"
+        case .denied:
+            "Notifications Disabled"
+        case .notDetermined:
+            "Permission Needed"
+        @unknown default:
+            "Notification Status Unknown"
+        }
+    }
+
+    private var authorizationSubtitle: String {
+        switch notificationSettings.authorizationStatus {
+        case .authorized:
+            "IssueCTL can deliver push alerts for enabled categories."
+        case .provisional, .ephemeral:
+            "IssueCTL can deliver quiet notification alerts."
+        case .denied:
+            "Enable notifications in iOS Settings to receive alerts."
+        case .notDetermined:
+            "Allow notifications before server-driven alerts can appear here."
+        @unknown default:
+            "Open iOS Settings if alerts do not arrive."
+        }
+    }
+
+    private var authorizationIcon: String {
+        switch notificationSettings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            "bell.badge.fill"
+        case .denied:
+            "bell.slash.fill"
+        case .notDetermined:
+            "bell"
+        @unknown default:
+            "bell"
+        }
+    }
+
+    private var authorizationTint: Color {
+        switch notificationSettings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            .green
+        case .denied:
+            .red
+        case .notDetermined:
+            IssueCTLColors.action
+        @unknown default:
+            .secondary
+        }
+    }
+
+    private func requestAuthorization() async {
+        isRequestingAuthorization = true
+        _ = await notificationSettings.requestAuthorization()
+        isRequestingAuthorization = false
+    }
+}

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -39,6 +39,8 @@ struct SettingsView: View {
                 switch dest {
                 case .advancedSettings:
                     AdvancedSettingsView()
+                case .notifications:
+                    NotificationSettingsView()
                 case .worktrees:
                     WorktreeListView()
                 }
@@ -176,6 +178,10 @@ struct SettingsView: View {
             NavigationLink(value: SettingsDestination.advancedSettings) {
                 Label("Agent Harness & Defaults", systemImage: "terminal")
             }
+            NavigationLink(value: SettingsDestination.notifications) {
+                Label("Notifications", systemImage: "bell.badge")
+            }
+            .accessibilityIdentifier("settings-notifications-link")
             NavigationLink(value: SettingsDestination.worktrees) {
                 Label("Worktrees", systemImage: "arrow.triangle.branch")
             }
@@ -261,6 +267,7 @@ struct SettingsView: View {
 
 enum SettingsDestination: Hashable {
     case advancedSettings
+    case notifications
     case worktrees
 }
 

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -45,6 +45,43 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertTrue(message.contains("Local Network access"))
     }
 
+    // MARK: - Offline Cache
+
+    func testOfflineCacheStoresValuesPerServer() throws {
+        let suiteName = "issuectl.tests.offline-cache.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let cache = OfflineCacheStore(defaults: defaults)
+        let repo = Repo(id: 1, owner: "org", name: "alpha", localPath: nil, branchPattern: nil, createdAt: "")
+
+        cache.save([repo], for: "repos", serverURL: "http://one.example", cachedAt: "2026-05-01T10:00:00.000Z")
+
+        let cached = try XCTUnwrap(cache.load([Repo].self, for: "repos", serverURL: "http://one.example"))
+        XCTAssertEqual(cached.value.map(\.fullName), ["org/alpha"])
+        XCTAssertEqual(cached.cachedAt, "2026-05-01T10:00:00.000Z")
+        XCTAssertNil(cache.load([Repo].self, for: "repos", serverURL: "http://two.example"))
+    }
+
+    // MARK: - Notification Preferences
+
+    @MainActor
+    func testNotificationPreferencesPersist() throws {
+        let suiteName = "issuectl.tests.notifications.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = NotificationSettingsStore(defaults: defaults)
+
+        store.setIdleTerminals(false)
+        store.setNewIssues(true)
+        store.setMergedPullRequests(false)
+
+        let reloaded = NotificationSettingsStore(defaults: defaults)
+        XCTAssertEqual(
+            reloaded.preferences,
+            NotificationPreferences(idleTerminals: false, newIssues: true, mergedPullRequests: false)
+        )
+    }
+
     // MARK: - Branch Name Generation
 
     func testBasicSlugGeneration() {


### PR DESCRIPTION
## Summary
- add iOS-side offline fallback caching for repos, issues, issue details, PRs, PR details, deployments, drafts, and current user
- add persisted iOS notification preferences for idle terminals, new issues, and merged PRs
- add Settings > Notifications with authorization status, enable flow, and category toggles

Closes #374
Refs #375

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL-Production -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests