### PR TITLE
perf: trim iOS launch work

### DIFF
--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @Environment(NotificationSettingsStore.self) private var notificationSettings
     @State private var selectedTab: AppTab = .today
     @State private var showSettings = false
+    private let launchNotificationSyncDelay: Duration = .seconds(1)
 
     init() {
         let appearance = UITabBarAppearance()
@@ -70,6 +71,7 @@ struct ContentView: View {
             Task { await notificationSettings.syncRegistration(apiClient: api) }
         }
         .task {
+            try? await Task.sleep(for: launchNotificationSyncDelay)
             await notificationSettings.registerForRemoteNotificationsIfAllowed()
             await notificationSettings.syncRegistration(apiClient: api)
         }

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -398,8 +398,6 @@ struct TodayView: View {
             PerformanceTrace.end(trace, metadata: "repos=\(repos.count) issues=\(allIssues.count) pulls=\(allPulls.count) deployments=\(activeDeployments.count)")
         }
         do {
-            repos = try await api.repos()
-
             async let deploymentsResult: Result<ActiveDeploymentsResponse, Error> = {
                 do { return .success(try await api.activeDeployments()) }
                 catch { return .failure(error) }
@@ -409,7 +407,10 @@ struct TodayView: View {
                 catch { return .failure(error) }
             }()
 
-            let repoSnapshot = repos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
+            let loadedRepos = try await api.repos()
+            repos = loadedRepos
+
+            let repoSnapshot = loadedRepos.map { (fullName: $0.fullName, owner: $0.owner, name: $0.name) }
             async let issueResults = loadIssues(for: repoSnapshot, refresh: refresh)
             async let pullResults = loadPulls(for: repoSnapshot, refresh: refresh)
 


### PR DESCRIPTION
## Summary
- defer launch-time notification registration/sync until after the first usable screen window
- start Today user/deployment requests in parallel with repo loading instead of waiting behind repos

## Timing evidence
Simulator: IssueCTL Fresh Preview Test, iOS 26.4, IssueCTLPreview-UISmoke single test IssueCTLPreviewUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs.

Before on current main (c1bed90):
- app_launch_usable: 577 ms
- today.load: 155 ms
- issues.load_all: 94 ms
- pulls.load_all: 22 ms
- sessions.load: 18 ms

After this branch:
- app_launch_usable: 543 ms
- today.load: 139 ms
- issues.load_all: 100 ms
- pulls.load_all: 23 ms
- sessions.load: 19 ms

Artifacts:
- /tmp/issuectl-perf-followup-sim.xcresult
- /tmp/issuectl-perf-followup-sim-after2.xcresult
- /tmp/issuectl-perf-followup-sim-trace.log
- /tmp/issuectl-perf-followup-sim-after2-trace.log

## Verification
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTLPreview-UISmoke -configuration Debug -destination 'id=FD37740E-E18B-4158-9C8D-4F91C1818925' -only-testing:IssueCTLPreviewUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs
- git diff --check