### PR TITLE
ci: update checkout action to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -73,7 +73,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -88,7 +88,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -103,7 +103,7 @@ jobs:
     needs: [changes, typecheck, lint, test]
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     needs: [changes, typecheck, lint, test]
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ios-physical-preview.yml
+++ b/.github/workflows/ios-physical-preview.yml
@@ -46,7 +46,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "Physical iPhone preview smoke runs against the merge queue tip on merge_group."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0

--- a/.github/workflows/ios-preview-install.yml
+++ b/.github/workflows/ios-preview-install.yml
@@ -51,7 +51,7 @@ jobs:
       IOS_PREVIEW_KEYCHAIN_PASSWORD: ${{ secrets.IOS_PREVIEW_KEYCHAIN_PASSWORD }}
       IOS_PREVIEW_SET_KEY_PARTITION_LIST: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}

--- a/.github/workflows/ios-preview-runner-health.yml
+++ b/.github/workflows/ios-preview-runner-health.yml
@@ -22,7 +22,7 @@ jobs:
       IOS_PREVIEW_KEYCHAIN_PASSWORD: ${{ secrets.IOS_PREVIEW_KEYCHAIN_PASSWORD }}
       IOS_PREVIEW_SET_KEY_PARTITION_LIST: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Preflight runner, signing, and iPhone-preview
         run: ./scripts/ios-preview-runner-preflight.sh

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- update workflow checkout steps from `actions/checkout@v4` to `actions/checkout@v6`
- remove the GitHub Actions Node.js 20 deprecation warning from checkout steps

## Verification
- `rg "actions/checkout@v4|actions/checkout@v6" .github/workflows`
- `git diff --check origin/main..HEAD`