### PR TITLE
Add Mac markdown image lightbox support

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -193,6 +193,19 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return
         }
 
+        if let imageData = Self.fixtureImageData(for: url.path) {
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: imageData)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
         let payload = Self.payload(for: request)
         let status = payload == nil ? 404 : 200
         let data = Self.jsonData(payload ?? ["error": "Unhandled \(url.path)"])
@@ -423,14 +436,14 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     ]
 
     nonisolated(unsafe) private static var detailIssueTitle = "Open alpha issue"
-    nonisolated(unsafe) private static var detailIssueBody = "Searchable **alpha** body\n\n```swift\nlet value = 1\n```"
+    nonisolated(unsafe) private static var detailIssueBody = "Searchable **alpha** body\n\n![Alpha diagram](https://issuectl-ui-test.local/fixtures/alpha.png)\n\n```swift\nlet value = 1\n```"
     nonisolated(unsafe) private static var detailIssueState = "open"
     nonisolated(unsafe) private static var detailIssueLabels = ["bug"]
     nonisolated(unsafe) private static var detailIssueAssignees = ["bob"]
     nonisolated(unsafe) private static var reassignedIssueNumber: Int?
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
-        commentFixture(id: 102, body: "Bob comment", author: "bob"),
+        commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
     ]
 
     private static var issues: [[String: Any]] {
@@ -551,6 +564,11 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "updated_at": isoDate,
             "html_url": "https://github.com/org/alpha/issues/1#issuecomment-\(id)",
         ]
+    }
+
+    private static func fixtureImageData(for path: String) -> Data? {
+        guard path == "/fixtures/alpha.png" else { return nil }
+        return Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVR42mP8z8AARLJgYGBgYAAAAP//AwAFxgICFhZbkAAAAABJRU5ErkJggg==")
     }
 
     private static var availableLabels: [[String: Any]] {

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -23,6 +23,7 @@ struct MacIssueDetailView: View {
     @State private var errorMessage: String?
     @State private var successMessage: String?
     @State private var activeSheet: MacIssueDetailSheet?
+    @State private var lightboxImage: MacLightboxImage?
     @State private var isShowingCloseWithComment = false
     @State private var commentPendingDeletion: GitHubComment?
 
@@ -127,6 +128,11 @@ struct MacIssueDetailView: View {
                     successMessage = "Reassigned to \(owner)/\(repo)#\(number)"
                     activeSheet = nil
                 }
+            }
+        }
+        .sheet(item: $lightboxImage) { image in
+            MacImageLightbox(url: image.url, altText: image.altText) {
+                lightboxImage = nil
             }
         }
         .sheet(isPresented: $isShowingCloseWithComment) {
@@ -429,8 +435,10 @@ struct MacIssueDetailView: View {
                 Divider()
                 Text("Description")
                     .font(.headline)
-                MacMarkdownView(content: body)
                     .accessibilityIdentifier("mac-issue-detail-body-markdown")
+                MacMarkdownView(content: body, accessibilityPrefix: "mac-issue-body") { image in
+                    lightboxImage = image
+                }
             }
         }
     }
@@ -487,7 +495,9 @@ struct MacIssueDetailView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
-                        MacMarkdownView(content: comment.body)
+                        MacMarkdownView(content: comment.body, accessibilityPrefix: "mac-comment-\(comment.id)") { image in
+                            lightboxImage = image
+                        }
 
                         if isOwnComment(comment) {
                             HStack(spacing: 8) {
@@ -1402,12 +1412,21 @@ private extension Color {
     }
 }
 
+private struct MacLightboxImage: Identifiable {
+    let url: URL
+    let altText: String
+
+    var id: String { url.absoluteString }
+}
+
 private struct MacMarkdownView: View {
     let content: String
+    let accessibilityPrefix: String
+    let openImage: (MacLightboxImage) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(MacMarkdownParser.blocks(from: content).enumerated()), id: \.offset) { _, block in
+            ForEach(Array(MacMarkdownParser.blocks(from: content).enumerated()), id: \.offset) { index, block in
                 if block.isCode {
                     Text(block.text)
                         .font(.body.monospaced())
@@ -1415,6 +1434,11 @@ private struct MacMarkdownView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color.secondary.opacity(0.10), in: RoundedRectangle(cornerRadius: 6))
                         .textSelection(.enabled)
+                } else if let image = block.image {
+                    MacMarkdownImageButton(image: image) {
+                        openImage(image)
+                    }
+                    .accessibilityIdentifier("\(accessibilityPrefix)-image-\(index)")
                 } else if let attributed = block.attributedText {
                     Text(attributed)
                         .font(.body)
@@ -1431,18 +1455,154 @@ private struct MacMarkdownView: View {
     }
 }
 
+private struct MacMarkdownImageButton: View {
+    let image: MacLightboxImage
+    let openImage: () -> Void
+
+    var body: some View {
+        Button(action: openImage) {
+            VStack(alignment: .leading, spacing: 6) {
+                if let fixtureImage = MacFixtureImageStore.image(for: image.url) {
+                    Image(nsImage: fixtureImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 260, maxHeight: 180)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .accessibilityIdentifier("mac-markdown-image-loaded")
+                } else {
+                    AsyncImage(url: image.url) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                                .frame(width: 180, height: 110)
+                                .accessibilityIdentifier("mac-markdown-image-loading")
+                        case .success(let loadedImage):
+                            loadedImage
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: 260, maxHeight: 180)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                                .accessibilityIdentifier("mac-markdown-image-loaded")
+                        case .failure:
+                            Label("Image unavailable", systemImage: "photo.badge.exclamationmark")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .accessibilityIdentifier("mac-markdown-image-error")
+                        @unknown default:
+                            EmptyView()
+                        }
+                    }
+                }
+
+                if !image.altText.isEmpty {
+                    Text(image.altText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(image.altText.isEmpty ? "Image attachment" : image.altText)
+    }
+}
+
+private struct MacImageLightbox: View {
+    let url: URL
+    let altText: String
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color.black.ignoresSafeArea()
+
+            Group {
+                if let fixtureImage = MacFixtureImageStore.image(for: url) {
+                    Image(nsImage: fixtureImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(24)
+                        .accessibilityIdentifier("mac-image-lightbox-loaded-image")
+                } else {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                                .tint(.white)
+                                .accessibilityIdentifier("mac-image-lightbox-loading")
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .padding(24)
+                                .accessibilityIdentifier("mac-image-lightbox-loaded-image")
+                        case .failure:
+                            ContentUnavailableView {
+                                Label("Failed to Load", systemImage: "photo.badge.exclamationmark")
+                                    .foregroundStyle(.white)
+                            } description: {
+                                Text("Could not load image")
+                                    .foregroundStyle(.white.opacity(0.75))
+                            }
+                            .accessibilityIdentifier("mac-image-lightbox-error")
+                        @unknown default:
+                            EmptyView()
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 28, weight: .semibold))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .white.opacity(0.35))
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(28)
+            .accessibilityLabel("Close image")
+            .accessibilityIdentifier("mac-image-lightbox-close-button")
+        }
+        .frame(minWidth: 520, minHeight: 420)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(altText.isEmpty ? "Image preview" : altText)
+    }
+}
+
+private enum MacFixtureImageStore {
+    static func image(for url: URL) -> NSImage? {
+        guard url.host == "issuectl-ui-test.local",
+              url.path == "/fixtures/alpha.png",
+              let data = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=") else {
+            return nil
+        }
+        return NSImage(data: data)
+    }
+}
+
 private enum MacMarkdownParser {
     static func blocks(from source: String) -> [MacMarkdownBlock] {
-        splitCodeBlocks(source).map { block in
-            guard !block.isCode else { return block }
-            return MacMarkdownBlock(
-                text: block.text,
-                isCode: false,
-                attributedText: try? AttributedString(
-                    markdown: block.text,
-                    options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        splitCodeBlocks(source).flatMap { block -> [MacMarkdownBlock] in
+            guard !block.isCode else { return [block] }
+
+            return splitImageBlocks(block.text).map { imageBlock in
+                guard imageBlock.image == nil else { return imageBlock }
+                return MacMarkdownBlock(
+                    text: imageBlock.text,
+                    isCode: false,
+                    attributedText: try? AttributedString(
+                        markdown: imageBlock.text,
+                        options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                    )
                 )
-            )
+            }
         }
     }
 
@@ -1476,17 +1636,73 @@ private enum MacMarkdownParser {
         }
         return blocks
     }
+
+    private static func splitImageBlocks(_ source: String) -> [MacMarkdownBlock] {
+        let pattern = #"!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [MacMarkdownBlock(text: source, isCode: false)]
+        }
+
+        let nsSource = source as NSString
+        let fullRange = NSRange(location: 0, length: nsSource.length)
+        let matches = regex.matches(in: source, range: fullRange)
+        guard !matches.isEmpty else {
+            return [MacMarkdownBlock(text: source, isCode: false)]
+        }
+
+        var blocks: [MacMarkdownBlock] = []
+        var cursor = 0
+
+        for match in matches {
+            if match.range.location > cursor {
+                let text = nsSource.substring(with: NSRange(location: cursor, length: match.range.location - cursor))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    blocks.append(MacMarkdownBlock(text: text, isCode: false))
+                }
+            }
+
+            let altText = match.range(at: 1).location == NSNotFound ? "" : nsSource.substring(with: match.range(at: 1))
+            let rawURL = match.range(at: 2).location == NSNotFound ? "" : nsSource.substring(with: match.range(at: 2))
+            if let url = URL(string: rawURL) {
+                blocks.append(MacMarkdownBlock(image: MacLightboxImage(url: url, altText: altText)))
+            } else {
+                blocks.append(MacMarkdownBlock(text: nsSource.substring(with: match.range), isCode: false))
+            }
+
+            cursor = match.range.location + match.range.length
+        }
+
+        if cursor < nsSource.length {
+            let text = nsSource.substring(with: NSRange(location: cursor, length: nsSource.length - cursor))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                blocks.append(MacMarkdownBlock(text: text, isCode: false))
+            }
+        }
+
+        return blocks
+    }
 }
 
 private struct MacMarkdownBlock {
     let text: String
     let isCode: Bool
     let attributedText: AttributedString?
+    let image: MacLightboxImage?
 
     init(text: String, isCode: Bool, attributedText: AttributedString? = nil) {
         self.text = text
         self.isCode = isCode
         self.attributedText = attributedText
+        self.image = nil
+    }
+
+    init(image: MacLightboxImage) {
+        self.text = ""
+        self.isCode = false
+        self.attributedText = nil
+        self.image = image
     }
 }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -164,6 +164,32 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(successText.contains("org/beta#77"), "\(successText)\n\(app.debugDescription)")
     }
 
+    func testIssueDetailMarkdownImagesOpenLightbox() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+
+        let imageAttachment = app.descendants(matching: .any)["mac-issue-body-image-1"]
+        firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        if !imageAttachment.waitForExistence(timeout: 2) {
+            firstIssue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+
+        XCTAssertTrue(imageAttachment.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertGreaterThan(imageAttachment.frame.height, 100, app.debugDescription)
+
+        imageAttachment.click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-loaded-image"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-image-lightbox-close-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-loaded-image"].waitForNonExistence(timeout: 5), app.debugDescription)
+
+        let missingImageAttachment = app.descendants(matching: .any)["mac-comment-102-image-1"]
+        XCTAssertTrue(missingImageAttachment.waitForExistence(timeout: 5), app.debugDescription)
+        missingImageAttachment.click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-error"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-image-lightbox-close-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-error"].waitForNonExistence(timeout: 5), app.debugDescription)
+    }
+
     func testStatusMenuOpensSettings() {
         openSettingsFromStatusMenu()
 

--- a/docs/goals/mac-ios-parity/notes/T026-phase-5c-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T026-phase-5c-branch-start.md
@@ -1,0 +1,6 @@
+# T026 Phase 5C Branch Start
+
+- Branch: `mac-parity-phase-5c-markdown-lightbox`
+- Base: `mac-sidebar-spaces-option-a`
+- Objective: implement Mac issue-detail markdown/image presentation and image lightbox support.
+- Scope guard: do not start draft/create/parse parity in this slice.

--- a/docs/goals/mac-ios-parity/notes/T026-phase-5c-markdown-lightbox.md
+++ b/docs/goals/mac-ios-parity/notes/T026-phase-5c-markdown-lightbox.md
@@ -1,0 +1,43 @@
+# T026 Phase 5C Markdown Lightbox
+
+## Result
+
+`done`.
+
+Implemented Mac issue-detail markdown image presentation and image lightbox support in PR #429.
+
+## PR Status
+
+- PR: https://github.com/mean-weasel/issuectl/pull/429
+- Branch: `mac-parity-phase-5c-markdown-lightbox`
+- Base: `mac-sidebar-spaces-option-a`
+- Status: draft until review/merge gate
+
+## Changes
+
+- Mac issue bodies and comments now split markdown image syntax into tappable rendered image attachments while preserving inline markdown text and fenced code rendering.
+- Rendered image attachments open a Mac lightbox with deterministic loaded-image coverage for fixture images.
+- Broken image URLs open a recoverable lightbox error state and can be dismissed.
+- Mac UI fixtures now include image and missing-image markdown in issue detail data.
+- `MacSidebarSmokeTests` covers rendered image visibility, loaded-image lightbox open/close, broken-image error state, and existing detail/settings flows.
+
+## Validation
+
+- `git diff --check`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-tests -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 29 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5c-tests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailMarkdownImagesOpenLightbox`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 11 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings
+
+## Notes
+
+- The focused lightbox test was strengthened after the first full smoke pass to assert broken-image error presentation and dismissal. The full smoke suite was rerun after that change and passed.
+- `pnpm lint` warnings are pre-existing TypeScript max-lines/unused/explicit-any warnings outside this slice.
+- The iOS build regenerated `apple/IssueCTL/Generated/AppVersion.swift`; that generated file was restored because it is unrelated to this Mac PR.
+
+## Next Gate
+
+Judge PR #429 for acceptance criteria coverage, update the PR body, inspect GitHub checks, then mark ready and merge only if the GitHub or accepted replacement validation gate is satisfied.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T026
+active_task: T027
 
 tasks:
   - id: T001
@@ -1126,7 +1126,7 @@ tasks:
   - id: T026
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 5C Mac issue-detail markdown/image presentation and image lightbox support as a PR-sized slice."
     inputs:
@@ -1170,6 +1170,65 @@ tasks:
       - "Lightbox support requires large cross-platform renderer extraction outside this PR-sized slice."
       - "Remote image loading cannot be made deterministic enough for local UI validation without a fixture strategy."
       - "Required files fall outside the allowed scope."
+    receipt:
+      result: done
+      note: "notes/T026-phase-5c-markdown-lightbox.md"
+      pr:
+        number: 429
+        url: "https://github.com/mean-weasel/issuectl/pull/429"
+        branch: "mac-parity-phase-5c-markdown-lightbox"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending post-push review in T027."
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-tests -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5c-tests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailMarkdownImagesOpenLightbox"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+      acceptance:
+        - "Mac detail markdown image syntax is parsed into rendered image attachments for issue body and comments."
+        - "Loaded fixture image attachments open and dismiss a nonblank lightbox in UI automation."
+        - "Broken fixture image attachments open and dismiss a lightbox error state without crashing detail."
+        - "Existing Phase 5A/5B detail actions remained covered by the full MacSidebarSmokeTests suite."
+      summary: "Implemented Mac detail markdown image rendering and lightbox support with deterministic loaded/error UI automation coverage."
+
+  - id: T027
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #429 for Phase 5C acceptance coverage, GitHub/check status, merge readiness, and next-slice sizing."
+    inputs:
+      - "T026 receipt"
+      - "PR #429 diff and metadata"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not implement product changes unless a merge-blocking defect is found and can be fixed inside the current slice."
+      - "Reject merge if markdown/image/lightbox acceptance criteria are not covered."
+      - "If GitHub reports no configured checks, document the accepted local validation replacement gate before merge."
+      - "Preserve the PR-sized slice cadence and activate the next safe Worker only after merge or an explicit blocker."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance coverage map."
+      - "CI or accepted replacement validation status."
+      - "Merge decision."
+      - "Next task recommendation."
     receipt: null
 
   - id: T999
@@ -1198,8 +1257,13 @@ tasks:
 checks:
   dirty_fingerprint: unknown
   last_verification:
-    result: partial
-    task: T010
+    result: pass
+    task: T026
     commands:
       - "git diff --check"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-tests -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5c-tests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "pnpm typecheck"
+      - "pnpm lint"


### PR DESCRIPTION
Phase 5C Issue Detail Rendering slice for Mac/iOS parity.

Base: `mac-sidebar-spaces-option-a`
GoalBuddy tasks: T026 worker, T027 review/merge gate
Branch: `mac-parity-phase-5c-markdown-lightbox`

## Scope

- Render Mac issue body/comment markdown image syntax as visually identifiable image attachments.
- Open rendered image attachments in a Mac lightbox.
- Support deterministic loaded-image state and recoverable broken-image error state.
- Preserve Phase 5A/5B issue-detail actions.

Out of scope: draft/create/parse parity and broader renderer refactors.

## Acceptance Evidence

- Mac issue body image fixture renders as `mac-issue-body-image-1` and opens `mac-image-lightbox-loaded-image`.
- Mac comment missing-image fixture renders as `mac-comment-102-image-1` and opens `mac-image-lightbox-error`.
- Lightbox close button dismisses both loaded and error states.
- Full `MacSidebarSmokeTests` still covers edit/comment/close/delete, labels, assignees, reassign, filters, pagination, settings, worktrees, and status-menu settings.

## Validation

- `git diff --check`: pass
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-tests -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 29 tests
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5c-tests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueDetailMarkdownImagesOpenLightbox`: pass
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 11 tests
- `pnpm typecheck`: pass
- `pnpm lint`: pass with existing warnings

## GitHub Checks

GitHub reported no combined statuses and no workflow runs for head `25ebe446adaed58e65b6c7aa0bd2160492ed964e`; the local validation above is the accepted replacement gate for this slice.
