### PR TITLE
Add native Mac repository settings

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -34,8 +34,18 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         PerformanceTrace.markAppLaunchStarted()
         NSApp.setActivationPolicy(.accessory)
+        configureUITestFixtureAPIIfNeeded()
         sidebarCoordinator.start()
         configureStatusItem()
+    }
+
+    private func configureUITestFixtureAPIIfNeeded() {
+        let env = ProcessInfo.processInfo.environment
+        guard env["ISSUECTL_UI_TESTING"] == "1",
+              env["ISSUECTL_MAC_UI_FIXTURE_API"] == "1" else {
+            return
+        }
+        URLProtocol.registerClass(MacUITestFixtureURLProtocol.self)
     }
 
     private func configureStatusItem() {
@@ -164,3 +174,87 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 }
 
 extension MacAppDelegate: NSMenuDelegate {}
+
+private final class MacUITestFixtureURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "issuectl-ui-test.local"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: APIError.invalidResponse)
+            return
+        }
+
+        let payload = Self.payload(for: request.httpMethod ?? "GET", path: url.path)
+        let status = payload == nil ? 404 : 200
+        let data = Self.jsonData(payload ?? ["error": "Unhandled \(url.path)"])
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func payload(for method: String, path: String) -> [String: Any]? {
+        switch (method, path) {
+        case ("GET", "/api/v1/health"):
+            return ["ok": true, "version": "ui-test", "timestamp": isoDate]
+        case ("GET", "/api/v1/user"):
+            return ["login": "alice"]
+        case ("GET", "/api/v1/settings"):
+            return ["settings": [
+                "launch_agent": "codex",
+                "claude_extra_args": "",
+                "codex_extra_args": "",
+            ]]
+        case ("GET", "/api/v1/repos"):
+            return ["repos": [repo]]
+        case ("GET", "/api/v1/repos/github"):
+            return ["repos": [
+                ["owner": "org", "name": "alpha", "private": false, "pushed_at": isoDate],
+                ["owner": "org", "name": "gamma", "private": true, "pushed_at": isoDate],
+            ], "synced_at": 1_775_000_000, "is_stale": false]
+        case ("GET", "/api/v1/deployments"):
+            return ["deployments": []]
+        case ("GET", "/api/v1/sessions/previews"):
+            return ["previews": []]
+        case ("GET", "/api/v1/drafts"):
+            return ["drafts": []]
+        case ("GET", "/api/v1/issues/org/alpha"):
+            return ["issues": [], "from_cache": false, "cached_at": NSNull()]
+        default:
+            return nil
+        }
+    }
+
+    private static var repo: [String: Any] {
+        [
+            "id": 1,
+            "owner": "org",
+            "name": "alpha",
+            "local_path": "/tmp/issuectl-alpha",
+            "branch_pattern": "jeremy/{slug}",
+            "created_at": isoDate,
+        ]
+    }
+
+    private static var isoDate: String {
+        "2026-05-14T00:00:00Z"
+    }
+
+    private static func jsonData(_ object: Any) -> Data {
+        (try? JSONSerialization.data(withJSONObject: object)) ?? Data("{}".utf8)
+    }
+}

--- a/apple/IssueCTLMac/Views/MacIssueFilterState.swift
+++ b/apple/IssueCTLMac/Views/MacIssueFilterState.swift
@@ -16,6 +16,40 @@ enum MacIssueFilter: String, CaseIterable, Identifiable {
     }
 }
 
+struct MacRepoNameInput: Equatable {
+    let owner: String
+    let name: String
+
+    var fullName: String { "\(owner)/\(name)" }
+
+    static func parse(_ input: String) throws -> MacRepoNameInput {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2 else {
+            throw MacRepoNameInputError.invalidFormat
+        }
+
+        let owner = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !owner.isEmpty, !name.isEmpty else {
+            throw MacRepoNameInputError.invalidFormat
+        }
+
+        return MacRepoNameInput(owner: owner, name: name)
+    }
+}
+
+enum MacRepoNameInputError: LocalizedError {
+    case invalidFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            "Enter a repository as owner/name."
+        }
+    }
+}
+
 @Observable @MainActor
 final class MacIssueFilterState {
     private let preferences: MacSidebarDisplayPreferences

--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -7,6 +7,13 @@ struct MacSettingsView: View {
     @Environment(SpaceSidebarCoordinator.self) private var sidebarCoordinator
     @Environment(\.resetSidebarLayout) private var resetSidebarLayout
     @State private var isUpdatingLaunchAtLogin = false
+    @State private var repos: [Repo] = []
+    @State private var isLoadingRepos = false
+    @State private var repoError: String?
+    @State private var showAddRepo = false
+    @State private var editingRepo: Repo?
+    @State private var repoPendingRemoval: Repo?
+    @State private var removingRepoFullName: String?
 
     var body: some View {
         Form {
@@ -57,12 +64,68 @@ struct MacSettingsView: View {
             }
 
             Section("Repositories") {
-                Text("Tracked repositories are managed in web settings.")
-                    .foregroundStyle(.secondary)
+                HStack {
+                    Button {
+                        showAddRepo = true
+                    } label: {
+                        Label("Add Repository", systemImage: "plus")
+                    }
+                    .accessibilityIdentifier("mac-settings-add-repository-button")
+
+                    Spacer()
+
+                    Button {
+                        Task { await loadRepos(refresh: true) }
+                    } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(isLoadingRepos)
+                    .accessibilityIdentifier("mac-settings-refresh-repositories-button")
+                }
+
+                if isLoadingRepos && repos.isEmpty {
+                    ProgressView("Loading repositories...")
+                        .accessibilityIdentifier("mac-settings-repositories-loading")
+                } else if let repoError, repos.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(repoError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("mac-settings-repositories-error")
+                        Button("Retry") {
+                            Task { await loadRepos(refresh: true) }
+                        }
+                    }
+                } else if repos.isEmpty {
+                    ContentUnavailableView(
+                        "No Repositories",
+                        systemImage: "folder",
+                        description: Text("Add a repo to populate sidebar issue filters.")
+                    )
+                    .accessibilityIdentifier("mac-settings-repositories-empty")
+                } else {
+                    ForEach(repos) { repo in
+                        MacSettingsRepoRow(
+                            repo: repo,
+                            isRemoving: removingRepoFullName == repo.fullName,
+                            onEdit: { editingRepo = repo },
+                            onRemove: { repoPendingRemoval = repo }
+                        )
+                    }
+                }
+
+                if let repoError, !repos.isEmpty {
+                    Label(repoError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("mac-settings-repositories-refresh-error")
+                }
 
                 Button("Open Web Settings") {
                     openWebSettings()
                 }
+                .accessibilityIdentifier("mac-settings-open-web-settings-button")
             }
 
             Section("Learned Desktops") {
@@ -85,8 +148,44 @@ struct MacSettingsView: View {
         .frame(minHeight: 560)
         .padding()
         .accessibilityIdentifier("mac-settings-view")
+        .sheet(isPresented: $showAddRepo) {
+            MacAddRepoSheet(trackedRepos: repos) { repo in
+                upsertRepo(repo)
+                await refreshSidebarAfterRepoMutation()
+            }
+            .environment(api)
+        }
+        .sheet(item: $editingRepo) { repo in
+            MacEditRepoSheet(repo: repo) { updated in
+                upsertRepo(updated)
+                await refreshSidebarAfterRepoMutation()
+            }
+            .environment(api)
+        }
+        .confirmationDialog(
+            "Remove repository?",
+            isPresented: Binding(
+                get: { repoPendingRemoval != nil },
+                set: { if !$0 { repoPendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let repo = repoPendingRemoval {
+                Button("Remove \(repo.fullName)", role: .destructive) {
+                    Task { await remove(repo) }
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                repoPendingRemoval = nil
+            }
+        } message: {
+            if let repo = repoPendingRemoval {
+                Text("This removes \(repo.fullName) from tracked repositories and sidebar filters.")
+            }
+        }
         .task {
             preferences.refreshLaunchAtLoginStatus()
+            await loadRepos(refresh: false)
         }
     }
 
@@ -115,6 +214,56 @@ struct MacSettingsView: View {
         let trimmedBaseURL = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard let url = URL(string: "\(trimmedBaseURL)/settings") else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    private func loadRepos(refresh: Bool) async {
+        isLoadingRepos = true
+        defer { isLoadingRepos = false }
+
+        do {
+            repos = try await api.repos(refresh: refresh)
+            repoError = nil
+            syncSidebarRepoFilters()
+        } catch {
+            repoError = error.localizedDescription
+        }
+    }
+
+    private func upsertRepo(_ repo: Repo) {
+        if let index = repos.firstIndex(where: { $0.id == repo.id || $0.fullName == repo.fullName }) {
+            repos[index] = repo
+        } else {
+            repos.insert(repo, at: 0)
+        }
+        syncSidebarRepoFilters()
+    }
+
+    private func remove(_ repo: Repo) async {
+        repoPendingRemoval = nil
+        removingRepoFullName = repo.fullName
+        repoError = nil
+        defer { removingRepoFullName = nil }
+
+        do {
+            try await api.removeRepo(owner: repo.owner, name: repo.name)
+            repos.removeAll { $0.id == repo.id || $0.fullName == repo.fullName }
+            await refreshSidebarAfterRepoMutation()
+        } catch {
+            repoError = "Failed to remove \(repo.fullName): \(error.localizedDescription)"
+            await loadRepos(refresh: true)
+        }
+    }
+
+    private func refreshSidebarAfterRepoMutation() async {
+        syncSidebarRepoFilters()
+        await sidebarCoordinator.store.load(api: api, refresh: true)
+        syncSidebarRepoFilters()
+    }
+
+    private func syncSidebarRepoFilters() {
+        for state in sidebarCoordinator.spaceStates {
+            state.issueFilterState.syncRepoSelection(repos: repos)
+        }
     }
 
     private func spaceSettingsRow(_ spaceState: MacSidebarSpaceState) -> some View {
@@ -162,5 +311,340 @@ struct MacSettingsView: View {
             }
         }
         .padding(.vertical, 6)
+    }
+}
+
+private struct MacSettingsRepoRow: View {
+    let repo: Repo
+    let isRemoving: Bool
+    let onEdit: () -> Void
+    let onRemove: () -> Void
+
+    private var hasLocalPath: Bool {
+        repo.localPath?.isEmpty == false
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: hasLocalPath ? "folder.badge.gearshape" : "folder.badge.questionmark")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(hasLocalPath ? .blue : .orange)
+                .frame(width: 30, height: 30)
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack {
+                    Text(repo.fullName)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Text(hasLocalPath ? "Ready" : "Path needed")
+                        .font(.caption)
+                        .foregroundStyle(hasLocalPath ? .green : .orange)
+                }
+
+                if let localPath = repo.localPath, !localPath.isEmpty {
+                    Label(localPath, systemImage: "externaldrive")
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                } else {
+                    Text("Add a local clone path before launching work sessions.")
+                }
+
+                Label(repo.branchPattern?.isEmpty == false ? repo.branchPattern! : "Default branch pattern", systemImage: "arrow.triangle.branch")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Spacer(minLength: 8)
+
+            if isRemoving {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Menu {
+                    Button("Edit") {
+                        onEdit()
+                    }
+                    .accessibilityIdentifier("mac-settings-edit-repository-\(repo.fullName)")
+
+                    Button("Remove", role: .destructive) {
+                        onRemove()
+                    }
+                    .accessibilityIdentifier("mac-settings-remove-repository-\(repo.fullName)")
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .menuStyle(.button)
+                .accessibilityIdentifier("mac-settings-repository-menu-\(repo.fullName)")
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("mac-settings-repository-row-\(repo.fullName)")
+    }
+}
+
+private struct MacAddRepoSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    let trackedRepos: [Repo]
+    let onAdded: (Repo) async -> Void
+
+    @State private var fullName = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+    @State private var browseRepos: [GitHubAccessibleRepo] = []
+    @State private var browseSearch = ""
+    @State private var browseError: String?
+    @State private var isBrowseLoading = false
+
+    private var trackedFullNames: Set<String> {
+        Set(trackedRepos.map(\.fullName))
+    }
+
+    private var parsedInput: MacRepoNameInput? {
+        try? MacRepoNameInput.parse(fullName)
+    }
+
+    private var filteredBrowseRepos: [GitHubAccessibleRepo] {
+        guard !browseSearch.isEmpty else { return browseRepos }
+        let query = browseSearch.lowercased()
+        return browseRepos.filter { $0.fullName.lowercased().contains(query) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Manual") {
+                    TextField("owner/name", text: $fullName)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("mac-add-repo-full-name-field")
+
+                    if let parsedInput {
+                        Text("Will add \(parsedInput.fullName)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if !fullName.isEmpty {
+                        Text(MacRepoNameInputError.invalidFormat.localizedDescription)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section("Browse GitHub") {
+                    HStack {
+                        TextField("Search repos", text: $browseSearch)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("mac-add-repo-browse-search-field")
+                        Button {
+                            Task { await loadBrowseRepos(refresh: true) }
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                        .disabled(isBrowseLoading)
+                        .accessibilityIdentifier("mac-add-repo-browse-refresh-button")
+                    }
+
+                    if isBrowseLoading && browseRepos.isEmpty {
+                        ProgressView("Loading GitHub repos...")
+                    } else if let browseError {
+                        Label(browseError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("mac-add-repo-browse-error")
+                    } else if browseRepos.isEmpty {
+                        Text("Refresh to load accessible GitHub repositories.")
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("mac-add-repo-browse-empty")
+                    } else {
+                        ForEach(filteredBrowseRepos) { repo in
+                            Button {
+                                fullName = repo.fullName
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(repo.fullName)
+                                            .foregroundStyle(.primary)
+                                        if let pushedAt = repo.pushedAt {
+                                            Text("Pushed \(pushedAt)")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    Spacer()
+                                    if trackedFullNames.contains(repo.fullName) {
+                                        Text("Tracked")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    } else if repo.private {
+                                        Image(systemName: "lock.fill")
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                            .disabled(trackedFullNames.contains(repo.fullName))
+                            .accessibilityIdentifier("mac-add-repo-browse-row-\(repo.fullName)")
+                        }
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("mac-add-repo-error")
+                    }
+                }
+            }
+            .navigationTitle("Add Repository")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSubmitting)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSubmitting {
+                        ProgressView()
+                    } else {
+                        Button("Add") {
+                            Task { await submit() }
+                        }
+                        .disabled(parsedInput == nil)
+                        .accessibilityIdentifier("mac-add-repo-submit-button")
+                    }
+                }
+            }
+            .frame(width: 460, height: 520)
+            .task {
+                await loadBrowseRepos(refresh: false)
+            }
+        }
+    }
+
+    private func loadBrowseRepos(refresh: Bool) async {
+        isBrowseLoading = true
+        browseError = nil
+        defer { isBrowseLoading = false }
+
+        do {
+            browseRepos = try await api.githubRepos(refresh: refresh).repos
+        } catch {
+            browseError = error.localizedDescription
+        }
+    }
+
+    private func submit() async {
+        do {
+            let input = try MacRepoNameInput.parse(fullName)
+            isSubmitting = true
+            errorMessage = nil
+            defer { isSubmitting = false }
+
+            let repo = try await api.addRepo(owner: input.owner, name: input.name)
+            await onAdded(repo)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacEditRepoSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    let repo: Repo
+    let onUpdated: (Repo) async -> Void
+
+    @State private var localPath: String
+    @State private var branchPattern: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(repo: Repo, onUpdated: @escaping (Repo) async -> Void) {
+        self.repo = repo
+        self.onUpdated = onUpdated
+        _localPath = State(initialValue: repo.localPath ?? "")
+        _branchPattern = State(initialValue: repo.branchPattern ?? "")
+    }
+
+    private var hasChanges: Bool {
+        localPath.trimmingCharacters(in: .whitespacesAndNewlines) != (repo.localPath ?? "")
+            || branchPattern.trimmingCharacters(in: .whitespacesAndNewlines) != (repo.branchPattern ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Repository") {
+                    Text(repo.fullName)
+                        .font(.headline)
+                    Text(repo.localPath?.isEmpty == false ? "Ready for local sessions." : "Add a local clone path to improve launches.")
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Local Clone") {
+                    TextField("Local path", text: $localPath)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("mac-edit-repo-local-path-field")
+                }
+
+                Section("Branch Pattern") {
+                    TextField("Branch pattern", text: $branchPattern)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("mac-edit-repo-branch-pattern-field")
+                    Text("Leave blank to use the server default.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("mac-edit-repo-error")
+                    }
+                }
+            }
+            .navigationTitle("Edit Repository")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .disabled(!hasChanges)
+                        .accessibilityIdentifier("mac-edit-repo-save-button")
+                    }
+                }
+            }
+            .frame(width: 440, height: 360)
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            let updated = try await api.updateRepo(
+                owner: repo.owner,
+                name: repo.name,
+                localPath: localPath.trimmingCharacters(in: .whitespacesAndNewlines),
+                branchPattern: branchPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            await onUpdated(updated)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -72,6 +72,22 @@ final class MacIssueFilterStateTests: XCTestCase {
         XCTAssertEqual(preferences.issueFilterRawValue, "unassigned")
     }
 
+    func testRepoNameInputParsesOwnerAndName() throws {
+        let input = try MacRepoNameInput.parse(" mean-weasel/issuectl ")
+
+        XCTAssertEqual(input.owner, "mean-weasel")
+        XCTAssertEqual(input.name, "issuectl")
+        XCTAssertEqual(input.fullName, "mean-weasel/issuectl")
+    }
+
+    func testRepoNameInputRejectsMalformedNames() {
+        XCTAssertThrowsError(try MacRepoNameInput.parse(""))
+        XCTAssertThrowsError(try MacRepoNameInput.parse("mean-weasel"))
+        XCTAssertThrowsError(try MacRepoNameInput.parse("mean-weasel/"))
+        XCTAssertThrowsError(try MacRepoNameInput.parse("/issuectl"))
+        XCTAssertThrowsError(try MacRepoNameInput.parse("mean-weasel/issuectl/extra"))
+    }
+
     private var repos: [Repo] {
         [
             repo(id: 1, owner: "mean-weasel", name: "issuectl"),

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -9,7 +9,8 @@ final class MacSidebarSmokeTests: XCTestCase {
 
         app = XCUIApplication()
         app.launchEnvironment["ISSUECTL_UI_TESTING"] = "1"
-        app.launchEnvironment["ISSUECTL_SERVER_URL"] = "http://127.0.0.1:9"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_API"] = "1"
+        app.launchEnvironment["ISSUECTL_SERVER_URL"] = "http://issuectl-ui-test.local"
         app.launchEnvironment["ISSUECTL_API_TOKEN"] = "mac-ui-smoke-token"
         app.launch()
     }
@@ -34,6 +35,27 @@ final class MacSidebarSmokeTests: XCTestCase {
     }
 
     func testStatusMenuOpensSettings() {
+        openSettings()
+
+        let settingsView = app.descendants(matching: .any)["mac-settings-view"]
+        XCTAssertTrue(settingsView.waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testSettingsShowsNativeRepositoryManagement() {
+        openSettings()
+
+        XCTAssertTrue(app.buttons["mac-settings-add-repository-button"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-settings-refresh-repositories-button"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-repository-row-org/alpha"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-settings-add-repository-button"].click()
+        XCTAssertTrue(app.textFields["mac-add-repo-full-name-field"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-add-repo-browse-row-org/gamma"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-add-repo-submit-button"].waitForExistence(timeout: 3), app.debugDescription)
+        app.buttons["Cancel"].click()
+    }
+
+    private func openSettings() {
         let statusItem = app.statusItems["IssueCTL"].firstMatch
         XCTAssertTrue(statusItem.waitForExistence(timeout: 8), app.debugDescription)
 
@@ -41,8 +63,5 @@ final class MacSidebarSmokeTests: XCTestCase {
         let settingsItem = app.menuItems["Settings..."].firstMatch
         XCTAssertTrue(settingsItem.waitForExistence(timeout: 3), app.debugDescription)
         settingsItem.click()
-
-        let settingsView = app.descendants(matching: .any)["mac-settings-view"]
-        XCTAssertTrue(settingsView.waitForExistence(timeout: 5), app.debugDescription)
     }
 }

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -45,6 +45,100 @@ final class APIClientExtensionTests: XCTestCase {
         return data
     }
 
+    // MARK: - Repository Settings
+
+    @MainActor
+    func testAddRepoSendsPostBodyAndDecodesRepo() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(json["owner"] as? String, "mean-weasel")
+            XCTAssertEqual(json["name"] as? String, "issuectl")
+
+            return (self.makeResponse(url: request.url!), """
+            {"success":true,"repo":{"id":7,"owner":"mean-weasel","name":"issuectl","local_path":null,"branch_pattern":null,"created_at":"2026-05-14T00:00:00Z"}}
+            """.data(using: .utf8)!)
+        }
+
+        let repo = try await client.addRepo(owner: "mean-weasel", name: "issuectl")
+
+        XCTAssertEqual(repo.id, 7)
+        XCTAssertEqual(repo.fullName, "mean-weasel/issuectl")
+    }
+
+    @MainActor
+    func testGitHubReposUsesRefreshQueryWhenRequested() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/github")
+            XCTAssertEqual(request.url?.query, "refresh=true")
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            return (self.makeResponse(url: request.url!), """
+            {"repos":[{"owner":"mean-weasel","name":"issuectl","private":true,"pushed_at":"2026-05-14T00:00:00Z"}],"synced_at":1778760000,"is_stale":false}
+            """.data(using: .utf8)!)
+        }
+
+        let response = try await client.githubRepos(refresh: true)
+
+        XCTAssertEqual(response.repos.map(\.fullName), ["mean-weasel/issuectl"])
+        XCTAssertEqual(response.syncedAt, 1_778_760_000)
+        XCTAssertFalse(response.isStale)
+    }
+
+    @MainActor
+    func testUpdateRepoSendsPatchBodyAndDecodesRepo() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl")
+            XCTAssertEqual(request.httpMethod, "PATCH")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(json["localPath"] as? String, "/Users/me/issuectl")
+            XCTAssertEqual(json["branchPattern"] as? String, "feature/{{number}}")
+
+            return (self.makeResponse(url: request.url!), """
+            {"success":true,"repo":{"id":7,"owner":"mean-weasel","name":"issuectl","local_path":"/Users/me/issuectl","branch_pattern":"feature/{{number}}","created_at":"2026-05-14T00:00:00Z"}}
+            """.data(using: .utf8)!)
+        }
+
+        let repo = try await client.updateRepo(
+            owner: "mean-weasel",
+            name: "issuectl",
+            localPath: "/Users/me/issuectl",
+            branchPattern: "feature/{{number}}"
+        )
+
+        XCTAssertEqual(repo.localPath, "/Users/me/issuectl")
+        XCTAssertEqual(repo.branchPattern, "feature/{{number}}")
+    }
+
+    @MainActor
+    func testRemoveRepoSendsDeleteAndSurfacesFailure() async throws {
+        var calls = 0
+        MockURLProtocol.requestHandler = { request in
+            calls += 1
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl")
+            XCTAssertEqual(request.httpMethod, "DELETE")
+
+            if calls == 1 {
+                return (self.makeResponse(url: request.url!), #"{"success":true}"#.data(using: .utf8)!)
+            }
+            return (self.makeResponse(url: request.url!), #"{"success":false,"error":"repo is required"}"#.data(using: .utf8)!)
+        }
+
+        try await client.removeRepo(owner: "mean-weasel", name: "issuectl")
+
+        do {
+            try await client.removeRepo(owner: "mean-weasel", name: "issuectl")
+            XCTFail("Expected removeRepo to surface backend failure")
+        } catch APIError.serverError(_, let message) {
+            XCTAssertEqual(message, "repo is required")
+        }
+    }
+
     // MARK: - Parse
 
     @MainActor

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -58,7 +58,11 @@ final class TestableAPIClient {
             throw APIError.notConfigured
         }
 
-        var urlRequest = URLRequest(url: base.appendingPathComponent(path))
+        guard let url = URL(string: path, relativeTo: base)?.absoluteURL else {
+            throw APIError.invalidPath(path)
+        }
+
+        var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
         urlRequest.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -90,6 +94,43 @@ final class TestableAPIClient {
     func repos() async throws -> [Repo] {
         let (data, _) = try await request(path: "/api/v1/repos")
         return try decoder.decode(ReposResponse.self, from: data).repos
+    }
+
+    func addRepo(owner: String, name: String) async throws -> Repo {
+        let body = AddRepoRequest(owner: owner, name: name)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/repos", method: "POST", body: bodyData)
+        let response = try decoder.decode(AddRepoResponse.self, from: data)
+        guard response.success, let repo = response.repo else {
+            throw APIError.serverError(400, response.error ?? "Failed to add repository")
+        }
+        return repo
+    }
+
+    func removeRepo(owner: String, name: String) async throws {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(name)", method: "DELETE", body: nil)
+        let response = try decoder.decode(RemoveRepoResponse.self, from: data)
+        guard response.success else {
+            throw APIError.serverError(400, response.error ?? "Failed to remove repository")
+        }
+    }
+
+    func githubRepos(refresh: Bool = false) async throws -> GitHubAccessibleReposResponse {
+        var path = "/api/v1/repos/github"
+        if refresh { path += "?refresh=true" }
+        let (data, _) = try await request(path: path)
+        return try decoder.decode(GitHubAccessibleReposResponse.self, from: data)
+    }
+
+    func updateRepo(owner: String, name: String, localPath: String, branchPattern: String) async throws -> Repo {
+        let body = UpdateRepoRequest(localPath: localPath, branchPattern: branchPattern)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(name)", method: "PATCH", body: bodyData)
+        let response = try decoder.decode(UpdateRepoResponse.self, from: data)
+        guard response.success, let repo = response.repo else {
+            throw APIError.serverError(400, response.error ?? "Failed to update repository")
+        }
+        return repo
     }
 
     func issues(owner: String, repo: String, refresh: Bool = false) async throws -> IssuesResponse {

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -303,8 +303,10 @@ final class MockIssueCTLServer: @unchecked Sendable {
                 for (key, value) in payload {
                     repos[idx][key] = value
                 }
+                body = ["success": true, "repo": repos[idx]]
+            } else {
+                return http(status: 404, json: ["success": false, "error": "repo not found"])
             }
-            body = ["success": true]
 
         case ("GET", "/api/v1/repos/org/alpha/labels"):
             body = ["labels": repoLabels]

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -261,6 +261,38 @@ final class MockIssueCTLServer: @unchecked Sendable {
             }
             body = ["repos": repos]
 
+        case ("GET", "/api/v1/repos/github"):
+            body = [
+                "repos": [
+                    ["owner": "org", "name": "alpha", "private": false, "pushed_at": isoDate],
+                    ["owner": "org", "name": "gamma", "private": true, "pushed_at": isoDate],
+                ],
+                "synced_at": 1_775_000_000,
+                "is_stale": false,
+            ]
+
+        case ("POST", "/api/v1/repos"):
+            let payload = jsonBody(from: request)
+            guard
+                let owner = payload["owner"] as? String,
+                let name = payload["name"] as? String,
+                !owner.isEmpty,
+                !name.isEmpty
+            else {
+                return http(status: 400, json: ["success": false, "error": "invalid repo"])
+            }
+            let nextId = ((repos.compactMap { $0["id"] as? Int }.max() ?? 0) + 1)
+            let repo: [String: Any] = [
+                "id": nextId,
+                "owner": owner,
+                "name": name,
+                "local_path": NSNull(),
+                "branch_pattern": NSNull(),
+                "created_at": isoDate,
+            ]
+            repos.insert(repo, at: 0)
+            body = ["success": true, "repo": repo]
+
         case ("DELETE", "/api/v1/repos/org/alpha"):
             repos.removeAll { $0["name"] as? String == "alpha" }
             body = ["success": true]

--- a/docs/goals/mac-ios-parity/notes/T002-native-mac-repo-settings.md
+++ b/docs/goals/mac-ios-parity/notes/T002-native-mac-repo-settings.md
@@ -1,0 +1,51 @@
+# T002 Worker Receipt: Native Mac Repository Settings
+
+## Result
+
+Implemented the first Phase 1 slice and opened draft child PR #423.
+
+PR: https://github.com/mean-weasel/issuectl/pull/423
+
+Branch: `mac-parity-phase-1-repos`
+
+Base: `mac-sidebar-spaces-option-a`
+
+Commit: see current PR head; the receipt commit updates board state and therefore changes the branch SHA.
+
+## Changed Files
+
+- `apple/IssueCTLMac/Views/MacSettingsView.swift`
+- `apple/IssueCTLMac/Views/MacIssueFilterState.swift`
+- `apple/IssueCTLMacTests/MacIssueFilterStateTests.swift`
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`
+
+## Acceptance Criteria Evidence
+
+- Manual add: `MacAddRepoSheet` parses `owner/name` with `MacRepoNameInput` and calls `api.addRepo(owner:name:)`.
+- Local validation: `MacRepoNameInput` rejects malformed inputs in `IssueCTLMacTests`.
+- Browse add: `MacAddRepoSheet` loads `api.githubRepos(refresh:)`, supports search/refresh, and disables already tracked repos.
+- Edit: `MacEditRepoSheet` persists local path and branch pattern via `api.updateRepo`.
+- Remove: `MacSettingsRepoRow` exposes remove, `MacSettingsView` confirms before calling `api.removeRepo`.
+- Sidebar filters: after add/edit/remove, settings refreshes `SpaceSidebarCoordinator.store` and re-runs each learned Desktop's `MacIssueFilterState.syncRepoSelection(repos:)`.
+- Empty/loading/recoverable errors: Mac settings now renders loading, empty, primary error, refresh error, add error, edit error, and browse error states.
+- Accessibility identifiers: added identifiers for Mac settings repo controls, add/edit fields, browse controls, and error states.
+- Mock API support: `MockIssueCTLServer` now handles `GET /api/v1/repos/github` and `POST /api/v1/repos`.
+
+## Validation
+
+- `git diff --check`: pass.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 23 tests.
+- `pnpm typecheck`: pass.
+- `pnpm lint`: pass with pre-existing warnings.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacUITests`: interrupted after no test output for about 60 seconds; this matches the existing accessory/menu-bar automation instability recorded in the plan.
+
+## GitHub CI
+
+`gh pr checks 423` reports no checks on `mac-parity-phase-1-repos`.
+
+## Remaining Risk For Judge
+
+- The implementation is concentrated in `MacSettingsView.swift`; Judge should decide whether to split helper views into dedicated files in a later cleanup PR.
+- Full Mac UI automation is not green because the suite hangs before test output; Judge should decide whether local build/unit tests plus documented UI limitation are sufficient for this draft PR, or require a deterministic replacement test before merge.
+- Real local dogfood with `issuectl web` has not been performed in this task to avoid mutating the user's actual tracked repository configuration without an explicit dogfood window.

--- a/docs/goals/mac-ios-parity/notes/T003-pr423-review.md
+++ b/docs/goals/mac-ios-parity/notes/T003-pr423-review.md
@@ -1,0 +1,32 @@
+# T003 Judge Receipt: PR #423 Review
+
+## Decision
+
+Changes required before merge readiness.
+
+PR #423 is a good draft slice and the local build/unit validation is strong enough to continue, but it is not merge-ready against the Phase 1 acceptance criteria yet.
+
+## Findings
+
+1. Missing HTTP assertion coverage for repo settings endpoints.
+   - Phase 1 requires mock-server or HTTP assertions for repo list, browse, add, update, and remove endpoints.
+   - The implementation uses shared APIs, but existing `IssueCTLTests` do not assert `addRepo`, `githubRepos`, `updateRepo`, or `removeRepo` method/path/body behavior.
+
+2. UI automation evidence is incomplete.
+   - `IssueCTLMacUITests` was attempted and interrupted after about 60 seconds with no test output.
+   - This matches the known Mac accessory/menu-bar automation instability, but the PR still needs either a deterministic replacement test or an explicit dogfood result before merge.
+
+3. PR has no GitHub checks configured.
+   - `gh pr checks 423` reports no checks on the branch.
+   - Local validation can substitute only if the receipt stays explicit about the absence of CI.
+
+## Approved Follow-Up Worker
+
+Add shared API HTTP assertion tests for:
+
+- `POST /api/v1/repos` body and success response.
+- `GET /api/v1/repos/github` and `GET /api/v1/repos/github?refresh=true`.
+- `PATCH /api/v1/repos/:owner/:name` body and response.
+- `DELETE /api/v1/repos/:owner/:name` success and failure behavior.
+
+After that, rerun focused tests and update PR #423.

--- a/docs/goals/mac-ios-parity/notes/T004-pr423-blocked.md
+++ b/docs/goals/mac-ios-parity/notes/T004-pr423-blocked.md
@@ -1,0 +1,21 @@
+# T004 PM Receipt: PR #423 Merge Gate
+
+## Result
+
+Blocked for merge. PR #423 remains open, draft, and mergeable, but should not be merged yet.
+
+## Evidence
+
+- PR #423 head: `3109e9ade8b36fe2b47d15aad08ac64827fe1548`.
+- Base: `mac-sidebar-spaces-option-a`.
+- GitHub reports the PR as mergeable.
+- GitHub reports no configured status checks.
+- A PR comment was posted with the current validation and blocker.
+
+## Blocker
+
+The HTTP assertion gap is closed, but the native Mac Settings repository workflow still lacks deterministic UI or accepted dogfood evidence. A focused Mac UI test that bypassed the status-menu path still hung in this environment, so the failed test hook was removed.
+
+## Next Active Task
+
+T012: dogfood the native Mac Settings repository management workflow locally and record accepted evidence, or explicitly choose to pursue a dedicated Mac UI automation fix before merge.

--- a/docs/goals/mac-ios-parity/notes/T010-pr423-http-assertions.md
+++ b/docs/goals/mac-ios-parity/notes/T010-pr423-http-assertions.md
@@ -1,0 +1,28 @@
+# T010 Worker Receipt: PR #423 HTTP Assertions
+
+## Result
+
+Added HTTP-level tests for the shared repository settings API used by the Mac repository settings flow.
+
+## Changed Files
+
+- `apple/IssueCTLTests/APIClientTests.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`
+
+## Coverage Added
+
+- `POST /api/v1/repos` method, body, and success response.
+- `GET /api/v1/repos/github?refresh=true` path, query, and response decoding.
+- `PATCH /api/v1/repos/:owner/:name` method, body, and updated repo response.
+- `DELETE /api/v1/repos/:owner/:name` method, success response, and backend failure behavior.
+- `TestableAPIClient.request` now uses URL-relative construction to preserve query strings in test requests, matching the production `APIClient` behavior more closely.
+
+## Validation
+
+- `git diff --check`: pass.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 31 tests.
+
+## Notes
+
+- The first attempted iOS test destination, `platform=iOS Simulator,name=iPhone 16`, failed because Xcode could not resolve `OS:latest`; rerun succeeded with `OS=18.6`.
+- This task intentionally did not address the Mac UI automation hang or real local dogfood requirement.

--- a/docs/goals/mac-ios-parity/notes/T011-mac-ui-settings-test.md
+++ b/docs/goals/mac-ios-parity/notes/T011-mac-ui-settings-test.md
@@ -1,0 +1,23 @@
+# T011 Worker Receipt: Mac UI Settings Test Attempt
+
+## Result
+
+Blocked.
+
+I attempted to add deterministic Mac UI coverage by bypassing the status-menu path with a UI-testing-only launch hook that opened Settings directly. The focused test compiled after removing the cross-target mock-server dependency, but still hung during execution and had to be interrupted.
+
+## Evidence
+
+- First attempt failed to compile because `MockIssueCTLServer` is not part of the `IssueCTLMacUITests` target.
+- Second attempt removed that dependency and used the existing unreachable test URL, but `xcodebuild ... test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNativeRepositoryManagement` still hung after launch and produced no test result before interruption.
+
+## Cleanup
+
+The UI-testing launch hook and hanging UI test were removed from the worktree. No product or test code from the failed UI-test experiment remains.
+
+## Blocker
+
+Mac accessory app UI automation remains unreliable for settings-window verification in this environment. PR #423 should stay draft until either:
+
+- the user dogfoods the settings repo workflow locally and accepts that evidence, or
+- a separate Mac UI automation investigation finds a non-hanging settings-window harness.

--- a/docs/goals/mac-ios-parity/notes/T012-ui-automation-path.md
+++ b/docs/goals/mac-ios-parity/notes/T012-ui-automation-path.md
@@ -1,0 +1,15 @@
+# T012 PM Receipt: Settings Evidence Path
+
+## Result
+
+Selected the dedicated UI automation repair path before merge.
+
+## Reasoning
+
+PR #423 still needs accepted Mac Settings repository workflow evidence. Owner dogfood would require interacting with real local settings and potentially mutating tracked repositories, which this task explicitly cannot do without owner approval.
+
+The safe local follow-up is to investigate and repair the Mac UI automation harness enough to open Settings and verify the native repository controls deterministically.
+
+## Next Active Task
+
+T013: investigate the Mac UI test hang and implement the smallest non-production-affecting harness fix that can verify the Settings repository section, or record a concrete blocker if the app cannot be automated reliably in this environment.

--- a/docs/goals/mac-ios-parity/notes/T013-mac-settings-ui-evidence.md
+++ b/docs/goals/mac-ios-parity/notes/T013-mac-settings-ui-evidence.md
@@ -1,0 +1,21 @@
+# T013 Worker Receipt: Mac Settings UI Evidence
+
+## Result
+
+Done. The Mac UI automation blocker for PR #423 is resolved for the native repository Settings workflow.
+
+## Changes
+
+- Added a UI-testing-only fixture API in the Mac app via `URLProtocol`.
+- Kept the fixture gated behind `ISSUECTL_UI_TESTING=1` and `ISSUECTL_MAC_UI_FIXTURE_API=1`.
+- Added a Mac UI smoke test that opens Settings through the real status-menu path, verifies native repository controls, verifies a tracked repo row, opens Add Repository, and verifies browsed GitHub repos.
+
+## Validation
+
+- `git diff --check` passed.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` passed with 3 tests.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests` passed with 23 tests.
+
+## Notes
+
+Mac UI tests should run with normal signing and an isolated DerivedData path. Forcing `CODE_SIGNING_ALLOWED=NO` on the UI-test runner caused the earlier silent hang.

--- a/docs/goals/mac-ios-parity/notes/T900-pr423-phase-review.md
+++ b/docs/goals/mac-ios-parity/notes/T900-pr423-phase-review.md
@@ -1,0 +1,24 @@
+# T900 Judge Receipt: PR #423 Phase Review
+
+## Decision
+
+Not merge-ready yet. Continue with one focused Worker task.
+
+The HTTP assertion gap identified in T003 is closed. PR #423 still needs deterministic Mac UI evidence for the settings repository workflow because the existing status-menu UI test path hangs before producing test output.
+
+## Current Evidence
+
+- Mac build passed.
+- `IssueCTLMacTests` passed with 23 tests.
+- `IssueCTLTests/APIClientExtensionTests` passed with 31 tests, including repository settings HTTP assertions.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed with pre-existing warnings.
+- PR #423 is draft, clean, mergeable, and has no configured GitHub checks.
+
+## Remaining Missing Evidence
+
+- A deterministic Mac UI test or accepted dogfood evidence for opening settings and seeing native repository management controls.
+
+## Next Worker
+
+Add a test-only Mac launch hook that opens Settings automatically under UI testing, then add a focused Mac UI test that uses the mock server to verify the Settings repository section renders tracked repos and exposes the native add/edit controls without going through the menu-bar status item.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T900
+active_task: T004
 
 tasks:
   - id: T001
@@ -228,7 +228,7 @@ tasks:
   - id: T004
     type: pm
     assignee: PM
-    status: queued
+    status: active
     reasoning_hint: default
     objective: "Merge or block the first parity PR according to T003, record the result, and activate the next PR-sized parity slice."
     inputs:
@@ -288,7 +288,7 @@ tasks:
   - id: T900
     type: judge
     assignee: Judge
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Periodic phase-boundary audit of completed PRs against the parity plan and remaining discrepancy matrix."
     inputs:
@@ -304,7 +304,48 @@ tasks:
       - "Remaining discrepancies."
       - "Risk or test debt."
       - "Next slice recommendation."
-    receipt: null
+    receipt:
+      result: done
+      decision: changes_required
+      full_outcome_complete: false
+      note: "notes/T900-pr423-phase-review.md"
+      summary: "HTTP assertions are now covered; PR #423 still needs deterministic Mac UI evidence because the status-menu UI suite hangs before test output."
+      next_task: T011
+
+  - id: T011
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Add deterministic Mac UI coverage for the native repository settings section without relying on the flaky status-menu path."
+    inputs:
+      - "T900 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/423"
+    constraints:
+      - "Keep the launch hook scoped to ISSUECTL_UI_TESTING."
+      - "Do not change normal app launch behavior."
+      - "Prefer a focused settings test over broad menu-bar automation."
+      - "Do not merge PR #423."
+    allowed_files:
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+      - "docs/goals/mac-ios-parity/**"
+    verify:
+      - "git diff --check"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNativeRepositoryManagement"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+    stop_if:
+      - "The UI test still hangs after bypassing the status menu."
+      - "Need files outside allowed_files."
+      - "The test hook would affect non-UI-testing app behavior."
+    receipt:
+      result: blocked
+      note: "notes/T011-mac-ui-settings-test.md"
+      summary: "Tried a UI-testing-only direct Settings launch hook, but the focused Mac UI test still hung; removed the failed hook/test and left PR #423 draft pending dogfood or a dedicated UI automation fix."
+      warnings:
+        - "xcodebuild UI test attempt was interrupted after hanging with no test output after launch."
+      blocker: "Mac accessory app UI automation still hangs even when bypassing the status menu."
 
   - id: T999
     type: judge

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T004
+active_task: T012
 
 tasks:
   - id: T001
@@ -228,7 +228,7 @@ tasks:
   - id: T004
     type: pm
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: default
     objective: "Merge or block the first parity PR according to T003, record the result, and activate the next PR-sized parity slice."
     inputs:
@@ -244,7 +244,23 @@ tasks:
       - "Merged PR URL and SHA, or blocked reason."
       - "Updated board with next active task."
       - "Next PR-sized slice."
-    receipt: null
+    receipt:
+      result: done
+      decision: do_not_merge
+      full_outcome_complete: false
+      note: "notes/T004-pr423-blocked.md"
+      pr:
+        number: 423
+        url: "https://github.com/mean-weasel/issuectl/pull/423"
+        branch: "mac-parity-phase-1-repos"
+        base: "mac-sidebar-spaces-option-a"
+        head_sha: "3109e9ade8b36fe2b47d15aad08ac64827fe1548"
+        draft: true
+        mergeable: "MERGEABLE"
+        checks: "No checks reported."
+        comment: "https://github.com/mean-weasel/issuectl/pull/423#issuecomment-4451901227"
+      blocker: "PR #423 still needs accepted Mac Settings repository workflow dogfood evidence or a separate deterministic Mac UI automation fix before merge."
+      next_task: T012
 
   - id: T010
     type: worker
@@ -346,6 +362,28 @@ tasks:
       warnings:
         - "xcodebuild UI test attempt was interrupted after hanging with no test output after launch."
       blocker: "Mac accessory app UI automation still hangs even when bypassing the status menu."
+
+  - id: T012
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: default
+    objective: "Dogfood the native Mac Settings repository management workflow for PR #423, or choose a dedicated UI automation fix before merge."
+    inputs:
+      - "https://github.com/mean-weasel/issuectl/pull/423"
+      - "T004 receipt"
+      - "T011 receipt"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not merge PR #423 until this task has accepted evidence."
+      - "Do not mutate real repository settings without explicit owner approval."
+      - "Record the exact dogfood steps, result, and any issues found."
+      - "If the owner chooses UI automation instead, create a focused Worker task before any further parity implementation slice."
+    expected_output:
+      - "Accepted dogfood evidence and merge approval for PR #423, or a queued Worker task for UI automation repair."
+      - "Updated PR comment and board receipt."
+      - "Clear next task after PR #423 is either merged or still blocked."
+    receipt: null
 
   - id: T999
     type: judge

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T012
+active_task: T014
 
 tasks:
   - id: T001
@@ -366,7 +366,7 @@ tasks:
   - id: T012
     type: pm
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: default
     objective: "Dogfood the native Mac Settings repository management workflow for PR #423, or choose a dedicated UI automation fix before merge."
     inputs:
@@ -383,6 +383,79 @@ tasks:
       - "Accepted dogfood evidence and merge approval for PR #423, or a queued Worker task for UI automation repair."
       - "Updated PR comment and board receipt."
       - "Clear next task after PR #423 is either merged or still blocked."
+    receipt:
+      result: done
+      decision: choose_ui_automation_repair
+      full_outcome_complete: false
+      note: "notes/T012-ui-automation-path.md"
+      summary: "Owner dogfood would require explicit approval to mutate real repository settings, so the next safe local path is a focused Mac UI automation repair before PR #423 can merge."
+      next_task: T013
+
+  - id: T013
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Investigate and repair the Mac UI test harness enough to verify the native Settings repository management section for PR #423, or record a concrete blocker."
+    inputs:
+      - "T011 receipt"
+      - "T012 receipt"
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLMacUITests/**"
+      - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+    constraints:
+      - "Do not change normal app launch behavior."
+      - "Keep any launch hook scoped to UI testing."
+      - "Prefer deterministic app-window automation over status-menu interaction."
+      - "Do not merge PR #423."
+      - "Do not mutate real local repository settings."
+    allowed_files:
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+      - "apple/IssueCTLMacUITests/**"
+      - "apple/IssueCTL.xcodeproj/project.pbxproj"
+      - "docs/goals/mac-ios-parity/**"
+    verify:
+      - "git diff --check"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+    stop_if:
+      - "The UI test still hangs after a UI-testing-only lifecycle fix."
+      - "The harness fix would affect normal app launch behavior."
+      - "Need to mutate real repo settings to pass the test."
+    receipt:
+      result: done
+      note: "notes/T013-mac-settings-ui-evidence.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+      summary: "Added a UI-testing-only fixture API and Mac smoke coverage that verifies native repository Settings controls through the real status-menu Settings path."
+
+  - id: T014
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: default
+    objective: "Update PR #423 with the resolved Mac Settings UI evidence, mark it ready if no new blocker is present, and merge it into the integration branch under the documented no-CI replacement validation."
+    inputs:
+      - "T013 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/423"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not merge if GitHub reports conflicts or red checks."
+      - "Record final PR state, merge SHA, or blocker."
+      - "Use the local validation from T013 plus prior Phase 1 validation as the no-checks replacement gate."
+    expected_output:
+      - "PR #423 marked ready and merged, or blocked with a concrete reason."
+      - "Updated board receipt."
+      - "Next active PR-sized parity slice."
     receipt: null
 
   - id: T999

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T002
+active_task: T003
 
 tasks:
   - id: T001
@@ -128,7 +128,7 @@ tasks:
   - id: T002
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: medium
     objective: "Implement the first PR-sized Mac parity slice selected by T001, expected to be Phase 1 Native Mac Repository Management unless T001 selects a safer prerequisite."
     inputs:
@@ -162,12 +162,43 @@ tasks:
       - "PR base branch is ambiguous."
       - "Local validation fails twice for the same unexplained reason."
       - "GitHub CI is unavailable or red and no safe local substitute is accepted."
-    receipt: null
+    receipt:
+      result: done
+      note: "notes/T002-native-mac-repo-settings.md"
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+        - "apple/IssueCTLMac/Views/MacIssueFilterState.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+      pr:
+        number: 423
+        url: "https://github.com/mean-weasel/issuectl/pull/423"
+        branch: "mac-parity-phase-1-repos"
+        base: "mac-sidebar-spaces-option-a"
+        head_sha: "See current PR head; receipt commits update board state and change the SHA."
+        draft: true
+        merge_state: "CLEAN"
+        checks: "No checks reported on the mac-parity-phase-1-repos branch."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+      warnings:
+        - "pnpm lint passed with pre-existing warnings."
+        - "IssueCTLMacUITests was attempted but interrupted after no test output for about 60 seconds; tracked as Judge review risk rather than a passing Worker command."
+      summary: "Implemented native Mac repository list/add/browse/edit/remove in settings, synced per-Desktop repo filters after mutations, added validation tests and mock-server repo add/browse endpoints, and opened draft PR #423."
 
   - id: T003
     type: judge
     assignee: Judge
-    status: queued
+    status: active
     reasoning_hint: high
     objective: "Review the first parity PR slice for acceptance criteria coverage, CI health, merge readiness, and next-slice sizing."
     inputs:
@@ -274,6 +305,12 @@ tasks:
 checks:
   dirty_fingerprint: unknown
   last_verification:
-    result: unknown
-    task: null
-    commands: []
+    result: partial
+    task: T002
+    commands:
+      - "git diff --check"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+      - "pnpm typecheck"
+      - "pnpm lint"
+      - "IssueCTLMacUITests attempted but interrupted after hang before test output"

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T003
+active_task: T900
 
 tasks:
   - id: T001
@@ -198,7 +198,7 @@ tasks:
   - id: T003
     type: judge
     assignee: Judge
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Review the first parity PR slice for acceptance criteria coverage, CI health, merge readiness, and next-slice sizing."
     inputs:
@@ -214,7 +214,16 @@ tasks:
       - "Missing acceptance criteria, if any."
       - "CI or replacement validation status."
       - "Merge decision and next task recommendation."
-    receipt: null
+    receipt:
+      result: done
+      decision: changes_required
+      full_outcome_complete: false
+      note: "notes/T003-pr423-review.md"
+      summary: "PR #423 is a good draft but not merge-ready; add HTTP assertion tests for shared repo settings endpoints and keep UI/dogfood evidence explicit."
+      missing_acceptance_criteria:
+        - "HTTP assertions for add/browse/update/remove repo endpoint method/path/body behavior."
+        - "Deterministic UI replacement or dogfood evidence for Mac settings repo workflows."
+      next_task: T010
 
   - id: T004
     type: pm
@@ -240,28 +249,46 @@ tasks:
   - id: T010
     type: worker
     assignee: Worker
-    status: queued
+    status: done
     reasoning_hint: medium
-    objective: "Continue implementing the next approved PR-sized parity slice from the plan after the first PR is merged or blocked with a workaround."
+    objective: "Close PR #423 review gaps by adding shared API HTTP assertion tests for repository settings endpoints and updating the PR evidence."
     inputs:
-      - "Latest PM/Judge receipt"
+      - "T003 receipt"
       - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+      - "https://github.com/mean-weasel/issuectl/pull/423"
     constraints:
-      - "PM must fill allowed_files and verify before activation."
-      - "Use the established PR/CI/merge cadence."
-      - "Record acceptance criteria evidence and PR status in receipt."
-    allowed_files: []
-    verify: []
+      - "Keep changes test-focused unless a tiny production fix is required to satisfy the tests."
+      - "Do not merge PR #423."
+      - "Record updated local validation and PR status in receipt."
+    allowed_files:
+      - "apple/IssueCTLTests/APIClientTests.swift"
+      - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      - "docs/goals/mac-ios-parity/**"
+    verify:
+      - "git diff --check"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
     stop_if:
       - "Need files outside allowed_files."
-      - "Phase scope is too large for one PR."
-      - "CI is red and recovery path is unclear."
-    receipt: null
+      - "Shared API contract differs from the Phase 1 plan."
+      - "iOS simulator destination is unavailable."
+    receipt:
+      result: done
+      note: "notes/T010-pr423-http-assertions.md"
+      changed_files:
+        - "apple/IssueCTLTests/APIClientTests.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+      summary: "Added shared API HTTP assertion coverage for repository add, browse refresh, update, and remove endpoints used by PR #423."
 
   - id: T900
     type: judge
     assignee: Judge
-    status: queued
+    status: active
     reasoning_hint: high
     objective: "Periodic phase-boundary audit of completed PRs against the parity plan and remaining discrepancy matrix."
     inputs:
@@ -306,11 +333,7 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: partial
-    task: T002
+    task: T010
     commands:
       - "git diff --check"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
-      - "pnpm typecheck"
-      - "pnpm lint"
-      - "IssueCTLMacUITests attempted but interrupted after hang before test output"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"


### PR DESCRIPTION
## Summary

Adds native repository management to the Mac settings window for the Phase 1 Mac/iOS parity slice. This replaces the web-settings-only placeholder with tracked repo listing, manual add, GitHub browse, edit local path/branch pattern, remove with confirmation, and sidebar filter refresh after mutations.

## Acceptance Criteria

- [x] Manual add sends shared add-repo request and rejects malformed `owner/name` locally.
- [x] Browse loads accessible GitHub repos, supports search/refresh, and disables already tracked repos.
- [x] Edit persists local clone path and branch pattern through the shared update API.
- [x] Remove requires confirmation and refreshes repo/sidebar filter state after success.
- [x] Sidebar repo filters reconcile after add/edit/remove through existing per-Desktop filter sync.
- [x] Empty, loading, and recoverable error states are visible in Mac settings.
- [x] Accessibility identifiers added for new Mac settings controls used by UI automation.

## Validation

- [x] `git diff --check`
- [x] `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`\n- [x] `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`\n- [x] `pnpm typecheck`\n- [x] `pnpm lint` (passes with pre-existing warnings)\n- [ ] `IssueCTLMacUITests` - attempted full suite; interrupted after no test output for ~60s, matching existing menu-bar/accessory automation instability.\n\n## Dogfood Note\n\nNeeds runtime dogfood with local `issuectl web`: open Mac settings, add a repo, confirm it appears in sidebar filters, edit path/pattern, remove the repo, and confirm filters prune stale selections without relaunch.