### PR TITLE
feat: add iOS session terminal previews

### DIFF
--- a/ios/IssueCTL/Models/Deployment.swift
+++ b/ios/IssueCTL/Models/Deployment.swift
@@ -110,6 +110,65 @@ struct ActiveDeploymentsResponse: Codable, Sendable {
     let deployments: [ActiveDeployment]
 }
 
+enum SessionPreviewStatus: String, Codable, Sendable {
+    case active
+    case idle
+    case error
+    case unavailable
+
+    var displayName: String {
+        switch self {
+        case .active:
+            return "Active"
+        case .idle:
+            return "Idle"
+        case .error:
+            return "Error"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+
+    var accessibilityName: String {
+        switch self {
+        case .active:
+            return "active"
+        case .idle:
+            return "idle"
+        case .error:
+            return "error"
+        case .unavailable:
+            return "preview unavailable"
+        }
+    }
+}
+
+struct SessionPreview: Codable, Sendable {
+    let lines: [String]
+    let lastUpdatedMs: Int
+    let lastChangedMs: Int?
+    let status: SessionPreviewStatus
+
+    var latestLine: String? {
+        lines.last
+    }
+
+    var lastUpdatedDate: Date {
+        Date(timeIntervalSince1970: TimeInterval(lastUpdatedMs) / 1000)
+    }
+}
+
+struct SessionPreviewsResponse: Codable, Sendable {
+    let previews: [String: SessionPreview]
+
+    var previewsByPort: [Int: SessionPreview] {
+        Dictionary(uniqueKeysWithValues: previews.compactMap { key, value in
+            guard let port = Int(key) else { return nil }
+            return (port, value)
+        })
+    }
+}
+
 struct LaunchRequestBody: Encodable, Sendable {
     let agent: LaunchAgent
     let branchName: String

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -217,6 +217,11 @@ final class APIClient {
         }
     }
 
+    func sessionPreviews() async throws -> SessionPreviewsResponse {
+        let (data, _) = try await request(path: "/api/v1/sessions/previews")
+        return try decoder.decode(SessionPreviewsResponse.self, from: data)
+    }
+
     func launch(owner: String, repo: String, number: Int, body: LaunchRequestBody) async throws -> LaunchResponse {
         let bodyData = try JSONEncoder().encode(body)
         let (data, _) = try await request(path: "/api/v1/launch/\(owner)/\(repo)/\(number)", method: "POST", body: bodyData)

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -2,12 +2,16 @@ import SwiftUI
 
 struct SessionListView: View {
     @Environment(APIClient.self) private var api
+    @Environment(\.scenePhase) private var scenePhase
     let onShowSettings: () -> Void
     let onShowIssues: () -> Void
 
     @State private var repos: [Repo] = []
     @State private var deployments: [ActiveDeployment] = []
+    @State private var previews: [Int: SessionPreview] = [:]
+    @State private var expandedPorts: Set<Int> = []
     @State private var isLoading = true
+    @State private var isFetchingPreviews = false
     @State private var errorMessage: String?
     @State private var actionError: String?
     @State private var terminalPresentation: TerminalPresentation?
@@ -72,7 +76,7 @@ struct SessionListView: View {
                             Text(sessionErrorDescription(errorMessage))
                         } actions: {
                             HStack {
-                                Button("Retry") { Task { await load(refresh: true) } }
+                                Button("Retry") { Task { await refreshSessions() } }
                                 Button("Open Settings", action: onShowSettings)
                             }
                         }
@@ -84,7 +88,7 @@ struct SessionListView: View {
                         } actions: {
                             HStack {
                                 Button("Open Issues", action: onShowIssues)
-                                Button("Refresh") { Task { await load(refresh: true) } }
+                                Button("Refresh") { Task { await refreshSessions() } }
                             }
                         }
                     } else {
@@ -116,9 +120,17 @@ struct SessionListView: View {
                                 }
 
                                 ForEach(filteredDeployments) { deployment in
+                                    let port = deployment.ttydPort
                                     SessionRowView(
                                         deployment: deployment,
+                                        preview: port.flatMap { previews[$0] },
+                                        isPreviewExpanded: port.map { expandedPorts.contains($0) } ?? false,
                                         isEnding: endingDeploymentId == deployment.id,
+                                        onTogglePreview: {
+                                            if let port {
+                                                togglePreview(port)
+                                            }
+                                        },
                                         onOpen: {
                                             openTerminal(deployment)
                                         },
@@ -131,7 +143,7 @@ struct SessionListView: View {
                             .padding(.horizontal, 16)
                             .padding(.top, 16)
                         }
-                        .refreshable { await load(refresh: true) }
+                        .refreshable { await refreshSessions() }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -140,6 +152,9 @@ struct SessionListView: View {
                 IssueDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
             .task { await load() }
+            .task(id: scenePhase) {
+                await pollPreviews()
+            }
             .onReceive(refreshTimer) { _ in
                 Task { await load() }
             }
@@ -213,7 +228,7 @@ struct SessionListView: View {
                     systemImage: "arrow.clockwise",
                     accessibilityIdentifier: "sessions-refresh-button"
                 ) {
-                    Task { await load(refresh: true) }
+                    Task { await refreshSessions() }
                 }
 
                 TopBarIconButton(
@@ -288,6 +303,17 @@ struct SessionListView: View {
         guard deployment.ttydPort != nil else { return }
         terminalPresentation = TerminalPresentation(deployment: deployment)
     }
+
+    private func togglePreview(_ port: Int) {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
+            if expandedPorts.contains(port) {
+                expandedPorts.remove(port)
+            } else {
+                expandedPorts.insert(port)
+            }
+        }
+    }
+
     private func load(refresh: Bool = false) async {
         if deployments.isEmpty { isLoading = true }
         errorMessage = nil
@@ -300,6 +326,7 @@ struct SessionListView: View {
             }()
             let response = try await deploymentsResult
             deployments = response.deployments
+            prunePreviewState()
             switch await reposResult {
             case .success(let loadedRepos):
                 repos = loadedRepos
@@ -316,6 +343,49 @@ struct SessionListView: View {
         isLoading = false
     }
 
+    private func fetchPreviews() async {
+        guard !isFetchingPreviews else { return }
+        guard !deployments.isEmpty else {
+            previews = [:]
+            expandedPorts = []
+            return
+        }
+        isFetchingPreviews = true
+        defer { isFetchingPreviews = false }
+        do {
+            let response = try await api.sessionPreviews()
+            previews = response.previewsByPort
+            prunePreviewState()
+        } catch {
+            // Preview data is supplementary; keep the session list usable if
+            // the endpoint is temporarily unavailable.
+        }
+    }
+
+    private func pollPreviews() async {
+        guard scenePhase == .active else { return }
+        while !Task.isCancelled {
+            if deployments.isEmpty {
+                previews = [:]
+                expandedPorts = []
+            } else {
+                await fetchPreviews()
+            }
+            try? await Task.sleep(for: .seconds(2))
+        }
+    }
+
+    private func refreshSessions() async {
+        await load(refresh: true)
+        await fetchPreviews()
+    }
+
+    private func prunePreviewState() {
+        let ports = Set(deployments.compactMap(\.ttydPort))
+        previews = previews.filter { ports.contains($0.key) }
+        expandedPorts = expandedPorts.intersection(ports)
+    }
+
     private func endSession(_ deployment: ActiveDeployment) async {
         endingDeploymentId = deployment.id
         do {
@@ -326,6 +396,10 @@ struct SessionListView: View {
                 issueNumber: deployment.issueNumber
             )
             deployments.removeAll { $0.id == deployment.id }
+            if let port = deployment.ttydPort {
+                previews.removeValue(forKey: port)
+                expandedPorts.remove(port)
+            }
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 struct SessionRowView: View {
     let deployment: ActiveDeployment
+    var preview: SessionPreview?
+    var isPreviewExpanded = false
     var isEnding = false
+    var onTogglePreview: () -> Void = {}
     var onOpen: () -> Void = {}
     var onControls: () -> Void = {}
 
@@ -42,6 +45,14 @@ struct SessionRowView: View {
                 }
             }
 
+            SessionPreviewBlock(
+                preview: preview,
+                isExpanded: isPreviewExpanded,
+                isTerminalReady: deployment.ttydPort != nil,
+                accessibilityIdentifier: "session-preview-\(deployment.id)",
+                onToggle: onTogglePreview
+            )
+
             HStack(spacing: 8) {
                 Button(action: onOpen) {
                     Label(deployment.ttydPort == nil ? "Starting..." : "Open Terminal", systemImage: "terminal")
@@ -72,13 +83,28 @@ struct SessionRowView: View {
         .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18))
         .overlay {
             RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.green.opacity(0.22), lineWidth: 1)
+                .stroke(previewBorderColor.opacity(0.34), lineWidth: 1)
         }
         .contentShape(Rectangle())
         .onTapGesture {
             if deployment.ttydPort != nil {
                 onOpen()
             }
+        }
+    }
+
+    private var previewBorderColor: Color {
+        switch preview?.status {
+        case .active:
+            Color.green
+        case .idle:
+            Color.orange
+        case .error:
+            Color.red
+        case .unavailable:
+            Color.secondary
+        case nil:
+            Color.green
         }
     }
 
@@ -100,5 +126,145 @@ struct SessionRowView: View {
         .padding(9)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct SessionPreviewBlock: View {
+    let preview: SessionPreview?
+    let isExpanded: Bool
+    let isTerminalReady: Bool
+    let accessibilityIdentifier: String
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 8, height: 8)
+
+                    Text(statusBadgeText)
+                        .font(.caption2.bold())
+                        .foregroundStyle(statusColor)
+                        .lineLimit(1)
+
+                    Text(summaryText)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(summaryColor)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text(freshnessText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.tertiary)
+                }
+
+                if isExpanded {
+                    VStack(alignment: .leading, spacing: 3) {
+                        ForEach(expandedLines.indices, id: \.self) { index in
+                            Text(expandedLines[index])
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(lineColor(expandedLines[index]))
+                                .lineLimit(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.black.opacity(0.88), in: RoundedRectangle(cornerRadius: 10))
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .padding(10)
+            .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isTerminalReady)
+        .accessibilityLabel("Session preview")
+        .accessibilityValue("\(statusAccessibilityText), \(summaryText)")
+        .accessibilityHint(isExpanded ? "Collapses terminal preview" : "Expands terminal preview")
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var expandedLines: [String] {
+        let lines = preview?.lines ?? []
+        if lines.isEmpty {
+            return [summaryText]
+        }
+        return Array(lines.suffix(6))
+    }
+
+    private var summaryText: String {
+        guard isTerminalReady else { return "Terminal starting" }
+        guard let preview else { return "Waiting for preview" }
+        if let latestLine = preview.latestLine, !latestLine.isEmpty {
+            return latestLine
+        }
+        switch preview.status {
+        case .active:
+            return "Session active"
+        case .idle:
+            return "No recent output"
+        case .error:
+            return "Review terminal output"
+        case .unavailable:
+            return "Preview unavailable"
+        }
+    }
+
+    private var freshnessText: String {
+        guard let preview else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: preview.lastUpdatedDate, relativeTo: Date())
+    }
+
+    private var statusColor: Color {
+        switch preview?.status {
+        case .active:
+            Color.green
+        case .idle:
+            Color.orange
+        case .error:
+            Color.red
+        case .unavailable:
+            Color.secondary
+        case nil:
+            isTerminalReady ? Color.secondary : Color.orange
+        }
+    }
+
+    private var statusAccessibilityText: String {
+        guard isTerminalReady else { return "terminal starting" }
+        return preview?.status.accessibilityName ?? "waiting for preview"
+    }
+
+    private var statusBadgeText: String {
+        guard isTerminalReady else { return "Starting" }
+        return preview?.status.displayName ?? "Preview"
+    }
+
+    private var summaryColor: Color {
+        preview?.status == .error ? .red : .secondary
+    }
+
+    private func lineColor(_ line: String) -> Color {
+        let lowercased = line.lowercased()
+        if lowercased.contains("error") || lowercased.contains("failed") || lowercased.contains("fatal") {
+            return .red
+        }
+        if lowercased.contains("pass") || lowercased.contains("success") {
+            return .green
+        }
+        if lowercased.contains("warn") {
+            return .yellow
+        }
+        return .white.opacity(0.92)
     }
 }

--- a/ios/IssueCTLTests/APIClientTests.swift
+++ b/ios/IssueCTLTests/APIClientTests.swift
@@ -108,6 +108,11 @@ final class TestableAPIClient {
         return try decoder.decode(ActiveDeploymentsResponse.self, from: data)
     }
 
+    func sessionPreviews() async throws -> SessionPreviewsResponse {
+        let (data, _) = try await request(path: "/api/v1/sessions/previews")
+        return try decoder.decode(SessionPreviewsResponse.self, from: data)
+    }
+
     private struct ErrorBody: Codable {
         let error: String
     }
@@ -274,6 +279,21 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.activeDeployments()
+    }
+
+    @MainActor
+    func testSessionPreviewsEndpointURL() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/sessions/previews"))
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {"previews": {}}
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        _ = try await client.sessionPreviews()
     }
 
     // MARK: - Successful Responses

--- a/ios/IssueCTLTests/ModelDecodingTests.swift
+++ b/ios/IssueCTLTests/ModelDecodingTests.swift
@@ -648,6 +648,37 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.deployments[0].repoFullName, "org/app")
     }
 
+    func testSessionPreviewsResponseDecoding() throws {
+        let json = """
+        {
+            "previews": {
+                "7700": {
+                    "lines": ["pnpm test", "pass"],
+                    "lastUpdatedMs": 1777800000000,
+                    "lastChangedMs": 1777799999000,
+                    "status": "active"
+                },
+                "7701": {
+                    "lines": [],
+                    "lastUpdatedMs": 1777800001000,
+                    "lastChangedMs": null,
+                    "status": "unavailable"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(SessionPreviewsResponse.self, from: json)
+        XCTAssertEqual(response.previews.count, 2)
+        XCTAssertEqual(response.previewsByPort[7700]?.latestLine, "pass")
+        XCTAssertEqual(response.previewsByPort[7700]?.status, .active)
+        XCTAssertEqual(response.previewsByPort[7700]?.status.displayName, "Active")
+        XCTAssertEqual(response.previewsByPort[7700]?.status.accessibilityName, "active")
+        XCTAssertEqual(response.previewsByPort[7701]?.status, .unavailable)
+        XCTAssertEqual(response.previewsByPort[7701]?.status.displayName, "Unavailable")
+        XCTAssertEqual(response.previewsByPort[7701]?.status.accessibilityName, "preview unavailable")
+    }
+
     // MARK: - GitHubAccessibleRepo
 
     func testGitHubAccessibleRepoDecoding() throws {

--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -221,6 +221,9 @@ final class MockIssueCTLServer: @unchecked Sendable {
             }
             body = ["deployments": activeDeployments]
 
+        case ("GET", "/api/v1/sessions/previews"):
+            body = ["previews": sessionPreviews()]
+
         case ("POST", "/api/v1/deployments/9001/end"):
             activeDeployments.removeAll { $0["id"] as? Int == 9001 }
             body = ["success": true]
@@ -568,6 +571,24 @@ final class MockIssueCTLServer: @unchecked Sendable {
             return []
         }
         return activeDeployments.filter { $0["issue_number"] as? Int == issueNumber }
+    }
+
+    func sessionPreviews() -> [String: Any] {
+        var previews: [String: Any] = [:]
+        for deployment in activeDeployments {
+            guard let port = deployment["ttyd_port"] as? Int else { continue }
+            let issueNumber = deployment["issue_number"] as? Int ?? 0
+            previews[String(port)] = [
+                "lines": [
+                    "issue #\(issueNumber): running checks",
+                    issueNumber == 101 ? "pass: launch handoff" : "waiting for agent output",
+                ],
+                "lastUpdatedMs": 1_777_800_000_000,
+                "lastChangedMs": 1_777_799_999_000,
+                "status": issueNumber == 101 ? "active" : "idle",
+            ]
+        }
+        return previews
     }
 
     // MARK: - Mutation helpers

--- a/ios/IssueCTLUITests/SessionManagementTests.swift
+++ b/ios/IssueCTLUITests/SessionManagementTests.swift
@@ -36,4 +36,34 @@ final class SessionManagementTests: XCTestCase {
         // Session should disappear from the list.
         waitForNonexistence("session-reenter-terminal-9001", in: app, timeout: 8)
     }
+
+    @MainActor
+    func testSessionCardShowsExpandableTerminalPreview() {
+        server.seedActiveDeployment()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
+        assertElement("session-preview-9001", existsIn: app, timeout: 5)
+        let preview = element("session-preview-9001", in: app)
+
+        XCTAssertTrue(
+            app.staticTexts["pass: launch handoff"].waitForExistence(timeout: 5),
+            "Collapsed session preview did not show latest output\n\(app.debugDescription)"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Active"].waitForExistence(timeout: 3),
+            "Session preview did not show a visible active status badge\n\(app.debugDescription)"
+        )
+        XCTAssertTrue(
+            String(describing: preview.value ?? "").contains("pass: launch handoff"),
+            "Session preview accessibility value did not include latest output"
+        )
+
+        preview.tap()
+        XCTAssertTrue(
+            app.staticTexts["issue #101: running checks"].waitForExistence(timeout: 3),
+            "Expanded session preview did not show captured terminal lines\n\(app.debugDescription)"
+        )
+    }
 }

--- a/packages/web/app/api/v1/sessions/previews/route.test.ts
+++ b/packages/web/app/api/v1/sessions/previews/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const getActiveDeployments = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getActiveDeployments: (...args: unknown[]) => getActiveDeployments(...args),
+}));
+
+const getSessionPreviews = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/session-previews", () => ({
+  getSessionPreviews: (...args: unknown[]) => getSessionPreviews(...args),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/v1/sessions/previews");
+}
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getDb.mockReset();
+  getActiveDeployments.mockReset();
+  getSessionPreviews.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue({ db: true });
+  getActiveDeployments.mockReturnValue([{ id: 1, ttydPort: 7700 }]);
+  getSessionPreviews.mockResolvedValue({
+    "7700": {
+      lines: ["pnpm test", "pass"],
+      lastUpdatedMs: 1_000,
+      lastChangedMs: 1_000,
+      status: "active",
+    },
+  });
+});
+
+describe("/api/v1/sessions/previews", () => {
+  it("returns previews for active deployments", async () => {
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getDb).toHaveBeenCalledOnce();
+    expect(getActiveDeployments).toHaveBeenCalledWith({ db: true });
+    expect(getSessionPreviews).toHaveBeenCalledWith([{ id: 1, ttydPort: 7700 }]);
+    expect(json).toEqual({
+      previews: {
+        "7700": {
+          lines: ["pnpm test", "pass"],
+          lastUpdatedMs: 1_000,
+          lastChangedMs: 1_000,
+          status: "active",
+        },
+      },
+    });
+  });
+
+  it("returns the auth denial without touching the database", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getDb).not.toHaveBeenCalled();
+    expect(getSessionPreviews).not.toHaveBeenCalled();
+  });
+
+  it("returns a 500 when preview loading fails", async () => {
+    getSessionPreviews.mockRejectedValueOnce(new Error("tmux failed"));
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(json).toEqual({ error: "Internal server error" });
+    expect(loggerError).toHaveBeenCalledWith({
+      err: expect.any(Error),
+      msg: "api_session_previews_failed",
+    });
+  });
+});

--- a/packages/web/app/api/v1/sessions/previews/route.ts
+++ b/packages/web/app/api/v1/sessions/previews/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getActiveDeployments, getDb } from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { getSessionPreviews } from "@/lib/session-previews";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const db = getDb();
+    const deployments = getActiveDeployments(db);
+    const previews = await getSessionPreviews(deployments);
+    return NextResponse.json({ previews });
+  } catch (err) {
+    log.error({ err, msg: "api_session_previews_failed" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/lib/session-previews.test.ts
+++ b/packages/web/lib/session-previews.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+import {
+  derivePreviewStatus,
+  getSessionPreviews,
+  normalizeCapturedPane,
+  resetSessionPreviewCache,
+} from "./session-previews";
+import type { ActiveDeploymentWithRepo } from "@issuectl/core";
+
+function deployment(port: number | null = 7700, issueNumber = 42): ActiveDeploymentWithRepo {
+  return {
+    id: issueNumber,
+    repoId: 1,
+    issueNumber,
+    agent: "codex",
+    branchName: "issue-42-preview",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/worktree",
+    linkedPrNumber: null,
+    state: "active",
+    launchedAt: "2026-05-03T00:00:00Z",
+    endedAt: null,
+    ttydPort: port,
+    ttydPid: 123,
+    idleSince: null,
+    owner: "org",
+    repoName: "api",
+  };
+}
+
+describe("session-previews", () => {
+  beforeEach(() => {
+    resetSessionPreviewCache();
+    execFileMock.mockReset();
+  });
+
+  it("normalizes captured pane text into the last non-empty preview lines", () => {
+    const output = "one\r\n\u001b[31mtwo\u001b[0m\n\nthree   \n";
+    expect(normalizeCapturedPane(output)).toEqual(["one", "two", "three"]);
+  });
+
+  it("strips OSC and single-character terminal escape sequences", () => {
+    const output = "\u001b]0;issuectl terminal\u0007ready\u001b(B\n\u001b]2;tab title\u001b\\done\n";
+    expect(normalizeCapturedPane(output)).toEqual(["ready", "done"]);
+  });
+
+  it("truncates very long preview lines", () => {
+    const [line] = normalizeCapturedPane(`${"x".repeat(260)}\n`);
+    expect(line).toHaveLength(240);
+    expect(line.endsWith("...")).toBe(true);
+  });
+
+  it("marks recent changed output as active", () => {
+    expect(derivePreviewStatus(["running tests"], 10_000, 12_000)).toBe("active");
+  });
+
+  it("marks old changed output as idle", () => {
+    expect(derivePreviewStatus(["waiting"], 10_000, 45_000)).toBe("idle");
+  });
+
+  it("marks empty captured output as idle", () => {
+    expect(derivePreviewStatus([], 10_000, 12_000)).toBe("idle");
+  });
+
+  it("marks error output as error", () => {
+    expect(derivePreviewStatus(["Error: failed to build"], 10_000, 45_000)).toBe("error");
+  });
+
+  it("captures tmux panes for deployments with ports", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, callback) => {
+      callback(null, "pnpm test\npass\n", "");
+    });
+
+    const previews = await getSessionPreviews([deployment()], 1_000);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      "tmux",
+      ["capture-pane", "-p", "-t", "issuectl-api-42", "-S", "-40"],
+      { timeout: 750, maxBuffer: 64 * 1024 },
+      expect.any(Function),
+    );
+    expect(previews["7700"]).toEqual({
+      lines: ["pnpm test", "pass"],
+      lastUpdatedMs: 1_000,
+      lastChangedMs: 1_000,
+      status: "active",
+    });
+  });
+
+  it("returns unavailable when tmux capture fails without a cache entry", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, callback) => {
+      callback(new Error("missing session"));
+    });
+
+    await expect(getSessionPreviews([deployment()], 1_000)).resolves.toEqual({
+      "7700": {
+        lines: [],
+        lastUpdatedMs: 1_000,
+        lastChangedMs: null,
+        status: "unavailable",
+      },
+    });
+  });
+
+  it("returns stale cached lines as unavailable when a later capture fails", async () => {
+    execFileMock.mockImplementationOnce((_bin, _args, _opts, callback) => {
+      callback(null, "first\n", "");
+    });
+    await getSessionPreviews([deployment()], 1_000);
+
+    execFileMock.mockImplementationOnce((_bin, _args, _opts, callback) => {
+      callback(new Error("timeout"));
+    });
+
+    await expect(getSessionPreviews([deployment()], 2_000)).resolves.toEqual({
+      "7700": {
+        lines: ["first"],
+        lastUpdatedMs: 2_000,
+        lastChangedMs: 1_000,
+        status: "unavailable",
+      },
+    });
+  });
+
+  it("skips deployments without a ttyd port", async () => {
+    const previews = await getSessionPreviews([deployment(null)], 1_000);
+    expect(previews).toEqual({});
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds concurrent tmux captures", async () => {
+    let active = 0;
+    let peakActive = 0;
+    const callbacks: Array<() => void> = [];
+    execFileMock.mockImplementation((_bin, _args, _opts, callback) => {
+      active += 1;
+      peakActive = Math.max(peakActive, active);
+      callbacks.push(() => {
+        active -= 1;
+        callback(null, "ready\n", "");
+      });
+    });
+
+    const promise = getSessionPreviews(
+      Array.from({ length: 10 }, (_, index) => deployment(7700 + index, 100 + index)),
+      1_000,
+    );
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(6));
+    expect(peakActive).toBe(6);
+
+    while (callbacks.length > 0) {
+      callbacks.shift()?.();
+      await Promise.resolve();
+    }
+
+    const previews = await promise;
+    expect(Object.keys(previews)).toHaveLength(10);
+    expect(peakActive).toBe(6);
+  });
+
+  it("reuses a short-lived aggregate preview response cache", async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, callback) => {
+      callback(null, "cached\n", "");
+    });
+
+    const first = await getSessionPreviews([deployment()], 1_000);
+    const second = await getSessionPreviews([deployment()], 1_500);
+    const third = await getSessionPreviews([deployment()], 2_100);
+
+    expect(first).toEqual(second);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(third["7700"].lastUpdatedMs).toBe(2_100);
+  });
+
+  it("coalesces simultaneous aggregate preview requests while capture is in flight", async () => {
+    const callbacks: Array<() => void> = [];
+    execFileMock.mockImplementation((_bin, _args, _opts, callback) => {
+      callbacks.push(() => callback(null, "in flight\n", ""));
+    });
+
+    const first = getSessionPreviews([deployment()], 1_000);
+    const second = getSessionPreviews([deployment()], 1_000);
+
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(1));
+    callbacks.shift()?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        "7700": {
+          lines: ["in flight"],
+          lastUpdatedMs: 1_000,
+          lastChangedMs: 1_000,
+          status: "active",
+        },
+      },
+      {
+        "7700": {
+          lines: ["in flight"],
+          lastUpdatedMs: 1_000,
+          lastChangedMs: 1_000,
+          status: "active",
+        },
+      },
+    ]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse the aggregate cache when a port is reused by another session", async () => {
+    execFileMock
+      .mockImplementationOnce((_bin, _args, _opts, callback) => {
+        callback(null, "first session\n", "");
+      })
+      .mockImplementationOnce((_bin, _args, _opts, callback) => {
+        callback(null, "second session\n", "");
+      });
+
+    const first = await getSessionPreviews([deployment(7700, 42)], 1_000);
+    const second = await getSessionPreviews([deployment(7700, 43)], 1_500);
+
+    expect(first["7700"].lines).toEqual(["first session"]);
+    expect(second["7700"].lines).toEqual(["second session"]);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not return stale per-port cached lines when a reused port capture fails", async () => {
+    execFileMock
+      .mockImplementationOnce((_bin, _args, _opts, callback) => {
+        callback(null, "old session\n", "");
+      })
+      .mockImplementationOnce((_bin, _args, _opts, callback) => {
+        callback(new Error("new session not ready"));
+      });
+
+    await getSessionPreviews([deployment(7700, 42)], 1_000);
+    const second = await getSessionPreviews([deployment(7700, 43)], 1_500);
+
+    expect(second["7700"]).toEqual({
+      lines: [],
+      lastUpdatedMs: 1_500,
+      lastChangedMs: null,
+      status: "unavailable",
+    });
+  });
+});

--- a/packages/web/lib/session-previews.ts
+++ b/packages/web/lib/session-previews.ts
@@ -1,0 +1,283 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { tmuxSessionName, type ActiveDeploymentWithRepo } from "@issuectl/core";
+
+const CAPTURE_HISTORY_LINES = 40;
+const PREVIEW_LINES = 20;
+const PREVIEW_LINE_MAX_CHARS = 240;
+const TMUX_CAPTURE_TIMEOUT_MS = 750;
+const MAX_CAPTURE_CONCURRENCY = 6;
+const RESPONSE_CACHE_TTL_MS = 1_000;
+const ACTIVE_WINDOW_MS = 5_000;
+const IDLE_WINDOW_MS = 30_000;
+const ESC = String.fromCharCode(27);
+const ANSI_SEQUENCE_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+const OSC_SEQUENCE_RE = new RegExp(`${ESC}\\][^\\u0007]*(?:\\u0007|${ESC}\\\\)`, "g");
+const SINGLE_CHAR_ESCAPE_RE = new RegExp(`${ESC}[ -/]*[@-~]`, "g");
+
+export type SessionPreviewStatus = "active" | "idle" | "error" | "unavailable";
+
+export interface SessionPreview {
+  lines: string[];
+  lastUpdatedMs: number;
+  lastChangedMs: number | null;
+  status: SessionPreviewStatus;
+}
+
+interface PreviewCacheEntry {
+  readonly port: number;
+  readonly sessionName: string;
+  lines: string[];
+  hash: string;
+  lastUpdatedMs: number;
+  lastChangedMs: number | null;
+  status: SessionPreviewStatus;
+}
+
+const previewCache = new Map<number, PreviewCacheEntry>();
+let responseCache:
+  | { activeSessionsKey: string; generatedAtMs: number; previews: Record<string, SessionPreview> }
+  | undefined;
+let responseInFlight:
+  | { activeSessionsKey: string; promise: Promise<Record<string, SessionPreview>> }
+  | undefined;
+
+const ERROR_PATTERNS = [
+  /\bError:/i,
+  /\bFAILED\b/i,
+  /\bpanic\b/i,
+  /\bexception\b/i,
+  /\btraceback\b/i,
+  /\bexit code\s+\d+/i,
+  /\bcommand failed\b/i,
+  /\bfatal:/i,
+];
+
+export function resetSessionPreviewCache(): void {
+  previewCache.clear();
+  responseCache = undefined;
+  responseInFlight = undefined;
+}
+
+export function derivePreviewStatus(
+  lines: string[],
+  lastChangedMs: number | null,
+  nowMs: number,
+): SessionPreviewStatus {
+  if (lines.length === 0) {
+    return "idle";
+  }
+  const text = lines.join("\n");
+  if (ERROR_PATTERNS.some((pattern) => pattern.test(text))) {
+    return "error";
+  }
+  if (lastChangedMs === null) {
+    return "idle";
+  }
+  const ageMs = nowMs - lastChangedMs;
+  if (ageMs <= ACTIVE_WINDOW_MS) {
+    return "active";
+  }
+  if (ageMs >= IDLE_WINDOW_MS) {
+    return "idle";
+  }
+  return "active";
+}
+
+export function normalizeCapturedPane(output: string): string[] {
+  return output
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => stripUnsupportedControlSequences(line).trimEnd())
+    .map(truncatePreviewLine)
+    .filter((line) => line.length > 0)
+    .slice(-PREVIEW_LINES);
+}
+
+function truncatePreviewLine(line: string): string {
+  if (line.length <= PREVIEW_LINE_MAX_CHARS) return line;
+  return `${line.slice(0, PREVIEW_LINE_MAX_CHARS - 3)}...`;
+}
+
+function stripUnsupportedControlSequences(value: string): string {
+  return [...value
+    .replace(OSC_SEQUENCE_RE, "")
+    .replace(ANSI_SEQUENCE_RE, "")
+    .replace(SINGLE_CHAR_ESCAPE_RE, "")]
+    .filter((char) => {
+      const codePoint = char.codePointAt(0);
+      if (codePoint === undefined) return false;
+      return codePoint === 9 || codePoint >= 32 && codePoint !== 127;
+    })
+    .join("");
+}
+
+function hashLines(lines: string[]): string {
+  return createHash("sha1").update(lines.join("\n")).digest("hex");
+}
+
+async function captureTmuxPane(sessionName: string): Promise<string[]> {
+  const stdout = await new Promise<string>((resolve, reject) => {
+    execFile(
+      "tmux",
+      ["capture-pane", "-p", "-t", sessionName, "-S", `-${CAPTURE_HISTORY_LINES}`],
+      { timeout: TMUX_CAPTURE_TIMEOUT_MS, maxBuffer: 64 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stdout);
+        }
+      },
+    );
+  });
+  return normalizeCapturedPane(stdout);
+}
+
+async function getPreviewForDeployment(
+  deployment: ActiveDeploymentWithRepo,
+  nowMs: number,
+): Promise<[number, SessionPreview] | null> {
+  const port = deployment.ttydPort;
+  if (port === null) return null;
+
+  const sessionName = tmuxSessionName(deployment.repoName, deployment.issueNumber);
+  const cachedForPort = previewCache.get(port);
+  const cached = cachedForPort?.sessionName === sessionName ? cachedForPort : undefined;
+
+  try {
+    const lines = await captureTmuxPane(sessionName);
+    const hash = hashLines(lines);
+    const changed = cached === undefined || cached.hash !== hash;
+    const lastChangedMs = changed ? nowMs : cached.lastChangedMs;
+    const status = derivePreviewStatus(lines, lastChangedMs, nowMs);
+    const entry: PreviewCacheEntry = {
+      port,
+      sessionName,
+      lines,
+      hash,
+      lastUpdatedMs: nowMs,
+      lastChangedMs,
+      status,
+    };
+    previewCache.set(port, entry);
+    return [port, previewFromEntry(entry)];
+  } catch {
+    if (cached) {
+      const entry: PreviewCacheEntry = {
+        ...cached,
+        lastUpdatedMs: nowMs,
+        status: "unavailable",
+      };
+      previewCache.set(port, entry);
+      return [port, previewFromEntry(entry)];
+    }
+
+    return [
+      port,
+      {
+        lines: [],
+        lastUpdatedMs: nowMs,
+        lastChangedMs: null,
+        status: "unavailable",
+      },
+    ];
+  }
+}
+
+function previewFromEntry(entry: PreviewCacheEntry): SessionPreview {
+  return {
+    lines: entry.lines,
+    lastUpdatedMs: entry.lastUpdatedMs,
+    lastChangedMs: entry.lastChangedMs,
+    status: entry.status,
+  };
+}
+
+export async function getSessionPreviews(
+  deployments: ActiveDeploymentWithRepo[],
+  nowMs = Date.now(),
+): Promise<Record<string, SessionPreview>> {
+  const activeSessions = deployments
+    .map((deployment) => {
+      if (deployment.ttydPort === null) return null;
+      return {
+        port: deployment.ttydPort,
+        sessionName: tmuxSessionName(deployment.repoName, deployment.issueNumber),
+      };
+    })
+    .filter((session): session is { port: number; sessionName: string } => session !== null);
+  const activePorts = new Set(activeSessions.map((session) => session.port));
+  const activeSessionsKey = activeSessions
+    .map((session) => `${session.port}:${session.sessionName}`)
+    .sort()
+    .join(",");
+  if (
+    responseCache
+    && responseCache.activeSessionsKey === activeSessionsKey
+    && nowMs - responseCache.generatedAtMs < RESPONSE_CACHE_TTL_MS
+  ) {
+    return responseCache.previews;
+  }
+
+  if (responseInFlight?.activeSessionsKey === activeSessionsKey) {
+    return responseInFlight.promise;
+  }
+
+  const promise = getFreshSessionPreviews(deployments, activePorts, activeSessionsKey, nowMs);
+  responseInFlight = { activeSessionsKey, promise };
+
+  try {
+    return await promise;
+  } finally {
+    if (responseInFlight?.promise === promise) {
+      responseInFlight = undefined;
+    }
+  }
+}
+
+async function getFreshSessionPreviews(
+  deployments: ActiveDeploymentWithRepo[],
+  activePorts: Set<number>,
+  activeSessionsKey: string,
+  nowMs: number,
+): Promise<Record<string, SessionPreview>> {
+  for (const port of previewCache.keys()) {
+    if (!activePorts.has(port)) {
+      previewCache.delete(port);
+    }
+  }
+
+  const entries = await mapLimit(
+    deployments,
+    MAX_CAPTURE_CONCURRENCY,
+    (deployment) => getPreviewForDeployment(deployment, nowMs),
+  );
+
+  const previews = Object.fromEntries(
+    entries.filter((entry): entry is [number, SessionPreview] => entry !== null),
+  );
+  responseCache = { activeSessionsKey, generatedAtMs: nowMs, previews };
+  return previews;
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index]);
+    }
+  }
+
+  const workerCount = Math.min(Math.max(limit, 1), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}


### PR DESCRIPTION
## Summary
- add a tmux-backed session previews API for active deployments
- show collapsed and expandable terminal previews on iOS session cards
- add preview status, accessibility text, polling safeguards, cache/coalescing, and normalization hardening

## Verification
- pnpm --filter @issuectl/web test -- --run session-previews.test app/api/v1/sessions/previews/route.test.ts
- pnpm --filter @issuectl/core build && pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/web lint (warnings only, pre-existing)
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests/APIClientTests/testSessionPreviewsEndpointURL -only-testing:IssueCTLTests/ModelDecodingTests/testSessionPreviewsResponseDecoding
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL-UISmoke -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLUITests/SessionManagementTests/testSessionCardShowsExpandableTerminalPreview
- git diff --check