### PR TITLE
Add macOS launch flow

### DIFF
--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -17,6 +17,8 @@ struct MacIssueDetailView: View {
     @State private var isSubmittingComment = false
     @State private var isUpdatingState = false
     @State private var isUpdatingPriority = false
+    @State private var isLaunching = false
+    @State private var activeSession: ActiveDeployment?
     @State private var errorMessage: String?
 
     private var issue: GitHubIssue {
@@ -38,6 +40,7 @@ struct MacIssueDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
                         issueSummary
+                        launchSection
                         actionBar
                         issueBody
                         commentComposer
@@ -143,6 +146,56 @@ struct MacIssueDetailView: View {
         }
     }
 
+    private var launchSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Divider()
+
+            HStack(alignment: .center, spacing: 10) {
+                Image(systemName: sessionIcon)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(sessionTint)
+                    .frame(width: 30, height: 30)
+                    .background(sessionTint.opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(sessionTitle)
+                        .font(.subheadline.weight(.semibold))
+                    Text(sessionSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                if let activeSession {
+                    Button {
+                        openTerminal(activeSession)
+                    } label: {
+                        Label(activeSession.ttydPort == nil ? "Starting" : "Open", systemImage: "terminal")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(activeSession.ttydPort == nil)
+                } else {
+                    Button {
+                        Task { await launchIssue() }
+                    } label: {
+                        if isLaunching {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Launch", systemImage: "play.fill")
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isLaunching || !issue.isOpen)
+                }
+            }
+            .padding(10)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
     private var actionBar: some View {
         HStack(spacing: 8) {
             Button {
@@ -183,6 +236,35 @@ struct MacIssueDetailView: View {
 
             Spacer()
         }
+    }
+
+    private var sessionTitle: String {
+        if let activeSession {
+            return activeSession.ttydPort == nil ? "Session Starting" : "Session Active"
+        }
+        return issue.isOpen ? "Ready to Launch" : "Issue Closed"
+    }
+
+    private var sessionSubtitle: String {
+        if let activeSession {
+            let terminalState = activeSession.ttydPort.map { "port \($0)" } ?? "terminal preparing"
+            return "\(activeSession.branchName) - \(terminalState)"
+        }
+        return issue.isOpen ? "Start an agent session with the shared launch settings." : "Reopen the issue before launching."
+    }
+
+    private var sessionIcon: String {
+        if let activeSession {
+            return activeSession.ttydPort == nil ? "hourglass" : "terminal"
+        }
+        return issue.isOpen ? "play.circle.fill" : "checkmark.circle.fill"
+    }
+
+    private var sessionTint: Color {
+        if let activeSession {
+            return activeSession.ttydPort == nil ? .orange : .green
+        }
+        return issue.isOpen ? .blue : .purple
     }
 
     @ViewBuilder
@@ -284,6 +366,8 @@ struct MacIssueDetailView: View {
             }()
 
             detail = try await detailResult
+            await store.refreshSessions(api: api)
+            activeSession = store.activeSession(for: item)
             switch await priorityResult {
             case .success(let loadedPriority):
                 priority = loadedPriority
@@ -337,6 +421,36 @@ struct MacIssueDetailView: View {
             committedPriority = newPriority
         } catch {
             priority = oldPriority
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func launchIssue() async {
+        isLaunching = true
+        errorMessage = nil
+        defer { isLaunching = false }
+
+        do {
+            let session = try await store.launchIssue(api: api, item: item, detail: detail)
+            activeSession = session
+            if session.ttydPort != nil {
+                await openTerminalAsync(session)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func openTerminal(_ session: ActiveDeployment) {
+        Task { await openTerminalAsync(session) }
+    }
+
+    private func openTerminalAsync(_ session: ActiveDeployment) async {
+        errorMessage = nil
+        do {
+            let url = try await store.terminalURL(api: api, session: session)
+            openURL(url)
+        } catch {
             errorMessage = error.localizedDescription
         }
     }

--- a/apple/IssueCTLMac/Views/MacSessionsView.swift
+++ b/apple/IssueCTLMac/Views/MacSessionsView.swift
@@ -1,10 +1,18 @@
 import SwiftUI
 
 struct MacSessionsView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.openURL) private var openURL
+
     let store: MacSidebarStore
 
+    @State private var endingSessionId: Int?
+    @State private var errorMessage: String?
+
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
+            controls
+
             if store.isLoading && store.sessions.isEmpty {
                 ProgressView("Loading sessions...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -13,28 +21,118 @@ struct MacSessionsView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(store.sessions) { session in
-                    VStack(alignment: .leading, spacing: 5) {
-                        HStack {
-                            Text("\(session.repoFullName) #\(session.issueNumber)")
-                                .font(.subheadline.weight(.medium))
-                            Spacer()
-                            Text(session.runningDuration)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Text(session.branchName)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                        Text(session.workspacePath)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
-                    }
-                    .padding(.vertical, 5)
+                    sessionRow(session)
                 }
                 .listStyle(.plain)
             }
+        }
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("\(store.sessions.count) active")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button {
+                    Task { await store.refreshSessions(api: api) }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .help("Refresh sessions")
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+    }
+
+    private func sessionRow(_ session: ActiveDeployment) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(session.repoFullName) #\(session.issueNumber)")
+                        .font(.subheadline.weight(.medium))
+                    Text(session.branchName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Text(session.runningDuration)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !session.workspacePath.isEmpty {
+                Text(session.workspacePath)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+
+            HStack(spacing: 8) {
+                Label(session.ttydPort == nil ? "Starting" : "Ready", systemImage: session.ttydPort == nil ? "hourglass" : "terminal")
+                    .font(.caption)
+                    .foregroundStyle(session.ttydPort == nil ? .orange : .green)
+
+                Spacer()
+
+                Button {
+                    openTerminal(session)
+                } label: {
+                    Label("Open", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+                .disabled(session.ttydPort == nil)
+
+                Button(role: .destructive) {
+                    Task { await endSession(session) }
+                } label: {
+                    if endingSessionId == session.id {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("End", systemImage: "stop.circle")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(endingSessionId != nil)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func openTerminal(_ session: ActiveDeployment) {
+        Task {
+            errorMessage = nil
+            do {
+                let url = try await store.terminalURL(api: api, session: session)
+                openURL(url)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func endSession(_ session: ActiveDeployment) async {
+        endingSessionId = session.id
+        errorMessage = nil
+        defer { endingSessionId = nil }
+
+        do {
+            try await store.endSession(api: api, session: session)
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -149,6 +149,106 @@ final class MacSidebarStore {
         }
     }
 
+    func refreshSessions(api: APIClient) async {
+        do {
+            sessions = try await api.activeDeployments(refresh: true).deployments
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func activeSession(for item: MacIssueListItem) -> ActiveDeployment? {
+        sessions.first { session in
+            session.isActive &&
+            session.owner == item.repo.owner &&
+            session.repoName == item.repo.name &&
+            session.issueNumber == item.issue.number
+        }
+    }
+
+    func launchIssue(api: APIClient, item: MacIssueListItem, detail: IssueDetailResponse?) async throws -> ActiveDeployment {
+        await refreshSessions(api: api)
+        if let existing = activeSession(for: item) {
+            return existing
+        }
+
+        let settings = try? await api.getSettings()
+        let agent = LaunchAgent.settingValue(settings?["launch_agent"])
+        let branchName = generateBranchName(issueNumber: item.issue.number, issueTitle: item.issue.title)
+        let workspaceMode: WorkspaceMode = item.repo.localPath?.isEmpty == false ? .worktree : .clone
+        let body = LaunchRequestBody(
+            agent: agent,
+            branchName: branchName,
+            workspaceMode: workspaceMode,
+            selectedCommentIndices: [],
+            selectedFilePaths: [],
+            preamble: nil,
+            forceResume: nil,
+            idempotencyKey: UUID().uuidString
+        )
+
+        let response = try await api.launch(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: body
+        )
+        guard response.success, let deploymentId = response.deploymentId else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to launch issue")
+        }
+
+        await refreshSessions(api: api)
+        return activeSession(for: item) ?? ActiveDeployment(
+            id: deploymentId,
+            repoId: item.repo.id,
+            issueNumber: item.issue.number,
+            branchName: branchName,
+            workspaceMode: workspaceMode,
+            workspacePath: "",
+            linkedPrNumber: nil,
+            state: .active,
+            launchedAt: sharedISO8601Formatter.string(from: Date()),
+            endedAt: nil,
+            ttydPort: response.ttydPort,
+            ttydPid: nil,
+            owner: item.repo.owner,
+            repoName: item.repo.name
+        )
+    }
+
+    func terminalURL(api: APIClient, session: ActiveDeployment) async throws -> URL {
+        let result = try await api.ensureTtyd(deploymentId: session.id)
+        switch result {
+        case .available(let port, let token, _):
+            var components = URLComponents(string: "\(api.serverURL)/api/terminal/\(port)/")
+            components?.queryItems = [
+                URLQueryItem(name: "terminalToken", value: token),
+                URLQueryItem(name: "lineHeight", value: "1.25"),
+                URLQueryItem(name: "disableResizeOverlay", value: "true"),
+                URLQueryItem(name: "rendererType", value: "canvas"),
+            ]
+            guard let url = components?.url else {
+                throw MacSidebarStoreError.operationFailed("Invalid terminal URL")
+            }
+            return url
+        case .unavailable(let error):
+            throw MacSidebarStoreError.operationFailed(error ?? "Terminal is not ready")
+        }
+    }
+
+    func endSession(api: APIClient, session: ActiveDeployment) async throws {
+        let response = try await api.endSession(
+            deploymentId: session.id,
+            owner: session.owner,
+            repo: session.repoName,
+            issueNumber: session.issueNumber
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to end session")
+        }
+        sessions.removeAll { $0.id == session.id }
+    }
+
     private func replaceIssue(_ issue: GitHubIssue, in repo: Repo) {
         let item = MacIssueListItem(issue: issue, repo: repo, repoIndex: repos.firstIndex(where: { $0.id == repo.id }) ?? 0)
         if let index = issues.firstIndex(where: { $0.id == item.id }) {


### PR DESCRIPTION
## Summary
- add a launch/re-enter card to the macOS issue detail sheet
- launch issues using shared settings, branch generation, and clone/worktree defaults
- refresh active session state before detail launch decisions
- open terminals through the authenticated web terminal route via ensure-ttyd
- add Active tab controls to refresh, open terminals, and end sessions

## Verification
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- launched built IssueCTLMac.app and confirmed it quits cleanly
- git diff --check