### PR TITLE
Add Mac direct quick issue creation

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -290,6 +290,11 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["previews": []]
         case ("GET", "/api/v1/drafts"):
             return ["drafts": drafts]
+        case ("POST", "/api/v1/drafts"):
+            let payload = jsonBody(from: request)
+            quickCreatedIssueTitle = payload["title"] as? String ?? "Untitled quick issue"
+            quickCreatedIssueBody = payload["body"] as? String
+            return ["success": true, "id": "quick-draft-1", "error": NSNull()]
         case ("POST", "/api/v1/drafts/draft-1/assign"):
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_DRAFT_ASSIGN_FAILURE"] == "1" {
                 return ["success": false, "error": "Fixture draft assignment failed"]
@@ -300,6 +305,20 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 "success": true,
                 "issue_number": 88,
                 "issue_url": "https://github.com/org/alpha/issues/88",
+                "cleanup_warning": NSNull(),
+                "labels_warning": NSNull(),
+                "error": NSNull(),
+            ]
+        case ("POST", "/api/v1/drafts/quick-draft-1/assign"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_QUICK_CREATE_FAILURE"] == "1" {
+                return ["success": false, "error": "Fixture quick create failed"]
+            }
+            quickCreatedIssueLabels = jsonBody(from: request)["labels"] as? [String] ?? []
+            quickCreatedIssueNumber = 89
+            return [
+                "success": true,
+                "issue_number": 89,
+                "issue_url": "https://github.com/org/alpha/issues/89",
                 "cleanup_warning": NSNull(),
                 "labels_warning": NSNull(),
                 "error": NSNull(),
@@ -449,6 +468,10 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var reassignedIssueNumber: Int?
     nonisolated(unsafe) private static var draftAssignedIssueNumber: Int?
     nonisolated(unsafe) private static var draftAssignmentLabels: [String] = []
+    nonisolated(unsafe) private static var quickCreatedIssueNumber: Int?
+    nonisolated(unsafe) private static var quickCreatedIssueTitle = "Quick created issue"
+    nonisolated(unsafe) private static var quickCreatedIssueBody: String?
+    nonisolated(unsafe) private static var quickCreatedIssueLabels: [String] = []
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
@@ -473,7 +496,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
             issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
             issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
-        ] + assignedDraftIssues + (5...55).map { number in
+        ] + assignedDraftIssues + quickCreatedIssues + (5...55).map { number in
             issue(
                 number: number,
                 title: "Paged issue \(number)",
@@ -484,6 +507,22 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 updatedAt: String(format: "2026-05-13T%02d:00:00.000Z", number % 24)
             )
         }
+    }
+
+    private static var quickCreatedIssues: [[String: Any]] {
+        guard let quickCreatedIssueNumber else { return [] }
+        return [
+            issue(
+                number: quickCreatedIssueNumber,
+                title: quickCreatedIssueTitle,
+                body: quickCreatedIssueBody ?? "",
+                state: "open",
+                labels: quickCreatedIssueLabels,
+                assignees: ["alice"],
+                author: "alice",
+                updatedAt: "2026-05-14T16:00:00.000Z"
+            ),
+        ]
     }
 
     private static var assignedDraftIssues: [[String: Any]] {

--- a/apple/IssueCTLMac/Views/MacDraftsView.swift
+++ b/apple/IssueCTLMac/Views/MacDraftsView.swift
@@ -22,12 +22,22 @@ struct MacDraftsView: View {
                 } description: {
                     Text("Create a local draft, then assign it to a repo when it is ready.")
                 } actions: {
-                    Button {
-                        activeSheet = .new
-                    } label: {
-                        Label("New Draft", systemImage: "plus")
+                    HStack {
+                        Button {
+                            activeSheet = .quickCreate
+                        } label: {
+                            Label("New Issue", systemImage: "square.and.pencil")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifier("mac-drafts-new-issue-button")
+
+                        Button {
+                            activeSheet = .new
+                        } label: {
+                            Label("New Draft", systemImage: "plus")
+                        }
+                        .buttonStyle(.bordered)
                     }
-                    .buttonStyle(.borderedProminent)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -56,6 +66,19 @@ struct MacDraftsView: View {
         }
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
+            case .quickCreate:
+                DirectIssueCreateSheet(repos: store.repos) { repo, title, body, priority, labels in
+                    _ = try await store.createIssue(
+                        api: api,
+                        title: title,
+                        body: body,
+                        priority: priority,
+                        repo: repo,
+                        labels: labels
+                    )
+                } loadLabels: { repo in
+                    try await api.repoLabels(owner: repo.owner, repo: repo.name)
+                }
             case .new:
                 DraftEditorSheet(mode: .new) { title, body, priority in
                     try await store.createDraft(api: api, title: title, body: body, priority: priority)
@@ -120,6 +143,15 @@ struct MacDraftsView: View {
             Spacer()
 
             Button {
+                activeSheet = .quickCreate
+            } label: {
+                Label("New Issue", systemImage: "square.and.pencil")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(store.repos.isEmpty)
+            .accessibilityIdentifier("mac-drafts-new-issue-button")
+
+            Button {
                 activeSheet = .new
             } label: {
                 Label("New Draft", systemImage: "plus")
@@ -141,12 +173,14 @@ struct MacDraftsView: View {
 }
 
 private enum DraftSheet: Identifiable {
+    case quickCreate
     case new
     case edit(Draft)
     case assign(Draft)
 
     var id: String {
         switch self {
+        case .quickCreate: "quick-create"
         case .new: "new"
         case .edit(let draft): "edit-\(draft.id)"
         case .assign(let draft): "assign-\(draft.id)"
@@ -198,6 +232,206 @@ private struct DraftRow: View {
     private var createdDateText: String {
         let date = Date(timeIntervalSince1970: draft.createdAt)
         return date.formatted(date: .abbreviated, time: .shortened)
+    }
+}
+
+private struct DirectIssueCreateSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let repos: [Repo]
+    let onCreate: (Repo, String, String?, Priority, [String]) async throws -> Void
+    let loadLabels: (Repo) async throws -> [GitHubLabel]
+
+    @State private var title = ""
+    @State private var bodyText = ""
+    @State private var selectedRepoId: Int?
+    @State private var priority: Priority = .normal
+    @State private var availableLabels: [GitHubLabel] = []
+    @State private var selectedLabels: Set<String> = []
+    @State private var isLoadingLabels = false
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    init(
+        repos: [Repo],
+        onCreate: @escaping (Repo, String, String?, Priority, [String]) async throws -> Void,
+        loadLabels: @escaping (Repo) async throws -> [GitHubLabel]
+    ) {
+        self.repos = repos
+        self.onCreate = onCreate
+        self.loadLabels = loadLabels
+        _selectedRepoId = State(initialValue: repos.first?.id)
+    }
+
+    private var selectedRepo: Repo? {
+        guard let selectedRepoId else { return nil }
+        return repos.first { $0.id == selectedRepoId }
+    }
+
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedBody: String? {
+        let value = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("New Issue")
+                    .font(.headline)
+                Text("Create directly in a tracked repository.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if repos.isEmpty {
+                ContentUnavailableView(
+                    "No Repositories",
+                    systemImage: "tray",
+                    description: Text("Add a tracked repository before creating issues.")
+                )
+                .frame(minHeight: 240)
+            } else {
+                Picker("Repository", selection: $selectedRepoId) {
+                    ForEach(repos) { repo in
+                        Text(repo.fullName).tag(Optional(repo.id))
+                    }
+                }
+                .accessibilityIdentifier("mac-quick-create-repo-picker")
+                .onChange(of: selectedRepoId) { _, _ in
+                    selectedLabels = []
+                    Task { await loadRepoLabels() }
+                }
+
+                TextField("Issue title", text: $title)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("mac-quick-create-title-field")
+
+                TextEditor(text: $bodyText)
+                    .font(.body)
+                    .frame(minHeight: 110)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.25))
+                    }
+                    .accessibilityIdentifier("mac-quick-create-body-field")
+
+                Picker("Priority", selection: $priority) {
+                    Text("Low").tag(Priority.low)
+                    Text("Normal").tag(Priority.normal)
+                    Text("High").tag(Priority.high)
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("mac-quick-create-priority-picker")
+
+                GroupBox("Labels") {
+                    if isLoadingLabels {
+                        ProgressView("Loading labels...")
+                            .frame(maxWidth: .infinity, minHeight: 120)
+                    } else if availableLabels.isEmpty {
+                        ContentUnavailableView("No Labels", systemImage: "tag")
+                            .frame(minHeight: 120)
+                    } else {
+                        List(availableLabels) { label in
+                            labelRow(label)
+                        }
+                        .frame(minHeight: 160)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-quick-create-error")
+            }
+
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button {
+                    Task { await create() }
+                } label: {
+                    if isCreating {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Create Issue")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(isCreating || selectedRepo == nil || trimmedTitle.isEmpty)
+                .accessibilityIdentifier("mac-quick-create-submit-button")
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+        .task { await loadRepoLabels() }
+    }
+
+    private func labelRow(_ label: GitHubLabel) -> some View {
+        let isSelected = selectedLabels.contains(label.name)
+
+        return Button {
+            if isSelected {
+                selectedLabels.remove(label.name)
+            } else {
+                selectedLabels.insert(label.name)
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(Color(macDraftHex: label.color) ?? .secondary)
+                    .frame(width: 12, height: 12)
+                Text(label.name)
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .accessibilityIdentifier("mac-quick-create-label-\(label.name)")
+    }
+
+    private func loadRepoLabels() async {
+        guard let selectedRepo else { return }
+        isLoadingLabels = true
+        errorMessage = nil
+        defer { isLoadingLabels = false }
+
+        do {
+            availableLabels = try await loadLabels(selectedRepo)
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            availableLabels = []
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func create() async {
+        guard let selectedRepo else { return }
+        isCreating = true
+        errorMessage = nil
+        defer { isCreating = false }
+
+        do {
+            try await onCreate(selectedRepo, trimmedTitle, trimmedBody, priority, Array(selectedLabels).sorted())
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -129,6 +129,31 @@ final class MacSidebarStore {
         await refreshDrafts(api: api)
     }
 
+    func createIssue(
+        api: APIClient,
+        title: String,
+        body: String?,
+        priority: Priority,
+        repo: Repo,
+        labels: [String]
+    ) async throws -> AssignDraftResponse {
+        let createResponse = try await api.createDraft(
+            body: CreateDraftRequestBody(title: title, body: body, priority: priority)
+        )
+        guard createResponse.success, let draftId = createResponse.id else {
+            throw MacSidebarStoreError.operationFailed(createResponse.error ?? "Failed to create issue")
+        }
+        let assignResponse = try await api.assignDraftWithLabels(
+            id: draftId,
+            body: AssignDraftWithLabelsRequestBody(repoId: repo.id, labels: labels.isEmpty ? nil : labels)
+        )
+        guard assignResponse.success else {
+            throw MacSidebarStoreError.operationFailed(assignResponse.error ?? "Failed to create issue")
+        }
+        await load(api: api, refresh: true)
+        return assignResponse
+    }
+
     func updateDraft(api: APIClient, id: String, title: String, body: String?, priority: Priority) async throws {
         let response = try await api.updateDraft(
             id: id,

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -228,6 +228,65 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(bugLabel.exists, app.debugDescription)
     }
 
+    func testQuickCreateIssueWithLabelsRefreshesIssues() {
+        selectRootSection("Drafts")
+
+        let newIssueButton = app.buttons["mac-drafts-new-issue-button"]
+        XCTAssertTrue(newIssueButton.waitForExistence(timeout: 5), app.debugDescription)
+        newIssueButton.click()
+
+        let titleField = app.textFields["mac-quick-create-title-field"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), app.debugDescription)
+        titleField.click()
+        titleField.typeText("Quick mac issue")
+
+        let bodyField = app.textViews["mac-quick-create-body-field"]
+        XCTAssertTrue(bodyField.waitForExistence(timeout: 5), app.debugDescription)
+        bodyField.click()
+        bodyField.typeText("Created directly from Mac")
+
+        let highPriority = app.descendants(matching: .any)["mac-quick-create-priority-picker"].radioButtons["High"]
+        XCTAssertTrue(highPriority.waitForExistence(timeout: 5), app.debugDescription)
+        highPriority.click()
+
+        let bugLabel = app.descendants(matching: .any)["mac-quick-create-label-bug"]
+        XCTAssertTrue(bugLabel.waitForExistence(timeout: 5), app.debugDescription)
+        bugLabel.click()
+
+        app.buttons["mac-quick-create-submit-button"].click()
+        XCTAssertTrue(titleField.waitForNonExistence(timeout: 5), app.debugDescription)
+
+        selectRootSection("Issues")
+        XCTAssertTrue(issueRow("org/alpha", 89).waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testQuickCreateFailurePreservesInput() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_QUICK_CREATE_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("Drafts")
+
+        let newIssueButton = app.buttons["mac-drafts-new-issue-button"]
+        XCTAssertTrue(newIssueButton.waitForExistence(timeout: 5), app.debugDescription)
+        newIssueButton.click()
+
+        let titleField = app.textFields["mac-quick-create-title-field"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), app.debugDescription)
+        titleField.click()
+        titleField.typeText("Preserved quick issue")
+
+        let bugLabel = app.descendants(matching: .any)["mac-quick-create-label-bug"]
+        XCTAssertTrue(bugLabel.waitForExistence(timeout: 5), app.debugDescription)
+        bugLabel.click()
+
+        app.buttons["mac-quick-create-submit-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-quick-create-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-quick-create-submit-button"].exists, app.debugDescription)
+        XCTAssertTrue(titleField.exists, app.debugDescription)
+        XCTAssertTrue(bugLabel.exists, app.debugDescription)
+    }
+
     func testStatusMenuOpensSettings() {
         openSettingsFromStatusMenu()
 

--- a/docs/goals/mac-ios-parity/notes/T030-phase-6b-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T030-phase-6b-branch-start.md
@@ -1,0 +1,5 @@
+# T030 Phase 6B Branch Start
+
+Started `mac-parity-phase-6b-quick-create` from `mac-sidebar-spaces-option-a` after PR #430 merged.
+
+Scope: direct Mac quick issue creation from the sidebar with tracked repo, title/body, priority, labels, failure preservation, and issue refresh/visibility. Image upload and AI parse/batch create remain separate Phase 6 slices.

--- a/docs/goals/mac-ios-parity/notes/T030-phase-6b-quick-create.md
+++ b/docs/goals/mac-ios-parity/notes/T030-phase-6b-quick-create.md
@@ -1,0 +1,45 @@
+# T030 Phase 6B Quick Create
+
+## Result
+
+`done`.
+
+Implemented direct Mac issue creation from the Drafts sidebar surface on PR #431.
+
+## PR
+
+- PR: https://github.com/mean-weasel/issuectl/pull/431
+- Branch: `mac-parity-phase-6b-quick-create`
+- Base: `mac-sidebar-spaces-option-a`
+
+## Changes
+
+- Added a Mac "New Issue" flow that creates a draft through the shared API and immediately assigns it to the selected tracked repository, so the user does not first manage a visible draft.
+- Added repo, title, body, priority, and multi-label controls to the direct create sheet.
+- Added label loading for the selected repo and preservation of form state when creation fails.
+- Refreshed sidebar data after successful creation so the created issue is visible in the issue list.
+- Extended the Mac UI fixture with successful and failed quick-create responses.
+- Added UI tests for successful label-backed quick create and recoverable failure preservation.
+
+## Acceptance Coverage
+
+- Direct creation without first creating or assigning a visible draft: covered by `testQuickCreateIssueWithLabelsRefreshesIssues`.
+- Tracked repo, title/body, priority, and label entry: covered by the quick-create UI flow and fixture label endpoint.
+- Successful creation refreshes issues and shows the created issue: covered by created issue `org/alpha#89` appearing after create.
+- Creation failure is recoverable and preserves input/selection: covered by `testQuickCreateFailurePreservesInput`.
+- Existing draft create/edit/delete and assignment behavior remains covered by the full `MacSidebarSmokeTests` suite.
+
+## Validation
+
+- `git diff --check`: pass
+- Mac build: pass
+- Focused quick-create UI tests: pass, 2 tests
+- Full `MacSidebarSmokeTests`: pass, 15 tests
+- `IssueCTLMacTests`: pass, 29 tests
+- `IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings
+
+## Notes
+
+This slice intentionally uses the existing shared draft-create plus assign API contract under a direct Mac UI. Image upload and AI parse/batch creation remain separate Phase 6 slices.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T030
+active_task: T031
 
 tasks:
   - id: T001
@@ -1384,7 +1384,7 @@ tasks:
   - id: T030
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 6B Mac direct quick issue creation from the sidebar: create an issue without first creating a draft, with repo, title/body, priority, labels, failure preservation, and issue refresh/selection where feasible."
     inputs:
@@ -1434,6 +1434,67 @@ tasks:
       - "Direct issue creation requires backend endpoints not present in shared API/client fixtures."
       - "Image upload or parse scope becomes necessary to safely complete direct creation."
       - "Required files fall outside the allowed scope."
+    receipt:
+      result: done
+      note: "notes/T030-phase-6b-quick-create.md"
+      pr:
+        number: 431
+        url: "https://github.com/mean-weasel/issuectl/pull/431"
+        branch: "mac-parity-phase-6b-quick-create"
+        base: "mac-sidebar-spaces-option-a"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacDraftsView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6b-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testQuickCreateIssueWithLabelsRefreshesIssues -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testQuickCreateFailurePreservesInput"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+      acceptance:
+        - "Direct Mac quick creation works without first creating or assigning a visible draft."
+        - "The flow supports tracked repo, title/body, priority, and labels loaded for the selected repo."
+        - "Successful creation refreshes issues and shows created issue org/alpha#89."
+        - "Failed creation preserves the entered title and selected label while showing a recoverable error."
+        - "Existing draft and sidebar workflows remain covered by the full MacSidebarSmokeTests suite."
+      warnings:
+        - "pnpm lint passed with existing warnings."
+      summary: "Implemented direct Mac quick issue creation from the Drafts sidebar surface with repo/priority/label inputs, refresh behavior, failure preservation, and UI fixture coverage."
+
+  - id: T031
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #431 for Phase 6B acceptance coverage, GitHub/check status, merge readiness, and the next Phase 6 slice."
+    inputs:
+      - "T030 receipt"
+      - "PR #431 diff and metadata"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not merge red CI without an explicit recorded exception."
+      - "If GitHub reports no configured checks, document the accepted local validation replacement gate before merge."
+      - "Reject merge if quick-create success, label selection, issue refresh, or failure preservation acceptance criteria are missing."
+      - "Preserve PR-sized slices and size image upload or AI parse/batch creation separately."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance coverage map."
+      - "CI or accepted replacement validation status."
+      - "Merge decision."
+      - "Next task recommendation."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary

Implements Phase 6B direct Mac quick issue creation from the sidebar.

- Adds a Mac `New Issue` sheet from Drafts that creates directly into a tracked repo without first exposing a visible draft workflow.
- Supports repo selection, title/body, priority, and labels loaded for the selected repo.
- Refreshes sidebar data after successful creation so the created issue is visible.
- Preserves form state and selected labels on recoverable creation failure.
- Extends the Mac UI fixture and smoke tests for success and failure paths.

## Validation

- `git diff --check`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6b-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testQuickCreateIssueWithLabelsRefreshesIssues -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testQuickCreateFailurePreservesInput`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`
- `pnpm typecheck`
- `pnpm lint` passes with existing warnings
