### PR TITLE
Show stale cached data indicators

### DIFF
--- a/ios/IssueCTL/Models/Deployment.swift
+++ b/ios/IssueCTL/Models/Deployment.swift
@@ -108,6 +108,25 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
 
 struct ActiveDeploymentsResponse: Codable, Sendable {
     let deployments: [ActiveDeployment]
+    let fromCache: Bool
+    let cachedAt: String?
+
+    init(deployments: [ActiveDeployment], fromCache: Bool = false, cachedAt: String? = nil) {
+        self.deployments = deployments
+        self.fromCache = fromCache
+        self.cachedAt = cachedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deployments = try container.decode([ActiveDeployment].self, forKey: .deployments)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case deployments, fromCache, cachedAt
+    }
 }
 
 enum SessionPreviewStatus: String, Codable, Sendable {

--- a/ios/IssueCTL/Models/Issue.swift
+++ b/ios/IssueCTL/Models/Issue.swift
@@ -95,6 +95,40 @@ struct IssueDetailResponse: Codable, Sendable {
     let linkedPRs: [GitHubPull]
     let referencedFiles: [String]
     let fromCache: Bool
+    let cachedAt: String?
+
+    init(
+        issue: GitHubIssue,
+        comments: [GitHubComment],
+        deployments: [Deployment],
+        linkedPRs: [GitHubPull],
+        referencedFiles: [String],
+        fromCache: Bool,
+        cachedAt: String? = nil
+    ) {
+        self.issue = issue
+        self.comments = comments
+        self.deployments = deployments
+        self.linkedPRs = linkedPRs
+        self.referencedFiles = referencedFiles
+        self.fromCache = fromCache
+        self.cachedAt = cachedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        issue = try container.decode(GitHubIssue.self, forKey: .issue)
+        comments = try container.decode([GitHubComment].self, forKey: .comments)
+        deployments = try container.decode([Deployment].self, forKey: .deployments)
+        linkedPRs = try container.decode([GitHubPull].self, forKey: .linkedPRs)
+        referencedFiles = try container.decode([String].self, forKey: .referencedFiles)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case issue, comments, deployments, linkedPRs, referencedFiles, fromCache, cachedAt
+    }
 }
 
 struct IssueStateRequestBody: Encodable, Sendable {

--- a/ios/IssueCTL/Models/PullRequest.swift
+++ b/ios/IssueCTL/Models/PullRequest.swift
@@ -83,6 +83,24 @@ struct PullDetailResponse: Codable, Sendable {
     let fromCache: Bool
     let cachedAt: String?
 
+    init(
+        pull: GitHubPull,
+        checks: [GitHubCheck],
+        files: [GitHubPullFile],
+        linkedIssue: GitHubIssue?,
+        reviews: [GitHubPullReview],
+        fromCache: Bool,
+        cachedAt: String? = nil
+    ) {
+        self.pull = pull
+        self.checks = checks
+        self.files = files
+        self.linkedIssue = linkedIssue
+        self.reviews = reviews
+        self.fromCache = fromCache
+        self.cachedAt = cachedAt
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         pull = try container.decode(GitHubPull.self, forKey: .pull)

--- a/ios/IssueCTL/Services/APIClient.swift
+++ b/ios/IssueCTL/Services/APIClient.swift
@@ -239,7 +239,16 @@ final class APIClient {
             return response
         } catch {
             if let cached = offlineCache.load(IssueDetailResponse.self, for: cacheKey, serverURL: serverURL) {
-                return cached.value
+                let value = cached.value
+                return IssueDetailResponse(
+                    issue: value.issue,
+                    comments: value.comments,
+                    deployments: value.deployments,
+                    linkedPRs: value.linkedPRs,
+                    referencedFiles: value.referencedFiles,
+                    fromCache: true,
+                    cachedAt: cached.cachedAt
+                )
             }
             throw error
         }
@@ -273,7 +282,16 @@ final class APIClient {
             return response
         } catch {
             if let cached = offlineCache.load(PullDetailResponse.self, for: cacheKey, serverURL: serverURL) {
-                return cached.value
+                let value = cached.value
+                return PullDetailResponse(
+                    pull: value.pull,
+                    checks: value.checks,
+                    files: value.files,
+                    linkedIssue: value.linkedIssue,
+                    reviews: value.reviews,
+                    fromCache: true,
+                    cachedAt: cached.cachedAt
+                )
             }
             throw error
         }
@@ -309,7 +327,11 @@ final class APIClient {
         } catch {
             activeDeploymentsTask = nil
             if let cached = offlineCache.load(ActiveDeploymentsResponse.self, for: "deployments", serverURL: serverURL) {
-                return cached.value
+                return ActiveDeploymentsResponse(
+                    deployments: cached.value.deployments,
+                    fromCache: true,
+                    cachedAt: cached.cachedAt
+                )
             }
             throw error
         }

--- a/ios/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -63,6 +63,12 @@ struct IssueDetailView: View {
                 }
             } else if let detail {
                 VStack(spacing: 0) {
+                    if detail.fromCache {
+                        OfflineStatusBanner(message: staleDataMessage(kind: "issue detail", cachedAt: detail.cachedAt.flatMap(parseIssueCTLDate)))
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+                    }
+
                     if let staleHint {
                         Label(staleHint, systemImage: "arrow.clockwise")
                             .font(.caption)

--- a/ios/IssueCTL/Views/Issues/IssueListView.swift
+++ b/ios/IssueCTL/Views/Issues/IssueListView.swift
@@ -46,6 +46,7 @@ struct IssueListView: View {
     @State private var isLoadingPriorities = false
 
     @State private var oldestCachedAt: Date?
+    @State private var isShowingCachedData = false
     private let pageSize = 15
     @State private var displayLimit = 15
     @State private var searchText = ""
@@ -53,7 +54,7 @@ struct IssueListView: View {
     @FocusState private var isSearchFocused: Bool
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
-    private typealias RepoIssueLoadResult = (fullName: String, name: String, issues: [GitHubIssue]?, cachedAt: String?, error: Error?)
+    private typealias RepoIssueLoadResult = (fullName: String, name: String, issues: [GitHubIssue]?, cachedAt: String?, fromCache: Bool, error: Error?)
 
     private func isRunning(_ issue: GitHubIssue, in repoFullName: String) -> Bool {
         runningDeployment(for: issue, in: repoFullName, deployments: activeDeployments) != nil
@@ -231,7 +232,11 @@ struct IssueListView: View {
                     Divider()
                 }
 
-                if let oldestCachedAt {
+                if isShowingCachedData {
+                    OfflineStatusBanner(message: staleDataMessage(kind: "issues", cachedAt: oldestCachedAt))
+                        .padding(.horizontal, 16)
+                        .padding(.top, 6)
+                } else if let oldestCachedAt {
                     CacheAgeLabel(date: oldestCachedAt)
                         .padding(.horizontal, 16)
                         .padding(.top, 4)
@@ -840,9 +845,9 @@ struct IssueListView: View {
                     group.addTask { [api] in
                         do {
                             let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.issues, response.cachedAt, nil)
+                            return (repo.fullName, repo.name, response.issues, response.cachedAt, response.fromCache, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil, nil, error)
+                            return (repo.fullName, repo.name, nil, nil, false, error)
                         }
                     }
                 }
@@ -869,10 +874,12 @@ struct IssueListView: View {
             }
 
             var cachedDates: [Date] = []
+            var didUseCachedData = false
             var nextIssuesByRepo: [String: [GitHubIssue]] = [:]
-            for (fullName, name, issues, cachedAt, error) in repoResults {
+            for (fullName, name, issues, cachedAt, fromCache, error) in repoResults {
                 if let issues {
                     nextIssuesByRepo[fullName] = issues
+                    didUseCachedData = didUseCachedData || fromCache
                     if let cachedAt, let date = sharedISO8601Formatter.date(from: cachedAt) {
                         cachedDates.append(date)
                     }
@@ -885,6 +892,7 @@ struct IssueListView: View {
             issuesByRepo = nextIssuesByRepo
             issueRepoLookup = makeIssueRepoLookup(itemsByRepo: nextIssuesByRepo)
             oldestCachedAt = cachedDates.min()
+            isShowingCachedData = didUseCachedData
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }

--- a/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -31,6 +31,12 @@ struct PRDetailView: View {
                 }
             } else if let detail {
                 VStack(spacing: 0) {
+                    if detail.fromCache {
+                        OfflineStatusBanner(message: staleDataMessage(kind: "pull request detail", cachedAt: detail.cachedAt.flatMap(parseIssueCTLDate)))
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+                    }
+
                     ScrollView {
                         VStack(alignment: .leading, spacing: 20) {
                             headerSection(detail.pull)

--- a/ios/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/ios/IssueCTL/Views/PullRequests/PRListView.swift
@@ -28,6 +28,7 @@ struct PRListView: View {
     @State private var actionError: String?
 
     @State private var oldestCachedAt: Date?
+    @State private var isShowingCachedData = false
     private let pageSize = 15
     @State private var displayLimit = 15
     @State private var searchText = ""
@@ -161,7 +162,11 @@ struct PRListView: View {
                     Divider()
                 }
 
-                if let oldestCachedAt {
+                if isShowingCachedData {
+                    OfflineStatusBanner(message: staleDataMessage(kind: "pull requests", cachedAt: oldestCachedAt))
+                        .padding(.horizontal, 16)
+                        .padding(.top, 6)
+                } else if let oldestCachedAt {
                     CacheAgeLabel(date: oldestCachedAt)
                         .padding(.horizontal, 16)
                         .padding(.top, 4)
@@ -516,28 +521,30 @@ struct PRListView: View {
                 currentUserLogin = nil
             }
 
-            let repoResults = await withTaskGroup(of: (String, String, [GitHubPull]?, String?, Error?).self) { group in
+            let repoResults = await withTaskGroup(of: (String, String, [GitHubPull]?, String?, Bool, Error?).self) { group in
                 for repo in repos {
                     group.addTask {
                         do {
                             let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
-                            return (repo.fullName, repo.name, response.pulls, response.cachedAt, nil)
+                            return (repo.fullName, repo.name, response.pulls, response.cachedAt, response.fromCache, nil)
                         } catch {
-                            return (repo.fullName, repo.name, nil, nil, error)
+                            return (repo.fullName, repo.name, nil, nil, false, error)
                         }
                     }
                 }
-                var collected: [(String, String, [GitHubPull]?, String?, Error?)] = []
+                var collected: [(String, String, [GitHubPull]?, String?, Bool, Error?)] = []
                 for await result in group {
                     collected.append(result)
                 }
                 return collected
             }
             var cachedDates: [Date] = []
+            var didUseCachedData = false
             var nextPullsByRepo: [String: [GitHubPull]] = [:]
-            for (fullName, name, pulls, cachedAt, error) in repoResults {
+            for (fullName, name, pulls, cachedAt, fromCache, error) in repoResults {
                 if let pulls {
                     nextPullsByRepo[fullName] = pulls
+                    didUseCachedData = didUseCachedData || fromCache
                     if let cachedAt, let date = sharedISO8601Formatter.date(from: cachedAt) {
                         cachedDates.append(date)
                     }
@@ -550,6 +557,7 @@ struct PRListView: View {
             pullsByRepo = nextPullsByRepo
             pullRepoLookup = makePullRepoLookup(itemsByRepo: nextPullsByRepo)
             oldestCachedAt = cachedDates.min()
+            isShowingCachedData = didUseCachedData
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"
             }

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -14,6 +14,8 @@ struct SessionListView: View {
     @State private var isFetchingPreviews = false
     @State private var errorMessage: String?
     @State private var actionError: String?
+    @State private var cachedDeploymentsAt: Date?
+    @State private var isShowingCachedDeployments = false
     @State private var terminalPresentation: TerminalPresentation?
     @State private var sessionControlsTarget: ActiveDeployment?
     @State private var showCreateSheet = false
@@ -115,6 +117,10 @@ struct SessionListView: View {
                     } else {
                         ScrollView {
                             LazyVStack(spacing: 12) {
+                                if isShowingCachedDeployments {
+                                    OfflineStatusBanner(message: staleDataMessage(kind: "sessions", cachedAt: cachedDeploymentsAt))
+                                }
+
                                 ActiveSessionsHeader(
                                     totalCount: deployments.count,
                                     activeCount: activeTerminalCount,
@@ -363,6 +369,8 @@ struct SessionListView: View {
             }() : nil
             let response = try await deploymentsResult
             deployments = response.deployments
+            isShowingCachedDeployments = response.fromCache
+            cachedDeploymentsAt = response.cachedAt.flatMap(parseIssueCTLDate)
             prunePreviewState()
             if let reposResult = await reposResult {
                 switch reposResult {

--- a/ios/IssueCTL/Views/Shared/CacheAgeLabel.swift
+++ b/ios/IssueCTL/Views/Shared/CacheAgeLabel.swift
@@ -26,3 +26,13 @@ struct CacheAgeLabel: View {
         }
     }
 }
+
+func staleDataMessage(kind: String, cachedAt: Date?) -> String {
+    guard let cachedAt else {
+        return "Showing cached \(kind)"
+    }
+
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .abbreviated
+    return "Showing cached \(kind) from \(formatter.localizedString(for: cachedAt, relativeTo: Date()))"
+}

--- a/ios/IssueCTL/Views/Today/TodayView.swift
+++ b/ios/IssueCTL/Views/Today/TodayView.swift
@@ -19,6 +19,7 @@ struct TodayView: View {
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var oldestCachedAt: Date?
+    @State private var isShowingCachedData = false
     @State private var currentUserLogin: String?
     @State private var userFetchFailed = false
     @State private var showCreateSheet = false
@@ -220,7 +221,7 @@ struct TodayView: View {
         } else {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    if !network.isConnected {
+                    if isShowingCachedData || !network.isConnected {
                         OfflineStatusBanner(message: cacheMessage)
                     }
 
@@ -382,6 +383,9 @@ struct TodayView: View {
     }
 
     private var cacheMessage: String {
+        if isShowingCachedData {
+            return staleDataMessage(kind: "today data", cachedAt: oldestCachedAt)
+        }
         if let oldestCachedAt {
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .abbreviated
@@ -414,8 +418,15 @@ struct TodayView: View {
             async let issueResults = loadIssues(for: repoSnapshot, refresh: refresh)
             async let pullResults = loadPulls(for: repoSnapshot, refresh: refresh)
 
+            var deploymentCachedDates: [Date] = []
+            var didUseCachedData = false
             switch await deploymentsResult {
-            case .success(let response): activeDeployments = response.deployments
+            case .success(let response):
+                activeDeployments = response.deployments
+                didUseCachedData = didUseCachedData || response.fromCache
+                if let cachedAt = response.cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                    deploymentCachedDates.append(date)
+                }
             case .failure: activeDeployments = []
             }
             switch await userResult {
@@ -433,7 +444,8 @@ struct TodayView: View {
             pullsByRepo = loadedPulls.items
             issueRepoLookup = makeRepoLookup(itemsByRepo: loadedIssues.items, htmlUrl: { $0.htmlUrl })
             pullRepoLookup = makeRepoLookup(itemsByRepo: loadedPulls.items, htmlUrl: { $0.htmlUrl })
-            oldestCachedAt = (loadedIssues.cachedDates + loadedPulls.cachedDates).min()
+            oldestCachedAt = (deploymentCachedDates + loadedIssues.cachedDates + loadedPulls.cachedDates).min()
+            isShowingCachedData = didUseCachedData || loadedIssues.usedCache || loadedPulls.usedCache
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -443,56 +455,60 @@ struct TodayView: View {
     private func loadIssues(
         for repos: [(fullName: String, owner: String, name: String)],
         refresh: Bool
-    ) async -> (items: [String: [GitHubIssue]], cachedDates: [Date]) {
-        await withTaskGroup(of: (String, [GitHubIssue]?, String?).self) { group in
+    ) async -> (items: [String: [GitHubIssue]], cachedDates: [Date], usedCache: Bool) {
+        await withTaskGroup(of: (String, [GitHubIssue]?, String?, Bool).self) { group in
             for repo in repos {
                 group.addTask { [api] in
                     do {
                         let response = try await api.issues(owner: repo.owner, repo: repo.name, refresh: refresh)
-                        return (repo.fullName, response.issues, response.cachedAt)
+                        return (repo.fullName, response.issues, response.cachedAt, response.fromCache)
                     } catch {
-                        return (repo.fullName, nil, nil)
+                        return (repo.fullName, nil, nil, false)
                     }
                 }
             }
 
             var items: [String: [GitHubIssue]] = [:]
             var cachedDates: [Date] = []
-            for await (fullName, issues, cachedAt) in group {
+            var usedCache = false
+            for await (fullName, issues, cachedAt, fromCache) in group {
                 if let issues { items[fullName] = issues }
+                usedCache = usedCache || fromCache
                 if let cachedAt, let date = parseIssueCTLDate(cachedAt) {
                     cachedDates.append(date)
                 }
             }
-            return (items, cachedDates)
+            return (items, cachedDates, usedCache)
         }
     }
 
     private func loadPulls(
         for repos: [(fullName: String, owner: String, name: String)],
         refresh: Bool
-    ) async -> (items: [String: [GitHubPull]], cachedDates: [Date]) {
-        await withTaskGroup(of: (String, [GitHubPull]?, String?).self) { group in
+    ) async -> (items: [String: [GitHubPull]], cachedDates: [Date], usedCache: Bool) {
+        await withTaskGroup(of: (String, [GitHubPull]?, String?, Bool).self) { group in
             for repo in repos {
                 group.addTask { [api] in
                     do {
                         let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
-                        return (repo.fullName, response.pulls, response.cachedAt)
+                        return (repo.fullName, response.pulls, response.cachedAt, response.fromCache)
                     } catch {
-                        return (repo.fullName, nil, nil)
+                        return (repo.fullName, nil, nil, false)
                     }
                 }
             }
 
             var items: [String: [GitHubPull]] = [:]
             var cachedDates: [Date] = []
-            for await (fullName, pulls, cachedAt) in group {
+            var usedCache = false
+            for await (fullName, pulls, cachedAt, fromCache) in group {
                 if let pulls { items[fullName] = pulls }
+                usedCache = usedCache || fromCache
                 if let cachedAt, let date = parseIssueCTLDate(cachedAt) {
                     cachedDates.append(date)
                 }
             }
-            return (items, cachedDates)
+            return (items, cachedDates, usedCache)
         }
     }
 

--- a/ios/IssueCTLTests/ModelDecodingTests.swift
+++ b/ios/IssueCTLTests/ModelDecodingTests.swift
@@ -639,13 +639,17 @@ final class ModelDecodingTests: XCTestCase {
                     "owner": "org",
                     "repo_name": "app"
                 }
-            ]
+            ],
+            "from_cache": true,
+            "cached_at": "2026-04-27T09:00:00Z"
         }
         """.data(using: .utf8)!
 
         let response = try decoder.decode(ActiveDeploymentsResponse.self, from: json)
         XCTAssertEqual(response.deployments.count, 1)
         XCTAssertEqual(response.deployments[0].repoFullName, "org/app")
+        XCTAssertTrue(response.fromCache)
+        XCTAssertEqual(response.cachedAt, "2026-04-27T09:00:00Z")
     }
 
     func testSessionPreviewsResponseDecoding() throws {


### PR DESCRIPTION
## Summary
- Preserve cache fallback metadata for issue details, pull details, and active deployments
- Show cached-data banners across Today, Issues, PRs, Sessions, and detail views when fallback data is displayed
- Cover deployment cache metadata decoding

Refs #289

## Tests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests
- xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests/testActiveDeploymentsResponseDecoding