### PR TITLE
Add Mac AI parse issue creation

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -288,6 +288,67 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             ]]
         case ("GET", "/api/v1/sessions/previews"):
             return ["previews": []]
+        case ("POST", "/api/v1/parse"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PARSE_FAILURE"] == "1" {
+                return ["error": "Fixture parse failed"]
+            }
+            return [
+                "parsed": [
+                    "issues": [
+                        [
+                            "id": "parsed-1",
+                            "originalText": "Fix parsed alpha bug",
+                            "title": "Parsed alpha bug",
+                            "body": "Created from Mac parse flow",
+                            "type": "bug",
+                            "repoOwner": "org",
+                            "repoName": "alpha",
+                            "repoConfidence": 0.95,
+                            "suggestedLabels": ["bug"],
+                            "clarity": "clear",
+                        ],
+                        [
+                            "id": "parsed-2",
+                            "originalText": "Document parsed beta workflow",
+                            "title": "Parsed beta docs",
+                            "body": "Second parsed issue",
+                            "type": "docs",
+                            "repoOwner": NSNull(),
+                            "repoName": NSNull(),
+                            "repoConfidence": 0.2,
+                            "suggestedLabels": ["docs"],
+                            "clarity": "unknown_repo",
+                        ],
+                    ],
+                    "suggestedOrder": ["parsed-1", "parsed-2"],
+                ],
+            ]
+        case ("POST", "/api/v1/parse/create"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PARSE_CREATE_FAILURE"] == "1" {
+                return ["error": "Fixture parse create failed"]
+            }
+            let payload = jsonBody(from: request)
+            let reviewedIssues = payload["issues"] as? [[String: Any]] ?? []
+            if reviewedIssues.contains(where: { $0["id"] as? String == "parsed-2" }) {
+                return ["error": "Rejected fixture issue should not be submitted"]
+            }
+            parsedCreatedIssueNumber = 90
+            return [
+                "created": 1,
+                "drafted": 0,
+                "failed": 0,
+                "results": [
+                    [
+                        "id": "parsed-1",
+                        "success": true,
+                        "issueNumber": 90,
+                        "draftId": NSNull(),
+                        "error": NSNull(),
+                        "owner": "org",
+                        "repo": "alpha",
+                    ],
+                ],
+            ]
         case ("POST", "/api/v1/images/upload"):
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_IMAGE_UPLOAD_FAILURE"] == "1" {
                 return ["error": "Fixture image upload failed"]
@@ -479,6 +540,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var quickCreatedIssueTitle = "Quick created issue"
     nonisolated(unsafe) private static var quickCreatedIssueBody: String?
     nonisolated(unsafe) private static var quickCreatedIssueLabels: [String] = []
+    nonisolated(unsafe) private static var parsedCreatedIssueNumber: Int?
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
@@ -503,7 +565,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             issue(number: 2, title: "Running alpha issue", body: "Has an active session", state: "open", assignees: ["alice"], author: "bob", updatedAt: "2026-05-14T11:00:00.000Z"),
             issue(number: 3, title: "Unassigned high priority", body: "Needs owner", state: "open", assignees: [], author: "alice", updatedAt: "2026-05-14T12:00:00.000Z"),
             issue(number: 4, title: "Closed alpha issue", body: "Done", state: "closed", assignees: [], author: "bob", updatedAt: "2026-05-14T13:00:00.000Z"),
-        ] + assignedDraftIssues + quickCreatedIssues + (5...55).map { number in
+        ] + assignedDraftIssues + quickCreatedIssues + parsedCreatedIssues + (5...55).map { number in
             issue(
                 number: number,
                 title: "Paged issue \(number)",
@@ -528,6 +590,22 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 assignees: ["alice"],
                 author: "alice",
                 updatedAt: "2026-05-14T16:00:00.000Z"
+            ),
+        ]
+    }
+
+    private static var parsedCreatedIssues: [[String: Any]] {
+        guard let parsedCreatedIssueNumber else { return [] }
+        return [
+            issue(
+                number: parsedCreatedIssueNumber,
+                title: "Parsed alpha bug",
+                body: "Created from Mac parse flow",
+                state: "open",
+                labels: ["bug"],
+                assignees: ["alice"],
+                author: "alice",
+                updatedAt: "2026-05-14T17:00:00.000Z"
             ),
         ]
     }

--- a/apple/IssueCTLMac/Views/MacDraftsView.swift
+++ b/apple/IssueCTLMac/Views/MacDraftsView.swift
@@ -27,6 +27,15 @@ struct MacDraftsView: View {
                 } actions: {
                     HStack {
                         Button {
+                            activeSheet = .parse
+                        } label: {
+                            Label("Parse with AI", systemImage: "text.viewfinder")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(store.repos.isEmpty)
+                        .accessibilityIdentifier("mac-drafts-parse-ai-button")
+
+                        Button {
                             activeSheet = .quickCreate
                         } label: {
                             Label("New Issue", systemImage: "square.and.pencil")
@@ -69,6 +78,10 @@ struct MacDraftsView: View {
         }
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
+            case .parse:
+                MacParseIssueSheet(repos: store.repos) {
+                    await store.load(api: api, refresh: true)
+                }
             case .quickCreate:
                 DirectIssueCreateSheet(repos: store.repos) { repo, title, body, priority, labels in
                     _ = try await store.createIssue(
@@ -146,6 +159,15 @@ struct MacDraftsView: View {
             Spacer()
 
             Button {
+                activeSheet = .parse
+            } label: {
+                Label("Parse with AI", systemImage: "text.viewfinder")
+            }
+            .buttonStyle(.bordered)
+            .disabled(store.repos.isEmpty)
+            .accessibilityIdentifier("mac-drafts-parse-ai-button")
+
+            Button {
                 activeSheet = .quickCreate
             } label: {
                 Label("New Issue", systemImage: "square.and.pencil")
@@ -176,6 +198,7 @@ struct MacDraftsView: View {
 }
 
 private enum DraftSheet: Identifiable {
+    case parse
     case quickCreate
     case new
     case edit(Draft)
@@ -183,11 +206,420 @@ private enum DraftSheet: Identifiable {
 
     var id: String {
         switch self {
+        case .parse: "parse"
         case .quickCreate: "quick-create"
         case .new: "new"
         case .edit(let draft): "edit-\(draft.id)"
         case .assign(let draft): "assign-\(draft.id)"
         }
+    }
+}
+
+private struct MacParseIssueSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let repos: [Repo]
+    let onComplete: () async -> Void
+
+    @State private var input = ""
+    @State private var isParsing = false
+    @State private var isCreating = false
+    @State private var reviewState: MacParseReviewState?
+    @State private var creationResult: BatchCreateResult?
+    @State private var errorMessage: String?
+
+    private var trimmedInput: String {
+        input.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+
+            if let creationResult {
+                resultView(creationResult)
+            } else if let reviewState {
+                reviewView(reviewState)
+            } else {
+                inputView
+            }
+        }
+        .padding(20)
+        .frame(width: 520, height: 580)
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Parse Issues")
+                    .font(.headline)
+                Text("Turn free-form notes into reviewed issues.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Cancel", role: .cancel) {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+    }
+
+    private var inputView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextEditor(text: $input)
+                .font(.body)
+                .frame(minHeight: 280)
+                .scrollContentBackground(.hidden)
+                .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                }
+                .accessibilityIdentifier("mac-parse-input-field")
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("\(input.count) / 8192")
+                    .font(.caption)
+                    .foregroundStyle(input.count > 8192 ? .red : .secondary)
+                    .accessibilityIdentifier("mac-parse-character-count")
+
+                Button {
+                    Task { await parse() }
+                } label: {
+                    if isParsing {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Parse with AI")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(trimmedInput.isEmpty || input.count > 8192 || isParsing || repos.isEmpty)
+                .accessibilityIdentifier("mac-parse-submit-button")
+            }
+
+            if repos.isEmpty {
+                Label("Add a tracked repository before creating parsed issues.", systemImage: "tray")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            errorLabel
+            Spacer()
+        }
+    }
+
+    private func reviewView(_ reviewState: MacParseReviewState) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("\(reviewState.parsedIssues.count) issues found")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text("\(reviewState.acceptedCount) accepted")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-parse-accepted-count")
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(reviewState.parsedIssues) { issue in
+                        parseIssueRow(issue)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(maxHeight: .infinity)
+
+            errorLabel
+
+            HStack {
+                Button("Start Over") {
+                    self.reviewState = nil
+                    errorMessage = nil
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-parse-start-over-button")
+
+                Button {
+                    Task { await createIssues() }
+                } label: {
+                    if isCreating {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Create \(reviewState.acceptedCount) Issue\(reviewState.acceptedCount == 1 ? "" : "s")")
+                    }
+                }
+                .frame(minWidth: 150, alignment: .leading)
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!reviewState.canCreate || isCreating)
+                .accessibilityIdentifier("mac-parse-create-button")
+            }
+        }
+    }
+
+    private func parseIssueRow(_ issue: ParsedIssue) -> some View {
+        let isAccepted = reviewState?.isAccepted(issue.id) ?? false
+        let selectedRepo = reviewState?.selectedRepo(for: issue.id)
+
+        return VStack(alignment: .leading, spacing: 9) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(issue.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(isAccepted ? .primary : .secondary)
+                        .strikethrough(!isAccepted)
+                        .accessibilityIdentifier("mac-parse-issue-\(issue.id)-title")
+                    if !issue.body.isEmpty {
+                        Text(issue.body)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+                Spacer()
+                Button {
+                    toggleAccepted(issue.id)
+                } label: {
+                    Label(isAccepted ? "Accepted" : "Rejected", systemImage: isAccepted ? "checkmark.circle.fill" : "circle")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("mac-parse-issue-\(issue.id)-accept-toggle")
+            }
+
+            HStack(spacing: 8) {
+                Text(issue.type.capitalized)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.12), in: Capsule())
+
+                if issue.clarity != "clear" {
+                    Label(issue.clarity == "ambiguous" ? "Ambiguous" : "Unknown repo", systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+
+                ForEach(issue.suggestedLabels.prefix(3), id: \.self) { label in
+                    Text(label)
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.1), in: Capsule())
+                }
+            }
+
+            if isAccepted {
+                HStack(spacing: 8) {
+                    Text("Repository")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    ForEach(repos) { repo in
+                        Button(repo.fullName) {
+                            selectRepo(repo, for: issue.id)
+                        }
+                        .buttonStyle(.bordered)
+                        .fontWeight(selectedRepo?.fullName == repo.fullName ? .semibold : .regular)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("mac-parse-issue-\(issue.id)-repo-\(repo.fullName)")
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            toggleAccepted(issue.id)
+        }
+        .opacity(isAccepted ? 1 : 0.65)
+    }
+
+    private func resultView(_ result: BatchCreateResult) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: result.failed == 0 ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(result.failed == 0 ? .green : .orange)
+            Text(resultSummary(result))
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .accessibilityIdentifier("mac-parse-result-summary")
+
+            if result.failed > 0 {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(result.results.filter { !$0.success }) { item in
+                        Label(item.error ?? "Unknown error", systemImage: "xmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+
+            Spacer()
+            Button("Done") {
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("mac-parse-done-button")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var errorLabel: some View {
+        if let errorMessage {
+            Label(errorMessage, systemImage: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("mac-parse-error")
+        }
+    }
+
+    private func parse() async {
+        isParsing = true
+        errorMessage = nil
+        defer { isParsing = false }
+
+        do {
+            let parsed = try await api.parseNaturalLanguage(input: input)
+            reviewState = MacParseReviewState(parsedIssues: parsed.issues, repos: repos)
+            if parsed.issues.isEmpty {
+                errorMessage = "No issues were parsed from the input."
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func toggleAccepted(_ id: String) {
+        guard var state = reviewState else { return }
+        state.toggleAccepted(id)
+        reviewState = state
+    }
+
+    private func selectRepo(_ repo: Repo, for id: String) {
+        guard var state = reviewState else { return }
+        state.selectRepo(repo, for: id)
+        reviewState = state
+    }
+
+    private func createIssues() async {
+        guard let reviewState else { return }
+        isCreating = true
+        errorMessage = nil
+        defer { isCreating = false }
+
+        do {
+            let result = try await api.batchCreateIssues(issues: reviewState.reviewedIssues())
+            creationResult = result
+            await onComplete()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func resultSummary(_ result: BatchCreateResult) -> String {
+        var parts: [String] = []
+        if result.created > 0 {
+            parts.append("\(result.created) issue\(result.created == 1 ? "" : "s") created")
+        }
+        if result.drafted > 0 {
+            parts.append("\(result.drafted) draft\(result.drafted == 1 ? "" : "s") saved")
+        }
+        if result.failed > 0 {
+            parts.append("\(result.failed) failed")
+        }
+        return parts.isEmpty ? "No issues created" : parts.joined(separator: ", ")
+    }
+}
+
+struct MacParseRepoSelection: Equatable {
+    let owner: String
+    let name: String
+
+    var fullName: String {
+        "\(owner)/\(name)"
+    }
+}
+
+struct MacParseReviewState {
+    private(set) var parsedIssues: [ParsedIssue]
+    private(set) var acceptedIds: Set<String>
+    private(set) var repoSelections: [String: MacParseRepoSelection]
+
+    init(parsedIssues: [ParsedIssue], repos: [Repo]) {
+        self.parsedIssues = parsedIssues
+        self.acceptedIds = Set(parsedIssues.map(\.id))
+        self.repoSelections = [:]
+
+        for issue in parsedIssues {
+            if let owner = issue.repoOwner,
+               let name = issue.repoName,
+               issue.repoConfidence >= 0.7,
+               repos.contains(where: { $0.owner == owner && $0.name == name }) {
+                repoSelections[issue.id] = MacParseRepoSelection(owner: owner, name: name)
+            } else if repos.count == 1, let repo = repos.first {
+                repoSelections[issue.id] = MacParseRepoSelection(owner: repo.owner, name: repo.name)
+            }
+        }
+    }
+
+    var acceptedCount: Int {
+        acceptedIds.count
+    }
+
+    var canCreate: Bool {
+        acceptedCount > 0 && acceptedIds.allSatisfy { repoSelections[$0] != nil }
+    }
+
+    func isAccepted(_ id: String) -> Bool {
+        acceptedIds.contains(id)
+    }
+
+    func selectedRepo(for id: String) -> MacParseRepoSelection? {
+        repoSelections[id]
+    }
+
+    mutating func toggleAccepted(_ id: String) {
+        if acceptedIds.contains(id) {
+            acceptedIds.remove(id)
+        } else {
+            acceptedIds.insert(id)
+        }
+    }
+
+    mutating func selectRepo(_ repo: Repo, for id: String) {
+        repoSelections[id] = MacParseRepoSelection(owner: repo.owner, name: repo.name)
+    }
+
+    func reviewedIssues() -> [ReviewedIssue] {
+        parsedIssues
+            .filter { acceptedIds.contains($0.id) }
+            .compactMap { issue in
+                guard let repo = repoSelections[issue.id] else { return nil }
+                return ReviewedIssue(
+                    id: issue.id,
+                    title: issue.title,
+                    body: issue.body,
+                    owner: repo.owner,
+                    repo: repo.name,
+                    labels: issue.suggestedLabels,
+                    accepted: true
+                )
+            }
     }
 }
 

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -239,6 +239,37 @@ final class MacIssueFilterStateTests: XCTestCase {
         }
     }
 
+    func testMacParseReviewStateAutoSelectsConfidentRepoAndAcceptedIssues() {
+        let state = MacParseReviewState(parsedIssues: [
+            parsedIssue(id: "parsed-1", owner: "mean-weasel", repo: "issuectl", confidence: 0.9),
+            parsedIssue(id: "parsed-2", owner: "missing", repo: "repo", confidence: 0.9),
+        ], repos: repos)
+
+        XCTAssertEqual(state.acceptedCount, 2)
+        XCTAssertTrue(state.isAccepted("parsed-1"))
+        XCTAssertEqual(state.selectedRepo(for: "parsed-1"), MacParseRepoSelection(owner: "mean-weasel", name: "issuectl"))
+        XCTAssertNil(state.selectedRepo(for: "parsed-2"))
+        XCTAssertFalse(state.canCreate)
+    }
+
+    func testMacParseReviewStateTogglesAndBuildsReviewedIssues() {
+        var state = MacParseReviewState(parsedIssues: [
+            parsedIssue(id: "parsed-1", owner: "mean-weasel", repo: "issuectl", confidence: 0.9, labels: ["bug"]),
+            parsedIssue(id: "parsed-2", owner: nil, repo: nil, confidence: 0.0, labels: ["docs"]),
+        ], repos: repos)
+
+        state.toggleAccepted("parsed-2")
+
+        XCTAssertEqual(state.acceptedCount, 1)
+        XCTAssertTrue(state.canCreate)
+        let reviewed = state.reviewedIssues()
+        XCTAssertEqual(reviewed.count, 1)
+        XCTAssertEqual(reviewed.first?.id, "parsed-1")
+        XCTAssertEqual(reviewed.first?.owner, "mean-weasel")
+        XCTAssertEqual(reviewed.first?.repo, "issuectl")
+        XCTAssertEqual(reviewed.first?.labels, ["bug"])
+    }
+
     private var repos: [Repo] {
         [
             repo(id: 1, owner: "mean-weasel", name: "issuectl"),
@@ -295,6 +326,27 @@ final class MacIssueFilterStateTests: XCTestCase {
 
     private func draft(id: String, title: String, body: String?) -> Draft {
         Draft(id: id, title: title, body: body, priority: .normal, createdAt: 1_775_000_000)
+    }
+
+    private func parsedIssue(
+        id: String,
+        owner: String?,
+        repo: String?,
+        confidence: Double,
+        labels: [String] = []
+    ) -> ParsedIssue {
+        ParsedIssue(
+            id: id,
+            originalText: "Original \(id)",
+            title: "Parsed \(id)",
+            body: "Parsed body",
+            type: "bug",
+            repoOwner: owner,
+            repoName: repo,
+            repoConfidence: confidence,
+            suggestedLabels: labels,
+            clarity: owner == nil ? "unknown_repo" : "clear"
+        )
     }
 
     private func session(owner: String, repo: String, issueNumber: Int) -> ActiveDeployment {

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -321,6 +321,66 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(bugLabel.exists, app.debugDescription)
     }
 
+    func testParseIssuesCreatesAcceptedIssueAndRefreshesList() {
+        selectRootSection("Drafts")
+
+        app.buttons["mac-drafts-parse-ai-button"].click()
+        let input = app.textViews["mac-parse-input-field"]
+        XCTAssertTrue(input.waitForExistence(timeout: 5), app.debugDescription)
+        input.click()
+        input.typeText("Fix parsed alpha bug\nDocument parsed beta workflow")
+
+        app.buttons["mac-parse-submit-button"].click()
+        let firstParsedIssue = app.descendants(matching: .any)["mac-parse-issue-parsed-1-title"]
+        XCTAssertTrue(firstParsedIssue.waitForExistence(timeout: 8), app.debugDescription)
+        let secondParsedIssue = app.descendants(matching: .any)["mac-parse-issue-parsed-2-title"]
+        XCTAssertTrue(secondParsedIssue.waitForExistence(timeout: 5), app.debugDescription)
+
+        let createButton = app.buttons["mac-parse-create-button"]
+        XCTAssertTrue(createButton.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(createButton.isEnabled, app.debugDescription)
+
+        app.buttons["mac-parse-issue-parsed-2-accept-toggle"].click()
+        XCTAssertTrue(createButton.isEnabled, app.debugDescription)
+        createButton.click()
+
+        let resultSummary = app.staticTexts["mac-parse-result-summary"]
+        XCTAssertTrue(resultSummary.waitForExistence(timeout: 5), app.debugDescription)
+        let resultText = (resultSummary.value as? String) ?? resultSummary.label
+        XCTAssertTrue(resultText.contains("1 issue created"), "\(resultText)\n\(app.debugDescription)")
+
+        app.buttons["mac-parse-done-button"].click()
+        XCTAssertTrue(input.waitForNonExistence(timeout: 5), app.debugDescription)
+
+        selectRootSection("Issues")
+        XCTAssertTrue(issueRow("org/alpha", 90).waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testParseCreateFailurePreservesReviewState() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_PARSE_CREATE_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("Drafts")
+
+        app.buttons["mac-drafts-parse-ai-button"].click()
+        let input = app.textViews["mac-parse-input-field"]
+        XCTAssertTrue(input.waitForExistence(timeout: 5), app.debugDescription)
+        input.click()
+        input.typeText("Fix parsed alpha bug")
+
+        app.buttons["mac-parse-submit-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-parse-issue-parsed-1-title"].waitForExistence(timeout: 8), app.debugDescription)
+        let secondParsedIssue = app.descendants(matching: .any)["mac-parse-issue-parsed-2-title"]
+        XCTAssertTrue(secondParsedIssue.waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-parse-issue-parsed-2-accept-toggle"].click()
+
+        app.buttons["mac-parse-create-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-parse-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-parse-issue-parsed-1-title"].exists, app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-parse-create-button"].exists, app.debugDescription)
+    }
+
     func testCommentImageAttachmentUploadsAndRenders() {
         let firstIssue = issueRow("org/alpha", 1)
         XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)

--- a/docs/goals/mac-ios-parity/notes/T035-phase-6d-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T035-phase-6d-branch-start.md
@@ -1,0 +1,8 @@
+# T035 Phase 6D Branch Start
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-6d-parse`
+Base: `mac-sidebar-spaces-option-a`
+
+Objective: implement the Mac AI parse/batch creation workflow with a draft child PR into the integration branch.

--- a/docs/goals/mac-ios-parity/notes/T035-phase-6d-parse.md
+++ b/docs/goals/mac-ios-parity/notes/T035-phase-6d-parse.md
@@ -1,0 +1,35 @@
+# T035 Phase 6D Parse Implementation
+
+## Result
+
+Implemented the Mac AI parse and batch issue creation workflow in PR #433.
+
+- Branch: `mac-parity-phase-6d-parse`
+- Base: `mac-sidebar-spaces-option-a`
+- PR: `https://github.com/mean-weasel/issuectl/pull/433`
+
+## Acceptance Evidence
+
+- Parse entry point is available from the Mac Drafts creation surface via `mac-drafts-parse-ai-button`.
+- Free-form input is submitted through the shared `parseNaturalLanguage(input:)` API with loading and error states.
+- Parsed issues can be accepted or rejected individually and assigned to tracked repositories before creation.
+- Batch creation uses the shared `batchCreateIssues(issues:)` API and posts only accepted reviewed issues.
+- Creation results summarize created/drafted/failed counts.
+- Create failure preserves the review state and exposes an inline parse error.
+- Successful creation refreshes Mac issue data; the UI fixture created issue `org/alpha#90` is visible in the issue list.
+
+## Validation
+
+- `git diff --check`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6d-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests`: pass, 33 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 20 tests
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests`: pass, 37 tests
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings only
+
+## Notes
+
+The iOS build regenerated `apple/IssueCTL/Generated/AppVersion.swift`; the generated churn was restored and is not part of this slice.
+
+Next gate is PR #433 status/check inspection, then ready/merge if clean or if the repository has no configured checks and local validation is accepted as the replacement evidence.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T035
+active_task: T036
 
 tasks:
   - id: T001
@@ -1735,6 +1735,69 @@ tasks:
       - "The flow requires real Claude/GitHub calls for deterministic UI validation."
       - "Required files fall outside the allowed scope."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      decision: implemented
+      full_outcome_complete: false
+      note: "notes/T035-phase-6d-parse.md"
+      pr:
+        number: 433
+        url: "https://github.com/mean-weasel/issuectl/pull/433"
+        branch: "mac-parity-phase-6d-parse"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacDraftsView.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      acceptance:
+        - "Drafts surface opens the Mac parse flow."
+        - "Free-form input parses via the shared parse API with loading and errors."
+        - "Parsed issues can be accepted/rejected and repo-selected before creation."
+        - "Batch create submits only accepted reviewed issues."
+        - "Success and failure paths preserve or refresh state as appropriate."
+      validation:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6d-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+          status: pass
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
+          status: pass
+          tests: 33
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          tests: 20
+        - cmd: "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+          tests: 37
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+      summary: "Added a native Mac parse/review/create sheet from Drafts, deterministic parse/create fixture endpoints, unit coverage for review state, and UI coverage for successful creation plus create failure preservation."
+
+  - id: T036
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #433 for merge readiness, check CI/status, merge when acceptable, then record the merge receipt and select the next parity slice."
+    inputs:
+      - "T035 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/433"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+      - "docs/goals/mac-ios-parity/goal.md"
+    constraints:
+      - "Do not expand Phase 6D implementation scope."
+      - "Merge only if PR checks are green, or if no checks are configured and local validation from T035 is accepted as replacement evidence."
+      - "After merge, record PR number, merge commit, validation/check status, and next active task."
+      - "Do not mark the overall goal complete."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "PR check state."
+      - "Merge result or required fixes."
+      - "Next PR-sized parity task."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary
- Adds a native Mac parse flow from Drafts for free-form notes -> reviewed issues -> batch creation.
- Uses the shared parse/create APIs and existing ParsedIssue/ReviewedIssue/BatchCreateResult types.
- Adds deterministic Mac UI fixture endpoints plus unit/UI coverage for parse success and create failure state preservation.

## Validation
- git diff --check
- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase6d-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build\n- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-tests-derived -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests (33 tests)\n- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests (20 tests)\n- xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-api-derived -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests (37 tests)\n- pnpm typecheck\n- pnpm lint (passes with existing warnings)\n\n## Checks\n- GitHub reports no status checks for this branch.\n- Merge state: CLEAN at head 94c24f0.