### PR TITLE
Fix iOS parse request timeout

### DIFF
--- a/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
+++ b/ios/IssueCTL/Services/APIClient+ListEnhancements.swift
@@ -66,6 +66,7 @@ struct BatchCreateItemResult: Codable, Identifiable, Sendable {
 // MARK: - APIClient extension for list enhancements
 
 extension APIClient {
+    private static let parseRequestTimeout: TimeInterval = 120
 
     /// Fetch the authenticated GitHub user login.
     func currentUser() async throws -> UserResponse {
@@ -86,7 +87,12 @@ extension APIClient {
     func parseNaturalLanguage(input: String) async throws -> ParsedIssuesData {
         let body = ParseRequestBody(input: input)
         let bodyData = try JSONEncoder().encode(body)
-        let (data, _) = try await request(path: "/api/v1/parse", method: "POST", body: bodyData)
+        let (data, _) = try await request(
+            path: "/api/v1/parse",
+            method: "POST",
+            body: bodyData,
+            timeoutInterval: Self.parseRequestTimeout
+        )
         return try decoder.decode(ParseResponse.self, from: data).parsed
     }
 

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -48,7 +48,7 @@ final class APIClient {
         URL(string: serverURL)
     }
 
-    func request(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+    func request(path: String, method: String = "GET", body: Data? = nil, timeoutInterval: TimeInterval? = nil) async throws -> (Data, HTTPURLResponse) {
         guard let base = baseURL else {
             throw APIError.notConfigured
         }
@@ -61,6 +61,7 @@ final class APIClient {
         urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let body { urlRequest.httpBody = body }
+        if let timeoutInterval { urlRequest.timeoutInterval = timeoutInterval }
 
         let (data, response) = try await URLSession.shared.data(for: urlRequest)
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/ios/IssueCTLTests/APIClientExtensionTests.swift
+++ b/ios/IssueCTLTests/APIClientExtensionTests.swift
@@ -45,6 +45,34 @@ final class APIClientExtensionTests: XCTestCase {
         return data
     }
 
+    // MARK: - Parse
+
+    @MainActor
+    func testParseNaturalLanguageUsesLongRequestTimeout() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/parse"))
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.timeoutInterval, 120)
+
+            let bodyData = self.readBody(from: request)
+            XCTAssertNotNil(bodyData)
+            if let bodyData {
+                let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+                XCTAssertEqual(json?["input"] as? String, "Create a bug issue for the iOS timeout")
+            }
+
+            return (self.makeResponse(url: request.url!), """
+            {"parsed": {"issues": [{"id": "parsed-1", "original_text": "Create a bug issue for the iOS timeout", "title": "Fix iOS timeout", "body": "Parse requests should have enough time to complete.", "type": "bug", "repo_owner": null, "repo_name": null, "repo_confidence": 0, "suggested_labels": ["bug"], "clarity": "clear"}], "suggested_order": ["parsed-1"]}}
+            """.data(using: .utf8)!)
+        }
+
+        let parsed = try await client.parseNaturalLanguage(input: "Create a bug issue for the iOS timeout")
+
+        XCTAssertEqual(parsed.issues.count, 1)
+        XCTAssertEqual(parsed.issues[0].title, "Fix iOS timeout")
+        XCTAssertEqual(parsed.suggestedOrder, ["parsed-1"])
+    }
+
     // MARK: - Drafts (APIClient+Drafts)
 
     @MainActor

--- a/ios/IssueCTLTests/APIClientTests.swift
+++ b/ios/IssueCTLTests/APIClientTests.swift
@@ -53,7 +53,7 @@ final class TestableAPIClient {
         self.session = URLSession(configuration: config)
     }
 
-    func request(path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+    func request(path: String, method: String = "GET", body: Data? = nil, timeoutInterval: TimeInterval? = nil) async throws -> (Data, HTTPURLResponse) {
         guard let base = URL(string: serverURL) else {
             throw APIError.notConfigured
         }
@@ -63,6 +63,7 @@ final class TestableAPIClient {
         urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let body { urlRequest.httpBody = body }
+        if let timeoutInterval { urlRequest.timeoutInterval = timeoutInterval }
 
         let (data, response) = try await session.data(for: urlRequest)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -111,6 +112,18 @@ final class TestableAPIClient {
     func sessionPreviews() async throws -> SessionPreviewsResponse {
         let (data, _) = try await request(path: "/api/v1/sessions/previews")
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
+    }
+
+    func parseNaturalLanguage(input: String) async throws -> ParsedIssuesData {
+        let body = ParseRequestBody(input: input)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(
+            path: "/api/v1/parse",
+            method: "POST",
+            body: bodyData,
+            timeoutInterval: 120
+        )
+        return try decoder.decode(ParseResponse.self, from: data).parsed
     }
 
     private struct ErrorBody: Codable {


### PR DESCRIPTION
## Summary
- add an optional iOS API request timeout override
- give the AI parse endpoint a 120s client timeout so it outlasts the backend parser window
- cover the parse request path and timeout in API client tests

Fixes #378

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests/APIClientTests -only-testing:IssueCTLTests/APIClientExtensionTests