### PR TITLE
Mac parity phase 7C: linked PR issue navigation

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -409,6 +409,11 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 return ["error": "Fixture pull detail failed"]
             }
             return pullDetail()
+        case ("GET", "/api/v1/pulls/org/alpha/7"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_DETAIL_FAILURE"] == "1" {
+                return ["error": "Fixture pull detail failed"]
+            }
+            return pullDetail(pull: linkedAlphaPull)
         case ("POST", "/api/v1/pulls/org/alpha/10/comments"):
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_ACTION_FAILURE"] == "1"
                 || ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULL_COMMENT_FAILURE"] == "1" {
@@ -728,6 +733,24 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         )
     }
 
+    private static var linkedAlphaPull: [String: Any] {
+        pull(
+            number: 7,
+            title: "Fix alpha detail",
+            body: "Linked PR",
+            state: "open",
+            merged: false,
+            author: "alice",
+            head: "fix-alpha-detail",
+            base: "main",
+            additions: 12,
+            deletions: 3,
+            changedFiles: 2,
+            checks: "success",
+            updatedAt: isoDate
+        )
+    }
+
     private static var betaPulls: [[String: Any]] {
         [
             pull(number: 21, title: "Pending beta review", body: "Beta review work", state: "open", merged: false, author: "carol", head: "pending-beta", base: "main", additions: 7, deletions: 3, changedFiles: 2, checks: "pending", updatedAt: "2026-05-14T12:00:00.000Z", repo: "beta"),
@@ -735,9 +758,9 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
         ]
     }
 
-    private static func pullDetail() -> [String: Any] {
+    private static func pullDetail(pull: [String: Any] = alphaPulls[0]) -> [String: Any] {
         [
-            "pull": alphaPulls[0],
+            "pull": pull,
             "checks": [
                 [
                     "name": "build",

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -27,6 +27,7 @@ struct MacIssueDetailView: View {
     @State private var lightboxImage: MacLightboxImage?
     @State private var isShowingCloseWithComment = false
     @State private var commentPendingDeletion: GitHubComment?
+    @State private var selectedLinkedPullRequest: MacPullRequestListItem?
 
     private var issue: GitHubIssue {
         detail?.issue ?? item.issue
@@ -131,6 +132,9 @@ struct MacIssueDetailView: View {
                 }
             }
         }
+        .sheet(item: $selectedLinkedPullRequest) { pullRequest in
+            MacPullRequestDetailView(item: pullRequest, store: store)
+        }
         .sheet(item: $lightboxImage) { image in
             MacImageLightbox(url: image.url, altText: image.altText) {
                 lightboxImage = nil
@@ -196,6 +200,7 @@ struct MacIssueDetailView: View {
                 Image(systemName: "xmark")
             }
             .buttonStyle(.borderless)
+            .accessibilityIdentifier("mac-issue-detail-close-button")
             .help("Close")
         }
         .padding(.horizontal, 16)
@@ -551,20 +556,26 @@ struct MacIssueDetailView: View {
                     .font(.headline)
 
                 ForEach(linkedPRs) { pr in
-                    HStack(spacing: 8) {
-                        Image(systemName: pr.isOpen ? "arrow.triangle.merge" : (pr.merged ? "checkmark.circle.fill" : "xmark.circle"))
-                            .foregroundStyle(pr.isOpen ? .green : (pr.merged ? .purple : .red))
-                        Text("#\(pr.number)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(pr.title)
-                            .font(.subheadline)
-                            .lineLimit(1)
-                        Spacer()
-                        Text(pr.diffSummary)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    Button {
+                        selectedLinkedPullRequest = MacPullRequestListItem(pull: pr, repo: item.repo, repoIndex: item.repoIndex)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: pr.isOpen ? "arrow.triangle.merge" : (pr.merged ? "checkmark.circle.fill" : "xmark.circle"))
+                                .foregroundStyle(pr.isOpen ? .green : (pr.merged ? .purple : .red))
+                            Text("#\(pr.number)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(pr.title)
+                                .font(.subheadline)
+                                .lineLimit(1)
+                            Spacer()
+                            Text(pr.diffSummary)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                     .accessibilityIdentifier("mac-issue-detail-linked-pr-\(pr.number)")
                 }
             }

--- a/apple/IssueCTLMac/Views/MacPullRequestsView.swift
+++ b/apple/IssueCTLMac/Views/MacPullRequestsView.swift
@@ -281,7 +281,7 @@ struct MacPullRequestsView: View {
         .onChange(of: mineOnly) { _, _ in resetPaging() }
         .onChange(of: sortOrder) { _, _ in resetPaging() }
         .sheet(item: $selectedPull) { item in
-            MacPullRequestDetailView(item: item)
+            MacPullRequestDetailView(item: item, store: store)
         }
     }
 
@@ -605,13 +605,14 @@ private struct MacChecksStatusBadge: View {
     }
 }
 
-private struct MacPullRequestDetailView: View {
+struct MacPullRequestDetailView: View {
     @Environment(APIClient.self) private var api
     @Environment(\.openURL) private var openURL
     @Environment(\.dismiss) private var dismiss
     @Environment(\.macSidebarTextScale) private var textScale
 
     let item: MacPullRequestListItem
+    let store: MacSidebarStore
 
     @State private var detail: PullDetailResponse?
     @State private var isLoading = false
@@ -620,6 +621,7 @@ private struct MacPullRequestDetailView: View {
     @State private var successMessage: String?
     @State private var isSubmittingAction = false
     @State private var textAction: MacPullRequestTextAction?
+    @State private var selectedLinkedIssue: MacIssueListItem?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -683,8 +685,14 @@ private struct MacPullRequestDetailView: View {
                         }
                         if let issue = detail.linkedIssue {
                             MacDetailSection(title: "Linked Issue", systemImage: "link") {
-                                detailRow(title: "#\(issue.number)", value: issue.title)
-                                    .accessibilityIdentifier("mac-pr-detail-linked-issue-\(issue.number)")
+                                Button {
+                                    selectedLinkedIssue = MacIssueListItem(issue: issue, repo: item.repo, repoIndex: item.repoIndex)
+                                } label: {
+                                    detailRow(title: "#\(issue.number)", value: issue.title)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("mac-pr-detail-linked-issue-\(issue.number)")
                             }
                         }
                     }
@@ -704,6 +712,9 @@ private struct MacPullRequestDetailView: View {
                     return await submitReview(event: "REQUEST_CHANGES", body: body, successMessage: "Changes requested")
                 }
             }
+        }
+        .sheet(item: $selectedLinkedIssue) { issue in
+            MacIssueDetailView(item: issue, store: store)
         }
     }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -198,6 +198,31 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.buttons["mac-pr-request-changes-submit-button"].exists, app.debugDescription)
     }
 
+    func testLinkedIssueAndPullRequestDetailNavigation() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        let linkedPullRequest = app.descendants(matching: .any)["mac-issue-detail-linked-pr-7"]
+        XCTAssertTrue(linkedPullRequest.waitForExistence(timeout: 5), app.debugDescription)
+        linkedPullRequest.click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-title"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Fix alpha detail"].waitForExistence(timeout: 5), app.debugDescription)
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(app.descendants(matching: .any)["mac-pr-detail-title"].waitForNonExistence(timeout: 5), app.debugDescription)
+
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(app.buttons["mac-issue-detail-edit-button"].waitForNonExistence(timeout: 5), app.debugDescription)
+        selectRootSection("PRs")
+        openPullRequest(prRow("org/alpha", 10))
+
+        let linkedIssue = app.descendants(matching: .any)["mac-pr-detail-linked-issue-1"]
+        XCTAssertTrue(linkedIssue.waitForExistence(timeout: 5), app.debugDescription)
+        linkedIssue.click()
+        XCTAssertTrue(app.buttons["mac-issue-detail-edit-button"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Open alpha issue"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testPullRequestFailuresAreRecoverableAndPreserveFilters() {
         app.terminate()
         app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_BETA_PULLS_FAILURE"] = "1"

--- a/docs/goals/mac-ios-parity/notes/T043-next-phase-7c-slice.md
+++ b/docs/goals/mac-ios-parity/notes/T043-next-phase-7c-slice.md
@@ -1,0 +1,25 @@
+# T043 Phase 7C Slice Decision
+
+Decision: approved.
+
+Next worker: T044.
+
+Scope: finish the remaining Phase 7 linked-navigation acceptance gap before moving to Phase 8. The PR should let a user open a linked issue from PR detail and open a linked PR from issue detail, preserving the current repo context and using existing shared API detail endpoints.
+
+Branch strategy:
+- integration branch: mac-sidebar-spaces-option-a
+- worker branch: mac-parity-phase-7c-linked-navigation
+- PR base: mac-sidebar-spaces-option-a
+
+Allowed files:
+- apple/IssueCTLMac/Views/MacPullRequestsView.swift
+- apple/IssueCTLMac/Views/MacIssueDetailView.swift
+- apple/IssueCTLMac/App/IssueCTLMacApp.swift
+- apple/IssueCTLMacUITests/**
+- docs/goals/mac-ios-parity/**
+
+Verification:
+- git diff --check
+- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests
+- pnpm typecheck
+- pnpm lint

--- a/docs/goals/mac-ios-parity/notes/T044-phase-7c-linked-navigation.md
+++ b/docs/goals/mac-ios-parity/notes/T044-phase-7c-linked-navigation.md
@@ -1,0 +1,22 @@
+# T044 Phase 7C Linked Navigation Receipt
+
+Result: done.
+
+PR: https://github.com/mean-weasel/issuectl/pull/436
+
+Implemented:
+- Mac issue detail linked PR rows now open the Mac PR detail sheet for the linked PR.
+- Mac PR detail linked issue rows now open the Mac issue detail sheet for the linked issue.
+- Linked navigation preserves the current repo context.
+- The Mac UI fixture now serves linked PR #7 detail.
+- `MacSidebarSmokeTests` covers both linked navigation directions.
+
+Validation:
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testLinkedIssueAndPullRequestDetailNavigation` passed, 1 test.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` passed, 25 tests.
+- `git diff --check` passed.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed with existing warnings only.
+
+Notes:
+- During UI test development, nested detail sheets opened far enough to the right that close buttons were not reliably hittable on this display. The test now dismisses nested sheets via Escape, matching the existing PR detail cancel shortcut and avoiding coordinate-sensitive clicks.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T044
+active_task: null
 
 tasks:
   - id: T001
@@ -2240,7 +2240,35 @@ tasks:
       - "Linked navigation requires backend or model changes outside allowed files."
       - "Nested sheet behavior is unreliable and needs a broader Mac navigation redesign."
       - "Local validation fails twice for the same unexplained reason."
-    receipt: null
+    receipt:
+      result: done
+      note: "notes/T044-phase-7c-linked-navigation.md"
+      pr:
+        number: 436
+        url: "https://github.com/mean-weasel/issuectl/pull/436"
+        branch: "mac-parity-phase-7c-linked-navigation"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      commands:
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testLinkedIssueAndPullRequestDetailNavigation"
+          status: pass
+          tests: 1
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          tests: 25
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          warnings: "Existing warnings only."
+      summary: "Implemented Mac linked navigation from issue detail linked PRs into PR detail and from PR detail linked issues into issue detail, using current repo context and fixture-backed UI coverage for both directions."
 
   - id: T999
     type: judge

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: null
+active_task: T044
 
 tasks:
   - id: T001
@@ -2162,6 +2162,85 @@ tasks:
           - "pnpm typecheck"
           - "pnpm lint with existing warnings only"
       summary: "Marked PR #435 ready, confirmed no GitHub checks were configured, and merged Phase 7B Mac PR detail actions into mac-sidebar-spaces-option-a."
+
+  - id: T043
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose the next safe Mac iOS parity slice after Phase 7B PR detail actions have merged."
+    inputs:
+      - "T041 receipt"
+      - "T042 receipt"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+      - "Current integration branch mac-sidebar-spaces-option-a"
+    constraints:
+      - "Do not implement."
+      - "Prefer finishing the remaining Phase 7 acceptance gap before moving to Phase 8."
+      - "Define branch/base, allowed files, verification commands, and stop_if conditions for the next Worker."
+    expected_output:
+      - "Decision: approved | blocked | revise_plan."
+      - "Next Worker objective."
+      - "PR branch/base strategy."
+      - "Allowed files and verification commands."
+      - "Risks or excluded follow-up scope."
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      note: "notes/T043-next-phase-7c-slice.md"
+      next_worker: T044
+      worker_objective: "Implement Phase 7C linked navigation between Mac PR detail linked issues and Mac issue detail linked PRs."
+      branch_strategy:
+        integration_branch: "mac-sidebar-spaces-option-a"
+        worker_branch: "mac-parity-phase-7c-linked-navigation"
+        worker_pr_base: "mac-sidebar-spaces-option-a"
+      allowed_files_for_t044:
+        - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacUITests/**"
+        - "docs/goals/mac-ios-parity/**"
+      summary: "Selected the remaining Phase 7 linked navigation gap as a bounded PR before advancing to Phase 8."
+
+  - id: T044
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: high
+    objective: "Implement Phase 7C linked navigation between Mac PR detail linked issues and Mac issue detail linked PRs."
+    inputs:
+      - "T043 receipt"
+      - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+      - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+    constraints:
+      - "Start from a new branch off mac-sidebar-spaces-option-a and open a draft PR before implementation."
+      - "Keep navigation Mac-native and sheet-based unless existing code already provides a better local pattern."
+      - "Do not add new backend endpoints."
+      - "Record branch, PR URL, validation, CI/check status, and merge readiness in the receipt."
+    allowed_files:
+      - "apple/IssueCTLMac/Views/MacPullRequestsView.swift"
+      - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLMacUITests/**"
+      - "docs/goals/mac-ios-parity/**"
+    acceptance:
+      - "Clicking a PR detail linked issue opens the Mac issue detail for that linked issue."
+      - "Clicking an issue detail linked PR opens the Mac PR detail for that linked PR."
+      - "Linked navigation uses the same repo context as the current detail view."
+      - "Fixture-backed UI coverage confirms both navigation directions."
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "pnpm typecheck"
+      - "pnpm lint"
+    stop_if:
+      - "Linked navigation requires backend or model changes outside allowed files."
+      - "Nested sheet behavior is unreliable and needs a broader Mac navigation redesign."
+      - "Local validation fails twice for the same unexplained reason."
+    receipt: null
 
   - id: T999
     type: judge


### PR DESCRIPTION
## Summary\n- Wire linked issue navigation from Mac PR detail into Mac issue detail\n- Wire linked PR navigation from Mac issue detail into Mac PR detail\n- Add fixture-backed UI coverage for both directions\n\n## Validation\n- [x] xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testLinkedIssueAndPullRequestDetailNavigation\n- [x] xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase7c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests (25 tests)\n- [x] git diff --check\n- [x] pnpm typecheck\n- [x] pnpm lint (existing warnings only)\n\n## CI\nNo GitHub checks are currently reported for this branch; local validation above is the merge gate evidence.