### PR TITLE
test(ios): fail preview perf capture without device logs

### DIFF
--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -99,7 +99,8 @@ Use the existing preview smoke wrapper to collect app-side `PerformanceTrace` ti
 Prerequisites:
 
 - `iPhone-preview` is connected, trusted, unlocked, and awake
-- `idevicesyslog` is available for live physical-device logs
+- `idevice_id` and `idevicesyslog` are available for live physical-device logs
+- `idevice_id -l` or `idevice_id -n -l` lists the `iPhone-preview` Xcode destination UDID
 - signing preflight passes:
 
 ```bash
@@ -120,7 +121,7 @@ The script writes artifacts to `/tmp` by default:
 
 Use `pnpm ios:preview-perf:full` when you need broader timing coverage across the preview smoke suite. Prefer the fast profile for quick before/after comparisons because it keeps the physical-device run shorter and reduces test-runner restart variance.
 
-If no `PerformanceTrace` lines appear, verify that the run used `IssueCTLPreview-UISmoke` and not the production scheme, then retry while the phone is unlocked. If `idevicesyslog` cannot attach by `IOS_XCODE_DEVICE_ID`, run `pnpm ios:list-devices` and use the physical device UDID shown for `iPhone-preview`.
+The wrapper fails the run if it cannot attach to the live device log stream or if the log stream produces no `PerformanceTrace` lines. If Xcode can run tests but `idevice_id` does not list the phone, reconnect or re-pair `iPhone-preview` so libimobiledevice can see it, then retry.
 
 ## Optional Pre-Push Check
 

--- a/scripts/ios-preview-perf-capture.sh
+++ b/scripts/ios-preview-perf-capture.sh
@@ -22,10 +22,12 @@ if ! command -v idevicesyslog >/dev/null 2>&1; then
   exit 69
 fi
 
-mkdir -p "$OUTPUT_DIR"
+if ! command -v idevice_id >/dev/null 2>&1; then
+  echo "idevice_id is required to verify physical-device log capture availability." >&2
+  exit 69
+fi
 
-echo "Running preview performance preflight."
-IOS_DEVICE_NAME="$DEVICE_NAME" pnpm ios:preview-runner-preflight
+mkdir -p "$OUTPUT_DIR"
 
 resolver_output="$(IOS_DEVICE_NAME="$DEVICE_NAME" ./scripts/ios-resolve-preview-device.sh shell)"
 eval "$resolver_output"
@@ -43,7 +45,24 @@ echo "Xcode result bundle: $RESULT_BUNDLE"
 rm -f "$LOG_FILE" "$SUMMARY_FILE"
 rm -rf "$RESULT_BUNDLE"
 
-idevicesyslog -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors > "$LOG_FILE" 2>&1 &
+syslog_args=()
+if idevice_id -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
+  :
+elif idevice_id -n -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
+  syslog_args=(-n)
+else
+  cat >&2 <<EOF
+idevicesyslog cannot see $DEVICE_NAME ($IOS_XCODE_DEVICE_ID), so PerformanceTrace logs cannot be captured.
+Xcode/CoreDevice may still be able to run tests over local-network pairing, but this wrapper requires libimobiledevice log access.
+Connect or re-pair $DEVICE_NAME so 'idevice_id -l' or 'idevice_id -n -l' lists $IOS_XCODE_DEVICE_ID, then retry.
+EOF
+  exit 70
+fi
+
+echo "Running preview performance preflight."
+IOS_DEVICE_NAME="$DEVICE_NAME" pnpm ios:preview-runner-preflight
+
+idevicesyslog "${syslog_args[@]}" -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors > "$LOG_FILE" 2>&1 &
 log_pid=$!
 
 cleanup() {
@@ -119,3 +138,8 @@ trap - EXIT
 
 printf '\nPerformanceTrace lines:\n'
 grep -n 'PerformanceTrace' "$LOG_FILE" || true
+
+if ! grep -q 'PerformanceTrace' "$LOG_FILE"; then
+  echo "No PerformanceTrace lines were captured; treating this as a failed performance capture." >&2
+  exit 70
+fi


### PR DESCRIPTION
## Summary
- require libimobiledevice to see iPhone-preview before starting the physical perf run
- support usb or network idevice lookup when starting idevicesyslog
- fail the perf wrapper when no PerformanceTrace lines are captured so empty summaries are not treated as valid measurements
- document the stricter device-log prerequisite

## Validation
- bash -n scripts/ios-preview-perf-capture.sh
- pnpm ios:preview-perf:fast (expected failure: idevice_id cannot currently see iPhone-preview, exits 70 before running XCTest)