### PR TITLE
Add Mac draft assignment with labels

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -289,15 +289,21 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         case ("GET", "/api/v1/sessions/previews"):
             return ["previews": []]
         case ("GET", "/api/v1/drafts"):
-            return ["drafts": [
-                [
-                    "id": "draft-1",
-                    "title": "Draft offline idea",
-                    "body": "draft body",
-                    "priority": "normal",
-                    "created_at": 1_775_000_000,
-                ],
-            ]]
+            return ["drafts": drafts]
+        case ("POST", "/api/v1/drafts/draft-1/assign"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_DRAFT_ASSIGN_FAILURE"] == "1" {
+                return ["success": false, "error": "Fixture draft assignment failed"]
+            }
+            draftAssignmentLabels = jsonBody(from: request)["labels"] as? [String] ?? []
+            draftAssignedIssueNumber = 88
+            return [
+                "success": true,
+                "issue_number": 88,
+                "issue_url": "https://github.com/org/alpha/issues/88",
+                "cleanup_warning": NSNull(),
+                "labels_warning": NSNull(),
+                "error": NSNull(),
+            ]
         case ("GET", "/api/v1/issues/org/alpha"):
             return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/beta"):
@@ -441,10 +447,25 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var detailIssueLabels = ["bug"]
     nonisolated(unsafe) private static var detailIssueAssignees = ["bob"]
     nonisolated(unsafe) private static var reassignedIssueNumber: Int?
+    nonisolated(unsafe) private static var draftAssignedIssueNumber: Int?
+    nonisolated(unsafe) private static var draftAssignmentLabels: [String] = []
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
     ]
+
+    private static var drafts: [[String: Any]] {
+        guard draftAssignedIssueNumber == nil else { return [] }
+        return [
+            [
+                "id": "draft-1",
+                "title": "Draft offline idea",
+                "body": "draft body",
+                "priority": "normal",
+                "created_at": 1_775_000_000,
+            ],
+        ]
+    }
 
     private static var issues: [[String: Any]] {
         [
@@ -452,7 +473,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
             issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
             issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
-        ] + (5...55).map { number in
+        ] + assignedDraftIssues + (5...55).map { number in
             issue(
                 number: number,
                 title: "Paged issue \(number)",
@@ -463,6 +484,22 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 updatedAt: String(format: "2026-05-13T%02d:00:00.000Z", number % 24)
             )
         }
+    }
+
+    private static var assignedDraftIssues: [[String: Any]] {
+        guard let draftAssignedIssueNumber else { return [] }
+        return [
+            issue(
+                number: draftAssignedIssueNumber,
+                title: "Draft offline idea",
+                body: "draft body",
+                state: "open",
+                labels: draftAssignmentLabels,
+                assignees: ["alice"],
+                author: "alice",
+                updatedAt: "2026-05-14T15:00:00.000Z"
+            ),
+        ]
     }
 
     private static var betaIssues: [[String: Any]] {

--- a/apple/IssueCTLMac/Views/MacDraftsView.swift
+++ b/apple/IssueCTLMac/Views/MacDraftsView.swift
@@ -32,7 +32,9 @@ struct MacDraftsView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(store.drafts) { draft in
-                    DraftRow(draft: draft)
+                    DraftRow(draft: draft) {
+                        activeSheet = .assign(draft)
+                    }
                         .contentShape(Rectangle())
                         .onTapGesture {
                             activeSheet = .edit(draft)
@@ -40,6 +42,9 @@ struct MacDraftsView: View {
                         .contextMenu {
                             Button("Edit") {
                                 activeSheet = .edit(draft)
+                            }
+                            Button("Assign to Repo") {
+                                activeSheet = .assign(draft)
                             }
                             Button("Delete", role: .destructive) {
                                 deleteTarget = draft
@@ -58,6 +63,12 @@ struct MacDraftsView: View {
             case .edit(let draft):
                 DraftEditorSheet(mode: .edit(draft)) { title, body, priority in
                     try await store.updateDraft(api: api, id: draft.id, title: title, body: body, priority: priority)
+                }
+            case .assign(let draft):
+                DraftAssignSheet(draft: draft, repos: store.repos) { repo, labels in
+                    _ = try await store.assignDraftWithLabels(api: api, id: draft.id, repo: repo, labels: labels)
+                } loadLabels: { repo in
+                    try await api.repoLabels(owner: repo.owner, repo: repo.name)
                 }
             }
         }
@@ -132,40 +143,54 @@ struct MacDraftsView: View {
 private enum DraftSheet: Identifiable {
     case new
     case edit(Draft)
+    case assign(Draft)
 
     var id: String {
         switch self {
         case .new: "new"
         case .edit(let draft): "edit-\(draft.id)"
+        case .assign(let draft): "assign-\(draft.id)"
         }
     }
 }
 
 private struct DraftRow: View {
     let draft: Draft
+    let onAssign: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(draft.title)
-                    .font(.subheadline.weight(.medium))
-                    .lineLimit(2)
-                Spacer(minLength: 8)
-                if let priority = draft.priority, priority != .normal {
-                    PriorityPill(priority: priority)
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(draft.title)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(2)
+                    Spacer(minLength: 8)
+                    if let priority = draft.priority, priority != .normal {
+                        PriorityPill(priority: priority)
+                    }
                 }
+
+                if let body = draft.body, !body.isEmpty {
+                    Text(body)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Text(createdDateText)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
 
-            if let body = draft.body, !body.isEmpty {
-                Text(body)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+            Button {
+                onAssign()
+            } label: {
+                Label("Assign", systemImage: "arrow.up.doc")
             }
-
-            Text(createdDateText)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityIdentifier("mac-draft-assign-\(draft.id)")
         }
         .padding(.vertical, 5)
     }
@@ -173,6 +198,186 @@ private struct DraftRow: View {
     private var createdDateText: String {
         let date = Date(timeIntervalSince1970: draft.createdAt)
         return date.formatted(date: .abbreviated, time: .shortened)
+    }
+}
+
+private struct DraftAssignSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let draft: Draft
+    let repos: [Repo]
+    let onAssign: (Repo, [String]) async throws -> Void
+    let loadLabels: (Repo) async throws -> [GitHubLabel]
+
+    @State private var selectedRepoId: Int?
+    @State private var availableLabels: [GitHubLabel] = []
+    @State private var selectedLabels: Set<String> = []
+    @State private var isLoadingLabels = false
+    @State private var isAssigning = false
+    @State private var errorMessage: String?
+
+    init(
+        draft: Draft,
+        repos: [Repo],
+        onAssign: @escaping (Repo, [String]) async throws -> Void,
+        loadLabels: @escaping (Repo) async throws -> [GitHubLabel]
+    ) {
+        self.draft = draft
+        self.repos = repos
+        self.onAssign = onAssign
+        self.loadLabels = loadLabels
+        _selectedRepoId = State(initialValue: repos.first?.id)
+    }
+
+    private var selectedRepo: Repo? {
+        guard let selectedRepoId else { return nil }
+        return repos.first { $0.id == selectedRepoId }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Assign Draft")
+                        .font(.headline)
+                    Text(draft.title)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+            }
+
+            if repos.isEmpty {
+                ContentUnavailableView(
+                    "No Repositories",
+                    systemImage: "tray",
+                    description: Text("Add a tracked repository before assigning drafts.")
+                )
+                .frame(minHeight: 220)
+            } else {
+                Picker("Repository", selection: $selectedRepoId) {
+                    ForEach(repos) { repo in
+                        Text(repo.fullName).tag(Optional(repo.id))
+                    }
+                }
+                .accessibilityIdentifier("mac-assign-draft-repo-picker")
+                .onChange(of: selectedRepoId) { _, _ in
+                    selectedLabels = []
+                    Task { await loadRepoLabels() }
+                }
+
+                if isLoadingLabels {
+                    ProgressView("Loading labels...")
+                        .frame(maxWidth: .infinity, minHeight: 160)
+                } else if availableLabels.isEmpty {
+                    ContentUnavailableView("No Labels", systemImage: "tag")
+                        .frame(minHeight: 160)
+                } else {
+                    List(availableLabels) { label in
+                        labelRow(label)
+                    }
+                    .frame(minHeight: 220)
+                }
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-assign-draft-error")
+            }
+
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button {
+                    Task { await assign() }
+                } label: {
+                    if isAssigning {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Assign")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(isAssigning || selectedRepo == nil)
+                .accessibilityIdentifier("mac-assign-draft-submit-button")
+            }
+        }
+        .padding(20)
+        .frame(width: 480)
+        .task { await loadRepoLabels() }
+    }
+
+    private func labelRow(_ label: GitHubLabel) -> some View {
+        let isSelected = selectedLabels.contains(label.name)
+
+        return Button {
+            if isSelected {
+                selectedLabels.remove(label.name)
+            } else {
+                selectedLabels.insert(label.name)
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(Color(macDraftHex: label.color) ?? .secondary)
+                    .frame(width: 12, height: 12)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label.name)
+                    if let description = label.description, !description.isEmpty {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .accessibilityIdentifier("mac-assign-draft-label-\(label.name)")
+    }
+
+    private func loadRepoLabels() async {
+        guard let selectedRepo else { return }
+        isLoadingLabels = true
+        errorMessage = nil
+        defer { isLoadingLabels = false }
+
+        do {
+            availableLabels = try await loadLabels(selectedRepo)
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            availableLabels = []
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func assign() async {
+        guard let selectedRepo else { return }
+        isAssigning = true
+        errorMessage = nil
+        defer { isAssigning = false }
+
+        do {
+            try await onAssign(selectedRepo, Array(selectedLabels).sorted())
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 
@@ -346,5 +551,20 @@ private extension Priority {
         case .normal: .blue
         case .high: .red
         }
+    }
+}
+
+private extension Color {
+    init?(macDraftHex: String) {
+        var value = macDraftHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("#") {
+            value.removeFirst()
+        }
+        guard value.count == 6, let integer = Int(value, radix: 16) else { return nil }
+        self.init(
+            red: Double((integer >> 16) & 0xFF) / 255.0,
+            green: Double((integer >> 8) & 0xFF) / 255.0,
+            blue: Double(integer & 0xFF) / 255.0
+        )
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -210,6 +210,7 @@ struct MacSidebarRootView: View {
             .labelsHidden()
             .padding(.horizontal, 14)
             .padding(.bottom, 10)
+            .accessibilityIdentifier("mac-sidebar-section-picker")
 
             Divider()
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -148,6 +148,18 @@ final class MacSidebarStore {
         drafts.removeAll { $0.id == id }
     }
 
+    func assignDraftWithLabels(api: APIClient, id: String, repo: Repo, labels: [String]) async throws -> AssignDraftResponse {
+        let response = try await api.assignDraftWithLabels(
+            id: id,
+            body: AssignDraftWithLabelsRequestBody(repoId: repo.id, labels: labels.isEmpty ? nil : labels)
+        )
+        guard response.success else {
+            throw MacSidebarStoreError.operationFailed(response.error ?? "Failed to assign draft")
+        }
+        await load(api: api, refresh: true)
+        return response
+    }
+
     func issueDetail(api: APIClient, item: MacIssueListItem, refresh: Bool) async throws -> IssueDetailResponse {
         let detail = try await api.issueDetail(
             owner: item.repo.owner,

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -190,6 +190,44 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-error"].waitForNonExistence(timeout: 5), app.debugDescription)
     }
 
+    func testDraftAssignsToRepoWithLabelsAndRefreshesIssues() {
+        selectRootSection("Drafts")
+
+        let assignButton = app.buttons["mac-draft-assign-draft-1"]
+        XCTAssertTrue(assignButton.waitForExistence(timeout: 5), app.debugDescription)
+        assignButton.click()
+        let bugLabel = app.descendants(matching: .any)["mac-assign-draft-label-bug"]
+        XCTAssertTrue(bugLabel.waitForExistence(timeout: 5), app.debugDescription)
+        bugLabel.click()
+
+        app.buttons["mac-assign-draft-submit-button"].click()
+        XCTAssertTrue(assignButton.waitForNonExistence(timeout: 5), app.debugDescription)
+
+        selectRootSection("Issues")
+        XCTAssertTrue(app.textFields["mac-issues-search-field"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(issueRow("org/alpha", 88).waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testDraftAssignmentFailurePreservesChoices() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_DRAFT_ASSIGN_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("Drafts")
+
+        let assignButton = app.buttons["mac-draft-assign-draft-1"]
+        XCTAssertTrue(assignButton.waitForExistence(timeout: 5), app.debugDescription)
+        assignButton.click()
+        let bugLabel = app.descendants(matching: .any)["mac-assign-draft-label-bug"]
+        XCTAssertTrue(bugLabel.waitForExistence(timeout: 5), app.debugDescription)
+        bugLabel.click()
+
+        app.buttons["mac-assign-draft-submit-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-assign-draft-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-assign-draft-submit-button"].exists, app.debugDescription)
+        XCTAssertTrue(bugLabel.exists, app.debugDescription)
+    }
+
     func testStatusMenuOpensSettings() {
         openSettingsFromStatusMenu()
 
@@ -315,5 +353,15 @@ final class MacSidebarSmokeTests: XCTestCase {
 
     private func issueSort(_ title: String) -> XCUIElement {
         app.descendants(matching: .any)["mac-issues-sort-picker"].radioButtons[title]
+    }
+
+    private func rootSection(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-sidebar-section-picker"].radioButtons[title].firstMatch
+    }
+
+    private func selectRootSection(_ title: String) {
+        let section = rootSection(title)
+        XCTAssertTrue(section.waitForExistence(timeout: 5), app.debugDescription)
+        section.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
 }

--- a/docs/goals/mac-ios-parity/notes/T028-phase-6a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T028-phase-6a-branch-start.md
@@ -1,0 +1,6 @@
+# T028 Phase 6A Branch Start
+
+- Branch: `mac-parity-phase-6a-draft-assignment`
+- Base: `mac-sidebar-spaces-option-a`
+- Objective: assign existing Mac drafts to tracked repos with label selection, refresh issues/drafts on success, and preserve choices on failure.
+- Started from integration commit `72fc841`.

--- a/docs/goals/mac-ios-parity/notes/T028-phase-6a-draft-assignment.md
+++ b/docs/goals/mac-ios-parity/notes/T028-phase-6a-draft-assignment.md
@@ -1,0 +1,45 @@
+# T028 Phase 6A Draft Assignment
+
+## Result
+
+`done`.
+
+Implemented Mac assignment of existing local drafts to a tracked repository in PR #430.
+
+## PR Status
+
+- PR: https://github.com/mean-weasel/issuectl/pull/430
+- Branch: `mac-parity-phase-6a-draft-assignment`
+- Base: `mac-sidebar-spaces-option-a`
+- Status: draft until review/merge gate
+
+## Changes
+
+- Added a visible Assign action and context-menu action to Mac draft rows.
+- Added a Mac draft assignment sheet with tracked-repo selection, repo label loading, multi-select label choices, and recoverable error display.
+- Wired assignment through `MacSidebarStore.assignDraftWithLabels`, using the shared draft assignment API request/response types.
+- Refreshes Mac sidebar data after successful assignment so the draft disappears and the created issue is visible in issue surfaces.
+- Preserves selected repo, selected labels, and the open assignment sheet when assignment fails.
+- Expanded the Mac UI fixture API to return assigned-draft issues and simulate assignment failure.
+- Added Mac sidebar UI tests for successful label assignment/refresh and failure preservation.
+
+## Validation
+
+- `git diff --check`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6a-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 29 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignsToRepoWithLabelsAndRefreshesIssues -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignmentFailurePreservesChoices`: pass, 2 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 13 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings
+
+## Notes
+
+- The first focused UI test run exposed ambiguous root/draft selection; the test now targets the root section picker and waits on the Drafts-view-only Assign button.
+- `pnpm lint` warnings are pre-existing TypeScript max-lines/unused/explicit-any warnings outside this slice.
+- The iOS build regenerated `apple/IssueCTL/Generated/AppVersion.swift`; that generated file was restored because it is unrelated to this Mac PR.
+
+## Next Gate
+
+Judge PR #430 for acceptance criteria coverage, update the PR body, inspect GitHub checks, then mark ready and merge only if the GitHub or accepted replacement validation gate is satisfied.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T028
+active_task: T029
 
 tasks:
   - id: T001
@@ -1250,7 +1250,7 @@ tasks:
   - id: T028
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 6A Mac draft assignment: assign an existing local draft to a tracked repo with label selection, preserve input on failure, and refresh issues/drafts after success."
     inputs:
@@ -1274,6 +1274,7 @@ tasks:
       - "apple/IssueCTLMac/Views/MacDraftsView.swift"
       - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
       - "apple/IssueCTLMac/Views/MacIssuesView.swift"
+      - "apple/IssueCTLMac/Views/MacSidebarRootView.swift"
       - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
       - "apple/IssueCTLMacTests/**"
       - "apple/IssueCTLMacUITests/**"
@@ -1300,6 +1301,68 @@ tasks:
       - "Draft assignment requires backend endpoints not present in shared API/client fixtures."
       - "Direct quick-create or image upload scope becomes necessary to complete assignment safely."
       - "Required files fall outside the allowed scope."
+    receipt:
+      result: done
+      note: "notes/T028-phase-6a-draft-assignment.md"
+      pr:
+        number: 430
+        url: "https://github.com/mean-weasel/issuectl/pull/430"
+        branch: "mac-parity-phase-6a-draft-assignment"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending post-push review in T029."
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacDraftsView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarRootView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6a-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignsToRepoWithLabelsAndRefreshesIssues -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignmentFailurePreservesChoices"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+      acceptance:
+        - "A Mac user can assign an existing local draft to one tracked repo."
+        - "Repo label options load for the selected repo and selected labels are sent with the assignment request."
+        - "Successful assignment refreshes drafts and issues so the draft disappears and the created issue is visible."
+        - "Assignment failure shows a recoverable error and preserves the selected draft, repo, and label choices."
+        - "Existing Mac draft and sidebar workflows remain covered by the full MacSidebarSmokeTests suite."
+      summary: "Implemented Mac existing-draft assignment with repo/label selection, refresh behavior, and success/failure UI automation coverage."
+
+  - id: T029
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #430 for Phase 6A acceptance coverage, GitHub/check status, merge readiness, and next-slice sizing."
+    inputs:
+      - "T028 receipt"
+      - "PR #430 diff and metadata"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not implement product changes unless a merge-blocking defect is found and can be fixed inside the current slice."
+      - "Reject merge if draft assignment success/failure acceptance criteria are not covered."
+      - "If GitHub reports no configured checks, document the accepted local validation replacement gate before merge."
+      - "Preserve the PR-sized slice cadence and activate the next safe Worker only after merge or an explicit blocker."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance coverage map."
+      - "CI or accepted replacement validation status."
+      - "Merge decision."
+      - "Next task recommendation."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary

- Add Mac draft assignment from the dedicated Drafts view, with tracked-repo selection and multi-select repo labels.
- Refresh drafts and issues after successful assignment so the draft disappears and the created issue is visible.
- Preserve the assignment sheet, selected repo, and selected labels when assignment fails.
- Extend Mac UI fixtures and smoke tests for assignment success and failure paths.

## Validation

- `git diff --check`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6a-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`\n- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests` (29 tests)\n- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignsToRepoWithLabelsAndRefreshesIssues -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testDraftAssignmentFailurePreservesChoices` (2 tests)\n- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (13 tests)\n- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests` (37 tests)\n- `pnpm typecheck`\n- `pnpm lint` (passes with existing warnings)\n\n## Check Status\n\nGitHub reports no configured status checks or workflow runs for this branch. Local validation above is the accepted replacement gate for this PR.