### PR TITLE
feat(ios): add offline queue for issue actions

### DIFF
--- a/ios/IssueCTL.xcodeproj/project.pbxproj
+++ b/ios/IssueCTL.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		4BB20ADE0BE999E563444C1B /* RepoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */; };
 		5029F9DC560599B76834000C /* APIClient+Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3079E105A528EED5BBA37B20 /* APIClient+Priority.swift */; };
 		51D419285114BB9B1F7B6D5A /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD45B1F8D03F28DE1ECAA00 /* GitHubAccessibleRepo.swift */; };
+		52543EF1C7077597CC6DC8F0 /* OfflineSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */; };
 		5317AF616D7D3E184371FA9B /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */; };
 		54C6FF5A24ED1F784D022F19 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */; };
 		554B56D3274A1BC49D0B3939 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5C5A4C468148B6D09FDA6F /* ServerHealth.swift */; };
@@ -85,6 +86,7 @@
 		78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E1C810B3BD014B117301B /* IssueCTLApp.swift */; };
 		7A144A11958A6F173128CE49 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
 		7AB66E17B8510A46A4AA9825 /* RepoFilterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41967EFA522B03BFB6FDADA7 /* RepoFilterHelpers.swift */; };
+		7DCCB51EE3C4FBCD4C6719A3 /* OfflineQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */; };
 		811BB01A63344A1A3CFCA423 /* PRBrowseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1A0D520FF36C8DB326D31F /* PRBrowseTests.swift */; };
 		81AFBA58B00DCECA768B0079 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4403330B1342AA7C19FA797D /* Constants.swift */; };
 		83664A1EEF860FABA2F49FDD /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94F959305A936F2643E3F6 /* APIClient+DetailActions.swift */; };
@@ -104,6 +106,7 @@
 		9D86848D19E2C82D05E7DBC6 /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		9DB9BDF2F2C21E172E73D8D2 /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5A265D82B7D9C9716818D /* APIClient+ListEnhancements.swift */; };
 		9E992E49A2D7059EA9BC4F34 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7ECAC829C2F7C7E8DE88F9 /* PullRequest.swift */; };
+		9EE10C9DAB5A8E58DFFD571E /* OfflineQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */; };
 		9F4A5C1ED1DFDCBC5EA8D823 /* InteractivePopDisabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCED89BF4650BDFC4262B48D /* InteractivePopDisabler.swift */; };
 		9FC4A8A601C39FEEDE496822 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA58C21063864ADB4BAC822 /* TodayView.swift */; };
 		A0D87C6AEC928127B7E8C4B2 /* OfflineCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */; };
@@ -139,12 +142,14 @@
 		C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
 		CAE2CE1A865667A1E4BD7CBC /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F091BF822565D8E0F15E7A /* APIClient.swift */; };
+		CB1BD4038692E9AD73D95C1B /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
 		CC83F861B2A764DB8AA4FC4A /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		CDB684F0D93BA2822BCFC541 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */; };
 		CF8A626D972649C230E5C866 /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */; };
 		CFB583BFD7F691C6730C4CEA /* IssueCTLUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FC68F504BF4FA08B86548 /* IssueCTLUITests.swift */; };
 		D1B085BF32A2BA054762456F /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC00C899D2ADA14475787AE7 /* APIClientTests.swift */; };
 		D52DC5DDE3BE88CF966B0675 /* IssueCTLUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FC68F504BF4FA08B86548 /* IssueCTLUITests.swift */; };
+		D54371BD0B51A23079CEEEFF /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
 		D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */; };
 		D9D891AEA02391C6479319B5 /* NotificationSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */; };
 		DBAAAF7B3925847446CC5E39 /* ModelDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */; };
@@ -219,6 +224,7 @@
 		223E1C810B3BD014B117301B /* IssueCTLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLApp.swift; sourceTree = "<group>"; };
 		22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIssueSheet.swift; sourceTree = "<group>"; };
 		22FAF4DCDBAB6A7A58E076C4 /* APIClient+Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Assignment.swift"; sourceTree = "<group>"; };
+		244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineSyncServiceTests.swift; sourceTree = "<group>"; };
 		2841D89323711B68449BB980 /* CacheAgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheAgeLabel.swift; sourceTree = "<group>"; };
 		28E6C0859937F6A85F709D99 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		2A0C921D1804F0904F029CC8 /* EnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTests.swift; sourceTree = "<group>"; };
@@ -246,6 +252,7 @@
 		5809ACB6716C100004867EC9 /* IssueCTLPreviewUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLPreviewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CE9191D87F0834C417E13B0 /* AssigneeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSheet.swift; sourceTree = "<group>"; };
 		5CEF9A9D19EA4BD4284C8F00 /* SessionManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagementTests.swift; sourceTree = "<group>"; };
+		5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueView.swift; sourceTree = "<group>"; };
 		5D7F67955189D36EB74DEA6A /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
 		61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsStore.swift; sourceTree = "<group>"; };
 		62E30AE4ECDAC300ED2EE8F2 /* APIClientExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientExtensionTests.swift; sourceTree = "<group>"; };
@@ -266,6 +273,7 @@
 		87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentButton.swift; sourceTree = "<group>"; };
 		9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepoSheet.swift; sourceTree = "<group>"; };
+		9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineSyncService.swift; sourceTree = "<group>"; };
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		A6B7390E54A0BCD855ECC978 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -372,6 +380,7 @@
 				FAC4DF9BB857B451A1F2B5B3 /* NetworkMonitor.swift */,
 				61B8353783F6D7E7BC9420E5 /* NotificationSettingsStore.swift */,
 				344AF8ECD4E65221811E904A /* OfflineCacheStore.swift */,
+				9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */,
 				BC1D044DCA62B13F4196F816 /* SetupLink.swift */,
 			);
 			path = Services;
@@ -400,6 +409,7 @@
 				6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */,
 				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
 				87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */,
+				5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */,
 				093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */,
 				723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */,
 			);
@@ -414,6 +424,7 @@
 				F3CF16B90E6F234095B67412 /* EdgeCaseModelTests.swift */,
 				2A0C921D1804F0904F029CC8 /* EnumTests.swift */,
 				533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */,
+				244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */,
 				F63680089A3314AB67CE5883 /* ViewLogicTests.swift */,
 			);
 			path = IssueCTLTests;
@@ -773,6 +784,7 @@
 				57F286E2B3615BA000C1987C /* EdgeCaseModelTests.swift in Sources */,
 				A6691865FCEEB29344BCCBAE /* EnumTests.swift in Sources */,
 				DBAAAF7B3925847446CC5E39 /* ModelDecodingTests.swift in Sources */,
+				52543EF1C7077597CC6DC8F0 /* OfflineSyncServiceTests.swift in Sources */,
 				EE5CBD61D807436206C48637 /* ViewLogicTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -831,6 +843,8 @@
 				D9D891AEA02391C6479319B5 /* NotificationSettingsStore.swift in Sources */,
 				55AEB0B56C5CDDF6FD4B7B0F /* NotificationSettingsView.swift in Sources */,
 				16F841C2C2ACBFE1AC1D4AA6 /* OfflineCacheStore.swift in Sources */,
+				9EE10C9DAB5A8E58DFFD571E /* OfflineQueueView.swift in Sources */,
+				D54371BD0B51A23079CEEEFF /* OfflineSyncService.swift in Sources */,
 				2B4C13B0BF6A1A03B8D80F28 /* OnboardingView.swift in Sources */,
 				A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */,
 				65142BB24364562CB5305E0F /* PRListView.swift in Sources */,
@@ -913,6 +927,8 @@
 				B6466C355DE3B70971FA8D7D /* NotificationSettingsStore.swift in Sources */,
 				54C6FF5A24ED1F784D022F19 /* NotificationSettingsView.swift in Sources */,
 				A0D87C6AEC928127B7E8C4B2 /* OfflineCacheStore.swift in Sources */,
+				7DCCB51EE3C4FBCD4C6719A3 /* OfflineQueueView.swift in Sources */,
+				CB1BD4038692E9AD73D95C1B /* OfflineSyncService.swift in Sources */,
 				227F5D726370EBF5F1C55F98 /* OnboardingView.swift in Sources */,
 				B5F6E35A791604A67AB43860 /* PRDetailView.swift in Sources */,
 				29142761332EA217923C5D78 /* PRListView.swift in Sources */,

--- a/ios/IssueCTL/App/ContentView.swift
+++ b/ios/IssueCTL/App/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @Environment(APIClient.self) private var api
     @Environment(NetworkMonitor.self) private var network
     @Environment(NotificationSettingsStore.self) private var notificationSettings
+    @Environment(OfflineSyncService.self) private var offlineSync
     @State private var selectedTab: AppTab = .today
     @State private var showSettings = false
     private let launchNotificationSyncDelay: Duration = .seconds(1)
@@ -58,12 +59,34 @@ struct ContentView: View {
                     SettingsView()
                 }
                 .overlay(alignment: .top) {
-                    OfflineBanner()
+                    VStack(spacing: 8) {
+                        OfflineBanner()
+                        OfflineQueueBanner(
+                            pendingCount: offlineSync.pendingCount,
+                            failedCount: offlineSync.failedCount,
+                            isSyncing: offlineSync.isSyncing,
+                            onSync: {
+                                offlineSync.retryFailedActions()
+                                await offlineSync.syncPendingActions()
+                            },
+                            onDismissFailed: {
+                                offlineSync.clearFailedActions()
+                            }
+                        )
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
                 }
                 .animation(.easeInOut(duration: 0.3), value: network.isConnected)
+                .animation(.easeInOut(duration: 0.25), value: offlineSync.pendingCount)
+                .animation(.easeInOut(duration: 0.25), value: offlineSync.failedCount)
             } else {
                 OnboardingView()
             }
+        }
+        .onChange(of: network.isConnected) { _, isConnected in
+            guard isConnected else { return }
+            Task { await offlineSync.syncPendingActions() }
         }
         .onOpenURL { url in
             guard let setup = SetupLink(url: url) else { return }

--- a/ios/IssueCTL/App/IssueCTLApp.swift
+++ b/ios/IssueCTL/App/IssueCTLApp.swift
@@ -33,12 +33,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct IssueCTLApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @State private var apiClient = APIClient()
+    @State private var apiClient: APIClient
     @State private var networkMonitor = NetworkMonitor()
     @State private var notificationSettings = NotificationSettingsStore()
+    @State private var offlineSync: OfflineSyncService
 
     init() {
         PerformanceTrace.markAppLaunchStarted()
+        let apiClient = APIClient()
+        _apiClient = State(initialValue: apiClient)
+        _offlineSync = State(initialValue: OfflineSyncService(client: apiClient))
     }
 
     var body: some Scene {
@@ -47,6 +51,7 @@ struct IssueCTLApp: App {
                 .environment(apiClient)
                 .environment(networkMonitor)
                 .environment(notificationSettings)
+                .environment(offlineSync)
         }
     }
 }

--- a/ios/IssueCTL/Services/OfflineCacheStore.swift
+++ b/ios/IssueCTL/Services/OfflineCacheStore.swift
@@ -46,3 +46,236 @@ struct OfflineCacheStore {
         sharedISO8601Formatter.string(from: Date())
     }
 }
+
+enum OfflineActionStatus: String, Codable, Equatable, Sendable {
+    case pending
+    case inFlight
+    case failed
+}
+
+struct IssueCommentOfflineAction: Codable, Equatable, Sendable {
+    let owner: String
+    let repo: String
+    let issueNumber: Int
+    let body: String
+}
+
+struct IssueStateOfflineAction: Codable, Equatable, Sendable {
+    let owner: String
+    let repo: String
+    let issueNumber: Int
+    let state: String
+    let comment: String?
+}
+
+enum OfflineActionKind: Codable, Equatable, Sendable {
+    case issueComment(IssueCommentOfflineAction)
+    case issueState(IssueStateOfflineAction)
+}
+
+struct QueuedOfflineAction: Codable, Identifiable, Equatable, Sendable {
+    let id: String
+    let kind: OfflineActionKind
+    var status: OfflineActionStatus
+    var retryCount: Int
+    var lastError: String?
+    let createdAt: String
+    var updatedAt: String
+}
+
+protocol OfflineActionQueueStoring {
+    func allActions() -> [QueuedOfflineAction]
+    func pendingActions() -> [QueuedOfflineAction]
+    func failedActions() -> [QueuedOfflineAction]
+
+    @discardableResult
+    func enqueueIssueComment(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        body: String,
+        id: String?,
+        now: Date
+    ) -> QueuedOfflineAction
+
+    @discardableResult
+    func enqueueIssueState(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        state: String,
+        comment: String?,
+        id: String?,
+        now: Date
+    ) -> QueuedOfflineAction
+
+    func remove(id: String)
+
+    @discardableResult
+    func markInFlight(id: String, now: Date) -> QueuedOfflineAction?
+
+    func markCompleted(id: String)
+
+    @discardableResult
+    func markFailed(id: String, error: String, now: Date) -> QueuedOfflineAction?
+
+    @discardableResult
+    func markPending(id: String, now: Date) -> QueuedOfflineAction?
+
+    func removeFailedActions()
+}
+
+struct OfflineActionQueueStore: OfflineActionQueueStoring {
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard, storageKey: String = "issuectl.offlineActionQueue") {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    func allActions() -> [QueuedOfflineAction] {
+        loadActions()
+    }
+
+    func pendingActions() -> [QueuedOfflineAction] {
+        loadActions().filter { $0.status == .pending }
+    }
+
+    func failedActions() -> [QueuedOfflineAction] {
+        loadActions().filter { $0.status == .failed }
+    }
+
+    @discardableResult
+    func enqueueIssueComment(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        body: String,
+        id: String? = nil,
+        now: Date = Date()
+    ) -> QueuedOfflineAction {
+        let timestamp = timestamp(for: now)
+        let action = QueuedOfflineAction(
+            id: id ?? UUID().uuidString,
+            kind: .issueComment(
+                IssueCommentOfflineAction(
+                    owner: owner,
+                    repo: repo,
+                    issueNumber: issueNumber,
+                    body: body
+                )
+            ),
+            status: .pending,
+            retryCount: 0,
+            lastError: nil,
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+
+        var actions = loadActions()
+        actions.append(action)
+        saveActions(actions)
+        return action
+    }
+
+    @discardableResult
+    func enqueueIssueState(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        state: String,
+        comment: String? = nil,
+        id: String? = nil,
+        now: Date = Date()
+    ) -> QueuedOfflineAction {
+        let timestamp = timestamp(for: now)
+        let action = QueuedOfflineAction(
+            id: id ?? UUID().uuidString,
+            kind: .issueState(
+                IssueStateOfflineAction(
+                    owner: owner,
+                    repo: repo,
+                    issueNumber: issueNumber,
+                    state: state,
+                    comment: comment
+                )
+            ),
+            status: .pending,
+            retryCount: 0,
+            lastError: nil,
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+
+        var actions = loadActions()
+        actions.append(action)
+        saveActions(actions)
+        return action
+    }
+
+    func remove(id: String) {
+        saveActions(loadActions().filter { $0.id != id })
+    }
+
+    func markCompleted(id: String) {
+        remove(id: id)
+    }
+
+    @discardableResult
+    func markInFlight(id: String, now: Date = Date()) -> QueuedOfflineAction? {
+        updateAction(id: id) { action in
+            action.status = .inFlight
+            action.updatedAt = timestamp(for: now)
+        }
+    }
+
+    @discardableResult
+    func markFailed(id: String, error: String, now: Date = Date()) -> QueuedOfflineAction? {
+        updateAction(id: id) { action in
+            action.status = .failed
+            action.retryCount += 1
+            action.lastError = error
+            action.updatedAt = timestamp(for: now)
+        }
+    }
+
+    @discardableResult
+    func markPending(id: String, now: Date = Date()) -> QueuedOfflineAction? {
+        updateAction(id: id) { action in
+            action.status = .pending
+            action.updatedAt = timestamp(for: now)
+        }
+    }
+
+    func removeFailedActions() {
+        saveActions(loadActions().filter { $0.status != .failed })
+    }
+
+    private func updateAction(
+        id: String,
+        update: (inout QueuedOfflineAction) -> Void
+    ) -> QueuedOfflineAction? {
+        var actions = loadActions()
+        guard let index = actions.firstIndex(where: { $0.id == id }) else { return nil }
+        update(&actions[index])
+        saveActions(actions)
+        return actions[index]
+    }
+
+    private func loadActions() -> [QueuedOfflineAction] {
+        guard let data = defaults.data(forKey: storageKey) else { return [] }
+        return (try? decoder.decode([QueuedOfflineAction].self, from: data)) ?? []
+    }
+
+    private func saveActions(_ actions: [QueuedOfflineAction]) {
+        guard let data = try? encoder.encode(actions) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+
+    private func timestamp(for date: Date) -> String {
+        sharedISO8601Formatter.string(from: date)
+    }
+}

--- a/ios/IssueCTL/Services/OfflineSyncService.swift
+++ b/ios/IssueCTL/Services/OfflineSyncService.swift
@@ -1,0 +1,259 @@
+import Foundation
+
+@MainActor
+protocol OfflineIssueCommentPosting: AnyObject {
+    func commentOnIssue(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueCommentRequestBody
+    ) async throws -> IssueCommentResponse
+}
+
+@MainActor
+protocol OfflineIssueStateUpdating: AnyObject {
+    func updateIssueState(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueStateRequestBody
+    ) async throws -> IssueStateResponse
+}
+
+extension APIClient: OfflineIssueCommentPosting {}
+extension APIClient: OfflineIssueStateUpdating {}
+
+func isQueueableNetworkFailure(_ error: Error, isConnected: Bool) -> Bool {
+    if !isConnected {
+        return true
+    }
+
+    let nsError = error as NSError
+    guard nsError.domain == NSURLErrorDomain else {
+        return false
+    }
+
+    switch nsError.code {
+    case NSURLErrorNotConnectedToInternet,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorCannotFindHost,
+        NSURLErrorTimedOut,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorDataNotAllowed:
+        return true
+    default:
+        return false
+    }
+}
+
+struct OfflineSyncResult: Equatable, Sendable {
+    let attempted: Int
+    let completed: Int
+    let failed: Int
+    let alreadyRunning: Bool
+
+    static var alreadyRunning: OfflineSyncResult {
+        OfflineSyncResult(
+            attempted: 0,
+            completed: 0,
+            failed: 0,
+            alreadyRunning: true
+        )
+    }
+}
+
+@MainActor
+@Observable
+final class OfflineSyncService {
+    private let store: any OfflineActionQueueStoring
+    private let client: any OfflineIssueCommentPosting & OfflineIssueStateUpdating
+
+    private(set) var isSyncing = false
+    private(set) var actions: [QueuedOfflineAction] = []
+    private(set) var pendingCount = 0
+    private(set) var failedCount = 0
+
+    init(
+        store: any OfflineActionQueueStoring = OfflineActionQueueStore(),
+        client: any OfflineIssueCommentPosting & OfflineIssueStateUpdating
+    ) {
+        self.store = store
+        self.client = client
+        refreshCounts()
+    }
+
+    @discardableResult
+    func enqueueIssueComment(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        body: String
+    ) -> QueuedOfflineAction {
+        let action = store.enqueueIssueComment(
+            owner: owner,
+            repo: repo,
+            issueNumber: issueNumber,
+            body: body,
+            id: nil,
+            now: Date()
+        )
+        refreshCounts()
+        return action
+    }
+
+    @discardableResult
+    func enqueueIssueState(
+        owner: String,
+        repo: String,
+        issueNumber: Int,
+        state: String,
+        comment: String? = nil
+    ) -> QueuedOfflineAction {
+        let action = store.enqueueIssueState(
+            owner: owner,
+            repo: repo,
+            issueNumber: issueNumber,
+            state: state,
+            comment: comment,
+            id: nil,
+            now: Date()
+        )
+        refreshCounts()
+        return action
+    }
+
+    func retryFailedActions() {
+        for action in store.failedActions() {
+            _ = store.markPending(id: action.id, now: Date())
+        }
+        refreshCounts()
+    }
+
+    func clearFailedActions() {
+        store.removeFailedActions()
+        refreshCounts()
+    }
+
+    func removeAction(id: String) {
+        store.remove(id: id)
+        refreshCounts()
+    }
+
+    func refreshCounts() {
+        actions = store.allActions()
+        pendingCount = actions.filter { $0.status == .pending }.count
+        failedCount = actions.filter { $0.status == .failed }.count
+    }
+
+    @discardableResult
+    func syncPendingActions() async -> OfflineSyncResult {
+        guard !isSyncing else {
+            return .alreadyRunning
+        }
+
+        isSyncing = true
+        defer {
+            isSyncing = false
+            refreshCounts()
+        }
+
+        let actions = store.pendingActions()
+        var attempted = 0
+        var completed = 0
+        var failed = 0
+
+        for action in actions {
+            attempted += 1
+            _ = store.markInFlight(id: action.id, now: Date())
+
+            do {
+                let success = try await replay(action)
+                if success {
+                    store.markCompleted(id: action.id)
+                    completed += 1
+                }
+            } catch {
+                _ = store.markFailed(id: action.id, error: Self.failureMessage(for: error), now: Date())
+                failed += 1
+            }
+        }
+
+        return OfflineSyncResult(
+            attempted: attempted,
+            completed: completed,
+            failed: failed,
+            alreadyRunning: false
+        )
+    }
+
+    private func replay(_ action: QueuedOfflineAction) async throws -> Bool {
+        switch action.kind {
+        case .issueComment(let comment):
+            let response = try await client.commentOnIssue(
+                owner: comment.owner,
+                repo: comment.repo,
+                number: comment.issueNumber,
+                body: IssueCommentRequestBody(body: comment.body)
+            )
+            if !response.success {
+                throw OfflineSyncFailure.message(Self.failureMessage(from: response))
+            }
+            return true
+
+        case .issueState(let issueState):
+            let response = try await client.updateIssueState(
+                owner: issueState.owner,
+                repo: issueState.repo,
+                number: issueState.issueNumber,
+                body: IssueStateRequestBody(state: issueState.state, comment: issueState.comment)
+            )
+            if !response.success {
+                throw OfflineSyncFailure.message(Self.failureMessage(from: response))
+            }
+            return true
+        }
+    }
+
+    @discardableResult
+    func requestSync() -> Task<OfflineSyncResult, Never> {
+        Task { @MainActor in
+            await syncPendingActions()
+        }
+    }
+
+    private static func failureMessage(for error: Error) -> String {
+        let localized = error.localizedDescription
+        if !localized.isEmpty {
+            return localized
+        }
+
+        let message = String(describing: error)
+        return message.isEmpty ? "Issue comment sync failed" : message
+    }
+
+    private static func failureMessage(from response: IssueCommentResponse) -> String {
+        guard let error = response.error, !error.isEmpty else {
+            return "Issue comment sync failed"
+        }
+        return error
+    }
+
+    private static func failureMessage(from response: IssueStateResponse) -> String {
+        guard let error = response.error, !error.isEmpty else {
+            return "Issue state sync failed"
+        }
+        return error
+    }
+}
+
+private enum OfflineSyncFailure: LocalizedError {
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .message(let message):
+            message
+        }
+    }
+}

--- a/ios/IssueCTL/Views/Issues/CloseIssueSheet.swift
+++ b/ios/IssueCTL/Views/Issues/CloseIssueSheet.swift
@@ -2,12 +2,29 @@ import SwiftUI
 
 struct CloseIssueSheet: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+    @Environment(OfflineSyncService.self) private var offlineSync
     @Environment(\.dismiss) private var dismiss
 
     let owner: String
     let repo: String
     let number: Int
     let onSuccess: () -> Void
+    let onQueued: () -> Void
+
+    init(
+        owner: String,
+        repo: String,
+        number: Int,
+        onSuccess: @escaping () -> Void,
+        onQueued: @escaping () -> Void = {}
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.onSuccess = onSuccess
+        self.onQueued = onQueued
+    }
 
     @State private var closingComment = ""
     @State private var isSubmitting = false
@@ -71,7 +88,20 @@ struct CloseIssueSheet: View {
                 errorMessage = response.error ?? "Failed to close issue"
             }
         } catch {
-            errorMessage = error.localizedDescription
+            let trimmed = closingComment.trimmingCharacters(in: .whitespacesAndNewlines)
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(
+                    owner: owner,
+                    repo: repo,
+                    issueNumber: number,
+                    state: "closed",
+                    comment: trimmed.isEmpty ? nil : trimmed
+                )
+                onQueued()
+                dismiss()
+            } else {
+                errorMessage = error.localizedDescription
+            }
         }
         isSubmitting = false
     }

--- a/ios/IssueCTL/Views/Issues/IssueCommentSheet.swift
+++ b/ios/IssueCTL/Views/Issues/IssueCommentSheet.swift
@@ -2,12 +2,29 @@ import SwiftUI
 
 struct IssueCommentSheet: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+    @Environment(OfflineSyncService.self) private var offlineSync
     @Environment(\.dismiss) private var dismiss
 
     let owner: String
     let repo: String
     let number: Int
     let onSuccess: () -> Void
+    let onQueued: () -> Void
+
+    init(
+        owner: String,
+        repo: String,
+        number: Int,
+        onSuccess: @escaping () -> Void,
+        onQueued: @escaping () -> Void = {}
+    ) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+        self.onSuccess = onSuccess
+        self.onQueued = onQueued
+    }
 
     @State private var commentBody = ""
     @State private var isSubmitting = false
@@ -75,7 +92,14 @@ struct IssueCommentSheet: View {
                 errorMessage = response.error ?? "Failed to add comment"
             }
         } catch {
-            errorMessage = error.localizedDescription
+            let trimmed = commentBody.trimmingCharacters(in: .whitespacesAndNewlines)
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueComment(owner: owner, repo: repo, issueNumber: number, body: trimmed)
+                onQueued()
+                dismiss()
+            } else {
+                errorMessage = error.localizedDescription
+            }
         }
         isSubmitting = false
     }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct IssueDetailView: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+    @Environment(OfflineSyncService.self) private var offlineSync
     @Environment(\.openURL) private var openURL
     let owner: String
     let repo: String
@@ -150,12 +152,14 @@ struct IssueDetailView: View {
             case .comment:
                 IssueCommentSheet(
                     owner: owner, repo: repo, number: number,
-                    onSuccess: { Task { await load(refresh: true) } }
+                    onSuccess: { Task { await load(refresh: true) } },
+                    onQueued: { showStaleHint("Comment queued - will sync when you're back online") }
                 )
             case .closeWithComment:
                 CloseIssueSheet(
                     owner: owner, repo: repo, number: number,
-                    onSuccess: { Task { await load(refresh: true) } }
+                    onSuccess: { Task { await load(refresh: true) } },
+                    onQueued: { showStaleHint("Issue close queued - will sync when you're back online") }
                 )
             case .editComment(let comment):
                 EditCommentSheet(
@@ -699,7 +703,12 @@ struct IssueDetailView: View {
                 actionError = response.error ?? "Failed to close issue"
             }
         } catch {
-            actionError = error.localizedDescription
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(owner: owner, repo: repo, issueNumber: number, state: "closed")
+                showStaleHint("Issue close queued - will sync when you're back online")
+            } else {
+                actionError = error.localizedDescription
+            }
         }
     }
 
@@ -717,7 +726,12 @@ struct IssueDetailView: View {
                 actionError = response.error ?? "Failed to reopen issue"
             }
         } catch {
-            actionError = error.localizedDescription
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(owner: owner, repo: repo, issueNumber: number, state: "open")
+                showStaleHint("Issue reopen queued - will sync when you're back online")
+            } else {
+                actionError = error.localizedDescription
+            }
         }
     }
 

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct IssueListView: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+    @Environment(OfflineSyncService.self) private var offlineSync
     let onShowSettings: () -> Void
 
     @State private var repos: [Repo] = []
@@ -764,7 +766,19 @@ struct IssueListView: View {
                 actionError = response.error ?? "Failed to \(verb) issue"
             }
         } catch {
-            actionError = error.localizedDescription
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(
+                    owner: owner,
+                    repo: repo,
+                    issueNumber: number,
+                    state: state
+                )
+                actionError = state == "closed"
+                    ? "Issue close queued - will sync when you're back online"
+                    : "Issue reopen queued - will sync when you're back online"
+            } else {
+                actionError = error.localizedDescription
+            }
         }
     }
 

--- a/ios/IssueCTL/Views/Settings/OfflineQueueView.swift
+++ b/ios/IssueCTL/Views/Settings/OfflineQueueView.swift
@@ -1,0 +1,403 @@
+import SwiftUI
+
+struct OfflineQueueView: View {
+    @Environment(OfflineSyncService.self) private var offlineSync
+    @State private var syncResult: OfflineSyncResult?
+
+    var body: some View {
+        List {
+            summarySection
+
+            if offlineSync.actions.isEmpty {
+                emptySection
+            } else {
+                actionsSection
+            }
+        }
+        .navigationTitle("Offline Queue")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if offlineSync.isSyncing {
+                    ProgressView()
+                } else if !offlineSync.actions.isEmpty {
+                    Button("Sync") {
+                        sync()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .disabled(offlineSync.pendingCount == 0)
+                    .accessibilityIdentifier("offline-queue-sync-button")
+                }
+            }
+        }
+        .task {
+            offlineSync.refreshCounts()
+        }
+        .refreshable {
+            syncResult = await offlineSync.syncPendingActions()
+        }
+    }
+
+    private var summarySection: some View {
+        Section {
+            HStack(spacing: 12) {
+                QueueMetricView(title: "Pending", value: offlineSync.pendingCount, tint: .orange)
+                QueueMetricView(title: "Failed", value: offlineSync.failedCount, tint: .red)
+                QueueMetricView(title: "Total", value: offlineSync.actions.count, tint: IssueCTLColors.action)
+            }
+
+            if let syncResult {
+                Text(resultSummary(syncResult))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if offlineSync.failedCount > 0 {
+                HStack {
+                    Button {
+                        offlineSync.retryFailedActions()
+                    } label: {
+                        Label("Retry Failed", systemImage: "arrow.clockwise")
+                    }
+                    .accessibilityIdentifier("offline-queue-retry-failed-button")
+
+                    Spacer()
+
+                    Button(role: .destructive) {
+                        offlineSync.clearFailedActions()
+                    } label: {
+                        Label("Clear Failed", systemImage: "trash")
+                    }
+                    .accessibilityIdentifier("offline-queue-clear-failed-button")
+                }
+                .font(.subheadline.weight(.semibold))
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+
+    private var emptySection: some View {
+        Section {
+            ContentUnavailableView {
+                Label("Queue Empty", systemImage: "checkmark.circle")
+            } description: {
+                Text("Offline issue actions will appear here until they sync.")
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        Section("Actions") {
+            ForEach(offlineSync.actions) { action in
+                NavigationLink {
+                    OfflineQueueActionDetailView(action: action)
+                } label: {
+                    OfflineQueueActionRow(action: action)
+                }
+                .accessibilityIdentifier("offline-queue-action-\(action.id)")
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button(role: .destructive) {
+                        offlineSync.removeAction(id: action.id)
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button(role: .destructive) {
+                        offlineSync.removeAction(id: action.id)
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                }
+            }
+        }
+    }
+
+    private func sync() {
+        Task {
+            syncResult = await offlineSync.syncPendingActions()
+        }
+    }
+
+    private func resultSummary(_ result: OfflineSyncResult) -> String {
+        if result.alreadyRunning {
+            return "Sync already in progress."
+        }
+
+        if result.attempted == 0 {
+            return "No pending actions to sync."
+        }
+
+        var parts = ["\(result.completed) synced"]
+        if result.failed > 0 {
+            parts.append("\(result.failed) failed")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+private struct OfflineQueueActionDetailView: View {
+    @Environment(OfflineSyncService.self) private var offlineSync
+    @Environment(\.dismiss) private var dismiss
+    let action: QueuedOfflineAction
+
+    var body: some View {
+        List {
+            Section {
+                LabeledContent("Action", value: actionTitle)
+                LabeledContent("Repository", value: repository)
+                LabeledContent("Issue", value: "#\(issueNumber)")
+                LabeledContent("Status", value: statusTitle)
+                LabeledContent("Queued", value: dateSummary(action.createdAt))
+                LabeledContent("Updated", value: dateSummary(action.updatedAt))
+                if action.retryCount > 0 {
+                    LabeledContent("Retries", value: "\(action.retryCount)")
+                }
+            }
+
+            if let bodyText, !bodyText.isEmpty {
+                Section(bodyHeader) {
+                    Text(bodyText)
+                        .font(.body)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let error = action.lastError, !error.isEmpty {
+                Section("Last Error") {
+                    Text(error)
+                        .font(.body)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    offlineSync.removeAction(id: action.id)
+                    dismiss()
+                } label: {
+                    Label("Remove Action", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle(actionTitle)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var actionTitle: String {
+        switch action.kind {
+        case .issueComment:
+            return "Issue Comment"
+        case .issueState(let state):
+            return state.state.lowercased() == "closed" ? "Close Issue" : "Reopen Issue"
+        }
+    }
+
+    private var repository: String {
+        switch action.kind {
+        case .issueComment(let comment):
+            return "\(comment.owner)/\(comment.repo)"
+        case .issueState(let state):
+            return "\(state.owner)/\(state.repo)"
+        }
+    }
+
+    private var issueNumber: Int {
+        switch action.kind {
+        case .issueComment(let comment):
+            return comment.issueNumber
+        case .issueState(let state):
+            return state.issueNumber
+        }
+    }
+
+    private var bodyHeader: String {
+        switch action.kind {
+        case .issueComment:
+            return "Comment"
+        case .issueState:
+            return "Comment"
+        }
+    }
+
+    private var bodyText: String? {
+        switch action.kind {
+        case .issueComment(let comment):
+            return comment.body
+        case .issueState(let state):
+            return state.comment
+        }
+    }
+
+    private var statusTitle: String {
+        switch action.status {
+        case .pending:
+            return "Pending"
+        case .inFlight:
+            return "Syncing"
+        case .failed:
+            return "Failed"
+        }
+    }
+
+    private func dateSummary(_ timestamp: String) -> String {
+        guard let date = parseIssueCTLDate(timestamp) else {
+            return timestamp
+        }
+
+        let absolute = DateFormatter()
+        absolute.dateStyle = .medium
+        absolute.timeStyle = .short
+
+        let relative = RelativeDateTimeFormatter()
+        relative.unitsStyle = .abbreviated
+        return "\(absolute.string(from: date)) (\(relative.localizedString(for: date, relativeTo: Date())))"
+    }
+}
+
+private struct QueueMetricView: View {
+    let title: String
+    let value: Int
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text("\(value)")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(tint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct OfflineQueueActionRow: View {
+    let action: QueuedOfflineAction
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Label(title, systemImage: icon)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+
+                Spacer(minLength: 8)
+
+                statusBadge
+            }
+
+            Text(repository)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let preview, !preview.isEmpty {
+                Text(preview)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+
+            HStack(spacing: 10) {
+                Text(createdSummary)
+                if action.retryCount > 0 {
+                    Text("Retries \(action.retryCount)")
+                }
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+
+            if let error = action.lastError, !error.isEmpty {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(3)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var title: String {
+        switch action.kind {
+        case .issueComment(let comment):
+            return "Comment on #\(comment.issueNumber)"
+        case .issueState(let state):
+            let verb = state.state.lowercased() == "closed" ? "Close" : "Reopen"
+            return "\(verb) #\(state.issueNumber)"
+        }
+    }
+
+    private var repository: String {
+        switch action.kind {
+        case .issueComment(let comment):
+            return "\(comment.owner)/\(comment.repo)"
+        case .issueState(let state):
+            return "\(state.owner)/\(state.repo)"
+        }
+    }
+
+    private var preview: String? {
+        switch action.kind {
+        case .issueComment(let comment):
+            return comment.body
+        case .issueState(let state):
+            return state.comment
+        }
+    }
+
+    private var icon: String {
+        switch action.kind {
+        case .issueComment:
+            return "text.bubble"
+        case .issueState(let state):
+            return state.state.lowercased() == "closed" ? "checkmark.circle" : "arrow.uturn.backward.circle"
+        }
+    }
+
+    private var statusBadge: some View {
+        Text(statusTitle)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(statusTint)
+            .background(statusTint.opacity(0.12), in: Capsule())
+    }
+
+    private var statusTitle: String {
+        switch action.status {
+        case .pending:
+            return "Pending"
+        case .inFlight:
+            return "Syncing"
+        case .failed:
+            return "Failed"
+        }
+    }
+
+    private var statusTint: Color {
+        switch action.status {
+        case .pending:
+            return .orange
+        case .inFlight:
+            return IssueCTLColors.action
+        case .failed:
+            return .red
+        }
+    }
+
+    private var createdSummary: String {
+        guard let created = parseIssueCTLDate(action.createdAt) else {
+            return "Queued"
+        }
+
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return "Queued \(formatter.localizedString(for: created, relativeTo: Date()))"
+    }
+}

--- a/ios/IssueCTL/Views/Settings/SettingsView.swift
+++ b/ios/IssueCTL/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(APIClient.self) private var api
+    @Environment(OfflineSyncService.self) private var offlineSync
     @Environment(\.dismiss) private var dismiss
     @State private var showDisconnectConfirm = false
     @State private var showAddRepo = false
@@ -43,6 +44,8 @@ struct SettingsView: View {
                     NotificationSettingsView()
                 case .worktrees:
                     WorktreeListView()
+                case .offlineQueue:
+                    OfflineQueueView()
                 }
             }
             .sheet(isPresented: $showAddRepo) {
@@ -185,7 +188,30 @@ struct SettingsView: View {
             NavigationLink(value: SettingsDestination.worktrees) {
                 Label("Worktrees", systemImage: "arrow.triangle.branch")
             }
+            NavigationLink(value: SettingsDestination.offlineQueue) {
+                HStack {
+                    Label("Offline Queue", systemImage: "tray.and.arrow.up")
+                    Spacer()
+                    if offlineSync.pendingCount > 0 || offlineSync.failedCount > 0 {
+                        Text(queueSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .accessibilityIdentifier("settings-offline-queue-link")
         }
+    }
+
+    private var queueSummary: String {
+        var parts: [String] = []
+        if offlineSync.pendingCount > 0 {
+            parts.append("\(offlineSync.pendingCount) pending")
+        }
+        if offlineSync.failedCount > 0 {
+            parts.append("\(offlineSync.failedCount) failed")
+        }
+        return parts.joined(separator: ", ")
     }
 
     // MARK: - Disconnect Section
@@ -269,6 +295,7 @@ enum SettingsDestination: Hashable {
     case advancedSettings
     case notifications
     case worktrees
+    case offlineQueue
 }
 
 // MARK: - Repo Row

--- a/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
+++ b/ios/IssueCTL/Views/Shared/NetworkErrorBanner.swift
@@ -133,3 +133,192 @@ struct OfflineBanner: View {
         }
     }
 }
+
+/// Compact offline queue status surface for root overlays or Settings sections.
+///
+/// The component is intentionally store-agnostic: pass counts and actions from the
+/// owning view instead of binding it to the concrete queue implementation.
+struct OfflineQueueBanner: View {
+    let pendingCount: Int
+    let failedCount: Int
+    let isSyncing: Bool
+    let onSync: (() async -> Void)?
+    let onDismissFailed: (() -> Void)?
+
+    @State private var isSyncRequested = false
+
+    init(
+        pendingCount: Int,
+        failedCount: Int,
+        isSyncing: Bool,
+        onSync: (() async -> Void)? = nil,
+        onDismissFailed: (() -> Void)? = nil
+    ) {
+        self.pendingCount = max(0, pendingCount)
+        self.failedCount = max(0, failedCount)
+        self.isSyncing = isSyncing
+        self.onSync = onSync
+        self.onDismissFailed = onDismissFailed
+    }
+
+    var body: some View {
+        if shouldShow {
+            HStack(alignment: .center, spacing: 12) {
+                statusIcon
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                .layoutPriority(1)
+
+                Spacer(minLength: 4)
+
+                actionGroup
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(borderColor, lineWidth: 0.75)
+            }
+            .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private var actionGroup: some View {
+        HStack(spacing: 6) {
+            if isBusy {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(statusTint)
+                    .frame(width: 32, height: 32)
+                    .accessibilityLabel("Syncing offline actions")
+            } else if let onSync {
+                Button {
+                    Task {
+                        isSyncRequested = true
+                        await onSync()
+                        isSyncRequested = false
+                    }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(statusTint)
+                .accessibilityLabel("Sync offline actions")
+            }
+
+            if failedCount > 0, let onDismissFailed {
+                Button(role: .destructive) {
+                    onDismissFailed()
+                } label: {
+                    Image(systemName: "xmark")
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel("Dismiss failed offline actions")
+            }
+        }
+    }
+
+    private var statusIcon: some View {
+        Image(systemName: statusSymbol)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(statusTint)
+            .frame(width: 34, height: 34)
+            .background(statusTint.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var shouldShow: Bool {
+        pendingCount > 0 || failedCount > 0 || isSyncing
+    }
+
+    private var isBusy: Bool {
+        isSyncing || isSyncRequested
+    }
+
+    private var title: String {
+        if failedCount > 0 {
+            return failedCount == 1 ? "Offline action failed" : "Offline actions failed"
+        }
+        if isBusy {
+            return "Syncing offline actions"
+        }
+        return pendingCount == 1 ? "Offline action pending" : "Offline actions pending"
+    }
+
+    private var detail: String {
+        var parts: [String] = []
+        if pendingCount > 0 {
+            parts.append("\(pendingCount) pending")
+        }
+        if failedCount > 0 {
+            parts.append("\(failedCount) failed")
+        }
+        if parts.isEmpty {
+            return "Queued changes are being sent."
+        }
+        return parts.joined(separator: " / ")
+    }
+
+    private var statusSymbol: String {
+        if failedCount > 0 { return "exclamationmark.triangle.fill" }
+        if isBusy { return "arrow.triangle.2.circlepath" }
+        return "tray.and.arrow.up.fill"
+    }
+
+    private var statusTint: Color {
+        failedCount > 0 ? .orange : IssueCTLColors.action
+    }
+
+    private var borderColor: Color {
+        failedCount > 0 ? Color.orange.opacity(0.45) : IssueCTLColors.hairline
+    }
+
+    private var accessibilityLabel: String {
+        "\(title), \(detail)"
+    }
+}
+
+#Preview("Offline Queue Pending") {
+    VStack(spacing: 12) {
+        OfflineQueueBanner(
+            pendingCount: 3,
+            failedCount: 0,
+            isSyncing: false,
+            onSync: {}
+        )
+
+        OfflineQueueBanner(
+            pendingCount: 1,
+            failedCount: 2,
+            isSyncing: false,
+            onSync: {},
+            onDismissFailed: {}
+        )
+
+        OfflineQueueBanner(
+            pendingCount: 0,
+            failedCount: 0,
+            isSyncing: true
+        )
+    }
+    .padding()
+    .background(IssueCTLColors.appBackground)
+}

--- a/ios/IssueCTLTests/OfflineSyncServiceTests.swift
+++ b/ios/IssueCTLTests/OfflineSyncServiceTests.swift
@@ -1,0 +1,348 @@
+import XCTest
+@testable import IssueCTL
+
+@MainActor
+final class OfflineSyncServiceTests: XCTestCase {
+    func testSyncPendingIssueCommentCompletesSuccessfulAction() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(responses: [
+            .success(IssueCommentResponse(success: true, commentId: 99, error: nil))
+        ])
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result, OfflineSyncResult(
+            attempted: 1,
+            completed: 1,
+            failed: 0,
+            alreadyRunning: false
+        ))
+        XCTAssertTrue(store.allActions().isEmpty)
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.failedCount, 0)
+        XCTAssertEqual(client.requests, [
+            .issueComment(FakeIssueCommentRequest(owner: "org", repo: "app", number: 42, body: "Queued comment"))
+        ])
+    }
+
+    func testSyncPendingIssueStateCompletesSuccessfulAction() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueState(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            state: "closed",
+            comment: "Closing while offline",
+            id: "state-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(issueStateResponses: [
+            .success(IssueStateResponse(success: true, commentPosted: true, error: nil))
+        ])
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result, OfflineSyncResult(
+            attempted: 1,
+            completed: 1,
+            failed: 0,
+            alreadyRunning: false
+        ))
+        XCTAssertTrue(store.allActions().isEmpty)
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.failedCount, 0)
+        XCTAssertEqual(client.requests, [
+            .issueState(FakeIssueStateRequest(
+                owner: "org",
+                repo: "app",
+                number: 42,
+                state: "closed",
+                comment: "Closing while offline"
+            ))
+        ])
+    }
+
+    func testSyncMarksActionFailedWhenAPIResponseIsUnsuccessful() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(responses: [
+            .success(IssueCommentResponse(success: false, commentId: nil, error: "GitHub rejected the comment"))
+        ])
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result.failed, 1)
+        XCTAssertEqual(store.failedActions().map(\.id), ["comment-1"])
+        XCTAssertEqual(store.failedActions().first?.lastError, "GitHub rejected the comment")
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.failedCount, 1)
+    }
+
+    func testSyncMarksIssueStateFailedWhenAPIResponseIsUnsuccessful() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueState(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            state: "closed",
+            comment: nil,
+            id: "state-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(issueStateResponses: [
+            .success(IssueStateResponse(success: false, commentPosted: nil, error: "GitHub rejected the state change"))
+        ])
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result.failed, 1)
+        XCTAssertEqual(store.failedActions().map(\.id), ["state-1"])
+        XCTAssertEqual(store.failedActions().first?.lastError, "GitHub rejected the state change")
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.failedCount, 1)
+    }
+
+    func testSyncMarksIssueStateFailedWhenAPIThrows() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueState(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            state: "open",
+            comment: nil,
+            id: "state-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(issueStateResponses: [
+            .failure(FakeSyncError(message: "offline state update failed"))
+        ])
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result.failed, 1)
+        XCTAssertEqual(store.failedActions().map(\.id), ["state-1"])
+        XCTAssertEqual(store.failedActions().first?.lastError, "offline state update failed")
+        XCTAssertEqual(service.pendingCount, 0)
+        XCTAssertEqual(service.failedCount, 1)
+    }
+
+    func testSyncReplaysMixedIssueCommentAndStateInFIFOOrder() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        store.enqueueIssueState(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            state: "closed",
+            comment: "Closing comment",
+            id: "state-1",
+            now: Date(timeIntervalSince1970: 1)
+        )
+        let client = FakeIssueCommentClient(
+            responses: [
+                .success(IssueCommentResponse(success: true, commentId: 99, error: nil))
+            ],
+            issueStateResponses: [
+                .success(IssueStateResponse(success: true, commentPosted: true, error: nil))
+            ]
+        )
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result, OfflineSyncResult(
+            attempted: 2,
+            completed: 2,
+            failed: 0,
+            alreadyRunning: false
+        ))
+        XCTAssertTrue(store.allActions().isEmpty)
+        XCTAssertEqual(client.requests, [
+            .issueComment(FakeIssueCommentRequest(owner: "org", repo: "app", number: 42, body: "Queued comment")),
+            .issueState(FakeIssueStateRequest(
+                owner: "org",
+                repo: "app",
+                number: 42,
+                state: "closed",
+                comment: "Closing comment"
+            ))
+        ])
+    }
+
+    func testRetryFailedActionsMovesFailuresBackToPending() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        store.markFailed(id: "comment-1", error: "offline", now: Date(timeIntervalSince1970: 1))
+        let service = OfflineSyncService(store: store, client: FakeIssueCommentClient())
+
+        service.retryFailedActions()
+
+        XCTAssertEqual(store.pendingActions().map(\.id), ["comment-1"])
+        XCTAssertTrue(store.failedActions().isEmpty)
+        XCTAssertEqual(service.pendingCount, 1)
+        XCTAssertEqual(service.failedCount, 0)
+    }
+
+    func testConcurrentSyncReturnsAlreadyRunning() async throws {
+        let (store, defaults, suiteName) = try makeStore()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "app",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        let client = FakeIssueCommentClient(
+            responses: [.success(IssueCommentResponse(success: true, commentId: 99, error: nil))],
+            delayNanoseconds: 50_000_000
+        )
+        let service = OfflineSyncService(store: store, client: client)
+
+        let firstSync = Task { @MainActor in
+            await service.syncPendingActions()
+        }
+        while !service.isSyncing {
+            await Task.yield()
+        }
+
+        let secondResult = await service.syncPendingActions()
+        let firstResult = await firstSync.value
+
+        XCTAssertTrue(secondResult.alreadyRunning)
+        XCTAssertEqual(firstResult.completed, 1)
+        XCTAssertEqual(client.requests.count, 1)
+    }
+
+    private func makeStore() throws -> (OfflineActionQueueStore, UserDefaults, String) {
+        let suiteName = "issuectl.tests.offline-sync.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        return (OfflineActionQueueStore(defaults: defaults), defaults, suiteName)
+    }
+}
+
+private struct FakeIssueCommentRequest: Equatable {
+    let owner: String
+    let repo: String
+    let number: Int
+    let body: String
+}
+
+private struct FakeIssueStateRequest: Equatable {
+    let owner: String
+    let repo: String
+    let number: Int
+    let state: String
+    let comment: String?
+}
+
+private enum FakeOfflineSyncRequest: Equatable {
+    case issueComment(FakeIssueCommentRequest)
+    case issueState(FakeIssueStateRequest)
+}
+
+private struct FakeSyncError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+@MainActor
+private final class FakeIssueCommentClient: OfflineIssueCommentPosting, OfflineIssueStateUpdating {
+    private var responses: [Result<IssueCommentResponse, Error>]
+    private var issueStateResponses: [Result<IssueStateResponse, Error>]
+    private let delayNanoseconds: UInt64
+    private(set) var requests: [FakeOfflineSyncRequest] = []
+
+    init(
+        responses: [Result<IssueCommentResponse, Error>] = [],
+        issueStateResponses: [Result<IssueStateResponse, Error>] = [],
+        delayNanoseconds: UInt64 = 0
+    ) {
+        self.responses = responses
+        self.issueStateResponses = issueStateResponses
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func commentOnIssue(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueCommentRequestBody
+    ) async throws -> IssueCommentResponse {
+        requests.append(.issueComment(FakeIssueCommentRequest(owner: owner, repo: repo, number: number, body: body.body)))
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+        guard !responses.isEmpty else {
+            return IssueCommentResponse(success: true, commentId: nil, error: nil)
+        }
+        return try responses.removeFirst().get()
+    }
+
+    func updateIssueState(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueStateRequestBody
+    ) async throws -> IssueStateResponse {
+        requests.append(.issueState(FakeIssueStateRequest(
+            owner: owner,
+            repo: repo,
+            number: number,
+            state: body.state,
+            comment: body.comment
+        )))
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+        guard !issueStateResponses.isEmpty else {
+            return IssueStateResponse(success: true, commentPosted: nil, error: nil)
+        }
+        return try issueStateResponses.removeFirst().get()
+    }
+}

--- a/ios/IssueCTLTests/ViewLogicTests.swift
+++ b/ios/IssueCTLTests/ViewLogicTests.swift
@@ -62,6 +62,304 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertNil(cache.load([Repo].self, for: "repos", serverURL: "http://two.example"))
     }
 
+    // MARK: - Offline Action Queue
+
+    func testOfflineActionQueuePersistsIssueComments() throws {
+        let suiteName = "issuectl.tests.offline-actions.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let createdAt = Date(timeIntervalSince1970: 0)
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        let action = store.enqueueIssueComment(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 42,
+            body: "Queued comment",
+            id: "action-1",
+            now: createdAt
+        )
+
+        XCTAssertEqual(action.id, "action-1")
+        XCTAssertEqual(action.status, .pending)
+        XCTAssertEqual(action.retryCount, 0)
+        XCTAssertNil(action.lastError)
+        XCTAssertEqual(action.createdAt, sharedISO8601Formatter.string(from: createdAt))
+        XCTAssertEqual(action.updatedAt, sharedISO8601Formatter.string(from: createdAt))
+
+        let reloaded = OfflineActionQueueStore(defaults: defaults)
+        let persisted = try XCTUnwrap(reloaded.allActions().first)
+        XCTAssertEqual(persisted.id, "action-1")
+        guard case let .issueComment(comment) = persisted.kind else {
+            return XCTFail("Expected issue comment action")
+        }
+        XCTAssertEqual(comment.owner, "owner")
+        XCTAssertEqual(comment.repo, "repo")
+        XCTAssertEqual(comment.issueNumber, 42)
+        XCTAssertEqual(comment.body, "Queued comment")
+    }
+
+    func testOfflineActionQueuePersistsIssueStateActions() throws {
+        let suiteName = "issuectl.tests.offline-action-state.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let createdAt = Date(timeIntervalSince1970: 100)
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        let action = store.enqueueIssueState(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 42,
+            state: "closed",
+            comment: "Closing while offline",
+            id: "state-1",
+            now: createdAt
+        )
+
+        XCTAssertEqual(action.id, "state-1")
+        XCTAssertEqual(action.status, .pending)
+        XCTAssertEqual(action.retryCount, 0)
+        XCTAssertNil(action.lastError)
+        XCTAssertEqual(action.createdAt, sharedISO8601Formatter.string(from: createdAt))
+        XCTAssertEqual(action.updatedAt, sharedISO8601Formatter.string(from: createdAt))
+
+        let reloaded = OfflineActionQueueStore(defaults: defaults)
+        let persisted = try XCTUnwrap(reloaded.allActions().first)
+        XCTAssertEqual(persisted.id, "state-1")
+        guard case let .issueState(stateAction) = persisted.kind else {
+            return XCTFail("Expected issue state action")
+        }
+        XCTAssertEqual(stateAction.owner, "owner")
+        XCTAssertEqual(stateAction.repo, "repo")
+        XCTAssertEqual(stateAction.issueNumber, 42)
+        XCTAssertEqual(stateAction.state, "closed")
+        XCTAssertEqual(stateAction.comment, "Closing while offline")
+    }
+
+    func testOfflineActionQueueListsPendingFailedAndAll() throws {
+        let suiteName = "issuectl.tests.offline-action-filters.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(
+            owner: "a",
+            repo: "one",
+            issueNumber: 1,
+            body: "first",
+            id: "pending",
+            now: Date(timeIntervalSince1970: 1)
+        )
+        store.enqueueIssueComment(
+            owner: "a",
+            repo: "two",
+            issueNumber: 2,
+            body: "second",
+            id: "failed",
+            now: Date(timeIntervalSince1970: 2)
+        )
+        store.enqueueIssueComment(
+            owner: "a",
+            repo: "three",
+            issueNumber: 3,
+            body: "third",
+            id: "in-flight",
+            now: Date(timeIntervalSince1970: 3)
+        )
+
+        store.markFailed(id: "failed", error: "Network unavailable", now: Date(timeIntervalSince1970: 4))
+        store.markInFlight(id: "in-flight", now: Date(timeIntervalSince1970: 5))
+
+        XCTAssertEqual(store.pendingActions().map(\.id), ["pending"])
+        XCTAssertEqual(store.failedActions().map(\.id), ["failed"])
+        XCTAssertEqual(store.allActions().map(\.id), ["pending", "failed", "in-flight"])
+    }
+
+    func testOfflineActionQueuePreservesFIFOOrderingWithMixedActionKinds() throws {
+        let suiteName = "issuectl.tests.offline-action-mixed-fifo.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(owner: "a", repo: "one", issueNumber: 1, body: "one", id: "comment-1", now: Date(timeIntervalSince1970: 1))
+        store.enqueueIssueState(owner: "a", repo: "one", issueNumber: 1, state: "closed", comment: nil, id: "state-1", now: Date(timeIntervalSince1970: 2))
+        store.enqueueIssueComment(owner: "a", repo: "two", issueNumber: 2, body: "two", id: "comment-2", now: Date(timeIntervalSince1970: 3))
+        store.enqueueIssueState(owner: "a", repo: "two", issueNumber: 2, state: "open", comment: "Reopening", id: "state-2", now: Date(timeIntervalSince1970: 4))
+        store.markInFlight(id: "comment-2", now: Date(timeIntervalSince1970: 5))
+
+        XCTAssertEqual(store.allActions().map(\.id), ["comment-1", "state-1", "comment-2", "state-2"])
+        XCTAssertEqual(store.pendingActions().map(\.id), ["comment-1", "state-1", "state-2"])
+    }
+
+    func testOfflineActionQueueLifecycleUpdatesIssueStateActionStatus() throws {
+        let suiteName = "issuectl.tests.offline-action-state-lifecycle.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueState(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 7,
+            state: "closed",
+            comment: nil,
+            id: "state-action",
+            now: Date(timeIntervalSince1970: 10)
+        )
+
+        let inFlightAt = Date(timeIntervalSince1970: 20)
+        let inFlight = try XCTUnwrap(store.markInFlight(id: "state-action", now: inFlightAt))
+        XCTAssertEqual(inFlight.status, .inFlight)
+        XCTAssertEqual(inFlight.updatedAt, sharedISO8601Formatter.string(from: inFlightAt))
+
+        let failedAt = Date(timeIntervalSince1970: 30)
+        let failed = try XCTUnwrap(store.markFailed(id: "state-action", error: "Timed out", now: failedAt))
+        XCTAssertEqual(failed.status, .failed)
+        XCTAssertEqual(failed.retryCount, 1)
+        XCTAssertEqual(failed.lastError, "Timed out")
+        XCTAssertEqual(failed.updatedAt, sharedISO8601Formatter.string(from: failedAt))
+
+        let pendingAt = Date(timeIntervalSince1970: 40)
+        let pending = try XCTUnwrap(store.markPending(id: "state-action", now: pendingAt))
+        XCTAssertEqual(pending.status, .pending)
+        XCTAssertEqual(pending.retryCount, 1)
+        XCTAssertEqual(pending.lastError, "Timed out")
+        XCTAssertEqual(pending.updatedAt, sharedISO8601Formatter.string(from: pendingAt))
+
+        store.markCompleted(id: "state-action")
+        XCTAssertTrue(store.allActions().isEmpty)
+    }
+
+    func testOfflineActionQueueLifecycleUpdatesMetadataAndRemovesCompletedActions() throws {
+        let suiteName = "issuectl.tests.offline-action-lifecycle.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 7,
+            body: "body",
+            id: "action",
+            now: Date(timeIntervalSince1970: 10)
+        )
+
+        let inFlightAt = Date(timeIntervalSince1970: 20)
+        let inFlight = try XCTUnwrap(store.markInFlight(id: "action", now: inFlightAt))
+        XCTAssertEqual(inFlight.status, .inFlight)
+        XCTAssertEqual(inFlight.updatedAt, sharedISO8601Formatter.string(from: inFlightAt))
+
+        let failedAt = Date(timeIntervalSince1970: 30)
+        let failed = try XCTUnwrap(store.markFailed(id: "action", error: "Timed out", now: failedAt))
+        XCTAssertEqual(failed.status, .failed)
+        XCTAssertEqual(failed.retryCount, 1)
+        XCTAssertEqual(failed.lastError, "Timed out")
+        XCTAssertEqual(failed.updatedAt, sharedISO8601Formatter.string(from: failedAt))
+
+        XCTAssertNil(store.markFailed(id: "missing", error: "No action", now: Date()))
+
+        store.markCompleted(id: "action")
+        XCTAssertTrue(store.allActions().isEmpty)
+    }
+
+    func testOfflineActionQueueFallsBackSafelyForCorruptedStoredData() throws {
+        let suiteName = "issuectl.tests.offline-action-corrupt.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(Data("not valid queue json".utf8), forKey: "issuectl.offlineActionQueue")
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        XCTAssertTrue(store.allActions().isEmpty)
+        XCTAssertTrue(store.pendingActions().isEmpty)
+        XCTAssertTrue(store.failedActions().isEmpty)
+
+        store.enqueueIssueComment(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 1,
+            body: "recovered",
+            id: "recovered",
+            now: Date(timeIntervalSince1970: 1)
+        )
+
+        let reloaded = OfflineActionQueueStore(defaults: defaults)
+        XCTAssertEqual(reloaded.allActions().map(\.id), ["recovered"])
+    }
+
+    func testOfflineActionQueueRemovesFailedActionsOnly() throws {
+        let suiteName = "issuectl.tests.offline-action-failed-cleanup.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(owner: "a", repo: "one", issueNumber: 1, body: "one", id: "pending", now: Date(timeIntervalSince1970: 1))
+        store.enqueueIssueComment(owner: "a", repo: "two", issueNumber: 2, body: "two", id: "failed", now: Date(timeIntervalSince1970: 2))
+        store.enqueueIssueComment(owner: "a", repo: "three", issueNumber: 3, body: "three", id: "in-flight", now: Date(timeIntervalSince1970: 3))
+        store.markFailed(id: "failed", error: "rejected", now: Date(timeIntervalSince1970: 4))
+        store.markInFlight(id: "in-flight", now: Date(timeIntervalSince1970: 5))
+
+        store.removeFailedActions()
+
+        XCTAssertEqual(store.allActions().map(\.id), ["pending", "in-flight"])
+        XCTAssertTrue(store.failedActions().isEmpty)
+    }
+
+    func testOfflineActionQueueMarkPendingPreservesRetryMetadata() throws {
+        let suiteName = "issuectl.tests.offline-action-retry-metadata.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(
+            owner: "owner",
+            repo: "repo",
+            issueNumber: 9,
+            body: "retry",
+            id: "action",
+            now: Date(timeIntervalSince1970: 10)
+        )
+        store.markFailed(id: "action", error: "first failure", now: Date(timeIntervalSince1970: 20))
+
+        let pendingAt = Date(timeIntervalSince1970: 30)
+        let pending = try XCTUnwrap(store.markPending(id: "action", now: pendingAt))
+
+        XCTAssertEqual(pending.status, .pending)
+        XCTAssertEqual(pending.retryCount, 1)
+        XCTAssertEqual(pending.lastError, "first failure")
+        XCTAssertEqual(pending.updatedAt, sharedISO8601Formatter.string(from: pendingAt))
+    }
+
+    func testOfflineActionQueuePreservesFIFOOrdering() throws {
+        let suiteName = "issuectl.tests.offline-action-fifo.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(owner: "a", repo: "one", issueNumber: 1, body: "one", id: "first", now: Date(timeIntervalSince1970: 1))
+        store.enqueueIssueComment(owner: "a", repo: "two", issueNumber: 2, body: "two", id: "second", now: Date(timeIntervalSince1970: 2))
+        store.enqueueIssueComment(owner: "a", repo: "three", issueNumber: 3, body: "three", id: "third", now: Date(timeIntervalSince1970: 3))
+        store.markInFlight(id: "second", now: Date(timeIntervalSince1970: 4))
+
+        XCTAssertEqual(store.allActions().map(\.id), ["first", "second", "third"])
+        XCTAssertEqual(store.pendingActions().map(\.id), ["first", "third"])
+    }
+
+    func testOfflineActionQueueRemoveMissingIDIsNoOp() throws {
+        let suiteName = "issuectl.tests.offline-action-remove-missing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = OfflineActionQueueStore(defaults: defaults)
+
+        store.enqueueIssueComment(owner: "a", repo: "one", issueNumber: 1, body: "one", id: "first", now: Date(timeIntervalSince1970: 1))
+        store.enqueueIssueComment(owner: "a", repo: "two", issueNumber: 2, body: "two", id: "second", now: Date(timeIntervalSince1970: 2))
+        let before = store.allActions()
+
+        store.remove(id: "missing")
+
+        XCTAssertEqual(store.allActions(), before)
+    }
+
     // MARK: - Notification Preferences
 
     @MainActor

--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -16,6 +16,8 @@ final class MockIssueCTLServer: @unchecked Sendable {
     var failRepos = false
     var failDeployments = false
     var issueDetailDeploymentsLagBehindLaunch = false
+    var dropIssueCommentRequests = false
+    var dropIssueStateRequests = false
 
     // Settings controls.
     var defaultLaunchAgent = "claude"
@@ -121,6 +123,18 @@ final class MockIssueCTLServer: @unchecked Sendable {
         issueComments[number] = comments
     }
 
+    func commentBodies(for number: Int) -> [String] {
+        queue.sync {
+            issueComments[number]?.compactMap { $0["body"] as? String } ?? []
+        }
+    }
+
+    func issueState(for number: Int) -> String? {
+        queue.sync {
+            issueStates[number]
+        }
+    }
+
     func seedSecondRepo() {
         repos = [defaultRepo, betaRepo]
     }
@@ -154,6 +168,10 @@ final class MockIssueCTLServer: @unchecked Sendable {
                     connection.cancel()
                     return
                 }
+                if self.shouldDropResponse(for: request) {
+                    connection.cancel()
+                    return
+                }
                 let response = self.response(for: request)
                 connection.send(content: response, completion: .contentProcessed { sendError in
                     if let sendError { print("[MockServer] send error: \(sendError)") }
@@ -180,6 +198,25 @@ final class MockIssueCTLServer: @unchecked Sendable {
             } ?? 0
         let bodyStart = request.distance(from: request.startIndex, to: headerRange.upperBound)
         return data.count >= bodyStart + contentLength
+    }
+
+    private func shouldDropResponse(for request: String) -> Bool {
+        let firstLine = request.split(separator: "\r\n", maxSplits: 1).first ?? ""
+        let parts = firstLine.split(separator: " ")
+        let method = parts.indices.contains(0) ? String(parts[0]) : "GET"
+        let rawPath = parts.indices.contains(1) ? String(parts[1]) : "/"
+        let path = rawPath.split(separator: "?", maxSplits: 1).first.map(String.init) ?? rawPath
+        guard method == "POST", path.hasPrefix("/api/v1/issues/") else { return false }
+
+        if dropIssueCommentRequests, path.hasSuffix("/comments") {
+            return true
+        }
+
+        if dropIssueStateRequests, path.hasSuffix("/state") {
+            return true
+        }
+
+        return false
     }
 
     // MARK: - Router

--- a/ios/IssueCTLUITests/IssueDetailActionTests.swift
+++ b/ios/IssueCTLUITests/IssueDetailActionTests.swift
@@ -49,29 +49,87 @@ final class IssueDetailActionTests: XCTestCase {
         assertElement("issue-row-101", existsIn: app, timeout: 8)
         element("issue-row-101", in: app).tap()
 
-        // Open the actions menu and tap Comment.
-        let actionsMenu = app.buttons["issue-detail-actions-menu"]
-        XCTAssertTrue(actionsMenu.waitForExistence(timeout: 5), "Issue actions menu missing\n\(app.debugDescription)")
-        actionsMenu.tap()
-
-        let commentButton = app.collectionViews.buttons["Comment"].firstMatch
-        XCTAssertTrue(commentButton.waitForExistence(timeout: 3), "Comment menu item missing")
-        commentButton.tap()
-
-        // The comment sheet should appear with a text editor.
-        // Type a comment and submit.
-        let textEditor = app.textViews.firstMatch
-        XCTAssertTrue(textEditor.waitForExistence(timeout: 3), "Comment text editor missing")
-        textEditor.tap()
-        app.typeText("Test comment from automation")
-
-        // Tap the "Add Comment" submit button.
-        let submitButton = app.buttons["Add Comment"]
-        XCTAssertTrue(submitButton.waitForExistence(timeout: 3), "Submit comment button missing")
-        submitButton.tap()
+        submitIssueComment("Test comment from automation", in: app)
 
         // Sheet should dismiss — wait for actions menu to reappear.
         assertElement("issue-detail-actions-menu", existsIn: app, timeout: 8)
+    }
+
+    @MainActor
+    func testOfflineIssueCommentQueuesAndManualSyncClearsBanner() {
+        server.dropIssueCommentRequests = true
+        let queuedComment = "Queued offline comment from automation"
+        let app = launchApp(server: server)
+
+        openIssuesSection(in: app)
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        element("issue-row-101", in: app).tap()
+
+        submitIssueComment(queuedComment, in: app)
+
+        assertOfflineQueueLabel(containing: "Offline action pending", in: app)
+        assertOfflineQueueLabel(containing: "1 pending", in: app)
+
+        server.dropIssueCommentRequests = false
+        let syncButton = app.buttons["Sync offline actions"].firstMatch
+        XCTAssertTrue(syncButton.waitForExistence(timeout: 5), "Sync offline actions button missing\n\(app.debugDescription)")
+        syncButton.tap()
+
+        waitForOfflineQueueToClear(in: app)
+        XCTAssertTrue(
+            server.commentBodies(for: 101).contains(queuedComment),
+            "Expected queued comment to replay to the mock server"
+        )
+    }
+
+    @MainActor
+    func testOfflineIssueCloseQueuesAndManualSyncClosesIssue() {
+        server.dropIssueStateRequests = true
+        let app = launchApp(server: server)
+
+        openIssuesSection(in: app)
+        assertElement("issue-row-101", existsIn: app, timeout: 8)
+        element("issue-row-101", in: app).tap()
+
+        closeIssueWithoutComment(in: app)
+
+        // Limitation: this currently exposes whether issue-state failures are queued by the app.
+        // If the app shows its generic network error alert here, app-side issue-state queueing is not wired up yet.
+        assertOfflineQueueLabel(containing: "Offline action pending", in: app)
+        assertOfflineQueueLabel(containing: "1 pending", in: app)
+        XCTAssertEqual(server.issueState(for: 101), "open", "Dropped state request should not mutate mock server state")
+
+        server.dropIssueStateRequests = false
+        let syncButton = app.buttons["Sync offline actions"].firstMatch
+        XCTAssertTrue(syncButton.waitForExistence(timeout: 5), "Sync offline actions button missing\n\(app.debugDescription)")
+        syncButton.tap()
+
+        waitForOfflineQueueToClear(in: app)
+        XCTAssertEqual(server.issueState(for: 101), "closed", "Expected queued close action to replay to the mock server")
+    }
+
+    @MainActor
+    func testOfflineIssueReopenQueuesAndManualSyncReopensIssue() {
+        server.seedClosedIssue(101)
+        server.dropIssueStateRequests = true
+        let app = launchApp(server: server)
+
+        openIssuesSection(in: app)
+        openClosedIssue101(in: app)
+
+        reopenIssue(in: app)
+
+        assertOfflineQueueLabel(containing: "Offline action pending", in: app)
+        assertOfflineQueueLabel(containing: "1 pending", in: app)
+        XCTAssertEqual(server.issueState(for: 101), "closed", "Dropped reopen request should not mutate mock server state")
+
+        server.dropIssueStateRequests = false
+        let syncButton = app.buttons["Sync offline actions"].firstMatch
+        XCTAssertTrue(syncButton.waitForExistence(timeout: 5), "Sync offline actions button missing\n\(app.debugDescription)")
+        syncButton.tap()
+
+        waitForOfflineQueueToClear(in: app)
+        XCTAssertEqual(server.issueState(for: 101), "open", "Expected queued reopen action to replay to the mock server")
     }
 
     @MainActor
@@ -106,10 +164,17 @@ final class IssueDetailActionTests: XCTestCase {
         let app = launchApp(server: server)
 
         openIssuesSection(in: app)
+        openClosedIssue101(in: app)
 
-        // Navigate to Closed section tab.
-        // The section tabs sit in a horizontal ScrollView; the Closed tab (last of 5)
-        // may be off-screen. Swipe left on the Open tab to scroll the row, then tap.
+        reopenIssue(in: app)
+
+        // After reopen, the launch status card should appear.
+        assertElement("issue-detail-launch-status-card", existsIn: app, timeout: 5)
+        XCTAssertTrue(app.buttons["Launch Agent"].firstMatch.waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    @MainActor
+    private func openClosedIssue101(in app: XCUIApplication) {
         let openTab = element("section-tab-open", in: app)
         XCTAssertTrue(openTab.waitForExistence(timeout: 8), app.debugDescription)
         openTab.swipeLeft()
@@ -120,19 +185,95 @@ final class IssueDetailActionTests: XCTestCase {
 
         assertElement("issue-row-101", existsIn: app, timeout: 8)
         element("issue-row-101", in: app).tap()
+    }
 
-        // Tap the Reopen button.
+    @MainActor
+    private func reopenIssue(in app: XCUIApplication) {
         let reopenButton = app.buttons["Reopen"].firstMatch
         XCTAssertTrue(reopenButton.waitForExistence(timeout: 5), "Reopen button missing\n\(app.debugDescription)")
         reopenButton.tap()
 
-        // Confirmation dialog — tap Reopen (firstMatch disambiguates from any list swipe buttons).
         let confirmButton = app.buttons["Reopen"].firstMatch
         XCTAssertTrue(confirmButton.waitForExistence(timeout: 3), "Reopen confirmation missing")
         confirmButton.tap()
+    }
 
-        // After reopen, the launch status card should appear.
-        assertElement("issue-detail-launch-status-card", existsIn: app, timeout: 5)
-        XCTAssertTrue(app.buttons["Launch Agent"].firstMatch.waitForExistence(timeout: 5), app.debugDescription)
+    @MainActor
+    private func closeIssueWithoutComment(in app: XCUIApplication) {
+        let actionsMenu = app.buttons["issue-detail-actions-menu"]
+        XCTAssertTrue(actionsMenu.waitForExistence(timeout: 5), "Issue actions menu missing\n\(app.debugDescription)")
+        actionsMenu.tap()
+
+        let closeButton = app.buttons["Close Issue"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 3), "Close Issue menu item missing")
+        closeButton.tap()
+
+        let confirmButton = app.buttons["Close"].firstMatch
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 3), "Close confirmation missing\n\(app.debugDescription)")
+        confirmButton.tap()
+    }
+
+    @MainActor
+    private func submitIssueComment(_ body: String, in app: XCUIApplication) {
+        let actionsMenu = app.buttons["issue-detail-actions-menu"]
+        XCTAssertTrue(actionsMenu.waitForExistence(timeout: 5), "Issue actions menu missing\n\(app.debugDescription)")
+        actionsMenu.tap()
+
+        let commentButton = app.collectionViews.buttons["Comment"].firstMatch
+        XCTAssertTrue(commentButton.waitForExistence(timeout: 3), "Comment menu item missing")
+        commentButton.tap()
+
+        let textEditor = app.textViews.firstMatch
+        XCTAssertTrue(textEditor.waitForExistence(timeout: 3), "Comment text editor missing")
+        textEditor.tap()
+        app.typeText(body)
+
+        let submitButton = app.buttons["Add Comment"]
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 3), "Submit comment button missing")
+        submitButton.tap()
+    }
+
+    @MainActor
+    private func assertOfflineQueueLabel(
+        containing text: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 8,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let label = offlineQueueElement(containing: text, in: app)
+        XCTAssertTrue(
+            label.waitForExistence(timeout: timeout),
+            "Missing offline queue label containing \(text)\n\(app.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    private func waitForOfflineQueueToClear(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 8,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let label = offlineQueueElement(containing: "Offline action", in: app)
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: label)
+        let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(
+            result,
+            .completed,
+            "Offline queue banner did not clear\n\(app.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    private func offlineQueueElement(containing text: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS %@", text))
+            .firstMatch
     }
 }

--- a/ios/IssueCTLUITests/SettingsTests.swift
+++ b/ios/IssueCTLUITests/SettingsTests.swift
@@ -58,6 +58,17 @@ final class SettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsOpensOfflineQueue() {
+        let app = launchApp(server: server)
+
+        openSettingsFromToday(in: app)
+        app.buttons["settings-offline-queue-link"].tap()
+
+        XCTAssertTrue(app.navigationBars["Offline Queue"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Queue Empty"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    @MainActor
     func testWorktreesCleanupRequiresConfirmation() {
         let app = launchApp(server: server)
 


### PR DESCRIPTION
## Summary
- add a persisted iOS offline action queue for issue comments, close, and reopen actions
- replay queued actions through a shared sync service with pending/failed states
- expose queue status, manual sync, retry, clear, and removal controls in the app
- add unit and UI coverage for queue lifecycle and replay flows

## Verification
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:IssueCTLTests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:IssueCTLUITests
- git diff --check

Refs #289