### PR TITLE
Harden iOS preview runner preflight

### DIFF
--- a/.github/workflows/ios-physical-preview.yml
+++ b/.github/workflows/ios-physical-preview.yml
@@ -39,6 +39,8 @@ jobs:
       IOS_CONFIGURATION: Debug
       IOS_DEVICE_READY_TIMEOUT: 60
       IOS_XCODEBUILD_EXTRA_ARGS: -allowProvisioningUpdates -allowProvisioningDeviceRegistration
+      IOS_PREVIEW_KEYCHAIN_PASSWORD: ${{ secrets.IOS_PREVIEW_KEYCHAIN_PASSWORD }}
+      IOS_PREVIEW_SET_KEY_PARTITION_LIST: '1'
     steps:
       - name: PR placeholder
         if: github.event_name == 'pull_request'
@@ -50,11 +52,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Preflight runner, signing, and iPhone-preview
+        if: github.event_name != 'pull_request'
+        run: ./scripts/ios-preview-runner-preflight.sh
+
       - name: Show build environment
         if: github.event_name != 'pull_request'
-        run: |
-          xcodebuild -version
-          swift --version
+        run: swift --version
 
       - name: Resolve iPhone-preview
         if: github.event_name != 'pull_request'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ Do not deploy `IssueCTL Preview`, run preview smoke tests, or run preview perfor
 
 The required physical preview merge-queue check is `Physical iPhone Preview Smoke` in `.github/workflows/ios-physical-preview.yml`. It must run only on the repo-scoped self-hosted runner named `issuectl-iphone-preview` with labels `issuectl-ios` and `iphone-preview`, and it should use `IOS_DEVICE_NAME=iPhone-preview` instead of hard-coded device identifiers. The runner is installed at `~/issuectl-iphone-preview-runner`; manage it with `./svc.sh status`, `./svc.sh start`, and `./svc.sh stop` from that directory.
 
+Before physical preview builds, run `pnpm ios:preview-runner-preflight`. The GitHub workflow runs the same script to unlock the signing keychain from `IOS_PREVIEW_KEYCHAIN_PASSWORD`, verify a visible Apple Development identity, verify Automation Mode, resolve `iPhone-preview`, and fail fast if the phone is locked. If the LaunchAgent runner reports `errSecInternalComponent` during `CodeSign`, treat it as a service keychain/signing-access failure first; do not switch preview tests to `iPhone-prod`.
+
 ### iOS performance timing
 
 The iOS app has lightweight `PerformanceTrace` instrumentation for measuring app-side performance. It logs:

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -60,6 +60,12 @@ Run the preview smoke suite on a physical iPhone:
 IOS_DEVICE_ID=<device-udid> pnpm ios:preview-device-smoke:fast
 ```
 
+Run the same preflight that GitHub Actions uses before a physical-device build:
+
+```bash
+pnpm ios:preview-runner-preflight
+```
+
 By default, the physical-device wrapper resolves `iPhone-preview` by name and uses the correct CoreDevice id for readiness checks and Xcode destination id for `xcodebuild`. Use `IOS_DEVICE_ID`, `IOS_XCODE_DEVICE_ID`, or `IOS_DESTINATION` only when overriding that default.
 
 The physical-device wrapper checks that the iPhone is visible through CoreDevice before launching Xcode. Keep the iPhone unlocked and awake until the test runner starts. By default, physical runs time out instead of waiting indefinitely:
@@ -122,6 +128,29 @@ Register the runner from repository settings with the GitHub-provided command, t
 ```bash
 cd ~/issuectl-iphone-preview-runner
 ./svc.sh status
+```
+
+The LaunchAgent service runs without the same interactive keychain session as a terminal. The physical workflow therefore runs `scripts/ios-preview-runner-preflight.sh` before building. That preflight:
+
+- unlocks the configured signing keychain when `IOS_PREVIEW_KEYCHAIN_PASSWORD` is set
+- optionally refreshes the key partition list for non-interactive `codesign` access
+- verifies an Apple Development signing identity is visible
+- verifies Automation Mode does not require local authentication
+- resolves `iPhone-preview` by name
+- fails fast if the phone is unavailable or locked
+
+Set the repository secret `IOS_PREVIEW_KEYCHAIN_PASSWORD` to the password for the login keychain or a dedicated preview signing keychain. The workflow passes that secret only to the self-hosted `merge_group` and `workflow_dispatch` job. The default keychain path is:
+
+```bash
+~/Library/Keychains/login.keychain-db
+```
+
+Override it with `IOS_PREVIEW_KEYCHAIN_PATH` only if the runner uses a dedicated CI keychain. If `codesign` fails from the LaunchAgent with `errSecInternalComponent`, run the preflight from the service-backed workflow first; the failure usually means the service cannot unlock or use the signing identity.
+
+Automation Mode must be prepared once from an interactive admin session on the runner Mac:
+
+```bash
+automationmodetool enable-automationmode-without-authentication
 ```
 
 After the workflow has run once and created the `Physical iPhone Preview Smoke` check context, add that check to the `main-protection` ruleset required status checks. Keep `iPhone-preview` unlocked and awake when the merge queue is active; the required check intentionally fails instead of skipping if the phone is unavailable.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ios:preview-device-smoke:fast": "IOS_UI_SMOKE_PROFILE=fast ./scripts/ios-preview-device-smoke.sh",
     "ios:preview-device-smoke:pr": "IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-preview-device-smoke.sh",
     "ios:preview-device-smoke:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-preview-device-smoke.sh",
+    "ios:preview-runner-preflight": "./scripts/ios-preview-runner-preflight.sh",
     "ios:list-devices": "./scripts/ios-list-devices.sh",
     "dev": "turbo dev",
     "prepare": "husky"

--- a/scripts/ios-preview-runner-preflight.sh
+++ b/scripts/ios-preview-runner-preflight.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+device_name="${IOS_DEVICE_NAME:-iPhone-preview}"
+scheme="${IOS_SCHEME:-IssueCTLPreview-UISmoke}"
+project="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
+keychain="${IOS_PREVIEW_KEYCHAIN_PATH:-$HOME/Library/Keychains/login.keychain-db}"
+identity_pattern="${IOS_PREVIEW_SIGNING_IDENTITY_PATTERN:-Apple Development:}"
+
+echo "iOS preview runner preflight"
+echo "User: $(id -un)"
+echo "Home: $HOME"
+echo "Runner service: ${ACTIONS_RUNNER_SVC:-0}"
+echo "Project: $project"
+echo "Scheme: $scheme"
+echo "Device role: $device_name"
+echo "Keychain: $keychain"
+
+if [ ! -f "$keychain" ]; then
+  echo "Expected keychain does not exist: $keychain" >&2
+  exit 66
+fi
+
+if [ -n "${IOS_PREVIEW_KEYCHAIN_PASSWORD:-}" ]; then
+  echo "Unlocking preview signing keychain."
+  security unlock-keychain -p "$IOS_PREVIEW_KEYCHAIN_PASSWORD" "$keychain"
+  security set-keychain-settings -lut "${IOS_PREVIEW_KEYCHAIN_TIMEOUT:-21600}" "$keychain"
+
+  current_keychains="$(security list-keychains -d user | tr -d '"')"
+  if ! printf '%s\n' "$current_keychains" | grep -Fxq "$keychain"; then
+    # Keep existing user keychains while making the signing keychain visible to launchd jobs.
+    # shellcheck disable=SC2086
+    security list-keychains -d user -s "$keychain" $current_keychains
+  fi
+
+  security default-keychain -d user -s "$keychain"
+
+  if [ "${IOS_PREVIEW_SET_KEY_PARTITION_LIST:-0}" = "1" ]; then
+    echo "Refreshing key partition list for non-interactive codesign access."
+    security set-key-partition-list \
+      -S apple-tool:,apple:,codesign: \
+      -s \
+      -k "$IOS_PREVIEW_KEYCHAIN_PASSWORD" \
+      "$keychain" >/dev/null
+  fi
+else
+  echo "IOS_PREVIEW_KEYCHAIN_PASSWORD is not set; assuming the keychain is already unlocked."
+fi
+
+echo "Default keychain:"
+security default-keychain -d user
+
+echo "Visible signing identities:"
+identities="$(security find-identity -v -p codesigning "$keychain" || true)"
+printf '%s\n' "$identities"
+if ! printf '%s\n' "$identities" | grep -q "$identity_pattern"; then
+  cat >&2 <<EOF
+No codesigning identity matching '$identity_pattern' was visible in $keychain.
+
+For the self-hosted runner service, set the GitHub secret IOS_PREVIEW_KEYCHAIN_PASSWORD
+to the login or dedicated preview keychain password, then retry.
+EOF
+  exit 65
+fi
+
+if command -v automationmodetool >/dev/null 2>&1; then
+  automation_status="$(automationmodetool help 2>&1 || true)"
+  printf '%s\n' "$automation_status"
+  if ! printf '%s\n' "$automation_status" | grep -q 'DOES NOT REQUIRE user authentication'; then
+    cat >&2 <<EOF
+Automation Mode still requires local user authentication.
+
+Run this once from an interactive admin session on the runner Mac:
+  automationmodetool enable-automationmode-without-authentication
+EOF
+    exit 69
+  fi
+else
+  echo "automationmodetool is unavailable; continuing."
+fi
+
+echo "Resolving preview device."
+resolver_output="$(IOS_DEVICE_NAME="$device_name" IOS_SCHEME="$scheme" IOS_PROJECT="$project" ./scripts/ios-resolve-preview-device.sh shell)"
+eval "$resolver_output"
+export IOS_DEVICE_ID IOS_XCODE_DEVICE_ID IOS_DESTINATION
+
+echo "CoreDevice id: $IOS_DEVICE_ID"
+echo "Xcode destination id: $IOS_XCODE_DEVICE_ID"
+echo "Xcode destination: $IOS_DESTINATION"
+
+details_json="$(mktemp "${TMPDIR:-/tmp}/issuectl-preview-device-details.XXXXXX")"
+lock_json="$(mktemp "${TMPDIR:-/tmp}/issuectl-preview-device-lock.XXXXXX")"
+trap 'rm -f "$details_json" "$lock_json"' EXIT
+
+xcrun devicectl device info details \
+  --device "$IOS_DEVICE_ID" \
+  --json-output "$details_json" \
+  --quiet \
+  --timeout 10 >/dev/null
+
+xcrun devicectl device info lockState \
+  --device "$IOS_DEVICE_ID" \
+  --json-output "$lock_json" \
+  --quiet \
+  --timeout 10 >/dev/null
+
+echo "Device lock state:"
+jq -r '.result | "  passcodeRequired=\(.passcodeRequired) unlockedSinceBoot=\(.unlockedSinceBoot)"' "$lock_json"
+
+passcode_required="$(jq -r '.result.passcodeRequired' "$lock_json")"
+if [ "$passcode_required" = "true" ]; then
+  echo "The preview iPhone is locked. Unlock iPhone-preview and retry." >&2
+  exit 69
+fi
+
+echo "Xcode version:"
+xcodebuild -version
+
+echo "Preflight passed."


### PR DESCRIPTION
## Summary
- add a reusable iOS preview runner preflight for keychain, signing, Automation Mode, and iPhone-preview readiness
- run the preflight before physical preview smoke in GitHub Actions
- document service-mode signing setup and the errSecInternalComponent recovery path

## Validation
- bash -n scripts/ios-preview-runner-preflight.sh scripts/ios-preview-device-smoke.sh scripts/ios-resolve-preview-device.sh scripts/ios-list-devices.sh
- git diff --check
- ./scripts/ios-preview-runner-preflight.sh
- GitHub Actions workflow_dispatch iOS Physical Preview on LaunchAgent runner: https://github.com/mean-weasel/issuectl/actions/runs/25327726100