### PR TITLE
Add Mac issue detail management actions

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -234,7 +234,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         case ("PATCH", "/api/v1/settings"):
             return ["success": true, "error": NSNull()]
         case ("GET", "/api/v1/repos"):
-            return ["repos": [repo]]
+            return ["repos": [repo, betaRepo]]
         case ("GET", "/api/v1/worktrees"):
             return ["worktrees": worktrees]
         case ("POST", "/api/v1/worktrees/cleanup"):
@@ -287,8 +287,18 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             ]]
         case ("GET", "/api/v1/issues/org/alpha"):
             return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/issues/org/beta"):
+            return ["issues": betaIssues, "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/1"):
             return issueDetail()
+        case ("GET", "/api/v1/repos/org/alpha/labels"):
+            return ["labels": availableLabels]
+        case ("GET", "/api/v1/repos/org/alpha/collaborators"):
+            return ["collaborators": [
+                ["login": "alice", "avatar_url": "https://example.com/alice.png"],
+                ["login": "bob", "avatar_url": "https://example.com/bob.png"],
+                ["login": "carol", "avatar_url": "https://example.com/carol.png"],
+            ]]
         case ("PATCH", "/api/v1/issues/org/alpha/1"):
             let payload = jsonBody(from: request)
             if let title = payload["title"] as? String {
@@ -298,6 +308,39 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 detailIssueBody = body
             }
             return ["success": true, "error": NSNull()]
+        case ("POST", "/api/v1/issues/org/alpha/1/labels"):
+            let payload = jsonBody(from: request)
+            if let label = payload["label"] as? String {
+                switch payload["action"] as? String {
+                case "remove":
+                    detailIssueLabels.removeAll { $0 == label }
+                default:
+                    if !detailIssueLabels.contains(label) {
+                        detailIssueLabels.append(label)
+                    }
+                }
+            }
+            return ["success": true, "error": NSNull()]
+        case ("PUT", "/api/v1/issues/org/alpha/1/assignees"):
+            let payload = jsonBody(from: request)
+            if let assignees = payload["assignees"] as? [String] {
+                detailIssueAssignees = assignees
+            }
+            return ["assignees": detailIssueAssignees]
+        case ("POST", "/api/v1/issues/org/alpha/1/reassign"):
+            let payload = jsonBody(from: request)
+            let targetOwner = payload["targetOwner"] as? String ?? "org"
+            let targetRepo = payload["targetRepo"] as? String ?? "beta"
+            reassignedIssueNumber = 77
+            detailIssueState = "closed"
+            return [
+                "success": true,
+                "new_issue_number": 77,
+                "new_owner": targetOwner,
+                "new_repo": targetRepo,
+                "cleanup_warning": NSNull(),
+                "error": NSNull(),
+            ]
         case ("POST", "/api/v1/issues/org/alpha/1/state"):
             let payload = jsonBody(from: request)
             detailIssueState = payload["state"] as? String ?? detailIssueState
@@ -347,6 +390,17 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ]
     }
 
+    private static var betaRepo: [String: Any] {
+        [
+            "id": 2,
+            "owner": "org",
+            "name": "beta",
+            "local_path": "/tmp/issuectl-beta",
+            "branch_pattern": "jeremy/{slug}",
+            "created_at": isoDate,
+        ]
+    }
+
     nonisolated(unsafe) private static var worktrees: [[String: Any]] = [
         [
             "path": "/tmp/alpha-worktree-101",
@@ -371,6 +425,9 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var detailIssueTitle = "Open alpha issue"
     nonisolated(unsafe) private static var detailIssueBody = "Searchable **alpha** body\n\n```swift\nlet value = 1\n```"
     nonisolated(unsafe) private static var detailIssueState = "open"
+    nonisolated(unsafe) private static var detailIssueLabels = ["bug"]
+    nonisolated(unsafe) private static var detailIssueAssignees = ["bob"]
+    nonisolated(unsafe) private static var reassignedIssueNumber: Int?
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment", author: "bob"),
@@ -378,7 +435,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
 
     private static var issues: [[String: Any]] {
         [
-            issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, assignees: ["bob"], author: "alice", updatedAt: "2026-05-14T10:00:00.000Z"),
+            issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, labels: detailIssueLabels, assignees: detailIssueAssignees, author: "alice", updatedAt: "2026-05-14T10:00:00.000Z"),
             issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
             issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
             issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
@@ -395,11 +452,28 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         }
     }
 
+    private static var betaIssues: [[String: Any]] {
+        guard let reassignedIssueNumber else { return [] }
+        return [
+            issue(
+                number: reassignedIssueNumber,
+                title: detailIssueTitle,
+                body: detailIssueBody,
+                state: "open",
+                labels: detailIssueLabels,
+                assignees: detailIssueAssignees,
+                author: "alice",
+                updatedAt: isoDate
+            ),
+        ]
+    }
+
     private static func issue(
         number: Int,
         title: String,
         body: String,
         state: String,
+        labels: [String] = [],
         assignees: [String],
         author: String,
         updatedAt: String
@@ -409,7 +483,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "title": title,
             "body": body,
             "state": state,
-            "labels": [],
+            "labels": labels.map(labelFixture),
             "assignees": assignees.map { ["login": $0, "avatar_url": "https://example.com/\($0).png"] },
             "user": ["login": author, "avatar_url": "https://example.com/\(author).png"],
             "comment_count": 0,
@@ -422,7 +496,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
 
     private static func issueDetail() -> [String: Any] {
         [
-            "issue": issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, assignees: ["bob"], author: "alice", updatedAt: isoDate),
+            "issue": issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, labels: detailIssueLabels, assignees: detailIssueAssignees, author: "alice", updatedAt: isoDate),
             "comments": detailComments,
             "deployments": [
                 [
@@ -476,6 +550,32 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "created_at": isoDate,
             "updated_at": isoDate,
             "html_url": "https://github.com/org/alpha/issues/1#issuecomment-\(id)",
+        ]
+    }
+
+    private static var availableLabels: [[String: Any]] {
+        [
+            labelFixture("bug"),
+            labelFixture("enhancement"),
+            labelFixture("docs"),
+        ]
+    }
+
+    private static func labelFixture(_ name: String) -> [String: Any] {
+        let colors = [
+            "bug": "d73a4a",
+            "enhancement": "a2eeef",
+            "docs": "0075ca",
+        ]
+        let descriptions = [
+            "bug": "Something is not working",
+            "enhancement": "New feature or request",
+            "docs": "Documentation",
+        ]
+        return [
+            "name": name,
+            "color": colors[name] ?? "6a737d",
+            "description": descriptions[name] ?? NSNull(),
         ]
     }
 

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -21,6 +21,7 @@ struct MacIssueDetailView: View {
     @State private var activeSession: ActiveDeployment?
     @State private var currentUserLogin: String?
     @State private var errorMessage: String?
+    @State private var successMessage: String?
     @State private var activeSheet: MacIssueDetailSheet?
     @State private var isShowingCloseWithComment = false
     @State private var commentPendingDeletion: GitHubComment?
@@ -96,6 +97,34 @@ struct MacIssueDetailView: View {
                 MacEditCommentSheet(comment: comment) { body in
                     try await store.editComment(api: api, item: item, commentId: comment.id, body: body)
                     await load(refresh: true)
+                    activeSheet = nil
+                }
+            case .labels:
+                MacLabelManagementSheet(issue: issue) {
+                    try await store.repoLabels(api: api, item: item)
+                } onToggle: { label, action in
+                    try await store.toggleLabel(api: api, item: item, label: label, action: action)
+                    await refreshAfterManagementAction()
+                }
+            case .assignees:
+                MacAssigneeManagementSheet(issue: issue) {
+                    try await store.collaborators(api: api, item: item)
+                } onUpdate: { assignees in
+                    _ = try await store.updateAssignees(api: api, item: item, assignees: assignees)
+                    await refreshAfterManagementAction()
+                }
+            case .reassign:
+                MacReassignIssueSheet(
+                    issue: issue,
+                    sourceRepo: item.repo,
+                    repos: store.repos
+                ) { target in
+                    let response = try await store.reassignIssue(api: api, item: item, target: target)
+                    await store.load(api: api, refresh: true)
+                    let owner = response.newOwner ?? target.owner
+                    let repo = response.newRepo ?? target.name
+                    let number = response.newIssueNumber.map(String.init) ?? "?"
+                    successMessage = "Reassigned to \(owner)/\(repo)#\(number)"
                     activeSheet = nil
                 }
             }
@@ -215,6 +244,14 @@ struct MacIssueDetailView: View {
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            if let successMessage {
+                Label(successMessage, systemImage: "checkmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-issue-detail-success-message")
+            }
         }
     }
 
@@ -269,66 +306,90 @@ struct MacIssueDetailView: View {
     }
 
     private var actionBar: some View {
-        HStack(spacing: 8) {
-            Button {
-                activeSheet = .editIssue
-            } label: {
-                Label("Edit", systemImage: "pencil")
-            }
-            .buttonStyle(.bordered)
-            .accessibilityIdentifier("mac-issue-detail-edit-button")
-
-            Button {
-                Task { await updateState(issue.isOpen ? "closed" : "open") }
-            } label: {
-                if isUpdatingState {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    Label(issue.isOpen ? "Close" : "Reopen", systemImage: issue.isOpen ? "xmark.circle" : "arrow.uturn.backward.circle")
-                }
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(issue.isOpen ? .red : .green)
-            .disabled(isUpdatingState)
-            .accessibilityIdentifier("mac-issue-detail-toggle-state-button")
-
-            if issue.isOpen {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
                 Button {
-                    activeSheet = nil
-                    isShowingCloseWithComment = true
+                    activeSheet = .editIssue
                 } label: {
-                    Label("Close With Comment", systemImage: "text.bubble")
+                    Label("Edit", systemImage: "pencil")
                 }
                 .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-issue-detail-edit-button")
+
+                Button {
+                    activeSheet = .labels
+                } label: {
+                    Label("Labels", systemImage: "tag")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-issue-detail-labels-button")
+
+                Button {
+                    activeSheet = .assignees
+                } label: {
+                    Label("Assignees", systemImage: "person.2")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-issue-detail-assignees-button")
+
+                Button {
+                    activeSheet = .reassign
+                } label: {
+                    Label("Reassign", systemImage: "arrow.triangle.swap")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-issue-detail-reassign-button")
+
+                Button {
+                    Task { await updateState(issue.isOpen ? "closed" : "open") }
+                } label: {
+                    if isUpdatingState {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label(issue.isOpen ? "Close" : "Reopen", systemImage: issue.isOpen ? "xmark.circle" : "arrow.uturn.backward.circle")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(issue.isOpen ? .red : .green)
                 .disabled(isUpdatingState)
-                .accessibilityIdentifier("mac-issue-detail-close-with-comment-button")
-            }
+                .accessibilityIdentifier("mac-issue-detail-toggle-state-button")
 
-            Picker("Priority", selection: $priority) {
-                ForEach(Priority.allCases, id: \.self) { priority in
-                    Text(priority.rawValue.capitalized).tag(priority)
+                if issue.isOpen {
+                    Button {
+                        activeSheet = nil
+                        isShowingCloseWithComment = true
+                    } label: {
+                        Label("Close With Comment", systemImage: "text.bubble")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isUpdatingState)
+                    .accessibilityIdentifier("mac-issue-detail-close-with-comment-button")
                 }
-            }
-            .pickerStyle(.menu)
-            .disabled(isUpdatingPriority)
-            .onChange(of: priority) { oldValue, newValue in
-                guard oldValue != newValue else { return }
-                guard newValue != committedPriority else { return }
-                Task { await setPriority(newValue, rollbackTo: oldValue) }
-            }
 
-            Button {
-                if let url = URL(string: issue.htmlUrl) {
-                    openURL(url)
+                Picker("Priority", selection: $priority) {
+                    ForEach(Priority.allCases, id: \.self) { priority in
+                        Text(priority.rawValue.capitalized).tag(priority)
+                    }
                 }
-            } label: {
-                Label("GitHub", systemImage: "safari")
-            }
-            .buttonStyle(.bordered)
-            .accessibilityIdentifier("mac-issue-detail-github-button")
+                .pickerStyle(.menu)
+                .disabled(isUpdatingPriority)
+                .onChange(of: priority) { oldValue, newValue in
+                    guard oldValue != newValue else { return }
+                    guard newValue != committedPriority else { return }
+                    Task { await setPriority(newValue, rollbackTo: oldValue) }
+                }
 
-            Spacer()
+                Button {
+                    if let url = URL(string: issue.htmlUrl) {
+                        openURL(url)
+                    }
+                } label: {
+                    Label("GitHub", systemImage: "safari")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-issue-detail-github-button")
+            }
         }
     }
 
@@ -537,6 +598,7 @@ struct MacIssueDetailView: View {
         }
 
         do {
+            successMessage = nil
             async let detailResult = store.issueDetail(api: api, item: item, refresh: refresh)
             async let userResult: Result<UserResponse, Error> = {
                 do { return .success(try await api.currentUser(refresh: refresh)) }
@@ -567,6 +629,11 @@ struct MacIssueDetailView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func refreshAfterManagementAction() async {
+        await store.load(api: api, refresh: true)
+        await load(refresh: true)
     }
 
     private func isOwnComment(_ comment: GitHubComment) -> Bool {
@@ -684,6 +751,9 @@ private enum MacIssueDetailSheet: Identifiable {
     case editIssue
     case closeWithComment
     case editComment(GitHubComment)
+    case labels
+    case assignees
+    case reassign
 
     var id: String {
         switch self {
@@ -693,6 +763,12 @@ private enum MacIssueDetailSheet: Identifiable {
             "close-with-comment"
         case .editComment(let comment):
             "edit-comment-\(comment.id)"
+        case .labels:
+            "labels"
+        case .assignees:
+            "assignees"
+        case .reassign:
+            "reassign"
         }
     }
 }
@@ -940,6 +1016,389 @@ private struct MacEditCommentSheet: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+}
+
+private struct MacLabelManagementSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issue: GitHubIssue
+    let loadLabels: () async throws -> [GitHubLabel]
+    let onToggle: (String, String) async throws -> Void
+
+    @State private var availableLabels: [GitHubLabel] = []
+    @State private var selectedLabels: Set<String>
+    @State private var isLoading = true
+    @State private var togglingLabels: Set<String> = []
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    init(
+        issue: GitHubIssue,
+        loadLabels: @escaping () async throws -> [GitHubLabel],
+        onToggle: @escaping (String, String) async throws -> Void
+    ) {
+        self.issue = issue
+        self.loadLabels = loadLabels
+        self.onToggle = onToggle
+        _selectedLabels = State(initialValue: Set(issue.labels.map(\.name)))
+    }
+
+    private var filteredLabels: [GitHubLabel] {
+        guard !searchText.isEmpty else { return availableLabels }
+        return availableLabels.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Manage Labels")
+                    .font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+
+            TextField("Filter labels", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-label-management-search-field")
+
+            if isLoading {
+                ProgressView("Loading labels...")
+                    .frame(maxWidth: .infinity, minHeight: 180)
+            } else if availableLabels.isEmpty {
+                ContentUnavailableView("No Labels", systemImage: "tag", description: Text("This repository has no labels."))
+                    .frame(minHeight: 180)
+            } else {
+                List(filteredLabels) { label in
+                    labelRow(label)
+                }
+                .frame(minHeight: 240)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-label-management-error")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 420, minHeight: 360)
+        .task { await load() }
+    }
+
+    private func labelRow(_ label: GitHubLabel) -> some View {
+        let isSelected = selectedLabels.contains(label.name)
+        let isToggling = togglingLabels.contains(label.name)
+
+        return Button {
+            Task { await toggle(label, isSelected: isSelected) }
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(Color(macHex: label.color) ?? .secondary)
+                    .frame(width: 12, height: 12)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label.name)
+                        .font(.body)
+                    if let description = label.description, !description.isEmpty {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                if isToggling {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .disabled(isToggling)
+        .accessibilityIdentifier("mac-label-management-row-\(label.name)")
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            availableLabels = try await loadLabels()
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func toggle(_ label: GitHubLabel, isSelected: Bool) async {
+        togglingLabels.insert(label.name)
+        errorMessage = nil
+        defer { togglingLabels.remove(label.name) }
+
+        do {
+            try await onToggle(label.name, isSelected ? "remove" : "add")
+            if isSelected {
+                selectedLabels.remove(label.name)
+            } else {
+                selectedLabels.insert(label.name)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacAssigneeManagementSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issue: GitHubIssue
+    let loadCollaborators: () async throws -> [CollaboratorInfo]
+    let onUpdate: ([String]) async throws -> Void
+
+    @State private var collaborators: [CollaboratorInfo] = []
+    @State private var selectedAssignees: Set<String>
+    @State private var isLoading = true
+    @State private var togglingAssignees: Set<String> = []
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+
+    init(
+        issue: GitHubIssue,
+        loadCollaborators: @escaping () async throws -> [CollaboratorInfo],
+        onUpdate: @escaping ([String]) async throws -> Void
+    ) {
+        self.issue = issue
+        self.loadCollaborators = loadCollaborators
+        self.onUpdate = onUpdate
+        _selectedAssignees = State(initialValue: Set((issue.assignees ?? []).map(\.login)))
+    }
+
+    private var filteredCollaborators: [CollaboratorInfo] {
+        guard !searchText.isEmpty else { return collaborators }
+        return collaborators.filter { $0.login.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Manage Assignees")
+                    .font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+
+            TextField("Filter collaborators", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-assignee-management-search-field")
+
+            if isLoading {
+                ProgressView("Loading collaborators...")
+                    .frame(maxWidth: .infinity, minHeight: 180)
+            } else if collaborators.isEmpty {
+                ContentUnavailableView("No Collaborators", systemImage: "person.2", description: Text("This repository has no collaborators."))
+                    .frame(minHeight: 180)
+            } else {
+                List(filteredCollaborators) { collaborator in
+                    collaboratorRow(collaborator)
+                }
+                .frame(minHeight: 240)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-assignee-management-error")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 420, minHeight: 360)
+        .task { await load() }
+    }
+
+    private func collaboratorRow(_ collaborator: CollaboratorInfo) -> some View {
+        let isSelected = selectedAssignees.contains(collaborator.login)
+        let isToggling = togglingAssignees.contains(collaborator.login)
+
+        return Button {
+            Task { await toggle(collaborator.login, isSelected: isSelected) }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "person.circle.fill")
+                    .foregroundStyle(.secondary)
+                Text(collaborator.login)
+                    .font(.body)
+                Spacer()
+                if isToggling {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .disabled(isToggling)
+        .accessibilityIdentifier("mac-assignee-management-row-\(collaborator.login)")
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            collaborators = try await loadCollaborators()
+                .sorted { $0.login.localizedCaseInsensitiveCompare($1.login) == .orderedAscending }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func toggle(_ login: String, isSelected: Bool) async {
+        togglingAssignees.insert(login)
+        errorMessage = nil
+        let previousAssignees = selectedAssignees
+        defer { togglingAssignees.remove(login) }
+
+        if isSelected {
+            selectedAssignees.remove(login)
+        } else {
+            selectedAssignees.insert(login)
+        }
+
+        do {
+            try await onUpdate(Array(selectedAssignees).sorted())
+        } catch {
+            selectedAssignees = previousAssignees
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MacReassignIssueSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issue: GitHubIssue
+    let sourceRepo: Repo
+    let repos: [Repo]
+    let onReassign: (Repo) async throws -> Void
+
+    @State private var selectedRepoId: Int?
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    private var targetRepos: [Repo] {
+        repos.filter { $0.id != sourceRepo.id }
+    }
+
+    private var selectedRepo: Repo? {
+        targetRepos.first { $0.id == selectedRepoId }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Reassign Issue")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .disabled(isSubmitting)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("#\(issue.number) \(issue.title)")
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                Text("From \(sourceRepo.fullName)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if targetRepos.isEmpty {
+                ContentUnavailableView("No Target Repositories", systemImage: "tray", description: Text("Track another repository before reassigning this issue."))
+                    .frame(minHeight: 160)
+            } else {
+                List(targetRepos) { repo in
+                    Button {
+                        selectedRepoId = repo.id
+                    } label: {
+                        HStack {
+                            Text(repo.fullName)
+                            Spacer()
+                            if selectedRepoId == repo.id {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.blue)
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("mac-reassign-target-\(repo.fullName)")
+                }
+                .frame(minHeight: 180)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-reassign-error")
+            }
+
+            HStack {
+                Spacer()
+                Button(role: .destructive) {
+                    Task { await submit() }
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Reassign", systemImage: "arrow.triangle.swap")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(selectedRepo == nil || isSubmitting)
+                .accessibilityIdentifier("mac-reassign-submit-button")
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 440, minHeight: 360)
+    }
+
+    private func submit() async {
+        guard let selectedRepo else { return }
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+
+        do {
+            try await onReassign(selectedRepo)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private extension Color {
+    init?(macHex: String) {
+        let hex = macHex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        guard hex.count == 6,
+              let value = UInt64(hex, radix: 16) else { return nil }
+
+        self.init(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
     }
 }
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -219,6 +219,49 @@ final class MacSidebarStore {
         }
     }
 
+    func repoLabels(api: APIClient, item: MacIssueListItem) async throws -> [GitHubLabel] {
+        try await api.listRepoLabels(owner: item.repo.owner, repo: item.repo.name).labels
+    }
+
+    func toggleLabel(api: APIClient, item: MacIssueListItem, label: String, action: String) async throws {
+        let response = try await api.toggleLabel(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            body: ToggleLabelRequestBody(label: label, action: action)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to update label")
+        }
+    }
+
+    func collaborators(api: APIClient, item: MacIssueListItem) async throws -> [CollaboratorInfo] {
+        try await api.collaborators(owner: item.repo.owner, repo: item.repo.name)
+    }
+
+    func updateAssignees(api: APIClient, item: MacIssueListItem, assignees: [String]) async throws -> [String] {
+        try await api.updateAssignees(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            assignees: assignees
+        )
+    }
+
+    func reassignIssue(api: APIClient, item: MacIssueListItem, target: Repo) async throws -> ReassignResponse {
+        let response = try await api.reassignIssue(
+            owner: item.repo.owner,
+            repo: item.repo.name,
+            number: item.issue.number,
+            targetOwner: target.owner,
+            targetRepo: target.name
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to reassign issue")
+        }
+        return response
+    }
+
     func setPriority(api: APIClient, item: MacIssueListItem, priority: Priority) async throws {
         let response = try await api.setPriority(
             owner: item.repo.owner,

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -128,6 +128,42 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-comment-101"].waitForNonExistence(timeout: 5), app.debugDescription)
     }
 
+    func testIssueDetailManagementActions() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+
+        let labelsButton = app.buttons["mac-issue-detail-labels-button"]
+        firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        if !labelsButton.waitForExistence(timeout: 2) {
+            firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+
+        XCTAssertTrue(labelsButton.waitForExistence(timeout: 5), app.debugDescription)
+        labelsButton.click()
+        let enhancementLabel = app.descendants(matching: .any)["mac-label-management-row-enhancement"]
+        XCTAssertTrue(enhancementLabel.waitForExistence(timeout: 5), app.debugDescription)
+        enhancementLabel.click()
+        app.buttons["Done"].firstMatch.click()
+        XCTAssertTrue(app.staticTexts["enhancement"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-issue-detail-assignees-button"].click()
+        let carolAssignee = app.descendants(matching: .any)["mac-assignee-management-row-carol"]
+        XCTAssertTrue(carolAssignee.waitForExistence(timeout: 5), app.debugDescription)
+        carolAssignee.click()
+        app.buttons["Done"].firstMatch.click()
+        XCTAssertTrue(app.staticTexts["Assigned to bob, carol"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-issue-detail-reassign-button"].click()
+        let betaTarget = app.descendants(matching: .any)["mac-reassign-target-org/beta"]
+        XCTAssertTrue(betaTarget.waitForExistence(timeout: 5), app.debugDescription)
+        betaTarget.click()
+        app.buttons["mac-reassign-submit-button"].click()
+        let successMessage = app.descendants(matching: .any)["mac-issue-detail-success-message"]
+        XCTAssertTrue(successMessage.waitForExistence(timeout: 5), app.debugDescription)
+        let successText = (successMessage.value as? String) ?? successMessage.label
+        XCTAssertTrue(successText.contains("org/beta#77"), "\(successText)\n\(app.debugDescription)")
+    }
+
     func testStatusMenuOpensSettings() {
         openSettingsFromStatusMenu()
 

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -410,6 +410,40 @@ final class APIClientExtensionTests: XCTestCase {
         _ = try await client.request(path: "/api/v1/issues/o/r/1/assignees", method: "PUT", body: body)
     }
 
+    @MainActor
+    func testReassignIssueURLAndBodyEncoding() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/issues/org/source/42/reassign"))
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = self.readBody(from: request)
+            if let bodyData {
+                let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+                XCTAssertEqual(json?["targetOwner"] as? String, "org")
+                XCTAssertEqual(json?["targetRepo"] as? String, "target")
+            }
+
+            return (self.makeResponse(url: request.url!), """
+            {"success": true, "new_issue_number": 77, "new_owner": "org", "new_repo": "target", "cleanup_warning": null, "error": null}
+            """.data(using: .utf8)!)
+        }
+
+        let body = try JSONEncoder().encode(
+            ReassignRequest(targetOwner: "org", targetRepo: "target")
+        )
+        let (data, _) = try await client.request(
+            path: "/api/v1/issues/org/source/42/reassign",
+            method: "POST",
+            body: body
+        )
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(ReassignResponse.self, from: data)
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.newIssueNumber, 77)
+        XCTAssertEqual(response.newRepo, "target")
+    }
+
     // MARK: - DetailActions (APIClient+DetailActions)
 
     @MainActor

--- a/docs/goals/mac-ios-parity/notes/T024-phase-5b-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T024-phase-5b-branch-start.md
@@ -1,0 +1,6 @@
+# T024 Phase 5B Branch Start
+
+Phase 5B work is starting on `mac-parity-phase-5b-detail-management`, branched from `mac-sidebar-spaces-option-a`.
+
+Draft PR should target `mac-sidebar-spaces-option-a` and cover Mac issue-detail label management, assignee management, and issue reassign. Image lightbox remains deferred.
+

--- a/docs/goals/mac-ios-parity/notes/T024-phase-5b-detail-management.md
+++ b/docs/goals/mac-ios-parity/notes/T024-phase-5b-detail-management.md
@@ -1,0 +1,36 @@
+# T024 Phase 5B Detail Management
+
+## Result
+
+Implemented Phase 5B Mac issue-detail management actions for labels, assignees, and reassign in draft PR #428.
+
+## PR
+
+- PR: https://github.com/mean-weasel/issuectl/pull/428
+- Branch: `mac-parity-phase-5b-detail-management`
+- Base: `mac-sidebar-spaces-option-a`
+- Status at worker handoff: draft, local validation passed, GitHub checks pending review after push
+
+## Acceptance Evidence
+
+- Labels: Mac issue detail now exposes a Labels action, loads repo labels, toggles labels through the shared label API, refreshes issue detail/list state after success, and leaves a recoverable sheet error on failure.
+- Assignees: Mac issue detail now exposes an Assignees action, loads collaborators, sends the full desired assignee set through the shared assignee API, refreshes issue detail/list state after success, and rolls local selection back on failure.
+- Reassign: Mac issue detail now exposes a Reassign action, lists tracked target repos excluding the source repo, calls the shared reassign API, refreshes sidebar issue data, and reports the new issue identity after success.
+- Phase 5A preservation: the full Mac sidebar smoke suite passed after adding the new actions, covering existing edit, close, comment, priority, settings, and sidebar flows.
+- Image lightbox: intentionally not implemented in this slice.
+
+## Validation
+
+- `git diff --check`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5b-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 10 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-unit-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacTests`: pass, 29 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-all -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings
+
+## Notes
+
+- Reran the focused management UI test after fixing Mac label swatch hex parsing:
+  `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailManagementActions`: pass.
+- Xcode regenerated `apple/IssueCTL/Generated/AppVersion.swift` during iOS test/build runs; the generated metadata churn was restored and not included in this slice.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T024
+active_task: T025
 
 tasks:
   - id: T001
@@ -999,7 +999,7 @@ tasks:
   - id: T024
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 5B Mac issue-detail label, assignee, and reassign action parity as a PR-sized slice."
     inputs:
@@ -1048,6 +1048,63 @@ tasks:
       - "Reassign requires navigation architecture changes outside Mac issue detail/list/store surfaces."
       - "Image lightbox or media rendering changes become necessary for this PR to compile or pass tests."
       - "Any required files fall outside the allowed scope."
+    receipt:
+      result: done
+      note: "notes/T024-phase-5b-detail-management.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      pr:
+        number: 428
+        url: "https://github.com/mean-weasel/issuectl/pull/428"
+        branch: "mac-parity-phase-5b-detail-management"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending review after push."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5b-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-unit-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-all -destination 'platform=iOS Simulator,id=002673DD-F669-4F62-A9BB-B5009A96E818' test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+      warnings:
+        - "pnpm lint passed with pre-existing warnings."
+        - "GitHub checks were not reviewed until after the branch push."
+      summary: "Added Mac label, assignee, and reassign management from issue detail, expanded the Mac dogfood fixture, covered the flow with Mac UI and shared API tests, and kept image lightbox deferred."
+
+  - id: T025
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review Phase 5B PR #428 for CI/merge readiness, merge it if green or accepted replacement validation applies, and size the next parity slice."
+    inputs:
+      - "T024 receipt"
+      - "PR #428"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md#phase-5-issue-detail-action-parity"
+      - "Remaining deferred Phase 5 image lightbox item"
+    constraints:
+      - "Do not implement product changes."
+      - "Reject merge if labels, assignees, reassign, or Phase 5A preservation evidence is missing."
+      - "Merge only with green CI or explicitly accepted replacement validation."
+      - "Record PR status, checks, merge result, and next Worker recommendation."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "CI or accepted replacement validation status."
+      - "Merge result when ready."
+      - "Next task recommendation and allowed scope."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
Phase 5B Issue Detail Action Parity slice for Mac/iOS parity.

Base: `mac-sidebar-spaces-option-a`
GoalBuddy task: T024
Branch: `mac-parity-phase-5b-detail-management`

## Scope

- Manage labels from the Mac issue detail surface.
- Manage assignees from the Mac issue detail surface.
- Reassign an issue to another tracked repository.
- Refresh detail and sidebar/list state after each successful mutation.
- Preserve Phase 5A actions and context display.

Deferred: image lightbox and rendered-media interaction.

## Acceptance Criteria

- Label management loads available repo labels, toggles selected labels through the shared label API, refreshes detail chips and list label counts after success, and shows recoverable errors without losing sheet state.
- Assignee management loads collaborators, sends the full desired assignee list through the shared assignment API, refreshes detail/list assignees and Mine/Unassigned filters after success, and rolls back or preserves recoverable state on failure.
- Reassign presents tracked target repos excluding the current repo, sends the shared reassign request, refreshes source and target repo issue lists, and clearly reports the new issue identity after success.
- Existing Phase 5A actions remain available: edit issue, close/reopen, close with comment, add comment, edit/delete own comments, priority, GitHub link, linked PRs, and session actions.
- No image lightbox or media-viewing UI is added in this slice.

## Validation

- `git diff --check`: pass
- Mac build: pass
- `IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 10 tests
- `IssueCTLMacTests`: pass, 29 tests
- `IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
- `pnpm typecheck`: pass
- `pnpm lint`: pass with existing warnings
- Post-fix focused management UI retest: pass

## CI / Merge Gate

GitHub reports no configured status checks for this branch. The accepted replacement validation is the local command set recorded in GoalBuddy T024.