### PR TITLE
Add iOS preview operational workflows

### DIFF
--- a/.github/workflows/ios-preview-install.yml
+++ b/.github/workflows/ios-preview-install.yml
@@ -1,0 +1,78 @@
+name: iOS Preview Install
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref or SHA to install. Defaults to the dispatch ref.'
+        required: false
+        type: string
+      configuration:
+        description: 'Build configuration for IssueCTLPreview'
+        required: true
+        default: Debug
+        type: choice
+        options:
+          - Debug
+          - Release
+      run_ui_smoke:
+        description: 'Run physical preview UI smoke after install'
+        required: true
+        default: false
+        type: boolean
+      smoke_profile:
+        description: 'UI smoke profile when run_ui_smoke is enabled'
+        required: true
+        default: fast
+        type: choice
+        options:
+          - fast
+          - pr
+          - full
+
+concurrency:
+  group: ${{ github.workflow }}-iphone-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  install-preview:
+    name: Install IssueCTL Preview on iPhone-preview
+    runs-on: [self-hosted, macOS, issuectl-ios, iphone-preview]
+    timeout-minutes: 25
+    env:
+      IOS_DEVICE_NAME: iPhone-preview
+      IOS_SCHEME: IssueCTLPreview
+      IOS_CONFIGURATION: ${{ inputs.configuration }}
+      IOS_DEVICE_READY_TIMEOUT: 60
+      IOS_XCODEBUILD_EXTRA_ARGS: -allowProvisioningUpdates -allowProvisioningDeviceRegistration
+      IOS_PREVIEW_KEYCHAIN_PASSWORD: ${{ secrets.IOS_PREVIEW_KEYCHAIN_PASSWORD }}
+      IOS_PREVIEW_SET_KEY_PARTITION_LIST: '1'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Preflight runner, signing, and iPhone-preview
+        run: ./scripts/ios-preview-runner-preflight.sh
+
+      - name: Show build environment
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve iPhone-preview
+        run: ./scripts/ios-resolve-preview-device.sh
+
+      - name: Install IssueCTL Preview
+        run: ./scripts/ios-preview-install.sh
+
+      - name: Run physical preview smoke
+        if: inputs.run_ui_smoke
+        env:
+          IOS_SCHEME: IssueCTLPreview-UISmoke
+          IOS_UI_SMOKE_PROFILE: ${{ inputs.smoke_profile }}
+        run: ./scripts/ios-preview-device-smoke.sh

--- a/.github/workflows/ios-preview-runner-health.yml
+++ b/.github/workflows/ios-preview-runner-health.yml
@@ -1,0 +1,28 @@
+name: iOS Preview Runner Health
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  runner-health:
+    name: iPhone Preview Runner Preflight
+    runs-on: [self-hosted, macOS, issuectl-ios, iphone-preview]
+    timeout-minutes: 10
+    env:
+      IOS_DEVICE_NAME: iPhone-preview
+      IOS_SCHEME: IssueCTLPreview-UISmoke
+      IOS_PROJECT: ios/IssueCTL.xcodeproj
+      IOS_PREVIEW_KEYCHAIN_PASSWORD: ${{ secrets.IOS_PREVIEW_KEYCHAIN_PASSWORD }}
+      IOS_PREVIEW_SET_KEY_PARTITION_LIST: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight runner, signing, and iPhone-preview
+        run: ./scripts/ios-preview-runner-preflight.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ The required physical preview merge-queue check is `Physical iPhone Preview Smok
 
 Before physical preview builds, run `pnpm ios:preview-runner-preflight`. The GitHub workflow runs the same script to unlock the signing keychain from `IOS_PREVIEW_KEYCHAIN_PASSWORD`, verify a visible Apple Development identity, verify Automation Mode, resolve `iPhone-preview`, and fail fast if the phone is locked. If the LaunchAgent runner reports `errSecInternalComponent` during `CodeSign`, treat it as a service keychain/signing-access failure first; do not switch preview tests to `iPhone-prod`.
 
+Manual operational workflows:
+- `iOS Preview Runner Health`: preflight only; use it to verify runner/signing/phone readiness without building.
+- `iOS Preview Install`: installs `IssueCTL Preview` on `iPhone-preview` from a selected ref and can optionally run physical preview smoke.
+
 ### iOS performance timing
 
 The iOS app has lightweight `PerformanceTrace` instrumentation for measuring app-side performance. It logs:
@@ -141,27 +145,33 @@ xcrun simctl spawn <simulator-id> log show --last 3m --style compact \
 Useful physical-device capture pattern:
 
 ```bash
-idevicesyslog -u <device-udid> -m '[PerformanceTrace]' --no-colors \
-  > /tmp/issuectl-device-perf-live.log 2>&1 &
+pnpm ios:preview-runner-preflight
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+perf_log="/tmp/issuectl-preview-perf-$stamp.log"
+result_bundle="/tmp/issuectl-preview-perf-$stamp.xcresult"
+
+eval "$(IOS_DEVICE_NAME=iPhone-preview ./scripts/ios-resolve-preview-device.sh shell)"
+export IOS_DEVICE_NAME IOS_DEVICE_ID IOS_XCODE_DEVICE_ID IOS_DESTINATION
+
+idevicesyslog -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors \
+  > "$perf_log" 2>&1 &
 log_pid=$!
 
-xcodebuild test \
-  -project ios/IssueCTL.xcodeproj \
-  -scheme IssueCTLPreview-UISmoke \
-  -configuration Debug \
-  -destination 'platform=iOS,id=<xcode-device-id>' \
-  -only-testing:IssueCTLPreviewUITests/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs \
-  -resultBundlePath /tmp/issuectl-perf-device.xcresult
+IOS_XCODEBUILD_EXTRA_ARGS="-allowProvisioningUpdates -allowProvisioningDeviceRegistration -resultBundlePath $result_bundle" \
+  pnpm ios:preview-device-smoke:fast
 
 kill "$log_pid" 2>/dev/null || true
-grep -n 'PerformanceTrace' /tmp/issuectl-device-perf-live.log
+grep -n 'PerformanceTrace' "$perf_log"
 ```
 
 Notes:
 
 - Prefer `IssueCTLPreview-UISmoke` for repeatable timing runs because its mock server removes internet/GitHub variance.
-- A single focused UI test is more stable on physical devices than a multi-test run; Xcode may mark multi-test physical sessions failed after test-runner restarts even when later individual tests pass.
+- Prefer `pnpm ios:preview-device-smoke:fast` for quick before/after timing comparisons. Use `pnpm ios:preview-device-smoke:full` with the same log capture when broader preview-smoke coverage is needed.
+- Use `iPhone-preview` for physical preview timing. Do not switch to `iPhone-prod` unless the user explicitly asks for a production-device check.
 - If `xcodebuildmcp` device log capture fails with CoreDevice provider errors, `idevicesyslog` works for live physical-device timing logs without root. `/usr/bin/log collect --device-*` requires root on this machine.
+- If `idevicesyslog` cannot attach by `IOS_XCODE_DEVICE_ID`, run `pnpm ios:list-devices` and use the physical device UDID shown for `iPhone-preview`.
 - Restore `ios/IssueCTL/Generated/AppVersion.swift` after Xcode builds if it is modified by the build script.
 
 ## Logging

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -92,6 +92,46 @@ List available device identifiers and preview destinations:
 pnpm ios:list-devices
 ```
 
+## Physical Preview Performance Timing
+
+Use the existing preview smoke wrapper to collect app-side `PerformanceTrace` timings from `iPhone-preview`. The wrapper resolves `iPhone-preview`, checks that the phone is visible and unlocked, and runs the `IssueCTLPreview-UISmoke` scheme with `ISSUECTL_UI_TESTING=1`, which mirrors timing events to device logs with a `[PerformanceTrace]` prefix.
+
+Prerequisites:
+
+- `iPhone-preview` is connected, trusted, unlocked, and awake
+- `idevicesyslog` is available for live physical-device logs
+- signing preflight passes:
+
+```bash
+pnpm ios:preview-runner-preflight
+```
+
+Run a repeatable timing pass and save both the live PerformanceTrace log and the Xcode result bundle:
+
+```bash
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+perf_log="/tmp/issuectl-preview-perf-$stamp.log"
+result_bundle="/tmp/issuectl-preview-perf-$stamp.xcresult"
+
+eval "$(IOS_DEVICE_NAME=iPhone-preview ./scripts/ios-resolve-preview-device.sh shell)"
+export IOS_DEVICE_NAME IOS_DEVICE_ID IOS_XCODE_DEVICE_ID IOS_DESTINATION
+
+idevicesyslog -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors \
+  > "$perf_log" 2>&1 &
+log_pid=$!
+
+IOS_XCODEBUILD_EXTRA_ARGS="-allowProvisioningUpdates -allowProvisioningDeviceRegistration -resultBundlePath $result_bundle" \
+  pnpm ios:preview-device-smoke:fast
+
+kill "$log_pid" 2>/dev/null || true
+grep -n 'PerformanceTrace' "$perf_log"
+printf 'PerformanceTrace log: %s\nXcode result bundle: %s\n' "$perf_log" "$result_bundle"
+```
+
+Use `pnpm ios:preview-device-smoke:full` with the same log capture when you need broader timing coverage across the preview smoke suite. Prefer the fast profile for quick before/after comparisons because it keeps the physical-device run shorter and reduces test-runner restart variance.
+
+If no `PerformanceTrace` lines appear, verify that the run used `IssueCTLPreview-UISmoke` and not the production scheme, then retry while the phone is unlocked. If `idevicesyslog` cannot attach by `IOS_XCODE_DEVICE_ID`, run `pnpm ios:list-devices` and use the physical device UDID shown for `iPhone-preview`.
+
 ## Optional Pre-Push Check
 
 Normal pushes do not require a connected iPhone. To opt into physical preview E2E before pushing iOS-related changes:
@@ -122,6 +162,64 @@ Runner defaults:
 - Test command: `IOS_DEVICE_NAME=iPhone-preview IOS_UI_SMOKE_PROFILE=pr ./scripts/ios-preview-device-smoke.sh`
 
 The workflow emits a lightweight passing `pull_request` check so PRs can enter the merge queue. The actual physical-device run happens on `merge_group` and `workflow_dispatch`, which validates the queue tip rather than the stale PR head.
+
+## Manual Preview Operations
+
+Use `iOS Preview Runner Health` when you only need to check whether the self-hosted runner, signing keychain, Automation Mode, and `iPhone-preview` are ready. It is a manual `workflow_dispatch` workflow and does not build, install, or test the app.
+
+Use `iOS Preview Install` when you need to install `IssueCTL Preview` on `iPhone-preview` from a selected ref. The workflow:
+
+- accepts an optional `ref`
+- builds the `IssueCTLPreview` scheme
+- verifies the bundle id is `com.issuectl.ios.preview`
+- installs only on `iPhone-preview`
+- can optionally run physical preview UI smoke after install
+
+These workflows are intentionally manual operational tools. Merge queue enforcement still happens through `iOS Physical Preview` and its required `Physical iPhone Preview Smoke` check.
+
+## Manual Merge Queue Tip Testing
+
+Use this flow when a PR needs a hands-on check of the exact merge queue build that will land on `main`.
+
+Before enqueueing, make sure `iPhone-preview` is connected to the runner Mac, trusted, unlocked, and awake:
+
+```bash
+pnpm ios:list-devices
+```
+
+Confirm the resolver output names `iPhone-preview`. Do not continue with `iPhone-prod`; it is reserved for the production `IssueCTL` app and production validation.
+
+Enqueue the PR from the GitHub PR page with **Merge when ready** or from the CLI:
+
+```bash
+gh pr merge <pr-number> --auto
+```
+
+For a branch protected by a merge queue, `gh pr merge` does not need a merge strategy. If required checks are still running, `--auto` enables auto-merge and GitHub enqueues the PR after the requirements pass. If requirements have already passed, GitHub adds the PR to the merge queue immediately.
+
+After the PR enters the queue, open the merge queue entry or the PR checks list and watch the `merge_group` run for `iOS Physical Preview`. The check to verify is:
+
+```text
+Physical iPhone Preview Smoke
+```
+
+This check must run on the self-hosted `issuectl-iphone-preview` runner with the `iphone-preview` label. The `pull_request` check is only a placeholder; the manual test should use the `merge_group` check because it builds the merge queue tip commit.
+
+When the `merge_group` check is running or has passed, verify the queue-tip app is installed on the physical preview phone:
+
+1. On `iPhone-preview`, find `IssueCTL Preview` on the Home Screen or App Library. It should be installed separately from `IssueCTL`.
+2. Open `IssueCTL Preview`, go to Settings, and check the app version/build string.
+3. Compare the short build SHA in Settings with the merge queue tip SHA shown in the GitHub `merge_group` run. They should match.
+4. Manually inspect the flow under review in `IssueCTL Preview`. Keep the phone unlocked and awake until inspection is complete.
+
+Use the installed app identity to distinguish the two physical-device lanes:
+
+| Device role | App to inspect | Bundle id | URL scheme | Use for |
+|---|---|---|---|---|
+| `iPhone-preview` | `IssueCTL Preview` | `com.issuectl.ios.preview` | `issuectl-preview` | merge queue tip builds, preview smoke tests, PR validation |
+| `iPhone-prod` | `IssueCTL` | `com.issuectl.ios` | `issuectl` | production installs and production validation |
+
+If `IssueCTL Preview` is missing from `iPhone-preview`, rerun or redispatch the `iOS Physical Preview` workflow for the merge queue ref. If the workflow cannot resolve the phone, unlock `iPhone-preview`, verify it appears in `pnpm ios:list-devices`, and rerun the failed check. Do not switch the merge queue check to `iPhone-prod`.
 
 Register the runner from repository settings with the GitHub-provided command, then add the custom labels above. Install it as a launchd service on the MacBook so it survives logout/reboot. To inspect the installed service locally:
 

--- a/scripts/ios-preview-install.sh
+++ b/scripts/ios-preview-install.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PROJECT="${IOS_PROJECT:-ios/IssueCTL.xcodeproj}"
+SCHEME="${IOS_SCHEME:-IssueCTLPreview}"
+CONFIGURATION="${IOS_CONFIGURATION:-Debug}"
+DEVICE_NAME="${IOS_DEVICE_NAME:-iPhone-preview}"
+DERIVED_DATA_PATH="${IOS_DERIVED_DATA_PATH:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/issuectl-preview-install-derived-data}"
+
+if [ "$DEVICE_NAME" != "iPhone-preview" ]; then
+  echo "Refusing to install preview app on unexpected device '$DEVICE_NAME'." >&2
+  exit 64
+fi
+
+if [ -z "${IOS_DESTINATION:-}" ] || [ -z "${IOS_DEVICE_ID:-}" ]; then
+  resolver_output="$(IOS_PROJECT="$PROJECT" IOS_SCHEME="$SCHEME" IOS_DEVICE_NAME="$DEVICE_NAME" ./scripts/ios-resolve-preview-device.sh shell)"
+  eval "$resolver_output"
+  export IOS_DEVICE_ID IOS_XCODE_DEVICE_ID IOS_DESTINATION
+fi
+
+if [ -z "${IOS_DEVICE_ID:-}" ] || [ -z "${IOS_DESTINATION:-}" ]; then
+  echo "Could not resolve $DEVICE_NAME for preview install." >&2
+  exit 69
+fi
+
+rm -rf "$DERIVED_DATA_PATH"
+mkdir -p "$DERIVED_DATA_PATH"
+
+args=()
+if [ -n "${IOS_XCODEBUILD_EXTRA_ARGS:-}" ]; then
+  # shellcheck disable=SC2206
+  XCODEBUILD_EXTRA_ARGS=($IOS_XCODEBUILD_EXTRA_ARGS)
+  args+=("${XCODEBUILD_EXTRA_ARGS[@]}")
+fi
+
+args+=(
+  build
+  -project "$PROJECT"
+  -scheme "$SCHEME"
+  -destination "$IOS_DESTINATION"
+  -configuration "$CONFIGURATION"
+  -derivedDataPath "$DERIVED_DATA_PATH"
+)
+
+echo "Building $SCHEME ($CONFIGURATION) for $DEVICE_NAME."
+echo "Xcode destination: $IOS_DESTINATION"
+if command -v xcpretty >/dev/null 2>&1; then
+  set -o pipefail
+  xcodebuild "${args[@]}" | xcpretty
+else
+  xcodebuild "${args[@]}"
+fi
+
+app_path="$DERIVED_DATA_PATH/Build/Products/${CONFIGURATION}-iphoneos/IssueCTLPreview.app"
+
+if [ ! -d "$app_path" ]; then
+  echo "Could not find built IssueCTLPreview.app under $DERIVED_DATA_PATH/Build/Products." >&2
+  exit 70
+fi
+
+bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
+if [ "$bundle_id" != "com.issuectl.ios.preview" ]; then
+  echo "Refusing to install unexpected bundle id '$bundle_id' from $app_path." >&2
+  exit 70
+fi
+
+echo "Installing $bundle_id on $DEVICE_NAME."
+xcrun devicectl device install app \
+  --device "$IOS_DEVICE_ID" \
+  "$app_path"
+
+echo "Installed $bundle_id from $app_path."


### PR DESCRIPTION
## Summary
- add a manual iOS preview runner health workflow that runs preflight only
- add a manual iOS preview install workflow and helper script for installing IssueCTL Preview on iPhone-preview from a selected ref
- document merge-queue-tip manual testing and physical preview performance timing

## Validation
- bash -n scripts/ios-preview-install.sh scripts/ios-preview-runner-preflight.sh scripts/ios-preview-device-smoke.sh scripts/ios-resolve-preview-device.sh
- Ruby YAML parse for iOS preview workflows
- git diff --check
- shellcheck on iOS preview scripts
- pnpm ios:preview-runner-preflight
- IOS_CONFIGURATION=Debug ./scripts/ios-preview-install.sh installed com.issuectl.ios.preview on iPhone-preview