### PR TITLE
Improve macOS sidebar recovery actions

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		F799F1B8BFD81FB4ED400EDD /* LoadMoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4497D324AB6CE09260737497 /* LoadMoreButton.swift */; };
 		F7DAA0E5DD04C7761ED3B88F /* MineFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */; };
 		F8A3608F607F4CB92B7D3385 /* SectionTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */; };
+		F8E1839B4CE74D977900874C /* MacRecoveryBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2F4EB488F40667A6499CFC /* MacRecoveryBanner.swift */; };
 		FA79A078516F768487A8D9D6 /* RequestChangesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */; };
 		FC3CDC9F728B2C926EBAFF13 /* AddRepoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */; };
 		FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4010BC691DB71B872353344A /* SessionListView.swift */; };
@@ -346,6 +347,7 @@
 		C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDetailView.swift; sourceTree = "<group>"; };
 		CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftDetailView.swift; sourceTree = "<group>"; };
 		CAB04FB5543994CCE2DE041E /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		CB2F4EB488F40667A6499CFC /* MacRecoveryBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacRecoveryBanner.swift; sourceTree = "<group>"; };
 		CCED89BF4650BDFC4262B48D /* InteractivePopDisabler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractivePopDisabler.swift; sourceTree = "<group>"; };
 		D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseIssueSheet.swift; sourceTree = "<group>"; };
 		D882E51722D47D736257AB4F /* IssueListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListView.swift; sourceTree = "<group>"; };
@@ -666,6 +668,7 @@
 				0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */,
 				AF37A7CB40F1701C4C149CE2 /* MacIssueDetailView.swift */,
 				43A60283ECC077E01E26EAC1 /* MacIssuesView.swift */,
+				CB2F4EB488F40667A6499CFC /* MacRecoveryBanner.swift */,
 				26774436FC5A498AFD32CF2B /* MacSessionsView.swift */,
 				959347AB556CB71BEA308105 /* MacSettingsView.swift */,
 				134385CA01429770C742CD89 /* MacSidebarRootView.swift */,
@@ -1211,6 +1214,7 @@
 				5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */,
 				C9D9618A4076FAE0E98D71AC /* MacIssueDetailView.swift in Sources */,
 				250D0308D12F0EE129E4C7E2 /* MacIssuesView.swift in Sources */,
+				F8E1839B4CE74D977900874C /* MacRecoveryBanner.swift in Sources */,
 				BDDD77609BB45F218D8DBFDC /* MacSessionsView.swift in Sources */,
 				AAFAE2475EF1A39328204F4F /* MacSettingsView.swift in Sources */,
 				A66082BC0A4EF30F160CF9C5 /* MacSidebarPreferences.swift in Sources */,

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -73,6 +73,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         collapseMenuItem = collapseItem
         menu.addItem(collapseItem)
         menu.addItem(NSMenuItem(title: "Hide Sidebar", action: #selector(hideSidebar), keyEquivalent: "w"))
+        menu.addItem(NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ","))
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit IssueCTL", action: #selector(quit), keyEquivalent: "q"))
         menu.items.forEach { $0.target = self }
@@ -94,6 +95,11 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     @objc private func hideSidebar() {
         panelController?.hide()
         updateStatusMenuTitles()
+    }
+
+    @objc private func openSettings() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
     }
 
     @objc private func quit() {

--- a/apple/IssueCTLMac/QA.md
+++ b/apple/IssueCTLMac/QA.md
@@ -10,7 +10,8 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] Confirm the app starts as a menu bar/accessory app, without a Dock window.
 - [ ] Confirm the IssueCTL sidebar appears automatically on launch.
 - [ ] Confirm the sidebar is positioned on the right side of the visible screen with usable height.
-- [ ] Open the IssueCTL menu bar item and verify these menu commands are present: Toggle Sidebar, Collapse Sidebar or Expand Sidebar, Hide Sidebar, Quit IssueCTL.
+- [ ] Open the IssueCTL menu bar item and verify these menu commands are present: Toggle Sidebar, Collapse Sidebar or Expand Sidebar, Hide Sidebar, Settings, Quit IssueCTL.
+- [ ] Open the IssueCTL menu bar item, choose Settings, and confirm the Settings window appears in front.
 - [ ] Use Quit IssueCTL and confirm the app exits cleanly.
 
 ## Spaces And Window Behavior
@@ -58,12 +59,14 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] Start the server with `issuectl web` and copy the printed API token.
 - [ ] Launch the macOS app with no saved connection and confirm the connection form appears.
 - [ ] Enter an invalid server URL or token and confirm an inline error appears.
+- [ ] After a failed connection, confirm Retry Connect is visible and reuses the entered URL/token.
 - [ ] Enter `http://localhost:3847` and a valid API token, then click Connect.
 - [ ] Confirm the dashboard replaces the connection form after a successful health check.
 - [ ] Confirm the toolbar summary shows issue, draft, and active session counts.
 - [ ] Click Refresh and confirm loading state appears without duplicating rows.
 - [ ] Use Disconnect from the header and confirm the sidebar returns to the connection form and clears loaded data.
 - [ ] Stop `issuectl web`, refresh, and confirm the sidebar reports a useful connection/load error without crashing.
+- [ ] Restart `issuectl web`, use Retry from the dashboard error banner, and confirm the sidebar reloads.
 
 ## Issues And Actions
 
@@ -72,6 +75,7 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] Search by issue title and confirm matching rows remain.
 - [ ] Search by repo full name and confirm matching rows remain.
 - [ ] Open an issue row and confirm the detail sheet loads title, repo, issue number, labels, assignees, body, and comments.
+- [ ] Simulate an issue detail load failure and confirm the detail sheet shows Retry without closing.
 - [ ] In the issue detail sheet, click Refresh and confirm the loading state completes.
 - [ ] Change Priority and confirm the badge updates, then refresh and confirm the persisted priority is shown.
 - [ ] Add a comment and confirm the composer clears and the comment appears after reload.
@@ -102,6 +106,7 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] When terminal setup is ready, click Open and confirm the browser opens the terminal URL.
 - [ ] Open the Active tab and confirm the active session row shows repo, issue number, branch, duration, workspace path, and Ready or Starting.
 - [ ] Click the Active tab Refresh control and confirm session state updates.
+- [ ] Simulate an Active tab refresh/open/end failure and confirm Retry Refresh is shown without dismissing the tab.
 - [ ] Click Open on a ready session and confirm the terminal opens.
 - [ ] Click End, confirm the progress state appears, and confirm the ended session is removed from the Active list.
 - [ ] Confirm launching a second time for the same issue reuses the existing active session instead of creating a duplicate.
@@ -110,7 +115,6 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 
 - [ ] Global hotkey to show/hide the sidebar.
 - [ ] Keyboard navigation for switching sections, selecting rows, opening details, and activating primary actions.
-- [ ] Menu item or command for opening Settings directly from the IssueCTL menu bar item.
 - [ ] Automated UI coverage for native macOS sidebar visibility, collapse state, and persistence.
 - [ ] Multi-display placement preferences beyond the current main-screen default.
-- [ ] More explicit empty/error recovery actions for connection, repo load, draft save, and session terminal failures.
+- [ ] Additional recovery actions for draft save and session terminal failures.

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -34,8 +34,24 @@ struct MacIssueDetailView: View {
                 ProgressView("Loading issue...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let errorMessage, detail == nil {
-                ContentUnavailableView("Could not load issue", systemImage: "wifi.exclamationmark", description: Text(errorMessage))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ContentUnavailableView {
+                    Label("Could not load issue", systemImage: "wifi.exclamationmark")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button {
+                        Task { await load(refresh: true) }
+                    } label: {
+                        if isRefreshing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Retry", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(isRefreshing)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -70,14 +70,6 @@ struct MacIssuesView: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-
-            if let errorMessage = store.errorMessage, !store.issues.isEmpty {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
         }
         .padding(12)
     }

--- a/apple/IssueCTLMac/Views/MacRecoveryBanner.swift
+++ b/apple/IssueCTLMac/Views/MacRecoveryBanner.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct MacRecoveryBanner: View {
+    let message: String
+    let actionTitle: String
+    let isActionDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 8)
+
+            Button(actionTitle) {
+                action()
+            }
+            .controlSize(.small)
+            .disabled(isActionDisabled)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 14)
+        .padding(.bottom, 10)
+    }
+}

--- a/apple/IssueCTLMac/Views/MacSessionsView.swift
+++ b/apple/IssueCTLMac/Views/MacSessionsView.swift
@@ -45,10 +45,19 @@ struct MacSessionsView: View {
             }
 
             if let errorMessage {
-                Label(errorMessage, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .fixedSize(horizontal: false, vertical: true)
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Spacer(minLength: 8)
+
+                    Button("Retry Refresh") {
+                        Task { await retryRefresh() }
+                    }
+                    .controlSize(.small)
+                }
             }
         }
         .padding(12)
@@ -133,6 +142,14 @@ struct MacSessionsView: View {
             try await store.endSession(api: api, session: session)
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func retryRefresh() async {
+        errorMessage = nil
+        await store.refreshSessions(api: api)
+        if let storeError = store.errorMessage {
+            errorMessage = storeError
         }
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -164,6 +164,15 @@ struct MacSidebarRootView: View {
     private var dashboard: some View {
         VStack(spacing: 0) {
             dashboardToolbar
+            if let errorMessage = store.errorMessage {
+                MacRecoveryBanner(
+                    message: errorMessage,
+                    actionTitle: "Retry",
+                    isActionDisabled: store.isLoading
+                ) {
+                    Task { await store.load(api: api, refresh: true) }
+                }
+            }
             Picker("Section", selection: $selectedSection) {
                 ForEach(MacSidebarSection.allCases) { section in
                     Label(section.title, systemImage: section.systemImage)
@@ -250,7 +259,7 @@ struct MacSidebarRootView: View {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    Label("Connect", systemImage: "bolt.horizontal.circle")
+                    Label(connectionError == nil ? "Connect" : "Retry Connect", systemImage: "bolt.horizontal.circle")
                 }
             }
             .buttonStyle(.borderedProminent)

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -66,6 +66,7 @@ final class MacSidebarStore {
     }
 
     func refreshDrafts(api: APIClient) async {
+        errorMessage = nil
         do {
             drafts = try await api.listDrafts().drafts
         } catch {
@@ -150,6 +151,7 @@ final class MacSidebarStore {
     }
 
     func refreshSessions(api: APIClient) async {
+        errorMessage = nil
         do {
             sessions = try await api.activeDeployments(refresh: true).deployments
         } catch {


### PR DESCRIPTION
## Summary
- add Settings to the IssueCTL menu bar menu
- add reusable Mac retry banner for sidebar load errors
- add Retry Connect, issue-detail Retry, and Active tab Retry Refresh affordances
- clear stale store errors when refreshing drafts/sessions
- update native macOS sidebar QA checklist and backlog

## Verification
- xcodegen generate --spec apple/project.yml
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS,arch=arm64' test
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
- launch/quit smoke for IssueCTLMac.app
- git diff --check

Notes:
- No native UI automation added in this slice; QA checklist covers the new menu and retry flows.
- Pre-commit typecheck/lint passed with existing warning-only lint output.