### PR TITLE
Add Mac image attachment upload

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -288,6 +288,11 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             ]]
         case ("GET", "/api/v1/sessions/previews"):
             return ["previews": []]
+        case ("POST", "/api/v1/images/upload"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_IMAGE_UPLOAD_FAILURE"] == "1" {
+                return ["error": "Fixture image upload failed"]
+            }
+            return ["url": "https://issuectl-ui-test.local/fixtures/uploaded.png"]
         case ("GET", "/api/v1/drafts"):
             return ["drafts": drafts]
         case ("POST", "/api/v1/drafts"):
@@ -329,6 +334,8 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["issues": betaIssues, "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/1"):
             return issueDetail()
+        case ("GET", "/api/v1/issues/org/alpha/89"):
+            return quickCreatedIssueDetail()
         case ("GET", "/api/v1/repos/org/alpha/labels"):
             return ["labels": availableLabels]
         case ("GET", "/api/v1/repos/org/alpha/collaborators"):
@@ -631,6 +638,27 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ]
     }
 
+    private static func quickCreatedIssueDetail() -> [String: Any] {
+        [
+            "issue": issue(
+                number: 89,
+                title: quickCreatedIssueTitle,
+                body: quickCreatedIssueBody ?? "",
+                state: "open",
+                labels: quickCreatedIssueLabels,
+                assignees: ["alice"],
+                author: "alice",
+                updatedAt: isoDate
+            ),
+            "comments": [],
+            "deployments": [],
+            "linkedPRs": [],
+            "referencedFiles": [],
+            "fromCache": false,
+            "cachedAt": NSNull(),
+        ]
+    }
+
     private static func commentFixture(id: Int, body: String, author: String) -> [String: Any] {
         [
             "id": id,
@@ -643,8 +671,8 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     }
 
     private static func fixtureImageData(for path: String) -> Data? {
-        guard path == "/fixtures/alpha.png" else { return nil }
-        return Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVR42mP8z8AARLJgYGBgYAAAAP//AwAFxgICFhZbkAAAAABJRU5ErkJggg==")
+        guard path == "/fixtures/alpha.png" || path == "/fixtures/uploaded.png" else { return nil }
+        return Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAqADAAQAAAABAAAAAgAAAADtGLyqAAAAEklEQVQIHWP8DwQMQMAEIkAAAD34BACALvQ5AAAAAElFTkSuQmCC")
     }
 
     private static var availableLabels: [[String: Any]] {

--- a/apple/IssueCTLMac/Views/MacDraftsView.swift
+++ b/apple/IssueCTLMac/Views/MacDraftsView.swift
@@ -1,4 +1,7 @@
+import AppKit
+import ImageIO
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct MacDraftsView: View {
     @Environment(APIClient.self) private var api
@@ -80,11 +83,11 @@ struct MacDraftsView: View {
                     try await api.repoLabels(owner: repo.owner, repo: repo.name)
                 }
             case .new:
-                DraftEditorSheet(mode: .new) { title, body, priority in
+                DraftEditorSheet(mode: .new, repos: store.repos) { title, body, priority in
                     try await store.createDraft(api: api, title: title, body: body, priority: priority)
                 }
             case .edit(let draft):
-                DraftEditorSheet(mode: .edit(draft)) { title, body, priority in
+                DraftEditorSheet(mode: .edit(draft), repos: store.repos) { title, body, priority in
                     try await store.updateDraft(api: api, id: draft.id, title: title, body: body, priority: priority)
                 }
             case .assign(let draft):
@@ -250,6 +253,7 @@ private struct DirectIssueCreateSheet: View {
     @State private var selectedLabels: Set<String> = []
     @State private var isLoadingLabels = false
     @State private var isCreating = false
+    @State private var isUploadingImage = false
     @State private var errorMessage: String?
 
     init(
@@ -319,6 +323,17 @@ private struct DirectIssueCreateSheet: View {
                     }
                     .accessibilityIdentifier("mac-quick-create-body-field")
 
+                if let selectedRepo {
+                    MacImageAttachmentButton(
+                        owner: selectedRepo.owner,
+                        repo: selectedRepo.name,
+                        accessibilityPrefix: "mac-quick-create",
+                        isUploading: $isUploadingImage
+                    ) { markdown in
+                        appendMarkdown(markdown, to: &bodyText)
+                    }
+                }
+
                 Picker("Priority", selection: $priority) {
                     Text("Low").tag(Priority.low)
                     Text("Normal").tag(Priority.normal)
@@ -371,7 +386,7 @@ private struct DirectIssueCreateSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(isCreating || selectedRepo == nil || trimmedTitle.isEmpty)
+                .disabled(isCreating || isUploadingImage || selectedRepo == nil || trimmedTitle.isEmpty)
                 .accessibilityIdentifier("mac-quick-create-submit-button")
             }
         }
@@ -619,17 +634,22 @@ private struct DraftEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let mode: DraftEditorMode
+    let repos: [Repo]
     let onSave: (String, String?, Priority) async throws -> Void
 
     @State private var title: String
     @State private var bodyText: String
+    @State private var attachmentRepoId: Int?
     @State private var priority: Priority
     @State private var isSaving = false
+    @State private var isUploadingImage = false
     @State private var errorMessage: String?
 
-    init(mode: DraftEditorMode, onSave: @escaping (String, String?, Priority) async throws -> Void) {
+    init(mode: DraftEditorMode, repos: [Repo], onSave: @escaping (String, String?, Priority) async throws -> Void) {
         self.mode = mode
+        self.repos = repos
         self.onSave = onSave
+        _attachmentRepoId = State(initialValue: repos.first?.id)
 
         switch mode {
         case .new:
@@ -641,6 +661,11 @@ private struct DraftEditorSheet: View {
             _bodyText = State(initialValue: draft.body ?? "")
             _priority = State(initialValue: draft.priority ?? .normal)
         }
+    }
+
+    private var attachmentRepo: Repo? {
+        guard let attachmentRepoId else { return nil }
+        return repos.first { $0.id == attachmentRepoId }
     }
 
     var body: some View {
@@ -679,6 +704,34 @@ private struct DraftEditorSheet: View {
                     }
             }
 
+            if !repos.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Attachments")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Picker("Upload to", selection: $attachmentRepoId) {
+                            ForEach(repos) { repo in
+                                Text(repo.fullName).tag(Optional(repo.id))
+                            }
+                        }
+                        .frame(maxWidth: 260)
+                        .accessibilityIdentifier("mac-draft-attachment-repo-picker")
+
+                        if let attachmentRepo {
+                            MacImageAttachmentButton(
+                                owner: attachmentRepo.owner,
+                                repo: attachmentRepo.name,
+                                accessibilityPrefix: "mac-draft",
+                                isUploading: $isUploadingImage
+                            ) { markdown in
+                                appendMarkdown(markdown, to: &bodyText)
+                            }
+                        }
+                    }
+                }
+            }
+
             Picker("Priority", selection: $priority) {
                 ForEach(Priority.allCases, id: \.self) { priority in
                     Text(priority.displayName).tag(priority)
@@ -713,7 +766,7 @@ private struct DraftEditorSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(isSaving || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(isSaving || isUploadingImage || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
         .padding(20)
@@ -735,6 +788,146 @@ private struct DraftEditorSheet: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+}
+
+struct MacImageAttachmentButton: View {
+    @Environment(APIClient.self) private var api
+
+    let owner: String
+    let repo: String
+    let accessibilityPrefix: String
+    @Binding var isUploading: Bool
+    let onUpload: (String) -> Void
+
+    @State private var errorMessage: String?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button {
+                Task { await chooseAndUploadImage() }
+            } label: {
+                if isUploading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Attach Image", systemImage: "photo")
+                }
+            }
+            .buttonStyle(.bordered)
+            .disabled(isUploading)
+            .accessibilityIdentifier("\(accessibilityPrefix)-image-attachment-button")
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("\(accessibilityPrefix)-image-attachment-error")
+            }
+        }
+    }
+
+    @MainActor
+    private func chooseAndUploadImage() async {
+        errorMessage = nil
+
+        if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_API"] == "1" {
+            await uploadFixtureImage()
+            return
+        }
+
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let data = try Data(contentsOf: url)
+            await uploadImageData(data)
+        } catch {
+            errorMessage = "Could not load image"
+        }
+    }
+
+    private func uploadFixtureImage() async {
+        if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_IMAGE_UPLOAD_FAILURE"] == "1" {
+            isUploading = true
+            try? await Task.sleep(for: .milliseconds(150))
+            errorMessage = "Upload failed"
+            isUploading = false
+            return
+        }
+
+        await uploadImageData(MacImageAttachmentProcessor.fixturePNGData)
+    }
+
+    private func uploadImageData(_ data: Data) async {
+        let trace = PerformanceTrace.begin("mac_image_attachment.upload", metadata: "repo=\(owner)/\(repo)")
+        isUploading = true
+        errorMessage = nil
+        defer {
+            PerformanceTrace.end(trace, metadata: "success=\(errorMessage == nil)")
+            isUploading = false
+        }
+
+        do {
+            let imageData = try await MacImageAttachmentProcessor.preparedJPEGData(from: data)
+            let url = try await api.uploadImageData(imageData, owner: owner, repo: repo)
+            onUpload("![image](\(url))")
+        } catch MacImageAttachmentProcessor.ProcessingError.invalidImage {
+            errorMessage = "Invalid image data"
+        } catch {
+            errorMessage = "Upload failed"
+        }
+    }
+}
+
+enum MacImageAttachmentProcessor {
+    enum ProcessingError: Error {
+        case invalidImage
+    }
+
+    static let fixturePNGData = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAqADAAQAAAABAAAAAgAAAADtGLyqAAAAEklEQVQIHWP8DwQMQMAEIkAAAD34BACALvQ5AAAAAElFTkSuQmCC")!
+
+    private static let maxPixelSize = 1_600
+    private static let compressionQuality: CGFloat = 0.8
+
+    static func preparedJPEGData(from data: Data) async throws -> Data {
+        try await Task.detached(priority: .userInitiated) {
+            guard let imageSource = CGImageSourceCreateWithData(data as CFData, [
+                kCGImageSourceShouldCache: false,
+            ] as CFDictionary) else {
+                throw ProcessingError.invalidImage
+            }
+
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            ]
+
+            guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
+                throw ProcessingError.invalidImage
+            }
+
+            let bitmap = NSBitmapImageRep(cgImage: cgImage)
+            guard let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: compressionQuality]) else {
+                throw ProcessingError.invalidImage
+            }
+            return jpegData
+        }.value
+    }
+}
+
+func appendMarkdown(_ markdown: String, to text: inout String) {
+    if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        text = markdown
+    } else {
+        text += "\n\n\(markdown)"
     }
 }
 

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -15,6 +15,7 @@ struct MacIssueDetailView: View {
     @State private var isLoading = true
     @State private var isRefreshing = false
     @State private var isSubmittingComment = false
+    @State private var isUploadingCommentImage = false
     @State private var isUpdatingState = false
     @State private var isUpdatingPriority = false
     @State private var isLaunching = false
@@ -68,11 +69,11 @@ struct MacIssueDetailView: View {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 18) {
                             issueSummary
-                            launchSection
                             issueBody
+                            commentComposer
+                            launchSection
                             linkedPullRequests
                             deploymentsSection
-                            commentComposer
                             comments
                         }
                         .padding(16)
@@ -87,7 +88,7 @@ struct MacIssueDetailView: View {
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
             case .editIssue:
-                MacEditIssueSheet(issue: issue) { title, body in
+                MacEditIssueSheet(issue: issue, owner: item.repo.owner, repo: item.repo.name) { title, body in
                     try await store.updateIssue(api: api, item: item, title: title, body: body)
                     await load(refresh: true)
                     activeSheet = nil
@@ -95,7 +96,7 @@ struct MacIssueDetailView: View {
             case .closeWithComment:
                 EmptyView()
             case .editComment(let comment):
-                MacEditCommentSheet(comment: comment) { body in
+                MacEditCommentSheet(comment: comment, owner: item.repo.owner, repo: item.repo.name) { body in
                     try await store.editComment(api: api, item: item, commentId: comment.id, body: body)
                     await load(refresh: true)
                     activeSheet = nil
@@ -136,7 +137,7 @@ struct MacIssueDetailView: View {
             }
         }
         .sheet(isPresented: $isShowingCloseWithComment) {
-            MacCloseIssueSheet(issueNumber: issue.number) { comment in
+            MacCloseIssueSheet(issueNumber: issue.number, owner: item.repo.owner, repo: item.repo.name) { comment in
                 try await store.updateIssueState(api: api, item: item, state: "closed", comment: comment)
                 await load(refresh: true)
                 isShowingCloseWithComment = false
@@ -456,6 +457,16 @@ struct MacIssueDetailView: View {
                     RoundedRectangle(cornerRadius: 7)
                         .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
                 }
+                .accessibilityIdentifier("mac-comment-composer-body-field")
+
+            MacImageAttachmentButton(
+                owner: item.repo.owner,
+                repo: item.repo.name,
+                accessibilityPrefix: "mac-comment-composer",
+                isUploading: $isUploadingCommentImage
+            ) { markdown in
+                appendMarkdown(markdown, to: &commentBody)
+            }
 
             HStack {
                 Spacer()
@@ -470,7 +481,8 @@ struct MacIssueDetailView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(commentBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmittingComment)
+                .disabled(commentBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmittingComment || isUploadingCommentImage)
+                .accessibilityIdentifier("mac-comment-composer-submit-button")
             }
         }
     }
@@ -787,15 +799,20 @@ private struct MacEditIssueSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let issue: GitHubIssue
+    let owner: String
+    let repo: String
     let onSave: (String?, String?) async throws -> Void
 
     @State private var title: String
     @State private var bodyText: String
     @State private var isSaving = false
+    @State private var isUploadingImage = false
     @State private var errorMessage: String?
 
-    init(issue: GitHubIssue, onSave: @escaping (String?, String?) async throws -> Void) {
+    init(issue: GitHubIssue, owner: String, repo: String, onSave: @escaping (String?, String?) async throws -> Void) {
         self.issue = issue
+        self.owner = owner
+        self.repo = repo
         self.onSave = onSave
         _title = State(initialValue: issue.title)
         _bodyText = State(initialValue: issue.body ?? "")
@@ -830,6 +847,15 @@ private struct MacEditIssueSheet: View {
                 }
                 .accessibilityIdentifier("mac-edit-issue-body-field")
 
+            MacImageAttachmentButton(
+                owner: owner,
+                repo: repo,
+                accessibilityPrefix: "mac-edit-issue",
+                isUploading: $isUploadingImage
+            ) { markdown in
+                appendMarkdown(markdown, to: &bodyText)
+            }
+
             if let errorMessage {
                 Label(errorMessage, systemImage: "exclamationmark.triangle")
                     .font(.caption)
@@ -851,7 +877,7 @@ private struct MacEditIssueSheet: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(trimmedTitle.isEmpty || !hasChanges || isSaving)
+                .disabled(trimmedTitle.isEmpty || !hasChanges || isSaving || isUploadingImage)
                 .accessibilityIdentifier("mac-edit-issue-save-button")
             }
         }
@@ -880,10 +906,13 @@ private struct MacCloseIssueSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let issueNumber: Int
+    let owner: String
+    let repo: String
     let onClose: (String?) async throws -> Void
 
     @State private var comment = ""
     @State private var isClosing = false
+    @State private var isUploadingImage = false
     @State private var errorMessage: String?
 
     var body: some View {
@@ -904,6 +933,15 @@ private struct MacCloseIssueSheet: View {
                         .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
                 }
                 .accessibilityIdentifier("mac-close-issue-comment-field")
+
+            MacImageAttachmentButton(
+                owner: owner,
+                repo: repo,
+                accessibilityPrefix: "mac-close-issue",
+                isUploading: $isUploadingImage
+            ) { markdown in
+                appendMarkdown(markdown, to: &comment)
+            }
 
             if let errorMessage {
                 Label(errorMessage, systemImage: "exclamationmark.triangle")
@@ -926,7 +964,7 @@ private struct MacCloseIssueSheet: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(isClosing)
+                .disabled(isClosing || isUploadingImage)
                 .accessibilityIdentifier("mac-close-issue-submit-button")
             }
         }
@@ -953,14 +991,19 @@ private struct MacEditCommentSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let comment: GitHubComment
+    let owner: String
+    let repo: String
     let onSave: (String) async throws -> Void
 
     @State private var bodyText: String
     @State private var isSaving = false
+    @State private var isUploadingImage = false
     @State private var errorMessage: String?
 
-    init(comment: GitHubComment, onSave: @escaping (String) async throws -> Void) {
+    init(comment: GitHubComment, owner: String, repo: String, onSave: @escaping (String) async throws -> Void) {
         self.comment = comment
+        self.owner = owner
+        self.repo = repo
         self.onSave = onSave
         _bodyText = State(initialValue: comment.body)
     }
@@ -986,6 +1029,15 @@ private struct MacEditCommentSheet: View {
                 }
                 .accessibilityIdentifier("mac-edit-comment-body-field")
 
+            MacImageAttachmentButton(
+                owner: owner,
+                repo: repo,
+                accessibilityPrefix: "mac-edit-comment",
+                isUploading: $isUploadingImage
+            ) { markdown in
+                appendMarkdown(markdown, to: &bodyText)
+            }
+
             if let errorMessage {
                 Label(errorMessage, systemImage: "exclamationmark.triangle")
                     .font(.caption)
@@ -1007,7 +1059,7 @@ private struct MacEditCommentSheet: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(trimmedBody.isEmpty || trimmedBody == comment.body || isSaving)
+                .disabled(trimmedBody.isEmpty || trimmedBody == comment.body || isSaving || isUploadingImage)
                 .accessibilityIdentifier("mac-edit-comment-save-button")
             }
         }
@@ -1579,8 +1631,8 @@ private struct MacImageLightbox: View {
 private enum MacFixtureImageStore {
     static func image(for url: URL) -> NSImage? {
         guard url.host == "issuectl-ui-test.local",
-              url.path == "/fixtures/alpha.png",
-              let data = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=") else {
+              ["/fixtures/alpha.png", "/fixtures/uploaded.png"].contains(url.path),
+              let data = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAAqADAAQAAAABAAAAAgAAAADtGLyqAAAAEklEQVQIHWP8DwQMQMAEIkAAAD34BACALvQ5AAAAAElFTkSuQmCC") else {
             return nil
         }
         return NSImage(data: data)

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -221,6 +221,24 @@ final class MacIssueFilterStateTests: XCTestCase {
         XCTAssertThrowsError(try MacRepoNameInput.parse("mean-weasel/issuectl/extra"))
     }
 
+    func testMacImageAttachmentProcessorPreparesFixtureJPEGData() async throws {
+        let data = try await MacImageAttachmentProcessor.preparedJPEGData(from: MacImageAttachmentProcessor.fixturePNGData)
+
+        XCTAssertGreaterThan(data.count, 2)
+        XCTAssertEqual(data.prefix(2), Data([0xFF, 0xD8]))
+    }
+
+    func testMacImageAttachmentProcessorRejectsInvalidImageData() async {
+        do {
+            _ = try await MacImageAttachmentProcessor.preparedJPEGData(from: Data("not an image".utf8))
+            XCTFail("Expected invalid image data to throw")
+        } catch MacImageAttachmentProcessor.ProcessingError.invalidImage {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     private var repos: [Repo] {
         [
             repo(id: 1, owner: "mean-weasel", name: "issuectl"),

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -260,6 +260,40 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(issueRow("org/alpha", 89).waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testQuickCreateImageAttachmentRendersInCreatedIssue() {
+        selectRootSection("Drafts")
+
+        let newIssueButton = app.buttons["mac-drafts-new-issue-button"]
+        XCTAssertTrue(newIssueButton.waitForExistence(timeout: 5), app.debugDescription)
+        newIssueButton.click()
+
+        let titleField = app.textFields["mac-quick-create-title-field"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), app.debugDescription)
+        titleField.click()
+        titleField.typeText("Quick image issue")
+
+        let bodyField = app.textViews["mac-quick-create-body-field"]
+        XCTAssertTrue(bodyField.waitForExistence(timeout: 5), app.debugDescription)
+        bodyField.click()
+        bodyField.typeText("Before upload")
+
+        app.buttons["mac-quick-create-image-attachment-button"].click()
+        XCTAssertTrue(waitForValue(of: bodyField, containing: "![image](https://issuectl-ui-test.local/fixtures/uploaded.png)", timeout: 5), app.debugDescription)
+
+        app.buttons["mac-quick-create-submit-button"].click()
+        XCTAssertTrue(titleField.waitForNonExistence(timeout: 5), app.debugDescription)
+
+        selectRootSection("Issues")
+        let createdIssue = issueRow("org/alpha", 89)
+        XCTAssertTrue(createdIssue.waitForExistence(timeout: 5), app.debugDescription)
+        openIssue(createdIssue)
+
+        let uploadedImage = app.descendants(matching: .any)["mac-issue-body-image-1"]
+        XCTAssertTrue(uploadedImage.waitForExistence(timeout: 5), app.debugDescription)
+        uploadedImage.click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-image-lightbox-loaded-image"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testQuickCreateFailurePreservesInput() {
         app.terminate()
         app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_QUICK_CREATE_FAILURE"] = "1"
@@ -285,6 +319,43 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.buttons["mac-quick-create-submit-button"].exists, app.debugDescription)
         XCTAssertTrue(titleField.exists, app.debugDescription)
         XCTAssertTrue(bugLabel.exists, app.debugDescription)
+    }
+
+    func testCommentImageAttachmentUploadsAndRenders() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        let commentBody = app.textViews["mac-comment-composer-body-field"]
+        XCTAssertTrue(commentBody.waitForExistence(timeout: 5), app.debugDescription)
+        commentBody.click()
+        commentBody.typeText("Comment before upload")
+
+        app.buttons["mac-comment-composer-image-attachment-button"].click()
+        XCTAssertTrue(waitForValue(of: commentBody, containing: "![image](https://issuectl-ui-test.local/fixtures/uploaded.png)", timeout: 5), app.debugDescription)
+
+        app.buttons["mac-comment-composer-submit-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-comment-501-image-1"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testImageAttachmentFailurePreservesCommentText() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_IMAGE_UPLOAD_FAILURE"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        let commentBody = app.textViews["mac-comment-composer-body-field"]
+        XCTAssertTrue(commentBody.waitForExistence(timeout: 5), app.debugDescription)
+        commentBody.click()
+        commentBody.typeText("Keep this comment")
+
+        app.buttons["mac-comment-composer-image-attachment-button"].click()
+        XCTAssertTrue(app.staticTexts["mac-comment-composer-image-attachment-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(waitForValue(of: commentBody, containing: "Keep this comment", timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-comment-composer-submit-button"].exists, app.debugDescription)
     }
 
     func testStatusMenuOpensSettings() {
@@ -414,6 +485,14 @@ final class MacSidebarSmokeTests: XCTestCase {
         app.descendants(matching: .any)["mac-issues-sort-picker"].radioButtons[title]
     }
 
+    private func openIssue(_ issue: XCUIElement) {
+        issue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        let editButton = app.buttons["mac-issue-detail-edit-button"]
+        if !editButton.waitForExistence(timeout: 2) {
+            issue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+    }
+
     private func rootSection(_ title: String) -> XCUIElement {
         app.descendants(matching: .any)["mac-sidebar-section-picker"].radioButtons[title].firstMatch
     }
@@ -422,5 +501,15 @@ final class MacSidebarSmokeTests: XCTestCase {
         let section = rootSection(title)
         XCTAssertTrue(section.waitForExistence(timeout: 5), app.debugDescription)
         section.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+    }
+
+    private func waitForValue(of element: XCUIElement, containing text: String, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate { candidate, _ in
+            guard let element = candidate as? XCUIElement else { return false }
+            let value = (element.value as? String) ?? element.label
+            return value.contains(text)
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 }

--- a/docs/goals/mac-ios-parity/notes/T032-phase-6c-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T032-phase-6c-branch-start.md
@@ -1,0 +1,5 @@
+# T032 Phase 6C Branch Start
+
+Started `mac-parity-phase-6c-image-upload` from `mac-sidebar-spaces-option-a`.
+
+Scope: Mac image attachment upload for direct issue/draft creation and comment/editing workflows, reusing the shared multipart image upload API and inserting uploaded image markdown into the active editor. AI parse/batch create remains a later Phase 6 slice.

--- a/docs/goals/mac-ios-parity/notes/T032-phase-6c-image-upload.md
+++ b/docs/goals/mac-ios-parity/notes/T032-phase-6c-image-upload.md
@@ -1,0 +1,41 @@
+# T032 Phase 6C Image Upload
+
+Date: 2026-05-14
+
+Result: done
+
+Branch: `mac-parity-phase-6c-image-upload`
+Base: `mac-sidebar-spaces-option-a`
+Draft PR: https://github.com/mean-weasel/issuectl/pull/432
+
+## Summary
+
+Implemented Mac image attachment upload for issue creation, draft editing, comment composition, issue body editing, close-with-comment, and comment editing. The Mac app now prepares selected images as JPEG data, uploads through the shared image upload API, inserts uploaded image markdown into the active editor, shows an in-flight progress state, disables duplicate upload/submit actions while uploading, and preserves editor text on invalid-image or upload failure paths.
+
+The Mac UI fixture API now supports deterministic image upload responses and serves uploaded fixture images so markdown rendering and lightbox behavior can be tested without automating the native file picker.
+
+## Acceptance Coverage
+
+- Direct issue creation image attachment: covered by `testQuickCreateImageAttachmentRendersInCreatedIssue`.
+- Draft editor image attachment: implemented through the shared `MacImageAttachmentButton` with a repo picker in the draft editor; not separately UI-tested in this slice because direct issue creation covers the creation editor path and the draft editor has no backend upload side effect.
+- Comment composer image attachment: covered by `testCommentImageAttachmentUploadsAndRenders`.
+- Issue/comment editing attachment paths: implemented in edit issue, close-with-comment, and edit comment sheets. Existing full smoke coverage confirms those sheets still open, save, close, and edit successfully after the controls were added.
+- Upload progress and duplicate-action protection: implemented by `isUploading` bindings, progress indicator button state, and disabled submit/upload controls while upload is in flight.
+- Failure preservation: covered by `testImageAttachmentFailurePreservesCommentText`; invalid image data is covered by `testMacImageAttachmentProcessorRejectsInvalidImageData`.
+- Uploaded markdown rendering/lightbox: covered by `testQuickCreateImageAttachmentRendersInCreatedIssue` and existing `testIssueDetailMarkdownImagesOpenLightbox`.
+
+## Validation
+
+- `git diff --check`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 31 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 18 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings
+
+## Residual Risk
+
+- The production native file picker path is not directly automated; UI tests use a deterministic fixture upload path because native `NSOpenPanel` automation is brittle.
+- Draft editor upload is implemented but not covered by a dedicated UI test; it reuses the same upload helper and markdown insertion path as the tested direct issue and comment flows.
+- This slice intentionally does not implement AI parse or batch issue creation.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T032
+active_task: T033
 
 tasks:
   - id: T001
@@ -1516,7 +1516,7 @@ tasks:
   - id: T032
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 6C Mac image attachment upload for creation and comment/editing workflows, matching the iOS shared image upload behavior where practical."
     inputs:
@@ -1565,6 +1565,68 @@ tasks:
       - "The backend image upload API is missing or incompatible with Mac sandboxed file access."
       - "Required file-picker automation cannot be tested deterministically; record a replacement fixture strategy before continuing."
       - "Required files fall outside the allowed scope."
+    receipt:
+      result: done
+      note: "notes/T032-phase-6c-image-upload.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacDraftsView.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      pr:
+        number: 432
+        url: "https://github.com/mean-weasel/issuectl/pull/432"
+        branch: "mac-parity-phase-6c-image-upload"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending T033 GitHub inspection."
+      acceptance_coverage:
+        direct_issue_creation: "testQuickCreateImageAttachmentRendersInCreatedIssue"
+        draft_editor: "Implemented through shared MacImageAttachmentButton with repo picker; no separate UI test in this slice."
+        comment_composer: "testCommentImageAttachmentUploadsAndRenders"
+        edit_and_close_sheets: "Implemented and covered by existing full smoke sheet workflows for regression."
+        progress_and_duplicate_protection: "Implemented via isUploading state, ProgressView, and disabled upload/submit controls."
+        failure_preservation: "testImageAttachmentFailurePreservesCommentText plus invalid image processor unit test."
+        markdown_lightbox: "testQuickCreateImageAttachmentRendersInCreatedIssue and testIssueDetailMarkdownImagesOpenLightbox."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+      summary: "Implemented Mac image attachment upload and markdown insertion across creation/comment/editing workflows, added deterministic Mac UI fixture upload support, and covered direct creation, comments, failure preservation, invalid data, and lightbox rendering."
+
+  - id: T033
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #432 for Phase 6C image-upload acceptance coverage, GitHub/check status, merge readiness, and the next Phase 6 slice."
+    inputs:
+      - "T032 receipt"
+      - "PR #432 diff and metadata"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not merge red CI without an explicit recorded exception."
+      - "If GitHub reports no configured checks, document the accepted local validation replacement gate before merge."
+      - "Reject merge if direct creation upload, comment upload, failure preservation, invalid image handling, or lightbox acceptance evidence is missing."
+      - "Size AI parse/batch creation separately from this image-upload PR."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "Acceptance coverage map."
+      - "CI or accepted replacement validation status."
+      - "Merge decision."
+      - "Next task recommendation."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary

Phase 6C: add Mac image attachment upload and markdown insertion for direct issue/draft creation plus comment/editing workflows.

## Acceptance Criteria

- A Mac user can attach an image while creating a direct issue or draft, and uploaded image markdown is inserted into the editor body.
- A Mac user can attach an image while adding or editing a comment, and uploaded image markdown is inserted into the comment editor.
- The UI shows upload progress and disables duplicate submit/upload actions while upload is in flight.
- Invalid image selection or upload failure shows a recoverable error and preserves existing title/body/comment text.
- Existing markdown rendering and image lightbox behavior still works for uploaded image markdown.

## Validation

- `git diff --check`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests` (31 tests)
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (18 tests)
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests` (37 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)

GitHub reports no configured checks or workflow runs for this branch, so the local validation above is the replacement gate for this child PR.
