### PR TITLE
ci: add physical iOS preview merge queue check

### DIFF
--- a/.github/workflows/ios-physical-preview.yml
+++ b/.github/workflows/ios-physical-preview.yml
@@ -1,0 +1,71 @@
+name: iOS Physical Preview
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref or SHA to test. Defaults to the dispatch ref.'
+        required: false
+        type: string
+      smoke_profile:
+        description: 'Physical iPhone preview smoke profile to run'
+        required: true
+        default: pr
+        type: choice
+        options:
+          - fast
+          - pr
+          - full
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  physical-preview:
+    name: Physical iPhone Preview Smoke
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","macOS","issuectl-ios","iphone-preview"]') }}
+    timeout-minutes: 25
+    env:
+      IOS_DEVICE_NAME: iPhone-preview
+      IOS_SCHEME: IssueCTLPreview-UISmoke
+      IOS_CONFIGURATION: Debug
+      IOS_DEVICE_READY_TIMEOUT: 60
+      IOS_XCODEBUILD_EXTRA_ARGS: -allowProvisioningUpdates -allowProvisioningDeviceRegistration
+    steps:
+      - name: PR placeholder
+        if: github.event_name == 'pull_request'
+        run: echo "Physical iPhone preview smoke runs against the merge queue tip on merge_group."
+
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Show build environment
+        if: github.event_name != 'pull_request'
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve iPhone-preview
+        if: github.event_name != 'pull_request'
+        run: ./scripts/ios-resolve-preview-device.sh
+
+      - name: List iOS devices
+        if: github.event_name != 'pull_request'
+        run: ./scripts/ios-list-devices.sh
+
+      - name: Run physical preview smoke
+        if: github.event_name != 'pull_request'
+        env:
+          IOS_UI_SMOKE_PROFILE: ${{ inputs.smoke_profile || 'pr' }}
+        run: ./scripts/ios-preview-device-smoke.sh

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -59,7 +59,7 @@ jobs:
           echo "Changed files:"
           printf '%s\n' "$changed_files"
 
-          if printf '%s\n' "$changed_files" | grep -E -q '^(ios/|scripts/ios-ui-smoke\.sh$|package\.json$|\.husky/pre-push$|\.github/workflows/ios\.yml$)'; then
+          if printf '%s\n' "$changed_files" | grep -E -q '^(ios/|scripts/ios-.*\.sh$|package\.json$|\.husky/pre-push$|\.github/workflows/ios(-physical-preview)?\.yml$)'; then
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_smoke=false" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ Use these device roles for physical iPhone deploys and testing:
 
 Do not deploy `IssueCTL Preview`, run preview smoke tests, or run preview performance timing on `iPhone-prod` unless the user explicitly asks for a production-device check. When a workflow asks for a physical preview device, select `iPhone-preview` from `pnpm ios:list-devices`, Xcode destinations, or CoreDevice output and use that device's current identifier.
 
+The required physical preview merge-queue check is `Physical iPhone Preview Smoke` in `.github/workflows/ios-physical-preview.yml`. It must run only on the repo-scoped self-hosted runner named `issuectl-iphone-preview` with labels `issuectl-ios` and `iphone-preview`, and it should use `IOS_DEVICE_NAME=iPhone-preview` instead of hard-coded device identifiers. The runner is installed at `~/issuectl-iphone-preview-runner`; manage it with `./svc.sh status`, `./svc.sh start`, and `./svc.sh stop` from that directory.
+
 ### iOS performance timing
 
 The iOS app has lightweight `PerformanceTrace` instrumentation for measuring app-side performance. It logs:

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -60,7 +60,7 @@ Run the preview smoke suite on a physical iPhone:
 IOS_DEVICE_ID=<device-udid> pnpm ios:preview-device-smoke:fast
 ```
 
-Use the CoreDevice identifier from `pnpm ios:list-devices` for `IOS_DEVICE_ID`. In practice this can differ from the lower-level hardware id shown by some Xcode destination output.
+By default, the physical-device wrapper resolves `iPhone-preview` by name and uses the correct CoreDevice id for readiness checks and Xcode destination id for `xcodebuild`. Use `IOS_DEVICE_ID`, `IOS_XCODE_DEVICE_ID`, or `IOS_DESTINATION` only when overriding that default.
 
 The physical-device wrapper checks that the iPhone is visible through CoreDevice before launching Xcode. Keep the iPhone unlocked and awake until the test runner starts. By default, physical runs time out instead of waiting indefinitely:
 
@@ -101,6 +101,30 @@ The existing simulator smoke hook is still available:
 ```bash
 RUN_IOS_UI_SMOKE=1 git push
 ```
+
+## Self-Hosted Merge Queue Runner
+
+The required physical-device merge queue lane runs on the repo-scoped self-hosted runner attached to `iPhone-preview`.
+
+Runner defaults:
+
+- Runner name: `issuectl-iphone-preview`
+- Runner labels: `self-hosted`, `macOS`, `issuectl-ios`, `iphone-preview`
+- Runner install path: `~/issuectl-iphone-preview-runner`
+- GitHub check name: `Physical iPhone Preview Smoke`
+- Workflow: `.github/workflows/ios-physical-preview.yml`
+- Test command: `IOS_DEVICE_NAME=iPhone-preview IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-preview-device-smoke.sh`
+
+The workflow emits a lightweight passing `pull_request` check so PRs can enter the merge queue. The actual physical-device run happens on `merge_group` and `workflow_dispatch`, which validates the queue tip rather than the stale PR head.
+
+Register the runner from repository settings with the GitHub-provided command, then add the custom labels above. Install it as a launchd service on the MacBook so it survives logout/reboot. To inspect the installed service locally:
+
+```bash
+cd ~/issuectl-iphone-preview-runner
+./svc.sh status
+```
+
+After the workflow has run once and created the `Physical iPhone Preview Smoke` check context, add that check to the `main-protection` ruleset required status checks. Keep `iPhone-preview` unlocked and awake when the merge queue is active; the required check intentionally fails instead of skipping if the phone is unavailable.
 
 ## Project Generation
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ios:preview-smoke:fast": "IOS_SCHEME=IssueCTLPreview-UISmoke IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-ui-smoke.sh",
     "ios:preview-smoke:full": "IOS_SCHEME=IssueCTLPreview-UISmoke IOS_UI_SMOKE_PROFILE=full ./scripts/ios-ui-smoke.sh",
     "ios:preview-device-smoke:fast": "IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-preview-device-smoke.sh",
+    "ios:preview-device-smoke:pr": "IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-preview-device-smoke.sh",
     "ios:preview-device-smoke:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-preview-device-smoke.sh",
     "ios:list-devices": "./scripts/ios-list-devices.sh",
     "dev": "turbo dev",

--- a/scripts/ios-list-devices.sh
+++ b/scripts/ios-list-devices.sh
@@ -5,6 +5,10 @@ echo "CoreDevice devices:"
 xcrun devicectl list devices
 
 echo
+echo "Default preview device resolution:"
+./scripts/ios-resolve-preview-device.sh || true
+
+echo
 echo "Xcode destinations for IssueCTLPreview-UISmoke:"
 xcodebuild \
   -project ios/IssueCTL.xcodeproj \

--- a/scripts/ios-preview-device-smoke.sh
+++ b/scripts/ios-preview-device-smoke.sh
@@ -4,23 +4,40 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+device_name="${IOS_DEVICE_NAME:-iPhone-preview}"
 device_id="${IOS_DEVICE_ID:-}"
 
 if [ -z "${IOS_DESTINATION:-}" ]; then
   if [ -z "$device_id" ]; then
-    echo "Set IOS_DEVICE_ID=<device-udid> or IOS_DESTINATION='platform=iOS,id=<device-udid>'." >&2
-    echo "Run 'pnpm ios:list-devices' to find the CoreDevice identifier." >&2
-    exit 64
+    echo "Resolving physical preview device by name: $device_name"
+    resolver_output="$(./scripts/ios-resolve-preview-device.sh shell)"
+    eval "$resolver_output"
+    device_id="$IOS_DEVICE_ID"
+    export IOS_DEVICE_ID
+    export IOS_XCODE_DEVICE_ID
+    export IOS_DESTINATION
+  else
+    if [ -z "${IOS_XCODE_DEVICE_ID:-}" ]; then
+      provided_device_id="$device_id"
+      resolver_output="$(./scripts/ios-resolve-preview-device.sh shell)"
+      eval "$resolver_output"
+      device_id="$provided_device_id"
+    fi
+    export IOS_DEVICE_ID="$device_id"
+    export IOS_DESTINATION="platform=iOS,id=${IOS_XCODE_DEVICE_ID:-$device_id}"
   fi
-  export IOS_DESTINATION="platform=iOS,id=${device_id}"
 else
-  device_id="$(printf '%s\n' "$IOS_DESTINATION" | sed -n 's/.*id=\([^,]*\).*/\1/p')"
+  destination_id="$(printf '%s\n' "$IOS_DESTINATION" | sed -n 's/.*id=\([^,]*\).*/\1/p')"
+  if [ -z "$device_id" ]; then
+    device_id="$destination_id"
+  fi
 fi
 
 export IOS_SCHEME="${IOS_SCHEME:-IssueCTLPreview-UISmoke}"
 export IOS_CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
 export IOS_UI_SMOKE_PROFILE="${IOS_UI_SMOKE_PROFILE:-fast}"
 export IOS_DEVICE_READY_TIMEOUT="${IOS_DEVICE_READY_TIMEOUT:-45}"
+export IOS_XCODEBUILD_EXTRA_ARGS="${IOS_XCODEBUILD_EXTRA_ARGS:--allowProvisioningUpdates -allowProvisioningDeviceRegistration}"
 
 case "$IOS_UI_SMOKE_PROFILE" in
   fast)
@@ -44,6 +61,8 @@ if [ -z "$device_id" ]; then
 fi
 
 echo "Checking physical iOS device readiness for: $device_id"
+echo "Device role: $device_name"
+echo "Xcode destination: $IOS_DESTINATION"
 echo "Keep the iPhone unlocked and awake until the UI test starts."
 
 ready_deadline=$((SECONDS + IOS_DEVICE_READY_TIMEOUT))
@@ -68,5 +87,14 @@ EOF
 
   sleep 3
 done
+
+lock_json="$(mktemp "${TMPDIR:-/tmp}/issuectl-device-lock.XXXXXX")"
+trap 'rm -f "$lock_json"' EXIT
+if xcrun devicectl device info lockState --device "$device_id" --json-output "$lock_json" --quiet --timeout 10 >/dev/null 2>&1; then
+  echo "Device lock state:"
+  jq -r '.result | "  passcodeRequired=\(.passcodeRequired) unlockedSinceBoot=\(.unlockedSinceBoot)"' "$lock_json"
+else
+  echo "Could not read device lock state; continuing to xcodebuild, which will fail if the phone is locked." >&2
+fi
 
 exec ./scripts/ios-ui-smoke.sh

--- a/scripts/ios-resolve-preview-device.sh
+++ b/scripts/ios-resolve-preview-device.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
+SCHEME="${IOS_SCHEME:-IssueCTLPreview-UISmoke}"
+DEVICE_NAME="${IOS_DEVICE_NAME:-iPhone-preview}"
+MODE="${1:-human}"
+
+json_file="$(mktemp "${TMPDIR:-/tmp}/issuectl-devices.XXXXXX")"
+trap 'rm -f "$json_file"' EXIT
+
+xcrun devicectl list devices --json-output "$json_file" >/dev/null
+
+coredevice_id="$(
+  jq -r --arg name "$DEVICE_NAME" '
+    .result.devices[]
+    | select(.deviceProperties.name == $name)
+    | .identifier
+  ' "$json_file" | head -n 1
+)"
+
+if [ -z "$coredevice_id" ]; then
+  echo "Could not find CoreDevice device named '$DEVICE_NAME'." >&2
+  echo "Available devices:" >&2
+  jq -r '.result.devices[] | "  \(.deviceProperties.name // "unknown") \(.identifier) \(.hardwareProperties.marketingName // "")"' "$json_file" >&2
+  exit 69
+fi
+
+xcode_device_id="$(
+  xcodebuild -project "$PROJECT" -scheme "$SCHEME" -showdestinations 2>/dev/null \
+    | awk -v name="$DEVICE_NAME" '
+        $0 ~ /platform:iOS,/ && $0 ~ "name:" name {
+          print
+          exit
+        }
+      ' \
+    | sed -n 's/.*id:\([^,}]*\).*/\1/p'
+)"
+
+if [ -z "$xcode_device_id" ]; then
+  echo "Could not find Xcode iOS destination named '$DEVICE_NAME' for scheme '$SCHEME'." >&2
+  echo "Available destinations:" >&2
+  xcodebuild -project "$PROJECT" -scheme "$SCHEME" -showdestinations >&2
+  exit 70
+fi
+
+case "$MODE" in
+  shell)
+    printf 'IOS_DEVICE_NAME=%q\n' "$DEVICE_NAME"
+    printf 'IOS_DEVICE_ID=%q\n' "$coredevice_id"
+    printf 'IOS_XCODE_DEVICE_ID=%q\n' "$xcode_device_id"
+    printf 'IOS_DESTINATION=%q\n' "platform=iOS,id=$xcode_device_id"
+    ;;
+  human)
+    printf 'Device name: %s\n' "$DEVICE_NAME"
+    printf 'CoreDevice id: %s\n' "$coredevice_id"
+    printf 'Xcode destination id: %s\n' "$xcode_device_id"
+    printf 'Xcode destination: platform=iOS,id=%s\n' "$xcode_device_id"
+    ;;
+  *)
+    echo "Usage: $0 [human|shell]" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -72,7 +72,14 @@ case "$PROFILE" in
     ;;
 esac
 
-args=(
+args=()
+if [ -n "${IOS_XCODEBUILD_EXTRA_ARGS:-}" ]; then
+  # shellcheck disable=SC2206
+  XCODEBUILD_EXTRA_ARGS=($IOS_XCODEBUILD_EXTRA_ARGS)
+  args+=("${XCODEBUILD_EXTRA_ARGS[@]}")
+fi
+
+args+=(
   test
   -project "$PROJECT"
   -scheme "$SCHEME"


### PR DESCRIPTION
## Summary
- add a physical iPhone preview smoke workflow for merge queue tips and manual dispatch
- resolve `iPhone-preview` by name for CoreDevice and Xcode destination ids
- document the repo-scoped self-hosted runner, local install path, labels, and required check setup for future agents
- register and start the repo-scoped MacBook runner service `issuectl-iphone-preview` at `~/issuectl-iphone-preview-runner`
- add `Physical iPhone Preview Smoke` to the `main-protection` required status checks after the check context was created

## Verification
- `bash -n scripts/ios-resolve-preview-device.sh scripts/ios-list-devices.sh scripts/ios-ui-smoke.sh scripts/ios-preview-device-smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios.yml"); YAML.load_file(".github/workflows/ios-physical-preview.yml"); puts "yaml ok"'`\n- `git diff --check`\n- `./scripts/ios-resolve-preview-device.sh`\n- `./scripts/ios-list-devices.sh`\n- `IOS_UI_SMOKE_PROFILE=fast IOS_UI_SMOKE_TIMEOUT=60 ./scripts/ios-ui-smoke.sh`\n- `IOS_UI_SMOKE_PROFILE=fast IOS_UI_SMOKE_TIMEOUT=240 ./scripts/ios-preview-device-smoke.sh` reached the physical `iPhone-preview` destination and failed because Xcode reported the phone was locked; the earlier simulator fallback bug found during testing was fixed before commit\n- GitHub reports runner `issuectl-iphone-preview` online with labels `self-hosted`, `macOS`, `ARM64`, `issuectl-ios`, `iphone-preview`\n- PR checks are green on the latest commit.