### PR TITLE
Persist macOS sidebar layout preferences

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		A18D8982D49319C633EE661A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C1581E55A12781F1E76A1 /* ContentView.swift */; };
 		A2F5F2C02EF56C3F98D596E8 /* EditRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */; };
 		A642DAF085F1B5DD608BF523 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162B5421C0F279C8492942 /* APIClient.swift */; };
+		A66082BC0A4EF30F160CF9C5 /* MacSidebarPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708F54652A23B2732C519A72 /* MacSidebarPreferences.swift */; };
 		A6691865FCEEB29344BCCBAE /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0C921D1804F0904F029CC8 /* EnumTests.swift */; };
 		A9B2111D17EC7F6C48EEE268 /* PRDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767FFF9158E604C69C4007DB /* PRDetailView.swift */; };
 		A9B874605B9902D25572BC69 /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */; };
@@ -299,6 +300,7 @@
 		6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailActionTests.swift; sourceTree = "<group>"; };
 		6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorBanner.swift; sourceTree = "<group>"; };
 		6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
+		708F54652A23B2732C519A72 /* MacSidebarPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarPreferences.swift; sourceTree = "<group>"; };
 		723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListView.swift; sourceTree = "<group>"; };
 		72AB7A2B9999184E67A3064A /* IssueCTLMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLMacApp.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
@@ -501,6 +503,7 @@
 		6FAB6ED3CEA82D4567F1E04B /* Platform */ = {
 			isa = PBXGroup;
 			children = (
+				708F54652A23B2732C519A72 /* MacSidebarPreferences.swift */,
 				EEA90F554E1CF22EA56B51AB /* PerformanceTrace.swift */,
 				8FB818A0B361A38DCB604FB7 /* SidebarPanelController.swift */,
 			);
@@ -1148,6 +1151,7 @@
 				250D0308D12F0EE129E4C7E2 /* MacIssuesView.swift in Sources */,
 				BDDD77609BB45F218D8DBFDC /* MacSessionsView.swift in Sources */,
 				AAFAE2475EF1A39328204F4F /* MacSettingsView.swift in Sources */,
+				A66082BC0A4EF30F160CF9C5 /* MacSidebarPreferences.swift in Sources */,
 				BFC0A82D9CCFD653415A4A82 /* MacSidebarRootView.swift in Sources */,
 				22B99716E42E20F0DA147C5B /* MacSidebarStore.swift in Sources */,
 				B4AF2A85F0768942BCD81D8C /* NetworkMonitor.swift in Sources */,

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -9,6 +9,11 @@ struct IssueCTLMacApp: App {
         Settings {
             MacSettingsView()
                 .environment(appDelegate.apiClient)
+                .environment(appDelegate.sidebarPreferences)
+                .environment(appDelegate.sidebarChrome)
+                .environment(\.resetSidebarLayout) {
+                    appDelegate.resetSidebarLayout()
+                }
         }
     }
 }
@@ -16,27 +21,40 @@ struct IssueCTLMacApp: App {
 @MainActor
 final class MacAppDelegate: NSObject, NSApplicationDelegate {
     let apiClient = APIClient()
+    let sidebarPreferences = MacSidebarPreferences()
+    let sidebarChrome = SidebarChromeState()
     private let networkMonitor = NetworkMonitor()
-    private let sidebarChrome = SidebarChromeState()
     private var panelController: SidebarPanelController?
     private var statusItem: NSStatusItem?
+    private var collapseMenuItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         PerformanceTrace.markAppLaunchStarted()
         NSApp.setActivationPolicy(.accessory)
+        sidebarChrome.isCollapsed = sidebarPreferences.isCollapsed
 
         let rootView = MacSidebarRootView()
             .environment(apiClient)
             .environment(networkMonitor)
             .environment(sidebarChrome)
+            .environment(sidebarPreferences)
             .environment(\.hideSidebar) { [weak self] in
                 self?.panelController?.hide()
+                self?.updateStatusMenuTitles()
             }
             .environment(\.toggleSidebarCollapsed) { [weak self] in
                 self?.panelController?.toggleCollapsed()
+                self?.updateStatusMenuTitles()
+            }
+            .environment(\.resetSidebarLayout) { [weak self] in
+                self?.resetSidebarLayout()
             }
 
-        let panelController = SidebarPanelController(rootView: rootView, chrome: sidebarChrome)
+        let panelController = SidebarPanelController(
+            rootView: rootView,
+            chrome: sidebarChrome,
+            preferences: sidebarPreferences
+        )
         self.panelController = panelController
         panelController.show()
 
@@ -50,7 +68,9 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Toggle Sidebar", action: #selector(toggleSidebar), keyEquivalent: "s"))
-        menu.addItem(NSMenuItem(title: "Collapse or Expand", action: #selector(toggleCollapsed), keyEquivalent: "m"))
+        let collapseItem = NSMenuItem(title: collapsedMenuTitle, action: #selector(toggleCollapsed), keyEquivalent: "m")
+        collapseMenuItem = collapseItem
+        menu.addItem(collapseItem)
         menu.addItem(NSMenuItem(title: "Hide Sidebar", action: #selector(hideSidebar), keyEquivalent: "w"))
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit IssueCTL", action: #selector(quit), keyEquivalent: "q"))
@@ -62,17 +82,34 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func toggleSidebar() {
         panelController?.toggleVisibility()
+        updateStatusMenuTitles()
     }
 
     @objc private func toggleCollapsed() {
         panelController?.toggleCollapsed()
+        updateStatusMenuTitles()
     }
 
     @objc private func hideSidebar() {
         panelController?.hide()
+        updateStatusMenuTitles()
     }
 
     @objc private func quit() {
         NSApp.terminate(nil)
+    }
+
+    func resetSidebarLayout() {
+        sidebarPreferences.resetLayout()
+        panelController?.applyPreferencesLayout()
+        updateStatusMenuTitles()
+    }
+
+    private var collapsedMenuTitle: String {
+        sidebarChrome.isCollapsed ? "Expand Sidebar" : "Collapse Sidebar"
+    }
+
+    private func updateStatusMenuTitles() {
+        collapseMenuItem?.title = collapsedMenuTitle
     }
 }

--- a/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
+++ b/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+import Foundation
+import ServiceManagement
+
+@Observable @MainActor
+final class MacSidebarPreferences {
+    private enum Keys {
+        static let isCollapsed = "mac.sidebar.isCollapsed"
+        static let selectedSection = "mac.sidebar.selectedSection"
+        static let expandedWidth = "mac.sidebar.expandedWidth"
+    }
+
+    private let defaults: UserDefaults
+
+    var isCollapsed: Bool {
+        didSet { defaults.set(isCollapsed, forKey: Keys.isCollapsed) }
+    }
+
+    var selectedSectionRawValue: String {
+        didSet { defaults.set(selectedSectionRawValue, forKey: Keys.selectedSection) }
+    }
+
+    var expandedWidth: CGFloat {
+        didSet { defaults.set(Double(expandedWidth), forKey: Keys.expandedWidth) }
+    }
+
+    var launchAtLogin = false
+    var launchAtLoginError: String?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        isCollapsed = defaults.object(forKey: Keys.isCollapsed) as? Bool ?? false
+        selectedSectionRawValue = defaults.string(forKey: Keys.selectedSection) ?? "issues"
+        expandedWidth = Self.clampedWidth(defaults.object(forKey: Keys.expandedWidth) as? Double ?? 380)
+        refreshLaunchAtLoginStatus()
+    }
+
+    func refreshLaunchAtLoginStatus() {
+        launchAtLogin = SMAppService.mainApp.status == .enabled
+    }
+
+    func setLaunchAtLogin(_ enabled: Bool) async {
+        launchAtLoginError = nil
+
+        do {
+            if enabled {
+                if SMAppService.mainApp.status != .enabled {
+                    try SMAppService.mainApp.register()
+                }
+            } else if SMAppService.mainApp.status == .enabled {
+                try await SMAppService.mainApp.unregister()
+            }
+        } catch {
+            launchAtLoginError = error.localizedDescription
+        }
+
+        refreshLaunchAtLoginStatus()
+    }
+
+    func resetLayout() {
+        isCollapsed = false
+        selectedSectionRawValue = "issues"
+        expandedWidth = Self.defaultExpandedWidth
+    }
+
+    nonisolated static let defaultExpandedWidth: CGFloat = 380
+    nonisolated static let minimumExpandedWidth: CGFloat = 340
+    nonisolated static let maximumExpandedWidth: CGFloat = 560
+
+    nonisolated static func clampedWidth(_ width: CGFloat) -> CGFloat {
+        min(max(width, minimumExpandedWidth), maximumExpandedWidth)
+    }
+
+    nonisolated static func clampedWidth(_ width: Double) -> CGFloat {
+        clampedWidth(CGFloat(width))
+    }
+}

--- a/apple/IssueCTLMac/Platform/SidebarPanelController.swift
+++ b/apple/IssueCTLMac/Platform/SidebarPanelController.swift
@@ -9,6 +9,10 @@ private struct ToggleSidebarCollapsedKey: EnvironmentKey {
     static let defaultValue: @MainActor () -> Void = {}
 }
 
+private struct ResetSidebarLayoutKey: EnvironmentKey {
+    static let defaultValue: @MainActor () -> Void = {}
+}
+
 extension EnvironmentValues {
     var hideSidebar: @MainActor () -> Void {
         get { self[HideSidebarKey.self] }
@@ -19,6 +23,11 @@ extension EnvironmentValues {
         get { self[ToggleSidebarCollapsedKey.self] }
         set { self[ToggleSidebarCollapsedKey.self] = newValue }
     }
+
+    var resetSidebarLayout: @MainActor () -> Void {
+        get { self[ResetSidebarLayoutKey.self] }
+        set { self[ResetSidebarLayoutKey.self] = newValue }
+    }
 }
 
 @Observable @MainActor
@@ -28,25 +37,36 @@ final class SidebarChromeState {
 }
 
 @MainActor
-final class SidebarPanelController {
+final class SidebarPanelController: NSObject, NSWindowDelegate {
     private enum Metrics {
         static let collapsedWidth: CGFloat = 76
-        static let expandedMinWidth: CGFloat = 340
-        static let expandedMaxWidth: CGFloat = 560
-        static let defaultExpandedWidth: CGFloat = 380
+        static let expandedMinWidth = MacSidebarPreferences.minimumExpandedWidth
+        static let expandedMaxWidth = MacSidebarPreferences.maximumExpandedWidth
+        static let defaultExpandedWidth = MacSidebarPreferences.defaultExpandedWidth
         static let horizontalInset: CGFloat = 12
         static let verticalInset: CGFloat = 12
         static let minimumHeight: CGFloat = 480
     }
 
-    private let panel: NSPanel
+    private var panel: NSPanel!
     private let chrome: SidebarChromeState
-    private var expandedWidth = Metrics.defaultExpandedWidth
+    private let preferences: MacSidebarPreferences
+    private var expandedWidth: CGFloat
 
-    init<Content: View>(rootView: Content, chrome: SidebarChromeState) {
+    init<Content: View>(
+        rootView: Content,
+        chrome: SidebarChromeState,
+        preferences: MacSidebarPreferences
+    ) {
         self.chrome = chrome
+        self.preferences = preferences
+        expandedWidth = MacSidebarPreferences.clampedWidth(preferences.expandedWidth)
+
+        super.init()
+
         let hostingController = NSHostingController(rootView: rootView)
-        let frame = Self.defaultFrame()
+        chrome.isCollapsed = preferences.isCollapsed
+        let frame = Self.defaultFrame(width: preferences.isCollapsed ? Metrics.collapsedWidth : expandedWidth)
 
         panel = NSPanel(
             contentRect: frame,
@@ -62,8 +82,8 @@ final class SidebarPanelController {
         panel.hidesOnDeactivate = false
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        panel.minSize = NSSize(width: Metrics.expandedMinWidth, height: Metrics.minimumHeight)
-        panel.maxSize = NSSize(width: Metrics.expandedMaxWidth, height: CGFloat.greatestFiniteMagnitude)
+        panel.delegate = self
+        updateSizeConstraints()
     }
 
     func show() {
@@ -92,27 +112,54 @@ final class SidebarPanelController {
     func setCollapsed(_ isCollapsed: Bool) {
         guard chrome.isCollapsed != isCollapsed else { return }
 
-        if isCollapsed {
-            expandedWidth = min(max(panel.frame.width, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
-            panel.minSize = NSSize(width: Metrics.collapsedWidth, height: Metrics.minimumHeight)
-            panel.maxSize = NSSize(width: Metrics.collapsedWidth, height: CGFloat.greatestFiniteMagnitude)
-        } else {
-            panel.minSize = NSSize(width: Metrics.expandedMinWidth, height: Metrics.minimumHeight)
-            panel.maxSize = NSSize(width: Metrics.expandedMaxWidth, height: CGFloat.greatestFiniteMagnitude)
+        if isCollapsed, panel.frame.width != Metrics.collapsedWidth {
+            saveExpandedWidth(panel.frame.width)
         }
 
         chrome.isCollapsed = isCollapsed
+        preferences.isCollapsed = isCollapsed
+        updateSizeConstraints()
         panel.setFrame(Self.defaultFrame(width: currentWidth), display: true, animate: true)
         if !panel.isVisible {
             show()
         }
     }
 
+    func applyPreferencesLayout() {
+        expandedWidth = MacSidebarPreferences.clampedWidth(preferences.expandedWidth)
+        chrome.isCollapsed = preferences.isCollapsed
+        updateSizeConstraints()
+        panel.setFrame(Self.defaultFrame(width: currentWidth), display: true, animate: true)
+        if !panel.isVisible {
+            show()
+        }
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        guard !chrome.isCollapsed else { return }
+        saveExpandedWidth(panel.frame.width)
+    }
+
     private var currentWidth: CGFloat {
         if chrome.isCollapsed {
             return Metrics.collapsedWidth
         }
-        return min(max(expandedWidth, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
+        return MacSidebarPreferences.clampedWidth(expandedWidth)
+    }
+
+    private func updateSizeConstraints() {
+        if chrome.isCollapsed {
+            panel.minSize = NSSize(width: Metrics.collapsedWidth, height: Metrics.minimumHeight)
+            panel.maxSize = NSSize(width: Metrics.collapsedWidth, height: CGFloat.greatestFiniteMagnitude)
+        } else {
+            panel.minSize = NSSize(width: Metrics.expandedMinWidth, height: Metrics.minimumHeight)
+            panel.maxSize = NSSize(width: Metrics.expandedMaxWidth, height: CGFloat.greatestFiniteMagnitude)
+        }
+    }
+
+    private func saveExpandedWidth(_ width: CGFloat) {
+        expandedWidth = MacSidebarPreferences.clampedWidth(width)
+        preferences.expandedWidth = expandedWidth
     }
 
     private static func defaultFrame(width requestedWidth: CGFloat = Metrics.defaultExpandedWidth) -> NSRect {

--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct MacSettingsView: View {
     @Environment(APIClient.self) private var api
+    @Environment(MacSidebarPreferences.self) private var preferences
+    @Environment(\.resetSidebarLayout) private var resetSidebarLayout
+    @State private var isUpdatingLaunchAtLogin = false
 
     var body: some View {
         Form {
@@ -10,9 +13,62 @@ struct MacSettingsView: View {
                 Text(api.apiToken.isEmpty ? "No API token saved" : "API token saved")
                     .foregroundStyle(.secondary)
             }
+
+            Section("Mac Sidebar") {
+                Toggle("Launch at Login", isOn: launchAtLoginBinding)
+                    .disabled(isUpdatingLaunchAtLogin)
+
+                if isUpdatingLaunchAtLogin {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                if let error = preferences.launchAtLoginError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Toggle("Open Collapsed on Next Launch", isOn: collapsedOnLaunchBinding)
+
+                HStack {
+                    Text("Saved Width")
+                    Spacer()
+                    Text("\(Int(preferences.expandedWidth)) px")
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Reset Sidebar Layout") {
+                    resetSidebarLayout()
+                }
+            }
         }
         .formStyle(.grouped)
         .frame(width: 420)
         .padding()
+        .task {
+            preferences.refreshLaunchAtLoginStatus()
+        }
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { preferences.launchAtLogin },
+            set: { newValue in
+                isUpdatingLaunchAtLogin = true
+                Task {
+                    await preferences.setLaunchAtLogin(newValue)
+                    isUpdatingLaunchAtLogin = false
+                }
+            }
+        )
+    }
+
+    private var collapsedOnLaunchBinding: Binding<Bool> {
+        Binding(
+            get: { preferences.isCollapsed },
+            set: { preferences.isCollapsed = $0 }
+        )
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MacSidebarRootView: View {
     @Environment(APIClient.self) private var api
     @Environment(SidebarChromeState.self) private var chrome
+    @Environment(MacSidebarPreferences.self) private var preferences
     @Environment(\.hideSidebar) private var hideSidebar
     @Environment(\.toggleSidebarCollapsed) private var toggleSidebarCollapsed
 
@@ -24,6 +25,15 @@ struct MacSidebarRootView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .onExitCommand {
             hideSidebar()
+        }
+        .onAppear {
+            selectedSection = MacSidebarSection(rawValue: preferences.selectedSectionRawValue) ?? .issues
+        }
+        .onChange(of: selectedSection) { _, newValue in
+            preferences.selectedSectionRawValue = newValue.rawValue
+        }
+        .onChange(of: preferences.selectedSectionRawValue) { _, newValue in
+            selectedSection = MacSidebarSection(rawValue: newValue) ?? .issues
         }
     }
 


### PR DESCRIPTION
## Summary
- add a macOS sidebar preferences store for collapsed state, selected section, saved width, and launch-at-login status
- restore saved sidebar layout at app launch and persist expanded width when the panel is resized
- add Mac Sidebar settings for launch at login, collapsed-on-launch, saved width display, and live layout reset

## Verification
- xcodegen generate
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- launch/quit smoke for IssueCTLMac.app
- git diff --check

Note: local hooks passed typecheck/lint with existing lint warnings only.