### PR TITLE
Add macOS issue detail actions

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		C8217EC2C8B846855E630648 /* IssueDetailActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */; };
 		C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
 		C8A54852FF04208EE66FB764 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */; };
+		C9D9618A4076FAE0E98D71AC /* MacIssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF37A7CB40F1701C4C149CE2 /* MacIssueDetailView.swift */; };
 		CA0880B76E28E6276050AEB3 /* IssueCTLMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AB7A2B9999184E67A3064A /* IssueCTLMacApp.swift */; };
 		CB1BD4038692E9AD73D95C1B /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
 		CC16C63936A1F4ECDEB3133E /* NotificationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2438738AD84484EC2E7B20C9 /* NotificationPreferences.swift */; };
@@ -320,6 +321,7 @@
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AEDAC9B7D3D9CF86D6381DAE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AF37A7CB40F1701C4C149CE2 /* MacIssueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacIssueDetailView.swift; sourceTree = "<group>"; };
 		B3E09DBD6D633B291650EFBE /* IssueCTL.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueCTL.entitlements; sourceTree = "<group>"; };
 		BC00C899D2ADA14475787AE7 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		BC1D044DCA62B13F4196F816 /* SetupLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupLink.swift; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 			isa = PBXGroup;
 			children = (
 				0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */,
+				AF37A7CB40F1701C4C149CE2 /* MacIssueDetailView.swift */,
 				43A60283ECC077E01E26EAC1 /* MacIssuesView.swift */,
 				26774436FC5A498AFD32CF2B /* MacSessionsView.swift */,
 				959347AB556CB71BEA308105 /* MacSettingsView.swift */,
@@ -1141,6 +1144,7 @@
 				CA0880B76E28E6276050AEB3 /* IssueCTLMacApp.swift in Sources */,
 				0C49D98F7B92CA24BCC44AEB /* KeychainService.swift in Sources */,
 				5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */,
+				C9D9618A4076FAE0E98D71AC /* MacIssueDetailView.swift in Sources */,
 				250D0308D12F0EE129E4C7E2 /* MacIssuesView.swift in Sources */,
 				BDDD77609BB45F218D8DBFDC /* MacSessionsView.swift in Sources */,
 				AAFAE2475EF1A39328204F4F /* MacSettingsView.swift in Sources */,

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -1,0 +1,380 @@
+import SwiftUI
+
+struct MacIssueDetailView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    let item: MacIssueListItem
+    let store: MacSidebarStore
+
+    @State private var detail: IssueDetailResponse?
+    @State private var priority: Priority = .normal
+    @State private var committedPriority: Priority = .normal
+    @State private var commentBody = ""
+    @State private var isLoading = true
+    @State private var isRefreshing = false
+    @State private var isSubmittingComment = false
+    @State private var isUpdatingState = false
+    @State private var isUpdatingPriority = false
+    @State private var errorMessage: String?
+
+    private var issue: GitHubIssue {
+        detail?.issue ?? item.issue
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if isLoading && detail == nil {
+                ProgressView("Loading issue...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage, detail == nil {
+                ContentUnavailableView("Could not load issue", systemImage: "wifi.exclamationmark", description: Text(errorMessage))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        issueSummary
+                        actionBar
+                        issueBody
+                        commentComposer
+                        comments
+                    }
+                    .padding(16)
+                }
+            }
+        }
+        .frame(minWidth: 520, idealWidth: 620, minHeight: 560, idealHeight: 720)
+        .task {
+            await load(refresh: false)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.repoFullName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("#\(issue.number)")
+                    .font(.headline)
+            }
+
+            Spacer()
+
+            Button {
+                Task { await load(refresh: true) }
+            } label: {
+                if isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .buttonStyle(.borderless)
+            .disabled(isRefreshing)
+            .help("Refresh")
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Close")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var issueSummary: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(issue.title)
+                .font(.title3.weight(.semibold))
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                MacStateBadge(isOpen: issue.isOpen)
+                MacPriorityBadge(priority: priority)
+
+                if let user = issue.user {
+                    Label(user.login, systemImage: "person")
+                        .labelStyle(.titleAndIcon)
+                }
+
+                if !issue.timeAgo.isEmpty {
+                    Text(issue.timeAgo)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if !issue.labels.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(issue.labels) { label in
+                            Text(label.name)
+                                .font(.caption.weight(.medium))
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(Color.secondary.opacity(0.12), in: Capsule())
+                        }
+                    }
+                }
+            }
+
+            if let assignees = issue.assignees, !assignees.isEmpty {
+                Text("Assigned to \(assignees.map(\.login).joined(separator: ", "))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 8) {
+            Button {
+                Task { await updateState(issue.isOpen ? "closed" : "open") }
+            } label: {
+                if isUpdatingState {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label(issue.isOpen ? "Close" : "Reopen", systemImage: issue.isOpen ? "xmark.circle" : "arrow.uturn.backward.circle")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(issue.isOpen ? .red : .green)
+            .disabled(isUpdatingState)
+
+            Picker("Priority", selection: $priority) {
+                ForEach(Priority.allCases, id: \.self) { priority in
+                    Text(priority.rawValue.capitalized).tag(priority)
+                }
+            }
+            .pickerStyle(.menu)
+            .disabled(isUpdatingPriority)
+            .onChange(of: priority) { oldValue, newValue in
+                guard oldValue != newValue else { return }
+                guard newValue != committedPriority else { return }
+                Task { await setPriority(newValue, rollbackTo: oldValue) }
+            }
+
+            Button {
+                if let url = URL(string: issue.htmlUrl) {
+                    openURL(url)
+                }
+            } label: {
+                Label("GitHub", systemImage: "safari")
+            }
+            .buttonStyle(.bordered)
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var issueBody: some View {
+        if let body = issue.body, !body.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Divider()
+                Text("Description")
+                    .font(.headline)
+                Text(body)
+                    .font(.body)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var commentComposer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            Text("Comment")
+                .font(.headline)
+
+            TextEditor(text: $commentBody)
+                .font(.body)
+                .frame(minHeight: 90)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                }
+
+            HStack {
+                Spacer()
+                Button {
+                    Task { await submitComment() }
+                } label: {
+                    if isSubmittingComment {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Add Comment", systemImage: "bubble.left.and.bubble.right")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(commentBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmittingComment)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var comments: some View {
+        if let comments = detail?.comments, !comments.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Divider()
+                Text("\(comments.count) Comment\(comments.count == 1 ? "" : "s")")
+                    .font(.headline)
+
+                ForEach(comments) { comment in
+                    VStack(alignment: .leading, spacing: 5) {
+                        HStack {
+                            Text(comment.user?.login ?? "Unknown")
+                                .font(.subheadline.weight(.semibold))
+                            Spacer()
+                            if let updatedAt = parseIssueCTLDate(comment.updatedAt) {
+                                Text(updatedAt, style: .relative)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Text(comment.body)
+                            .font(.body)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(10)
+                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+
+    private func load(refresh: Bool) async {
+        if refresh {
+            isRefreshing = true
+        } else {
+            isLoading = true
+        }
+        errorMessage = nil
+        defer {
+            isLoading = false
+            isRefreshing = false
+        }
+
+        do {
+            async let detailResult = store.issueDetail(api: api, item: item, refresh: refresh)
+            async let priorityResult: Result<Priority, Error> = {
+                do { return .success(try await api.getPriority(owner: item.repo.owner, repo: item.repo.name, number: item.issue.number)) }
+                catch { return .failure(error) }
+            }()
+
+            detail = try await detailResult
+            switch await priorityResult {
+            case .success(let loadedPriority):
+                priority = loadedPriority
+                committedPriority = loadedPriority
+            case .failure:
+                priority = .normal
+                committedPriority = .normal
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func submitComment() async {
+        let trimmed = commentBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        isSubmittingComment = true
+        errorMessage = nil
+        defer { isSubmittingComment = false }
+
+        do {
+            try await store.commentOnIssue(api: api, item: item, body: trimmed)
+            commentBody = ""
+            await load(refresh: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func updateState(_ state: String) async {
+        isUpdatingState = true
+        errorMessage = nil
+        defer { isUpdatingState = false }
+
+        do {
+            try await store.updateIssueState(api: api, item: item, state: state)
+            await load(refresh: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func setPriority(_ newPriority: Priority, rollbackTo oldPriority: Priority) async {
+        isUpdatingPriority = true
+        errorMessage = nil
+        defer { isUpdatingPriority = false }
+
+        do {
+            try await store.setPriority(api: api, item: item, priority: newPriority)
+            committedPriority = newPriority
+        } catch {
+            priority = oldPriority
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacStateBadge: View {
+    let isOpen: Bool
+
+    var body: some View {
+        Label(isOpen ? "Open" : "Closed", systemImage: isOpen ? "circle.circle" : "checkmark.circle.fill")
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isOpen ? Color.green.opacity(0.15) : Color.purple.opacity(0.15), in: Capsule())
+            .foregroundStyle(isOpen ? .green : .purple)
+    }
+}
+
+private struct MacPriorityBadge: View {
+    let priority: Priority
+
+    var body: some View {
+        Label(priority.rawValue.capitalized, systemImage: "flag")
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.14), in: Capsule())
+            .foregroundStyle(tint)
+    }
+
+    private var tint: Color {
+        switch priority {
+        case .high:
+            .red
+        case .normal:
+            .blue
+        case .low:
+            .secondary
+        }
+    }
+}

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -5,6 +5,7 @@ struct MacIssuesView: View {
 
     @State private var searchText = ""
     @State private var selectedFilter: IssueFilter = .open
+    @State private var selectedIssue: MacIssueListItem?
 
     private var visibleIssues: [MacIssueListItem] {
         let filtered = store.issues.filter { item in
@@ -42,10 +43,18 @@ struct MacIssuesView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(visibleIssues) { item in
-                    MacIssueRow(item: item, isRunning: isRunning(item))
+                    Button {
+                        selectedIssue = item
+                    } label: {
+                        MacIssueRow(item: item, isRunning: isRunning(item))
+                    }
+                    .buttonStyle(.plain)
                 }
                 .listStyle(.plain)
             }
+        }
+        .sheet(item: $selectedIssue) { item in
+            MacIssueDetailView(item: item, store: store)
         }
     }
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -101,6 +101,65 @@ final class MacSidebarStore {
         }
         drafts.removeAll { $0.id == id }
     }
+
+    func issueDetail(api: APIClient, item: MacIssueListItem, refresh: Bool) async throws -> IssueDetailResponse {
+        let detail = try await api.issueDetail(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            refresh: refresh
+        )
+        replaceIssue(detail.issue, in: item.repo)
+        return detail
+    }
+
+    func commentOnIssue(api: APIClient, item: MacIssueListItem, body: String) async throws {
+        let response = try await api.commentOnIssue(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: IssueCommentRequestBody(body: body)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to add comment")
+        }
+    }
+
+    func updateIssueState(api: APIClient, item: MacIssueListItem, state: String) async throws {
+        let response = try await api.updateIssueState(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: IssueStateRequestBody(state: state, comment: nil)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to update issue")
+        }
+    }
+
+    func setPriority(api: APIClient, item: MacIssueListItem, priority: Priority) async throws {
+        let response = try await api.setPriority(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            priority: priority
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to set priority")
+        }
+    }
+
+    private func replaceIssue(_ issue: GitHubIssue, in repo: Repo) {
+        let item = MacIssueListItem(issue: issue, repo: repo, repoIndex: repos.firstIndex(where: { $0.id == repo.id }) ?? 0)
+        if let index = issues.firstIndex(where: { $0.id == item.id }) {
+            issues[index] = item
+        } else {
+            issues.append(item)
+        }
+        issues.sort { lhs, rhs in
+            (lhs.issue.updatedDate ?? .distantPast) > (rhs.issue.updatedDate ?? .distantPast)
+        }
+    }
 }
 
 struct MacIssueListItem: Identifiable {


### PR DESCRIPTION
## Summary
- open Mac issue rows into a native detail sheet
- load issue detail, comments, and priority from the shared API
- add Mac actions for comment, close/reopen, priority updates, refresh, and GitHub open
- keep the Mac issue list synchronized when refreshed detail returns updated issue state

## Verification
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- launched built IssueCTLMac.app and confirmed it quits cleanly
- git diff --check