### PR TITLE
docs: correct iOS device role names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,10 @@ xcodebuildmcp tools                      # list all 72 tools
 
 Use these device roles for physical iPhone deploys and testing:
 
-- `IPhone-preivew`: the only/default iPhone for preview-app deployments, preview UI tests, physical-device performance timing, and future GitHub Actions runner work.
-- `Iphone-prod`: the production iPhone. Use it only for production app installs and production validation.
+- `iPhone-preview`: the only/default iPhone for preview-app deployments, preview UI tests, physical-device performance timing, and future GitHub Actions runner work.
+- `iPhone-prod`: the production iPhone. Use it only for production app installs and production validation.
 
-Do not deploy `IssueCTL Preview`, run preview smoke tests, or run preview performance timing on `Iphone-prod` unless the user explicitly asks for a production-device check. When a workflow asks for a physical preview device, select `IPhone-preivew` from `pnpm ios:list-devices`, Xcode destinations, or CoreDevice output and use that device's current identifier.
+Do not deploy `IssueCTL Preview`, run preview smoke tests, or run preview performance timing on `iPhone-prod` unless the user explicitly asks for a production-device check. When a workflow asks for a physical preview device, select `iPhone-preview` from `pnpm ios:list-devices`, Xcode destinations, or CoreDevice output and use that device's current identifier.
 
 ### iOS performance timing
 

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -11,16 +11,16 @@ Merge queue validation should use the preview lane when a PR needs iOS smoke cov
 
 ## Physical Device Roles
 
-Use `IPhone-preivew` as the only/default physical iPhone for preview-app deployment and testing. This is the device for:
+Use `iPhone-preview` as the only/default physical iPhone for preview-app deployment and testing. This is the device for:
 
 - `IssueCTL Preview` installs
 - preview smoke tests
 - preview performance timing
 - future preview/GitHub Actions runner workflows
 
-Keep `Iphone-prod` reserved for production `IssueCTL` installs and production validation. Do not run preview deployments or preview smoke tests on `Iphone-prod` unless explicitly doing a production-device check.
+Keep `iPhone-prod` reserved for production `IssueCTL` installs and production validation. Do not run preview deployments or preview smoke tests on `iPhone-prod` unless explicitly doing a production-device check.
 
-When commands require `IOS_DEVICE_ID` or an Xcode destination id, list the currently connected devices and choose the identifier for `IPhone-preivew`:
+When commands require `IOS_DEVICE_ID` or an Xcode destination id, list the currently connected devices and choose the identifier for `iPhone-preview`:
 
 ```bash
 pnpm ios:list-devices


### PR DESCRIPTION
## Summary
- correct the documented physical device names to match CoreDevice/Xcode output: iPhone-preview and iPhone-prod
- keep preview workflows pinned to iPhone-preview and production validation pinned to iPhone-prod

## Verification
- git diff --check
- installed IssueCTL Preview on iPhone-preview (com.issuectl.ios.preview)
- installed IssueCTL production on iPhone-prod (com.issuectl.ios)

Note: app launch verification was blocked because iPhone-preview was locked.