### PR TITLE
fix: simplify iOS running sessions tab

### DIFF
--- a/ios/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionListView.swift
@@ -24,7 +24,6 @@ struct SessionListView: View {
     @State private var isSearchVisible = false
     @State private var selectedRepoIds: Set<Int> = []
     @State private var showFiltersSheet = false
-    @State private var collapsedPreviewPorts: Set<Int> = []
     @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
@@ -36,9 +35,12 @@ struct SessionListView: View {
             items = items.filter { selectedRepoIds.contains($0.repoId) }
         }
 
-        guard !searchText.isEmpty else { return items }
+        if searchText.isEmpty {
+            return sortDeploymentsForInvestigation(items)
+        }
+
         let query = searchText.lowercased()
-        return items.filter { deployment in
+        let matchingItems = items.filter { deployment in
             [
                 deployment.repoFullName,
                 "#\(deployment.issueNumber)",
@@ -50,40 +52,7 @@ struct SessionListView: View {
             .lowercased()
             .contains(query)
         }
-    }
-
-    private var readyCount: Int {
-        deployments.filter { $0.ttydPort != nil }.count
-    }
-
-    private var activeTerminalCount: Int {
-        deployments.filter { deployment in
-            guard let port = deployment.ttydPort else { return false }
-            return previews[port]?.status == .active
-        }.count
-    }
-
-    private var idleTerminalCount: Int {
-        deployments.filter { deployment in
-            guard let port = deployment.ttydPort else { return false }
-            return previews[port]?.status == .idle
-        }.count
-    }
-
-    private var checkingTerminalCount: Int {
-        deployments.filter { deployment in
-            guard let port = deployment.ttydPort else { return false }
-            return previews[port] == nil
-        }.count
-    }
-
-    private var startingCount: Int {
-        deployments.count - readyCount
-    }
-
-    private var activeRepoFullNames: [String] {
-        let names = Set(deployments.map(\.repoFullName))
-        return repos.map(\.fullName).filter { names.contains($0) }
+        return sortDeploymentsForInvestigation(matchingItems)
     }
 
     private var hasActiveFilters: Bool {
@@ -118,8 +87,8 @@ struct SessionListView: View {
 
                 RepoContextStrip(
                     repos: repos,
-                    activeRepoFullNames: activeRepoFullNames,
                     valueOverride: selectedRepoSummary,
+                    showsActiveSummary: false,
                     onTap: { showFiltersSheet = true }
                 )
 
@@ -179,13 +148,7 @@ struct SessionListView: View {
                                     SessionRowView(
                                         deployment: deployment,
                                         preview: port.flatMap { previews[$0] },
-                                        isPreviewExpanded: port.map { previews[$0] != nil && !collapsedPreviewPorts.contains($0) } ?? false,
                                         isEnding: endingDeploymentId == deployment.id,
-                                        onTogglePreview: {
-                                            if let port {
-                                                togglePreview(port)
-                                            }
-                                        },
                                         onOpen: {
                                             openTerminal(deployment)
                                         },
@@ -322,17 +285,7 @@ struct SessionListView: View {
             return "No active sessions"
         }
 
-        var parts = [
-            "\(activeTerminalCount) active",
-            "\(idleTerminalCount) idle",
-        ]
-        if checkingTerminalCount > 0 {
-            parts.append("\(checkingTerminalCount) checking")
-        }
-        if startingCount > 0 {
-            parts.append("\(startingCount) starting")
-        }
-        return parts.joined(separator: " • ")
+        return "Running sessions"
     }
 
     private var sessionSearchBar: some View {
@@ -382,6 +335,37 @@ struct SessionListView: View {
         hideSearch()
     }
 
+    private func sortDeploymentsForInvestigation(_ items: [ActiveDeployment]) -> [ActiveDeployment] {
+        items
+            .enumerated()
+            .sorted { lhs, rhs in
+                let lhsRank = sessionSortRank(lhs.element)
+                let rhsRank = sessionSortRank(rhs.element)
+                if lhsRank != rhsRank {
+                    return lhsRank < rhsRank
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    private func sessionSortRank(_ deployment: ActiveDeployment) -> Int {
+        guard let port = deployment.ttydPort else {
+            return 4
+        }
+
+        switch previews[port]?.status {
+        case .idle:
+            return 0
+        case .error:
+            return 1
+        case .unavailable, nil:
+            return 2
+        case .active:
+            return 3
+        }
+    }
+
     private func sessionErrorDescription(_ message: String) -> String {
         "\(message)\n\nRetry after starting issuectl web, or open Settings to update the server."
     }
@@ -389,16 +373,6 @@ struct SessionListView: View {
     private func openTerminal(_ deployment: ActiveDeployment) {
         guard deployment.ttydPort != nil else { return }
         terminalPresentation = TerminalPresentation(deployment: deployment)
-    }
-
-    private func togglePreview(_ port: Int) {
-        withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
-            if collapsedPreviewPorts.contains(port) {
-                collapsedPreviewPorts.remove(port)
-            } else {
-                collapsedPreviewPorts.insert(port)
-            }
-        }
     }
 
     private func load(refresh: Bool = false, includeRepos: Bool? = nil) async {
@@ -443,7 +417,6 @@ struct SessionListView: View {
         guard !isFetchingPreviews else { return }
         guard !deployments.isEmpty else {
             previews = [:]
-            collapsedPreviewPorts = []
             return
         }
         isFetchingPreviews = true
@@ -463,7 +436,6 @@ struct SessionListView: View {
         while !Task.isCancelled {
             if deployments.isEmpty {
                 previews = [:]
-                collapsedPreviewPorts = []
             } else {
                 await fetchPreviews()
             }
@@ -479,7 +451,6 @@ struct SessionListView: View {
     private func prunePreviewState() {
         let ports = Set(deployments.compactMap(\.ttydPort))
         previews = previews.filter { ports.contains($0.key) }
-        collapsedPreviewPorts = collapsedPreviewPorts.intersection(ports)
     }
 
     private func endSession(_ deployment: ActiveDeployment) async {
@@ -494,7 +465,6 @@ struct SessionListView: View {
             deployments.removeAll { $0.id == deployment.id }
             if let port = deployment.ttydPort {
                 previews.removeValue(forKey: port)
-                collapsedPreviewPorts.remove(port)
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/ios/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 struct SessionRowView: View {
     let deployment: ActiveDeployment
     var preview: SessionPreview?
-    var isPreviewExpanded = false
     var isEnding = false
-    var onTogglePreview: () -> Void = {}
     var onOpen: () -> Void = {}
     var onControls: () -> Void = {}
 
@@ -13,7 +11,7 @@ struct SessionRowView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 6) {
                 Circle()
-                    .fill(.green)
+                    .fill(statusColor)
                     .frame(width: 8, height: 8)
                 Text(deployment.repoFullName)
                     .font(.subheadline.weight(.medium))
@@ -22,12 +20,12 @@ struct SessionRowView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 8)
-                Text("Running")
+                Text(statusText)
                     .font(.caption.bold())
-                    .foregroundStyle(.green)
+                    .foregroundStyle(statusColor)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Color.green.opacity(0.14), in: Capsule())
+                    .background(statusColor.opacity(0.14), in: Capsule())
             }
 
             Label(deployment.branchName, systemImage: "arrow.triangle.branch")
@@ -44,14 +42,6 @@ struct SessionRowView: View {
                     sessionMetric(value: "Starting", label: "Terminal", systemImage: "terminal")
                 }
             }
-
-            SessionPreviewBlock(
-                preview: preview,
-                isExpanded: isPreviewExpanded,
-                isTerminalReady: deployment.ttydPort != nil,
-                accessibilityIdentifier: "session-preview-\(deployment.id)",
-                onToggle: onTogglePreview
-            )
 
             HStack(spacing: 8) {
                 Button(action: onOpen) {
@@ -83,7 +73,7 @@ struct SessionRowView: View {
         .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18))
         .overlay {
             RoundedRectangle(cornerRadius: 18)
-                .stroke(previewBorderColor.opacity(0.34), lineWidth: 1)
+                .stroke(statusColor.opacity(0.34), lineWidth: 1)
         }
         .contentShape(Rectangle())
         .onTapGesture {
@@ -93,7 +83,7 @@ struct SessionRowView: View {
         }
     }
 
-    private var previewBorderColor: Color {
+    private var statusColor: Color {
         switch preview?.status {
         case .active:
             Color.green
@@ -104,7 +94,23 @@ struct SessionRowView: View {
         case .unavailable:
             Color.secondary
         case nil:
-            Color.green
+            deployment.ttydPort == nil ? Color.orange : Color.secondary
+        }
+    }
+
+    private var statusText: String {
+        guard deployment.ttydPort != nil else { return "Starting" }
+        switch preview?.status {
+        case .idle:
+            return "Idle"
+        case .error:
+            return "Error"
+        case .unavailable:
+            return "Checking"
+        case .active:
+            return "Running"
+        case nil:
+            return "Checking"
         }
     }
 
@@ -126,145 +132,5 @@ struct SessionRowView: View {
         .padding(9)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
-    }
-}
-
-private struct SessionPreviewBlock: View {
-    let preview: SessionPreview?
-    let isExpanded: Bool
-    let isTerminalReady: Bool
-    let accessibilityIdentifier: String
-    let onToggle: () -> Void
-
-    var body: some View {
-        Button(action: onToggle) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    Circle()
-                        .fill(statusColor)
-                        .frame(width: 8, height: 8)
-
-                    Text(statusBadgeText)
-                        .font(.caption2.bold())
-                        .foregroundStyle(statusColor)
-                        .lineLimit(1)
-
-                    Text(summaryText)
-                        .font(.caption.monospaced())
-                        .foregroundStyle(summaryColor)
-                        .lineLimit(1)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Text(freshnessText)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.tertiary)
-                }
-
-                if isExpanded {
-                    VStack(alignment: .leading, spacing: 3) {
-                        ForEach(expandedLines.indices, id: \.self) { index in
-                            Text(expandedLines[index])
-                                .font(.caption2.monospaced())
-                                .foregroundStyle(lineColor(expandedLines[index]))
-                                .lineLimit(1)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-                    .padding(10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.black.opacity(0.88), in: RoundedRectangle(cornerRadius: 10))
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-                }
-            }
-            .padding(10)
-            .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
-        }
-        .buttonStyle(.plain)
-        .disabled(!isTerminalReady)
-        .accessibilityLabel("Session preview")
-        .accessibilityValue("\(statusAccessibilityText), \(summaryText)")
-        .accessibilityHint(isExpanded ? "Collapses terminal preview" : "Expands terminal preview")
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-
-    private var expandedLines: [String] {
-        let lines = preview?.lines ?? []
-        if lines.isEmpty {
-            return [summaryText]
-        }
-        return Array(lines.suffix(6))
-    }
-
-    private var summaryText: String {
-        guard isTerminalReady else { return "Terminal starting" }
-        guard let preview else { return "Waiting for preview" }
-        if let latestLine = preview.latestLine, !latestLine.isEmpty {
-            return latestLine
-        }
-        switch preview.status {
-        case .active:
-            return "Session active"
-        case .idle:
-            return "No recent output"
-        case .error:
-            return "Review terminal output"
-        case .unavailable:
-            return "Preview unavailable"
-        }
-    }
-
-    private var freshnessText: String {
-        guard let preview else { return "" }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: preview.lastUpdatedDate, relativeTo: Date())
-    }
-
-    private var statusColor: Color {
-        switch preview?.status {
-        case .active:
-            Color.green
-        case .idle:
-            Color.orange
-        case .error:
-            Color.red
-        case .unavailable:
-            Color.secondary
-        case nil:
-            isTerminalReady ? Color.secondary : Color.orange
-        }
-    }
-
-    private var statusAccessibilityText: String {
-        guard isTerminalReady else { return "terminal starting" }
-        return preview?.status.accessibilityName ?? "waiting for preview"
-    }
-
-    private var statusBadgeText: String {
-        guard isTerminalReady else { return "Starting" }
-        return preview?.status.displayName ?? "Preview"
-    }
-
-    private var summaryColor: Color {
-        preview?.status == .error ? .red : .secondary
-    }
-
-    private func lineColor(_ line: String) -> Color {
-        let lowercased = line.lowercased()
-        if lowercased.contains("error") || lowercased.contains("failed") || lowercased.contains("fatal") {
-            return .red
-        }
-        if lowercased.contains("pass") || lowercased.contains("success") {
-            return .green
-        }
-        if lowercased.contains("warn") {
-            return .yellow
-        }
-        return .white.opacity(0.92)
     }
 }

--- a/ios/IssueCTL/Views/Shared/RepoFilterChips.swift
+++ b/ios/IssueCTL/Views/Shared/RepoFilterChips.swift
@@ -86,6 +86,7 @@ struct RepoContextStrip: View {
     var activeRepoFullNames: [String] = []
     var leadingTitle = "Repos"
     var valueOverride: String?
+    var showsActiveSummary = true
     var onTap: (() -> Void)?
 
     var body: some View {
@@ -111,7 +112,7 @@ struct RepoContextStrip: View {
                         )
                     }
 
-                    if !activeRepoFullNames.isEmpty && activeRepoFullNames.count < repos.count {
+                    if showsActiveSummary && !activeRepoFullNames.isEmpty && activeRepoFullNames.count < repos.count {
                         RepoContextChip(
                             title: "Active",
                             value: "\(activeRepoFullNames.count)",

--- a/ios/IssueCTLUITests/SessionManagementTests.swift
+++ b/ios/IssueCTLUITests/SessionManagementTests.swift
@@ -37,53 +37,62 @@ final class SessionManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testSessionCardShowsExpandableTerminalPreview() {
+    func testSessionCardOmitsTerminalPreviewOutput() {
         server.seedActiveDeployment()
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
-        assertElement("session-preview-9001", existsIn: app, timeout: 5)
-        let preview = element("session-preview-9001", in: app)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
 
         XCTAssertTrue(
-            app.staticTexts["pass: launch handoff"].waitForExistence(timeout: 5),
-            "Collapsed session preview did not show latest output\n\(app.debugDescription)"
+            app.staticTexts["Running"].waitForExistence(timeout: 5),
+            "Session card did not show running status\n\(app.debugDescription)"
         )
-        XCTAssertTrue(
-            app.staticTexts["Active"].waitForExistence(timeout: 3),
-            "Session preview did not show a visible active status badge\n\(app.debugDescription)"
+        XCTAssertFalse(
+            app.staticTexts["pass: launch handoff"].waitForExistence(timeout: 2),
+            "Session card should not render terminal preview output\n\(app.debugDescription)"
         )
-        XCTAssertTrue(
-            String(describing: preview.value ?? "").contains("pass: launch handoff"),
-            "Session preview accessibility value did not include latest output"
-        )
-        XCTAssertTrue(
-            app.staticTexts["issue #101: running checks"].waitForExistence(timeout: 3),
-            "Session preview did not show captured terminal lines by default\n\(app.debugDescription)"
+        XCTAssertFalse(
+            app.staticTexts["issue #101: running checks"].waitForExistence(timeout: 2),
+            "Session card should not render expanded terminal preview lines\n\(app.debugDescription)"
         )
     }
 
     @MainActor
-    func testSessionHeaderCountsActiveAndIdleTerminalPreviews() {
+    func testIdleSessionsSortToTop() {
         server.seedMixedActivityDeployments()
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9002", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9003", existsIn: app, timeout: 5)
+
         XCTAssertTrue(
-            app.staticTexts["2 active • 1 idle"].waitForExistence(timeout: 8),
-            "Expected Sessions subtitle to count active and idle terminal previews\n\(app.debugDescription)"
+            app.staticTexts["Idle"].waitForExistence(timeout: 8),
+            "Expected idle status to appear after preview polling\n\(app.debugDescription)"
         )
+
+        let idleFrame = element("session-reenter-terminal-9002", in: app).frame
+        let firstActiveFrame = element("session-reenter-terminal-9001", in: app).frame
+        let secondActiveFrame = element("session-reenter-terminal-9003", in: app).frame
+        XCTAssertLessThan(idleFrame.minY, firstActiveFrame.minY, "Idle session should sort before active sessions")
+        XCTAssertLessThan(idleFrame.minY, secondActiveFrame.minY, "Idle session should sort before active sessions")
     }
 
     @MainActor
-    func testSessionHeaderShowsCheckingForMissingTerminalPreview() {
+    func testSessionHeaderOmitsPreviewStats() {
         server.seedDeploymentWithMissingPreview()
         let app = launchApp(server: server)
 
         tapMainTab("active-tab", label: "Active", in: app)
         XCTAssertTrue(
-            app.staticTexts["0 active • 0 idle • 1 checking"].waitForExistence(timeout: 8),
-            "Expected Sessions subtitle to show ready terminals waiting for preview data\n\(app.debugDescription)"
+            app.staticTexts["Running sessions"].waitForExistence(timeout: 5),
+            "Expected simplified Sessions subtitle\n\(app.debugDescription)"
+        )
+        XCTAssertFalse(
+            app.staticTexts["0 active • 0 idle • 1 checking"].waitForExistence(timeout: 2),
+            "Sessions subtitle should not render preview stats\n\(app.debugDescription)"
         )
     }
 


### PR DESCRIPTION
## Summary
- remove terminal preview output from iOS running session cards
- simplify the Sessions header by removing preview stats/counts
- sort idle sessions first while preserving stable order inside each status group
- keep the Repos chip as the filter entry point and cover it with UI tests

## Verification
- `pnpm --filter @issuectl/web test -- session-previews.test.ts`
- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests/testSessionPreviewsResponseDecoding`
- `xcodebuild test -project ios/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests`
- `pnpm ios:preview-runner-preflight`
- `./scripts/ios-preview-install.sh`
- `pnpm ios:preview-device-smoke:fast`
- `xcodebuild -allowProvisioningUpdates -allowProvisioningDeviceRegistration test -project ios/IssueCTL.xcodeproj -scheme IssueCTLPreview-UISmoke -destination "$IOS_DESTINATION" -configuration Debug -only-testing:IssueCTLPreviewUITests/SessionManagementTests` on iPhone-preview
