### PR TITLE
[codex] Improve macOS sidebar dogfood setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ issuectl tracks GitHub issues across multiple repos and launches agent sessions 
 
 Native Apple clients live in `apple/`: the iOS app, the macOS sidebar app, and shared Swift models/services used by both.
 
+For native macOS sidebar dogfooding from a fresh clone, see [macOS Sidebar Dogfood Setup](docs/workflows/macos-sidebar-dogfood.md). The helper command is:
+
+```bash
+pnpm mac:sidebar:dev
+```
+
 ## Launch agents
 
 issuectl can launch issues with either Claude Code or Codex. Choose a default agent in Settings, or select an agent per launch from the web and iOS launch flows.

--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		358CDAE5EB531763716F6364 /* PushDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013A1B391EF1CD6F786CEE87 /* PushDevice.swift */; };
 		368A4541ED8C153C41267751 /* SetupLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1D044DCA62B13F4196F816 /* SetupLink.swift */; };
 		3719E03E98785A8075A6F871 /* ErrorAutoDismissModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458A6E2819377536E7EDF138 /* ErrorAutoDismissModifier.swift */; };
+		37FE4957D5AE2E66CA7860DB /* LocalIssueCTLConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE84C571530B405E4375D9C /* LocalIssueCTLConnectionTests.swift */; };
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
 		3C8E5B7EEE8B870210CB8DDC /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162B5421C0F279C8492942 /* APIClient.swift */; };
 		3D1ECFFEF7507D51F7F2E0C2 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
@@ -144,6 +145,7 @@
 		AA3252F10785CFF948F2B058 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C1581E55A12781F1E76A1 /* ContentView.swift */; };
 		AAFAE2475EF1A39328204F4F /* MacSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959347AB556CB71BEA308105 /* MacSettingsView.swift */; };
 		AB8FF61639D060883C77859B /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */; };
+		ABD4FEB7F53690ECF6E60CDC /* MacSidebarTextScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CDE37EDB8F4EA3712FE68E /* MacSidebarTextScale.swift */; };
 		AC365E4994FF7C90DE1AB835 /* IssueCommentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */; };
 		AC8A27DFD7686F7350A8B4D3 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EDF1F24285C1D3795B24B1 /* TestHelpers.swift */; };
 		B0B4D310A36FCCDF3F73C336 /* CacheAgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2841D89323711B68449BB980 /* CacheAgeLabel.swift */; };
@@ -161,6 +163,7 @@
 		BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
 		BD0B799349874304A0D862B1 /* LaunchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */; };
 		BDDD77609BB45F218D8DBFDC /* MacSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26774436FC5A498AFD32CF2B /* MacSessionsView.swift */; };
+		BFA2973BEE286F4D40E43FDE /* LocalIssueCTLConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07231E41ACD9BCAD8B40A095 /* LocalIssueCTLConnection.swift */; };
 		BFC0A82D9CCFD653415A4A82 /* MacSidebarRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134385CA01429770C742CD89 /* MacSidebarRootView.swift */; };
 		C02C3F84D16B27F60A6622E0 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EDD5BE2AB56ED93A092C0C /* MarkdownView.swift */; };
 		C056855F40043A20AC6DD43D /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2045894076CF711FE18DAA /* GitHubAccessibleRepo.swift */; };
@@ -267,6 +270,7 @@
 		013A1B391EF1CD6F786CEE87 /* PushDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushDevice.swift; sourceTree = "<group>"; };
 		0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoFilterChips.swift; sourceTree = "<group>"; };
 		0673773EAA795511DA62722B /* IssueCTLMacUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLMacUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		07231E41ACD9BCAD8B40A095 /* LocalIssueCTLConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalIssueCTLConnection.swift; sourceTree = "<group>"; };
 		0881CAEF6DBC120F31F7D3D8 /* APIClient+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Settings.swift"; sourceTree = "<group>"; };
 		093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacDraftsView.swift; sourceTree = "<group>"; };
@@ -278,6 +282,7 @@
 		13760098C8ED1658B27AD54B /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		15319A8AF148A10DF82FE6DD /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
+		1DE84C571530B405E4375D9C /* LocalIssueCTLConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalIssueCTLConnectionTests.swift; sourceTree = "<group>"; };
 		223E1C810B3BD014B117301B /* IssueCTLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCTLApp.swift; sourceTree = "<group>"; };
 		22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIssueSheet.swift; sourceTree = "<group>"; };
 		2438738AD84484EC2E7B20C9 /* NotificationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferences.swift; sourceTree = "<group>"; };
@@ -305,6 +310,7 @@
 		48746522237ABF37AF77B1DA /* APIClient+ListEnhancements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ListEnhancements.swift"; sourceTree = "<group>"; };
 		488FA6CF4785A8769D688726 /* IssueCommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentSheet.swift; sourceTree = "<group>"; };
 		493D2F4114A7CD0C28DC8F76 /* APIClient+DetailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+DetailActions.swift"; sourceTree = "<group>"; };
+		49CDE37EDB8F4EA3712FE68E /* MacSidebarTextScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarTextScale.swift; sourceTree = "<group>"; };
 		4F2045894076CF711FE18DAA /* GitHubAccessibleRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAccessibleRepo.swift; sourceTree = "<group>"; };
 		533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDecodingTests.swift; sourceTree = "<group>"; };
 		5695C48F5E921940A3CBDA5A /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
@@ -527,6 +533,7 @@
 		6FAB6ED3CEA82D4567F1E04B /* Platform */ = {
 			isa = PBXGroup;
 			children = (
+				07231E41ACD9BCAD8B40A095 /* LocalIssueCTLConnection.swift */,
 				708F54652A23B2732C519A72 /* MacSidebarPreferences.swift */,
 				EEA90F554E1CF22EA56B51AB /* PerformanceTrace.swift */,
 				8FB818A0B361A38DCB604FB7 /* SidebarPanelController.swift */,
@@ -564,6 +571,7 @@
 		82D31594429EC9DE06A2DFF6 /* IssueCTLMacTests */ = {
 			isa = PBXGroup;
 			children = (
+				1DE84C571530B405E4375D9C /* LocalIssueCTLConnectionTests.swift */,
 				78C02C0464A65420CBD5D90E /* MacSidebarPreferencesTests.swift */,
 			);
 			path = IssueCTLMacTests;
@@ -685,6 +693,7 @@
 				959347AB556CB71BEA308105 /* MacSettingsView.swift */,
 				134385CA01429770C742CD89 /* MacSidebarRootView.swift */,
 				E04E7DE3BF0A6826FE986B1D /* MacSidebarStore.swift */,
+				49CDE37EDB8F4EA3712FE68E /* MacSidebarTextScale.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1202,6 +1211,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37FE4957D5AE2E66CA7860DB /* LocalIssueCTLConnectionTests.swift in Sources */,
 				CCD66F76181E54FD2700F813 /* MacSidebarPreferencesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1263,6 +1273,7 @@
 				5C8B076C5D41EB2832394E74 /* Issue.swift in Sources */,
 				CA0880B76E28E6276050AEB3 /* IssueCTLMacApp.swift in Sources */,
 				0C49D98F7B92CA24BCC44AEB /* KeychainService.swift in Sources */,
+				BFA2973BEE286F4D40E43FDE /* LocalIssueCTLConnection.swift in Sources */,
 				5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */,
 				C9D9618A4076FAE0E98D71AC /* MacIssueDetailView.swift in Sources */,
 				250D0308D12F0EE129E4C7E2 /* MacIssuesView.swift in Sources */,
@@ -1272,6 +1283,7 @@
 				A66082BC0A4EF30F160CF9C5 /* MacSidebarPreferences.swift in Sources */,
 				BFC0A82D9CCFD653415A4A82 /* MacSidebarRootView.swift in Sources */,
 				22B99716E42E20F0DA147C5B /* MacSidebarStore.swift in Sources */,
+				ABD4FEB7F53690ECF6E60CDC /* MacSidebarTextScale.swift in Sources */,
 				B4AF2A85F0768942BCD81D8C /* NetworkMonitor.swift in Sources */,
 				D9E454235B1E43451B1B9597 /* NotificationPreferences.swift in Sources */,
 				3F98C9896C5653D619ABA40F /* OfflineCacheStore.swift in Sources */,

--- a/apple/IssueCTLMac/Platform/LocalIssueCTLConnection.swift
+++ b/apple/IssueCTLMac/Platform/LocalIssueCTLConnection.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SQLite3
+
+struct LocalIssueCTLConnection {
+    static let defaultServerURL = "http://localhost:3847"
+
+    let databaseURL: URL
+    let serverURL: String
+
+    init(
+        databaseURL: URL = Self.defaultDatabaseURL(),
+        serverURL: String = Self.defaultServerURL
+    ) {
+        self.databaseURL = databaseURL
+        self.serverURL = serverURL
+    }
+
+    static func defaultDatabaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        if let path = environment["ISSUECTL_DB_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !path.isEmpty {
+            return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+        }
+
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".issuectl")
+            .appendingPathComponent("issuectl.db")
+    }
+
+    func apiToken() throws -> String? {
+        guard FileManager.default.fileExists(atPath: databaseURL.path) else {
+            return nil
+        }
+
+        var database: OpaquePointer?
+        let openResult = sqlite3_open_v2(databaseURL.path, &database, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil)
+        guard openResult == SQLITE_OK, let database else {
+            defer { sqlite3_close(database) }
+            throw LocalIssueCTLConnectionError.openFailed(message: sqliteMessage(database))
+        }
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        let query = "SELECT value FROM settings WHERE key = 'api_token' LIMIT 1"
+        guard sqlite3_prepare_v2(database, query, -1, &statement, nil) == SQLITE_OK else {
+            defer { sqlite3_finalize(statement) }
+            throw LocalIssueCTLConnectionError.queryFailed(message: sqliteMessage(database))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              let tokenPointer = sqlite3_column_text(statement, 0) else {
+            return nil
+        }
+
+        let token = String(cString: tokenPointer).trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.isEmpty ? nil : token
+    }
+
+    private func sqliteMessage(_ database: OpaquePointer?) -> String {
+        guard let message = sqlite3_errmsg(database) else { return "Unknown SQLite error" }
+        return String(cString: message)
+    }
+}
+
+enum LocalIssueCTLConnectionError: LocalizedError {
+    case openFailed(message: String)
+    case queryFailed(message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .openFailed(let message):
+            "Could not open local issuectl database: \(message)"
+        case .queryFailed(let message):
+            "Could not read local issuectl API token: \(message)"
+        }
+    }
+}

--- a/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
+++ b/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
@@ -8,6 +8,7 @@ final class MacSidebarPreferences {
         static let isCollapsed = "mac.sidebar.isCollapsed"
         static let selectedSection = "mac.sidebar.selectedSection"
         static let expandedWidth = "mac.sidebar.expandedWidth"
+        static let textScale = "mac.sidebar.textScale"
     }
 
     private let defaults: UserDefaults
@@ -24,6 +25,10 @@ final class MacSidebarPreferences {
         didSet { defaults.set(Double(expandedWidth), forKey: Keys.expandedWidth) }
     }
 
+    var textScale: Double {
+        didSet { defaults.set(textScale, forKey: Keys.textScale) }
+    }
+
     var launchAtLogin = false
     var launchAtLoginError: String?
 
@@ -32,6 +37,7 @@ final class MacSidebarPreferences {
         isCollapsed = defaults.object(forKey: Keys.isCollapsed) as? Bool ?? false
         selectedSectionRawValue = defaults.string(forKey: Keys.selectedSection) ?? "issues"
         expandedWidth = Self.clampedWidth(defaults.object(forKey: Keys.expandedWidth) as? Double ?? 380)
+        textScale = Self.clampedTextScale(defaults.object(forKey: Keys.textScale) as? Double ?? Self.defaultTextScale)
         refreshLaunchAtLoginStatus()
     }
 
@@ -61,11 +67,15 @@ final class MacSidebarPreferences {
         isCollapsed = false
         selectedSectionRawValue = "issues"
         expandedWidth = Self.defaultExpandedWidth
+        textScale = Self.defaultTextScale
     }
 
     nonisolated static let defaultExpandedWidth: CGFloat = 380
     nonisolated static let minimumExpandedWidth: CGFloat = 340
     nonisolated static let maximumExpandedWidth: CGFloat = 560
+    nonisolated static let defaultTextScale = 1.1
+    nonisolated static let minimumTextScale = 0.95
+    nonisolated static let maximumTextScale = 1.35
 
     nonisolated static func clampedWidth(_ width: CGFloat) -> CGFloat {
         min(max(width, minimumExpandedWidth), maximumExpandedWidth)
@@ -73,5 +83,9 @@ final class MacSidebarPreferences {
 
     nonisolated static func clampedWidth(_ width: Double) -> CGFloat {
         clampedWidth(CGFloat(width))
+    }
+
+    nonisolated static func clampedTextScale(_ scale: Double) -> Double {
+        min(max(scale, minimumTextScale), maximumTextScale)
     }
 }

--- a/apple/IssueCTLMac/Platform/SidebarPanelController.swift
+++ b/apple/IssueCTLMac/Platform/SidebarPanelController.swift
@@ -70,25 +70,33 @@ final class SidebarPanelController: NSObject, NSWindowDelegate {
 
         panel = NSPanel(
             contentRect: frame,
-            styleMask: [.nonactivatingPanel, .titled, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false
         )
         panel.contentViewController = hostingController
         panel.title = "IssueCTL"
-        panel.titleVisibility = .hidden
-        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .visible
+        panel.titlebarAppearsTransparent = false
+        panel.backgroundColor = .windowBackgroundColor
+        panel.isOpaque = true
+        panel.hasShadow = true
         panel.isFloatingPanel = true
+        panel.isReleasedWhenClosed = false
         panel.hidesOnDeactivate = false
         panel.level = .floating
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        panel.collectionBehavior = [.moveToActiveSpace]
         panel.delegate = self
         updateSizeConstraints()
     }
 
     func show() {
         panel.setFrame(Self.defaultFrame(width: currentWidth), display: true)
+        alignToSidebarPosition()
+        panel.level = .statusBar
+        panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
+        NSApp.activate(ignoringOtherApps: true)
         chrome.isVisible = true
     }
 
@@ -120,6 +128,7 @@ final class SidebarPanelController: NSObject, NSWindowDelegate {
         preferences.isCollapsed = isCollapsed
         updateSizeConstraints()
         panel.setFrame(Self.defaultFrame(width: currentWidth), display: true, animate: true)
+        alignToSidebarPosition()
         if !panel.isVisible {
             show()
         }
@@ -130,6 +139,7 @@ final class SidebarPanelController: NSObject, NSWindowDelegate {
         chrome.isCollapsed = preferences.isCollapsed
         updateSizeConstraints()
         panel.setFrame(Self.defaultFrame(width: currentWidth), display: true, animate: true)
+        alignToSidebarPosition()
         if !panel.isVisible {
             show()
         }
@@ -138,6 +148,11 @@ final class SidebarPanelController: NSObject, NSWindowDelegate {
     func windowDidResize(_ notification: Notification) {
         guard !chrome.isCollapsed else { return }
         saveExpandedWidth(panel.frame.width)
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        hide()
+        return false
     }
 
     private var currentWidth: CGFloat {
@@ -162,16 +177,31 @@ final class SidebarPanelController: NSObject, NSWindowDelegate {
         preferences.expandedWidth = expandedWidth
     }
 
+    private func alignToSidebarPosition() {
+        let visibleFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+        panel.center()
+
+        var frame = panel.frame
+        frame.origin.x = visibleFrame.maxX - frame.width - Metrics.horizontalInset
+        frame.origin.y = min(
+            max(frame.origin.y, visibleFrame.minY + Metrics.verticalInset),
+            visibleFrame.maxY - frame.height - Metrics.verticalInset
+        )
+        panel.setFrame(frame, display: true)
+    }
+
     private static func defaultFrame(width requestedWidth: CGFloat = Metrics.defaultExpandedWidth) -> NSRect {
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let width = requestedWidth == Metrics.collapsedWidth
             ? Metrics.collapsedWidth
             : min(max(requestedWidth, Metrics.expandedMinWidth), Metrics.expandedMaxWidth)
+        let height = min(max(Metrics.minimumHeight, 720), max(screenFrame.height - (Metrics.verticalInset * 2), Metrics.minimumHeight))
         return NSRect(
             x: screenFrame.maxX - width - Metrics.horizontalInset,
-            y: screenFrame.minY + Metrics.verticalInset,
+            y: screenFrame.maxY - height - Metrics.verticalInset,
             width: width,
-            height: max(screenFrame.height - (Metrics.verticalInset * 2), Metrics.minimumHeight)
+            height: height
         )
     }
 }

--- a/apple/IssueCTLMac/QA.md
+++ b/apple/IssueCTLMac/QA.md
@@ -1,12 +1,16 @@
 # IssueCTLMac Sidebar Manual QA
 
-Use this checklist for manual regression passes on the native macOS sidebar. Run against a local `issuectl web` server with at least one tracked repo, one open issue, and a valid API token.
+Use this checklist for manual regression passes on the native macOS sidebar. Run against a local `issuectl web` server with at least one tracked repo, one open issue, and a saved local API token.
+
+For fresh-clone setup on another Mac, follow [macOS Sidebar Dogfood Setup](../../docs/workflows/macos-sidebar-dogfood.md) first.
 
 ## Build And Launch
 
-- [ ] From the repo root, build the macOS target:
-  `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' build`
-- [ ] Launch `IssueCTLMac` from Xcode with the `IssueCTLMac` scheme.
+- [ ] From the repo root, build and launch the macOS target:
+  `pnpm mac:sidebar:dev`
+- [ ] Or build manually with `xcodegen generate --spec apple/project.yml`, then:
+  `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- [ ] Launch `IssueCTLMac` from Xcode with the `IssueCTLMac` scheme, or open the built app from DerivedData.
 - [ ] Confirm the app starts as a menu bar/accessory app, without a Dock window.
 - [ ] Confirm the IssueCTL sidebar appears automatically on launch.
 - [ ] Confirm the sidebar is positioned on the right side of the visible screen with usable height.
@@ -28,9 +32,9 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] Use the menu bar Toggle Sidebar command and confirm the panel reappears.
 - [ ] Use Escape while the sidebar has focus and confirm the panel hides.
 - [ ] Click the header Collapse Sidebar button and confirm the panel animates to the narrow rail.
-- [ ] In collapsed mode, verify the rail shows Issues, Drafts, Active, Refresh, Expand Sidebar, and Hide Sidebar controls.
+- [ ] In collapsed mode, verify the rail shows a labeled Expand control near the top plus Issues, Drafts, Active, Refresh, and Hide Sidebar controls.
+- [ ] Click the labeled Expand control and confirm the full sidebar returns.
 - [ ] Select each collapsed rail section and confirm the selected icon highlight moves.
-- [ ] Click Expand Sidebar and confirm the full sidebar returns.
 - [ ] Resize the expanded sidebar narrower and wider; confirm it respects the min and max width limits.
 - [ ] Collapse and expand after resizing; confirm the previous expanded width is restored.
 
@@ -51,16 +55,19 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 - [ ] Toggle Launch at Login off and confirm no error is shown.
 - [ ] Toggle Open Collapsed on Next Launch on, relaunch, and confirm the sidebar starts collapsed.
 - [ ] Toggle Open Collapsed on Next Launch off, relaunch, and confirm the sidebar starts expanded.
+- [ ] Adjust Text Size, quit, relaunch, and confirm the saved text scale is restored.
 - [ ] Resize the expanded sidebar and confirm Saved Width updates in Settings.
 - [ ] Click Reset Sidebar Layout and confirm the sidebar state changes immediately.
 
 ## Connection
 
-- [ ] Start the server with `issuectl web` and copy the printed API token.
-- [ ] Launch the macOS app with no saved connection and confirm the connection form appears.
+- [ ] Start the server with `issuectl web`.
+- [ ] Confirm `issuectl web` is running on the same Mac as `IssueCTLMac` when using `http://localhost:3847`.
+- [ ] Launch the macOS app with no saved Keychain connection and confirm it auto-connects from `~/.issuectl/issuectl.db`.
+- [ ] If `issuectl web` is stopped or the local token is missing, confirm the connection form appears.
 - [ ] Enter an invalid server URL or token and confirm an inline error appears.
 - [ ] After a failed connection, confirm Retry Connect is visible and reuses the entered URL/token.
-- [ ] Enter `http://localhost:3847` and a valid API token, then click Connect.
+- [ ] Enter `http://localhost:3847` and a valid API token, then click Connect to verify manual fallback.
 - [ ] Confirm the dashboard replaces the connection form after a successful health check.
 - [ ] Confirm the toolbar summary shows issue, draft, and active session counts.
 - [ ] Click Refresh and confirm loading state appears without duplicating rows.
@@ -72,6 +79,8 @@ Use this checklist for manual regression passes on the native macOS sidebar. Run
 
 - [ ] Open the Issues tab and confirm open issues load for tracked repos.
 - [ ] Verify the Open, Unassigned, and All filters update the visible list.
+- [ ] Use the Repositories filter to select one repo, all repos, and no repos; confirm the visible issue count updates.
+- [ ] If more than 50 issues match, confirm the list stops at the first batch and Show 50 More appends the next batch.
 - [ ] Search by issue title and confirm matching rows remain.
 - [ ] Search by repo full name and confirm matching rows remain.
 - [ ] Open an issue row and confirm the detail sheet loads title, repo, issue number, labels, assignees, body, and comments.

--- a/apple/IssueCTLMac/RELEASE.md
+++ b/apple/IssueCTLMac/RELEASE.md
@@ -10,6 +10,12 @@ Replace the asset catalog when final shared Apple branding is available.
 From the repo root:
 
 ```sh
+pnpm mac:sidebar:dev --no-open
+```
+
+Or run the build commands directly:
+
+```sh
 xcodegen generate --spec apple/project.yml
 xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
 ```

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -1,15 +1,25 @@
 import SwiftUI
 
 struct MacIssuesView: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
     let store: MacSidebarStore
 
     @State private var searchText = ""
     @State private var selectedFilter: IssueFilter = .open
+    @State private var selectedRepoIds = Set<Int>()
+    @State private var knownRepoIds = Set<Int>()
+    @State private var hasInitializedRepoSelection = false
+    @State private var isRepoFilterExpanded = true
+    @State private var visiblePageCount = 1
     @State private var selectedIssue: MacIssueListItem?
+
+    private let pageSize = 50
 
     private var visibleIssues: [MacIssueListItem] {
         let filtered = store.issues.filter { item in
-            switch selectedFilter {
+            let matchesRepo = selectedRepoIds.contains(item.repo.id)
+            let matchesState = switch selectedFilter {
             case .open:
                 item.issue.isOpen
             case .all:
@@ -17,6 +27,7 @@ struct MacIssuesView: View {
             case .unassigned:
                 item.issue.isOpen && (item.issue.assignees ?? []).isEmpty
             }
+            return matchesRepo && matchesState
         }
 
         guard !searchText.isEmpty else { return filtered }
@@ -26,6 +37,31 @@ struct MacIssuesView: View {
                 || (item.issue.body ?? "").lowercased().contains(query)
                 || item.repoFullName.lowercased().contains(query)
         }
+    }
+
+    private var pagedIssues: [MacIssueListItem] {
+        Array(visibleIssues.prefix(visibleLimit))
+    }
+
+    private var visibleLimit: Int {
+        max(pageSize, visiblePageCount * pageSize)
+    }
+
+    private var hasMoreIssues: Bool {
+        visibleIssues.count > pagedIssues.count
+    }
+
+    private var repoFilterSummary: String {
+        if store.repos.isEmpty {
+            return "No repos"
+        }
+        if selectedRepoIds.isEmpty {
+            return "No repos selected"
+        }
+        if selectedRepoIds.count == store.repos.count {
+            return "All repos"
+        }
+        return "\(selectedRepoIds.count) of \(store.repos.count) repos"
     }
 
     var body: some View {
@@ -42,36 +78,152 @@ struct MacIssuesView: View {
                 ContentUnavailableView(emptyTitle, systemImage: "tray", description: Text(emptyDescription))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                List(visibleIssues) { item in
-                    Button {
-                        selectedIssue = item
-                    } label: {
-                        MacIssueRow(item: item, isRunning: isRunning(item))
+                List {
+                    ForEach(pagedIssues) { item in
+                        Button {
+                            selectedIssue = item
+                        } label: {
+                            MacIssueRow(item: item, isRunning: isRunning(item))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
+
+                    if hasMoreIssues {
+                        HStack {
+                            Spacer()
+                            Button {
+                                visiblePageCount += 1
+                            } label: {
+                                Label("Show 50 More", systemImage: "chevron.down")
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            Spacer()
+                        }
+                        .padding(.vertical, 10)
+                    } else if visibleIssues.count > pageSize {
+                        Text("Showing all \(visibleIssues.count) matching issues")
+                            .font(.macSidebar(size: 11, scale: textScale))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                    }
                 }
                 .listStyle(.plain)
             }
         }
+        .onChange(of: searchText) { _, _ in resetPaging() }
+        .onChange(of: selectedFilter) { _, _ in resetPaging() }
+        .onChange(of: selectedRepoIds) { _, _ in resetPaging() }
+        .onChange(of: store.issues.count) { _, _ in
+            syncRepoSelection()
+            resetPaging()
+        }
+        .onChange(of: store.repos.count) { _, _ in syncRepoSelection() }
+        .onAppear { syncRepoSelection() }
         .sheet(item: $selectedIssue) { item in
             MacIssueDetailView(item: item, store: store)
         }
     }
 
     private var controls: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             TextField("Search issues", text: $searchText)
                 .textFieldStyle(.roundedBorder)
 
-            Picker("Filter", selection: $selectedFilter) {
-                ForEach(IssueFilter.allCases) { filter in
-                    Text(filter.title).tag(filter)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Filters")
+                    .font(.macSidebar(size: 11, weight: .semibold, scale: textScale))
+                    .foregroundStyle(.secondary)
+
+                Picker("Issue state", selection: $selectedFilter) {
+                    ForEach(IssueFilter.allCases) { filter in
+                        Text(filter.title).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+
+            DisclosureGroup(isExpanded: $isRepoFilterExpanded) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Button("All") {
+                            selectedRepoIds = Set(store.repos.map(\.id))
+                        }
+                        .controlSize(.small)
+
+                        Button("None") {
+                            selectedRepoIds.removeAll()
+                        }
+                        .controlSize(.small)
+
+                        Spacer()
+                    }
+
+                    ForEach(store.repos) { repo in
+                        Toggle(repo.fullName, isOn: repoBinding(repo))
+                            .toggleStyle(.checkbox)
+                            .font(.macSidebar(size: 12, scale: textScale))
+                    }
+                }
+                .padding(.top, 4)
+            } label: {
+                HStack {
+                    Text("Repositories")
+                        .font(.macSidebar(size: 11, weight: .semibold, scale: textScale))
+                    Spacer()
+                    Text(repoFilterSummary)
+                        .font(.macSidebar(size: 11, scale: textScale))
+                        .foregroundStyle(.secondary)
                 }
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
+
+            Text("Showing \(pagedIssues.count) of \(visibleIssues.count) matching issues")
+                .font(.macSidebar(size: 11, scale: textScale))
+                .foregroundStyle(.secondary)
         }
         .padding(12)
+    }
+
+    private func repoBinding(_ repo: Repo) -> Binding<Bool> {
+        Binding(
+            get: { selectedRepoIds.contains(repo.id) },
+            set: { isSelected in
+                if isSelected {
+                    selectedRepoIds.insert(repo.id)
+                } else {
+                    selectedRepoIds.remove(repo.id)
+                }
+            }
+        )
+    }
+
+    private func resetPaging() {
+        visiblePageCount = 1
+    }
+
+    private func syncRepoSelection() {
+        let repoIds = Set(store.repos.map(\.id))
+        guard !repoIds.isEmpty else {
+            selectedRepoIds.removeAll()
+            knownRepoIds.removeAll()
+            return
+        }
+
+        if !hasInitializedRepoSelection {
+            selectedRepoIds = repoIds
+            knownRepoIds = repoIds
+            hasInitializedRepoSelection = true
+            return
+        }
+
+        if selectedRepoIds == knownRepoIds {
+            selectedRepoIds = repoIds
+        } else {
+            selectedRepoIds = selectedRepoIds.intersection(repoIds)
+        }
+        knownRepoIds = repoIds
     }
 
     private func isRunning(_ item: MacIssueListItem) -> Bool {
@@ -90,6 +242,12 @@ struct MacIssuesView: View {
     private var emptyDescription: String {
         if !searchText.isEmpty {
             return "Clear search to show visible issues."
+        }
+        if selectedRepoIds.isEmpty && !store.repos.isEmpty {
+            return "Select at least one repository to show issues."
+        }
+        if selectedRepoIds.count < store.repos.count {
+            return "No issues match the selected repositories."
         }
         switch selectedFilter {
         case .open:
@@ -119,6 +277,8 @@ private enum IssueFilter: String, CaseIterable, Identifiable {
 }
 
 private struct MacIssueRow: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
     let item: MacIssueListItem
     let isRunning: Bool
 
@@ -126,7 +286,7 @@ private struct MacIssueRow: View {
         VStack(alignment: .leading, spacing: 7) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(item.issue.title)
-                    .font(.subheadline.weight(.medium))
+                    .font(.macSidebar(size: 14, weight: .medium, scale: textScale))
                     .lineLimit(2)
                 if isRunning {
                     Image(systemName: "terminal.fill")
@@ -157,8 +317,8 @@ private struct MacIssueRow: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .font(.caption)
+            .font(.macSidebar(size: 12, scale: textScale))
         }
-        .padding(.vertical, 5)
+        .padding(.vertical, 6)
     }
 }

--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -32,6 +32,29 @@ struct MacSettingsView: View {
 
                 Toggle("Open Collapsed on Next Launch", isOn: collapsedOnLaunchBinding)
 
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Text Size")
+                        Spacer()
+                        Text("\(Int(preferences.textScale * 100))%")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Slider(
+                        value: textScaleBinding,
+                        in: MacSidebarPreferences.minimumTextScale...MacSidebarPreferences.maximumTextScale,
+                        step: 0.05
+                    )
+
+                    HStack {
+                        Text("Smaller")
+                        Spacer()
+                        Text("Larger")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
                 HStack {
                     Text("Saved Width")
                     Spacer()
@@ -70,6 +93,13 @@ struct MacSettingsView: View {
         Binding(
             get: { preferences.isCollapsed },
             set: { preferences.isCollapsed = $0 }
+        )
+    }
+
+    private var textScaleBinding: Binding<Double> {
+        Binding(
+            get: { preferences.textScale },
+            set: { preferences.textScale = MacSidebarPreferences.clampedTextScale($0) }
         )
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -11,6 +11,8 @@ struct MacSidebarRootView: View {
     @State private var serverURL = "http://localhost:3847"
     @State private var apiToken = ""
     @State private var isCheckingConnection = false
+    @State private var isAutoConnecting = false
+    @State private var hasAttemptedAutoConnect = false
     @State private var connectionError: String?
     @State private var store = MacSidebarStore()
 
@@ -26,8 +28,12 @@ struct MacSidebarRootView: View {
         .onExitCommand {
             hideSidebar()
         }
+        .environment(\.macSidebarTextScale, preferences.textScale)
         .onAppear {
             selectedSection = MacSidebarSection(rawValue: preferences.selectedSectionRawValue) ?? .issues
+        }
+        .task {
+            await autoConnectIfAvailable()
         }
         .onChange(of: selectedSection) { _, newValue in
             preferences.selectedSectionRawValue = newValue.rawValue
@@ -82,6 +88,7 @@ struct MacSidebarRootView: View {
                 Button {
                     api.disconnect()
                     store.reset()
+                    hasAttemptedAutoConnect = true
                 } label: {
                     Image(systemName: "rectangle.portrait.and.arrow.right")
                 }
@@ -100,6 +107,24 @@ struct MacSidebarRootView: View {
             Image(systemName: "list.bullet.rectangle")
                 .font(.title3.weight(.semibold))
                 .padding(.top, 12)
+
+            Button {
+                toggleSidebarCollapsed()
+            } label: {
+                VStack(spacing: 3) {
+                    Image(systemName: "sidebar.leading")
+                        .font(.system(size: 17, weight: .semibold))
+                    Text("Expand")
+                        .font(.caption2.weight(.semibold))
+                }
+                .frame(width: 60, height: 48)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel("Expand Sidebar")
+            .help("Expand Sidebar")
+            .accessibilityIdentifier("mac-sidebar-expand-button")
 
             Divider()
 
@@ -138,17 +163,6 @@ struct MacSidebarRootView: View {
             .help("Refresh")
 
             Spacer()
-
-            Button {
-                toggleSidebarCollapsed()
-            } label: {
-                Image(systemName: "sidebar.leading")
-                    .frame(width: 36, height: 32)
-            }
-            .buttonStyle(.borderless)
-            .accessibilityLabel("Expand Sidebar")
-            .help("Expand Sidebar")
-            .accessibilityIdentifier("mac-sidebar-expand-button")
 
             Button {
                 hideSidebar()
@@ -242,11 +256,21 @@ struct MacSidebarRootView: View {
     private var connectionView: some View {
         VStack(alignment: .leading, spacing: 14) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Connect to issuectl web")
+                Text(isAutoConnecting ? "Connecting to local issuectl web" : "Connect to issuectl web")
                     .font(.title3.weight(.semibold))
-                Text("Start `issuectl web`, then use the API token printed by the server.")
+                Text(connectionHelpText)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if isAutoConnecting {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Using the local server token from ~/.issuectl/issuectl.db")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             TextField("Server URL", text: $serverURL)
@@ -265,7 +289,7 @@ struct MacSidebarRootView: View {
             Button {
                 Task { await connect() }
             } label: {
-                if isCheckingConnection {
+                if isCheckingConnection || isAutoConnecting {
                     ProgressView()
                         .controlSize(.small)
                 } else {
@@ -273,11 +297,40 @@ struct MacSidebarRootView: View {
                 }
             }
             .buttonStyle(.borderedProminent)
-            .disabled(isCheckingConnection || serverURL.isEmpty || apiToken.isEmpty)
+            .disabled(isCheckingConnection || isAutoConnecting || serverURL.isEmpty || apiToken.isEmpty)
 
             Spacer()
         }
         .padding(18)
+    }
+
+    private var connectionHelpText: String {
+        if isAutoConnecting {
+            return "The mac sidebar runs on the same Mac as `issuectl web`, so it can connect automatically."
+        }
+        return "Start `issuectl web`; the sidebar will try localhost automatically. You can still enter a URL and token manually."
+    }
+
+    private func autoConnectIfAvailable() async {
+        guard !api.isConfigured, !hasAttemptedAutoConnect, !isAutoConnecting else { return }
+
+        hasAttemptedAutoConnect = true
+        isAutoConnecting = true
+        connectionError = nil
+        defer { isAutoConnecting = false }
+
+        let localConnection = LocalIssueCTLConnection()
+
+        do {
+            guard let token = try localConnection.apiToken() else { return }
+            _ = try await api.checkHealth(url: localConnection.serverURL, token: token)
+            try api.configure(url: localConnection.serverURL, token: token)
+            serverURL = localConnection.serverURL
+            apiToken = token
+            await store.load(api: api, refresh: true)
+        } catch {
+            connectionError = "Could not auto-connect to local issuectl web: \(error.localizedDescription)"
+        }
     }
 
     private func connect() async {

--- a/apple/IssueCTLMac/Views/MacSidebarTextScale.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarTextScale.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+private struct MacSidebarTextScaleKey: EnvironmentKey {
+    static let defaultValue = MacSidebarPreferences.defaultTextScale
+}
+
+extension EnvironmentValues {
+    var macSidebarTextScale: Double {
+        get { self[MacSidebarTextScaleKey.self] }
+        set { self[MacSidebarTextScaleKey.self] = newValue }
+    }
+}
+
+extension Font {
+    static func macSidebar(size: Double, weight: Font.Weight = .regular, scale: Double) -> Font {
+        .system(size: size * scale, weight: weight)
+    }
+}

--- a/apple/IssueCTLMacTests/LocalIssueCTLConnectionTests.swift
+++ b/apple/IssueCTLMacTests/LocalIssueCTLConnectionTests.swift
@@ -1,0 +1,86 @@
+import SQLite3
+import XCTest
+@testable import IssueCTLMac
+
+final class LocalIssueCTLConnectionTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issuectl-local-connection-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectory {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testDefaultDatabaseURLUsesEnvironmentOverride() {
+        let url = LocalIssueCTLConnection.defaultDatabaseURL(environment: [
+            "ISSUECTL_DB_PATH": "~/custom/issuectl.db",
+        ])
+
+        XCTAssertTrue(url.path.hasSuffix("/custom/issuectl.db"))
+        XCTAssertFalse(url.path.contains("~"))
+    }
+
+    func testDefaultDatabaseURLFallsBackToHomeIssueCTLDatabase() {
+        let url = LocalIssueCTLConnection.defaultDatabaseURL(environment: [:])
+
+        XCTAssertTrue(url.path.hasSuffix("/.issuectl/issuectl.db"))
+    }
+
+    func testAPITokenReadsStoredSetting() throws {
+        let databaseURL = temporaryDirectory.appendingPathComponent("issuectl.db")
+        try createSettingsDatabase(at: databaseURL, token: "test-token")
+
+        let connection = LocalIssueCTLConnection(databaseURL: databaseURL)
+
+        XCTAssertEqual(try connection.apiToken(), "test-token")
+    }
+
+    func testAPITokenReturnsNilForMissingDatabase() throws {
+        let databaseURL = temporaryDirectory.appendingPathComponent("missing.db")
+        let connection = LocalIssueCTLConnection(databaseURL: databaseURL)
+
+        XCTAssertNil(try connection.apiToken())
+    }
+
+    func testAPITokenReturnsNilWhenSettingIsAbsent() throws {
+        let databaseURL = temporaryDirectory.appendingPathComponent("issuectl.db")
+        try createSettingsDatabase(at: databaseURL, token: nil)
+
+        let connection = LocalIssueCTLConnection(databaseURL: databaseURL)
+
+        XCTAssertNil(try connection.apiToken())
+    }
+
+    private func createSettingsDatabase(at url: URL, token: String?) throws {
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &database), SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        XCTAssertEqual(
+            sqlite3_exec(database, "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)", nil, nil, nil),
+            SQLITE_OK
+        )
+
+        if let token {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(database, "INSERT INTO settings (key, value) VALUES ('api_token', ?)", -1, &statement, nil),
+                SQLITE_OK
+            )
+            defer { sqlite3_finalize(statement) }
+
+            let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            sqlite3_bind_text(statement, 1, token, -1, transient)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+        }
+    }
+}

--- a/apple/IssueCTLMacTests/MacSidebarPreferencesTests.swift
+++ b/apple/IssueCTLMacTests/MacSidebarPreferencesTests.swift
@@ -26,6 +26,7 @@ final class MacSidebarPreferencesTests: XCTestCase {
         XCTAssertFalse(preferences.isCollapsed)
         XCTAssertEqual(preferences.selectedSectionRawValue, "issues")
         XCTAssertEqual(preferences.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+        XCTAssertEqual(preferences.textScale, MacSidebarPreferences.defaultTextScale)
     }
 
     func testPersistsCollapsedSelectedSectionAndExpandedWidth() {
@@ -34,11 +35,13 @@ final class MacSidebarPreferencesTests: XCTestCase {
         preferences.isCollapsed = true
         preferences.selectedSectionRawValue = "drafts"
         preferences.expandedWidth = 440
+        preferences.textScale = 1.25
 
         let reloaded = MacSidebarPreferences(defaults: defaults)
         XCTAssertTrue(reloaded.isCollapsed)
         XCTAssertEqual(reloaded.selectedSectionRawValue, "drafts")
         XCTAssertEqual(reloaded.expandedWidth, 440)
+        XCTAssertEqual(reloaded.textScale, 1.25)
     }
 
     func testLoadsExpandedWidthClampedToSupportedRange() {
@@ -55,22 +58,39 @@ final class MacSidebarPreferencesTests: XCTestCase {
         )
     }
 
+    func testLoadsTextScaleClampedToSupportedRange() {
+        defaults.set(0.5, forKey: "mac.sidebar.textScale")
+        XCTAssertEqual(
+            MacSidebarPreferences(defaults: defaults).textScale,
+            MacSidebarPreferences.minimumTextScale
+        )
+
+        defaults.set(2.0, forKey: "mac.sidebar.textScale")
+        XCTAssertEqual(
+            MacSidebarPreferences(defaults: defaults).textScale,
+            MacSidebarPreferences.maximumTextScale
+        )
+    }
+
     func testResetLayoutRestoresAndPersistsDefaults() {
         let preferences = MacSidebarPreferences(defaults: defaults)
         preferences.isCollapsed = true
         preferences.selectedSectionRawValue = "settings"
         preferences.expandedWidth = 520
+        preferences.textScale = 1.3
 
         preferences.resetLayout()
 
         XCTAssertFalse(preferences.isCollapsed)
         XCTAssertEqual(preferences.selectedSectionRawValue, "issues")
         XCTAssertEqual(preferences.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+        XCTAssertEqual(preferences.textScale, MacSidebarPreferences.defaultTextScale)
 
         let reloaded = MacSidebarPreferences(defaults: defaults)
         XCTAssertFalse(reloaded.isCollapsed)
         XCTAssertEqual(reloaded.selectedSectionRawValue, "issues")
         XCTAssertEqual(reloaded.expandedWidth, MacSidebarPreferences.defaultExpandedWidth)
+        XCTAssertEqual(reloaded.textScale, MacSidebarPreferences.defaultTextScale)
     }
 
     func testClampedWidthEdgeValues() {
@@ -93,6 +113,29 @@ final class MacSidebarPreferencesTests: XCTestCase {
         XCTAssertEqual(
             MacSidebarPreferences.clampedWidth(MacSidebarPreferences.maximumExpandedWidth + 1),
             MacSidebarPreferences.maximumExpandedWidth
+        )
+    }
+
+    func testClampedTextScaleEdgeValues() {
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedTextScale(MacSidebarPreferences.minimumTextScale - 0.1),
+            MacSidebarPreferences.minimumTextScale
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedTextScale(MacSidebarPreferences.minimumTextScale),
+            MacSidebarPreferences.minimumTextScale
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedTextScale(MacSidebarPreferences.defaultTextScale),
+            MacSidebarPreferences.defaultTextScale
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedTextScale(MacSidebarPreferences.maximumTextScale),
+            MacSidebarPreferences.maximumTextScale
+        )
+        XCTAssertEqual(
+            MacSidebarPreferences.clampedTextScale(MacSidebarPreferences.maximumTextScale + 0.1),
+            MacSidebarPreferences.maximumTextScale
         )
     }
 }

--- a/docs/workflows/macos-sidebar-dogfood.md
+++ b/docs/workflows/macos-sidebar-dogfood.md
@@ -1,0 +1,116 @@
+# macOS Sidebar Dogfood Setup
+
+Use this workflow to clone `issuectl` on another Mac, build the native macOS sidebar app, connect it to a local `issuectl web` server, and run the manual dogfood checklist.
+
+This is a developer dogfood build path. It is not a signed, notarized, or stapled distribution build. Developer ID signing, export, notarization, stapling, app updates, and installer packaging are still release backlog; see [IssueCTLMac release notes](../../apple/IssueCTLMac/RELEASE.md).
+
+## Prerequisites
+
+- macOS with Xcode installed.
+- Homebrew, `pnpm`, and `xcodegen`.
+- `ttyd` and `tmux` if you want launch/session actions to open terminals.
+- A configured `issuectl` database with at least one tracked repo.
+
+Install the native build prerequisites:
+
+```sh
+brew install pnpm xcodegen ttyd tmux
+```
+
+## Fresh Clone Setup
+
+From the new Mac:
+
+```sh
+git clone https://github.com/mean-weasel/issuectl.git
+cd issuectl
+pnpm install
+pnpm turbo build
+issuectl init
+```
+
+If the `issuectl` binary is not on your `PATH`, use the workspace CLI after building it:
+
+```sh
+pnpm --filter @issuectl/cli build
+node packages/cli/dist/index.js init
+```
+
+## Build And Launch The Sidebar
+
+Generate the Xcode project:
+
+```sh
+xcodegen generate --spec apple/project.yml
+```
+
+Build the native Mac app:
+
+```sh
+xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
+```
+
+The Debug app is usually written under:
+
+```text
+~/Library/Developer/Xcode/DerivedData/IssueCTL-*/Build/Products/Debug/IssueCTLMac.app
+```
+
+You can build and launch the newest Debug app with the helper script:
+
+```sh
+pnpm mac:sidebar:dev
+```
+
+To build without launching:
+
+```sh
+pnpm mac:sidebar:dev --no-open
+```
+
+To launch a previously built app without rebuilding:
+
+```sh
+pnpm mac:sidebar:dev --no-build
+```
+
+You can also open the project in Xcode, select the `IssueCTLMac` scheme, and run it from Xcode.
+
+## Start The Local Server
+
+Start `issuectl web` on the same Mac that will own repos, worktrees, and terminal sessions:
+
+```sh
+issuectl web
+```
+
+Keep this process running while dogfooding. The macOS sidebar sends launch/session actions to this server. Any terminal windows, worktrees, agent sessions, and local filesystem effects happen on the machine running `issuectl web`, not on a different client device.
+
+If the `issuectl` binary is not on your `PATH`, run:
+
+```sh
+node packages/cli/dist/index.js web
+```
+
+## Connect IssueCTLMac
+
+Launch `IssueCTLMac.app`. When `issuectl web` is running on the same Mac, the sidebar automatically reads the saved local API token from `~/.issuectl/issuectl.db`, verifies `http://localhost:3847`, and opens the dashboard.
+
+If automatic connection fails, use the connection form manually:
+
+- Server URL: `http://localhost:3847`
+- API token: copy the token printed by `issuectl web`
+
+Use `localhost` for this native macOS dogfood flow because the app and server are running on the same Mac. If you intentionally run `issuectl web` on another machine, use that machine's reachable URL instead and remember that launch/session actions will execute there.
+
+## Dogfood Checklist
+
+Run the manual checklist in [apple/IssueCTLMac/QA.md](../../apple/IssueCTLMac/QA.md). At minimum, cover:
+
+- Build and launch.
+- Automatic connection using `http://localhost:3847`, plus manual fallback with the printed API token.
+- Issues, drafts, and active sessions.
+- Launch/session behavior with `ttyd` and `tmux` installed.
+- Disconnect and server restart recovery.
+
+Record pass/fail notes against the checklist before treating a second-machine setup as ready.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ios:setup-preview-sim": "pnpm --filter @issuectl/cli build && node packages/cli/dist/index.js ios setup --simulator --preview",
     "ios:dev": "./scripts/ios-dev.sh",
     "ios:dev-preview": "IOS_DEV_SCHEME=IssueCTLPreview ./scripts/ios-dev.sh",
+    "mac:sidebar:dev": "./scripts/mac-sidebar-dev.sh",
     "dev": "turbo dev",
     "prepare": "husky"
   },

--- a/scripts/mac-sidebar-dev.sh
+++ b/scripts/mac-sidebar-dev.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+ARCH="${ARCH:-$(uname -m)}"
+DESTINATION="${DESTINATION:-platform=macOS,arch=${ARCH}}"
+CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED:-NO}"
+OPEN_APP=1
+BUILD=1
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/mac-sidebar-dev.sh [--no-open] [--no-build] [--help]
+
+Builds the native macOS sidebar app and opens the Debug .app from Xcode
+DerivedData. Run issuectl web separately on the same Mac; the app will try to
+connect to http://localhost:3847 using the local API token automatically.
+
+Environment overrides:
+  CONFIGURATION=Debug|Release
+  ARCH=arm64|x86_64
+  DESTINATION='platform=macOS,arch=arm64'
+  CODE_SIGNING_ALLOWED=NO|YES
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --)
+      ;;
+    --no-open)
+      OPEN_APP=0
+      ;;
+    --no-build)
+      BUILD=0
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "IssueCTLMac can only be built and launched on macOS." >&2
+  exit 1
+fi
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "Missing xcodegen. Install it with: brew install xcodegen" >&2
+  exit 1
+fi
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  echo "Missing xcodebuild. Install Xcode and run: xcode-select --install" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if [ "$BUILD" -eq 1 ]; then
+  xcodegen generate --spec apple/project.yml
+  xcodebuild \
+    -project apple/IssueCTL.xcodeproj \
+    -scheme IssueCTLMac \
+    -configuration "$CONFIGURATION" \
+    -destination "$DESTINATION" \
+    CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED" \
+    build
+fi
+
+APP_PATH="$(find "$HOME/Library/Developer/Xcode/DerivedData" \
+  -path "*/Build/Products/${CONFIGURATION}/IssueCTLMac.app" \
+  -type d \
+  -print 2>/dev/null | sort -r | head -n 1 || true)"
+
+if [ -z "$APP_PATH" ]; then
+  echo "Could not find IssueCTLMac.app in DerivedData for ${CONFIGURATION}." >&2
+  echo "Try building from Xcode with the IssueCTLMac scheme, then rerun with --no-build." >&2
+  exit 1
+fi
+
+echo "IssueCTLMac app: $APP_PATH"
+echo
+echo "Before connecting, run this in another terminal on this Mac:"
+echo "  issuectl web"
+echo
+echo "IssueCTLMac should auto-connect to:"
+echo "  Server URL: http://localhost:3847"
+echo "  API token:  read from ~/.issuectl/issuectl.db"
+echo
+echo "If auto-connect fails, use the connection form with the token printed by issuectl web."
+echo
+echo "Manual QA checklist:"
+echo "  apple/IssueCTLMac/QA.md"
+
+if [ "$OPEN_APP" -eq 1 ]; then
+  open "$APP_PATH"
+fi


### PR DESCRIPTION
## Summary
- Add a fresh-clone macOS sidebar dogfood workflow and `pnpm mac:sidebar:dev` helper for local unsigned builds.
- Make the macOS sidebar easier to recover and dogfood: visible right-edge window, explicit collapsed Expand control, stable close-as-hide behavior.
- Add issue pagination, clearer repository filters, and persisted adjustable text size.

## Validation
- `pnpm mac:sidebar:dev --no-open`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS,arch=arm64' -only-testing:IssueCTLMacTests/MacSidebarPreferencesTests CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
- Husky pre-push typecheck passed; commit hook lint passed with existing warnings only.

Addresses #419
