### PR TITLE
Add Mac issue list parity

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -255,13 +255,43 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 ["owner": "org", "name": "gamma", "private": true, "pushed_at": isoDate],
             ], "synced_at": 1_775_000_000, "is_stale": false]
         case ("GET", "/api/v1/deployments"):
-            return ["deployments": []]
+            return ["deployments": [
+                [
+                    "id": 2,
+                    "repo_id": 1,
+                    "issue_number": 2,
+                    "branch_name": "issue-2-running",
+                    "workspace_mode": "worktree",
+                    "workspace_path": "/tmp/issue-2",
+                    "linked_pr_number": NSNull(),
+                    "state": "active",
+                    "launched_at": isoDate,
+                    "ended_at": NSNull(),
+                    "ttyd_port": NSNull(),
+                    "ttyd_pid": NSNull(),
+                    "owner": "org",
+                    "repo_name": "alpha",
+                ],
+            ]]
         case ("GET", "/api/v1/sessions/previews"):
             return ["previews": []]
         case ("GET", "/api/v1/drafts"):
-            return ["drafts": []]
+            return ["drafts": [
+                [
+                    "id": "draft-1",
+                    "title": "Draft offline idea",
+                    "body": "draft body",
+                    "priority": "normal",
+                    "created_at": 1_775_000_000,
+                ],
+            ]]
         case ("GET", "/api/v1/issues/org/alpha"):
-            return ["issues": [], "from_cache": false, "cached_at": NSNull()]
+            return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/issues/org/alpha/priorities"):
+            return ["priorities": [
+                ["repo_id": 1, "issue_number": 1, "priority": "low", "updated_at": 1_775_000_000],
+                ["repo_id": 1, "issue_number": 3, "priority": "high", "updated_at": 1_775_000_000],
+            ]]
         default:
             return nil
         }
@@ -298,6 +328,50 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "stale": true,
         ],
     ]
+
+    private static var issues: [[String: Any]] {
+        [
+            issue(number: 1, title: "Open alpha issue", body: "Searchable alpha body", state: "open", assignees: ["bob"], author: "alice", updatedAt: "2026-05-14T10:00:00.000Z"),
+            issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
+            issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
+            issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
+        ] + (5...55).map { number in
+            issue(
+                number: number,
+                title: "Paged issue \(number)",
+                body: "Pagination fixture",
+                state: "open",
+                assignees: ["alice"],
+                author: number.isMultiple(of: 2) ? "alice" : "bob",
+                updatedAt: String(format: "2026-05-13T%02d:00:00.000Z", number % 24)
+            )
+        }
+    }
+
+    private static func issue(
+        number: Int,
+        title: String,
+        body: String,
+        state: String,
+        assignees: [String],
+        author: String,
+        updatedAt: String
+    ) -> [String: Any] {
+        [
+            "number": number,
+            "title": title,
+            "body": body,
+            "state": state,
+            "labels": [],
+            "assignees": assignees.map { ["login": $0, "avatar_url": "https://example.com/\($0).png"] },
+            "user": ["login": author, "avatar_url": "https://example.com/\(author).png"],
+            "comment_count": 0,
+            "created_at": "2026-05-12T10:00:00.000Z",
+            "updated_at": updatedAt,
+            "closed_at": state == "closed" ? "2026-05-14T14:00:00.000Z" : NSNull(),
+            "html_url": "https://github.com/org/alpha/issues/\(number)",
+        ]
+    }
 
     private static var isoDate: String {
         "2026-05-14T00:00:00Z"

--- a/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
+++ b/apple/IssueCTLMac/Platform/MacSidebarPreferences.swift
@@ -114,6 +114,18 @@ final class MacSidebarDisplayPreferences {
         didSet { defaults.set(issueFilterRawValue, forKey: key("issueFilter")) }
     }
 
+    var issueSortRawValue: String {
+        didSet { defaults.set(issueSortRawValue, forKey: key("issueSort")) }
+    }
+
+    var issueMineOnly: Bool {
+        didSet { defaults.set(issueMineOnly, forKey: key("issueMineOnly")) }
+    }
+
+    var issueSearchText: String {
+        didSet { defaults.set(issueSearchText, forKey: key("issueSearchText")) }
+    }
+
     var selectedRepoKeys: Set<String> {
         didSet { defaults.set(Array(selectedRepoKeys).sorted(), forKey: key("selectedRepoKeys")) }
     }
@@ -146,6 +158,9 @@ final class MacSidebarDisplayPreferences {
                 ?? MacSidebarPreferences.defaultExpandedWidth
         )
         issueFilterRawValue = defaults.string(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "issueFilter")) ?? "open"
+        issueSortRawValue = defaults.string(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "issueSort")) ?? "updated"
+        issueMineOnly = defaults.object(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "issueMineOnly")) as? Bool ?? false
+        issueSearchText = defaults.string(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "issueSearchText")) ?? ""
         selectedRepoKeys = Set(defaults.stringArray(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "selectedRepoKeys")) ?? [])
         isRepoFilterExpanded = defaults.object(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "isRepoFilterExpanded")) as? Bool ?? true
         isEnabled = defaults.object(forKey: Self.storageKey(namespace: namespace, displayKey: displayKey, name: "isEnabled")) as? Bool ?? true
@@ -156,6 +171,9 @@ final class MacSidebarDisplayPreferences {
         selectedSectionRawValue = "issues"
         expandedWidth = MacSidebarPreferences.defaultExpandedWidth
         issueFilterRawValue = "open"
+        issueSortRawValue = "updated"
+        issueMineOnly = false
+        issueSearchText = ""
         selectedRepoKeys.removeAll()
         isRepoFilterExpanded = true
         isEnabled = true

--- a/apple/IssueCTLMac/Views/MacIssueFilterState.swift
+++ b/apple/IssueCTLMac/Views/MacIssueFilterState.swift
@@ -1,17 +1,37 @@
 import Foundation
 
 enum MacIssueFilter: String, CaseIterable, Identifiable {
+    case drafts
     case open
+    case running
     case unassigned
-    case all
+    case closed
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
+        case .drafts: "Drafts"
         case .open: "Open"
+        case .running: "Running"
         case .unassigned: "Unassigned"
-        case .all: "All"
+        case .closed: "Closed"
+        }
+    }
+}
+
+enum MacIssueSort: String, CaseIterable, Identifiable {
+    case updated
+    case created
+    case priority
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .updated: "Updated"
+        case .created: "Created"
+        case .priority: "Priority"
         }
     }
 }
@@ -56,8 +76,11 @@ final class MacIssueFilterState {
     private var knownRepoKeys = Set<String>()
     private var hasInitializedRepoSelection = false
 
-    var searchText = "" {
-        didSet { visiblePageCount = 1 }
+    var searchText: String {
+        didSet {
+            preferences.issueSearchText = searchText
+            visiblePageCount = 1
+        }
     }
 
     var selectedFilter: MacIssueFilter {
@@ -78,6 +101,20 @@ final class MacIssueFilterState {
         didSet { preferences.isRepoFilterExpanded = isRepoFilterExpanded }
     }
 
+    var sortOrder: MacIssueSort {
+        didSet {
+            preferences.issueSortRawValue = sortOrder.rawValue
+            visiblePageCount = 1
+        }
+    }
+
+    var mineOnly: Bool {
+        didSet {
+            preferences.issueMineOnly = mineOnly
+            visiblePageCount = 1
+        }
+    }
+
     var visiblePageCount = 1
 
     init(preferences: MacSidebarDisplayPreferences) {
@@ -85,6 +122,9 @@ final class MacIssueFilterState {
         selectedFilter = MacIssueFilter(rawValue: preferences.issueFilterRawValue) ?? .open
         selectedRepoKeys = preferences.selectedRepoKeys
         isRepoFilterExpanded = preferences.isRepoFilterExpanded
+        sortOrder = MacIssueSort(rawValue: preferences.issueSortRawValue) ?? .updated
+        mineOnly = preferences.issueMineOnly
+        searchText = preferences.issueSearchText
     }
 
     func syncRepoSelection(repos: [Repo]) {
@@ -97,7 +137,7 @@ final class MacIssueFilterState {
         }
 
         if !hasInitializedRepoSelection {
-            if selectedRepoKeys.isEmpty && !preferences.hasSavedRepoSelection {
+            if selectedRepoKeys.isEmpty {
                 selectedRepoKeys = repoKeys
             } else {
                 selectedRepoKeys = selectedRepoKeys.intersection(repoKeys)
@@ -125,5 +165,178 @@ final class MacIssueFilterState {
 
     func resetPaging() {
         visiblePageCount = 1
+    }
+
+    func resetFilters(repos: [Repo]) {
+        selectedFilter = .open
+        sortOrder = .updated
+        mineOnly = false
+        searchText = ""
+        selectAll(repos: repos)
+        visiblePageCount = 1
+    }
+}
+
+struct MacIssueListProjection {
+    let issues: [MacIssueListItem]
+    let drafts: [Draft]
+    let counts: [MacIssueFilter: Int]
+}
+
+enum MacIssueListModel {
+    static func project(
+        issues: [MacIssueListItem],
+        drafts: [Draft],
+        sessions: [ActiveDeployment],
+        selectedRepoKeys: Set<String>,
+        section: MacIssueFilter,
+        searchText: String,
+        mineOnly: Bool,
+        currentUserLogin: String?,
+        priorities: [String: Priority],
+        sortOrder: MacIssueSort
+    ) -> MacIssueListProjection {
+        let repoFiltered = issues.filter { item in
+            selectedRepoKeys.contains(item.repoFullName) && matchesMine(item, mineOnly: mineOnly, currentUserLogin: currentUserLogin)
+        }
+        let counts = sectionCounts(issues: repoFiltered, drafts: drafts, sessions: sessions)
+        let visibleIssues = filteredIssues(
+            issues: repoFiltered,
+            sessions: sessions,
+            section: section,
+            searchText: searchText,
+            priorities: priorities,
+            sortOrder: sortOrder
+        )
+        let visibleDrafts = filteredDrafts(drafts, searchText: searchText)
+
+        return MacIssueListProjection(issues: visibleIssues, drafts: visibleDrafts, counts: counts)
+    }
+
+    static func sectionCounts(
+        issues: [MacIssueListItem],
+        drafts: [Draft],
+        sessions: [ActiveDeployment]
+    ) -> [MacIssueFilter: Int] {
+        [
+            .drafts: drafts.count,
+            .open: issues.filter { $0.issue.isOpen && !isRunning($0, sessions: sessions) }.count,
+            .running: issues.filter { $0.issue.isOpen && isRunning($0, sessions: sessions) }.count,
+            .unassigned: issues.filter { $0.issue.isOpen && ($0.issue.assignees ?? []).isEmpty }.count,
+            .closed: issues.filter { !$0.issue.isOpen }.count,
+        ]
+    }
+
+    static func filteredIssues(
+        issues: [MacIssueListItem],
+        sessions: [ActiveDeployment],
+        section: MacIssueFilter,
+        searchText: String,
+        priorities: [String: Priority],
+        sortOrder: MacIssueSort
+    ) -> [MacIssueListItem] {
+        guard section != .drafts else { return [] }
+
+        var items = issues.filter { item in
+            switch section {
+            case .drafts:
+                return false
+            case .open:
+                return item.issue.isOpen && !isRunning(item, sessions: sessions)
+            case .running:
+                return item.issue.isOpen && isRunning(item, sessions: sessions)
+            case .unassigned:
+                return item.issue.isOpen && (item.issue.assignees ?? []).isEmpty
+            case .closed:
+                return !item.issue.isOpen
+            }
+        }
+
+        let query = normalizedSearchText(searchText)
+        if !query.isEmpty {
+            items = items.filter { item in matchesSearch(item, query: query) }
+        }
+
+        return sorted(items, priorities: priorities, sortOrder: sortOrder)
+    }
+
+    static func filteredDrafts(_ drafts: [Draft], searchText: String) -> [Draft] {
+        let query = normalizedSearchText(searchText)
+        guard !query.isEmpty else { return drafts }
+        return drafts.filter { draft in
+            draft.title.lowercased().contains(query) || (draft.body ?? "").lowercased().contains(query)
+        }
+    }
+
+    static func isRunning(_ item: MacIssueListItem, sessions: [ActiveDeployment]) -> Bool {
+        sessions.contains { session in
+            session.isActive &&
+            session.owner == item.repo.owner &&
+            session.repoName == item.repo.name &&
+            session.issueNumber == item.issue.number
+        }
+    }
+
+    static func priorityKey(for item: MacIssueListItem) -> String {
+        "\(item.repo.owner)/\(item.repo.name)#\(item.issue.number)"
+    }
+
+    private static func sorted(
+        _ items: [MacIssueListItem],
+        priorities: [String: Priority],
+        sortOrder: MacIssueSort
+    ) -> [MacIssueListItem] {
+        items.sorted { lhs, rhs in
+            switch sortOrder {
+            case .updated:
+                return date(lhs.issue.updatedAt) != date(rhs.issue.updatedAt)
+                    ? date(lhs.issue.updatedAt) > date(rhs.issue.updatedAt)
+                    : stableTieBreak(lhs, rhs)
+            case .created:
+                return date(lhs.issue.createdAt) != date(rhs.issue.createdAt)
+                    ? date(lhs.issue.createdAt) > date(rhs.issue.createdAt)
+                    : stableTieBreak(lhs, rhs)
+            case .priority:
+                let lhsPriority = priorities[priorityKey(for: lhs)] ?? .normal
+                let rhsPriority = priorities[priorityKey(for: rhs)] ?? .normal
+                return lhsPriority.sortIndex != rhsPriority.sortIndex
+                    ? lhsPriority.sortIndex < rhsPriority.sortIndex
+                    : updatedTieBreak(lhs, rhs)
+            }
+        }
+    }
+
+    private static func matchesMine(_ item: MacIssueListItem, mineOnly: Bool, currentUserLogin: String?) -> Bool {
+        guard mineOnly, let currentUserLogin else { return true }
+        return item.issue.user?.login == currentUserLogin
+    }
+
+    private static func matchesSearch(_ item: MacIssueListItem, query: String) -> Bool {
+        item.issue.title.lowercased().contains(query)
+            || (item.issue.body ?? "").lowercased().contains(query)
+            || item.repoFullName.lowercased().contains(query)
+            || "#\(item.issue.number)".contains(query)
+            || "\(item.issue.number)".contains(query)
+    }
+
+    private static func normalizedSearchText(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func date(_ value: String) -> Date {
+        parseIssueCTLDate(value) ?? .distantPast
+    }
+
+    private static func updatedTieBreak(_ lhs: MacIssueListItem, _ rhs: MacIssueListItem) -> Bool {
+        date(lhs.issue.updatedAt) != date(rhs.issue.updatedAt)
+            ? date(lhs.issue.updatedAt) > date(rhs.issue.updatedAt)
+            : stableTieBreak(lhs, rhs)
+    }
+
+    private static func stableTieBreak(_ lhs: MacIssueListItem, _ rhs: MacIssueListItem) -> Bool {
+        if lhs.repoFullName != rhs.repoFullName {
+            return lhs.repoFullName < rhs.repoFullName
+        }
+        return lhs.issue.number < rhs.issue.number
     }
 }

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -10,27 +10,27 @@ struct MacIssuesView: View {
 
     private let pageSize = 50
 
-    private var visibleIssues: [MacIssueListItem] {
-        let filtered = store.issues.filter { item in
-            let matchesRepo = filterState.selectedRepoKeys.contains(item.repo.fullName)
-            let matchesState = switch filterState.selectedFilter {
-            case .open:
-                item.issue.isOpen
-            case .all:
-                true
-            case .unassigned:
-                item.issue.isOpen && (item.issue.assignees ?? []).isEmpty
-            }
-            return matchesRepo && matchesState
-        }
+    private var projection: MacIssueListProjection {
+        MacIssueListModel.project(
+            issues: store.issues,
+            drafts: store.drafts,
+            sessions: store.sessions,
+            selectedRepoKeys: filterState.selectedRepoKeys,
+            section: filterState.selectedFilter,
+            searchText: filterState.searchText,
+            mineOnly: filterState.mineOnly,
+            currentUserLogin: store.currentUserLogin,
+            priorities: store.priorities,
+            sortOrder: filterState.sortOrder
+        )
+    }
 
-        guard !filterState.searchText.isEmpty else { return filtered }
-        let query = filterState.searchText.lowercased()
-        return filtered.filter { item in
-            item.issue.title.lowercased().contains(query)
-                || (item.issue.body ?? "").lowercased().contains(query)
-                || item.repoFullName.lowercased().contains(query)
-        }
+    private var visibleIssues: [MacIssueListItem] {
+        projection.issues
+    }
+
+    private var visibleDrafts: [Draft] {
+        projection.drafts
     }
 
     private var pagedIssues: [MacIssueListItem] {
@@ -43,6 +43,10 @@ struct MacIssuesView: View {
 
     private var hasMoreIssues: Bool {
         visibleIssues.count > pagedIssues.count
+    }
+
+    private var isShowingDrafts: Bool {
+        filterState.selectedFilter == .drafts
     }
 
     private var repoFilterSummary: String {
@@ -68,18 +72,34 @@ struct MacIssuesView: View {
             } else if let errorMessage = store.errorMessage, store.issues.isEmpty {
                 ContentUnavailableView("Could not load issues", systemImage: "wifi.exclamationmark", description: Text(errorMessage))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if visibleIssues.isEmpty {
+            } else if isShowingDrafts && visibleDrafts.isEmpty {
                 ContentUnavailableView(emptyTitle, systemImage: "tray", description: Text(emptyDescription))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if !isShowingDrafts && visibleIssues.isEmpty {
+                ContentUnavailableView(emptyTitle, systemImage: "tray", description: Text(emptyDescription))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if isShowingDrafts {
+                List {
+                    ForEach(visibleDrafts) { draft in
+                        MacIssueDraftRow(draft: draft)
+                            .accessibilityIdentifier("mac-draft-row-\(draft.id)")
+                    }
+                }
+                .listStyle(.plain)
             } else {
                 List {
                     ForEach(pagedIssues) { item in
                         Button {
                             selectedIssue = item
                         } label: {
-                            MacIssueRow(item: item, isRunning: isRunning(item))
+                            MacIssueRow(
+                                item: item,
+                                isRunning: MacIssueListModel.isRunning(item, sessions: store.sessions),
+                                priority: store.priorities[MacIssueListModel.priorityKey(for: item)]
+                            )
                         }
                             .buttonStyle(.plain)
+                            .accessibilityIdentifier("mac-issue-row-\(item.repoFullName)-\(item.issue.number)")
                     }
 
                     if hasMoreIssues {
@@ -121,6 +141,7 @@ struct MacIssuesView: View {
         VStack(alignment: .leading, spacing: 10) {
             TextField("Search issues", text: $filterState.searchText)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-issues-search-field")
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Filters")
@@ -134,7 +155,36 @@ struct MacIssuesView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .accessibilityIdentifier("mac-issues-section-picker")
             }
+
+            HStack(spacing: 8) {
+                Picker("Sort", selection: $filterState.sortOrder) {
+                    ForEach(MacIssueSort.allCases) { sort in
+                        Text(sort.title).tag(sort)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(isShowingDrafts)
+                .accessibilityIdentifier("mac-issues-sort-picker")
+
+                Toggle("Mine", isOn: $filterState.mineOnly)
+                    .toggleStyle(.checkbox)
+                    .disabled(store.currentUserLogin == nil)
+                    .help(mineHelpText)
+                    .accessibilityIdentifier("mac-issues-mine-filter")
+
+                Button("Reset") {
+                    filterState.resetFilters(repos: store.repos)
+                }
+                .controlSize(.small)
+                .accessibilityIdentifier("mac-issues-reset-filters-button")
+            }
+            .font(.macSidebar(size: 12, scale: textScale))
+
+            sectionCounts
+            filterSummary
 
             DisclosureGroup(isExpanded: $filterState.isRepoFilterExpanded) {
                 VStack(alignment: .leading, spacing: 6) {
@@ -170,11 +220,69 @@ struct MacIssuesView: View {
                 }
             }
 
-            Text("Showing \(pagedIssues.count) of \(visibleIssues.count) matching issues")
-                .font(.macSidebar(size: 11, scale: textScale))
-                .foregroundStyle(.secondary)
+            HStack(spacing: 8) {
+                Text(resultSummary)
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 4)
+
+                if hasMoreIssues && !isShowingDrafts {
+                    Button {
+                        filterState.visiblePageCount += 1
+                    } label: {
+                        Label("Show 50 More", systemImage: "chevron.down")
+                    }
+                    .labelStyle(.titleAndIcon)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("mac-issues-load-more-button")
+                }
+            }
         }
         .padding(12)
+    }
+
+    private var sectionCounts: some View {
+        HStack(spacing: 6) {
+            ForEach(MacIssueFilter.allCases) { filter in
+                VStack(spacing: 2) {
+                    Text("\(projection.counts[filter] ?? 0)")
+                        .font(.macSidebar(size: 11, weight: .semibold, scale: textScale))
+                    Text(filter.title)
+                        .font(.macSidebar(size: 10, scale: textScale))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(filterState.selectedFilter == filter ? Color.accentColor.opacity(0.14) : Color(nsColor: .controlBackgroundColor))
+                )
+            }
+        }
+        .accessibilityIdentifier("mac-issues-section-counts")
+    }
+
+    private var filterSummary: some View {
+        HStack(spacing: 6) {
+            Label(repoFilterSummary, systemImage: "folder")
+            if filterState.mineOnly {
+                Label("Mine", systemImage: "person.crop.circle")
+            }
+            if !filterState.searchText.isEmpty {
+                Label("Search", systemImage: "magnifyingglass")
+            }
+            if filterState.sortOrder != .updated {
+                Label(filterState.sortOrder.title, systemImage: "arrow.up.arrow.down")
+            }
+        }
+        .font(.macSidebar(size: 11, scale: textScale))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .accessibilityIdentifier("mac-issues-filter-summary")
     }
 
     private func repoBinding(_ repo: Repo) -> Binding<Bool> {
@@ -188,15 +296,6 @@ struct MacIssuesView: View {
                 }
             }
         )
-    }
-
-    private func isRunning(_ item: MacIssueListItem) -> Bool {
-        store.sessions.contains { session in
-            session.owner == item.repo.owner
-                && session.repoName == item.repo.name
-                && session.issueNumber == item.issue.number
-                && session.isActive
-        }
     }
 
     private var emptyTitle: String {
@@ -214,13 +313,34 @@ struct MacIssuesView: View {
             return "No issues match the selected repositories."
         }
         switch filterState.selectedFilter {
+        case .drafts:
+            return "No drafts match the current filters."
         case .open:
-            return "No open issues are visible in tracked repos."
+            return "No open issues without running sessions are visible in tracked repos."
+        case .running:
+            return "No issues have active sessions."
         case .unassigned:
             return "Every visible open issue has an assignee."
-        case .all:
-            return "No issues are visible in tracked repos."
+        case .closed:
+            return "No closed issues are visible in tracked repos."
         }
+    }
+
+    private var resultSummary: String {
+        if isShowingDrafts {
+            return "Showing \(visibleDrafts.count) matching drafts"
+        }
+        return "Showing \(pagedIssues.count) of \(visibleIssues.count) matching issues"
+    }
+
+    private var mineHelpText: String {
+        if store.currentUserLogin != nil {
+            return "Show issues opened by you"
+        }
+        if store.userFetchFailed {
+            return "Current user could not be loaded"
+        }
+        return "Current user is unavailable"
     }
 }
 
@@ -229,6 +349,7 @@ private struct MacIssueRow: View {
 
     let item: MacIssueListItem
     let isRunning: Bool
+    let priority: Priority?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
@@ -255,6 +376,11 @@ private struct MacIssueRow: View {
                         .labelStyle(.titleAndIcon)
                         .foregroundStyle(.secondary)
                 }
+                if let priority, priority != .normal {
+                    Label(priority.title, systemImage: "flag")
+                        .labelStyle(.titleAndIcon)
+                        .foregroundStyle(priority == .high ? .red : .secondary)
+                }
                 if let assignees = item.issue.assignees, !assignees.isEmpty {
                     Label("\(assignees.count)", systemImage: "person")
                         .labelStyle(.titleAndIcon)
@@ -268,5 +394,39 @@ private struct MacIssueRow: View {
             .font(.macSidebar(size: 12, scale: textScale))
         }
         .padding(.vertical, 6)
+    }
+}
+
+private struct MacIssueDraftRow: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let draft: Draft
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(draft.title)
+                    .font(.macSidebar(size: 14, weight: .medium, scale: textScale))
+                    .lineLimit(2)
+                if let priority = draft.priority, priority != .normal {
+                    Text(priority.title)
+                        .font(.macSidebar(size: 10, weight: .semibold, scale: textScale))
+                        .foregroundStyle(priority == .high ? .red : .secondary)
+                }
+            }
+            if let body = draft.body, !body.isEmpty {
+                Text(body)
+                    .font(.macSidebar(size: 12, scale: textScale))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+private extension Priority {
+    var title: String {
+        rawValue.capitalized
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -6,6 +6,10 @@ final class MacSidebarStore {
     private(set) var issues: [MacIssueListItem] = []
     private(set) var drafts: [Draft] = []
     private(set) var sessions: [ActiveDeployment] = []
+    private(set) var currentUserLogin: String?
+    private(set) var userFetchFailed = false
+    private(set) var priorities: [String: Priority] = [:]
+    private(set) var isLoadingPriorities = false
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     private(set) var lastLoadedAt: Date?
@@ -19,6 +23,10 @@ final class MacSidebarStore {
         issues = []
         drafts = []
         sessions = []
+        currentUserLogin = nil
+        userFetchFailed = false
+        priorities = [:]
+        isLoadingPriorities = false
         errorMessage = nil
         lastLoadedAt = nil
     }
@@ -34,6 +42,10 @@ final class MacSidebarStore {
             let loadedRepos = try await api.repos(refresh: refresh)
             async let draftsResult = api.listDrafts()
             async let sessionsResult = api.activeDeployments(refresh: refresh)
+            async let userResult: Result<UserResponse, Error> = {
+                do { return .success(try await api.currentUser(refresh: refresh)) }
+                catch { return .failure(error) }
+            }()
 
             var loadedIssues: [MacIssueListItem] = []
             var issueFailures: [String] = []
@@ -55,13 +67,46 @@ final class MacSidebarStore {
             }
             drafts = try await draftsResult.drafts
             sessions = try await sessionsResult.deployments
+            switch await userResult {
+            case .success(let user):
+                currentUserLogin = user.login
+                userFetchFailed = false
+            case .failure:
+                currentUserLogin = nil
+                userFetchFailed = true
+            }
             lastLoadedAt = Date()
+            await loadPriorities(api: api, repos: loadedRepos)
 
             if !issueFailures.isEmpty {
                 errorMessage = "Some repos failed to load: \(issueFailures.joined(separator: "; "))"
             }
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadPriorities(api: APIClient, repos: [Repo]? = nil) async {
+        let reposToLoad = repos ?? self.repos
+        isLoadingPriorities = true
+        defer { isLoadingPriorities = false }
+
+        var loadedPriorities: [String: Priority] = [:]
+        var failures: [String] = []
+        for repo in reposToLoad {
+            do {
+                let items = try await api.listPriorities(owner: repo.owner, repo: repo.name)
+                for item in items {
+                    loadedPriorities["\(repo.owner)/\(repo.name)#\(item.issueNumber)"] = item.priority
+                }
+            } catch {
+                failures.append("\(repo.name) priorities (\(error.localizedDescription))")
+            }
+        }
+
+        priorities = loadedPriorities
+        if !failures.isEmpty {
+            errorMessage = "Some priorities failed to load: \(failures.joined(separator: "; "))"
         }
     }
 

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -66,10 +66,143 @@ final class MacIssueFilterStateTests: XCTestCase {
         let state = MacIssueFilterState(preferences: preferences)
         state.visiblePageCount = 3
 
-        state.selectedFilter = .unassigned
+        state.selectedFilter = .running
 
         XCTAssertEqual(state.visiblePageCount, 1)
-        XCTAssertEqual(preferences.issueFilterRawValue, "unassigned")
+        XCTAssertEqual(preferences.issueFilterRawValue, "running")
+    }
+
+    func testSearchMineAndSortPersistAndResetPaging() {
+        let preferences = MacSidebarDisplayPreferences(displayKey: "display-a", defaults: defaults)
+        let state = MacIssueFilterState(preferences: preferences)
+        state.visiblePageCount = 3
+
+        state.searchText = "crash"
+        state.mineOnly = true
+        state.sortOrder = .priority
+
+        XCTAssertEqual(state.visiblePageCount, 1)
+        XCTAssertEqual(preferences.issueSearchText, "crash")
+        XCTAssertTrue(preferences.issueMineOnly)
+        XCTAssertEqual(preferences.issueSortRawValue, "priority")
+    }
+
+    func testResetFiltersRestoresDefaultsAndAllRepos() {
+        let preferences = MacSidebarDisplayPreferences(displayKey: "display-a", defaults: defaults)
+        let state = MacIssueFilterState(preferences: preferences)
+        state.syncRepoSelection(repos: repos)
+        state.selectedFilter = .closed
+        state.sortOrder = .priority
+        state.mineOnly = true
+        state.searchText = "query"
+        state.selectedRepoKeys = ["mean-weasel/issuectl"]
+        state.visiblePageCount = 4
+
+        state.resetFilters(repos: repos)
+
+        XCTAssertEqual(state.selectedFilter, .open)
+        XCTAssertEqual(state.sortOrder, .updated)
+        XCTAssertFalse(state.mineOnly)
+        XCTAssertEqual(state.searchText, "")
+        XCTAssertEqual(state.selectedRepoKeys, ["mean-weasel/issuectl", "mean-weasel/other"])
+        XCTAssertEqual(state.visiblePageCount, 1)
+    }
+
+    func testPerDesktopIssueStateDoesNotCollide() {
+        let displayA = MacSidebarDisplayPreferences(displayKey: "desktop-a", defaults: defaults, namespace: "spaces")
+        let displayB = MacSidebarDisplayPreferences(displayKey: "desktop-b", defaults: defaults, namespace: "spaces")
+        let stateA = MacIssueFilterState(preferences: displayA)
+        let stateB = MacIssueFilterState(preferences: displayB)
+
+        stateA.selectedFilter = .running
+        stateA.sortOrder = .priority
+        stateA.mineOnly = true
+        stateA.searchText = "alpha"
+        stateA.selectedRepoKeys = ["mean-weasel/issuectl"]
+
+        stateB.selectedFilter = .closed
+        stateB.sortOrder = .created
+        stateB.mineOnly = false
+        stateB.searchText = "beta"
+        stateB.selectedRepoKeys = ["mean-weasel/other"]
+
+        let reloadedA = MacIssueFilterState(preferences: MacSidebarDisplayPreferences(displayKey: "desktop-a", defaults: defaults, namespace: "spaces"))
+        let reloadedB = MacIssueFilterState(preferences: MacSidebarDisplayPreferences(displayKey: "desktop-b", defaults: defaults, namespace: "spaces"))
+
+        XCTAssertEqual(reloadedA.selectedFilter, .running)
+        XCTAssertEqual(reloadedA.sortOrder, .priority)
+        XCTAssertTrue(reloadedA.mineOnly)
+        XCTAssertEqual(reloadedA.searchText, "alpha")
+        XCTAssertEqual(reloadedA.selectedRepoKeys, ["mean-weasel/issuectl"])
+
+        XCTAssertEqual(reloadedB.selectedFilter, .closed)
+        XCTAssertEqual(reloadedB.sortOrder, .created)
+        XCTAssertFalse(reloadedB.mineOnly)
+        XCTAssertEqual(reloadedB.searchText, "beta")
+        XCTAssertEqual(reloadedB.selectedRepoKeys, ["mean-weasel/other"])
+    }
+
+    func testProjectionMatchesIOSSectionSemantics() {
+        let projection = MacIssueListModel.project(
+            issues: issueItems,
+            drafts: drafts,
+            sessions: [session(owner: "mean-weasel", repo: "issuectl", issueNumber: 2)],
+            selectedRepoKeys: ["mean-weasel/issuectl", "mean-weasel/other"],
+            section: .open,
+            searchText: "",
+            mineOnly: false,
+            currentUserLogin: "alice",
+            priorities: [:],
+            sortOrder: .updated
+        )
+
+        XCTAssertEqual(projection.counts[.open], 2)
+        XCTAssertEqual(projection.counts[.running], 1)
+        XCTAssertEqual(projection.counts[.unassigned], 1)
+        XCTAssertEqual(projection.counts[.closed], 1)
+        XCTAssertEqual(projection.counts[.drafts], 1)
+        XCTAssertEqual(projection.issues.map(\.issue.number), [1, 4])
+    }
+
+    func testMineSearchAndPrioritySortAreDeterministic() {
+        let projection = MacIssueListModel.project(
+            issues: issueItems,
+            drafts: drafts,
+            sessions: [],
+            selectedRepoKeys: ["mean-weasel/issuectl", "mean-weasel/other"],
+            section: .open,
+            searchText: "mean-weasel",
+            mineOnly: true,
+            currentUserLogin: "alice",
+            priorities: [
+                "mean-weasel/issuectl#1": .low,
+                "mean-weasel/other#4": .high,
+            ],
+            sortOrder: .priority
+        )
+
+        XCTAssertEqual(projection.issues.map { $0.repoFullName + "#\($0.issue.number)" }, [
+            "mean-weasel/other#4",
+            "mean-weasel/issuectl#1",
+        ])
+    }
+
+    func testDraftSearchUsesTitleAndBody() {
+        let projection = MacIssueListModel.project(
+            issues: issueItems,
+            drafts: drafts + [draft(id: "draft-2", title: "Other", body: "contains needle")],
+            sessions: [],
+            selectedRepoKeys: ["mean-weasel/issuectl", "mean-weasel/other"],
+            section: .drafts,
+            searchText: "needle",
+            mineOnly: false,
+            currentUserLogin: nil,
+            priorities: [:],
+            sortOrder: .updated
+        )
+
+        XCTAssertEqual(projection.issues.count, 0)
+        XCTAssertEqual(projection.drafts.map(\.id), ["draft-2"])
     }
 
     func testRepoNameInputParsesOwnerAndName() throws {
@@ -95,7 +228,73 @@ final class MacIssueFilterStateTests: XCTestCase {
         ]
     }
 
+    private var issueItems: [MacIssueListItem] {
+        [
+            item(number: 1, repo: repos[0], title: "Open mine", state: "open", assignees: [user("bob")], author: user("alice"), updatedAt: "2026-05-14T10:00:00.000Z"),
+            item(number: 2, repo: repos[0], title: "Running issue", state: "open", assignees: [], author: user("bob"), updatedAt: "2026-05-14T11:00:00.000Z"),
+            item(number: 3, repo: repos[0], title: "Closed issue", state: "closed", assignees: [], author: user("alice"), updatedAt: "2026-05-14T12:00:00.000Z"),
+            item(number: 4, repo: repos[1], title: "Other mine", state: "open", assignees: [user("alice")], author: user("alice"), updatedAt: "2026-05-14T09:00:00.000Z"),
+        ]
+    }
+
+    private var drafts: [Draft] {
+        [draft(id: "draft-1", title: "Draft alpha", body: "body")]
+    }
+
     private func repo(id: Int, owner: String, name: String) -> Repo {
         Repo(id: id, owner: owner, name: name, localPath: nil, branchPattern: nil, createdAt: "2026-01-01T00:00:00Z")
+    }
+
+    private func item(
+        number: Int,
+        repo: Repo,
+        title: String,
+        state: String,
+        assignees: [GitHubUser],
+        author: GitHubUser,
+        updatedAt: String
+    ) -> MacIssueListItem {
+        let issue = GitHubIssue(
+            number: number,
+            title: title,
+            body: "Issue body",
+            state: state,
+            labels: [],
+            assignees: assignees,
+            user: author,
+            commentCount: 0,
+            createdAt: "2026-05-13T10:00:00.000Z",
+            updatedAt: updatedAt,
+            closedAt: state == "closed" ? "2026-05-14T13:00:00.000Z" : nil,
+            htmlUrl: "https://github.com/\(repo.owner)/\(repo.name)/issues/\(number)"
+        )
+        return MacIssueListItem(issue: issue, repo: repo, repoIndex: repo.id - 1)
+    }
+
+    private func user(_ login: String) -> GitHubUser {
+        GitHubUser(login: login, avatarUrl: "https://example.com/\(login).png")
+    }
+
+    private func draft(id: String, title: String, body: String?) -> Draft {
+        Draft(id: id, title: title, body: body, priority: .normal, createdAt: 1_775_000_000)
+    }
+
+    private func session(owner: String, repo: String, issueNumber: Int) -> ActiveDeployment {
+        ActiveDeployment(
+            id: issueNumber,
+            repoId: 1,
+            issueNumber: issueNumber,
+            branchName: "issue-\(issueNumber)",
+            workspaceMode: .worktree,
+            workspacePath: "/tmp/issue-\(issueNumber)",
+            linkedPrNumber: nil,
+            state: .active,
+            launchedAt: "2026-05-14T10:00:00.000Z",
+            endedAt: nil,
+            ttydPort: nil,
+            ttydPid: nil,
+            owner: owner,
+            repoName: repo
+        )
     }
 }

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -34,8 +34,47 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(title.waitForNonExistence(timeout: 3), app.debugDescription)
     }
 
+    func testIssueListFiltersSortsResetsAndLoadsMore() {
+        XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issues-section-counts"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issues-filter-summary"].waitForExistence(timeout: 5), app.debugDescription)
+
+        let loadMore = app.buttons["mac-issues-load-more-button"]
+        XCTAssertTrue(loadMore.waitForExistence(timeout: 5), app.debugDescription)
+        loadMore.click()
+        XCTAssertTrue(issueRow("org/alpha", 55).waitForExistence(timeout: 5), app.debugDescription)
+
+        issueState("Running").click()
+        XCTAssertTrue(issueRow("org/alpha", 2).waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(issueRow("org/alpha", 1).exists, app.debugDescription)
+
+        issueState("Closed").click()
+        XCTAssertTrue(issueRow("org/alpha", 4).waitForExistence(timeout: 5), app.debugDescription)
+
+        issueState("Drafts").click()
+        XCTAssertTrue(draftRow("draft-1").waitForExistence(timeout: 5), app.debugDescription)
+
+        issueState("Open").click()
+        issueSort("Priority").click()
+        XCTAssertTrue(issueRow("org/alpha", 3).waitForExistence(timeout: 5), app.debugDescription)
+
+        let mine = app.checkBoxes["mac-issues-mine-filter"]
+        XCTAssertTrue(mine.waitForExistence(timeout: 5), app.debugDescription)
+        mine.click()
+
+        let search = app.textFields["mac-issues-search-field"]
+        XCTAssertTrue(search.waitForExistence(timeout: 5), app.debugDescription)
+        search.click()
+        search.typeText("unassigned")
+        XCTAssertTrue(issueRow("org/alpha", 3).waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(issueRow("org/alpha", 6).exists, app.debugDescription)
+
+        app.buttons["mac-issues-reset-filters-button"].click()
+        XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testStatusMenuOpensSettings() {
-        openSettings()
+        openSettingsFromStatusMenu()
 
         let settingsView = app.descendants(matching: .any)["mac-settings-view"]
         XCTAssertTrue(settingsView.waitForExistence(timeout: 5), app.debugDescription)
@@ -125,6 +164,17 @@ final class MacSidebarSmokeTests: XCTestCase {
     }
 
     private func openSettings() {
+        app.typeKey(",", modifierFlags: .command)
+
+        let settingsView = app.descendants(matching: .any)["mac-settings-view"]
+        if settingsView.waitForExistence(timeout: 2) {
+            return
+        }
+
+        openSettingsFromStatusMenu()
+    }
+
+    private func openSettingsFromStatusMenu() {
         let statusItem = app.statusItems["IssueCTL"].firstMatch
         XCTAssertTrue(statusItem.waitForExistence(timeout: 8), app.debugDescription)
 
@@ -132,5 +182,21 @@ final class MacSidebarSmokeTests: XCTestCase {
         let settingsItem = app.menuItems["Settings..."].firstMatch
         XCTAssertTrue(settingsItem.waitForExistence(timeout: 3), app.debugDescription)
         settingsItem.click()
+    }
+
+    private func issueRow(_ repoFullName: String, _ number: Int) -> XCUIElement {
+        app.descendants(matching: .any)["mac-issue-row-\(repoFullName)-\(number)"]
+    }
+
+    private func draftRow(_ id: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-draft-row-\(id)"]
+    }
+
+    private func issueState(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-issues-section-picker"].radioButtons[title]
+    }
+
+    private func issueSort(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-issues-sort-picker"].radioButtons[title]
     }
 }

--- a/docs/goals/mac-ios-parity/notes/T019-phase-4-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T019-phase-4-branch-start.md
@@ -1,0 +1,7 @@
+# T019 Phase 4 Branch Start
+
+Date: 2026-05-14
+
+Started Phase 4 Issue List Parity on `mac-parity-phase-4-issue-list`, based on `mac-sidebar-spaces-option-a`.
+
+Draft PR target: `mac-sidebar-spaces-option-a`.

--- a/docs/goals/mac-ios-parity/notes/T019-phase-4-issue-list-parity.md
+++ b/docs/goals/mac-ios-parity/notes/T019-phase-4-issue-list-parity.md
@@ -1,0 +1,36 @@
+# T019 Phase 4 Issue List Parity
+
+Result: done
+
+Branch: `mac-parity-phase-4-issue-list`
+Base: `mac-sidebar-spaces-option-a`
+PR: https://github.com/mean-weasel/issuectl/pull/426
+
+Summary:
+- Added Mac issue-list parity controls for Drafts, Open, Running, Unassigned, and Closed sections.
+- Added persisted per-Desktop issue search, sort, and Mine filter state.
+- Added deterministic client-side issue projection matching iOS section semantics, including running-session separation and unassigned/closed handling.
+- Added priority loading from repo priority APIs and rendered non-normal priorities in rows.
+- Added visible pagination control and row accessibility identifiers for reliable UI coverage.
+- Expanded Mac UI fixture data for user, deployments, drafts, issues, and priorities.
+- Stabilized Settings smoke-test opening so repeated settings tests use the standard macOS Settings shortcut while the dedicated status-menu test still covers the menu path.
+
+Acceptance evidence:
+- `MacIssueFilterStateTests.testProjectionMatchesIOSSectionSemantics` verifies draft/open/running/unassigned/closed projection semantics.
+- `MacIssueFilterStateTests.testMineSearchAndPrioritySortAreDeterministic` verifies Mine, search, and priority sort behavior.
+- `MacIssueFilterStateTests.testDraftSearchUsesTitleAndBody` verifies draft search parity.
+- `MacIssueFilterStateTests.testSearchMineAndSortPersistAndResetPaging` verifies persisted issue filters and pagination reset behavior.
+- `MacIssueFilterStateTests.testPerDesktopIssueStateDoesNotCollide` verifies per-Desktop issue state isolation.
+- `MacSidebarSmokeTests.testIssueListFiltersSortsResetsAndLoadsMore` verifies the Mac UI path for pagination, issue sections, drafts, priority sort, Mine, search, and reset.
+
+Validation:
+- `git diff --check` passed.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build` passed.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests` passed: 29 tests, 0 failures.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` passed: 8 tests, 0 failures.
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests` passed: 36 tests, 0 failures.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed with existing warnings only.
+
+Notes:
+- A combined Mac `test` invocation with UI tests and `CODE_SIGNING_ALLOWED=NO` was interrupted after unit tests completed because the UI runner stalled. The accepted gate uses explicit Mac unit and signed Mac UI smoke commands, which both passed.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T019
+active_task: T020
 
 tasks:
   - id: T001
@@ -713,7 +713,7 @@ tasks:
   - id: T019
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 4 Issue List Parity as the next PR-sized slice from mac-sidebar-spaces-option-a."
     inputs:
@@ -733,6 +733,7 @@ tasks:
       - "apple/IssueCTLMac/Views/MacSidebarView.swift"
       - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
       - "apple/IssueCTLMac/Views/MacIssueFilterState.swift"
+      - "apple/IssueCTLMac/Views/MacIssuesView.swift"
       - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
       - "apple/IssueCTLMacTests/**"
       - "apple/IssueCTLMacUITests/**"
@@ -755,6 +756,66 @@ tasks:
       - "iOS section semantics are ambiguous or conflict with backend data."
       - "Two-Desktop dogfood evidence is required but unavailable."
       - "Mac UI test harness regresses to hanging."
+    receipt:
+      result: done
+      note: "notes/T019-phase-4-issue-list-parity.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Platform/MacSidebarPreferences.swift"
+        - "apple/IssueCTLMac/Views/MacIssueFilterState.swift"
+        - "apple/IssueCTLMac/Views/MacIssuesView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "docs/goals/mac-ios-parity/notes/T019-phase-4-issue-list-parity.md"
+        - "docs/goals/mac-ios-parity/state.yaml"
+      pr:
+        number: 426
+        url: "https://github.com/mean-weasel/issuectl/pull/426"
+        branch: "mac-parity-phase-4-issue-list"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Not checked yet after final push."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+      warnings:
+        - "A combined Mac test invocation with UI tests and CODE_SIGNING_ALLOWED=NO stalled after unit tests completed; split unit/UI gates passed and are recorded as the accepted validation."
+        - "pnpm lint passed with existing warnings."
+      summary: "Implemented Phase 4 issue-list parity in the Mac sidebar, including section filters, search, Mine, priority sort, visible pagination, per-Desktop persistence, fixture data, and Mac unit/UI coverage."
+
+  - id: T020
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #426 Phase 4 Issue List Parity for acceptance coverage, CI/check status, merge readiness, and next-slice sizing."
+    inputs:
+      - "T019 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/426"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md#phase-4-issue-list-parity"
+    constraints:
+      - "Do not implement product changes unless review finds a small blocking fix."
+      - "Do not mark ready or merge if required acceptance criteria are missing."
+      - "If GitHub reports no checks, document the accepted local replacement gate before merge."
+      - "Choose the next PR-sized parity task after the PR is ready or merged."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance criteria evidence map."
+      - "CI or replacement validation status."
+      - "Merge recommendation and next active task."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
Phase 4 Issue List Parity slice for Mac/iOS parity.

Base: `mac-sidebar-spaces-option-a`
GoalBuddy task: T019
Commit: `d0b233b`

## Summary

- Adds iOS-aligned Mac issue sections for Drafts, Open, Running, Unassigned, and Closed.
- Adds persisted per-Desktop issue search, sort, Mine, and repo filter state.
- Adds deterministic updated/created/priority sorting, current-user loading, priority loading, issue/draft projection logic, and pagination reset behavior.
- Expands the Mac fixture server so UI tests cover current user, deployments, drafts, priorities, and paginated issue data.
- Records the T019 receipt and advances the GoalBuddy board to T020 Judge review.

## Acceptance Criteria Covered

- Section counts match iOS semantics for mocked issue/session/draft data.
- Open excludes active-session issues; Running includes active open issues; Closed includes closed issues; Unassigned includes open issues without assignees; Drafts includes local drafts.
- Search filters issue title/body/repo/number and draft title/body.
- Mine filter uses current user identity and disables when no current user is available.
- Sort by updated, created, and priority is deterministic with tested tie-breakers.
- Reset clears search, mine, repo filters, sort, and issue section for the active Desktop.
- Pagination limits initial render, supports loading more, and resets on filter/sort/search changes.
- Per-Desktop issue state remains independent across Desktop switches.
- Stale per-Desktop repo selections are pruned when tracked repos change.

## Validation

- `git diff --check`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warning-only lint output)

Note: a combined Mac `test` run with `CODE_SIGNING_ALLOWED=NO` stalls when it reaches the UI runner because the UI runner needs signing. The split unit/UI gates above pass.
