### PR TITLE
Add iOS push notification delivery

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		DFD20FE91CC408AA0423C202 /* PRRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75027D57516F296784BEDA4B /* PRRowView.swift */; };
 		E2D468E8711EE284137A31FF /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EBC2D036E0950B774A3A43 /* LaunchView.swift */; };
 		E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
+		E79CA4CB4A4EAC6D5623771D /* PushDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0296223F49033E2D87EA88F /* PushDevice.swift */; };
+		E7AFF7B8A0822FEB2ED1C9DC /* PushDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0296223F49033E2D87EA88F /* PushDevice.swift */; };
 		E807BE283E8635AEE32B9058 /* IssueDetailActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */; };
 		E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */; };
 		EA782E1A1F8C5112A664DAAA /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695C48F5E921940A3CBDA5A /* AppVersion.swift */; };
@@ -271,6 +273,8 @@
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AEDAC9B7D3D9CF86D6381DAE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAccessibleRepo.swift; sourceTree = "<group>"; };
+		B0296223F49033E2D87EA88F /* PushDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushDevice.swift; sourceTree = "<group>"; };
+		B3E09DBD6D633B291650EFBE /* IssueCTL.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueCTL.entitlements; sourceTree = "<group>"; };
 		B7701223E13D43C4F74244B0 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
 		BC00C899D2ADA14475787AE7 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		BC1D044DCA62B13F4196F816 /* SetupLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupLink.swift; sourceTree = "<group>"; };
@@ -422,6 +426,7 @@
 				AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */,
 				80A4F0FF399CC75CAB4F1A1C /* Issue.swift */,
 				FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */,
+				B0296223F49033E2D87EA88F /* PushDevice.swift */,
 				B7701223E13D43C4F74244B0 /* Repo.swift */,
 				BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */,
 			);
@@ -507,6 +512,7 @@
 			isa = PBXGroup;
 			children = (
 				AEDAC9B7D3D9CF86D6381DAE /* Info.plist */,
+				B3E09DBD6D633B291650EFBE /* IssueCTL.entitlements */,
 				19FC5A79EAAEE874C3E00DC4 /* App */,
 				588A6B273EDAC92EB9CC34D7 /* Generated */,
 				ED2CC4AD425EA63DC9DADA90 /* Helpers */,
@@ -832,6 +838,7 @@
 				6BD63A6BA0C7651A5C860A82 /* ParseResultRow.swift in Sources */,
 				327EF2CAB79710212AEE37A6 /* ParseView.swift in Sources */,
 				9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */,
+				E79CA4CB4A4EAC6D5623771D /* PushDevice.swift in Sources */,
 				0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */,
 				435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */,
 				59D20056C3E281403735631D /* Repo.swift in Sources */,
@@ -913,6 +920,7 @@
 				1D5A7B3B1899F179EA4EB9AE /* ParseResultRow.swift in Sources */,
 				581AE97A9F49881B53EF3D39 /* ParseView.swift in Sources */,
 				7A144A11958A6F173128CE49 /* PullRequest.swift in Sources */,
+				E7AFF7B8A0822FEB2ED1C9DC /* PushDevice.swift in Sources */,
 				9D86848D19E2C82D05E7DBC6 /* QuickCreateSheet.swift in Sources */,
 				43E594DAA101C705A5CBF4B6 /* ReassignSheet.swift in Sources */,
 				267E4F891530E9024D710531 /* Repo.swift in Sources */,
@@ -987,7 +995,9 @@
 		0054D3D69C742503141BCA2C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = IssueCTL/IssueCTL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;
@@ -1178,7 +1188,9 @@
 		9A5A01FEE56B7EF3CA31CC62 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = IssueCTL/IssueCTL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;
@@ -1236,7 +1248,9 @@
 		CA1F3322A8D6FCFC5B4D19F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = IssueCTL/IssueCTL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;
@@ -1348,7 +1362,9 @@
 		D9A22A0BB67B1A1A61E5313F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = IssueCTL/IssueCTL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = B3A6AN2HA4;

--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct ContentView: View {
     @Environment(APIClient.self) private var api
     @Environment(NetworkMonitor.self) private var network
+    @Environment(NotificationSettingsStore.self) private var notificationSettings
     @State private var selectedTab: AppTab = .today
     @State private var showSettings = false
 
@@ -66,6 +67,20 @@ struct ContentView: View {
         .onOpenURL { url in
             guard let setup = SetupLink(url: url) else { return }
             try? api.configure(url: setup.serverURL, token: setup.token)
+            Task { await notificationSettings.syncRegistration(apiClient: api) }
+        }
+        .task {
+            await notificationSettings.registerForRemoteNotificationsIfAllowed()
+            await notificationSettings.syncRegistration(apiClient: api)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .apnsDeviceTokenReceived)) { notification in
+            if let error = notification.userInfo?["error"] as? String {
+                notificationSettings.updateRegistrationError(error)
+                return
+            }
+            guard let token = notification.userInfo?["token"] as? String else { return }
+            notificationSettings.updateDeviceToken(token)
+            Task { await notificationSettings.syncRegistration(apiClient: api) }
         }
     }
 }

--- a/ios/IssueCTL/App/IssueCTLApp.swift
+++ b/ios/IssueCTL/App/IssueCTLApp.swift
@@ -1,7 +1,38 @@
 import SwiftUI
+import UIKit
+
+extension Notification.Name {
+    static let apnsDeviceTokenReceived = Notification.Name("issuectl.apnsDeviceTokenReceived")
+}
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        NotificationCenter.default.post(
+            name: .apnsDeviceTokenReceived,
+            object: nil,
+            userInfo: ["token": token]
+        )
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        NotificationCenter.default.post(
+            name: .apnsDeviceTokenReceived,
+            object: nil,
+            userInfo: ["error": error.localizedDescription]
+        )
+    }
+}
 
 @main
 struct IssueCTLApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var apiClient = APIClient()
     @State private var networkMonitor = NetworkMonitor()
     @State private var notificationSettings = NotificationSettingsStore()

--- a/ios/IssueCTL/IssueCTL.entitlements
+++ b/ios/IssueCTL/IssueCTL.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
+</dict>
+</plist>

--- a/ios/IssueCTL/Models/PushDevice.swift
+++ b/ios/IssueCTL/Models/PushDevice.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct PushDeviceRegistrationRequest: Codable, Equatable {
+    let platform: String
+    let token: String
+    let environment: String
+    let enabled: Bool
+    let preferences: NotificationPreferences
+}
+
+struct PushDeviceUnregisterRequest: Codable, Equatable {
+    let platform: String
+    let token: String
+}
+
+struct PushDeviceRegistrationResponse: Codable, Equatable {
+    let success: Bool
+    let device: RegisteredPushDevice
+}
+
+struct RegisteredPushDevice: Codable, Equatable {
+    let id: Int
+    let platform: String
+    let environment: String
+    let preferences: NotificationPreferences
+    let enabled: Bool
+    let lastRegisteredAt: String
+}

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -109,6 +109,18 @@ final class APIClient {
         return try decoder.decode(ServerHealth.self, from: data)
     }
 
+    func registerPushDevice(body: PushDeviceRegistrationRequest) async throws -> PushDeviceRegistrationResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/notifications/devices", method: "POST", body: bodyData)
+        return try decoder.decode(PushDeviceRegistrationResponse.self, from: data)
+    }
+
+    func unregisterPushDevice(token: String) async throws {
+        let body = PushDeviceUnregisterRequest(platform: "ios", token: token)
+        let bodyData = try JSONEncoder().encode(body)
+        _ = try await request(path: "/api/v1/notifications/devices", method: "DELETE", body: bodyData)
+    }
+
     func repos() async throws -> [Repo] {
         do {
             let (data, _) = try await request(path: "/api/v1/repos")

--- a/ios/IssueCTL/Services/NotificationSettingsStore.swift
+++ b/ios/IssueCTL/Services/NotificationSettingsStore.swift
@@ -18,8 +18,13 @@ struct NotificationPreferences: Codable, Equatable, Sendable {
 final class NotificationSettingsStore {
     private let defaults: UserDefaults
     private let defaultsKey = "issuectl.notification-preferences"
+    private let tokenKey = "issuectl.apns-device-token"
 
     private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+    private(set) var deviceToken: String?
+    private(set) var isSyncing = false
+    private(set) var lastSyncError: String?
+    private(set) var lastSyncedAt: Date?
     var preferences: NotificationPreferences {
         didSet {
             savePreferences()
@@ -38,6 +43,7 @@ final class NotificationSettingsStore {
         } else {
             self.preferences = .defaults
         }
+        self.deviceToken = defaults.string(forKey: tokenKey)
     }
 
     func refreshAuthorizationStatus() async {
@@ -59,6 +65,52 @@ final class NotificationSettingsStore {
         }
     }
 
+    func updateDeviceToken(_ token: String) {
+        deviceToken = token
+        defaults.set(token, forKey: tokenKey)
+        lastSyncError = nil
+    }
+
+    func updateRegistrationError(_ message: String) {
+        lastSyncError = message
+    }
+
+    func syncRegistration(apiClient: APIClient) async {
+        guard apiClient.isConfigured else { return }
+        guard let deviceToken else { return }
+
+        isSyncing = true
+        lastSyncError = nil
+        defer { isSyncing = false }
+
+        await refreshAuthorizationStatus()
+        let enabled = hasEnabledNotificationTypes && canReceiveNotifications
+
+        do {
+            if enabled {
+                let body = PushDeviceRegistrationRequest(
+                    platform: "ios",
+                    token: deviceToken,
+                    environment: apnsEnvironment,
+                    enabled: true,
+                    preferences: preferences
+                )
+                _ = try await apiClient.registerPushDevice(body: body)
+            } else {
+                try await apiClient.unregisterPushDevice(token: deviceToken)
+            }
+            lastSyncedAt = Date()
+        } catch {
+            lastSyncError = error.localizedDescription
+        }
+    }
+
+    func registerForRemoteNotificationsIfAllowed() async {
+        await refreshAuthorizationStatus()
+        guard canReceiveNotifications else { return }
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+
     func setIdleTerminals(_ isEnabled: Bool) {
         preferences.idleTerminals = isEnabled
     }
@@ -74,5 +126,24 @@ final class NotificationSettingsStore {
     private func savePreferences() {
         guard let data = try? JSONEncoder().encode(preferences) else { return }
         defaults.set(data, forKey: defaultsKey)
+    }
+
+    private var canReceiveNotifications: Bool {
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            true
+        case .denied, .notDetermined:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    private var apnsEnvironment: String {
+        #if DEBUG
+        return "development"
+        #else
+        return "production"
+        #endif
     }
 }

--- a/ios/IssueCTL/Views/Settings/NotificationSettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/NotificationSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UserNotifications
 
 struct NotificationSettingsView: View {
+    @Environment(APIClient.self) private var api
     @Environment(NotificationSettingsStore.self) private var notificationSettings
     @Environment(\.scenePhase) private var scenePhase
     @State private var isRequestingAuthorization = false
@@ -13,7 +14,10 @@ struct NotificationSettingsView: View {
             Section {
                 Toggle(isOn: Binding(
                     get: { notificationSettings.preferences.idleTerminals },
-                    set: { notificationSettings.setIdleTerminals($0) }
+                    set: {
+                        notificationSettings.setIdleTerminals($0)
+                        Task { await notificationSettings.syncRegistration(apiClient: api) }
+                    }
                 )) {
                     Label("Idle Terminals", systemImage: "terminal")
                 }
@@ -21,7 +25,10 @@ struct NotificationSettingsView: View {
 
                 Toggle(isOn: Binding(
                     get: { notificationSettings.preferences.newIssues },
-                    set: { notificationSettings.setNewIssues($0) }
+                    set: {
+                        notificationSettings.setNewIssues($0)
+                        Task { await notificationSettings.syncRegistration(apiClient: api) }
+                    }
                 )) {
                     Label("New Issues", systemImage: "number")
                 }
@@ -29,7 +36,10 @@ struct NotificationSettingsView: View {
 
                 Toggle(isOn: Binding(
                     get: { notificationSettings.preferences.mergedPullRequests },
-                    set: { notificationSettings.setMergedPullRequests($0) }
+                    set: {
+                        notificationSettings.setMergedPullRequests($0)
+                        Task { await notificationSettings.syncRegistration(apiClient: api) }
+                    }
                 )) {
                     Label("Merged Pull Requests", systemImage: "arrow.triangle.merge")
                 }
@@ -43,10 +53,12 @@ struct NotificationSettingsView: View {
         .navigationTitle("Notifications")
         .task {
             await notificationSettings.refreshAuthorizationStatus()
+            await notificationSettings.syncRegistration(apiClient: api)
         }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active else { return }
             Task { await notificationSettings.refreshAuthorizationStatus() }
+            Task { await notificationSettings.syncRegistration(apiClient: api) }
         }
     }
 
@@ -83,6 +95,21 @@ struct NotificationSettingsView: View {
                 }
                 .disabled(isRequestingAuthorization)
                 .accessibilityIdentifier("notifications-enable-button")
+            }
+
+            if notificationSettings.isSyncing {
+                HStack {
+                    Text("Syncing with server")
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else if let lastSyncError = notificationSettings.lastSyncError {
+                Text(lastSyncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
             }
         }
     }
@@ -144,6 +171,7 @@ struct NotificationSettingsView: View {
     private func requestAuthorization() async {
         isRequestingAuthorization = true
         _ = await notificationSettings.requestAuthorization()
+        await notificationSettings.syncRegistration(apiClient: api)
         isRequestingAuthorization = false
     }
 }

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -82,6 +82,33 @@ final class ViewLogicTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testNotificationDeviceTokenPersists() throws {
+        let suiteName = "issuectl.tests.notification-token.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = NotificationSettingsStore(defaults: defaults)
+
+        store.updateDeviceToken("abcdef123456")
+
+        let reloaded = NotificationSettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.deviceToken, "abcdef123456")
+    }
+
+    @MainActor
+    func testNotificationRegistrationErrorIsRecordedAndClearedByToken() throws {
+        let suiteName = "issuectl.tests.notification-error.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = NotificationSettingsStore(defaults: defaults)
+
+        store.updateRegistrationError("registration failed")
+        XCTAssertEqual(store.lastSyncError, "registration failed")
+
+        store.updateDeviceToken("abcdef123456")
+        XCTAssertNil(store.lastSyncError)
+    }
+
     // MARK: - Branch Name Generation
 
     func testBasicSlugGeneration() {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -45,8 +45,15 @@ targets:
         ISSUECTL_KEYCHAIN_SERVICE: com.issuectl.ios
         ISSUECTL_URL_SCHEME: issuectl
         ISSUECTL_LOCAL_NETWORK_USAGE_DESCRIPTION: IssueCTL connects to the issuectl server running on your Mac.
+        CODE_SIGN_ENTITLEMENTS: IssueCTL/IssueCTL.entitlements
+        APS_ENVIRONMENT: development
         DEVELOPMENT_TEAM: B3A6AN2HA4
         CODE_SIGN_STYLE: Automatic
+      configs:
+        Debug:
+          APS_ENVIRONMENT: development
+        Release:
+          APS_ENVIRONMENT: production
     preBuildScripts:
       - name: Generate AppVersion.swift
         basedOnDependencyAnalysis: false
@@ -113,8 +120,15 @@ targets:
         ISSUECTL_KEYCHAIN_SERVICE: com.issuectl.ios.preview
         ISSUECTL_URL_SCHEME: issuectl-preview
         ISSUECTL_LOCAL_NETWORK_USAGE_DESCRIPTION: IssueCTL Preview connects to the issuectl server running on your Mac.
+        CODE_SIGN_ENTITLEMENTS: IssueCTL/IssueCTL.entitlements
+        APS_ENVIRONMENT: development
         DEVELOPMENT_TEAM: B3A6AN2HA4
         CODE_SIGN_STYLE: Automatic
+      configs:
+        Debug:
+          APS_ENVIRONMENT: development
+        Release:
+          APS_ENVIRONMENT: production
     preBuildScripts:
       - name: Generate AppVersion.swift
         basedOnDependencyAnalysis: false

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -268,6 +268,31 @@ const migrations: Migration[] = [
       );
     },
   },
+  {
+    version: 14,
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS push_devices (
+          id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+          platform                TEXT NOT NULL CHECK (platform IN ('ios')),
+          token                   TEXT NOT NULL,
+          environment             TEXT NOT NULL DEFAULT 'production'
+                                  CHECK (environment IN ('development', 'production')),
+          idle_terminals          INTEGER NOT NULL DEFAULT 1 CHECK (idle_terminals IN (0, 1)),
+          new_issues              INTEGER NOT NULL DEFAULT 1 CHECK (new_issues IN (0, 1)),
+          merged_pull_requests    INTEGER NOT NULL DEFAULT 1 CHECK (merged_pull_requests IN (0, 1)),
+          enabled                 INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+          last_registered_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at              TEXT NOT NULL DEFAULT (datetime('now')),
+          UNIQUE(platform, token)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_push_devices_enabled
+          ON push_devices(enabled);
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/push-devices.test.ts
+++ b/packages/core/src/db/push-devices.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { createTestDb } from "./test-helpers.js";
+import {
+  deletePushDevice,
+  disablePushDevice,
+  listPushDevicesForKind,
+  upsertPushDevice,
+} from "./push-devices.js";
+
+const token = "a".repeat(64);
+
+describe("push devices", () => {
+  it("upserts an iOS device and preferences", () => {
+    const db = createTestDb();
+
+    const device = upsertPushDevice(db, {
+      platform: "ios",
+      token,
+      environment: "development",
+      preferences: {
+        idleTerminals: true,
+        newIssues: false,
+        mergedPullRequests: true,
+      },
+    });
+
+    expect(device.platform).toBe("ios");
+    expect(device.environment).toBe("development");
+    expect(device.preferences).toEqual({
+      idleTerminals: true,
+      newIssues: false,
+      mergedPullRequests: true,
+    });
+
+    const updated = upsertPushDevice(db, {
+      platform: "ios",
+      token,
+      environment: "production",
+      preferences: {
+        idleTerminals: false,
+        newIssues: true,
+        mergedPullRequests: false,
+      },
+    });
+
+    expect(updated.id).toBe(device.id);
+    expect(updated.environment).toBe("production");
+    expect(updated.preferences.newIssues).toBe(true);
+  });
+
+  it("lists only enabled devices that opted into a notification kind", () => {
+    const db = createTestDb();
+    upsertPushDevice(db, {
+      platform: "ios",
+      token,
+      environment: "production",
+      preferences: {
+        idleTerminals: true,
+        newIssues: false,
+        mergedPullRequests: false,
+      },
+    });
+    upsertPushDevice(db, {
+      platform: "ios",
+      token: "b".repeat(64),
+      environment: "production",
+      enabled: false,
+      preferences: {
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true,
+      },
+    });
+
+    expect(listPushDevicesForKind(db, "idleTerminals").map((d) => d.token)).toEqual([token]);
+    expect(listPushDevicesForKind(db, "newIssues")).toEqual([]);
+  });
+
+  it("can disable or delete a device", () => {
+    const db = createTestDb();
+    upsertPushDevice(db, {
+      platform: "ios",
+      token,
+      environment: "production",
+      preferences: {
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true,
+      },
+    });
+
+    expect(disablePushDevice(db, "ios", token)).toBe(true);
+    expect(listPushDevicesForKind(db, "idleTerminals")).toEqual([]);
+    expect(deletePushDevice(db, "ios", token)).toBe(true);
+  });
+});

--- a/packages/core/src/db/push-devices.ts
+++ b/packages/core/src/db/push-devices.ts
@@ -1,0 +1,144 @@
+import type Database from "better-sqlite3";
+import type {
+  PushDevice,
+  PushDeviceEnvironment,
+  PushDevicePlatform,
+  PushNotificationKind,
+  PushNotificationPreferences,
+} from "../types.js";
+
+type PushDeviceRow = {
+  id: number;
+  platform: string;
+  token: string;
+  environment: string;
+  idle_terminals: number;
+  new_issues: number;
+  merged_pull_requests: number;
+  enabled: number;
+  last_registered_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PushDeviceInput = {
+  platform: PushDevicePlatform;
+  token: string;
+  environment: PushDeviceEnvironment;
+  preferences: PushNotificationPreferences;
+  enabled?: boolean;
+};
+
+function rowToPushDevice(row: PushDeviceRow): PushDevice {
+  return {
+    id: row.id,
+    platform: row.platform as PushDevicePlatform,
+    token: row.token,
+    environment: row.environment as PushDeviceEnvironment,
+    preferences: {
+      idleTerminals: row.idle_terminals === 1,
+      newIssues: row.new_issues === 1,
+      mergedPullRequests: row.merged_pull_requests === 1,
+    },
+    enabled: row.enabled === 1,
+    lastRegisteredAt: row.last_registered_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function upsertPushDevice(
+  db: Database.Database,
+  input: PushDeviceInput,
+): PushDevice {
+  db.prepare(
+    `INSERT INTO push_devices (
+       platform, token, environment, idle_terminals, new_issues,
+       merged_pull_requests, enabled, last_registered_at, updated_at
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+     ON CONFLICT(platform, token) DO UPDATE SET
+       environment = excluded.environment,
+       idle_terminals = excluded.idle_terminals,
+       new_issues = excluded.new_issues,
+       merged_pull_requests = excluded.merged_pull_requests,
+       enabled = excluded.enabled,
+       last_registered_at = datetime('now'),
+       updated_at = datetime('now')`,
+  ).run(
+    input.platform,
+    input.token,
+    input.environment,
+    input.preferences.idleTerminals ? 1 : 0,
+    input.preferences.newIssues ? 1 : 0,
+    input.preferences.mergedPullRequests ? 1 : 0,
+    input.enabled === false ? 0 : 1,
+  );
+
+  const device = getPushDevice(db, input.platform, input.token);
+  if (!device) throw new Error("Failed to read back push device after upsert");
+  return device;
+}
+
+export function getPushDevice(
+  db: Database.Database,
+  platform: PushDevicePlatform,
+  token: string,
+): PushDevice | undefined {
+  const row = db
+    .prepare("SELECT * FROM push_devices WHERE platform = ? AND token = ?")
+    .get(platform, token) as PushDeviceRow | undefined;
+  return row ? rowToPushDevice(row) : undefined;
+}
+
+export function disablePushDevice(
+  db: Database.Database,
+  platform: PushDevicePlatform,
+  token: string,
+): boolean {
+  const result = db
+    .prepare(
+      `UPDATE push_devices
+       SET enabled = 0, updated_at = datetime('now')
+       WHERE platform = ? AND token = ?`,
+    )
+    .run(platform, token);
+  return result.changes > 0;
+}
+
+export function deletePushDevice(
+  db: Database.Database,
+  platform: PushDevicePlatform,
+  token: string,
+): boolean {
+  const result = db
+    .prepare("DELETE FROM push_devices WHERE platform = ? AND token = ?")
+    .run(platform, token);
+  return result.changes > 0;
+}
+
+export function listPushDevicesForKind(
+  db: Database.Database,
+  kind: PushNotificationKind,
+): PushDevice[] {
+  const column = {
+    idleTerminals: "idle_terminals",
+    newIssues: "new_issues",
+    mergedPullRequests: "merged_pull_requests",
+  }[kind];
+  const rows = db
+    .prepare(
+      `SELECT * FROM push_devices
+       WHERE enabled = 1 AND ${column} = 1
+       ORDER BY last_registered_at DESC`,
+    )
+    .all() as PushDeviceRow[];
+  return rows.map(rowToPushDevice);
+}
+
+export function listPushDevices(db: Database.Database): PushDevice[] {
+  const rows = db
+    .prepare("SELECT * FROM push_devices ORDER BY updated_at DESC")
+    .all() as PushDeviceRow[];
+  return rows.map(rowToPushDevice);
+}

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -28,21 +28,22 @@ describe("initSchema", () => {
       "drafts",
       "github_accessible_repos",
       "issue_metadata",
+      "push_devices",
       "repos",
       "schema_version",
       "settings",
     ]);
   });
 
-  it("sets schema_version to 13", () => {
+  it("sets schema_version to 14", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
   });
 });
 
@@ -59,7 +60,7 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
   });
 
   it("migrates v1 schema through v9 and drops claude_aliases", () => {
@@ -75,7 +76,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -99,7 +100,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -142,7 +143,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -161,7 +162,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
   it("initSchema on a fresh DB produces schema version 9", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -237,7 +238,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -325,7 +326,7 @@ describe("schema v8 — deployments FK cascade", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
 
     // Pre-existing row should have been copied over with its state intact
     const row = db
@@ -408,7 +409,7 @@ describe("schema v9 — live deployment unique index", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     // Row id=1 (older duplicate) → ended. id=2 (most recent live) → live.
     // id=3 (historic ended) → still ended, untouched.
     const live = db
@@ -560,7 +561,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
       runMigrations(db);
     }).not.toThrow();
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
 
     // Verify the dedupe ran and the index now exists.
     const live = db
@@ -590,7 +591,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
 
   it("v10 migration creates github_accessible_repos with expected columns", () => {
     const db = createTestDb();
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
 
     const cols = db
       .prepare("PRAGMA table_info(github_accessible_repos)")
@@ -605,7 +606,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
     expect(pkCols).toEqual(["name", "owner"]);
   });
 
-  it("v12 to v13 migration adds deployment agent and default settings", () => {
+  it("v12 to v14 migration adds deployment agent, default settings, and push devices", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE schema_version (version INTEGER NOT NULL);
@@ -641,7 +642,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(13);
+    expect(getSchemaVersion(db)).toBe(14);
     const deployment = db
       .prepare("SELECT agent FROM deployments WHERE id = 1")
       .get() as { agent: string };
@@ -657,5 +658,9 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
     expect(() =>
       db.prepare("UPDATE deployments SET agent = 'unknown' WHERE id = 1").run(),
     ).toThrow();
+    const pushDeviceCols = db
+      .prepare("PRAGMA table_info(push_devices)")
+      .all() as { name: string }[];
+    expect(pushDeviceCols.map((c) => c.name)).toContain("merged_pull_requests");
   });
 });

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 13;
+const SCHEMA_VERSION = 14;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -83,6 +83,25 @@ const CREATE_TABLES = `
     synced_at  INTEGER NOT NULL,
     PRIMARY KEY (owner, name)
   );
+
+  CREATE TABLE IF NOT EXISTS push_devices (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform                TEXT NOT NULL CHECK (platform IN ('ios')),
+    token                   TEXT NOT NULL,
+    environment             TEXT NOT NULL DEFAULT 'production'
+                            CHECK (environment IN ('development', 'production')),
+    idle_terminals          INTEGER NOT NULL DEFAULT 1 CHECK (idle_terminals IN (0, 1)),
+    new_issues              INTEGER NOT NULL DEFAULT 1 CHECK (new_issues IN (0, 1)),
+    merged_pull_requests    INTEGER NOT NULL DEFAULT 1 CHECK (merged_pull_requests IN (0, 1)),
+    enabled                 INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    last_registered_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(platform, token)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_push_devices_enabled
+    ON push_devices(enabled);
 
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,11 @@ export type {
   DraftListItem,
   IssueListItem,
   UnifiedList,
+  PushDevice,
+  PushDeviceEnvironment,
+  PushDevicePlatform,
+  PushNotificationKind,
+  PushNotificationPreferences,
 } from "./types.js";
 export { SORT_MODES } from "./types.js";
 
@@ -94,6 +99,15 @@ export {
   isValidNonce,
   DuplicateInFlightError,
 } from "./db/idempotency.js";
+export {
+  upsertPushDevice,
+  getPushDevice,
+  disablePushDevice,
+  deletePushDevice,
+  listPushDevices,
+  listPushDevicesForKind,
+  type PushDeviceInput,
+} from "./db/push-devices.js";
 // GitHub client
 export type {
   GitHubUser,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -122,3 +122,29 @@ export type UnifiedList = {
   running: IssueListItem[];
   closed: IssueListItem[];
 };
+
+export type PushNotificationKind =
+  | "idleTerminals"
+  | "newIssues"
+  | "mergedPullRequests";
+
+export type PushNotificationPreferences = {
+  idleTerminals: boolean;
+  newIssues: boolean;
+  mergedPullRequests: boolean;
+};
+
+export type PushDeviceEnvironment = "development" | "production";
+export type PushDevicePlatform = "ios";
+
+export type PushDevice = {
+  id: number;
+  platform: PushDevicePlatform;
+  token: string;
+  environment: PushDeviceEnvironment;
+  preferences: PushNotificationPreferences;
+  enabled: boolean;
+  lastRegisteredAt: string;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/issues/[owner]/[repo]/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
-import { getDb, getRepo, getIssues, withAuthRetry } from "@issuectl/core";
+import { notifyNewIssue } from "@/lib/push/notifications";
+import {
+  getCached,
+  getDb,
+  getRepo,
+  getIssues,
+  withAuthRetry,
+  type GitHubIssue,
+} from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
@@ -20,9 +28,24 @@ export async function GET(
     }
 
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
+    const previousIssues = forceRefresh
+      ? getCached<GitHubIssue[]>(db, `issues:${owner}/${repo}`)?.data
+      : undefined;
     const result = await withAuthRetry((octokit) =>
       getIssues(db, octokit, owner, repo, { forceRefresh }),
     );
+    if (forceRefresh && previousIssues && !result.fromCache) {
+      const previousNumbers = new Set(previousIssues.map((issue) => issue.number));
+      for (const issue of result.issues) {
+        if (previousNumbers.has(issue.number)) continue;
+        notifyNewIssue({
+          owner,
+          repo,
+          issueNumber: issue.number,
+          title: issue.title,
+        });
+      }
+    }
     return NextResponse.json(result);
   } catch (err) {
     console.error(`[issuectl] GET /api/v1/issues/${owner}/${repo} failed:`, err);

--- a/packages/web/app/api/v1/notifications/devices/route.test.ts
+++ b/packages/web/app/api/v1/notifications/devices/route.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const upsertPushDevice = vi.hoisted(() => vi.fn());
+const disablePushDevice = vi.hoisted(() => vi.fn());
+const deletePushDevice = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  upsertPushDevice: (...args: unknown[]) => upsertPushDevice(...args),
+  disablePushDevice: (...args: unknown[]) => disablePushDevice(...args),
+  deletePushDevice: (...args: unknown[]) => deletePushDevice(...args),
+  formatErrorForUser: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+import { DELETE, POST } from "./route";
+
+const token = "a".repeat(64);
+
+function request(method: string, body: unknown, url = "http://localhost/api/v1/notifications/devices") {
+  return new NextRequest(url, {
+    method,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  getDb.mockReset();
+  upsertPushDevice.mockReset();
+  disablePushDevice.mockReset();
+  deletePushDevice.mockReset();
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue({});
+  upsertPushDevice.mockReturnValue({
+    id: 1,
+    platform: "ios",
+    token,
+    environment: "development",
+    preferences: {
+      idleTerminals: true,
+      newIssues: false,
+      mergedPullRequests: true,
+    },
+    enabled: true,
+    lastRegisteredAt: "2026-05-03T00:00:00Z",
+  });
+});
+
+describe("/api/v1/notifications/devices", () => {
+  it("registers an iOS APNs token with preferences", async () => {
+    const response = await POST(request("POST", {
+      platform: "ios",
+      token: token.toUpperCase(),
+      environment: "development",
+      preferences: {
+        idleTerminals: true,
+        newIssues: false,
+        mergedPullRequests: true,
+      },
+    }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(upsertPushDevice).toHaveBeenCalledWith(expect.anything(), {
+      platform: "ios",
+      token,
+      environment: "development",
+      enabled: true,
+      preferences: {
+        idleTerminals: true,
+        newIssues: false,
+        mergedPullRequests: true,
+      },
+    });
+  });
+
+  it("rejects malformed tokens", async () => {
+    const response = await POST(request("POST", {
+      platform: "ios",
+      token: "not-a-token",
+      preferences: {
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true,
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(upsertPushDevice).not.toHaveBeenCalled();
+  });
+
+  it("rejects odd-length hex tokens", async () => {
+    const response = await POST(request("POST", {
+      platform: "ios",
+      token: `${"a".repeat(64)}b`,
+      preferences: {
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true,
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(upsertPushDevice).not.toHaveBeenCalled();
+  });
+
+  it("disables devices by default on DELETE", async () => {
+    disablePushDevice.mockReturnValue(true);
+
+    const response = await DELETE(request("DELETE", {
+      platform: "ios",
+      token,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(disablePushDevice).toHaveBeenCalledWith(expect.anything(), "ios", token);
+    expect(deletePushDevice).not.toHaveBeenCalled();
+  });
+
+  it("validates tokens on DELETE", async () => {
+    const response = await DELETE(request("DELETE", {
+      platform: "ios",
+      token: "not-a-token",
+    }));
+
+    expect(response.status).toBe(400);
+    expect(disablePushDevice).not.toHaveBeenCalled();
+  });
+
+  it("honors auth denials", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await POST(request("POST", {
+      platform: "ios",
+      token,
+      preferences: {
+        idleTerminals: true,
+        newIssues: true,
+        mergedPullRequests: true,
+      },
+    }));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/packages/web/app/api/v1/notifications/devices/route.ts
+++ b/packages/web/app/api/v1/notifications/devices/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  deletePushDevice,
+  disablePushDevice,
+  formatErrorForUser,
+  getDb,
+  upsertPushDevice,
+  type PushDeviceEnvironment,
+  type PushNotificationPreferences,
+} from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type DeviceBody = {
+  platform?: unknown;
+  token?: unknown;
+  environment?: unknown;
+  enabled?: unknown;
+  preferences?: Partial<Record<keyof PushNotificationPreferences, unknown>>;
+};
+
+function parseBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${name} must be a boolean`);
+  }
+  return value;
+}
+
+function parseToken(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length < 32 ||
+    value.length % 2 !== 0 ||
+    !/^[0-9a-fA-F]+$/.test(value)
+  ) {
+    throw new Error("token must be an even-length APNs token hex string");
+  }
+  return value.toLowerCase();
+}
+
+function parseBody(body: DeviceBody): {
+  platform: "ios";
+  token: string;
+  environment: PushDeviceEnvironment;
+  enabled: boolean;
+  preferences: PushNotificationPreferences;
+} {
+  if (body.platform !== "ios") {
+    throw new Error("platform must be ios");
+  }
+  const environment = body.environment ?? "production";
+  if (environment !== "development" && environment !== "production") {
+    throw new Error("environment must be development or production");
+  }
+  const preferences = body.preferences;
+  if (!preferences || typeof preferences !== "object") {
+    throw new Error("preferences are required");
+  }
+
+  return {
+    platform: "ios",
+    token: parseToken(body.token),
+    environment,
+    enabled: body.enabled === undefined ? true : parseBoolean(body.enabled, "enabled"),
+    preferences: {
+      idleTerminals: parseBoolean(preferences.idleTerminals, "preferences.idleTerminals"),
+      newIssues: parseBoolean(preferences.newIssues, "preferences.newIssues"),
+      mergedPullRequests: parseBoolean(
+        preferences.mergedPullRequests,
+        "preferences.mergedPullRequests",
+      ),
+    },
+  };
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let parsed;
+  try {
+    parsed = parseBody(await request.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const device = upsertPushDevice(db, parsed);
+    log.info({
+      msg: "push_device_registered",
+      platform: device.platform,
+      environment: device.environment,
+      enabled: device.enabled,
+    });
+    return NextResponse.json({
+      success: true,
+      device: {
+        id: device.id,
+        platform: device.platform,
+        environment: device.environment,
+        preferences: device.preferences,
+        enabled: device.enabled,
+        lastRegisteredAt: device.lastRegisteredAt,
+      },
+    });
+  } catch (err) {
+    log.error({ err, msg: "push_device_register_failed" });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  let body: DeviceBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (body.platform !== "ios") {
+    return NextResponse.json({ error: "platform must be ios" }, { status: 400 });
+  }
+  let token: string;
+  try {
+    token = parseToken(body.token);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Invalid token" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const db = getDb();
+    const removed = request.nextUrl.searchParams.get("hard") === "true"
+      ? deletePushDevice(db, "ios", token)
+      : disablePushDevice(db, "ios", token);
+    return NextResponse.json({ success: true, removed });
+  } catch (err) {
+    log.error({ err, msg: "push_device_delete_failed" });
+    return NextResponse.json(
+      { success: false, error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/merge/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/merge/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
+import { notifyMergedPullRequest } from "@/lib/push/notifications";
 import {
   getDb,
   getRepo,
@@ -62,6 +63,12 @@ export async function POST(
 
     clearCacheKey(db, `pull-detail:${owner}/${repo}#${pullNumber}`);
     clearCacheKey(db, `pulls-open:${owner}/${repo}`);
+    notifyMergedPullRequest({
+      owner,
+      repo,
+      pullNumber,
+      sha: result.sha,
+    });
 
     return NextResponse.json({ success: true, sha: result.sha });
   } catch (err) {

--- a/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/pulls/[owner]/[repo]/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
-import { getDb, getRepo, getPulls, getPullsWithChecks, withAuthRetry } from "@issuectl/core";
+import { notifyMergedPullRequest } from "@/lib/push/notifications";
+import {
+  getCached,
+  getDb,
+  getRepo,
+  getPulls,
+  getPullsWithChecks,
+  withAuthRetry,
+  type GitHubPull,
+} from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +30,12 @@ export async function GET(
 
     const forceRefresh = request.nextUrl.searchParams.get("refresh") === "true";
     const includeChecks = request.nextUrl.searchParams.get("checks") !== "false";
+    const cacheKey = includeChecks
+      ? `pulls-with-checks:${owner}/${repo}`
+      : `pulls-open:${owner}/${repo}`;
+    const previousPulls = forceRefresh
+      ? getCached<GitHubPull[]>(db, cacheKey)?.data
+      : undefined;
 
     const result = includeChecks
       ? await withAuthRetry((octokit) =>
@@ -29,6 +44,36 @@ export async function GET(
       : await withAuthRetry((octokit) =>
           getPulls(db, octokit, owner, repo, { forceRefresh }),
         );
+    if (forceRefresh && previousPulls && !result.fromCache) {
+      const openNumbers = new Set(result.pulls.map((pull) => pull.number));
+      const missing = previousPulls.filter((pull) => !openNumbers.has(pull.number));
+      if (missing.length > 0) {
+        await withAuthRetry(async (octokit) => {
+          await Promise.all(missing.slice(0, 10).map(async (pull) => {
+            try {
+              const response = await octokit.pulls.get({
+                owner,
+                repo,
+                pull_number: pull.number,
+              });
+              if (response.data.merged_at) {
+                notifyMergedPullRequest({
+                  owner,
+                  repo,
+                  pullNumber: pull.number,
+                  sha: response.data.merge_commit_sha ?? undefined,
+                });
+              }
+            } catch (err) {
+              console.warn(
+                `[issuectl] Failed to inspect disappeared PR ${owner}/${repo}#${pull.number}:`,
+                err,
+              );
+            }
+          }));
+        });
+      }
+    }
     return NextResponse.json(result);
   } catch (err) {
     console.error(`[issuectl] GET /api/v1/pulls/${owner}/${repo} failed:`, err);

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -20,6 +20,7 @@ import {
   type ReassignResult,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
+import { notifyNewIssue } from "@/lib/push/notifications";
 
 const MAX_TITLE = 256;
 const MAX_BODY = 65536;
@@ -76,6 +77,12 @@ export async function createIssue(data: {
       ? await withIdempotency(db, "create-issue", idempotencyKey, runCreate)
       : await runCreate();
     issueNumber = result.number;
+    notifyNewIssue({
+      owner,
+      repo,
+      issueNumber,
+      title: title.trim(),
+    });
     try {
       setSetting(db, "default_repo_id", String(trackedRepo.id));
     } catch (err) {

--- a/packages/web/lib/actions/parse.ts
+++ b/packages/web/lib/actions/parse.ts
@@ -21,6 +21,7 @@ import type {
   BatchCreateResult,
 } from "@issuectl/core";
 import { revalidateSafely } from "@/lib/revalidate";
+import { notifyNewIssue } from "@/lib/push/notifications";
 
 // Parse input is a free-form prompt that gets piped to the Claude CLI;
 // cost and latency are proportional to token count and the content is
@@ -191,6 +192,12 @@ export async function batchCreateIssues(
         );
 
         clearCacheKey(db, `issues:${issue.owner}/${issue.repo}`);
+        notifyNewIssue({
+          owner: issue.owner,
+          repo: issue.repo,
+          issueNumber: created.number,
+          title: issue.title.trim(),
+        });
 
         return {
           id: issue.id,

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -1,6 +1,7 @@
 import {
   getDb,
   getActiveDeploymentByPort,
+  getRepoById,
   getActiveDeployments,
   endDeployment,
   isTmuxSessionAlive,
@@ -11,6 +12,7 @@ import {
 } from "@issuectl/core";
 import { getRegisteredPorts, getLastPtyOutput } from "./idle-registry";
 import log from "./logger";
+import { notifyIdleTerminal } from "./push/notifications";
 
 const DEFAULT_GRACE_SECONDS = 300;
 const DEFAULT_THRESHOLD_SECONDS = 300;
@@ -57,6 +59,15 @@ export function checkIdleDeployments(): void {
 
       if (isIdle && !deployment.idleSince) {
         setIdleSince(db, deployment.id);
+        const repo = getRepoById(db, deployment.repoId);
+        if (repo) {
+          notifyIdleTerminal({
+            owner: repo.owner,
+            repo: repo.name,
+            issueNumber: deployment.issueNumber,
+            deploymentId: deployment.id,
+          });
+        }
         log.info({
           msg: "idle_detected",
           port,

--- a/packages/web/lib/push/apns.ts
+++ b/packages/web/lib/push/apns.ts
@@ -1,0 +1,155 @@
+import { createPrivateKey, sign } from "node:crypto";
+import { connect } from "node:http2";
+import type { PushDevice } from "@issuectl/core";
+
+export type ApnsPayload = {
+  aps: {
+    alert: {
+      title: string;
+      body: string;
+    };
+    sound?: string;
+  };
+  type: string;
+  url?: string;
+  [key: string]: unknown;
+};
+
+export type ApnsSendResult =
+  | { status: "sent"; token: string }
+  | { status: "skipped"; token: string; reason: string }
+  | { status: "failed"; token: string; reason: string; statusCode?: number };
+
+type ApnsConfig = {
+  teamId: string;
+  keyId: string;
+  bundleId: string;
+  privateKey: string;
+};
+
+const APNS_TIMEOUT_MS = 10_000;
+
+function readConfig(): ApnsConfig | undefined {
+  const teamId = process.env.ISSUECTL_APNS_TEAM_ID;
+  const keyId = process.env.ISSUECTL_APNS_KEY_ID;
+  const bundleId = process.env.ISSUECTL_APNS_BUNDLE_ID;
+  const privateKey = process.env.ISSUECTL_APNS_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  if (!teamId || !keyId || !bundleId || !privateKey) return undefined;
+  return { teamId, keyId, bundleId, privateKey };
+}
+
+function base64Url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function createJwt(config: ApnsConfig): string {
+  const header = base64Url(JSON.stringify({ alg: "ES256", kid: config.keyId }));
+  const claims = base64Url(JSON.stringify({
+    iss: config.teamId,
+    iat: Math.floor(Date.now() / 1000),
+  }));
+  const signingInput = `${header}.${claims}`;
+  const signature = sign(
+    "sha256",
+    Buffer.from(signingInput),
+    {
+      key: createPrivateKey(config.privateKey),
+      dsaEncoding: "ieee-p1363",
+    },
+  );
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+export async function sendApnsNotification(
+  device: PushDevice,
+  payload: ApnsPayload,
+): Promise<ApnsSendResult> {
+  const config = readConfig();
+  if (!config) {
+    return {
+      status: "skipped",
+      token: device.token,
+      reason: "APNs credentials are not configured",
+    };
+  }
+
+  let jwt: string;
+  try {
+    jwt = createJwt(config);
+  } catch (err) {
+    return {
+      status: "failed",
+      token: device.token,
+      reason: err instanceof Error ? err.message : "Failed to create APNs JWT",
+    };
+  }
+
+  const host = device.environment === "development"
+    ? "https://api.sandbox.push.apple.com"
+    : "https://api.push.apple.com";
+  const client = connect(host);
+
+  return await new Promise<ApnsSendResult>((resolve) => {
+    let settled = false;
+    const finish = (result: ApnsSendResult) => {
+      if (settled) return;
+      settled = true;
+      client.close();
+      resolve(result);
+    };
+
+    client.on("error", (err) => {
+      finish({ status: "failed", token: device.token, reason: err.message });
+    });
+
+    const request = client.request({
+      ":method": "POST",
+      ":path": `/3/device/${device.token}`,
+      authorization: `bearer ${jwt}`,
+      "apns-topic": config.bundleId,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+      "content-type": "application/json",
+    });
+
+    let responseBody = "";
+    let statusCode = 0;
+
+    request.setEncoding("utf8");
+    request.on("response", (headers) => {
+      statusCode = Number(headers[":status"] ?? 0);
+    });
+    request.on("data", (chunk) => {
+      responseBody += chunk;
+    });
+    request.on("end", () => {
+      if (statusCode >= 200 && statusCode < 300) {
+        finish({ status: "sent", token: device.token });
+        return;
+      }
+      finish({
+        status: "failed",
+        token: device.token,
+        statusCode,
+        reason: responseBody || `APNs returned ${statusCode}`,
+      });
+    });
+    request.on("error", (err) => {
+      finish({ status: "failed", token: device.token, reason: err.message });
+    });
+    request.setTimeout(APNS_TIMEOUT_MS, () => {
+      request.close();
+      finish({
+        status: "failed",
+        token: device.token,
+        reason: `APNs request timed out after ${APNS_TIMEOUT_MS}ms`,
+      });
+    });
+
+    request.end(JSON.stringify(payload));
+  });
+}

--- a/packages/web/lib/push/notifications.ts
+++ b/packages/web/lib/push/notifications.ts
@@ -1,0 +1,113 @@
+import {
+  deletePushDevice,
+  getDb,
+  listPushDevicesForKind,
+  type PushNotificationKind,
+} from "@issuectl/core";
+import log from "@/lib/logger";
+import { sendApnsNotification, type ApnsPayload } from "./apns";
+
+type PushEvent = {
+  kind: PushNotificationKind;
+  title: string;
+  body: string;
+  url?: string;
+  data?: Record<string, unknown>;
+};
+
+export async function notifyDevices(event: PushEvent): Promise<void> {
+  let devices;
+  try {
+    devices = listPushDevicesForKind(getDb(), event.kind);
+  } catch (err) {
+    log.error({ err, msg: "push_device_query_failed", kind: event.kind });
+    return;
+  }
+
+  if (devices.length === 0) return;
+
+  const payload: ApnsPayload = {
+    aps: {
+      alert: {
+        title: event.title,
+        body: event.body,
+      },
+      sound: "default",
+    },
+    type: event.kind,
+    ...(event.url ? { url: event.url } : {}),
+    ...(event.data ?? {}),
+  };
+
+  await Promise.all(devices.map(async (device) => {
+    const result = await sendApnsNotification(device, payload);
+    if (result.status === "sent") {
+      log.info({ msg: "push_notification_sent", kind: event.kind, platform: device.platform });
+      return;
+    }
+
+    log[result.status === "skipped" ? "debug" : "warn"]({
+      msg: "push_notification_not_sent",
+      kind: event.kind,
+      platform: device.platform,
+      result,
+    });
+
+    if (
+      result.status === "failed" &&
+      (result.statusCode === 400 || result.statusCode === 410) &&
+      /BadDeviceToken|Unregistered|DeviceTokenNotForTopic/.test(result.reason)
+    ) {
+      try {
+        deletePushDevice(getDb(), device.platform, device.token);
+      } catch (err) {
+        log.error({ err, msg: "push_device_delete_invalid_failed" });
+      }
+    }
+  }));
+}
+
+export function notifyIdleTerminal(input: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  deploymentId: number;
+}): void {
+  void notifyDevices({
+    kind: "idleTerminals",
+    title: "Terminal idle",
+    body: `${input.owner}/${input.repo} #${input.issueNumber} has gone idle.`,
+    url: `/issues/${input.owner}/${input.repo}/${input.issueNumber}`,
+    data: input,
+  });
+}
+
+export function notifyNewIssue(input: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  title: string;
+}): void {
+  void notifyDevices({
+    kind: "newIssues",
+    title: "New issue",
+    body: `${input.owner}/${input.repo} #${input.issueNumber}: ${input.title}`,
+    url: `/issues/${input.owner}/${input.repo}/${input.issueNumber}`,
+    data: input,
+  });
+}
+
+export function notifyMergedPullRequest(input: {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  sha?: string;
+}): void {
+  void notifyDevices({
+    kind: "mergedPullRequests",
+    title: "Pull request merged",
+    body: `${input.owner}/${input.repo} #${input.pullNumber} was merged.`,
+    url: `/pulls/${input.owner}/${input.repo}/${input.pullNumber}`,
+    data: input,
+  });
+}


### PR DESCRIPTION
## Summary
- add backend push device persistence, registration API, and APNs HTTP/2 sender
- wire notification triggers for idle terminals, new issues, and merged PRs, including refresh-discovered events
- capture and sync iOS APNs tokens/preferences, add push entitlements, and surface registration errors

## Verification
- pnpm --filter @issuectl/core test -- src/db/push-devices.test.ts src/db/schema.test.ts
- pnpm --filter @issuectl/web test -- app/api/v1/notifications/devices/route.test.ts
- pnpm --filter @issuectl/core typecheck
- pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/core lint (existing warnings only)
- pnpm --filter @issuectl/web lint (existing warnings only)
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL-Production -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests\n\n## Notes\n- Real APNs delivery requires ISSUECTL_APNS_TEAM_ID, ISSUECTL_APNS_KEY_ID, ISSUECTL_APNS_BUNDLE_ID, ISSUECTL_APNS_PRIVATE_KEY and a physical-device smoke test.\n\nCloses #375