### PR TITLE
Add Mac PR browse and read-only detail

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
 		5C8B076C5D41EB2832394E74 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9961C2183D56ACC7E5650E0 /* Issue.swift */; };
 		5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */; };
+		9D4E0A6C52F14F3A9B8C7D22 /* MacPullRequestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A0E9C4D2B4F68852C3D11 /* MacPullRequestsView.swift */; };
 		5F5DEDA652F31AC394A5A596 /* DraftWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FAC416FAB2ACA469E0EC6F /* DraftWorkflowTests.swift */; };
 		62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */; };
 		62A88EE9440FC6032A029F78 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB04FB5543994CCE2DE041E /* KeychainService.swift */; };
@@ -284,6 +285,7 @@
 		0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
 		0FA58C21063864ADB4BAC822 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		134385CA01429770C742CD89 /* MacSidebarRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarRootView.swift; sourceTree = "<group>"; };
+		7F1A0E9C4D2B4F68852C3D11 /* MacPullRequestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPullRequestsView.swift; sourceTree = "<group>"; };
 		13760098C8ED1658B27AD54B /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		15319A8AF148A10DF82FE6DD /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
@@ -700,6 +702,7 @@
 				AF37A7CB40F1701C4C149CE2 /* MacIssueDetailView.swift */,
 				55EF912AC678D9B7E8C90570 /* MacIssueFilterState.swift */,
 				43A60283ECC077E01E26EAC1 /* MacIssuesView.swift */,
+				7F1A0E9C4D2B4F68852C3D11 /* MacPullRequestsView.swift */,
 				CB2F4EB488F40667A6499CFC /* MacRecoveryBanner.swift */,
 				26774436FC5A498AFD32CF2B /* MacSessionsView.swift */,
 				959347AB556CB71BEA308105 /* MacSettingsView.swift */,
@@ -1292,6 +1295,7 @@
 				C9D9618A4076FAE0E98D71AC /* MacIssueDetailView.swift in Sources */,
 				AA387A7D58A22216752A24DC /* MacIssueFilterState.swift in Sources */,
 				250D0308D12F0EE129E4C7E2 /* MacIssuesView.swift in Sources */,
+				9D4E0A6C52F14F3A9B8C7D22 /* MacPullRequestsView.swift in Sources */,
 				F8E1839B4CE74D977900874C /* MacRecoveryBanner.swift in Sources */,
 				BDDD77609BB45F218D8DBFDC /* MacSessionsView.swift in Sources */,
 				AAFAE2475EF1A39328204F4F /* MacSettingsView.swift in Sources */,

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -393,6 +393,22 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
         case ("GET", "/api/v1/issues/org/beta"):
             return ["issues": betaIssues, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/pulls/org/alpha"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULLS_FAILURE"] == "1" {
+                return ["error": "Fixture pulls failed"]
+            }
+            return ["pulls": alphaPulls, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/pulls/org/beta"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULLS_FAILURE"] == "1"
+                || ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_BETA_PULLS_FAILURE"] == "1" {
+                return ["error": "Fixture pulls failed"]
+            }
+            return ["pulls": betaPulls, "from_cache": false, "cached_at": NSNull()]
+        case ("GET", "/api/v1/pulls/org/alpha/10"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_DETAIL_FAILURE"] == "1" {
+                return ["error": "Fixture pull detail failed"]
+            }
+            return pullDetail()
         case ("GET", "/api/v1/issues/org/alpha/1"):
             return issueDetail()
         case ("GET", "/api/v1/issues/org/alpha/89"):
@@ -639,6 +655,104 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 author: "alice",
                 updatedAt: isoDate
             ),
+        ]
+    }
+
+    private static var alphaPulls: [[String: Any]] {
+        [
+            pull(number: 10, title: "Fix failing alpha workflow", body: "PR body with alpha details", state: "open", merged: false, author: "alice", head: "fix-alpha", base: "main", additions: 24, deletions: 6, changedFiles: 3, checks: "failure", updatedAt: "2026-05-14T18:00:00.000Z"),
+            pull(number: 11, title: "Pending alpha migration", body: "Migration work", state: "open", merged: false, author: "bob", head: "pending-alpha", base: "main", additions: 10, deletions: 2, changedFiles: 2, checks: "pending", updatedAt: "2026-05-14T17:00:00.000Z"),
+            pull(number: 12, title: "Passing alpha cleanup", body: "Cleanup work", state: "open", merged: false, author: "alice", head: "cleanup-alpha", base: "main", additions: 5, deletions: 1, changedFiles: 1, checks: "success", updatedAt: "2026-05-14T16:00:00.000Z"),
+            pull(number: 13, title: "Merged alpha docs", body: "Docs update", state: "closed", merged: true, author: "carol", head: "docs-alpha", base: "main", additions: 8, deletions: 0, changedFiles: 1, checks: "success", updatedAt: "2026-05-14T15:00:00.000Z", mergedAt: "2026-05-14T15:30:00.000Z", closedAt: "2026-05-14T15:30:00.000Z"),
+            pull(number: 14, title: "Closed alpha experiment", body: "Abandoned experiment", state: "closed", merged: false, author: "bob", head: "experiment-alpha", base: "main", additions: 2, deletions: 2, changedFiles: 1, checks: "failure", updatedAt: "2026-05-14T14:00:00.000Z", closedAt: "2026-05-14T14:30:00.000Z"),
+            pull(number: 15, title: "Searchable alpha design", body: "Find this design PR", state: "open", merged: false, author: "alice", head: "design-alpha", base: "main", additions: 12, deletions: 4, changedFiles: 2, checks: "success", updatedAt: "2026-05-14T13:00:00.000Z"),
+        ]
+    }
+
+    private static var betaPulls: [[String: Any]] {
+        [
+            pull(number: 21, title: "Pending beta review", body: "Beta review work", state: "open", merged: false, author: "carol", head: "pending-beta", base: "main", additions: 7, deletions: 3, changedFiles: 2, checks: "pending", updatedAt: "2026-05-14T12:00:00.000Z", repo: "beta"),
+            pull(number: 22, title: "Merged beta fix", body: "Beta fix", state: "closed", merged: true, author: "alice", head: "fix-beta", base: "main", additions: 3, deletions: 1, changedFiles: 1, checks: "success", updatedAt: "2026-05-14T11:00:00.000Z", mergedAt: "2026-05-14T11:30:00.000Z", closedAt: "2026-05-14T11:30:00.000Z", repo: "beta"),
+        ]
+    }
+
+    private static func pullDetail() -> [String: Any] {
+        [
+            "pull": alphaPulls[0],
+            "checks": [
+                [
+                    "name": "build",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "started_at": "2026-05-14T17:45:00.000Z",
+                    "completed_at": "2026-05-14T17:50:00.000Z",
+                    "html_url": "https://github.com/org/alpha/actions/runs/1",
+                ],
+                [
+                    "name": "lint",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "started_at": "2026-05-14T17:45:00.000Z",
+                    "completed_at": "2026-05-14T17:49:00.000Z",
+                    "html_url": "https://github.com/org/alpha/actions/runs/2",
+                ],
+            ],
+            "files": [
+                ["filename": "Sources/Alpha.swift", "status": "modified", "additions": 18, "deletions": 4],
+                ["filename": "Tests/AlphaTests.swift", "status": "added", "additions": 6, "deletions": 2],
+            ],
+            "linked_issue": issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, labels: detailIssueLabels, assignees: detailIssueAssignees, author: "alice", updatedAt: isoDate),
+            "reviews": [
+                [
+                    "id": 301,
+                    "user": ["login": "bob", "avatar_url": "https://example.com/bob.png"],
+                    "state": "changes_requested",
+                    "body": "Please fix the build.",
+                    "submitted_at": "2026-05-14T18:05:00.000Z",
+                ],
+            ],
+            "from_cache": false,
+            "cached_at": NSNull(),
+        ]
+    }
+
+    private static func pull(
+        number: Int,
+        title: String,
+        body: String,
+        state: String,
+        merged: Bool,
+        author: String,
+        head: String,
+        base: String,
+        additions: Int,
+        deletions: Int,
+        changedFiles: Int,
+        checks: String,
+        updatedAt: String,
+        mergedAt: String? = nil,
+        closedAt: String? = nil,
+        repo: String = "alpha"
+    ) -> [String: Any] {
+        [
+            "number": number,
+            "title": title,
+            "body": body,
+            "state": state,
+            "draft": false,
+            "merged": merged,
+            "user": ["login": author, "avatar_url": "https://example.com/\(author).png"],
+            "head_ref": head,
+            "base_ref": base,
+            "additions": additions,
+            "deletions": deletions,
+            "changed_files": changedFiles,
+            "created_at": "2026-05-12T10:00:00.000Z",
+            "updated_at": updatedAt,
+            "merged_at": mergedAt ?? NSNull(),
+            "closed_at": closedAt ?? NSNull(),
+            "html_url": "https://github.com/org/\(repo)/pull/\(number)",
+            "checks_status": checks,
         ]
     }
 

--- a/apple/IssueCTLMac/Views/MacPullRequestsView.swift
+++ b/apple/IssueCTLMac/Views/MacPullRequestsView.swift
@@ -1,0 +1,814 @@
+import SwiftUI
+
+enum MacPullRequestSection: String, CaseIterable, Identifiable {
+    case review
+    case open
+    case merged
+    case closed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .review: "Review"
+        case .open: "Open"
+        case .merged: "Merged"
+        case .closed: "Closed"
+        }
+    }
+}
+
+enum MacPullRequestSort: String, CaseIterable, Identifiable {
+    case updated
+    case created
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .updated: "Updated"
+        case .created: "Created"
+        }
+    }
+}
+
+struct MacPullRequestListItem: Identifiable {
+    let pull: GitHubPull
+    let repo: Repo
+    let repoIndex: Int
+
+    var id: String { pull.id }
+    var repoFullName: String { repo.fullName }
+}
+
+struct MacPullRequestListProjection {
+    let pulls: [MacPullRequestListItem]
+    let counts: [MacPullRequestSection: Int]
+}
+
+enum MacPullRequestListModel {
+    static func project(
+        pulls: [MacPullRequestListItem],
+        selectedRepoKeys: Set<String>,
+        section: MacPullRequestSection,
+        searchText: String,
+        mineOnly: Bool,
+        currentUserLogin: String?,
+        sortOrder: MacPullRequestSort
+    ) -> MacPullRequestListProjection {
+        let repoFiltered = pulls.filter { item in
+            selectedRepoKeys.contains(item.repoFullName) && matchesMine(item, mineOnly: mineOnly, currentUserLogin: currentUserLogin)
+        }
+
+        let counts = sectionCounts(pulls: repoFiltered)
+        let visiblePulls = filteredPulls(
+            pulls: repoFiltered,
+            section: section,
+            searchText: searchText,
+            sortOrder: sortOrder
+        )
+
+        return MacPullRequestListProjection(pulls: visiblePulls, counts: counts)
+    }
+
+    static func sectionCounts(pulls: [MacPullRequestListItem]) -> [MacPullRequestSection: Int] {
+        [
+            .review: pulls.filter { $0.pull.macNeedsReviewAttention }.count,
+            .open: pulls.filter { $0.pull.isOpen }.count,
+            .merged: pulls.filter { !$0.pull.isOpen && $0.pull.merged }.count,
+            .closed: pulls.filter { !$0.pull.isOpen && !$0.pull.merged }.count,
+        ]
+    }
+
+    static func filteredPulls(
+        pulls: [MacPullRequestListItem],
+        section: MacPullRequestSection,
+        searchText: String,
+        sortOrder: MacPullRequestSort
+    ) -> [MacPullRequestListItem] {
+        var items = pulls.filter { item in
+            switch section {
+            case .review:
+                return item.pull.macNeedsReviewAttention
+            case .open:
+                return item.pull.isOpen
+            case .merged:
+                return !item.pull.isOpen && item.pull.merged
+            case .closed:
+                return !item.pull.isOpen && !item.pull.merged
+            }
+        }
+
+        let query = normalizedSearchText(searchText)
+        if !query.isEmpty {
+            items = items.filter { item in matchesSearch(item, query: query) }
+        }
+
+        return sorted(items, sortOrder: sortOrder)
+    }
+
+    private static func matchesMine(_ item: MacPullRequestListItem, mineOnly: Bool, currentUserLogin: String?) -> Bool {
+        guard mineOnly, let currentUserLogin else { return true }
+        return item.pull.user?.login == currentUserLogin
+    }
+
+    private static func matchesSearch(_ item: MacPullRequestListItem, query: String) -> Bool {
+        item.pull.title.lowercased().contains(query)
+            || (item.pull.body ?? "").lowercased().contains(query)
+            || item.repoFullName.lowercased().contains(query)
+            || "#\(item.pull.number)".contains(query)
+            || "\(item.pull.number)".contains(query)
+    }
+
+    private static func sorted(_ items: [MacPullRequestListItem], sortOrder: MacPullRequestSort) -> [MacPullRequestListItem] {
+        items.sorted { lhs, rhs in
+            switch sortOrder {
+            case .updated:
+                return date(lhs.pull.updatedAt) != date(rhs.pull.updatedAt)
+                    ? date(lhs.pull.updatedAt) > date(rhs.pull.updatedAt)
+                    : stableTieBreak(lhs, rhs)
+            case .created:
+                return date(lhs.pull.createdAt) != date(rhs.pull.createdAt)
+                    ? date(lhs.pull.createdAt) > date(rhs.pull.createdAt)
+                    : stableTieBreak(lhs, rhs)
+            }
+        }
+    }
+
+    private static func normalizedSearchText(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func date(_ value: String) -> Date {
+        parseIssueCTLDate(value) ?? .distantPast
+    }
+
+    private static func stableTieBreak(_ lhs: MacPullRequestListItem, _ rhs: MacPullRequestListItem) -> Bool {
+        if lhs.repoFullName != rhs.repoFullName {
+            return lhs.repoFullName < rhs.repoFullName
+        }
+        return lhs.pull.number < rhs.pull.number
+    }
+}
+
+struct MacPullRequestsView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let store: MacSidebarStore
+
+    @State private var pulls: [MacPullRequestListItem] = []
+    @State private var selectedSection: MacPullRequestSection = .review
+    @State private var selectedRepoKeys = Set<String>()
+    @State private var knownRepoKeys = Set<String>()
+    @State private var searchText = ""
+    @State private var mineOnly = false
+    @State private var sortOrder: MacPullRequestSort = .updated
+    @State private var isRepoFilterExpanded = true
+    @State private var visiblePageCount = 1
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var isShowingCachedData = false
+    @State private var oldestCachedAt: Date?
+    @State private var selectedPull: MacPullRequestListItem?
+
+    private let pageSize = 3
+
+    private var projection: MacPullRequestListProjection {
+        MacPullRequestListModel.project(
+            pulls: pulls,
+            selectedRepoKeys: selectedRepoKeys,
+            section: selectedSection,
+            searchText: searchText,
+            mineOnly: mineOnly,
+            currentUserLogin: store.currentUserLogin,
+            sortOrder: sortOrder
+        )
+    }
+
+    private var visiblePulls: [MacPullRequestListItem] {
+        projection.pulls
+    }
+
+    private var pagedPulls: [MacPullRequestListItem] {
+        Array(visiblePulls.prefix(visibleLimit))
+    }
+
+    private var visibleLimit: Int {
+        max(pageSize, visiblePageCount * pageSize)
+    }
+
+    private var hasMorePulls: Bool {
+        visiblePulls.count > pagedPulls.count
+    }
+
+    private var repoFilterSummary: String {
+        if store.repos.isEmpty {
+            return "No repos"
+        }
+        if selectedRepoKeys.isEmpty {
+            return "No repos selected"
+        }
+        if selectedRepoKeys.count == store.repos.count {
+            return "All repos"
+        }
+        return "\(selectedRepoKeys.count) of \(store.repos.count) repos"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controls
+
+            if isLoading && pulls.isEmpty {
+                ProgressView("Loading pull requests...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage, pulls.isEmpty {
+                ContentUnavailableView("Could not load pull requests", systemImage: "wifi.exclamationmark", description: Text(errorMessage))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityIdentifier("mac-prs-load-error")
+            } else if visiblePulls.isEmpty {
+                ContentUnavailableView(emptyTitle, systemImage: "arrow.triangle.merge", description: Text(emptyDescription))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(pagedPulls) { item in
+                            Button {
+                                selectedPull = item
+                            } label: {
+                                MacPullRequestRow(item: item)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("mac-pr-row-\(item.repoFullName)-\(item.pull.number)")
+
+                            Divider()
+                        }
+
+                        if hasMorePulls {
+                            HStack {
+                                Spacer()
+                                Button {
+                                    visiblePageCount += 1
+                                } label: {
+                                    Label("Show \(pageSize) More", systemImage: "chevron.down")
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .accessibilityIdentifier("mac-prs-load-more-button")
+                                Spacer()
+                            }
+                            .padding(.vertical, 10)
+                        } else if visiblePulls.count > pageSize {
+                            Text("Showing all \(visiblePulls.count) matching pull requests")
+                                .font(.macSidebar(size: 11, scale: textScale))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                                .accessibilityIdentifier("mac-prs-pagination-summary")
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                }
+            }
+        }
+        .task { await loadPulls(refresh: false) }
+        .onChange(of: store.repos.count) { _, _ in syncRepoSelection() }
+        .onChange(of: selectedSection) { _, _ in resetPaging() }
+        .onChange(of: selectedRepoKeys) { _, _ in resetPaging() }
+        .onChange(of: searchText) { _, _ in resetPaging() }
+        .onChange(of: mineOnly) { _, _ in resetPaging() }
+        .onChange(of: sortOrder) { _, _ in resetPaging() }
+        .sheet(item: $selectedPull) { item in
+            MacPullRequestDetailView(item: item)
+        }
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            TextField("Search pull requests", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-prs-search-field")
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Sections")
+                    .font(.macSidebar(size: 11, weight: .semibold, scale: textScale))
+                    .foregroundStyle(.secondary)
+
+                Picker("Pull request section", selection: $selectedSection) {
+                    ForEach(MacPullRequestSection.allCases) { section in
+                        Text(section.title).tag(section)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityIdentifier("mac-prs-section-picker")
+            }
+
+            HStack(spacing: 8) {
+                Picker("Sort", selection: $sortOrder) {
+                    ForEach(MacPullRequestSort.allCases) { sort in
+                        Text(sort.title).tag(sort)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityIdentifier("mac-prs-sort-picker")
+
+                Toggle("Mine", isOn: $mineOnly)
+                    .toggleStyle(.checkbox)
+                    .disabled(store.currentUserLogin == nil)
+                    .help(store.currentUserLogin == nil ? "Sign in is required for this filter." : "Show pull requests opened by you.")
+                    .accessibilityIdentifier("mac-prs-mine-filter")
+
+                Button("Reset") {
+                    resetFilters()
+                }
+                .controlSize(.small)
+                .accessibilityIdentifier("mac-prs-reset-filters-button")
+            }
+            .font(.macSidebar(size: 12, scale: textScale))
+
+            sectionCounts
+            filterSummary
+
+            DisclosureGroup(isExpanded: $isRepoFilterExpanded) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Button("All") {
+                            selectedRepoKeys = Set(store.repos.map(\.fullName))
+                        }
+                        .controlSize(.small)
+
+                        Button("None") {
+                            selectedRepoKeys.removeAll()
+                        }
+                        .controlSize(.small)
+
+                        Spacer()
+                    }
+
+                    ForEach(store.repos) { repo in
+                        Toggle(repo.fullName, isOn: repoBinding(repo))
+                            .toggleStyle(.checkbox)
+                            .font(.macSidebar(size: 12, scale: textScale))
+                            .accessibilityIdentifier("mac-prs-repo-filter-\(repo.fullName)")
+                    }
+                }
+                .padding(.top, 4)
+            } label: {
+                HStack {
+                    Text("Repositories")
+                    Spacer()
+                    Text(repoFilterSummary)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.macSidebar(size: 12, weight: .semibold, scale: textScale))
+            }
+            .accessibilityIdentifier("mac-prs-repo-filter")
+
+            if isShowingCachedData {
+                Label("Showing cached pull requests", systemImage: "externaldrive.badge.clock")
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("mac-prs-cached-banner")
+            } else if let oldestCachedAt {
+                Text("Updated \(oldestCachedAt.formatted(date: .omitted, time: .shortened))")
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.secondary)
+            }
+
+            if let errorMessage, !pulls.isEmpty {
+                MacRecoveryBanner(message: errorMessage, actionTitle: "Retry", isActionDisabled: isLoading) {
+                    Task { await loadPulls(refresh: true) }
+                }
+                .accessibilityIdentifier("mac-prs-inline-error")
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var sectionCounts: some View {
+        HStack(spacing: 6) {
+            ForEach(MacPullRequestSection.allCases) { section in
+                let count = projection.counts[section] ?? 0
+                Text("\(section.title) \(count)")
+                    .font(.macSidebar(size: 11, weight: selectedSection == section ? .semibold : .regular, scale: textScale))
+                    .foregroundStyle(selectedSection == section ? .primary : .secondary)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(selectedSection == section ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08), in: Capsule())
+            }
+        }
+        .accessibilityIdentifier("mac-prs-section-counts")
+    }
+
+    private var filterSummary: some View {
+        Text("Showing \(selectedSection.title.lowercased()) PRs • \(repoFilterSummary) • \(sortOrder.title)")
+            .font(.macSidebar(size: 11, scale: textScale))
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .accessibilityIdentifier("mac-prs-filter-summary")
+    }
+
+    private var emptyTitle: String {
+        searchText.isEmpty ? "No Pull Requests" : "No Matching Pull Requests"
+    }
+
+    private var emptyDescription: String {
+        if !searchText.isEmpty {
+            return "No \(selectedSection.title.lowercased()) pull requests match \"\(searchText)\"."
+        }
+        return "No \(selectedSection.title.lowercased()) pull requests match the current filters."
+    }
+
+    private func loadPulls(refresh: Bool) async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        if store.repos.isEmpty {
+            await store.load(api: api, refresh: refresh)
+        }
+        syncRepoSelection()
+
+        var loadedPulls: [MacPullRequestListItem] = []
+        var failures: [String] = []
+        var cachedDates: [Date] = []
+        var didUseCachedData = false
+
+        for (index, repo) in store.repos.enumerated() {
+            do {
+                let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
+                loadedPulls.append(contentsOf: response.pulls.map { pull in
+                    MacPullRequestListItem(pull: pull, repo: repo, repoIndex: index)
+                })
+                didUseCachedData = didUseCachedData || response.fromCache
+                if let cachedAt = response.cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                    cachedDates.append(date)
+                }
+            } catch {
+                failures.append("\(repo.fullName): \(error.localizedDescription)")
+            }
+        }
+
+        pulls = loadedPulls
+        oldestCachedAt = cachedDates.min()
+        isShowingCachedData = didUseCachedData
+        if !failures.isEmpty {
+            errorMessage = "Some repos failed to load pull requests: \(failures.joined(separator: "; "))"
+        }
+    }
+
+    private func syncRepoSelection() {
+        let repoKeys = Set(store.repos.map(\.fullName))
+        guard !repoKeys.isEmpty else {
+            selectedRepoKeys.removeAll()
+            knownRepoKeys.removeAll()
+            return
+        }
+
+        if knownRepoKeys.isEmpty {
+            selectedRepoKeys = repoKeys
+        } else if selectedRepoKeys == knownRepoKeys {
+            selectedRepoKeys = repoKeys
+        } else {
+            selectedRepoKeys = selectedRepoKeys.intersection(repoKeys)
+        }
+        knownRepoKeys = repoKeys
+    }
+
+    private func resetFilters() {
+        selectedSection = .review
+        selectedRepoKeys = Set(store.repos.map(\.fullName))
+        searchText = ""
+        mineOnly = false
+        sortOrder = .updated
+        resetPaging()
+    }
+
+    private func resetPaging() {
+        visiblePageCount = 1
+    }
+
+    private func repoBinding(_ repo: Repo) -> Binding<Bool> {
+        Binding(
+            get: { selectedRepoKeys.contains(repo.fullName) },
+            set: { isSelected in
+                if isSelected {
+                    selectedRepoKeys.insert(repo.fullName)
+                } else {
+                    selectedRepoKeys.remove(repo.fullName)
+                }
+            }
+        )
+    }
+}
+
+private struct MacPullRequestRow: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let item: MacPullRequestListItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 9) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(MacPullRepoColors.color(for: item.repoIndex))
+                .frame(width: 5, height: 42)
+                .padding(.top, 3)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.pull.title)
+                    .font(.macSidebar(size: 13, weight: .semibold, scale: textScale))
+                    .lineLimit(2)
+
+                HStack(spacing: 6) {
+                    Text("\(item.repoFullName)#\(item.pull.number)")
+                    if let login = item.pull.user?.login {
+                        Text(login)
+                    }
+                    Text(item.pull.diffSummary)
+                }
+                .font(.macSidebar(size: 11, scale: textScale))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+                HStack(spacing: 6) {
+                    MacPullRequestStateBadge(pull: item.pull)
+                    MacChecksStatusBadge(status: item.pull.checksStatus)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 7)
+        .padding(.horizontal, 6)
+    }
+}
+
+private struct MacPullRequestStateBadge: View {
+    let pull: GitHubPull
+
+    private var label: String {
+        if pull.merged { return "Merged" }
+        return pull.isOpen ? "Open" : "Closed"
+    }
+
+    private var color: Color {
+        if pull.merged { return .purple }
+        return pull.isOpen ? .green : .red
+    }
+
+    var body: some View {
+        Text(label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.14), in: Capsule())
+    }
+}
+
+private struct MacChecksStatusBadge: View {
+    let status: String?
+
+    private var label: String {
+        switch status {
+        case "success": "Passing"
+        case "failure": "Failing"
+        case "pending": "Pending"
+        default: "Unknown"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case "success": .green
+        case "failure": .red
+        case "pending": .orange
+        default: .secondary
+        }
+    }
+
+    var body: some View {
+        if status != nil {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(color)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(color.opacity(0.14), in: Capsule())
+        }
+    }
+}
+
+private struct MacPullRequestDetailView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.openURL) private var openURL
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let item: MacPullRequestListItem
+
+    @State private var detail: PullDetailResponse?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+
+            if isLoading && detail == nil {
+                ProgressView("Loading pull request...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorMessage, detail == nil {
+                ContentUnavailableView("Could not load pull request", systemImage: "wifi.exclamationmark", description: Text(errorMessage))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityIdentifier("mac-pr-detail-error")
+            } else if let detail {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        MacPullRequestDetailHeader(detail: detail)
+                        if let body = detail.pull.body, !body.isEmpty {
+                            MacDetailSection(title: "Description", systemImage: "text.alignleft") {
+                                Text(body)
+                                    .font(.macSidebar(size: 12, scale: textScale))
+                                    .textSelection(.enabled)
+                            }
+                            .accessibilityIdentifier("mac-pr-detail-body")
+                        }
+                        MacDetailSection(title: "Checks", systemImage: "checkmark.shield") {
+                            ForEach(detail.checks) { check in
+                                detailRow(title: check.name, value: check.conclusion ?? check.status)
+                                    .accessibilityIdentifier("mac-pr-detail-check-\(check.name)")
+                            }
+                        }
+                        MacDetailSection(title: "Changed Files", systemImage: "doc.text") {
+                            ForEach(detail.files) { file in
+                                detailRow(title: file.filename, value: "+\(file.additions) -\(file.deletions)")
+                                    .accessibilityIdentifier("mac-pr-detail-file-\(file.filename)")
+                            }
+                        }
+                        if !detail.reviews.isEmpty {
+                            MacDetailSection(title: "Reviews", systemImage: "eye") {
+                                ForEach(detail.reviews) { review in
+                                    detailRow(title: review.user?.login ?? "Unknown", value: review.state)
+                                        .accessibilityIdentifier("mac-pr-detail-review-\(review.id)")
+                                }
+                            }
+                        }
+                        if let issue = detail.linkedIssue {
+                            MacDetailSection(title: "Linked Issue", systemImage: "link") {
+                                detailRow(title: "#\(issue.number)", value: issue.title)
+                                    .accessibilityIdentifier("mac-pr-detail-linked-issue-\(issue.number)")
+                            }
+                        }
+                    }
+                    .padding(14)
+                }
+                .accessibilityIdentifier("mac-pr-detail")
+            }
+        }
+        .frame(width: 560, height: 620)
+        .task { await load(refresh: false) }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Pull Request #\(item.pull.number)")
+                    .font(.headline)
+                Text(item.repoFullName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let url = URL(string: item.pull.htmlUrl) {
+                Button {
+                    openURL(url)
+                } label: {
+                    Label("Open GitHub", systemImage: "safari")
+                }
+                .accessibilityIdentifier("mac-pr-detail-open-github-button")
+            }
+            Button("Done") {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("mac-pr-detail-done-button")
+        }
+        .padding(14)
+    }
+
+    private func load(refresh: Bool) async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            detail = try await api.pullDetail(owner: item.repo.owner, repo: item.repo.name, number: item.pull.number, refresh: refresh)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func detailRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(.macSidebar(size: 12, weight: .semibold, scale: textScale))
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.macSidebar(size: 11, scale: textScale))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+}
+
+private struct MacPullRequestDetailHeader: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let detail: PullDetailResponse
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(detail.pull.title)
+                .font(.macSidebar(size: 17, weight: .semibold, scale: textScale))
+                .lineLimit(3)
+                .accessibilityIdentifier("mac-pr-detail-title")
+
+            HStack(spacing: 8) {
+                MacPullRequestStateBadge(pull: detail.pull)
+                MacChecksStatusBadge(status: detail.pull.checksStatus)
+                if let login = detail.pull.user?.login {
+                    Text(login)
+                        .font(.macSidebar(size: 12, scale: textScale))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Text(detail.pull.headRef)
+                Image(systemName: "arrow.right")
+                Text(detail.pull.baseRef)
+                Spacer()
+                Text(detail.pull.diffSummary)
+                Text("\(detail.pull.changedFiles) files")
+            }
+            .font(.macSidebar(size: 11, scale: textScale))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .accessibilityIdentifier("mac-pr-detail-branch-summary")
+        }
+    }
+}
+
+private struct MacDetailSection<Content: View>: View {
+    let title: String
+    let systemImage: String
+    let content: Content
+
+    init(title: String, systemImage: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.systemImage = systemImage
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 6) {
+                content
+            }
+        }
+    }
+}
+
+private extension GitHubPull {
+    var macNeedsReviewAttention: Bool {
+        isOpen && (checksStatus == "failure" || checksStatus == "pending")
+    }
+}
+
+private enum MacPullRepoColors {
+    private static let palette: [Color] = [
+        Color(red: 248 / 255, green: 81 / 255, blue: 73 / 255),
+        Color(red: 88 / 255, green: 166 / 255, blue: 255 / 255),
+        Color(red: 63 / 255, green: 185 / 255, blue: 80 / 255),
+        Color(red: 188 / 255, green: 140 / 255, blue: 255 / 255),
+        Color(red: 210 / 255, green: 153 / 255, blue: 34 / 255),
+        Color(red: 57 / 255, green: 208 / 255, blue: 214 / 255),
+        Color(red: 232 / 255, green: 113 / 255, blue: 37 / 255),
+    ]
+
+    static func color(for index: Int) -> Color {
+        palette[index % palette.count]
+    }
+}

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -145,6 +145,8 @@ struct MacSidebarRootView: View {
                         .fill(selectedSection == section ? Color.accentColor.opacity(0.16) : Color.clear)
                 )
                 .help(section.title)
+                .accessibilityLabel(section.title)
+                .accessibilityIdentifier("mac-sidebar-section-\(section.rawValue)")
             }
 
             Divider()
@@ -218,6 +220,8 @@ struct MacSidebarRootView: View {
                 switch selectedSection {
                 case .issues:
                     MacIssuesView(store: store, filterState: issueFilterState)
+                case .pullRequests:
+                    MacPullRequestsView(store: store)
                 case .drafts:
                     MacDraftsView(store: store)
                 case .active:
@@ -354,6 +358,7 @@ struct MacSidebarRootView: View {
 
 private enum MacSidebarSection: String, CaseIterable, Identifiable {
     case issues
+    case pullRequests
     case drafts
     case active
 
@@ -362,6 +367,7 @@ private enum MacSidebarSection: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .issues: "Issues"
+        case .pullRequests: "PRs"
         case .drafts: "Drafts"
         case .active: "Active"
         }
@@ -370,6 +376,7 @@ private enum MacSidebarSection: String, CaseIterable, Identifiable {
     var systemImage: String {
         switch self {
         case .issues: "list.bullet"
+        case .pullRequests: "arrow.triangle.merge"
         case .drafts: "doc.text"
         case .active: "terminal"
         }

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -270,6 +270,43 @@ final class MacIssueFilterStateTests: XCTestCase {
         XCTAssertEqual(reviewed.first?.labels, ["bug"])
     }
 
+    func testPullRequestProjectionMatchesIOSSectionSemantics() {
+        let projection = MacPullRequestListModel.project(
+            pulls: pullItems,
+            selectedRepoKeys: ["mean-weasel/issuectl", "mean-weasel/other"],
+            section: .review,
+            searchText: "",
+            mineOnly: false,
+            currentUserLogin: "alice",
+            sortOrder: .updated
+        )
+
+        XCTAssertEqual(projection.counts[.review], 2)
+        XCTAssertEqual(projection.counts[.open], 3)
+        XCTAssertEqual(projection.counts[.merged], 1)
+        XCTAssertEqual(projection.counts[.closed], 1)
+        XCTAssertEqual(projection.pulls.map(\.pull.number), [10, 11])
+    }
+
+    func testPullRequestSearchMineSortAndRepoFilterAreDeterministic() {
+        let projection = MacPullRequestListModel.project(
+            pulls: pullItems,
+            selectedRepoKeys: ["mean-weasel/issuectl"],
+            section: .open,
+            searchText: "alpha",
+            mineOnly: true,
+            currentUserLogin: "alice",
+            sortOrder: .created
+        )
+
+        XCTAssertEqual(projection.counts[.review], 1)
+        XCTAssertEqual(projection.counts[.open], 2)
+        XCTAssertEqual(projection.pulls.map { $0.repoFullName + "#\($0.pull.number)" }, [
+            "mean-weasel/issuectl#12",
+            "mean-weasel/issuectl#10",
+        ])
+    }
+
     private var repos: [Repo] {
         [
             repo(id: 1, owner: "mean-weasel", name: "issuectl"),
@@ -288,6 +325,16 @@ final class MacIssueFilterStateTests: XCTestCase {
 
     private var drafts: [Draft] {
         [draft(id: "draft-1", title: "Draft alpha", body: "body")]
+    }
+
+    private var pullItems: [MacPullRequestListItem] {
+        [
+            pullItem(number: 10, repo: repos[0], title: "Fix alpha workflow", state: "open", merged: false, author: "alice", checksStatus: "failure", createdAt: "2026-05-12T10:00:00.000Z", updatedAt: "2026-05-14T18:00:00.000Z"),
+            pullItem(number: 11, repo: repos[0], title: "Pending alpha migration", state: "open", merged: false, author: "bob", checksStatus: "pending", createdAt: "2026-05-12T11:00:00.000Z", updatedAt: "2026-05-14T17:00:00.000Z"),
+            pullItem(number: 12, repo: repos[0], title: "Alpha cleanup", state: "open", merged: false, author: "alice", checksStatus: "success", createdAt: "2026-05-12T12:00:00.000Z", updatedAt: "2026-05-14T16:00:00.000Z"),
+            pullItem(number: 13, repo: repos[0], title: "Merged docs", state: "closed", merged: true, author: "carol", checksStatus: "success", createdAt: "2026-05-12T13:00:00.000Z", updatedAt: "2026-05-14T15:00:00.000Z", mergedAt: "2026-05-14T15:30:00.000Z", closedAt: "2026-05-14T15:30:00.000Z"),
+            pullItem(number: 21, repo: repos[1], title: "Other pending review", state: "closed", merged: false, author: "alice", checksStatus: "failure", createdAt: "2026-05-12T14:00:00.000Z", updatedAt: "2026-05-14T14:00:00.000Z", closedAt: "2026-05-14T14:30:00.000Z"),
+        ]
     }
 
     private func repo(id: Int, owner: String, name: String) -> Repo {
@@ -322,6 +369,45 @@ final class MacIssueFilterStateTests: XCTestCase {
 
     private func user(_ login: String) -> GitHubUser {
         GitHubUser(login: login, avatarUrl: "https://example.com/\(login).png")
+    }
+
+    private func pullItem(
+        number: Int,
+        repo: Repo,
+        title: String,
+        state: String,
+        merged: Bool,
+        author: String,
+        checksStatus: String?,
+        createdAt: String,
+        updatedAt: String,
+        mergedAt: String? = nil,
+        closedAt: String? = nil
+    ) -> MacPullRequestListItem {
+        MacPullRequestListItem(
+            pull: GitHubPull(
+                number: number,
+                title: title,
+                body: "Pull body",
+                state: state,
+                draft: false,
+                merged: merged,
+                user: user(author),
+                headRef: "head-\(number)",
+                baseRef: "main",
+                additions: 10,
+                deletions: 2,
+                changedFiles: 3,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                mergedAt: mergedAt,
+                closedAt: closedAt,
+                htmlUrl: "https://github.com/\(repo.owner)/\(repo.name)/pull/\(number)",
+                checksStatus: checksStatus
+            ),
+            repo: repo,
+            repoIndex: repo.id - 1
+        )
     }
 
     private func draft(id: String, title: String, body: String?) -> Draft {

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -80,6 +80,93 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testPullRequestListFiltersPaginatesAndOpensDetail() {
+        selectRootSection("PRs")
+
+        XCTAssertTrue(prRow("org/alpha", 10).waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-prs-section-counts"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-prs-filter-summary"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-sidebar-collapse-button"].click()
+        XCTAssertTrue(app.buttons["mac-sidebar-section-pullRequests"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-sidebar-expand-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-prs-search-field"].waitForExistence(timeout: 5), app.debugDescription)
+
+        prSection("Open").click()
+        XCTAssertTrue(prRow("org/alpha", 12).waitForExistence(timeout: 5), app.debugDescription)
+        let loadMore = app.buttons["mac-prs-load-more-button"]
+        XCTAssertTrue(loadMore.waitForExistence(timeout: 5), app.debugDescription)
+        loadMore.click()
+        XCTAssertTrue(prRow("org/beta", 21).waitForExistence(timeout: 5), app.debugDescription)
+
+        let search = app.textFields["mac-prs-search-field"]
+        XCTAssertTrue(search.waitForExistence(timeout: 5), app.debugDescription)
+        search.click()
+        search.typeText("design")
+        XCTAssertTrue(prRow("org/alpha", 15).waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(prRow("org/alpha", 10).exists, app.debugDescription)
+
+        app.buttons["mac-prs-reset-filters-button"].click()
+        prSection("Open").click()
+        prSort("Created").click()
+        XCTAssertTrue(prRow("org/alpha", 12).waitForExistence(timeout: 5), app.debugDescription)
+
+        let alphaRepo = app.checkBoxes["org/alpha"]
+        XCTAssertTrue(alphaRepo.waitForExistence(timeout: 5), app.debugDescription)
+        alphaRepo.click()
+        XCTAssertTrue(prRow("org/beta", 21).waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(prRow("org/alpha", 10).exists, app.debugDescription)
+
+        app.buttons["mac-prs-reset-filters-button"].click()
+        prSection("Open").click()
+
+        let mine = app.checkBoxes["mac-prs-mine-filter"]
+        XCTAssertTrue(mine.waitForExistence(timeout: 5), app.debugDescription)
+        mine.click()
+        XCTAssertTrue(prRow("org/alpha", 10).waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(prRow("org/alpha", 11).exists, app.debugDescription)
+
+        app.buttons["mac-prs-reset-filters-button"].click()
+        openPullRequest(prRow("org/alpha", 10))
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-title"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-body"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-check-build"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-file-Sources/Alpha.swift"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-review-301"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-linked-issue-1"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["Merge"].exists, app.debugDescription)
+        XCTAssertFalse(app.buttons["Approve"].exists, app.debugDescription)
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    func testPullRequestFailuresAreRecoverableAndPreserveFilters() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_BETA_PULLS_FAILURE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_PULL_DETAIL_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("PRs")
+
+        XCTAssertTrue(prRow("org/alpha", 10).waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-prs-inline-error"].waitForExistence(timeout: 5), app.debugDescription)
+
+        prSection("Open").click()
+        let search = app.textFields["mac-prs-search-field"]
+        XCTAssertTrue(search.waitForExistence(timeout: 5), app.debugDescription)
+        search.click()
+        search.typeText("alpha")
+        XCTAssertTrue(waitForValue(of: search, containing: "alpha", timeout: 3), app.debugDescription)
+        XCTAssertTrue(prRow("org/alpha", 10).exists, app.debugDescription)
+
+        openPullRequest(prRow("org/alpha", 10))
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-error"].waitForExistence(timeout: 5), app.debugDescription)
+        app.typeKey(.escape, modifierFlags: [])
+
+        XCTAssertTrue(waitForValue(of: search, containing: "alpha", timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-prs-inline-error"].exists, app.debugDescription)
+        XCTAssertTrue(prRow("org/alpha", 10).exists, app.debugDescription)
+    }
+
     func testIssueDetailCoreActionsAndContext() {
         let firstIssue = issueRow("org/alpha", 1)
         XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
@@ -537,6 +624,10 @@ final class MacSidebarSmokeTests: XCTestCase {
         app.descendants(matching: .any)["mac-draft-row-\(id)"]
     }
 
+    private func prRow(_ repoFullName: String, _ number: Int) -> XCUIElement {
+        app.descendants(matching: .any)["mac-pr-row-\(repoFullName)-\(number)"]
+    }
+
     private func issueState(_ title: String) -> XCUIElement {
         app.descendants(matching: .any)["mac-issues-section-picker"].radioButtons[title]
     }
@@ -545,11 +636,27 @@ final class MacSidebarSmokeTests: XCTestCase {
         app.descendants(matching: .any)["mac-issues-sort-picker"].radioButtons[title]
     }
 
+    private func prSection(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-prs-section-picker"].radioButtons[title]
+    }
+
+    private func prSort(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)["mac-prs-sort-picker"].radioButtons[title]
+    }
+
     private func openIssue(_ issue: XCUIElement) {
         issue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         let editButton = app.buttons["mac-issue-detail-edit-button"]
         if !editButton.waitForExistence(timeout: 2) {
             issue.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+    }
+
+    private func openPullRequest(_ pullRequest: XCUIElement) {
+        pullRequest.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        let doneButton = app.buttons["mac-pr-detail-done-button"]
+        if !doneButton.waitForExistence(timeout: 2) {
+            pullRequest.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         }
     }
 

--- a/docs/goals/mac-ios-parity/notes/T038-phase-7a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T038-phase-7a-branch-start.md
@@ -1,0 +1,9 @@
+# T038 Phase 7A Branch Start
+
+Started Phase 7A Mac PR browse/read-only detail implementation.
+
+- Branch: `mac-parity-phase-7a-pr-browse`
+- Base: `mac-sidebar-spaces-option-a`
+- Required draft PR: open before product edits
+- Scope: PR sidebar section, PR list filters/pagination/counts, read-only PR detail, deterministic PR fixtures, focused unit/UI tests
+- Excluded: merge, approve, request changes, PR comments, linked issue deep navigation

--- a/docs/goals/mac-ios-parity/notes/T038-phase-7a-pr-browse-implementation.md
+++ b/docs/goals/mac-ios-parity/notes/T038-phase-7a-pr-browse-implementation.md
@@ -1,0 +1,26 @@
+# T038 Phase 7A PR Browse Implementation
+
+## Result
+
+Implemented the first Phase 7 Mac pull-request slice on `mac-parity-phase-7a-pr-browse` with draft PR #434 targeting `mac-sidebar-spaces-option-a`.
+
+## Scope
+
+- Added a native Mac `PRs` sidebar section in expanded and collapsed modes.
+- Added read-only PR browse UI with Review/Open/Merged/Closed sections.
+- Matched iOS review-attention semantics for open PRs with failing or pending checks.
+- Added search, repo filter, mine filter, sort, reset, and incremental pagination.
+- Added read-only PR detail showing body, checks, changed files, reviews, linked issue, and branch/diff summary.
+- Added deterministic Mac UI fixture endpoints for PR list/detail success and failure paths.
+- Explicitly excluded merge, approve, request changes, and PR comments from this slice.
+
+## Validation
+
+- `git diff --check` passed.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestListFiltersPaginatesAndOpensDetail -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestFailuresAreRecoverableAndPreserveFilters` passed.
+
+## Notes
+
+- The first local `xcodebuild` attempt using the default DerivedData failed while linking the UI test runner because Xcode could not write the existing runner binary. Re-running with isolated DerivedData at `/tmp/issuectl-phase7a-dd` removed the stale artifact and passed.
+- UI tests dismiss PR detail with Escape because the sheet Done button can be reported outside the hittable region on the current multi-display/macOS desktop layout.
+- Repo filters are expanded by default in the PR surface to make the filter location explicit during dogfood.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T038
+active_task: T039
 
 tasks:
   - id: T001
@@ -1869,7 +1869,7 @@ tasks:
   - id: T038
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 7A Mac pull-request browse plus read-only detail, matching iOS PR list/detail semantics where practical while keeping Mac sidebar UI native."
     inputs:
@@ -1919,6 +1919,65 @@ tasks:
       - "Required files fall outside allowed scope."
       - "Deterministic PR fixture data cannot represent review/open/merged/closed sections."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      decision: local_validation_passed
+      full_outcome_complete: false
+      note: "notes/T038-phase-7a-pr-browse-implementation.md"
+      pr:
+        number: 434
+        url: "https://github.com/mean-weasel/issuectl/pull/434"
+        branch: "mac-parity-phase-7a-pr-browse"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending push/CI refresh after implementation commit."
+        merge_state: "Not evaluated after implementation commit yet."
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarRootView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "apple/IssueCTL.xcodeproj/project.pbxproj"
+        - "docs/goals/mac-ios-parity/notes/T038-phase-7a-pr-browse-implementation.md"
+        - "docs/goals/mac-ios-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestListFiltersPaginatesAndOpensDetail -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestFailuresAreRecoverableAndPreserveFilters"
+          status: pass
+      acceptance_evidence:
+        - "Expanded PRs section is selectable through mac-sidebar-section-picker; collapsed rail exposes mac-sidebar-section-pullRequests."
+        - "Deterministic fixtures cover alpha and beta PRs across review/open/merged/closed states."
+        - "MacPullRequestListModel tests assert review/open/merged/closed counts and review-attention semantics."
+        - "UI smoke covers search, repo filter, mine filter, sort, reset, and load-more pagination."
+        - "UI smoke opens read-only PR detail and asserts body, checks, files, review, and linked issue content with no merge/approve controls."
+        - "UI smoke covers beta list failure plus detail failure while preserving search/filter state."
+      warnings:
+        - "Default DerivedData test attempt failed at UI test runner link output; isolated DerivedData validation passed."
+        - "Full scheme/UI suite not run; validation focused on T038 model and PR UI acceptance paths."
+      summary: "Implemented Mac read-only PR browse/detail parity slice with deterministic fixtures, unit coverage for list semantics, and UI coverage for expanded/collapsed navigation, filters, pagination, detail, and recoverable failures."
+
+  - id: T039
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: medium
+    objective: "Commit and push T038, monitor PR #434 CI/checks, and merge into mac-sidebar-spaces-option-a only when green or when an accepted replacement validation is recorded."
+    inputs:
+      - "T038 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/434"
+      - "Current local branch mac-parity-phase-7a-pr-browse"
+    constraints:
+      - "Do not merge red CI without a documented accepted replacement validation."
+      - "Record implementation commit SHA, CI/check status, merge readiness, and merge SHA if merged."
+      - "If checks fail, create a follow-up fix task on the same PR branch."
+      - "If checks are absent, record that explicitly and use the local validation receipt as replacement evidence."
+    expected_output:
+      - "Commit SHA and pushed branch."
+      - "PR check status."
+      - "Merge decision."
+      - "Updated board receipt."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary
- Phase 7A: add Mac PR sidebar browse and read-only detail.
- Scope includes PR sections, filters/search/mine/sort/reset, pagination, deterministic fixtures, and tests.
- Mutating PR actions are intentionally deferred to the next Phase 7 slice.

## Acceptance Criteria
- Mac sidebar exposes a PRs section in expanded and collapsed sidebar modes.
- User can browse PRs from tracked repos and section counts match deterministic fixture data.
- Review section contains open PRs with failing or pending checks, matching iOS needsReviewAttention.
- Search, repo filter, mine filter, sort, reset, and pagination behave deterministically.
- User can open PR detail and inspect checks, changed files, linked issue, reviews, and body content.
- Failed PR list/detail loads show recoverable errors and preserve selected PR filters.

## Validation
- `git diff --check`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestListFiltersPaginatesAndOpensDetail -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestFailuresAreRecoverableAndPreserveFilters`
- Pre-commit hook: `pnpm typecheck` and `pnpm lint` passed; lint reported existing warnings only.

## Check Status
- GitHub reports no checks for this branch, so local validation is the replacement gate.
