### PR TITLE
Validate merge queue token path

### DIFF
--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -7,6 +7,8 @@ IssueCTL has two installable iOS app variants:
 
 The preview app is intended for development, physical-device smoke tests, and feature validation without overwriting the production app on the same iPhone.
 
+Merge queue validation should use the preview lane when a PR needs iOS smoke coverage before landing.
+
 ## App Lanes
 
 Use `IssueCTL Preview` as the active development lane. It is the app to run from feature branches, local simulator testing, and physical-device smoke tests.


### PR DESCRIPTION
## Summary
- add a tiny docs-only change to validate the new token-backed merge queue enqueue path

## Validation
- git diff --check -- docs/ios-preview-testing.md

This PR is intentionally small so we can confirm auto-merge enqueues with MERGE_QUEUE_TOKEN and dispatches merge_group checks without manual requeue.