### PR TITLE
Harden macOS sidebar workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,95 @@
+name: macOS
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Mac App
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine macOS build relevance
+        id: macos_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            base_ref="origin/${{ github.base_ref }}"
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            changed_files="$(git diff --name-only "$base_ref"...HEAD)"
+          elif [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            if git rev-parse --verify HEAD^1 >/dev/null 2>&1; then
+              changed_files="$(git diff --name-only HEAD^1 HEAD)"
+            else
+              changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+            fi
+          else
+            changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+          fi
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -E -q '^(apple/|\.github/workflows/macos\.yml$)'; then
+            echo "run_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Select Xcode
+        if: steps.macos_changes.outputs.run_build == 'true'
+        run: |
+          for developer_dir in \
+            /Applications/Xcode_16.4.app/Contents/Developer \
+            /Applications/Xcode_16.3.app/Contents/Developer \
+            /Applications/Xcode.app/Contents/Developer
+          do
+            if [ -d "$developer_dir" ]; then
+              sudo xcode-select -s "$developer_dir"
+              echo "Selected $developer_dir"
+              exit 0
+            fi
+          done
+
+          echo "No Xcode installation found" >&2
+          exit 70
+
+      - name: Show build environment
+        if: steps.macos_changes.outputs.run_build == 'true'
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build IssueCTLMac
+        if: steps.macos_changes.outputs.run_build == 'true'
+        run: |
+          xcodebuild \
+            -project apple/IssueCTL.xcodeproj \
+            -scheme IssueCTLMac \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Skip macOS build
+        if: steps.macos_changes.outputs.run_build != 'true'
+        run: echo "No macOS-relevant changes detected; required macOS check passes without building."

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -17,6 +17,7 @@ struct IssueCTLMacApp: App {
 final class MacAppDelegate: NSObject, NSApplicationDelegate {
     let apiClient = APIClient()
     private let networkMonitor = NetworkMonitor()
+    private let sidebarChrome = SidebarChromeState()
     private var panelController: SidebarPanelController?
     private var statusItem: NSStatusItem?
 
@@ -27,11 +28,15 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let rootView = MacSidebarRootView()
             .environment(apiClient)
             .environment(networkMonitor)
+            .environment(sidebarChrome)
             .environment(\.hideSidebar) { [weak self] in
                 self?.panelController?.hide()
             }
+            .environment(\.toggleSidebarCollapsed) { [weak self] in
+                self?.panelController?.toggleCollapsed()
+            }
 
-        let panelController = SidebarPanelController(rootView: rootView)
+        let panelController = SidebarPanelController(rootView: rootView, chrome: sidebarChrome)
         self.panelController = panelController
         panelController.show()
 
@@ -44,7 +49,8 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         item.button?.imagePosition = .imageOnly
 
         let menu = NSMenu()
-        menu.addItem(NSMenuItem(title: "Show Sidebar", action: #selector(showSidebar), keyEquivalent: "s"))
+        menu.addItem(NSMenuItem(title: "Toggle Sidebar", action: #selector(toggleSidebar), keyEquivalent: "s"))
+        menu.addItem(NSMenuItem(title: "Collapse or Expand", action: #selector(toggleCollapsed), keyEquivalent: "m"))
         menu.addItem(NSMenuItem(title: "Hide Sidebar", action: #selector(hideSidebar), keyEquivalent: "w"))
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit IssueCTL", action: #selector(quit), keyEquivalent: "q"))
@@ -54,8 +60,12 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         statusItem = item
     }
 
-    @objc private func showSidebar() {
-        panelController?.show()
+    @objc private func toggleSidebar() {
+        panelController?.toggleVisibility()
+    }
+
+    @objc private func toggleCollapsed() {
+        panelController?.toggleCollapsed()
     }
 
     @objc private func hideSidebar() {

--- a/apple/IssueCTLMac/Platform/SidebarPanelController.swift
+++ b/apple/IssueCTLMac/Platform/SidebarPanelController.swift
@@ -5,18 +5,46 @@ private struct HideSidebarKey: EnvironmentKey {
     static let defaultValue: @MainActor () -> Void = {}
 }
 
+private struct ToggleSidebarCollapsedKey: EnvironmentKey {
+    static let defaultValue: @MainActor () -> Void = {}
+}
+
 extension EnvironmentValues {
     var hideSidebar: @MainActor () -> Void {
         get { self[HideSidebarKey.self] }
         set { self[HideSidebarKey.self] = newValue }
     }
+
+    var toggleSidebarCollapsed: @MainActor () -> Void {
+        get { self[ToggleSidebarCollapsedKey.self] }
+        set { self[ToggleSidebarCollapsedKey.self] = newValue }
+    }
+}
+
+@Observable @MainActor
+final class SidebarChromeState {
+    var isCollapsed = false
+    var isVisible = false
 }
 
 @MainActor
 final class SidebarPanelController {
-    private let panel: NSPanel
+    private enum Metrics {
+        static let collapsedWidth: CGFloat = 76
+        static let expandedMinWidth: CGFloat = 340
+        static let expandedMaxWidth: CGFloat = 560
+        static let defaultExpandedWidth: CGFloat = 380
+        static let horizontalInset: CGFloat = 12
+        static let verticalInset: CGFloat = 12
+        static let minimumHeight: CGFloat = 480
+    }
 
-    init<Content: View>(rootView: Content) {
+    private let panel: NSPanel
+    private let chrome: SidebarChromeState
+    private var expandedWidth = Metrics.defaultExpandedWidth
+
+    init<Content: View>(rootView: Content, chrome: SidebarChromeState) {
+        self.chrome = chrome
         let hostingController = NSHostingController(rootView: rootView)
         let frame = Self.defaultFrame()
 
@@ -34,27 +62,69 @@ final class SidebarPanelController {
         panel.hidesOnDeactivate = false
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        panel.minSize = NSSize(width: 340, height: 480)
-        panel.maxSize = NSSize(width: 560, height: CGFloat.greatestFiniteMagnitude)
+        panel.minSize = NSSize(width: Metrics.expandedMinWidth, height: Metrics.minimumHeight)
+        panel.maxSize = NSSize(width: Metrics.expandedMaxWidth, height: CGFloat.greatestFiniteMagnitude)
     }
 
     func show() {
-        panel.setFrame(Self.defaultFrame(width: panel.frame.width), display: true)
+        panel.setFrame(Self.defaultFrame(width: currentWidth), display: true)
         panel.orderFrontRegardless()
+        chrome.isVisible = true
     }
 
     func hide() {
         panel.orderOut(nil)
+        chrome.isVisible = false
     }
 
-    private static func defaultFrame(width requestedWidth: CGFloat = 380) -> NSRect {
+    func toggleVisibility() {
+        if panel.isVisible {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    func toggleCollapsed() {
+        setCollapsed(!chrome.isCollapsed)
+    }
+
+    func setCollapsed(_ isCollapsed: Bool) {
+        guard chrome.isCollapsed != isCollapsed else { return }
+
+        if isCollapsed {
+            expandedWidth = min(max(panel.frame.width, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
+            panel.minSize = NSSize(width: Metrics.collapsedWidth, height: Metrics.minimumHeight)
+            panel.maxSize = NSSize(width: Metrics.collapsedWidth, height: CGFloat.greatestFiniteMagnitude)
+        } else {
+            panel.minSize = NSSize(width: Metrics.expandedMinWidth, height: Metrics.minimumHeight)
+            panel.maxSize = NSSize(width: Metrics.expandedMaxWidth, height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        chrome.isCollapsed = isCollapsed
+        panel.setFrame(Self.defaultFrame(width: currentWidth), display: true, animate: true)
+        if !panel.isVisible {
+            show()
+        }
+    }
+
+    private var currentWidth: CGFloat {
+        if chrome.isCollapsed {
+            return Metrics.collapsedWidth
+        }
+        return min(max(expandedWidth, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
+    }
+
+    private static func defaultFrame(width requestedWidth: CGFloat = Metrics.defaultExpandedWidth) -> NSRect {
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let width = min(max(requestedWidth, 340), 560)
+        let width = requestedWidth == Metrics.collapsedWidth
+            ? Metrics.collapsedWidth
+            : min(max(requestedWidth, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
         return NSRect(
-            x: screenFrame.maxX - width - 12,
-            y: screenFrame.minY + 12,
+            x: screenFrame.maxX - width - Metrics.horizontalInset,
+            y: screenFrame.minY + Metrics.verticalInset,
             width: width,
-            height: max(screenFrame.height - 24, 480)
+            height: max(screenFrame.height - (Metrics.verticalInset * 2), Metrics.minimumHeight)
         )
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct MacSidebarRootView: View {
     @Environment(APIClient.self) private var api
+    @Environment(SidebarChromeState.self) private var chrome
     @Environment(\.hideSidebar) private var hideSidebar
+    @Environment(\.toggleSidebarCollapsed) private var toggleSidebarCollapsed
 
     @State private var selectedSection: MacSidebarSection = .issues
     @State private var serverURL = "http://localhost:3847"
@@ -12,6 +14,20 @@ struct MacSidebarRootView: View {
     @State private var store = MacSidebarStore()
 
     var body: some View {
+        Group {
+            if chrome.isCollapsed {
+                collapsedRail
+            } else {
+                expandedSidebar
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onExitCommand {
+            hideSidebar()
+        }
+    }
+
+    private var expandedSidebar: some View {
         VStack(spacing: 0) {
             header
             Divider()
@@ -23,10 +39,6 @@ struct MacSidebarRootView: View {
             }
         }
         .frame(minWidth: 340, idealWidth: 380, minHeight: 480)
-        .background(Color(nsColor: .windowBackgroundColor))
-        .onExitCommand {
-            hideSidebar()
-        }
     }
 
     private var header: some View {
@@ -37,9 +49,17 @@ struct MacSidebarRootView: View {
                 .font(.headline)
             Spacer()
             Button {
-                hideSidebar()
+                toggleSidebarCollapsed()
             } label: {
                 Image(systemName: "sidebar.right")
+            }
+            .buttonStyle(.borderless)
+            .help("Collapse Sidebar")
+
+            Button {
+                hideSidebar()
+            } label: {
+                Image(systemName: "xmark")
             }
             .buttonStyle(.borderless)
             .help("Hide Sidebar")
@@ -57,6 +77,78 @@ struct MacSidebarRootView: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
+    }
+
+    private var collapsedRail: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "list.bullet.rectangle")
+                .font(.title3.weight(.semibold))
+                .padding(.top, 12)
+
+            Divider()
+
+            ForEach(MacSidebarSection.allCases) { section in
+                Button {
+                    selectedSection = section
+                } label: {
+                    Image(systemName: section.systemImage)
+                        .frame(width: 36, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.borderless)
+                .background(
+                    RoundedRectangle(cornerRadius: 7)
+                        .fill(selectedSection == section ? Color.accentColor.opacity(0.16) : Color.clear)
+                )
+                .help(section.title)
+            }
+
+            Divider()
+
+            Button {
+                Task { await store.load(api: api, refresh: true) }
+            } label: {
+                if store.isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 36, height: 32)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .frame(width: 36, height: 32)
+                }
+            }
+            .buttonStyle(.borderless)
+            .disabled(!api.isConfigured || store.isLoading)
+            .help("Refresh")
+
+            Spacer()
+
+            Button {
+                toggleSidebarCollapsed()
+            } label: {
+                Image(systemName: "sidebar.leading")
+                    .frame(width: 36, height: 32)
+            }
+            .buttonStyle(.borderless)
+            .help("Expand Sidebar")
+
+            Button {
+                hideSidebar()
+            } label: {
+                Image(systemName: "xmark")
+                    .frame(width: 36, height: 32)
+            }
+            .buttonStyle(.borderless)
+            .help("Hide Sidebar")
+            .padding(.bottom, 12)
+        }
+        .frame(width: 76)
+        .frame(minHeight: 480)
+        .task {
+            if api.isConfigured {
+                await store.load(api: api, refresh: false)
+            }
+        }
     }
 
     private var dashboard: some View {


### PR DESCRIPTION
## Summary
- add collapsed rail mode for the native macOS sidebar, separate from fully hiding the panel
- wire menu-bar actions for toggling visibility and collapse/expand
- add a dedicated macOS CI workflow that builds IssueCTLMac for Apple-related changes

## Verification
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- launched built IssueCTLMac.app and confirmed it quits cleanly
- git diff --check