### PR TITLE
Fix mobile session activity counts and durations

### DIFF
--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -14,9 +14,18 @@ nonisolated(unsafe) private let sharedISO8601FormatterWithoutFractionalSeconds: 
     return f
 }()
 
+nonisolated(unsafe) private let sharedSQLiteDateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.timeZone = TimeZone(secondsFromGMT: 0)
+    f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    return f
+}()
+
 func parseIssueCTLDate(_ value: String) -> Date? {
     sharedISO8601Formatter.date(from: value)
         ?? sharedISO8601FormatterWithoutFractionalSeconds.date(from: value)
+        ?? sharedSQLiteDateFormatter.date(from: value)
 }
 
 struct GitHubUser: Codable, Sendable {

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -46,6 +46,27 @@ struct SessionListView: View {
         deployments.filter { $0.ttydPort != nil }.count
     }
 
+    private var activeTerminalCount: Int {
+        deployments.filter { deployment in
+            guard let port = deployment.ttydPort else { return false }
+            return previews[port]?.status == .active
+        }.count
+    }
+
+    private var idleTerminalCount: Int {
+        deployments.filter { deployment in
+            guard let port = deployment.ttydPort else { return false }
+            return previews[port]?.status == .idle
+        }.count
+    }
+
+    private var checkingTerminalCount: Int {
+        deployments.filter { deployment in
+            guard let port = deployment.ttydPort else { return false }
+            return previews[port] == nil
+        }.count
+    }
+
     private var startingCount: Int {
         deployments.count - readyCount
     }
@@ -96,7 +117,9 @@ struct SessionListView: View {
                             LazyVStack(spacing: 12) {
                                 ActiveSessionsHeader(
                                     totalCount: deployments.count,
-                                    readyCount: readyCount,
+                                    activeCount: activeTerminalCount,
+                                    idleCount: idleTerminalCount,
+                                    checkingCount: checkingTerminalCount,
                                     startingCount: startingCount
                                 )
 
@@ -246,11 +269,19 @@ struct SessionListView: View {
     private var sessionSubtitle: String {
         if deployments.isEmpty {
             return "No active sessions"
-        } else if startingCount > 0 {
-            return "\(readyCount) ready • \(startingCount) starting"
-        } else {
-            return "\(readyCount) ready"
         }
+
+        var parts = [
+            "\(activeTerminalCount) active",
+            "\(idleTerminalCount) idle",
+        ]
+        if checkingTerminalCount > 0 {
+            parts.append("\(checkingTerminalCount) checking")
+        }
+        if startingCount > 0 {
+            parts.append("\(startingCount) starting")
+        }
+        return parts.joined(separator: " • ")
     }
 
     private var sessionSearchBar: some View {
@@ -414,7 +445,9 @@ private struct TerminalPresentation: Identifiable {
 
 private struct ActiveSessionsHeader: View {
     let totalCount: Int
-    let readyCount: Int
+    let activeCount: Int
+    let idleCount: Int
+    let checkingCount: Int
     let startingCount: Int
 
     var body: some View {
@@ -429,8 +462,12 @@ private struct ActiveSessionsHeader: View {
             }
 
             HStack(spacing: 10) {
-                metric(value: "\(readyCount)", label: "ready", systemImage: "terminal")
-                metric(value: "\(startingCount)", label: "starting", systemImage: "hourglass")
+                metric(value: "\(activeCount)", label: "active", systemImage: "bolt.fill", accessibilityIdentifier: "sessions-active-count")
+                metric(value: "\(idleCount)", label: "idle", systemImage: "pause.circle", accessibilityIdentifier: "sessions-idle-count")
+                if checkingCount > 0 {
+                    metric(value: "\(checkingCount)", label: "checking", systemImage: "dot.radiowaves.left.and.right", accessibilityIdentifier: "sessions-checking-count")
+                }
+                metric(value: "\(startingCount)", label: "starting", systemImage: "hourglass", accessibilityIdentifier: "sessions-starting-count")
             }
         }
         .padding(14)
@@ -443,7 +480,12 @@ private struct ActiveSessionsHeader: View {
         .accessibilityIdentifier("sessions-command-header")
     }
 
-    private func metric(value: String, label: String, systemImage: String) -> some View {
+    private func metric(
+        value: String,
+        label: String,
+        systemImage: String,
+        accessibilityIdentifier: String
+    ) -> some View {
         HStack(spacing: 7) {
             Image(systemName: systemImage)
                 .font(.caption)
@@ -460,6 +502,10 @@ private struct ActiveSessionsHeader: View {
         .padding(9)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(IssueCTLColors.elevatedBackground, in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label) sessions")
+        .accessibilityValue(value)
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 

--- a/ios/IssueCTLTests/EdgeCaseModelTests.swift
+++ b/ios/IssueCTLTests/EdgeCaseModelTests.swift
@@ -330,6 +330,23 @@ final class EdgeCaseModelTests: XCTestCase {
         XCTAssertEqual(deployment.runningDuration, "")
     }
 
+    func testDeploymentRunningDurationParsesSQLiteDate() throws {
+        let json = """
+        {
+            "id": 1, "repo_id": 1, "issue_number": 1,
+            "branch_name": "b", "workspace_mode": "worktree",
+            "workspace_path": "/tmp", "linked_pr_number": null,
+            "state": "active",
+            "launched_at": "2026-04-29 08:00:00", "ended_at": null,
+            "ttyd_port": 7682, "ttyd_pid": 100
+        }
+        """.data(using: .utf8)!
+
+        let deployment = try decoder.decode(Deployment.self, from: json)
+        XCTAssertNotNil(deployment.launchedDate)
+        XCTAssertFalse(deployment.runningDuration.isEmpty)
+    }
+
     func testActiveDeploymentLaunchedDate() throws {
         let json = """
         {

--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -9,6 +9,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
     // Mutable state seeded before launch and mutated by endpoint handlers.
     private var activeDeployments: [[String: Any]] = []
     private var drafts: [[String: Any]] = []
+    private var hiddenPreviewIssueNumbers: Set<Int> = []
 
     // Failure controls for recovery-path UI tests.
     var failUserProfile = false
@@ -94,7 +95,22 @@ final class MockIssueCTLServer: @unchecked Sendable {
     // MARK: - Seed Helpers
 
     func seedActiveDeployment() {
+        hiddenPreviewIssueNumbers = []
         activeDeployments = [deployment(issueNumber: 101)]
+    }
+
+    func seedMixedActivityDeployments() {
+        hiddenPreviewIssueNumbers = []
+        activeDeployments = [
+            deployment(issueNumber: 101),
+            deployment(issueNumber: 102),
+            deployment(issueNumber: 103),
+        ]
+    }
+
+    func seedDeploymentWithMissingPreview() {
+        activeDeployments = [deployment(issueNumber: 101)]
+        hiddenPreviewIssueNumbers = [101]
     }
 
     func seedClosedIssue(_ number: Int) {
@@ -545,25 +561,34 @@ final class MockIssueCTLServer: @unchecked Sendable {
     }
 
     func deployment(issueNumber: Int) -> [String: Any] {
-        let id = issueNumber == 101 ? 9001 : 9002
+        let id = 8900 + issueNumber
         return [
             "id": id,
             "repo_id": 1,
             "issue_number": issueNumber,
-            "branch_name": issueNumber == 101
-                ? "issue-101-improve-launch-handoff"
-                : "issue-102-persist-multiple-sessions",
+            "branch_name": branchName(for: issueNumber),
             "workspace_mode": "worktree",
             "workspace_path": "/tmp/alpha-worktree-\(issueNumber)",
             "linked_pr_number": NSNull(),
             "state": "active",
-            "launched_at": isoDate,
+            "launched_at": "2026-04-29 08:00:00",
             "ended_at": NSNull(),
-            "ttyd_port": issueNumber == 101 ? 19001 : 19002,
-            "ttyd_pid": issueNumber == 101 ? 12345 : 12346,
+            "ttyd_port": 19000 + issueNumber,
+            "ttyd_pid": 12000 + issueNumber,
             "owner": "org",
             "repo_name": "alpha",
         ]
+    }
+
+    private func branchName(for issueNumber: Int) -> String {
+        switch issueNumber {
+        case 101:
+            return "issue-101-improve-launch-handoff"
+        case 102:
+            return "issue-102-persist-multiple-sessions"
+        default:
+            return "issue-\(issueNumber)-terminal-activity"
+        }
     }
 
     func deployments(for issueNumber: Int) -> [[String: Any]] {
@@ -578,6 +603,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
         for deployment in activeDeployments {
             guard let port = deployment["ttyd_port"] as? Int else { continue }
             let issueNumber = deployment["issue_number"] as? Int ?? 0
+            guard !hiddenPreviewIssueNumbers.contains(issueNumber) else { continue }
             previews[String(port)] = [
                 "lines": [
                     "issue #\(issueNumber): running checks",
@@ -585,7 +611,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
                 ],
                 "lastUpdatedMs": 1_777_800_000_000,
                 "lastChangedMs": 1_777_799_999_000,
-                "status": issueNumber == 101 ? "active" : "idle",
+                "status": issueNumber == 102 ? "idle" : "active",
             ]
         }
         return previews

--- a/ios/IssueCTLUITests/SessionManagementTests.swift
+++ b/ios/IssueCTLUITests/SessionManagementTests.swift
@@ -66,4 +66,30 @@ final class SessionManagementTests: XCTestCase {
             "Expanded session preview did not show captured terminal lines\n\(app.debugDescription)"
         )
     }
+
+    @MainActor
+    func testSessionHeaderCountsActiveAndIdleTerminalPreviews() {
+        server.seedMixedActivityDeployments()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
+        XCTAssertTrue(
+            app.staticTexts["2 active • 1 idle"].waitForExistence(timeout: 8),
+            "Expected Sessions subtitle to count active and idle terminal previews\n\(app.debugDescription)"
+        )
+    }
+
+    @MainActor
+    func testSessionHeaderShowsCheckingForMissingTerminalPreview() {
+        server.seedDeploymentWithMissingPreview()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("sessions-command-header", existsIn: app, timeout: 5)
+        XCTAssertTrue(
+            app.staticTexts["0 active • 0 idle • 1 checking"].waitForExistence(timeout: 8),
+            "Expected Sessions subtitle to show ready terminals waiting for preview data\n\(app.debugDescription)"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Parse SQLite-style `launched_at` timestamps on iOS so mobile running durations render again
- Count terminal preview statuses as active/idle in the Sessions header instead of counting every ready ttyd deployment as ready
- Show a checking bucket while a ready terminal is waiting for preview status data
- Add model and UI coverage for SQLite dates, active/idle counts, and missing preview status

Closes #371.
Closes #373.

## Verification
- `xcodebuild test -derivedDataPath /tmp/issuectl-dd-371373-final-model -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/EdgeCaseModelTests/testDeploymentRunningDurationParsesSQLiteDate -only-testing:IssueCTLTests/EdgeCaseModelTests/testDeploymentRunningDurationMinutesOnly -only-testing:IssueCTLTests/EdgeCaseModelTests/testActiveDeploymentLaunchedDate`
- `xcodebuild test -derivedDataPath /tmp/issuectl-dd-371373-final-ui -project ios/IssueCTL.xcodeproj -scheme IssueCTL-UISmoke -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests`
- `git diff --check`