### PR TITLE
Add macOS sidebar tests and QA checklist

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		CB1BD4038692E9AD73D95C1B /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
 		CC16C63936A1F4ECDEB3133E /* NotificationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2438738AD84484EC2E7B20C9 /* NotificationPreferences.swift */; };
 		CC83F861B2A764DB8AA4FC4A /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
+		CCD66F76181E54FD2700F813 /* MacSidebarPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C02C0464A65420CBD5D90E /* MacSidebarPreferencesTests.swift */; };
 		CCEACC5EE38BAC8DEC2DF70F /* PushDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013A1B391EF1CD6F786CEE87 /* PushDevice.swift */; };
 		CD346337E88C758F51FECA8B /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48746522237ABF37AF77B1DA /* APIClient+ListEnhancements.swift */; };
 		CF8A626D972649C230E5C866 /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */; };
@@ -227,6 +228,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 364129AB76D09B38C3DD6476;
 			remoteInfo = IssueCTLPreview;
+		};
+		BE6D29DCAC3866F179F9C3EB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EF5E413184FCD5C1D397759F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B09EBAF173B9C47BCA316EE2;
+			remoteInfo = IssueCTLMac;
 		};
 		CC2BD2F35AE9F4F4FD860CF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -300,11 +308,13 @@
 		6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailActionTests.swift; sourceTree = "<group>"; };
 		6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorBanner.swift; sourceTree = "<group>"; };
 		6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
+		6F07F4595D2598182637073E /* IssueCTLMacTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		708F54652A23B2732C519A72 /* MacSidebarPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarPreferences.swift; sourceTree = "<group>"; };
 		723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListView.swift; sourceTree = "<group>"; };
 		72AB7A2B9999184E67A3064A /* IssueCTLMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLMacApp.swift; sourceTree = "<group>"; };
 		75027D57516F296784BEDA4B /* PRRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowView.swift; sourceTree = "<group>"; };
 		767FFF9158E604C69C4007DB /* PRDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRDetailView.swift; sourceTree = "<group>"; };
+		78C02C0464A65420CBD5D90E /* MacSidebarPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarPreferencesTests.swift; sourceTree = "<group>"; };
 		78D638F823877AD0CAA946A4 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		79D271A21BE61236E7F177D4 /* IssueCTLMac.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTLMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRowView.swift; sourceTree = "<group>"; };
@@ -527,12 +537,21 @@
 			children = (
 				AB6764D0DF2A55EB3796889D /* IssueCTL.app */,
 				79D271A21BE61236E7F177D4 /* IssueCTLMac.app */,
+				6F07F4595D2598182637073E /* IssueCTLMacTests.xctest */,
 				2D10373E745B3E9EC223B684 /* IssueCTLPreview.app */,
 				5809ACB6716C100004867EC9 /* IssueCTLPreviewUITests.xctest */,
 				0075145AA41F584D8D58036B /* IssueCTLTests.xctest */,
 				0CF6456214BCA5794B4D8A25 /* IssueCTLUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		82D31594429EC9DE06A2DFF6 /* IssueCTLMacTests */ = {
+			isa = PBXGroup;
+			children = (
+				78C02C0464A65420CBD5D90E /* MacSidebarPreferencesTests.swift */,
+			);
+			path = IssueCTLMacTests;
 			sourceTree = "<group>";
 		};
 		90117C5D62583C300C6DA37E /* Services */ = {
@@ -559,6 +578,7 @@
 			children = (
 				D5E657213913F2B68B41C505 /* IssueCTL */,
 				DA7D2CCD426BE9BEFF0C149F /* IssueCTLMac */,
+				82D31594429EC9DE06A2DFF6 /* IssueCTLMacTests */,
 				0DB8D12D04D2C393548E5DB0 /* IssueCTLShared */,
 				679803C9E7560FAB9A36EE85 /* IssueCTLTests */,
 				BFBE2D0C9B03282DA5585CAC /* IssueCTLUITests */,
@@ -794,6 +814,24 @@
 			productReference = 79D271A21BE61236E7F177D4 /* IssueCTLMac.app */;
 			productType = "com.apple.product-type.application";
 		};
+		CEE9BB5CF15E3B33594AF851 /* IssueCTLMacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AEE0642504D39CB13C230E81 /* Build configuration list for PBXNativeTarget "IssueCTLMacTests" */;
+			buildPhases = (
+				409394BA89CDA6FF4077B446 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FF5A729EC7F7C96C05584622 /* PBXTargetDependency */,
+			);
+			name = IssueCTLMacTests;
+			packageProductDependencies = (
+			);
+			productName = IssueCTLMacTests;
+			productReference = 6F07F4595D2598182637073E /* IssueCTLMacTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		E733D5763E64E8270AF7A0E2 /* IssueCTLUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BAF8116DB5A235F69E11B3A1 /* Build configuration list for PBXNativeTarget "IssueCTLUITests" */;
@@ -861,6 +899,7 @@
 			targets = (
 				791AFA96580A5FB3D384B678 /* IssueCTL */,
 				B09EBAF173B9C47BCA316EE2 /* IssueCTLMac */,
+				CEE9BB5CF15E3B33594AF851 /* IssueCTLMacTests */,
 				364129AB76D09B38C3DD6476 /* IssueCTLPreview */,
 				8FA5DBB4D9BC0711D23A3797 /* IssueCTLPreviewUITests */,
 				74A5540D3FF8CC05F0E56974 /* IssueCTLTests */,
@@ -1097,6 +1136,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		409394BA89CDA6FF4077B446 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCD66F76181E54FD2700F813 /* MacSidebarPreferencesTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6CC27A3A4AB52D4C60C6B85C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1183,6 +1230,11 @@
 			isa = PBXTargetDependency;
 			target = 791AFA96580A5FB3D384B678 /* IssueCTL */;
 			targetProxy = CC2BD2F35AE9F4F4FD860CF7 /* PBXContainerItemProxy */;
+		};
+		FF5A729EC7F7C96C05584622 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B09EBAF173B9C47BCA316EE2 /* IssueCTLMac */;
+			targetProxy = BE6D29DCAC3866F179F9C3EB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1356,6 +1408,28 @@
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = IssueCTLPreview;
+			};
+			name = Debug;
+		};
+		7081DB104F1066B62A0EB981 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.issuectl.mac.tests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IssueCTLMac.app/Contents/MacOS/IssueCTLMac";
 			};
 			name = Debug;
 		};
@@ -1644,6 +1718,28 @@
 			};
 			name = Release;
 		};
+		E77B32435105D33ABD58F821 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.issuectl.mac.tests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IssueCTLMac.app/Contents/MacOS/IssueCTLMac";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1679,6 +1775,15 @@
 			buildConfigurations = (
 				CA1F3322A8D6FCFC5B4D19F2 /* Debug */,
 				0054D3D69C742503141BCA2C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		AEE0642504D39CB13C230E81 /* Build configuration list for PBXNativeTarget "IssueCTLMacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7081DB104F1066B62A0EB981 /* Debug */,
+				E77B32435105D33ABD58F821 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/apple/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTLMac.xcscheme
+++ b/apple/IssueCTL.xcodeproj/xcshareddata/xcschemes/IssueCTLMac.xcscheme
@@ -39,6 +39,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CEE9BB5CF15E3B33594AF851"
+               BuildableName = "IssueCTLMacTests.xctest"
+               BlueprintName = "IssueCTLMacTests"
+               ReferencedContainer = "container:IssueCTL.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -65,6 +65,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.image = NSImage(systemSymbolName: "list.bullet.rectangle", accessibilityDescription: "IssueCTL")
         item.button?.imagePosition = .imageOnly
+        item.button?.toolTip = "IssueCTL"
 
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Toggle Sidebar", action: #selector(toggleSidebar), keyEquivalent: "s"))

--- a/apple/IssueCTLMac/QA.md
+++ b/apple/IssueCTLMac/QA.md
@@ -1,0 +1,116 @@
+# IssueCTLMac Sidebar Manual QA
+
+Use this checklist for manual regression passes on the native macOS sidebar. Run against a local `issuectl web` server with at least one tracked repo, one open issue, and a valid API token.
+
+## Build And Launch
+
+- [ ] From the repo root, build the macOS target:
+  `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' build`
+- [ ] Launch `IssueCTLMac` from Xcode with the `IssueCTLMac` scheme.
+- [ ] Confirm the app starts as a menu bar/accessory app, without a Dock window.
+- [ ] Confirm the IssueCTL sidebar appears automatically on launch.
+- [ ] Confirm the sidebar is positioned on the right side of the visible screen with usable height.
+- [ ] Open the IssueCTL menu bar item and verify these menu commands are present: Toggle Sidebar, Collapse Sidebar or Expand Sidebar, Hide Sidebar, Quit IssueCTL.
+- [ ] Use Quit IssueCTL and confirm the app exits cleanly.
+
+## Spaces And Window Behavior
+
+- [ ] With the sidebar visible, switch to another Space and confirm the sidebar remains visible there.
+- [ ] Enter a full-screen app Space and confirm the sidebar can appear as an auxiliary floating panel.
+- [ ] Move focus to another app and confirm the sidebar does not hide just because IssueCTL lost focus.
+- [ ] Verify the sidebar stays stationary when switching Spaces and does not jump to a different screen edge.
+- [ ] If using multiple displays, show the sidebar and confirm it opens on the active main screen without covering the menu bar.
+
+## Visibility And Collapse
+
+- [ ] Click the header Hide Sidebar button and confirm the panel disappears.
+- [ ] Use the menu bar Toggle Sidebar command and confirm the panel reappears.
+- [ ] Use Escape while the sidebar has focus and confirm the panel hides.
+- [ ] Click the header Collapse Sidebar button and confirm the panel animates to the narrow rail.
+- [ ] In collapsed mode, verify the rail shows Issues, Drafts, Active, Refresh, Expand Sidebar, and Hide Sidebar controls.
+- [ ] Select each collapsed rail section and confirm the selected icon highlight moves.
+- [ ] Click Expand Sidebar and confirm the full sidebar returns.
+- [ ] Resize the expanded sidebar narrower and wider; confirm it respects the min and max width limits.
+- [ ] Collapse and expand after resizing; confirm the previous expanded width is restored.
+
+## Persistence
+
+- [ ] Select Drafts, quit the app, relaunch, and confirm Drafts remains selected.
+- [ ] Select Active, quit the app, relaunch, and confirm Active remains selected.
+- [ ] Collapse the sidebar, quit the app, relaunch, and confirm it opens collapsed.
+- [ ] Expand the sidebar, resize it, quit the app, relaunch, and confirm the saved width is restored.
+- [ ] Open Settings, use Reset Sidebar Layout, and confirm the sidebar expands, selects Issues, and returns to the default width.
+
+## Settings
+
+- [ ] Open the app Settings window.
+- [ ] In Connection, verify the server URL displays when configured.
+- [ ] In Connection, verify the API token status changes from not saved to saved after connecting.
+- [ ] Toggle Launch at Login on and confirm no error is shown.
+- [ ] Toggle Launch at Login off and confirm no error is shown.
+- [ ] Toggle Open Collapsed on Next Launch on, relaunch, and confirm the sidebar starts collapsed.
+- [ ] Toggle Open Collapsed on Next Launch off, relaunch, and confirm the sidebar starts expanded.
+- [ ] Resize the expanded sidebar and confirm Saved Width updates in Settings.
+- [ ] Click Reset Sidebar Layout and confirm the sidebar state changes immediately.
+
+## Connection
+
+- [ ] Start the server with `issuectl web` and copy the printed API token.
+- [ ] Launch the macOS app with no saved connection and confirm the connection form appears.
+- [ ] Enter an invalid server URL or token and confirm an inline error appears.
+- [ ] Enter `http://localhost:3847` and a valid API token, then click Connect.
+- [ ] Confirm the dashboard replaces the connection form after a successful health check.
+- [ ] Confirm the toolbar summary shows issue, draft, and active session counts.
+- [ ] Click Refresh and confirm loading state appears without duplicating rows.
+- [ ] Use Disconnect from the header and confirm the sidebar returns to the connection form and clears loaded data.
+- [ ] Stop `issuectl web`, refresh, and confirm the sidebar reports a useful connection/load error without crashing.
+
+## Issues And Actions
+
+- [ ] Open the Issues tab and confirm open issues load for tracked repos.
+- [ ] Verify the Open, Unassigned, and All filters update the visible list.
+- [ ] Search by issue title and confirm matching rows remain.
+- [ ] Search by repo full name and confirm matching rows remain.
+- [ ] Open an issue row and confirm the detail sheet loads title, repo, issue number, labels, assignees, body, and comments.
+- [ ] In the issue detail sheet, click Refresh and confirm the loading state completes.
+- [ ] Change Priority and confirm the badge updates, then refresh and confirm the persisted priority is shown.
+- [ ] Add a comment and confirm the composer clears and the comment appears after reload.
+- [ ] Close an open issue and confirm the state badge updates.
+- [ ] Reopen the issue and confirm the state badge updates.
+- [ ] Click GitHub and confirm the issue opens in the browser.
+- [ ] Close the detail sheet and confirm the sidebar remains usable.
+
+## Drafts
+
+- [ ] Open the Drafts tab and confirm the empty state appears when there are no drafts.
+- [ ] Click New Draft from the empty state or toolbar.
+- [ ] Confirm Create is disabled until a title is entered.
+- [ ] Create a draft with title, body, and High priority.
+- [ ] Confirm the draft appears in the list with title, body preview, created time, and priority pill.
+- [ ] Open the draft, edit the title/body/priority, save, and confirm the list updates.
+- [ ] Right-click a draft and choose Edit; confirm the editor opens for that draft.
+- [ ] Right-click a draft and choose Delete; cancel the confirmation and confirm the draft remains.
+- [ ] Delete the draft and confirm it disappears from the list.
+- [ ] Simulate a server error while saving or deleting and confirm the error is shown without dismissing the current context unexpectedly.
+
+## Sessions And Terminal
+
+- [ ] Open an issue with no active session and confirm the launch section shows Ready to Launch.
+- [ ] Click Launch and confirm the button shows progress while the request is in flight.
+- [ ] Confirm the issue row shows the terminal/running indicator after a session starts.
+- [ ] In the issue detail sheet, confirm Session Starting appears while terminal setup is pending.
+- [ ] When terminal setup is ready, click Open and confirm the browser opens the terminal URL.
+- [ ] Open the Active tab and confirm the active session row shows repo, issue number, branch, duration, workspace path, and Ready or Starting.
+- [ ] Click the Active tab Refresh control and confirm session state updates.
+- [ ] Click Open on a ready session and confirm the terminal opens.
+- [ ] Click End, confirm the progress state appears, and confirm the ended session is removed from the Active list.
+- [ ] Confirm launching a second time for the same issue reuses the existing active session instead of creating a duplicate.
+
+## Known Backlog
+
+- [ ] Global hotkey to show/hide the sidebar.
+- [ ] Keyboard navigation for switching sections, selecting rows, opening details, and activating primary actions.
+- [ ] Menu item or command for opening Settings directly from the IssueCTL menu bar item.
+- [ ] Automated UI coverage for native macOS sidebar visibility, collapse state, and persistence.
+- [ ] Multi-display placement preferences beyond the current main-screen default.
+- [ ] More explicit empty/error recovery actions for connection, repo load, draft save, and session terminal failures.

--- a/apple/IssueCTLMacTests/MacSidebarPreferencesTests.swift
+++ b/apple/IssueCTLMacTests/MacSidebarPreferencesTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import IssueCTLMac
+
+@MainActor
+final class MacSidebarPreferencesTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "issuectl.tests.mac-sidebar.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try super.tearDownWithError()
+    }
+
+    func testDefaultsUseExpandedIssueSidebar() {
+        let preferences = MacSidebarPreferences(defaults: defaults)
+
+        XCTAssertFalse(preferences.isCollapsed)
+        XCTAssertEqual(preferences.selectedSectionRawValue, "issues")
+        XCTAssertEqual(preferences.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+    }
+
+    func testPersistsCollapsedSelectedSectionAndExpandedWidth() {
+        let preferences = MacSidebarPreferences(defaults: defaults)
+
+        preferences.isCollapsed = true
+        preferences.selectedSectionRawValue = "drafts"
+        preferences.expandedWidth = 440
+
+        let reloaded = MacSidebarPreferences(defaults: defaults)
+        XCTAssertTrue(reloaded.isCollapsed)
+        XCTAssertEqual(reloaded.selectedSectionRawValue, "drafts")
+        XCTAssertEqual(reloaded.expandedWidth, 440)
+    }
+
+    func testLoadsExpandedWidthClampedToSupportedRange() {
+        defaults.set(120, forKey: "mac.sidebar.expandedWidth")
+        XCTAssertEqual(
+            MacSidebarPreferences(defaults: defaults).expandedWidth,
+            MacSidebarPreferences.minimumExpandedWidth
+        )
+
+        defaults.set(1_200, forKey: "mac.sidebar.expandedWidth")
+        XCTAssertEqual(
+            MacSidebarPreferences(defaults: defaults).expandedWidth,
+            MacSidebarPreferences.maximumExpandedWidth
+        )
+    }
+
+    func testResetLayoutRestoresAndPersistsDefaults() {
+        let preferences = MacSidebarPreferences(defaults: defaults)
+        preferences.isCollapsed = true
+        preferences.selectedSectionRawValue = "settings"
+        preferences.expandedWidth = 520
+
+        preferences.resetLayout()
+
+        XCTAssertFalse(preferences.isCollapsed)
+        XCTAssertEqual(preferences.selectedSectionRawValue, "issues")
+        XCTAssertEqual(preferences.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+
+        let reloaded = MacSidebarPreferences(defaults: defaults)
+        XCTAssertFalse(reloaded.isCollapsed)
+        XCTAssertEqual(reloaded.selectedSectionRawValue, "issues")
+        XCTAssertEqual(reloaded.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+    }
+
+    func testClampedWidthEdgeValues() {
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedWidth(MacSidebarPreferences.minimumExpandedWidth - 1),
+            MacSidebarPreferences.minimumExpandedWidth
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedWidth(MacSidebarPreferences.minimumExpandedWidth),
+            MacSidebarPreferences.minimumExpandedWidth
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedWidth(MacSidebarPreferences.defaultExpandedWidth),
+            MacSidebarPreferences.defaultExpandedWidth
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedWidth(MacSidebarPreferences.maximumExpandedWidth),
+            MacSidebarPreferences.maximumExpandedWidth
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedWidth(MacSidebarPreferences.maximumExpandedWidth + 1),
+            MacSidebarPreferences.maximumExpandedWidth
+        )
+    }
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -11,6 +11,8 @@ targets:
     supportedDestinations: [macOS]
     sources:
       - path: IssueCTLMac
+        excludes:
+          - QA.md
       - path: IssueCTLShared
     settings:
       base:
@@ -23,7 +25,9 @@ targets:
         ISSUECTL_KEYCHAIN_SERVICE: com.issuectl.mac
         DEVELOPMENT_TEAM: B3A6AN2HA4
         CODE_SIGN_STYLE: Automatic
-    scheme: {}
+    scheme:
+      testTargets:
+        - IssueCTLMacTests
   IssueCTL:
     type: application
     supportedDestinations: [iOS]
@@ -222,6 +226,20 @@ targets:
         DEVELOPMENT_TEAM: B3A6AN2HA4
         CODE_SIGN_STYLE: Automatic
         BUNDLE_LOADER: ""  # UI tests run out-of-process; no bundle injection
+  IssueCTLMacTests:
+    type: bundle.unit-test
+    supportedDestinations: [macOS]
+    sources:
+      - path: IssueCTLMacTests
+    dependencies:
+      - target: IssueCTLMac
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: true
+        PRODUCT_BUNDLE_IDENTIFIER: com.issuectl.mac.tests
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/IssueCTLMac.app/Contents/MacOS/IssueCTLMac"
+        BUNDLE_LOADER: "$(TEST_HOST)"
 # Standalone schemes (supplement the per-target inline scheme above)
 schemes:
   IssueCTL-Production:


### PR DESCRIPTION
## Summary
- add IssueCTLMacTests to the XcodeGen project and IssueCTLMac scheme
- cover MacSidebarPreferences defaults, persistence, width clamping, and reset behavior
- add a manual QA checklist for the native macOS sidebar and exclude it from the app bundle
- add a tooltip to the IssueCTL menu bar item

## Verification
- xcodegen generate
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS,arch=arm64' test
- launch/quit smoke for IssueCTLMac.app
- git diff --check

Notes:
- Focus/panel audit found no concrete `.nonactivatingPanel` text-entry bug, so no behavior patch was made.
- App icon/shared asset catalog remains backlog.
- Local hooks passed typecheck/lint with existing warnings only.
