### PR TITLE
Add Mac worktree management settings

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -193,7 +193,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return
         }
 
-        let payload = Self.payload(for: request.httpMethod ?? "GET", path: url.path)
+        let payload = Self.payload(for: request)
         let status = payload == nil ? 404 : 200
         let data = Self.jsonData(payload ?? ["error": "Unhandled \(url.path)"])
 
@@ -210,7 +210,10 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
 
     override func stopLoading() {}
 
-    private static func payload(for method: String, path: String) -> [String: Any]? {
+    private static func payload(for request: URLRequest) -> [String: Any]? {
+        let method = request.httpMethod ?? "GET"
+        let path = request.url?.path ?? "/"
+
         switch (method, path) {
         case ("GET", "/api/v1/health"):
             return ["ok": true, "version": "ui-test", "timestamp": isoDate]
@@ -232,6 +235,20 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["success": true, "error": NSNull()]
         case ("GET", "/api/v1/repos"):
             return ["repos": [repo]]
+        case ("GET", "/api/v1/worktrees"):
+            return ["worktrees": worktrees]
+        case ("POST", "/api/v1/worktrees/cleanup"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_CLEANUP_FAILURE"] == "1" {
+                return ["success": false, "error": "Fixture cleanup failed"]
+            }
+            let payload = jsonBody(from: request)
+            if let path = payload["path"] as? String {
+                worktrees.removeAll { $0["path"] as? String == path }
+                return ["success": true, "error": NSNull()]
+            }
+            let staleCount = worktrees.filter { ($0["stale"] as? Bool) == true }.count
+            worktrees.removeAll { ($0["stale"] as? Bool) == true }
+            return ["success": true, "removed": staleCount, "error": NSNull()]
         case ("GET", "/api/v1/repos/github"):
             return ["repos": [
                 ["owner": "org", "name": "alpha", "private": false, "pushed_at": isoDate],
@@ -261,11 +278,40 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ]
     }
 
+    nonisolated(unsafe) private static var worktrees: [[String: Any]] = [
+        [
+            "path": "/tmp/alpha-worktree-101",
+            "name": "alpha-worktree-101",
+            "repo": "alpha",
+            "owner": "org",
+            "local_path": "/tmp/issuectl-alpha",
+            "issue_number": 101,
+            "stale": false,
+        ],
+        [
+            "path": "/tmp/alpha-worktree-stale",
+            "name": "alpha-worktree-stale",
+            "repo": "alpha",
+            "owner": "org",
+            "local_path": "/tmp/issuectl-alpha",
+            "issue_number": 102,
+            "stale": true,
+        ],
+    ]
+
     private static var isoDate: String {
         "2026-05-14T00:00:00Z"
     }
 
     private static func jsonData(_ object: Any) -> Data {
         (try? JSONSerialization.data(withJSONObject: object)) ?? Data("{}".utf8)
+    }
+
+    private static func jsonBody(from request: URLRequest) -> [String: Any] {
+        guard let data = request.httpBody,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
     }
 }

--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -35,6 +35,12 @@ struct MacSettingsView: View {
     @State private var branchPattern = ""
     @State private var worktreeDir = ""
     @State private var defaultRepoId = ""
+    @State private var worktrees: [WorktreeInfo] = []
+    @State private var isLoadingWorktrees = false
+    @State private var worktreeError: String?
+    @State private var worktreeActionError: String?
+    @State private var isCleaningStaleWorktrees = false
+    @State private var cleaningWorktreePath: String?
     @State private var showAddRepo = false
     @State private var editingRepo: Repo?
     @State private var repoPendingRemoval: Repo?
@@ -45,6 +51,8 @@ struct MacSettingsView: View {
             connectionSection
 
             advancedSettingsSection
+
+            worktreesSection
 
             Section("Mac Sidebar") {
                 Toggle("Launch at Login", isOn: launchAtLoginBinding)
@@ -385,6 +393,111 @@ struct MacSettingsView: View {
         }
     }
 
+    private var worktreesSection: some View {
+        Section("Worktrees") {
+            HStack {
+                Button {
+                    Task { await loadWorktrees() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(isLoadingWorktrees)
+                .accessibilityIdentifier("mac-settings-refresh-worktrees-button")
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    Task { await cleanupStaleWorktrees() }
+                } label: {
+                    if isCleaningStaleWorktrees {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Clean Up Stale", systemImage: "trash")
+                    }
+                }
+                .disabled(staleWorktrees.isEmpty || isLoadingWorktrees || isCleaningStaleWorktrees || cleaningWorktreePath != nil)
+                .accessibilityIdentifier("mac-settings-cleanup-stale-worktrees-button")
+            }
+
+            if isLoadingWorktrees && worktrees.isEmpty {
+                ProgressView("Checking worktrees...")
+                    .accessibilityIdentifier("mac-settings-worktrees-loading")
+            } else if let worktreeError, worktrees.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(worktreeError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("mac-settings-worktrees-error")
+                    Button("Retry") {
+                        Task { await loadWorktrees() }
+                    }
+                }
+            } else if worktrees.isEmpty {
+                ContentUnavailableView(
+                    "No Worktrees",
+                    systemImage: "folder",
+                    description: Text("No active or stale git worktrees were found.")
+                )
+                .accessibilityIdentifier("mac-settings-worktrees-empty")
+            } else {
+                MacWorktreeSummaryCard(
+                    totalCount: worktrees.count,
+                    activeCount: activeWorktrees.count,
+                    staleCount: staleWorktrees.count
+                )
+                .accessibilityIdentifier("mac-settings-worktrees-summary")
+
+                if let worktreeActionError {
+                    Label(worktreeActionError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("mac-settings-worktrees-action-error")
+                }
+
+                if !staleWorktrees.isEmpty {
+                    Text("Needs Cleanup")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(staleWorktrees) { worktree in
+                        MacSettingsWorktreeRow(
+                            worktree: worktree,
+                            isCleaning: cleaningWorktreePath == worktree.path,
+                            canClean: true
+                        ) {
+                            Task { await cleanupWorktree(path: worktree.path) }
+                        }
+                    }
+                }
+
+                if !activeWorktrees.isEmpty {
+                    Text("Active")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(activeWorktrees) { worktree in
+                        MacSettingsWorktreeRow(
+                            worktree: worktree,
+                            isCleaning: false,
+                            canClean: false,
+                            onCleanup: {}
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var staleWorktrees: [WorktreeInfo] {
+        worktrees.filter(\.stale)
+    }
+
+    private var activeWorktrees: [WorktreeInfo] {
+        worktrees.filter { !$0.stale }
+    }
+
     private var launchAtLoginBinding: Binding<Bool> {
         Binding(
             get: { preferences.launchAtLogin },
@@ -441,7 +554,8 @@ struct MacSettingsView: View {
         async let connectionTask: () = loadConnectionStatus()
         async let reposTask: () = loadRepos(refresh: false)
         async let advancedTask: () = loadAdvancedSettings()
-        _ = await (connectionTask, reposTask, advancedTask)
+        async let worktreesTask: () = loadWorktrees()
+        _ = await (connectionTask, reposTask, advancedTask, worktreesTask)
     }
 
     private func loadConnectionStatus() async {
@@ -514,6 +628,9 @@ struct MacSettingsView: View {
         connectionError = "Disconnected"
         settings = [:]
         settingsError = nil
+        worktrees = []
+        worktreeError = nil
+        worktreeActionError = nil
         syncManualConnectionFields()
     }
 
@@ -577,6 +694,59 @@ struct MacSettingsView: View {
             showSettingsSaved = false
         } catch {
             settingsSaveError = error.localizedDescription
+        }
+    }
+
+    private func loadWorktrees() async {
+        guard api.isConfigured else {
+            worktrees = []
+            worktreeError = "Connect to issuectl web before checking worktrees."
+            return
+        }
+
+        isLoadingWorktrees = true
+        worktreeError = nil
+        worktreeActionError = nil
+        defer { isLoadingWorktrees = false }
+
+        do {
+            worktrees = try await api.listWorktrees()
+        } catch {
+            worktreeError = error.localizedDescription
+        }
+    }
+
+    private func cleanupWorktree(path: String) async {
+        cleaningWorktreePath = path
+        worktreeActionError = nil
+        defer { cleaningWorktreePath = nil }
+
+        do {
+            let response = try await api.cleanupWorktree(path: path)
+            guard response.success else {
+                worktreeActionError = response.error ?? "Failed to clean up worktree"
+                return
+            }
+            worktrees.removeAll { $0.path == path }
+        } catch {
+            worktreeActionError = error.localizedDescription
+        }
+    }
+
+    private func cleanupStaleWorktrees() async {
+        isCleaningStaleWorktrees = true
+        worktreeActionError = nil
+        defer { isCleaningStaleWorktrees = false }
+
+        do {
+            let response = try await api.cleanupStaleWorktrees()
+            guard response.success else {
+                worktreeActionError = response.error ?? "Failed to clean up stale worktrees"
+                return
+            }
+            await loadWorktrees()
+        } catch {
+            worktreeActionError = error.localizedDescription
         }
     }
 
@@ -795,6 +965,115 @@ private enum MacSettingsAppVersion {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         return "\(version) (\(build))"
+    }
+}
+
+private struct MacWorktreeSummaryCard: View {
+    let totalCount: Int
+    let activeCount: Int
+    let staleCount: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: staleCount > 0 ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(staleCount > 0 ? .orange : .green)
+                    .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(staleCount > 0 ? "Cleanup Available" : "Worktrees Clear")
+                        .font(.headline)
+                    Text(staleCount > 0 ? "\(staleCount) stale worktree\(staleCount == 1 ? "" : "s") can be cleaned up." : "No stale worktrees were found.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 8) {
+                metric("Total", totalCount, "folder")
+                metric("Active", activeCount, "checkmark.circle")
+                metric("Stale", staleCount, "exclamationmark.circle")
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func metric(_ title: String, _ value: Int, _ systemImage: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Label(title, systemImage: systemImage)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("\(value)")
+                .font(.caption.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color(nsColor: .windowBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private struct MacSettingsWorktreeRow: View {
+    let worktree: WorktreeInfo
+    let isCleaning: Bool
+    let canClean: Bool
+    let onCleanup: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: worktree.stale ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .foregroundStyle(worktree.stale ? .orange : .green)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(worktree.name)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Text(worktree.stale ? "Stale" : "Active")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(worktree.stale ? .orange : .green)
+                }
+
+                if let repoFullName = worktree.repoFullName {
+                    Label(repoFullName, systemImage: "arrow.triangle.branch")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let issueNumber = worktree.issueNumber {
+                    Label("Issue #\(issueNumber)", systemImage: "number")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Label(worktree.path, systemImage: "externaldrive")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 8)
+
+            if isCleaning {
+                ProgressView()
+                    .controlSize(.small)
+            } else if canClean {
+                Button(role: .destructive) {
+                    onCleanup()
+                } label: {
+                    Label("Clean Up", systemImage: "trash")
+                }
+                .accessibilityIdentifier("mac-settings-cleanup-worktree-\(worktree.name)")
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("mac-settings-worktree-row-\(worktree.name)")
     }
 }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -76,6 +76,54 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["mac-settings-advanced-save-error"].waitForExistence(timeout: 1), app.debugDescription)
     }
 
+    func testSettingsShowsWorktreesAndCleansStaleRows() {
+        openSettings()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktrees-summary"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-101"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["mac-settings-cleanup-worktree-alpha-worktree-101"].exists, app.debugDescription)
+
+        let cleanupStale = app.buttons["mac-settings-cleanup-stale-worktrees-button"]
+        XCTAssertTrue(cleanupStale.waitForExistence(timeout: 5), app.debugDescription)
+        cleanupStale.click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForNonExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-101"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-settings-worktrees-action-error"].exists, app.debugDescription)
+    }
+
+    func testSettingsCleansIndividualStaleWorktree() {
+        openSettings()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForExistence(timeout: 5), app.debugDescription)
+
+        let cleanup = app.buttons["mac-settings-cleanup-worktree-alpha-worktree-stale"]
+        XCTAssertTrue(cleanup.waitForExistence(timeout: 5), app.debugDescription)
+        cleanup.click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForNonExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-101"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-settings-worktrees-action-error"].exists, app.debugDescription)
+    }
+
+    func testSettingsWorktreeCleanupFailureKeepsRowsAndShowsError() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_CLEANUP_FAILURE"] = "1"
+        app.launch()
+
+        openSettings()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForExistence(timeout: 5), app.debugDescription)
+
+        let cleanupStale = app.buttons["mac-settings-cleanup-stale-worktrees-button"]
+        XCTAssertTrue(cleanupStale.waitForExistence(timeout: 5), app.debugDescription)
+        cleanupStale.click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktrees-action-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-worktree-row-alpha-worktree-stale"].waitForExistence(timeout: 3), app.debugDescription)
+    }
+
     private func openSettings() {
         let statusItem = app.statusItems["IssueCTL"].firstMatch
         XCTAssertTrue(statusItem.waitForExistence(timeout: 8), app.debugDescription)

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -90,6 +90,70 @@ final class APIClientExtensionTests: XCTestCase {
         XCTAssertNil(response.error)
     }
 
+    // MARK: - Worktrees
+
+    @MainActor
+    func testListWorktreesUsesEndpointAndDecodesRows() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/worktrees")
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            return (self.makeResponse(url: request.url!), """
+            {"worktrees":[{"path":"/tmp/alpha","name":"alpha","repo":"issuectl","owner":"mean-weasel","local_path":"/tmp/repo","issue_number":42,"stale":true}]}
+            """.data(using: .utf8)!)
+        }
+
+        let worktrees = try await client.listWorktrees()
+
+        XCTAssertEqual(worktrees.count, 1)
+        XCTAssertEqual(worktrees[0].repoFullName, "mean-weasel/issuectl")
+        XCTAssertEqual(worktrees[0].issueNumber, 42)
+        XCTAssertTrue(worktrees[0].stale)
+    }
+
+    @MainActor
+    func testCleanupWorktreeSendsPathBody() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/worktrees/cleanup")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(json["path"] as? String, "/tmp/alpha")
+
+            return (self.makeResponse(url: request.url!), """
+            {"success":true,"error":null}
+            """.data(using: .utf8)!)
+        }
+
+        let response = try await client.cleanupWorktree(path: "/tmp/alpha")
+
+        XCTAssertTrue(response.success)
+        XCTAssertNil(response.error)
+    }
+
+    @MainActor
+    func testCleanupStaleWorktreesSendsEmptyBodyAndDecodesRemovedCount() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/worktrees/cleanup")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertTrue(json.isEmpty)
+
+            return (self.makeResponse(url: request.url!), """
+            {"success":true,"removed":2,"error":null}
+            """.data(using: .utf8)!)
+        }
+
+        let response = try await client.cleanupStaleWorktrees()
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.removed, 2)
+        XCTAssertNil(response.error)
+    }
+
     // MARK: - Repository Settings
 
     @MainActor

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -144,6 +144,25 @@ final class TestableAPIClient {
         return try decoder.decode(SuccessResponse.self, from: data)
     }
 
+    func listWorktrees() async throws -> [WorktreeInfo] {
+        let (data, _) = try await request(path: "/api/v1/worktrees")
+        return try decoder.decode(WorktreesResponse.self, from: data).worktrees
+    }
+
+    func cleanupWorktree(path: String) async throws -> SuccessResponse {
+        let body = WorktreeCleanupRequest(path: path)
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/worktrees/cleanup", method: "POST", body: bodyData)
+        return try decoder.decode(SuccessResponse.self, from: data)
+    }
+
+    func cleanupStaleWorktrees() async throws -> WorktreeCleanupResponse {
+        let body: [String: String?] = [:]
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/worktrees/cleanup", method: "POST", body: bodyData)
+        return try decoder.decode(WorktreeCleanupResponse.self, from: data)
+    }
+
     func issues(owner: String, repo: String, refresh: Bool = false) async throws -> IssuesResponse {
         var path = "/api/v1/issues/\(owner)/\(repo)"
         if refresh { path += "?refresh=true" }

--- a/docs/goals/mac-ios-parity/notes/T017-phase-3-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T017-phase-3-branch-start.md
@@ -1,0 +1,7 @@
+# T017 Phase 3 Branch Start
+
+Date: 2026-05-14
+
+Started Phase 3 Worktree Management on `mac-parity-phase-3-worktrees`, based on `mac-sidebar-spaces-option-a`.
+
+Draft PR target: `mac-sidebar-spaces-option-a`.

--- a/docs/goals/mac-ios-parity/notes/T017-phase-3-worktrees.md
+++ b/docs/goals/mac-ios-parity/notes/T017-phase-3-worktrees.md
@@ -1,0 +1,37 @@
+# T017 Phase 3 Worktree Management
+
+## Result
+
+Done. Implemented Phase 3 Worktree Management on branch `mac-parity-phase-3-worktrees` with draft PR #425 targeting `mac-sidebar-spaces-option-a`.
+
+## Product Changes
+
+- Added a native Mac Settings `Worktrees` section.
+- Lists active and stale worktrees with repo, issue number, path, and status.
+- Shows total, active, and stale counts.
+- Supports refresh, individual stale worktree cleanup, and bulk stale cleanup.
+- Active worktrees do not expose destructive cleanup controls.
+- Cleanup failures keep rows intact and show a recoverable error.
+
+## Test Evidence
+
+- `git diff --check`: pass.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 23 tests.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 7 tests.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 36 tests.
+- `pnpm typecheck`: pass.
+- `pnpm lint`: pass with existing warnings.
+
+## Acceptance Evidence
+
+- View active and stale worktrees: covered by `testSettingsShowsWorktreesAndCleansStaleRows`.
+- Clean one stale worktree: covered by `testSettingsCleansIndividualStaleWorktree`.
+- Clean all stale worktrees: covered by `testSettingsShowsWorktreesAndCleansStaleRows`.
+- Active worktrees not destructive-cleanable: covered by `testSettingsShowsWorktreesAndCleansStaleRows`.
+- Cleanup failure leaves rows intact and shows error: covered by `testSettingsWorktreeCleanupFailureKeepsRowsAndShowsError`.
+- API route/body coverage for list, single cleanup, and stale cleanup: covered by `APIClientExtensionTests`.
+
+## Residual Risk
+
+- No real-disk dogfood cleanup pass was run in this slice; fixture-backed UI and API tests cover behavior deterministically.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T017
+active_task: T018
 
 tasks:
   - id: T001
@@ -599,7 +599,7 @@ tasks:
   - id: T017
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 3 Worktree Management as the next PR-sized slice from mac-sidebar-spaces-option-a."
     inputs:
@@ -637,6 +637,62 @@ tasks:
       - "Cleanup semantics are ambiguous for active worktrees."
       - "Need backend route or schema changes."
       - "Mac UI test harness regresses to hanging."
+    receipt:
+      result: done
+      note: "notes/T017-phase-3-worktrees.md"
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "apple/IssueCTLTests/APIClientTests.swift"
+      pr:
+        number: 425
+        url: "https://github.com/mean-weasel/issuectl/pull/425"
+        branch: "mac-parity-phase-3-worktrees"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Not checked yet after final push."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+      warnings:
+        - "pnpm lint passed with pre-existing warnings."
+      summary: "Implemented native Mac worktree management in Settings with active/stale listing, refresh, individual stale cleanup, bulk stale cleanup, failure recovery, fixture API support, and focused API/UI validation."
+      next_task: T018
+
+  - id: T018
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #425 Phase 3 for acceptance coverage, CI/check status, merge readiness, and next-slice sizing."
+    inputs:
+      - "T017 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/425"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md#phase-3-worktree-management"
+    constraints:
+      - "Do not implement product changes unless review finds a small blocking fix."
+      - "Do not mark ready or merge if required acceptance criteria are missing."
+      - "If GitHub reports no checks, document the accepted local replacement gate before merge."
+      - "Choose the next PR-sized parity task after the PR is ready or merged."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance criteria evidence map."
+      - "CI or replacement validation status."
+      - "Merge recommendation and next active task."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
Phase 3 Worktree Management slice for Mac/iOS parity.

Base: `mac-sidebar-spaces-option-a`
GoalBuddy tasks: T017 worker, T018 judge
Head: `11c30bddd2a8ca1cd685bdb7bec85f8561c71e13`

## Summary

- Adds a native Mac Settings `Worktrees` section.
- Lists active and stale worktrees with repo, issue, path, status, and count summary.
- Supports refresh, individual stale cleanup, and bulk stale cleanup.
- Keeps active worktrees free of destructive cleanup controls.
- Shows recoverable cleanup errors without removing rows.
- Extends the Mac UI fixture API and shared API client tests for worktree list/cleanup endpoints.

## Validation

- `git diff --check`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests` - 23 tests
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` - 7 tests
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests` - 36 tests
- `pnpm typecheck`
- `pnpm lint` - passes with existing warnings

GitHub reports no configured status checks for this PR head, so the local validation above is the replacement gate.