### PR TITLE
Add Mac PR detail actions

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -409,6 +409,41 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 return ["error": "Fixture pull detail failed"]
             }
             return pullDetail()
+        case ("POST", "/api/v1/pulls/org/alpha/10/comments"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_ACTION_FAILURE"] == "1"
+                || ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_COMMENT_FAILURE"] == "1" {
+                return ["success": false, "comment_id": NSNull(), "error": "Fixture PR comment failed"]
+            }
+            let payload = jsonBody(from: request)
+            let commentBody = payload["body"] as? String ?? ""
+            pullCommentBodies.append(commentBody)
+            return ["success": true, "comment_id": 901 + pullCommentBodies.count, "error": NSNull()]
+        case ("POST", "/api/v1/pulls/org/alpha/10/review"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_ACTION_FAILURE"] == "1"
+                || ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_REVIEW_FAILURE"] == "1" {
+                return ["success": false, "review_id": NSNull(), "error": "Fixture PR review failed"]
+            }
+            let payload = jsonBody(from: request)
+            let event = payload["event"] as? String ?? "COMMENT"
+            let reviewBody = payload["body"] as? String ?? ""
+            let id = 401 + pullActionReviews.count
+            pullActionReviews.append([
+                "id": id,
+                "user": ["login": "alice", "avatar_url": "https://example.com/alice.png"],
+                "state": event == "APPROVE" ? "approved" : "changes_requested",
+                "body": reviewBody,
+                "submitted_at": isoDate,
+            ])
+            return ["success": true, "review_id": id, "error": NSNull()]
+        case ("POST", "/api/v1/pulls/org/alpha/10/merge"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_ACTION_FAILURE"] == "1"
+                || ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_MERGE_FAILURE"] == "1" {
+                return ["success": false, "sha": NSNull(), "error": "Fixture PR merge failed"]
+            }
+            let payload = jsonBody(from: request)
+            pullMerged = true
+            pullMergeMethod = (payload["mergeMethod"] as? String) ?? (payload["merge_method"] as? String)
+            return ["success": true, "sha": "fixture-\(pullMergeMethod ?? "merge")-sha", "error": NSNull()]
         case ("GET", "/api/v1/issues/org/alpha/1"):
             return issueDetail()
         case ("GET", "/api/v1/issues/org/alpha/89"):
@@ -557,6 +592,10 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var quickCreatedIssueBody: String?
     nonisolated(unsafe) private static var quickCreatedIssueLabels: [String] = []
     nonisolated(unsafe) private static var parsedCreatedIssueNumber: Int?
+    nonisolated(unsafe) private static var pullActionReviews: [[String: Any]] = []
+    nonisolated(unsafe) private static var pullCommentBodies: [String] = []
+    nonisolated(unsafe) private static var pullMerged = false
+    nonisolated(unsafe) private static var pullMergeMethod: String?
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
@@ -660,13 +699,33 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
 
     private static var alphaPulls: [[String: Any]] {
         [
-            pull(number: 10, title: "Fix failing alpha workflow", body: "PR body with alpha details", state: "open", merged: false, author: "alice", head: "fix-alpha", base: "main", additions: 24, deletions: 6, changedFiles: 3, checks: "failure", updatedAt: "2026-05-14T18:00:00.000Z"),
+            alphaPrimaryPull,
             pull(number: 11, title: "Pending alpha migration", body: "Migration work", state: "open", merged: false, author: "bob", head: "pending-alpha", base: "main", additions: 10, deletions: 2, changedFiles: 2, checks: "pending", updatedAt: "2026-05-14T17:00:00.000Z"),
             pull(number: 12, title: "Passing alpha cleanup", body: "Cleanup work", state: "open", merged: false, author: "alice", head: "cleanup-alpha", base: "main", additions: 5, deletions: 1, changedFiles: 1, checks: "success", updatedAt: "2026-05-14T16:00:00.000Z"),
             pull(number: 13, title: "Merged alpha docs", body: "Docs update", state: "closed", merged: true, author: "carol", head: "docs-alpha", base: "main", additions: 8, deletions: 0, changedFiles: 1, checks: "success", updatedAt: "2026-05-14T15:00:00.000Z", mergedAt: "2026-05-14T15:30:00.000Z", closedAt: "2026-05-14T15:30:00.000Z"),
             pull(number: 14, title: "Closed alpha experiment", body: "Abandoned experiment", state: "closed", merged: false, author: "bob", head: "experiment-alpha", base: "main", additions: 2, deletions: 2, changedFiles: 1, checks: "failure", updatedAt: "2026-05-14T14:00:00.000Z", closedAt: "2026-05-14T14:30:00.000Z"),
             pull(number: 15, title: "Searchable alpha design", body: "Find this design PR", state: "open", merged: false, author: "alice", head: "design-alpha", base: "main", additions: 12, deletions: 4, changedFiles: 2, checks: "success", updatedAt: "2026-05-14T13:00:00.000Z"),
         ]
+    }
+
+    private static var alphaPrimaryPull: [String: Any] {
+        pull(
+            number: 10,
+            title: "Fix failing alpha workflow",
+            body: pullCommentBodies.isEmpty ? "PR body with alpha details" : "PR body with alpha details\n\nLatest comment: \(pullCommentBodies.last ?? "")",
+            state: pullMerged ? "closed" : "open",
+            merged: pullMerged,
+            author: "alice",
+            head: "fix-alpha",
+            base: "main",
+            additions: 24,
+            deletions: 6,
+            changedFiles: 3,
+            checks: pullMerged ? "success" : "failure",
+            updatedAt: "2026-05-14T18:00:00.000Z",
+            mergedAt: pullMerged ? isoDate : nil,
+            closedAt: pullMerged ? isoDate : nil
+        )
     }
 
     private static var betaPulls: [[String: Any]] {
@@ -702,7 +761,14 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 ["filename": "Tests/AlphaTests.swift", "status": "added", "additions": 6, "deletions": 2],
             ],
             "linked_issue": issue(number: 1, title: detailIssueTitle, body: detailIssueBody, state: detailIssueState, labels: detailIssueLabels, assignees: detailIssueAssignees, author: "alice", updatedAt: isoDate),
-            "reviews": [
+            "reviews": basePullReviews + pullActionReviews,
+            "from_cache": false,
+            "cached_at": NSNull(),
+        ]
+    }
+
+    private static var basePullReviews: [[String: Any]] {
+        [
                 [
                     "id": 301,
                     "user": ["login": "bob", "avatar_url": "https://example.com/bob.png"],
@@ -710,9 +776,6 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                     "body": "Please fix the build.",
                     "submitted_at": "2026-05-14T18:05:00.000Z",
                 ],
-            ],
-            "from_cache": false,
-            "cached_at": NSNull(),
         ]
     }
 

--- a/apple/IssueCTLMac/Views/MacPullRequestsView.swift
+++ b/apple/IssueCTLMac/Views/MacPullRequestsView.swift
@@ -616,6 +616,10 @@ private struct MacPullRequestDetailView: View {
     @State private var detail: PullDetailResponse?
     @State private var isLoading = false
     @State private var errorMessage: String?
+    @State private var actionError: String?
+    @State private var successMessage: String?
+    @State private var isSubmittingAction = false
+    @State private var textAction: MacPullRequestTextAction?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -633,6 +637,22 @@ private struct MacPullRequestDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
                         MacPullRequestDetailHeader(detail: detail)
+                        if canMutate(detail.pull) {
+                            actionBar
+                        }
+                        if let successMessage {
+                            Label(successMessage, systemImage: "checkmark.circle")
+                                .font(.macSidebar(size: 12, weight: .semibold, scale: textScale))
+                                .foregroundStyle(.green)
+                                .accessibilityIdentifier("mac-pr-detail-success-message")
+                        }
+                        if let actionError {
+                            Text(actionError)
+                                .font(.macSidebar(size: 12, scale: textScale))
+                                .foregroundStyle(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .accessibilityIdentifier("mac-pr-detail-action-error")
+                        }
                         if let body = detail.pull.body, !body.isEmpty {
                             MacDetailSection(title: "Description", systemImage: "text.alignleft") {
                                 Text(body)
@@ -675,6 +695,16 @@ private struct MacPullRequestDetailView: View {
         }
         .frame(width: 560, height: 620)
         .task { await load(refresh: false) }
+        .sheet(item: $textAction) { action in
+            MacPullRequestTextActionSheet(action: action) { body in
+                switch action {
+                case .comment:
+                    return await submitComment(body)
+                case .requestChanges:
+                    return await submitReview(event: "REQUEST_CHANGES", body: body, successMessage: "Changes requested")
+                }
+            }
+        }
     }
 
     private var header: some View {
@@ -704,6 +734,63 @@ private struct MacPullRequestDetailView: View {
         .padding(14)
     }
 
+    private var actionBar: some View {
+        HStack(spacing: 8) {
+            Button {
+                textAction = .comment
+            } label: {
+                Label("Comment", systemImage: "bubble.left")
+            }
+            .controlSize(.small)
+            .accessibilityIdentifier("mac-pr-detail-comment-button")
+
+            Button {
+                Task { await approve() }
+            } label: {
+                if isSubmittingAction {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Approve", systemImage: "checkmark.circle")
+                }
+            }
+            .controlSize(.small)
+            .disabled(isSubmittingAction)
+            .accessibilityIdentifier("mac-pr-detail-approve-button")
+
+            Button {
+                textAction = .requestChanges
+            } label: {
+                Label("Request Changes", systemImage: "xmark.circle")
+            }
+            .controlSize(.small)
+            .accessibilityIdentifier("mac-pr-detail-request-changes-button")
+
+            Menu {
+                Button("Merge Commit") {
+                    Task { await merge(method: "merge", label: "Merge commit") }
+                }
+                .accessibilityIdentifier("mac-pr-detail-merge-merge-button")
+
+                Button("Squash and Merge") {
+                    Task { await merge(method: "squash", label: "Squash merge") }
+                }
+                .accessibilityIdentifier("mac-pr-detail-merge-squash-button")
+
+                Button("Rebase and Merge") {
+                    Task { await merge(method: "rebase", label: "Rebase merge") }
+                }
+                .accessibilityIdentifier("mac-pr-detail-merge-rebase-button")
+            } label: {
+                Label("Merge", systemImage: "arrow.triangle.merge")
+            }
+            .controlSize(.small)
+            .disabled(isSubmittingAction)
+            .accessibilityIdentifier("mac-pr-detail-merge-menu")
+        }
+        .font(.macSidebar(size: 12, scale: textScale))
+    }
+
     private func load(refresh: Bool) async {
         guard !isLoading else { return }
         isLoading = true
@@ -717,6 +804,89 @@ private struct MacPullRequestDetailView: View {
         }
     }
 
+    private func canMutate(_ pull: GitHubPull) -> Bool {
+        pull.isOpen && !pull.merged
+    }
+
+    private func approve() async {
+        await submitAction {
+            await submitReview(event: "APPROVE", body: nil, successMessage: "Pull request approved")
+        }
+    }
+
+    private func merge(method: String, label: String) async {
+        await submitAction {
+            do {
+                let response = try await api.mergePull(
+                    owner: item.repo.owner,
+                    repo: item.repo.name,
+                    number: item.pull.number,
+                    body: MergeRequestBody(mergeMethod: method)
+                )
+                guard response.success else {
+                    return response.error ?? "Failed to merge pull request"
+                }
+                successMessage = "\(label) complete"
+                await load(refresh: true)
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        }
+    }
+
+    private func submitAction(_ action: () async -> String?) async {
+        guard !isSubmittingAction else { return }
+        isSubmittingAction = true
+        actionError = nil
+        successMessage = nil
+        defer { isSubmittingAction = false }
+
+        if let error = await action() {
+            actionError = error
+        }
+    }
+
+    private func submitComment(_ body: String) async -> String? {
+        actionError = nil
+        successMessage = nil
+        do {
+            let response = try await api.commentOnPull(
+                owner: item.repo.owner,
+                repo: item.repo.name,
+                number: item.pull.number,
+                body: PullCommentRequestBody(body: body)
+            )
+            guard response.success else {
+                return response.error ?? "Failed to add comment"
+            }
+            successMessage = "Comment posted"
+            await load(refresh: true)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    private func submitReview(event: String, body: String?, successMessage: String) async -> String? {
+        do {
+            let response = try await api.reviewPull(
+                owner: item.repo.owner,
+                repo: item.repo.name,
+                number: item.pull.number,
+                body: ReviewRequestBody(event: event, body: body)
+            )
+            guard response.success else {
+                return response.error ?? "Failed to submit review"
+            }
+            self.successMessage = successMessage
+            await load(refresh: true)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
     private func detailRow(title: String, value: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(title)
@@ -727,6 +897,118 @@ private struct MacPullRequestDetailView: View {
                 .font(.macSidebar(size: 11, scale: textScale))
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
+        }
+    }
+}
+
+private enum MacPullRequestTextAction: String, Identifiable {
+    case comment
+    case requestChanges
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .comment: "Comment"
+        case .requestChanges: "Request Changes"
+        }
+    }
+
+    var placeholder: String {
+        switch self {
+        case .comment: "Add a pull request comment"
+        case .requestChanges: "Describe the required changes"
+        }
+    }
+
+    var submitTitle: String {
+        switch self {
+        case .comment: "Post Comment"
+        case .requestChanges: "Submit Review"
+        }
+    }
+
+    var accessibilityPrefix: String {
+        switch self {
+        case .comment: "mac-pr-comment"
+        case .requestChanges: "mac-pr-request-changes"
+        }
+    }
+}
+
+private struct MacPullRequestTextActionSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let action: MacPullRequestTextAction
+    let submit: (String) async -> String?
+
+    @State private var bodyText = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(action.title)
+                .font(.headline)
+
+            TextEditor(text: $bodyText)
+                .font(.body)
+                .frame(minHeight: 140)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.25))
+                )
+                .accessibilityIdentifier("\(action.accessibilityPrefix)-body-field")
+
+            if bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(action.placeholder)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("\(action.accessibilityPrefix)-error")
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                Button {
+                    Task { await submitBody() }
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text(action.submitTitle)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                .accessibilityIdentifier("\(action.accessibilityPrefix)-submit-button")
+            }
+        }
+        .padding(18)
+        .frame(width: 420)
+    }
+
+    private func submitBody() async {
+        guard !isSubmitting else { return }
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+
+        let trimmed = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let error = await submit(trimmed) {
+            errorMessage = error
+        } else {
+            dismiss()
         }
     }
 }

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -134,9 +134,68 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-file-Sources/Alpha.swift"].waitForExistence(timeout: 5), app.debugDescription)
         XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-review-301"].waitForExistence(timeout: 5), app.debugDescription)
         XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-linked-issue-1"].waitForExistence(timeout: 5), app.debugDescription)
-        XCTAssertFalse(app.buttons["Merge"].exists, app.debugDescription)
-        XCTAssertFalse(app.buttons["Approve"].exists, app.debugDescription)
         app.typeKey(.escape, modifierFlags: [])
+    }
+
+    func testPullRequestDetailActionsSucceedAndRefresh() {
+        selectRootSection("PRs")
+        openPullRequest(prRow("org/alpha", 10))
+
+        XCTAssertTrue(app.buttons["mac-pr-detail-comment-button"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-pr-detail-approve-button"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-pr-detail-request-changes-button"].waitForExistence(timeout: 5), app.debugDescription)
+        let mergeMenu = app.descendants(matching: .any)["mac-pr-detail-merge-menu"]
+        XCTAssertTrue(mergeMenu.waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-pr-detail-comment-button"].click()
+        let commentBody = app.textViews["mac-pr-comment-body-field"]
+        XCTAssertTrue(commentBody.waitForExistence(timeout: 5), app.debugDescription)
+        commentBody.click()
+        commentBody.typeText("Mac PR comment")
+        app.buttons["mac-pr-comment-submit-button"].click()
+        XCTAssertTrue(commentBody.waitForNonExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["mac-pr-detail-success-message"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-body"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-pr-detail-approve-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-review-401"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-pr-detail-request-changes-button"].click()
+        let requestChangesBody = app.textViews["mac-pr-request-changes-body-field"]
+        XCTAssertTrue(requestChangesBody.waitForExistence(timeout: 5), app.debugDescription)
+        requestChangesBody.click()
+        requestChangesBody.typeText("Please adjust the Mac implementation")
+        app.buttons["mac-pr-request-changes-submit-button"].click()
+        XCTAssertTrue(requestChangesBody.waitForNonExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-review-402"].waitForExistence(timeout: 5), app.debugDescription)
+
+        mergeMenu.click()
+        app.menuItems["Squash and Merge"].firstMatch.click()
+        XCTAssertTrue(app.staticTexts["mac-pr-detail-success-message"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-pr-detail-comment-button"].waitForNonExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["mac-pr-detail-approve-button"].exists, app.debugDescription)
+        XCTAssertFalse(app.buttons["mac-pr-detail-request-changes-button"].exists, app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-pr-detail-merge-menu"].exists, app.debugDescription)
+    }
+
+    func testPullRequestActionFailurePreservesTypedText() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_PULL_ACTION_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("PRs")
+        openPullRequest(prRow("org/alpha", 10))
+
+        app.buttons["mac-pr-detail-request-changes-button"].click()
+        let requestChangesBody = app.textViews["mac-pr-request-changes-body-field"]
+        XCTAssertTrue(requestChangesBody.waitForExistence(timeout: 5), app.debugDescription)
+        requestChangesBody.click()
+        requestChangesBody.typeText("Keep this review text")
+        app.buttons["mac-pr-request-changes-submit-button"].click()
+
+        XCTAssertTrue(app.staticTexts["mac-pr-request-changes-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(waitForValue(of: requestChangesBody, containing: "Keep this review text", timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-pr-request-changes-submit-button"].exists, app.debugDescription)
     }
 
     func testPullRequestFailuresAreRecoverableAndPreserveFilters() {

--- a/docs/goals/mac-ios-parity/notes/T041-phase-7b-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T041-phase-7b-branch-start.md
@@ -1,0 +1,7 @@
+# T041 Phase 7B Branch Start
+
+Started Phase 7B Mac PR detail actions on branch `mac-parity-phase-7b-pr-actions` from `mac-sidebar-spaces-option-a`.
+
+Planned PR base: `mac-sidebar-spaces-option-a`.
+
+Scope is limited to Mac PR detail actions: comment, approve, request changes, and merge methods.

--- a/docs/goals/mac-ios-parity/notes/T041-phase-7b-pr-actions.md
+++ b/docs/goals/mac-ios-parity/notes/T041-phase-7b-pr-actions.md
@@ -1,0 +1,31 @@
+# T041 Phase 7B PR Actions
+
+## Result
+
+Implemented Mac PR detail mutating actions for open, unmerged pull requests:
+
+- Comment sheet posts through the shared PR comment endpoint and refreshes the detail surface with a success message.
+- Approve posts an `APPROVE` review through the shared PR review endpoint and refreshes review rows.
+- Request Changes requires text, posts `REQUEST_CHANGES`, and preserves typed text plus an inline error on failure.
+- Merge menu supports merge commit, squash, and rebase methods through the shared PR merge endpoint.
+- Merged/closed PR details hide mutating actions after refresh.
+
+## Pull Request
+
+- PR: https://github.com/mean-weasel/issuectl/pull/435
+- Branch: `mac-parity-phase-7b-pr-actions`
+- Base: `mac-sidebar-spaces-option-a`
+
+## Validation
+
+- `git diff --check` passed.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` passed: 19 tests.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestDetailActionsSucceedAndRefresh -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestActionFailurePreservesTypedText` passed: 2 tests.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` passed: 24 tests.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed with existing warnings only.
+
+## Notes
+
+- The Mac UI test fixture now handles PR comment, review, and merge endpoints for `org/alpha#10`, including failure toggles for recoverability coverage.
+- The PR action UI remains scoped to the PR detail sheet; list-row actions and linked issue navigation are still excluded from this slice.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T041
+active_task: null
 
 tasks:
   - id: T001
@@ -2050,7 +2050,7 @@ tasks:
   - id: T041
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 7B Mac PR detail actions: comment, approve, request changes, and merge methods from the Mac PR detail sheet."
     inputs:
@@ -2093,7 +2093,37 @@ tasks:
       - "Shared PR action APIs require backend changes outside allowed files."
       - "Action UI needs broad Mac navigation changes outside the PR detail surface."
       - "Local validation fails twice for the same unexplained reason."
-    receipt: null
+    receipt:
+      result: done
+      note: "notes/T041-phase-7b-pr-actions.md"
+      pr:
+        number: 435
+        url: "https://github.com/mean-weasel/issuectl/pull/435"
+        branch: "mac-parity-phase-7b-pr-actions"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          tests: 19
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestDetailActionsSucceedAndRefresh -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestActionFailurePreservesTypedText"
+          status: pass
+          tests: 2
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          tests: 24
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          warnings: "Existing warnings only."
+      summary: "Implemented Mac PR detail actions for comment, approve, request changes, and merge methods with fixture-backed UI coverage for success, refresh, hidden actions after merge, and failure text preservation."
 
   - id: T999
     type: judge


### PR DESCRIPTION
## Summary
- Phase 7B: add Mac PR detail actions for comment, approve, request changes, and merge methods.
- Scope is limited to PR detail actions; list-row merge actions and linked issue navigation are deferred.
- Uses shared PR action APIs already present in the app and fixture-backed Mac UI coverage for success/failure paths.

## Acceptance Criteria
- Open PR detail exposes Comment, Approve, Request Changes, and Merge actions for open unmerged PRs.
- Comment action posts body through the shared PR comment endpoint and refreshes detail or shows success.
- Approve action posts an APPROVE review through the shared PR review endpoint and refreshes detail or shows success.
- Request Changes action requires text, posts REQUEST_CHANGES through the shared PR review endpoint, and preserves text on failure.
- Merge action supports merge, squash, and rebase methods through the shared PR merge endpoint.
- Failed PR actions show recoverable errors and preserve typed comment/request text.
- Closed or merged PRs do not expose mutating actions.

## Validation
- [x] `git diff --check`
- [x] `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` (19 tests)
- [x] `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestDetailActionsSucceedAndRefresh -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testPullRequestActionFailurePreservesTypedText` (2 tests)
- [x] `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7b-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (24 tests)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (passes with existing warnings)
