### PR TITLE
test(ios): add CoreDevice preview perf trace fallback

### DIFF
--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -99,8 +99,7 @@ Use the existing preview smoke wrapper to collect app-side `PerformanceTrace` ti
 Prerequisites:
 
 - `iPhone-preview` is connected, trusted, unlocked, and awake
-- `idevice_id` and `idevicesyslog` are available for live physical-device logs
-- `idevice_id -l` or `idevice_id -n -l` lists the `iPhone-preview` Xcode destination UDID
+- `idevice_id` and `idevicesyslog` are available when using live physical-device logs
 - signing preflight passes:
 
 ```bash
@@ -119,9 +118,9 @@ The script writes artifacts to `/tmp` by default:
 - `/tmp/issuectl-preview-perf-<timestamp>.summary.txt`
 - `/tmp/issuectl-preview-perf-<timestamp>.xcresult`
 
-Use `pnpm ios:preview-perf:full` when you need broader timing coverage across the preview smoke suite. Prefer the fast profile for quick before/after comparisons because it keeps the physical-device run shorter and reduces test-runner restart variance.
+Use `pnpm ios:preview-perf:full` when you need broader timing coverage across the preview smoke suite. Prefer the fast profile for quick before/after comparisons because it keeps the physical-device run shorter and reduces test-runner restart variance. The performance wrapper disables Xcode code coverage for these runs to avoid runtime-profile overhead and device file-service failures that are not relevant to timing.
 
-The wrapper fails the run if it cannot attach to the live device log stream or if the log stream produces no `PerformanceTrace` lines. If Xcode can run tests but `idevice_id` does not list the phone, reconnect or re-pair `iPhone-preview` so libimobiledevice can see it, then retry.
+The wrapper prefers live `idevicesyslog` capture when libimobiledevice can see the phone. If Xcode can run tests but `idevice_id` does not list the phone, the preview app writes the same `PerformanceTrace` lines to `Library/Caches/IssueCTLPerformanceTrace.log`, and the wrapper copies that file back through CoreDevice after XCTest. The wrapper fails the run if neither capture path produces `PerformanceTrace` lines.
 
 ## Optional Pre-Push Check
 

--- a/docs/performance/ios-preview-baselines.md
+++ b/docs/performance/ios-preview-baselines.md
@@ -39,3 +39,36 @@ Slowest API requests in the run:
 | `/api/v1/worktrees/status?owner=org&repo=alpha&issueNumber=101` | 33 ms | 404 |
 
 Use this baseline as a comparison point for local branch or merge queue tip runs. Prefer comparing two fresh captures from the same phone session when making a performance claim.
+
+## 2026-05-04 Merged Main Baseline
+
+- Git ref: `main` at `aabdc50`
+- Device: `iPhone-preview`
+- Profile: `fast`
+- Capture mode: CoreDevice app-container trace fallback, with code coverage disabled
+- Log: `/tmp/issuectl-preview-perf-20260504T200526Z.log`
+- Xcode result bundle: `/tmp/issuectl-preview-perf-20260504T200526Z.xcresult`
+
+| Metric | Time |
+|---|---:|
+| `app_launch_usable` | 347 ms |
+| `today.load` | 116 ms |
+| `issues.load_all` | 38 ms |
+| `sessions.load` | 38 ms |
+| Fast UI smoke test case | 35.410 s |
+| Wrapper elapsed | 47 s |
+
+Slowest API requests in the run:
+
+| Request | Time | Status |
+|---|---:|---:|
+| `/api/v1/settings` | 120 ms | 200 |
+| `/api/v1/deployments/9001/ensure-ttyd` | 67 ms | 404 |
+| `/api/v1/repos` | 36 ms | 200 |
+| `/api/v1/deployments/9001/ensure-ttyd` | 31 ms | 404 |
+| `/api/v1/user` | 27 ms | 200 |
+| `/api/v1/deployments` | 26 ms | 200 |
+| `/api/v1/launch/org/alpha/101` | 24 ms | 200 |
+| `/api/v1/worktrees/status?owner=org&repo=alpha&issueNumber=101` | 21 ms | 404 |
+| `/api/v1/sessions/previews` | 8 ms | 200 |
+| `/api/v1/issues/org/alpha/101/priority` | 6 ms | 200 |

--- a/ios/IssueCTL/Views/Shared/Constants.swift
+++ b/ios/IssueCTL/Views/Shared/Constants.swift
@@ -4,6 +4,8 @@ import OSLog
 enum PerformanceTrace {
     private static let logger = Logger(subsystem: "com.issuectl.ios", category: "performance")
     private static let appLaunchStartedAt = Date()
+    private static let testLogQueue = DispatchQueue(label: "com.issuectl.ios.performance-trace-test-log")
+    private static let testLogFileName = "IssueCTLPerformanceTrace.log"
 
     struct Token {
         let name: String
@@ -12,6 +14,7 @@ enum PerformanceTrace {
 
     static func markAppLaunchStarted() {
         _ = appLaunchStartedAt
+        resetTestLog()
     }
 
     static func begin(_ name: String, metadata: String = "") -> Token {
@@ -34,7 +37,49 @@ enum PerformanceTrace {
 
     private static func testLog(_ message: String) {
         guard ProcessInfo.processInfo.environment["ISSUECTL_UI_TESTING"] == "1" else { return }
-        NSLog("[PerformanceTrace] %@", message)
+        let line = "[PerformanceTrace] \(message)"
+        NSLog("%@", line)
+        writeTestLog(line)
+    }
+
+    private static func resetTestLog() {
+        guard ProcessInfo.processInfo.environment["ISSUECTL_UI_TESTING"] == "1" else { return }
+        testLogQueue.sync {
+            do {
+                try FileManager.default.createDirectory(
+                    at: testLogURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try Data().write(to: testLogURL, options: .atomic)
+            } catch {
+                NSLog("[PerformanceTrace] failed_to_reset_file error=%@", error.localizedDescription)
+            }
+        }
+    }
+
+    private static func writeTestLog(_ line: String) {
+        testLogQueue.sync {
+            do {
+                try FileManager.default.createDirectory(
+                    at: testLogURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                if !FileManager.default.fileExists(atPath: testLogURL.path) {
+                    FileManager.default.createFile(atPath: testLogURL.path, contents: nil)
+                }
+                let handle = try FileHandle(forWritingTo: testLogURL)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: Data((line + "\n").utf8))
+                try handle.close()
+            } catch {
+                NSLog("[PerformanceTrace] failed_to_write_file error=%@", error.localizedDescription)
+            }
+        }
+    }
+
+    private static var testLogURL: URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(testLogFileName)
     }
 }
 

--- a/scripts/ios-preview-perf-capture.sh
+++ b/scripts/ios-preview-perf-capture.sh
@@ -11,19 +11,16 @@ OUTPUT_DIR="${IOS_PREVIEW_PERF_OUTPUT_DIR:-/tmp}"
 LOG_FILE="${IOS_PREVIEW_PERF_LOG:-$OUTPUT_DIR/issuectl-preview-perf-$STAMP.log}"
 SUMMARY_FILE="${IOS_PREVIEW_PERF_SUMMARY:-$OUTPUT_DIR/issuectl-preview-perf-$STAMP.summary.txt}"
 RESULT_BUNDLE="${IOS_PREVIEW_PERF_XCRESULT:-$OUTPUT_DIR/issuectl-preview-perf-$STAMP.xcresult}"
+APP_BUNDLE_ID="com.issuectl.ios.preview"
+APP_TRACE_SOURCE="Library/Caches/IssueCTLPerformanceTrace.log"
 
 if [ "$DEVICE_NAME" != "iPhone-preview" ]; then
   echo "Refusing to capture preview performance on unexpected device '$DEVICE_NAME'." >&2
   exit 64
 fi
 
-if ! command -v idevicesyslog >/dev/null 2>&1; then
-  echo "idevicesyslog is required for physical-device PerformanceTrace capture." >&2
-  exit 69
-fi
-
-if ! command -v idevice_id >/dev/null 2>&1; then
-  echo "idevice_id is required to verify physical-device log capture availability." >&2
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "xcrun is required for physical-device PerformanceTrace capture." >&2
   exit 69
 fi
 
@@ -44,41 +41,67 @@ echo "Xcode result bundle: $RESULT_BUNDLE"
 
 rm -f "$LOG_FILE" "$SUMMARY_FILE"
 rm -rf "$RESULT_BUNDLE"
+touch "$LOG_FILE"
 
 syslog_args=()
-if idevice_id -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
-  :
-elif idevice_id -n -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
-  syslog_args=(-n)
+use_syslog=0
+if command -v idevicesyslog >/dev/null 2>&1 && command -v idevice_id >/dev/null 2>&1; then
+  if idevice_id -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
+    use_syslog=1
+  elif idevice_id -n -l | grep -Fxq "$IOS_XCODE_DEVICE_ID"; then
+    syslog_args=(-n)
+    use_syslog=1
+  else
+    echo "libimobiledevice cannot see $DEVICE_NAME; will copy PerformanceTrace file via CoreDevice after XCTest."
+  fi
 else
-  cat >&2 <<EOF
-idevicesyslog cannot see $DEVICE_NAME ($IOS_XCODE_DEVICE_ID), so PerformanceTrace logs cannot be captured.
-Xcode/CoreDevice may still be able to run tests over local-network pairing, but this wrapper requires libimobiledevice log access.
-Connect or re-pair $DEVICE_NAME so 'idevice_id -l' or 'idevice_id -n -l' lists $IOS_XCODE_DEVICE_ID, then retry.
-EOF
-  exit 70
+  echo "libimobiledevice tools are unavailable; will copy PerformanceTrace file via CoreDevice after XCTest."
 fi
 
 echo "Running preview performance preflight."
 IOS_DEVICE_NAME="$DEVICE_NAME" pnpm ios:preview-runner-preflight
 
-idevicesyslog "${syslog_args[@]}" -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors > "$LOG_FILE" 2>&1 &
-log_pid=$!
+log_pid=""
+if [ "$use_syslog" -eq 1 ]; then
+  idevicesyslog "${syslog_args[@]}" -u "$IOS_XCODE_DEVICE_ID" -m '[PerformanceTrace]' --no-colors > "$LOG_FILE" 2>&1 &
+  log_pid=$!
+fi
 
 cleanup() {
-  kill "$log_pid" 2>/dev/null || true
+  if [ -n "$log_pid" ]; then
+    kill "$log_pid" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
 started_at="$SECONDS"
 IOS_UI_SMOKE_PROFILE="$PROFILE" \
-IOS_XCODEBUILD_EXTRA_ARGS="-allowProvisioningUpdates -allowProvisioningDeviceRegistration -resultBundlePath $RESULT_BUNDLE ${IOS_XCODEBUILD_EXTRA_ARGS:-}" \
+IOS_XCODEBUILD_EXTRA_ARGS="-allowProvisioningUpdates -allowProvisioningDeviceRegistration -enableCodeCoverage NO -resultBundlePath $RESULT_BUNDLE ${IOS_XCODEBUILD_EXTRA_ARGS:-}" \
   ./scripts/ios-preview-device-smoke.sh
 wrapper_elapsed=$((SECONDS - started_at))
 
 sleep 2
 cleanup
 trap - EXIT
+
+if ! grep -Fq '[PerformanceTrace]' "$LOG_FILE"; then
+  trace_copy_dir="$(mktemp -d "$OUTPUT_DIR/issuectl-preview-perf-trace.XXXXXX")"
+  copied_trace="$trace_copy_dir/$(basename "$APP_TRACE_SOURCE")"
+  if xcrun devicectl device copy from \
+      --device "$IOS_DEVICE_ID" \
+      --domain-type appDataContainer \
+      --domain-identifier "$APP_BUNDLE_ID" \
+      --source "$APP_TRACE_SOURCE" \
+      --destination "$copied_trace" \
+      --quiet \
+      --timeout 30 >/dev/null 2>&1; then
+    if [ -f "$copied_trace" ]; then
+      cp "$copied_trace" "$LOG_FILE"
+    fi
+  else
+    echo "CoreDevice trace file copy failed from $APP_TRACE_SOURCE." >> "$LOG_FILE"
+  fi
+fi
 
 {
   printf 'iOS Preview Performance Summary\n'
@@ -92,36 +115,36 @@ trap - EXIT
   printf 'Xcode result bundle: %s\n' "$RESULT_BUNDLE"
   printf '\nKey timings:\n'
 
-  if grep -q 'PerformanceTrace' "$LOG_FILE"; then
+  if grep -Fq '[PerformanceTrace]' "$LOG_FILE"; then
     awk '
-      /PerformanceTrace/ && /app_launch_usable/ {
+      /\[PerformanceTrace\]/ && /app_launch_usable/ {
         if (match($0, /screen=[^ ]+/)) screen = substr($0, RSTART, RLENGTH);
         if (match($0, /elapsed_ms=[0-9]+/)) print "app_launch_usable " screen " " substr($0, RSTART, RLENGTH);
       }
-      /PerformanceTrace/ && /end today\.load/ {
+      /\[PerformanceTrace\]/ && /end today\.load/ {
         if (match($0, /elapsed_ms=[0-9]+/)) print "today.load " substr($0, RSTART, RLENGTH);
       }
-      /PerformanceTrace/ && /end issues\.load_all/ {
+      /\[PerformanceTrace\]/ && /end issues\.load_all/ {
         if (match($0, /elapsed_ms=[0-9]+/)) print "issues.load_all " substr($0, RSTART, RLENGTH);
       }
-      /PerformanceTrace/ && /end pulls\.load_all/ {
+      /\[PerformanceTrace\]/ && /end pulls\.load_all/ {
         if (match($0, /elapsed_ms=[0-9]+/)) print "pulls.load_all " substr($0, RSTART, RLENGTH);
       }
-      /PerformanceTrace/ && /end sessions\.load/ {
+      /\[PerformanceTrace\]/ && /end sessions\.load/ {
         if (match($0, /elapsed_ms=[0-9]+/)) print "sessions.load " substr($0, RSTART, RLENGTH);
       }
     ' "$LOG_FILE"
 
     printf '\nSlowest API requests:\n'
     awk '
-      /PerformanceTrace/ && /begin api\.request/ {
+      /\[PerformanceTrace\]/ && /begin api\.request/ {
         method = "";
         path = "";
         if (match($0, /method=[^ ]+/)) method = substr($0, RSTART, RLENGTH);
         if (match($0, /path=[^ ]+/)) path = substr($0, RSTART, RLENGTH);
         pending[++tail] = method " " path;
       }
-      /PerformanceTrace/ && /end api\.request/ {
+      /\[PerformanceTrace\]/ && /end api\.request/ {
         elapsed = "";
         request = "";
         status = "";
@@ -137,9 +160,9 @@ trap - EXIT
 } | tee "$SUMMARY_FILE"
 
 printf '\nPerformanceTrace lines:\n'
-grep -n 'PerformanceTrace' "$LOG_FILE" || true
+grep -Fn '[PerformanceTrace]' "$LOG_FILE" || true
 
-if ! grep -q 'PerformanceTrace' "$LOG_FILE"; then
-  echo "No PerformanceTrace lines were captured; treating this as a failed performance capture." >&2
+if ! grep -Fq '[PerformanceTrace]' "$LOG_FILE"; then
+  echo "No PerformanceTrace lines were captured from live syslog or CoreDevice app-container file copy." >&2
   exit 70
 fi


### PR DESCRIPTION
## Summary
- write UI-test PerformanceTrace lines to an app-container file in addition to NSLog
- make the preview perf wrapper fall back to copying that file with CoreDevice when idevicesyslog/libimobiledevice cannot see iPhone-preview
- disable code coverage for preview perf runs to avoid runtime-profile file-service overhead
- document the fallback and record the merged-main physical baseline

## Validation
- bash -n scripts/ios-preview-perf-capture.sh
- pnpm ios:preview-perf:fast on iPhone-preview using CoreDevice fallback

## Physical timing baseline
Artifacts:
- Summary: /tmp/issuectl-preview-perf-20260504T200526Z.summary.txt
- Log: /tmp/issuectl-preview-perf-20260504T200526Z.log
- Xcode result: /tmp/issuectl-preview-perf-20260504T200526Z.xcresult

Key timings:
- app_launch_usable=347ms
- today.load=116ms
- issues.load_all=38ms
- sessions.load=38ms
- fast UI case=35.410s
- wrapper elapsed=47s