### PR TITLE
docs: record iOS device roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,15 @@ xcodebuildmcp tools                      # list all 72 tools
 - All `--simulator-id` values come from `xcodebuildmcp simulator list`
 - Use `--help` on any command to discover flags — don't guess
 
+### iOS physical-device roles
+
+Use these device roles for physical iPhone deploys and testing:
+
+- `IPhone-preivew`: the only/default iPhone for preview-app deployments, preview UI tests, physical-device performance timing, and future GitHub Actions runner work.
+- `Iphone-prod`: the production iPhone. Use it only for production app installs and production validation.
+
+Do not deploy `IssueCTL Preview`, run preview smoke tests, or run preview performance timing on `Iphone-prod` unless the user explicitly asks for a production-device check. When a workflow asks for a physical preview device, select `IPhone-preivew` from `pnpm ios:list-devices`, Xcode destinations, or CoreDevice output and use that device's current identifier.
+
 ### iOS performance timing
 
 The iOS app has lightweight `PerformanceTrace` instrumentation for measuring app-side performance. It logs:

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -9,6 +9,23 @@ The preview app is intended for development, physical-device smoke tests, and fe
 
 Merge queue validation should use the preview lane when a PR needs iOS smoke coverage before landing.
 
+## Physical Device Roles
+
+Use `IPhone-preivew` as the only/default physical iPhone for preview-app deployment and testing. This is the device for:
+
+- `IssueCTL Preview` installs
+- preview smoke tests
+- preview performance timing
+- future preview/GitHub Actions runner workflows
+
+Keep `Iphone-prod` reserved for production `IssueCTL` installs and production validation. Do not run preview deployments or preview smoke tests on `Iphone-prod` unless explicitly doing a production-device check.
+
+When commands require `IOS_DEVICE_ID` or an Xcode destination id, list the currently connected devices and choose the identifier for `IPhone-preivew`:
+
+```bash
+pnpm ios:list-devices
+```
+
 ## App Lanes
 
 Use `IssueCTL Preview` as the active development lane. It is the app to run from feature branches, local simulator testing, and physical-device smoke tests.


### PR DESCRIPTION
## Summary
- document IPhone-preivew as the only/default physical iPhone for preview deployments, smoke tests, timing, and future runner workflows
- document Iphone-prod as reserved for production installs and validation
- add the same guidance to future-agent notes and the iOS preview testing guide

## Verification
- git diff --check