### PR TITLE
Add Mac issue detail core actions

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -287,6 +287,45 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             ]]
         case ("GET", "/api/v1/issues/org/alpha"):
             return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/issues/org/alpha/1"):
+            return issueDetail()
+        case ("PATCH", "/api/v1/issues/org/alpha/1"):
+            let payload = jsonBody(from: request)
+            if let title = payload["title"] as? String {
+                detailIssueTitle = title
+            }
+            if let body = payload["body"] as? String {
+                detailIssueBody = body
+            }
+            return ["success": true, "error": NSNull()]
+        case ("POST", "/api/v1/issues/org/alpha/1/state"):
+            let payload = jsonBody(from: request)
+            detailIssueState = payload["state"] as? String ?? detailIssueState
+            if let comment = payload["comment"] as? String, !comment.isEmpty {
+                detailComments.append(commentFixture(id: 500, body: comment, author: "alice"))
+            }
+            return ["success": true, "error": NSNull()]
+        case ("POST", "/api/v1/issues/org/alpha/1/comments"):
+            let payload = jsonBody(from: request)
+            if let body = payload["body"] as? String {
+                detailComments.append(commentFixture(id: 501, body: body, author: "alice"))
+            }
+            return ["success": true, "comment_id": 501, "error": NSNull()]
+        case ("PATCH", "/api/v1/issues/org/alpha/1/comments"):
+            let payload = jsonBody(from: request)
+            let commentId = payload["comment_id"] as? Int ?? payload["commentId"] as? Int
+            if let commentId, let body = payload["body"] as? String,
+               let index = detailComments.firstIndex(where: { $0["id"] as? Int == commentId }) {
+                detailComments[index] = commentFixture(id: commentId, body: body, author: "alice")
+            }
+            return ["success": true, "error": NSNull()]
+        case ("DELETE", "/api/v1/issues/org/alpha/1/comments"):
+            let payload = jsonBody(from: request)
+            let commentId = payload["comment_id"] as? Int ?? payload["commentId"] as? Int
+            if let commentId {
+                detailComments.removeAll { $0["id"] as? Int == commentId }
+            }
+            return ["success": true, "error": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/priorities"):
             return ["priorities": [
                 ["repo_id": 1, "issue_number": 1, "priority": "low", "updated_at": 1_775_000_000],
@@ -329,9 +368,17 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ],
     ]
 
+    nonisolated(unsafe) private static var detailIssueTitle = "Open alpha issue"
+    nonisolated(unsafe) private static var detailIssueBody = "Searchable **alpha** body\n\n```swift\nlet value = 1\n```"
+    nonisolated(unsafe) private static var detailIssueState = "open"
+    nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
+        commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
+        commentFixture(id: 102, body: "Bob comment", author: "bob"),
+    ]
+
     private static var issues: [[String: Any]] {
         [
-            issue(number: 1, title: "Open alpha issue", body: "Searchable alpha body", state: "open", assignees: ["bob"], author: "alice", updatedAt: "2026-05-14T10:00:00.000Z"),
+            issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, assignees: ["bob"], author: "alice", updatedAt: "2026-05-14T10:00:00.000Z"),
             issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
             issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
             issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
@@ -373,6 +420,65 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ]
     }
 
+    private static func issueDetail() -> [String: Any] {
+        [
+            "issue": issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, assignees: ["bob"], author: "alice", updatedAt: isoDate),
+            "comments": detailComments,
+            "deployments": [
+                [
+                    "id": 9,
+                    "repo_id": 1,
+                    "issue_number": 1,
+                    "branch_name": "issue-1-active",
+                    "workspace_mode": "worktree",
+                    "workspace_path": "/tmp/issue-1",
+                    "linked_pr_number": 7,
+                    "state": "active",
+                    "launched_at": isoDate,
+                    "ended_at": NSNull(),
+                    "ttyd_port": 7681,
+                    "ttyd_pid": 1234,
+                ],
+            ],
+            "linkedPRs": [
+                [
+                    "number": 7,
+                    "title": "Fix alpha detail",
+                    "body": "Linked PR",
+                    "state": "open",
+                    "draft": false,
+                    "merged": false,
+                    "user": ["login": "alice", "avatar_url": "https://example.com/alice.png"],
+                    "head_ref": "fix-alpha-detail",
+                    "base_ref": "main",
+                    "additions": 12,
+                    "deletions": 3,
+                    "changed_files": 2,
+                    "created_at": isoDate,
+                    "updated_at": isoDate,
+                    "merged_at": NSNull(),
+                    "closed_at": NSNull(),
+                    "html_url": "https://github.com/org/alpha/pull/7",
+                    "checks_status": "success",
+                ],
+            ],
+            "referencedFiles": [],
+            "fromCache": false,
+            "cachedAt": NSNull(),
+        ]
+    }
+
+    private static func commentFixture(id: Int, body: String, author: String) -> [String: Any] {
+        [
+            "id": id,
+            "body": body,
+            "user": ["login": author, "avatar_url": "https://example.com/\(author).png"],
+            "created_at": isoDate,
+            "updated_at": isoDate,
+            "html_url": "https://github.com/org/alpha/issues/1#issuecomment-\(id)",
+        ]
+    }
+
     private static var isoDate: String {
         "2026-05-14T00:00:00Z"
     }
@@ -382,7 +488,32 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     }
 
     private static func jsonBody(from request: URLRequest) -> [String: Any] {
-        guard let data = request.httpBody,
+        let data: Data?
+        if let body = request.httpBody {
+            data = body
+        } else if let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+
+            var body = Data()
+            let bufferSize = 1_024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+
+            while stream.hasBytesAvailable {
+                let bytesRead = stream.read(buffer, maxLength: bufferSize)
+                if bytesRead > 0 {
+                    body.append(buffer, count: bytesRead)
+                } else {
+                    break
+                }
+            }
+            data = body
+        } else {
+            data = nil
+        }
+
+        guard let data,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return [:]
         }

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -19,7 +19,11 @@ struct MacIssueDetailView: View {
     @State private var isUpdatingPriority = false
     @State private var isLaunching = false
     @State private var activeSession: ActiveDeployment?
+    @State private var currentUserLogin: String?
     @State private var errorMessage: String?
+    @State private var activeSheet: MacIssueDetailSheet?
+    @State private var isShowingCloseWithComment = false
+    @State private var commentPendingDeletion: GitHubComment?
 
     private var issue: GitHubIssue {
         detail?.issue ?? item.issue
@@ -53,22 +57,74 @@ struct MacIssueDetailView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
-                        issueSummary
-                        launchSection
-                        actionBar
-                        issueBody
-                        commentComposer
-                        comments
+                VStack(spacing: 0) {
+                    actionBar
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                    Divider()
+
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 18) {
+                            issueSummary
+                            launchSection
+                            issueBody
+                            linkedPullRequests
+                            deploymentsSection
+                            commentComposer
+                            comments
+                        }
+                        .padding(16)
                     }
-                    .padding(16)
                 }
             }
         }
         .frame(minWidth: 520, idealWidth: 620, minHeight: 560, idealHeight: 720)
         .task {
             await load(refresh: false)
+        }
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .editIssue:
+                MacEditIssueSheet(issue: issue) { title, body in
+                    try await store.updateIssue(api: api, item: item, title: title, body: body)
+                    await load(refresh: true)
+                    activeSheet = nil
+                }
+            case .closeWithComment:
+                EmptyView()
+            case .editComment(let comment):
+                MacEditCommentSheet(comment: comment) { body in
+                    try await store.editComment(api: api, item: item, commentId: comment.id, body: body)
+                    await load(refresh: true)
+                    activeSheet = nil
+                }
+            }
+        }
+        .sheet(isPresented: $isShowingCloseWithComment) {
+            MacCloseIssueSheet(issueNumber: issue.number) { comment in
+                try await store.updateIssueState(api: api, item: item, state: "closed", comment: comment)
+                await load(refresh: true)
+                isShowingCloseWithComment = false
+            }
+        }
+        .confirmationDialog(
+            "Delete Comment",
+            isPresented: .init(
+                get: { commentPendingDeletion != nil },
+                set: { if !$0 { commentPendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let comment = commentPendingDeletion {
+                    Task { await deleteComment(comment) }
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                commentPendingDeletion = nil
+            }
+        } message: {
+            Text("This cannot be undone.")
         }
     }
 
@@ -215,6 +271,14 @@ struct MacIssueDetailView: View {
     private var actionBar: some View {
         HStack(spacing: 8) {
             Button {
+                activeSheet = .editIssue
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("mac-issue-detail-edit-button")
+
+            Button {
                 Task { await updateState(issue.isOpen ? "closed" : "open") }
             } label: {
                 if isUpdatingState {
@@ -227,6 +291,19 @@ struct MacIssueDetailView: View {
             .buttonStyle(.borderedProminent)
             .tint(issue.isOpen ? .red : .green)
             .disabled(isUpdatingState)
+            .accessibilityIdentifier("mac-issue-detail-toggle-state-button")
+
+            if issue.isOpen {
+                Button {
+                    activeSheet = nil
+                    isShowingCloseWithComment = true
+                } label: {
+                    Label("Close With Comment", systemImage: "text.bubble")
+                }
+                .buttonStyle(.bordered)
+                .disabled(isUpdatingState)
+                .accessibilityIdentifier("mac-issue-detail-close-with-comment-button")
+            }
 
             Picker("Priority", selection: $priority) {
                 ForEach(Priority.allCases, id: \.self) { priority in
@@ -249,6 +326,7 @@ struct MacIssueDetailView: View {
                 Label("GitHub", systemImage: "safari")
             }
             .buttonStyle(.bordered)
+            .accessibilityIdentifier("mac-issue-detail-github-button")
 
             Spacer()
         }
@@ -290,10 +368,8 @@ struct MacIssueDetailView: View {
                 Divider()
                 Text("Description")
                     .font(.headline)
-                Text(body)
-                    .font(.body)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
+                MacMarkdownView(content: body)
+                    .accessibilityIdentifier("mac-issue-detail-body-markdown")
             }
         }
     }
@@ -350,13 +426,99 @@ struct MacIssueDetailView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
-                        Text(comment.body)
-                            .font(.body)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: false, vertical: true)
+                        MacMarkdownView(content: comment.body)
+
+                        if isOwnComment(comment) {
+                            HStack(spacing: 8) {
+                                Spacer()
+                                Button {
+                                    activeSheet = .editComment(comment)
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                .buttonStyle(.borderless)
+                                .accessibilityIdentifier("mac-issue-detail-edit-comment-\(comment.id)")
+
+                                Button(role: .destructive) {
+                                    commentPendingDeletion = comment
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                .buttonStyle(.borderless)
+                                .accessibilityIdentifier("mac-issue-detail-delete-comment-\(comment.id)")
+                            }
+                            .font(.caption)
+                        }
                     }
                     .padding(10)
                     .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("mac-issue-detail-comment-\(comment.id)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var linkedPullRequests: some View {
+        if let linkedPRs = detail?.linkedPRs, !linkedPRs.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Divider()
+                Text("Linked Pull Requests")
+                    .font(.headline)
+
+                ForEach(linkedPRs) { pr in
+                    HStack(spacing: 8) {
+                        Image(systemName: pr.isOpen ? "arrow.triangle.merge" : (pr.merged ? "checkmark.circle.fill" : "xmark.circle"))
+                            .foregroundStyle(pr.isOpen ? .green : (pr.merged ? .purple : .red))
+                        Text("#\(pr.number)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(pr.title)
+                            .font(.subheadline)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(pr.diffSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("mac-issue-detail-linked-pr-\(pr.number)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var deploymentsSection: some View {
+        if let deployments = detail?.deployments, !deployments.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Divider()
+                Text("Sessions")
+                    .font(.headline)
+
+                ForEach(deployments) { deployment in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(deployment.isActive ? .green : .secondary)
+                            .frame(width: 8, height: 8)
+                        Text(deployment.branchName)
+                            .font(.subheadline)
+                        Spacer()
+                        if deployment.isActive, deployment.ttydPort != nil {
+                            Button {
+                                openTerminal(activeDeployment(from: deployment))
+                            } label: {
+                                Label("Open", systemImage: "terminal")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityIdentifier("mac-issue-detail-open-session-\(deployment.id)")
+                        } else {
+                            Text(deployment.isActive ? deployment.state.rawValue : "ended")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .accessibilityIdentifier("mac-issue-detail-deployment-\(deployment.id)")
                 }
             }
         }
@@ -376,6 +538,10 @@ struct MacIssueDetailView: View {
 
         do {
             async let detailResult = store.issueDetail(api: api, item: item, refresh: refresh)
+            async let userResult: Result<UserResponse, Error> = {
+                do { return .success(try await api.currentUser(refresh: refresh)) }
+                catch { return .failure(error) }
+            }()
             async let priorityResult: Result<Priority, Error> = {
                 do { return .success(try await api.getPriority(owner: item.repo.owner, repo: item.repo.name, number: item.issue.number)) }
                 catch { return .failure(error) }
@@ -384,6 +550,12 @@ struct MacIssueDetailView: View {
             detail = try await detailResult
             await store.refreshSessions(api: api)
             activeSession = store.activeSession(for: item)
+            switch await userResult {
+            case .success(let user):
+                currentUserLogin = user.login
+            case .failure:
+                currentUserLogin = nil
+            }
             switch await priorityResult {
             case .success(let loadedPriority):
                 priority = loadedPriority
@@ -395,6 +567,11 @@ struct MacIssueDetailView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func isOwnComment(_ comment: GitHubComment) -> Bool {
+        guard let currentUserLogin else { return false }
+        return comment.user?.login == currentUserLogin
     }
 
     private func submitComment() async {
@@ -421,6 +598,18 @@ struct MacIssueDetailView: View {
 
         do {
             try await store.updateIssueState(api: api, item: item, state: state)
+            await load(refresh: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func deleteComment(_ comment: GitHubComment) async {
+        commentPendingDeletion = nil
+        errorMessage = nil
+
+        do {
+            try await store.deleteComment(api: api, item: item, commentId: comment.id)
             await load(refresh: true)
         } catch {
             errorMessage = error.localizedDescription
@@ -461,6 +650,25 @@ struct MacIssueDetailView: View {
         Task { await openTerminalAsync(session) }
     }
 
+    private func activeDeployment(from deployment: Deployment) -> ActiveDeployment {
+        ActiveDeployment(
+            id: deployment.id,
+            repoId: deployment.repoId,
+            issueNumber: deployment.issueNumber,
+            branchName: deployment.branchName,
+            workspaceMode: deployment.workspaceMode,
+            workspacePath: deployment.workspacePath,
+            linkedPrNumber: deployment.linkedPrNumber,
+            state: deployment.state,
+            launchedAt: deployment.launchedAt,
+            endedAt: deployment.endedAt,
+            ttydPort: deployment.ttydPort,
+            ttydPid: deployment.ttydPid,
+            owner: item.repo.owner,
+            repoName: item.repo.name
+        )
+    }
+
     private func openTerminalAsync(_ session: ActiveDeployment) async {
         errorMessage = nil
         do {
@@ -469,6 +677,357 @@ struct MacIssueDetailView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+}
+
+private enum MacIssueDetailSheet: Identifiable {
+    case editIssue
+    case closeWithComment
+    case editComment(GitHubComment)
+
+    var id: String {
+        switch self {
+        case .editIssue:
+            "edit-issue"
+        case .closeWithComment:
+            "close-with-comment"
+        case .editComment(let comment):
+            "edit-comment-\(comment.id)"
+        }
+    }
+}
+
+private struct MacEditIssueSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issue: GitHubIssue
+    let onSave: (String?, String?) async throws -> Void
+
+    @State private var title: String
+    @State private var bodyText: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(issue: GitHubIssue, onSave: @escaping (String?, String?) async throws -> Void) {
+        self.issue = issue
+        self.onSave = onSave
+        _title = State(initialValue: issue.title)
+        _bodyText = State(initialValue: issue.body ?? "")
+    }
+
+    private var trimmedTitle: String { title.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedBody: String { bodyText.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var hasChanges: Bool {
+        trimmedTitle != issue.title || trimmedBody != (issue.body ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Edit Issue")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .disabled(isSaving)
+            }
+
+            TextField("Title", text: $title)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-edit-issue-title-field")
+
+            TextEditor(text: $bodyText)
+                .font(.body)
+                .frame(minHeight: 220)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                }
+                .accessibilityIdentifier("mac-edit-issue-body-field")
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-edit-issue-error")
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    Task { await save() }
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Save", systemImage: "checkmark.circle")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(trimmedTitle.isEmpty || !hasChanges || isSaving)
+                .accessibilityIdentifier("mac-edit-issue-save-button")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 460, minHeight: 420)
+    }
+
+    private func save() async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            try await onSave(
+                trimmedTitle != issue.title ? trimmedTitle : nil,
+                trimmedBody != (issue.body ?? "") ? trimmedBody : nil
+            )
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacCloseIssueSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issueNumber: Int
+    let onClose: (String?) async throws -> Void
+
+    @State private var comment = ""
+    @State private var isClosing = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Close Issue #\(issueNumber)")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .disabled(isClosing)
+            }
+
+            TextEditor(text: $comment)
+                .font(.body)
+                .frame(minHeight: 160)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                }
+                .accessibilityIdentifier("mac-close-issue-comment-field")
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-close-issue-error")
+            }
+
+            HStack {
+                Spacer()
+                Button(role: .destructive) {
+                    Task { await close() }
+                } label: {
+                    if isClosing {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Close Issue", systemImage: "xmark.circle")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isClosing)
+                .accessibilityIdentifier("mac-close-issue-submit-button")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 440, minHeight: 320)
+    }
+
+    private func close() async {
+        isClosing = true
+        errorMessage = nil
+        defer { isClosing = false }
+
+        do {
+            let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+            try await onClose(trimmed.isEmpty ? nil : trimmed)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacEditCommentSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let comment: GitHubComment
+    let onSave: (String) async throws -> Void
+
+    @State private var bodyText: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(comment: GitHubComment, onSave: @escaping (String) async throws -> Void) {
+        self.comment = comment
+        self.onSave = onSave
+        _bodyText = State(initialValue: comment.body)
+    }
+
+    private var trimmedBody: String { bodyText.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Edit Comment")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .disabled(isSaving)
+            }
+
+            TextEditor(text: $bodyText)
+                .font(.body)
+                .frame(minHeight: 180)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+                }
+                .accessibilityIdentifier("mac-edit-comment-body-field")
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-edit-comment-error")
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    Task { await save() }
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Save", systemImage: "checkmark.circle")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(trimmedBody.isEmpty || trimmedBody == comment.body || isSaving)
+                .accessibilityIdentifier("mac-edit-comment-save-button")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 440, minHeight: 340)
+    }
+
+    private func save() async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            try await onSave(trimmedBody)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacMarkdownView: View {
+    let content: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(MacMarkdownParser.blocks(from: content).enumerated()), id: \.offset) { _, block in
+                if block.isCode {
+                    Text(block.text)
+                        .font(.body.monospaced())
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.secondary.opacity(0.10), in: RoundedRectangle(cornerRadius: 6))
+                        .textSelection(.enabled)
+                } else if let attributed = block.attributedText {
+                    Text(attributed)
+                        .font(.body)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text(block.text)
+                        .font(.body)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}
+
+private enum MacMarkdownParser {
+    static func blocks(from source: String) -> [MacMarkdownBlock] {
+        splitCodeBlocks(source).map { block in
+            guard !block.isCode else { return block }
+            return MacMarkdownBlock(
+                text: block.text,
+                isCode: false,
+                attributedText: try? AttributedString(
+                    markdown: block.text,
+                    options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                )
+            )
+        }
+    }
+
+    private static func splitCodeBlocks(_ source: String) -> [MacMarkdownBlock] {
+        var blocks: [MacMarkdownBlock] = []
+        var current = ""
+        var insideCode = false
+
+        for line in source.components(separatedBy: "\n") {
+            if line.hasPrefix("```") {
+                if insideCode {
+                    blocks.append(MacMarkdownBlock(text: current, isCode: true))
+                    current = ""
+                    insideCode = false
+                } else {
+                    let prose = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !prose.isEmpty {
+                        blocks.append(MacMarkdownBlock(text: prose, isCode: false))
+                    }
+                    current = ""
+                    insideCode = true
+                }
+            } else {
+                current += current.isEmpty ? line : "\n" + line
+            }
+        }
+
+        let remaining = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !remaining.isEmpty {
+            blocks.append(MacMarkdownBlock(text: remaining, isCode: insideCode))
+        }
+        return blocks
+    }
+}
+
+private struct MacMarkdownBlock {
+    let text: String
+    let isCode: Bool
+    let attributedText: AttributedString?
+
+    init(text: String, isCode: Bool, attributedText: AttributedString? = nil) {
+        self.text = text
+        self.isCode = isCode
+        self.attributedText = attributedText
     }
 }
 

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -87,43 +87,49 @@ struct MacIssuesView: View {
                 }
                 .listStyle(.plain)
             } else {
-                List {
-                    ForEach(pagedIssues) { item in
-                        Button {
-                            selectedIssue = item
-                        } label: {
-                            MacIssueRow(
-                                item: item,
-                                isRunning: MacIssueListModel.isRunning(item, sessions: store.sessions),
-                                priority: store.priorities[MacIssueListModel.priorityKey(for: item)]
-                            )
-                        }
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(pagedIssues) { item in
+                            Button {
+                                selectedIssue = item
+                            } label: {
+                                MacIssueRow(
+                                    item: item,
+                                    isRunning: MacIssueListModel.isRunning(item, sessions: store.sessions),
+                                    priority: store.priorities[MacIssueListModel.priorityKey(for: item)]
+                                )
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                            }
                             .buttonStyle(.plain)
                             .accessibilityIdentifier("mac-issue-row-\(item.repoFullName)-\(item.issue.number)")
-                    }
 
-                    if hasMoreIssues {
-                        HStack {
-                            Spacer()
-                            Button {
-                                filterState.visiblePageCount += 1
-                            } label: {
-                                Label("Show 50 More", systemImage: "chevron.down")
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                            Spacer()
+                            Divider()
                         }
-                        .padding(.vertical, 10)
-                    } else if visibleIssues.count > pageSize {
-                        Text("Showing all \(visibleIssues.count) matching issues")
-                            .font(.macSidebar(size: 11, scale: textScale))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
+
+                        if hasMoreIssues {
+                            HStack {
+                                Spacer()
+                                Button {
+                                    filterState.visiblePageCount += 1
+                                } label: {
+                                    Label("Show 50 More", systemImage: "chevron.down")
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                Spacer()
+                            }
                             .padding(.vertical, 10)
+                        } else if visibleIssues.count > pageSize {
+                            Text("Showing all \(visibleIssues.count) matching issues")
+                                .font(.macSidebar(size: 11, scale: textScale))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                        }
                     }
+                    .padding(.horizontal, 8)
                 }
-                .listStyle(.plain)
             }
         }
         .onChange(of: store.issues.count) { _, _ in
@@ -225,6 +231,7 @@ struct MacIssuesView: View {
                     .font(.macSidebar(size: 11, scale: textScale))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .accessibilityIdentifier("mac-issues-pagination-summary")
 
                 Spacer(minLength: 4)
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -171,15 +171,51 @@ final class MacSidebarStore {
         }
     }
 
-    func updateIssueState(api: APIClient, item: MacIssueListItem, state: String) async throws {
+    func updateIssue(api: APIClient, item: MacIssueListItem, title: String?, body: String?) async throws {
+        let response = try await api.updateIssue(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: UpdateIssueRequestBody(title: title, body: body)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to update issue")
+        }
+    }
+
+    func updateIssueState(api: APIClient, item: MacIssueListItem, state: String, comment: String? = nil) async throws {
         let response = try await api.updateIssueState(
             owner: item.repo.owner,
             repo: item.repo.name,
             number: item.issue.number,
-            body: IssueStateRequestBody(state: state, comment: nil)
+            body: IssueStateRequestBody(state: state, comment: comment)
         )
         guard response.success else {
             throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to update issue")
+        }
+    }
+
+    func editComment(api: APIClient, item: MacIssueListItem, commentId: Int, body: String) async throws {
+        let response = try await api.editComment(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: EditCommentRequestBody(commentId: commentId, body: body)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to edit comment")
+        }
+    }
+
+    func deleteComment(api: APIClient, item: MacIssueListItem, commentId: Int) async throws {
+        let response = try await api.deleteComment(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: DeleteCommentRequestBody(commentId: commentId)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to delete comment")
         }
     }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -42,7 +42,14 @@ final class MacSidebarSmokeTests: XCTestCase {
         let loadMore = app.buttons["mac-issues-load-more-button"]
         XCTAssertTrue(loadMore.waitForExistence(timeout: 5), app.debugDescription)
         loadMore.click()
-        XCTAssertTrue(issueRow("org/alpha", 55).waitForExistence(timeout: 5), app.debugDescription)
+        let paginationSummary = app.staticTexts["mac-issues-pagination-summary"]
+        XCTAssertTrue(paginationSummary.waitForExistence(timeout: 5), app.debugDescription)
+        let paginationSummaryText = (paginationSummary.value as? String) ?? paginationSummary.label
+        XCTAssertTrue(
+            paginationSummaryText.contains("Showing 53 of 53"),
+            "\(paginationSummaryText)\n\(app.debugDescription)"
+        )
+        XCTAssertFalse(loadMore.exists, app.debugDescription)
 
         issueState("Running").click()
         XCTAssertTrue(issueRow("org/alpha", 2).waitForExistence(timeout: 5), app.debugDescription)
@@ -71,6 +78,54 @@ final class MacSidebarSmokeTests: XCTestCase {
 
         app.buttons["mac-issues-reset-filters-button"].click()
         XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testIssueDetailCoreActionsAndContext() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+
+        let editButton = app.buttons["mac-issue-detail-edit-button"]
+        firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        if !editButton.waitForExistence(timeout: 2) {
+            firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-body-markdown"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-linked-pr-7"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-deployment-9"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-issue-detail-edit-comment-101"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["mac-issue-detail-edit-comment-102"].exists, app.debugDescription)
+
+        app.buttons["mac-issue-detail-edit-button"].click()
+        let titleField = app.textFields["mac-edit-issue-title-field"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), app.debugDescription)
+        titleField.click()
+        titleField.typeKey("a", modifierFlags: .command)
+        titleField.typeText("Updated alpha issue")
+        app.buttons["mac-edit-issue-save-button"].click()
+        XCTAssertTrue(app.staticTexts["Updated alpha issue"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-issue-detail-edit-comment-101"].click()
+        let commentBody = app.textViews["mac-edit-comment-body-field"]
+        XCTAssertTrue(commentBody.waitForExistence(timeout: 5), app.debugDescription)
+        commentBody.click()
+        commentBody.typeKey("a", modifierFlags: .command)
+        commentBody.typeText("Edited own comment")
+        app.buttons["mac-edit-comment-save-button"].click()
+        XCTAssertTrue(app.staticTexts["Edited own comment"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-issue-detail-close-with-comment-button"].click()
+        let closingComment = app.textViews["mac-close-issue-comment-field"]
+        XCTAssertTrue(closingComment.waitForExistence(timeout: 5), app.debugDescription)
+        closingComment.click()
+        closingComment.typeText("Closing with mac detail parity")
+        app.buttons["mac-close-issue-submit-button"].click()
+        XCTAssertTrue(app.staticTexts["Closed"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-issue-detail-delete-comment-101"].click()
+        app.buttons["action-button-1"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-comment-101"].waitForNonExistence(timeout: 5), app.debugDescription)
     }
 
     func testStatusMenuOpensSettings() {

--- a/docs/goals/mac-ios-parity/notes/T022-phase-5a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T022-phase-5a-branch-start.md
@@ -1,0 +1,5 @@
+# T022 Phase 5A Branch Start
+
+Phase 5A work is starting on `mac-parity-phase-5a-detail-core-actions`, branched from `mac-sidebar-spaces-option-a`.
+
+Draft PR should target `mac-sidebar-spaces-option-a` and cover Mac issue-detail core actions plus context display.

--- a/docs/goals/mac-ios-parity/notes/T022-phase-5a-detail-core-actions.md
+++ b/docs/goals/mac-ios-parity/notes/T022-phase-5a-detail-core-actions.md
@@ -1,0 +1,60 @@
+# T022 Phase 5A Detail Core Actions
+
+## Result
+
+Done. Phase 5A now gives the Mac issue detail surface the core action parity slice from the iOS app without taking on labels, assignees, reassignment, or image lightbox behavior.
+
+## Implemented
+
+- Added Mac detail Markdown rendering for issue bodies and comments, including fenced code blocks and plain text fallback.
+- Rendered linked pull requests and deployment/session context from issue detail payloads.
+- Loaded the current user in Mac detail and permission-gated comment edit/delete controls to comments authored by that user.
+- Added Edit Issue support for title/body updates.
+- Added Close With Comment support while keeping the normal close/reopen action path available.
+- Added own-comment edit and own-comment delete flows with recoverable sheet errors and delete confirmation.
+- Refreshed detail and sidebar/list state after successful mutations.
+- Extended the Mac UI fixture API for detail fetches, issue PATCH, state updates with optional comments, comment creation, comment edit, and comment delete.
+- Stabilized Mac issue-row activation by using a scroll-backed lazy stack for the issue list.
+- Added a stable pagination summary identifier and updated the smoke test to assert loaded-result counts instead of relying on far-offscreen row materialization.
+
+## Files Changed
+
+- `apple/IssueCTLMac/App/IssueCTLMacApp.swift`
+- `apple/IssueCTLMac/Views/MacIssueDetailView.swift`
+- `apple/IssueCTLMac/Views/MacIssuesView.swift`
+- `apple/IssueCTLMac/Views/MacSidebarStore.swift`
+- `apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift`
+- `docs/goals/mac-ios-parity/state.yaml`
+
+## Validation
+
+- PASS: `git diff --check`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5a-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5a-unit -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5a-api -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests`
+- PASS: `pnpm typecheck`
+- PASS: `pnpm lint`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailCoreActionsAndContext`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueListFiltersSortsResetsAndLoadsMore`
+- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (9 tests)
+
+Known warnings:
+
+- `pnpm lint` still reports existing unrelated web/core warnings.
+- Mac UI test builds still report existing Swift actor-isolation warnings in `MacSidebarSmokeTests`.
+
+## PR
+
+- Branch: `mac-parity-phase-5a-detail-core-actions`
+- Base: `mac-sidebar-spaces-option-a`
+- PR: https://github.com/mean-weasel/issuectl/pull/427
+- Merge readiness: local validation is green. Merge remains gated on remote checks after the final commit is pushed.
+
+## Deferred
+
+- Labels
+- Assignees
+- Reassign
+- Image lightbox
+- Any broader issue-detail parity polish outside the core action/context slice
+

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T022
+active_task: T023
 
 tasks:
   - id: T001
@@ -867,6 +867,7 @@ tasks:
         worker_pr_base: "mac-sidebar-spaces-option-a"
       allowed_files_for_t022:
         - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacIssuesView.swift"
         - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
         - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
         - "apple/IssueCTLMacTests/**"
@@ -886,13 +887,14 @@ tasks:
   - id: T022
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 5A Mac issue-detail core actions and context display as a PR-sized slice."
     inputs:
       - "T021 receipt"
       - "docs/specs/2026-05-14-mac-ios-parity-plan.md#phase-5-issue-detail-action-parity"
       - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/Views/MacIssuesView.swift"
       - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
       - "Relevant iOS detail action views"
     constraints:
@@ -903,6 +905,7 @@ tasks:
       - "Do not merge without green CI or a documented accepted replacement validation."
     allowed_files:
       - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/Views/MacIssuesView.swift"
       - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
       - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
       - "apple/IssueCTLMacTests/**"
@@ -922,6 +925,59 @@ tasks:
       - "UI tests cannot deterministically reach detail action controls after one stabilization attempt."
       - "Implementing labels, assignees, reassign, or image lightbox becomes necessary to keep this PR coherent."
       - "Any required files fall outside the allowed scope."
+    receipt:
+      result: done
+      full_outcome_complete: false
+      note: "notes/T022-phase-5a-detail-core-actions.md"
+      summary: "Implemented Phase 5A Mac issue-detail core actions and context display: Markdown body/comment rendering, linked PR and deployment/session context, current-user-gated own-comment edit/delete, edit issue, close with comment, and fixture-backed Mac UI smoke coverage."
+      branch: "mac-parity-phase-5a-detail-core-actions"
+      base: "mac-sidebar-spaces-option-a"
+      pr: "https://github.com/mean-weasel/issuectl/pull/427"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacIssuesView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "docs/goals/mac-ios-parity/state.yaml"
+      validation:
+        - "PASS: git diff --check"
+        - "PASS: IssueCTLMac Debug build on macOS arm64"
+        - "PASS: IssueCTLMacTests"
+        - "PASS: IssueCTLTests/APIClientExtensionTests on iOS simulator"
+        - "PASS: pnpm typecheck"
+        - "PASS: pnpm lint, with existing unrelated warnings"
+        - "PASS: MacSidebarSmokeTests/testIssueDetailCoreActionsAndContext"
+        - "PASS: MacSidebarSmokeTests/testIssueListFiltersSortsResetsAndLoadsMore"
+        - "PASS: full MacSidebarSmokeTests suite, 9 tests"
+      deferred:
+        - "labels"
+        - "assignees"
+        - "reassign"
+        - "image lightbox"
+      next_task: T023
+
+  - id: T023
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review Phase 5A PR #427 for CI/merge readiness and size the next Phase 5B issue-detail parity PR."
+    inputs:
+      - "T022 receipt"
+      - "PR #427"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md#phase-5-issue-detail-action-parity"
+      - "Remaining deferred Phase 5 items"
+    constraints:
+      - "Do not implement product changes."
+      - "Prefer one small follow-up PR for labels/assignees/reassign unless the acceptance map shows that should split further."
+      - "Keep image lightbox separate if it introduces a distinct media-viewing interaction path."
+      - "Record merge status for PR #427 before assigning a Worker to the next slice."
+    expected_output:
+      - "PR #427 CI and merge recommendation."
+      - "Next Worker objective and branch/base strategy."
+      - "Allowed files and validation commands for the next slice."
+      - "Acceptance criteria for each remaining Phase 5 gap."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
Phase 5A Issue Detail Action Parity slice for Mac/iOS parity.

Base: `mac-sidebar-spaces-option-a`
GoalBuddy task: T022
Branch: `mac-parity-phase-5a-detail-core-actions`
Head: `579f393`

This PR remains a draft until the Phase 5A review/merge gate decides whether the local validation below is an accepted replacement for remote CI. GitHub currently reports no checks for this branch.

## Scope

- Markdown rendering for issue bodies and comments, with fallback plain text.
- Linked pull request and deployment/session sections from `IssueDetailResponse`.
- Current-user loading and permission-gated own-comment edit/delete actions.
- Edit Issue sheet for title/body updates.
- Close With Comment behavior while preserving existing close/reopen.
- Refresh detail and sidebar row state after successful mutations.
- Fixture-backed Mac UI coverage for detail actions/context and pagination/filtering.

Deferred to Phase 5B: labels, assignees, reassign, and image lightbox.

## Acceptance Criteria

- Edit issue sends `PATCH /api/v1/issues/:owner/:repo/:number`, updates title/body in detail and sidebar without relaunch, and preserves unsaved input on failure.
- Close with comment sends state body with `comment`, updates detail/sidebar counts and list placement, and preserves unsaved input on failure.
- Current user is loaded; only own comments expose edit/delete; edit and delete refresh visible comments after success.
- Markdown body/comment rendering supports inline emphasis/code, fenced code blocks, and fallback plain text.
- Linked PR and deployment/session sections render from detail payload; active terminal-capable sessions expose Open.
- Existing comment, close/reopen, priority, GitHub link, and launch actions remain available.
- Issue pagination smoke coverage validates loaded-result count through the pagination summary instead of brittle offscreen row materialization.

## Validation

- PASS: `git diff --check`
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5a-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5a-unit -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5a-api -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests`
- PASS: `pnpm typecheck`
- PASS: `pnpm lint` with existing unrelated warnings
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailCoreActionsAndContext`
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueListFiltersSortsResetsAndLoadsMore`
- PASS: `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (9 tests)

## Known Warnings

- `pnpm lint` reports existing unrelated warnings in web/core test and web files.
- Mac UI test builds report existing Swift actor-isolation warnings in `MacSidebarSmokeTests`.

## Merge Gate

- GitHub reports no remote checks for this branch.
- Do not merge until the Phase 5A review gate accepts local validation as the replacement evidence or CI is added and green.
