### PR TITLE
Fix iOS running sessions and dev loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ pnpm install
 pnpm turbo build
 issuectl init        # First-time setup (creates DB)
 issuectl web         # Start dashboard and print iOS setup link/QR
+pnpm ios:setup-sim   # Configure the booted iOS Simulator from the saved API token
+pnpm ios:dev         # Start web, build/run iOS Simulator, and apply setup link
 ```
 
 ## What it does

--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -9,7 +9,6 @@ struct SessionListView: View {
     @State private var repos: [Repo] = []
     @State private var deployments: [ActiveDeployment] = []
     @State private var previews: [Int: SessionPreview] = [:]
-    @State private var expandedPorts: Set<Int> = []
     @State private var isLoading = true
     @State private var isFetchingPreviews = false
     @State private var errorMessage: String?
@@ -23,14 +22,23 @@ struct SessionListView: View {
     @State private var navigationPath = NavigationPath()
     @State private var searchText = ""
     @State private var isSearchVisible = false
+    @State private var selectedRepoIds: Set<Int> = []
+    @State private var showFiltersSheet = false
+    @State private var collapsedPreviewPorts: Set<Int> = []
     @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
 
     private var filteredDeployments: [ActiveDeployment] {
-        guard !searchText.isEmpty else { return deployments }
+        var items = deployments
+
+        if !selectedRepoIds.isEmpty {
+            items = items.filter { selectedRepoIds.contains($0.repoId) }
+        }
+
+        guard !searchText.isEmpty else { return items }
         let query = searchText.lowercased()
-        return deployments.filter { deployment in
+        return items.filter { deployment in
             [
                 deployment.repoFullName,
                 "#\(deployment.issueNumber)",
@@ -78,6 +86,27 @@ struct SessionListView: View {
         return repos.map(\.fullName).filter { names.contains($0) }
     }
 
+    private var hasActiveFilters: Bool {
+        !selectedRepoIds.isEmpty
+    }
+
+    private var selectedRepoSummary: String {
+        let names = repos
+            .filter { selectedRepoIds.contains($0.id) }
+            .map(\.name)
+
+        if selectedRepoIds.isEmpty {
+            return repos.count > 1 ? "All \(repos.count)" : repos.first?.name ?? "None"
+        }
+        if names.isEmpty {
+            return "\(selectedRepoIds.count) selected"
+        }
+        if names.count <= 2 {
+            return names.joined(separator: ", ")
+        }
+        return "\(names[0]), \(names[1]) +\(names.count - 2)"
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             VStack(spacing: 0) {
@@ -87,7 +116,12 @@ struct SessionListView: View {
                     sessionHeader
                 }
 
-                RepoContextStrip(repos: repos, activeRepoFullNames: activeRepoFullNames)
+                RepoContextStrip(
+                    repos: repos,
+                    activeRepoFullNames: activeRepoFullNames,
+                    valueOverride: selectedRepoSummary,
+                    onTap: { showFiltersSheet = true }
+                )
 
                 Group {
                     if isLoading && deployments.isEmpty {
@@ -121,14 +155,6 @@ struct SessionListView: View {
                                     OfflineStatusBanner(message: staleDataMessage(kind: "sessions", cachedAt: cachedDeploymentsAt))
                                 }
 
-                                ActiveSessionsHeader(
-                                    totalCount: deployments.count,
-                                    activeCount: activeTerminalCount,
-                                    idleCount: idleTerminalCount,
-                                    checkingCount: checkingTerminalCount,
-                                    startingCount: startingCount
-                                )
-
                                 if let actionError {
                                     Label(actionError, systemImage: "exclamationmark.triangle")
                                         .foregroundStyle(.red)
@@ -143,7 +169,7 @@ struct SessionListView: View {
                                     } description: {
                                         Text("Try another repo, issue number, branch, or port.")
                                     } actions: {
-                                        Button("Clear Search", action: hideSearch)
+                                        Button(hasActiveFilters ? "Clear Filters" : "Clear Search", action: resetFiltersAndSearch)
                                     }
                                     .padding(.top, 18)
                                 }
@@ -153,7 +179,7 @@ struct SessionListView: View {
                                     SessionRowView(
                                         deployment: deployment,
                                         preview: port.flatMap { previews[$0] },
-                                        isPreviewExpanded: port.map { expandedPorts.contains($0) } ?? false,
+                                        isPreviewExpanded: port.map { previews[$0] != nil && !collapsedPreviewPorts.contains($0) } ?? false,
                                         isEnding: endingDeploymentId == deployment.id,
                                         onTogglePreview: {
                                             if let port {
@@ -239,6 +265,15 @@ struct SessionListView: View {
                     Task { await load(refresh: true) }
                 })
             }
+            .sheet(isPresented: $showFiltersSheet) {
+                SessionFilterSheet(
+                    repos: repos,
+                    selectedRepoIds: $selectedRepoIds,
+                    selectedRepoSummary: selectedRepoSummary
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+            }
         }
     }
 
@@ -259,6 +294,15 @@ struct SessionListView: View {
                     accessibilityIdentifier: "sessions-refresh-button"
                 ) {
                     Task { await refreshSessions() }
+                }
+
+                TopBarIconButton(
+                    title: "Session filters",
+                    systemImage: "line.3.horizontal.decrease",
+                    accessibilityIdentifier: "sessions-filter-button",
+                    showsActiveIndicator: hasActiveFilters
+                ) {
+                    showFiltersSheet = true
                 }
 
                 TopBarIconButton(
@@ -333,6 +377,11 @@ struct SessionListView: View {
         isSearchVisible = false
     }
 
+    private func resetFiltersAndSearch() {
+        selectedRepoIds.removeAll()
+        hideSearch()
+    }
+
     private func sessionErrorDescription(_ message: String) -> String {
         "\(message)\n\nRetry after starting issuectl web, or open Settings to update the server."
     }
@@ -344,10 +393,10 @@ struct SessionListView: View {
 
     private func togglePreview(_ port: Int) {
         withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
-            if expandedPorts.contains(port) {
-                expandedPorts.remove(port)
+            if collapsedPreviewPorts.contains(port) {
+                collapsedPreviewPorts.remove(port)
             } else {
-                expandedPorts.insert(port)
+                collapsedPreviewPorts.insert(port)
             }
         }
     }
@@ -394,7 +443,7 @@ struct SessionListView: View {
         guard !isFetchingPreviews else { return }
         guard !deployments.isEmpty else {
             previews = [:]
-            expandedPorts = []
+            collapsedPreviewPorts = []
             return
         }
         isFetchingPreviews = true
@@ -414,7 +463,7 @@ struct SessionListView: View {
         while !Task.isCancelled {
             if deployments.isEmpty {
                 previews = [:]
-                expandedPorts = []
+                collapsedPreviewPorts = []
             } else {
                 await fetchPreviews()
             }
@@ -430,7 +479,7 @@ struct SessionListView: View {
     private func prunePreviewState() {
         let ports = Set(deployments.compactMap(\.ttydPort))
         previews = previews.filter { ports.contains($0.key) }
-        expandedPorts = expandedPorts.intersection(ports)
+        collapsedPreviewPorts = collapsedPreviewPorts.intersection(ports)
     }
 
     private func endSession(_ deployment: ActiveDeployment) async {
@@ -445,7 +494,7 @@ struct SessionListView: View {
             deployments.removeAll { $0.id == deployment.id }
             if let port = deployment.ttydPort {
                 previews.removeValue(forKey: port)
-                expandedPorts.remove(port)
+                collapsedPreviewPorts.remove(port)
             }
         } catch {
             errorMessage = error.localizedDescription
@@ -459,69 +508,105 @@ private struct TerminalPresentation: Identifiable {
     let deployment: ActiveDeployment
 }
 
-private struct ActiveSessionsHeader: View {
-    let totalCount: Int
-    let activeCount: Int
-    let idleCount: Int
-    let checkingCount: Int
-    let startingCount: Int
+private struct SessionFilterSheet: View {
+    let repos: [Repo]
+    @Binding var selectedRepoIds: Set<Int>
+    let selectedRepoSummary: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("\(totalCount) running")
-                    .font(.title3.bold())
-                Text("Re-enter terminals without losing active agent work.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    sheetHeader
 
-            HStack(spacing: 10) {
-                metric(value: "\(activeCount)", label: "active", systemImage: "bolt.fill", accessibilityIdentifier: "sessions-active-count")
-                metric(value: "\(idleCount)", label: "idle", systemImage: "pause.circle", accessibilityIdentifier: "sessions-idle-count")
-                if checkingCount > 0 {
-                    metric(value: "\(checkingCount)", label: "checking", systemImage: "dot.radiowaves.left.and.right", accessibilityIdentifier: "sessions-checking-count")
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 8) {
+                            Label("Repository", systemImage: "tray.2")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            if !selectedRepoIds.isEmpty {
+                                Button("Clear") {
+                                    selectedRepoIds.removeAll()
+                                }
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(IssueCTLColors.action)
+                                .buttonStyle(.plain)
+                            }
+                        }
+
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                            Button {
+                                selectedRepoIds.removeAll()
+                            } label: {
+                                optionContent(title: "All Repos", subtitle: "\(repos.count) configured", isSelected: selectedRepoIds.isEmpty)
+                            }
+                            .buttonStyle(.plain)
+
+                            ForEach(repos) { repo in
+                                let isSelected = selectedRepoIds.contains(repo.id)
+                                Button {
+                                    if isSelected {
+                                        selectedRepoIds.remove(repo.id)
+                                    } else {
+                                        selectedRepoIds.insert(repo.id)
+                                    }
+                                } label: {
+                                    optionContent(title: repo.name, subtitle: repo.owner, isSelected: isSelected)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .padding(12)
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
                 }
-                metric(value: "\(startingCount)", label: "starting", systemImage: "hourglass", accessibilityIdentifier: "sessions-starting-count")
+                .padding(16)
             }
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: 18))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
-        }
-        .accessibilityIdentifier("sessions-command-header")
     }
 
-    private func metric(
-        value: String,
-        label: String,
-        systemImage: String,
-        accessibilityIdentifier: String
-    ) -> some View {
-        HStack(spacing: 7) {
-            Image(systemName: systemImage)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(value)
-                    .font(.subheadline.bold())
-                Text(label)
+    private var sheetHeader: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Filters")
+                    .font(.title3.bold())
+                Text("Showing \(selectedRepoSummary)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            Spacer(minLength: 0)
+            Spacer()
+            if !selectedRepoIds.isEmpty {
+                Button("Reset") {
+                    selectedRepoIds.removeAll()
+                }
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(IssueCTLColors.action)
+                .buttonStyle(.plain)
+            }
         }
-        .padding(9)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(IssueCTLColors.elevatedBackground, in: RoundedRectangle(cornerRadius: 12))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(label) sessions")
-        .accessibilityValue(value)
-        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func optionContent(title: String, subtitle: String, isSelected: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+        .padding(10)
+        .background(isSelected ? IssueCTLColors.action.opacity(0.14) : Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSelected ? IssueCTLColors.action.opacity(0.55) : Color.clear, lineWidth: 1)
+        }
     }
 }
 

--- a/ios/IssueCTL/Views/Shared/RepoFilterChips.swift
+++ b/ios/IssueCTL/Views/Shared/RepoFilterChips.swift
@@ -85,16 +85,31 @@ struct RepoContextStrip: View {
     let repos: [Repo]
     var activeRepoFullNames: [String] = []
     var leadingTitle = "Repos"
+    var valueOverride: String?
+    var onTap: (() -> Void)?
 
     var body: some View {
         if shouldShow {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
-                    RepoContextChip(
-                        title: leadingTitle,
-                        value: repoSummary,
-                        systemImage: "folder"
-                    )
+                    if let onTap {
+                        Button(action: onTap) {
+                            RepoContextChip(
+                                title: leadingTitle,
+                                value: displayedRepoSummary,
+                                systemImage: "folder"
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens repository filters")
+                        .accessibilityIdentifier("repo-context-filter-button")
+                    } else {
+                        RepoContextChip(
+                            title: leadingTitle,
+                            value: displayedRepoSummary,
+                            systemImage: "folder"
+                        )
+                    }
 
                     if !activeRepoFullNames.isEmpty && activeRepoFullNames.count < repos.count {
                         RepoContextChip(
@@ -124,5 +139,9 @@ struct RepoContextStrip: View {
             return repos[0].name
         }
         return "All \(repos.count)"
+    }
+
+    private var displayedRepoSummary: String {
+        valueOverride ?? repoSummary
     }
 }

--- a/ios/IssueCTLUITests/Helpers/MockServer.swift
+++ b/ios/IssueCTLUITests/Helpers/MockServer.swift
@@ -110,6 +110,15 @@ final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
+    func seedDeploymentsAcrossRepos() {
+        hiddenPreviewIssueNumbers = []
+        repos = [defaultRepo, betaRepo]
+        activeDeployments = [
+            deployment(issueNumber: 101),
+            deployment(issueNumber: 201, repoId: 2, owner: "org", repoName: "beta"),
+        ]
+    }
+
     func seedDeploymentWithMissingPreview() {
         activeDeployments = [deployment(issueNumber: 101)]
         hiddenPreviewIssueNumbers = [101]
@@ -597,23 +606,23 @@ final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
-    func deployment(issueNumber: Int) -> [String: Any] {
+    func deployment(issueNumber: Int, repoId: Int = 1, owner: String = "org", repoName: String = "alpha") -> [String: Any] {
         let id = 8900 + issueNumber
         return [
             "id": id,
-            "repo_id": 1,
+            "repo_id": repoId,
             "issue_number": issueNumber,
             "branch_name": branchName(for: issueNumber),
             "workspace_mode": "worktree",
-            "workspace_path": "/tmp/alpha-worktree-\(issueNumber)",
+            "workspace_path": "/tmp/\(repoName)-worktree-\(issueNumber)",
             "linked_pr_number": NSNull(),
             "state": "active",
             "launched_at": "2026-04-29 08:00:00",
             "ended_at": NSNull(),
             "ttyd_port": 19000 + issueNumber,
             "ttyd_pid": 12000 + issueNumber,
-            "owner": "org",
-            "repo_name": "alpha",
+            "owner": owner,
+            "repo_name": repoName,
         ]
     }
 

--- a/ios/IssueCTLUITests/Helpers/TestHelpers.swift
+++ b/ios/IssueCTLUITests/Helpers/TestHelpers.swift
@@ -149,7 +149,9 @@ func openSettingsFromRecovery(in app: XCUIApplication) {
 
 @MainActor
 func assertRepoContext(_ expectedValue: String, in app: XCUIApplication) {
-    let context = element("repo-context-repos", in: app)
+    let staticContext = element("repo-context-repos", in: app)
+    let tappableContext = element("repo-context-filter-button", in: app)
+    let context = staticContext.exists ? staticContext : tappableContext
     XCTAssertTrue(context.waitForExistence(timeout: 8), "Repo context missing\n\(app.debugDescription)")
     XCTAssertTrue(
         context.label.contains(expectedValue),

--- a/ios/IssueCTLUITests/IssueCTLUITests.swift
+++ b/ios/IssueCTLUITests/IssueCTLUITests.swift
@@ -88,7 +88,7 @@ final class IssueCTLUITests: XCTestCase {
         assertRepoContext("All 2", in: app)
 
         tapElement("active-tab", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 8)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 8)
         assertRepoContext("All 2", in: app)
         let activeContext = element("repo-context-active", in: app)
         XCTAssertTrue(activeContext.waitForExistence(timeout: 3), "Active repo context missing\n\(app.debugDescription)")
@@ -220,7 +220,6 @@ final class IssueCTLUITests: XCTestCase {
         )
         activeSessionsButton.tap()
 
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app)
     }
 
@@ -243,7 +242,6 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("issue-detail-reenter-terminal-button", existsIn: app, timeout: 5)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
         element("session-reenter-terminal-9001", in: app).tap()
 
@@ -304,7 +302,6 @@ final class IssueCTLUITests: XCTestCase {
         launchIssueSession(102, in: app)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9002", existsIn: app, timeout: 5)
         XCTAssertTrue(element("session-reenter-terminal-9001", in: app).isEnabled)

--- a/ios/IssueCTLUITests/SessionManagementTests.swift
+++ b/ios/IssueCTLUITests/SessionManagementTests.swift
@@ -21,7 +21,6 @@ final class SessionManagementTests: XCTestCase {
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
 
         // Tap session controls to open the control sheet.
@@ -43,7 +42,6 @@ final class SessionManagementTests: XCTestCase {
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         assertElement("session-preview-9001", existsIn: app, timeout: 5)
         let preview = element("session-preview-9001", in: app)
 
@@ -59,11 +57,9 @@ final class SessionManagementTests: XCTestCase {
             String(describing: preview.value ?? "").contains("pass: launch handoff"),
             "Session preview accessibility value did not include latest output"
         )
-
-        preview.tap()
         XCTAssertTrue(
             app.staticTexts["issue #101: running checks"].waitForExistence(timeout: 3),
-            "Expanded session preview did not show captured terminal lines\n\(app.debugDescription)"
+            "Session preview did not show captured terminal lines by default\n\(app.debugDescription)"
         )
     }
 
@@ -73,7 +69,6 @@ final class SessionManagementTests: XCTestCase {
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         XCTAssertTrue(
             app.staticTexts["2 active • 1 idle"].waitForExistence(timeout: 8),
             "Expected Sessions subtitle to count active and idle terminal previews\n\(app.debugDescription)"
@@ -86,10 +81,31 @@ final class SessionManagementTests: XCTestCase {
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("sessions-command-header", existsIn: app, timeout: 5)
         XCTAssertTrue(
             app.staticTexts["0 active • 0 idle • 1 checking"].waitForExistence(timeout: 8),
             "Expected Sessions subtitle to show ready terminals waiting for preview data\n\(app.debugDescription)"
         )
+    }
+
+    @MainActor
+    func testRepoContextChipOpensSessionFiltersAndFiltersRunningSessions() {
+        server.seedDeploymentsAcrossRepos()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9101", existsIn: app, timeout: 5)
+
+        assertElement("repo-context-filter-button", existsIn: app, timeout: 5)
+        element("repo-context-filter-button", in: app).tap()
+
+        XCTAssertTrue(app.staticTexts["Filters"].waitForExistence(timeout: 3), app.debugDescription)
+        app.buttons["beta, org"].tap()
+
+        XCTAssertTrue(app.staticTexts["Showing beta"].waitForExistence(timeout: 3), app.debugDescription)
+        app.swipeDown()
+
+        waitForNonexistence("session-reenter-terminal-9001", in: app, timeout: 5)
+        assertElement("session-reenter-terminal-9101", existsIn: app, timeout: 5)
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "ios:preview-perf:full": "IOS_UI_SMOKE_PROFILE=full ./scripts/ios-preview-perf-capture.sh",
     "ios:preview-runner-preflight": "./scripts/ios-preview-runner-preflight.sh",
     "ios:list-devices": "./scripts/ios-list-devices.sh",
+    "ios:setup": "pnpm --filter @issuectl/cli build && node packages/cli/dist/index.js ios setup",
+    "ios:setup-sim": "pnpm --filter @issuectl/cli build && node packages/cli/dist/index.js ios setup --simulator",
+    "ios:setup-preview-sim": "pnpm --filter @issuectl/cli build && node packages/cli/dist/index.js ios setup --simulator --preview",
+    "ios:dev": "./scripts/ios-dev.sh",
+    "ios:dev-preview": "IOS_DEV_SCHEME=IssueCTLPreview ./scripts/ios-dev.sh",
     "dev": "turbo dev",
     "prepare": "husky"
   },

--- a/packages/cli/src/commands/ios.ts
+++ b/packages/cli/src/commands/ios.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { generateApiToken } from "@issuectl/core";
+import { requireDb } from "../utils/db.js";
+import * as log from "../utils/logger.js";
+import { buildIosSetupUrl, detectLanIp } from "../utils/mobile-setup.js";
+
+const execFileAsync = promisify(execFile);
+
+type IosSetupOptions = {
+  port: string;
+  serverUrl?: string;
+  simulator?: boolean;
+  preview?: boolean;
+};
+
+function normalizeServerUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function resolveServerUrl(options: IosSetupOptions): string | null {
+  if (options.serverUrl) {
+    return normalizeServerUrl(options.serverUrl);
+  }
+
+  const lanIp = detectLanIp();
+  if (!lanIp) {
+    return null;
+  }
+
+  return `http://${lanIp}:${options.port}`;
+}
+
+export async function iosSetupCommand(options: IosSetupOptions): Promise<void> {
+  const db = requireDb();
+  const token = generateApiToken(db);
+  const serverUrl = resolveServerUrl(options);
+
+  if (!serverUrl) {
+    log.warn("Could not detect a LAN IP. Pass --server-url with the URL your device can reach.");
+    log.info(`iOS API token: ${token}`);
+    process.exit(options.simulator ? 1 : 0);
+  }
+
+  const appSetupUrl = buildIosSetupUrl(serverUrl, token);
+  const previewSetupUrl = buildIosSetupUrl(serverUrl, token, "issuectl-preview");
+  const setupUrl = options.preview ? previewSetupUrl : appSetupUrl;
+
+  log.info(`iOS server URL: ${serverUrl}`);
+  log.info(`iOS API token: ${token}`);
+  log.info(`iOS setup link: ${appSetupUrl}`);
+  log.info(`iOS preview setup link: ${previewSetupUrl}`);
+  log.info(`iOS setup page: ${serverUrl}/setup/ios`);
+
+  if (!options.simulator) {
+    return;
+  }
+
+  try {
+    await execFileAsync("xcrun", ["simctl", "openurl", "booted", setupUrl]);
+    log.success(`Opened ${options.preview ? "preview" : "app"} setup link in the booted simulator.`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Could not open setup link in the booted simulator: ${message}`);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { initCommand } from "./commands/init.js";
+import { iosSetupCommand } from "./commands/ios.js";
 import { webCommand } from "./commands/web.js";
 import {
   repoAddCommand,
@@ -27,6 +28,19 @@ program
   .description("Start the web dashboard")
   .option("-p, --port <port>", "Port number", "3847")
   .action(webCommand);
+
+const ios = program
+  .command("ios")
+  .description("iOS development helpers");
+
+ios
+  .command("setup")
+  .description("Print iOS setup credentials, or open the setup link in the booted simulator")
+  .option("-p, --port <port>", "Port number", "3847")
+  .option("--server-url <url>", "Server URL reachable from the app")
+  .option("--simulator", "Open the setup deep link in the booted simulator")
+  .option("--preview", "Use the preview app URL scheme when opening the simulator")
+  .action(iosSetupCommand);
 
 const repo = program
   .command("repo")

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -5,6 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 PORT="${IOS_DEV_PORT:-3847}"
+PORT_WAS_EXPLICIT="0"
+if [ -n "${IOS_DEV_PORT:-}" ]; then
+  PORT_WAS_EXPLICIT="1"
+fi
 PROJECT="${IOS_DEV_PROJECT:-ios/IssueCTL.xcodeproj}"
 SCHEME="${IOS_DEV_SCHEME:-IssueCTL}"
 CONFIGURATION="${IOS_DEV_CONFIGURATION:-Debug}"
@@ -45,28 +49,52 @@ healthcheck() {
   curl -fsS "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1
 }
 
+port_is_listening() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
 ios_api_status() {
   curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/api/v1/sessions/previews" 2>/dev/null || true
 }
 
-assert_compatible_web_server() {
+compatible_web_server() {
   local status
   status="$(ios_api_status)"
   case "$status" in
     200|401|500)
       return 0
       ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+explain_incompatible_web_server() {
+  local status
+  status="$(ios_api_status)"
+  case "$status" in
     404)
       echo "Port ${PORT} is already running an issuectl web server without the current iOS session preview API." >&2
-      echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
-      exit 1
       ;;
     *)
       echo "Port ${PORT} is responding, but the current iOS API could not be verified (HTTP ${status:-none})." >&2
-      echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
-      exit 1
       ;;
   esac
+}
+
+find_free_port() {
+  local start="$1"
+  local candidate
+  for candidate in $(seq "$((start + 1))" "$((start + 50))"); do
+    if ! port_is_listening "$candidate"; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  echo "Could not find a free port near ${start}." >&2
+  exit 1
 }
 
 wait_for_web() {
@@ -124,14 +152,40 @@ echo "Building issuectl CLI..."
 pnpm --filter @issuectl/cli build
 
 if healthcheck; then
-  assert_compatible_web_server
-  echo "Reusing existing issuectl web server on port ${PORT}."
-else
+  if compatible_web_server; then
+    echo "Reusing existing issuectl web server on port ${PORT}."
+  elif [ "$PORT_WAS_EXPLICIT" = "1" ]; then
+    explain_incompatible_web_server
+    echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
+    exit 1
+  else
+    explain_incompatible_web_server
+    fallback_port="$(find_free_port "$PORT")"
+    echo "Using free port ${fallback_port} for this iOS dev session."
+    PORT="$fallback_port"
+  fi
+elif port_is_listening "$PORT"; then
+  if [ "$PORT_WAS_EXPLICIT" = "1" ]; then
+    echo "Port ${PORT} is already in use." >&2
+    echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
+    exit 1
+  fi
+  fallback_port="$(find_free_port "$PORT")"
+  echo "Port ${PORT} is already in use. Using free port ${fallback_port} for this iOS dev session."
+  PORT="$fallback_port"
+fi
+
+if ! healthcheck; then
+  if [ "$PORT" != "${IOS_DEV_PORT:-3847}" ]; then
+    WEB_LOG="/tmp/issuectl-ios-dev-web-${PORT}.log"
+  fi
   echo "Starting issuectl web on port ${PORT}..."
   : > "$WEB_LOG"
   node packages/cli/dist/index.js web --port "$PORT" >"$WEB_LOG" 2>&1 &
   web_pid="$!"
   wait_for_web
+else
+  echo "Using issuectl web on port ${PORT}."
 fi
 
 destination_id="$(resolve_destination_id)"

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PORT="${IOS_DEV_PORT:-3847}"
+PROJECT="${IOS_DEV_PROJECT:-ios/IssueCTL.xcodeproj}"
+SCHEME="${IOS_DEV_SCHEME:-IssueCTL}"
+CONFIGURATION="${IOS_DEV_CONFIGURATION:-Debug}"
+DERIVED_DATA="${IOS_DEV_DERIVED_DATA:-/tmp/issuectl-ios-dev-derived-data}"
+SERVER_URL="${IOS_DEV_SERVER_URL:-}"
+WEB_LOG="${IOS_DEV_WEB_LOG:-/tmp/issuectl-ios-dev-web.log}"
+
+web_pid=""
+
+cleanup() {
+  if [ -n "$web_pid" ] && kill -0 "$web_pid" 2>/dev/null; then
+    kill "$web_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+is_preview_scheme() {
+  [[ "$SCHEME" == *Preview* ]]
+}
+
+bundle_id() {
+  if is_preview_scheme; then
+    echo "com.issuectl.ios.preview"
+  else
+    echo "com.issuectl.ios"
+  fi
+}
+
+app_name() {
+  if is_preview_scheme; then
+    echo "IssueCTLPreview"
+  else
+    echo "IssueCTL"
+  fi
+}
+
+healthcheck() {
+  curl -fsS "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1
+}
+
+wait_for_web() {
+  for _ in $(seq 1 60); do
+    if healthcheck; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for issuectl web on port ${PORT}." >&2
+  if [ -f "$WEB_LOG" ]; then
+    tail -40 "$WEB_LOG" >&2 || true
+  fi
+  exit 1
+}
+
+resolve_destination_id() {
+  if [ -n "${IOS_DEV_SIMULATOR_ID:-}" ]; then
+    echo "$IOS_DEV_SIMULATOR_ID"
+    return
+  fi
+
+  if [ -n "${IOS_DESTINATION:-}" ]; then
+    local destination_id
+    destination_id="${IOS_DESTINATION##*id=}"
+    destination_id="${destination_id%%,*}"
+    echo "$destination_id"
+    return
+  fi
+
+  local destination_id
+  destination_id="$(
+    xcodebuild -project "$PROJECT" -scheme "$SCHEME" -showdestinations 2>/dev/null \
+      | awk '/platform:iOS Simulator/ && /name:iPhone/ { print; exit }' \
+      | sed -n 's/.*id:\([^,}]*\).*/\1/p'
+  )"
+
+  if [ -z "$destination_id" ]; then
+    destination_id="$(
+      xcrun simctl list devices available 2>/dev/null \
+        | awk -F '[()]' '/iPhone/ { print $2; exit }'
+    )"
+  fi
+
+  if [ -z "$destination_id" ]; then
+    echo "No available iPhone simulator destination found for ${SCHEME}." >&2
+    exit 70
+  fi
+
+  echo "$destination_id"
+}
+
+echo "Building issuectl CLI..."
+pnpm --filter @issuectl/cli build
+
+if healthcheck; then
+  echo "Reusing existing issuectl web server on port ${PORT}."
+else
+  echo "Starting issuectl web on port ${PORT}..."
+  : > "$WEB_LOG"
+  node packages/cli/dist/index.js web --port "$PORT" >"$WEB_LOG" 2>&1 &
+  web_pid="$!"
+  wait_for_web
+fi
+
+destination_id="$(resolve_destination_id)"
+destination="platform=iOS Simulator,id=${destination_id}"
+
+echo "Booting simulator ${destination_id}..."
+xcrun simctl boot "$destination_id" 2>/dev/null || true
+
+echo "Building ${SCHEME} for ${destination}..."
+xcodebuild_args=(
+  -project "$PROJECT"
+  -scheme "$SCHEME"
+  -destination "$destination"
+  -configuration "$CONFIGURATION"
+  -derivedDataPath "$DERIVED_DATA"
+  CODE_SIGNING_ALLOWED=NO
+  build
+)
+
+if command -v xcpretty >/dev/null 2>&1; then
+  set -o pipefail
+  xcodebuild "${xcodebuild_args[@]}" | xcpretty
+else
+  xcodebuild "${xcodebuild_args[@]}"
+fi
+
+built_app="$(
+  find "$DERIVED_DATA/Build/Products/${CONFIGURATION}-iphonesimulator" \
+    -maxdepth 1 \
+    -name "$(app_name).app" \
+    -print \
+    -quit
+)"
+
+if [ -z "$built_app" ]; then
+  echo "Could not find built app in ${DERIVED_DATA}." >&2
+  exit 1
+fi
+
+echo "Installing $(basename "$built_app")..."
+xcrun simctl install "$destination_id" "$built_app"
+
+echo "Launching $(bundle_id)..."
+xcrun simctl launch "$destination_id" "$(bundle_id)" >/dev/null
+
+setup_args=(ios setup --port "$PORT" --simulator)
+if [ -n "$SERVER_URL" ]; then
+  setup_args+=(--server-url "$SERVER_URL")
+fi
+if is_preview_scheme; then
+  setup_args+=(--preview)
+fi
+
+echo "Applying iOS setup link..."
+node packages/cli/dist/index.js "${setup_args[@]}"
+
+if [ -n "$web_pid" ]; then
+  echo "issuectl web is running for this dev session. Press Ctrl-C to stop it."
+  wait "$web_pid"
+else
+  echo "Done. Existing issuectl web server was left running."
+fi

--- a/scripts/ios-dev.sh
+++ b/scripts/ios-dev.sh
@@ -45,9 +45,33 @@ healthcheck() {
   curl -fsS "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1
 }
 
+ios_api_status() {
+  curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/api/v1/sessions/previews" 2>/dev/null || true
+}
+
+assert_compatible_web_server() {
+  local status
+  status="$(ios_api_status)"
+  case "$status" in
+    200|401|500)
+      return 0
+      ;;
+    404)
+      echo "Port ${PORT} is already running an issuectl web server without the current iOS session preview API." >&2
+      echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
+      exit 1
+      ;;
+    *)
+      echo "Port ${PORT} is responding, but the current iOS API could not be verified (HTTP ${status:-none})." >&2
+      echo "Stop that process, or rerun with IOS_DEV_PORT set to a free port." >&2
+      exit 1
+      ;;
+  esac
+}
+
 wait_for_web() {
   for _ in $(seq 1 60); do
-    if healthcheck; then
+    if healthcheck && [ "$(ios_api_status)" != "404" ]; then
       return 0
     fi
     sleep 1
@@ -100,6 +124,7 @@ echo "Building issuectl CLI..."
 pnpm --filter @issuectl/cli build
 
 if healthcheck; then
+  assert_compatible_web_server
   echo "Reusing existing issuectl web server on port ${PORT}."
 else
   echo "Starting issuectl web on port ${PORT}..."


### PR DESCRIPTION
## Summary
- Improve the iOS Sessions/Running tab by removing the top stats card, showing terminal previews by default when available, and making the repo context chip open filters
- Add CLI helpers for iOS setup and simulator setup
- Add `pnpm ios:dev` / preview dev loops that build, launch, configure the simulator, and auto-select a fallback port when a stale server owns 3847

## Verification
- iOS simulator live check: Sessions screen shows terminal preview content, repo chip opens filters, stats card removed
- `pnpm --filter @issuectl/cli typecheck`
- `pnpm --filter @issuectl/cli lint`
- `bash -n scripts/ios-dev.sh`
- `pnpm ios:dev` with stale 3847 server present auto-selected 3848 and configured the simulator
- Commit hooks typecheck/lint passed; existing lint warnings only

Note: `ios/IssueCTL/Generated/AppVersion.swift` is generated and intentionally left uncommitted.