### PR TITLE
Mac parity phase 8A: launch options

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -268,7 +268,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 ["owner": "org", "name": "gamma", "private": true, "pushed_at": isoDate],
             ], "synced_at": 1_775_000_000, "is_stale": false]
         case ("GET", "/api/v1/deployments"):
-            return ["deployments": [
+            return ["deployments": launchedDeployments + [
                 [
                     "id": 2,
                     "repo_id": 1,
@@ -286,6 +286,24 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                     "repo_name": "alpha",
                 ],
             ]]
+        case ("POST", "/api/v1/launch/org/alpha/1"):
+            let payload = jsonBody(from: request)
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CUSTOM_LAUNCH"] == "1" {
+                let selectedComments = payload["selectedCommentIndices"] as? [Int] ?? []
+                let selectedFiles = payload["selectedFilePaths"] as? [String] ?? []
+                guard payload["agent"] as? String == "claude",
+                      payload["workspaceMode"] as? String == "clone",
+                      payload["branchName"] as? String == "custom-mac-launch",
+                      selectedComments == [0],
+                      selectedFiles == ["Sources/Alpha.swift"],
+                      payload["preamble"] as? String == "Custom Mac preamble",
+                      payload["forceResume"] as? Bool == true else {
+                    return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture custom launch assertion failed", "label_warning": NSNull()]
+                }
+            }
+            let deploymentId = 700 + launchedDeployments.count
+            launchedDeployments.append(launchedDeployment(id: deploymentId, payload: payload))
+            return ["success": true, "deployment_id": deploymentId, "ttyd_port": NSNull(), "error": NSNull(), "label_warning": NSNull()]
         case ("GET", "/api/v1/sessions/previews"):
             return ["previews": []]
         case ("POST", "/api/v1/parse"):
@@ -601,6 +619,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var pullCommentBodies: [String] = []
     nonisolated(unsafe) private static var pullMerged = false
     nonisolated(unsafe) private static var pullMergeMethod: String?
+    nonisolated(unsafe) private static var launchedDeployments: [[String: Any]] = []
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),
@@ -910,9 +929,28 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                     "checks_status": "success",
                 ],
             ],
-            "referencedFiles": [],
+            "referencedFiles": ["Sources/Alpha.swift"],
             "fromCache": false,
             "cachedAt": NSNull(),
+        ]
+    }
+
+    private static func launchedDeployment(id: Int, payload: [String: Any]) -> [String: Any] {
+        [
+            "id": id,
+            "repo_id": 1,
+            "issue_number": 1,
+            "branch_name": payload["branchName"] as? String ?? "issue-1-open-alpha-issue",
+            "workspace_mode": payload["workspaceMode"] as? String ?? "worktree",
+            "workspace_path": "/tmp/issuectl-launch-\(id)",
+            "linked_pr_number": NSNull(),
+            "state": "active",
+            "launched_at": isoDate,
+            "ended_at": NSNull(),
+            "ttyd_port": NSNull(),
+            "ttyd_pid": 3210 + id,
+            "owner": "org",
+            "repo_name": "alpha",
         ]
     }
 

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -28,6 +28,7 @@ struct MacIssueDetailView: View {
     @State private var isShowingCloseWithComment = false
     @State private var commentPendingDeletion: GitHubComment?
     @State private var selectedLinkedPullRequest: MacPullRequestListItem?
+    @State private var isShowingLaunchOptions = false
 
     private var issue: GitHubIssue {
         detail?.issue ?? item.issue
@@ -134,6 +135,16 @@ struct MacIssueDetailView: View {
         }
         .sheet(item: $selectedLinkedPullRequest) { pullRequest in
             MacPullRequestDetailView(item: pullRequest, store: store)
+        }
+        .sheet(isPresented: $isShowingLaunchOptions) {
+            MacLaunchOptionsSheet(
+                item: item,
+                detail: detail,
+                initialOptions: MacIssueLaunchOptions.defaults(for: item, detail: detail, settings: nil)
+            ) { options in
+                await launchIssue(options: options, openTerminalWhenReady: true)
+            }
+            .environment(api)
         }
         .sheet(item: $lightboxImage) { image in
             MacImageLightbox(url: image.url, altText: image.altText) {
@@ -255,6 +266,7 @@ struct MacIssueDetailView: View {
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-issue-detail-error-message")
             }
 
             if let successMessage {
@@ -298,18 +310,30 @@ struct MacIssueDetailView: View {
                     .buttonStyle(.borderedProminent)
                     .disabled(activeSession.ttydPort == nil)
                 } else {
-                    Button {
-                        Task { await launchIssue() }
-                    } label: {
-                        if isLaunching {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Label("Launch", systemImage: "play.fill")
+                    HStack(spacing: 8) {
+                        Button {
+                            Task { await launchIssue(options: nil, openTerminalWhenReady: true) }
+                        } label: {
+                            if isLaunching {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Label("Launch", systemImage: "play.fill")
+                            }
                         }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isLaunching || !issue.isOpen)
+                        .accessibilityIdentifier("mac-issue-detail-launch-button")
+
+                        Button {
+                            isShowingLaunchOptions = true
+                        } label: {
+                            Label("Options", systemImage: "slider.horizontal.3")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isLaunching || !issue.isOpen)
+                        .accessibilityIdentifier("mac-issue-detail-launch-options-button")
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isLaunching || !issue.isOpen)
                 }
             }
             .padding(10)
@@ -730,15 +754,16 @@ struct MacIssueDetailView: View {
         }
     }
 
-    private func launchIssue() async {
+    private func launchIssue(options: MacIssueLaunchOptions?, openTerminalWhenReady: Bool) async {
         isLaunching = true
         errorMessage = nil
         defer { isLaunching = false }
 
         do {
-            let session = try await store.launchIssue(api: api, item: item, detail: detail)
+            let session = try await store.launchIssue(api: api, item: item, detail: detail, options: options)
             activeSession = session
-            if session.ttydPort != nil {
+            isShowingLaunchOptions = false
+            if openTerminalWhenReady, session.ttydPort != nil {
                 await openTerminalAsync(session)
             }
         } catch {
@@ -803,6 +828,287 @@ private enum MacIssueDetailSheet: Identifiable {
         case .reassign:
             "reassign"
         }
+    }
+}
+
+private struct MacLaunchOptionsSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let item: MacIssueListItem
+    let detail: IssueDetailResponse?
+    let submit: (MacIssueLaunchOptions) async -> Void
+
+    @State private var options: MacIssueLaunchOptions
+    @State private var isSubmitting = false
+
+    init(
+        item: MacIssueListItem,
+        detail: IssueDetailResponse?,
+        initialOptions: MacIssueLaunchOptions,
+        submit: @escaping (MacIssueLaunchOptions) async -> Void
+    ) {
+        self.item = item
+        self.detail = detail
+        self.submit = submit
+        _options = State(initialValue: initialOptions)
+    }
+
+    private var comments: [GitHubComment] {
+        detail?.comments ?? []
+    }
+
+    private var referencedFiles: [String] {
+        detail?.referencedFiles ?? []
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    agentSection
+                    workspaceSection
+                    branchSection
+                    resumeSection
+                    commentsSection
+                    filesSection
+                    preambleSection
+                }
+                .padding(16)
+            }
+
+            Divider()
+            footer
+        }
+        .frame(width: 520, height: 620)
+        .task { await loadSavedAgent() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Launch Options")
+                .font(.headline)
+            Text("\(item.repoFullName)#\(item.issue.number)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+    }
+
+    private var agentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Agent")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Picker("Agent", selection: $options.agent) {
+                ForEach(LaunchAgent.allCases) { agent in
+                    Text(agent.displayName).tag(agent)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("mac-launch-options-agent-picker")
+        }
+    }
+
+    private var workspaceSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Workspace")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Picker("Workspace", selection: $options.workspaceMode) {
+                Text("Worktree").tag(WorkspaceMode.worktree)
+                Text("Existing").tag(WorkspaceMode.existing)
+                Text("Clone").tag(WorkspaceMode.clone)
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("mac-launch-options-workspace-picker")
+
+            if item.repo.localPath?.isEmpty != false, options.workspaceMode == .worktree {
+                Label("This repo has no local path; clone mode is usually safer.", systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-launch-options-workspace-warning")
+            }
+        }
+    }
+
+    private var branchSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Branch")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextField("Branch name", text: $options.branchName)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .accessibilityIdentifier("mac-launch-options-branch-field")
+        }
+    }
+
+    private var resumeSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Existing Changes")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Picker("Existing changes", selection: $options.resumeBehavior) {
+                ForEach(MacLaunchResumeBehavior.allCases) { behavior in
+                    Text(behavior.title).tag(behavior)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("mac-launch-options-resume-picker")
+        }
+    }
+
+    @ViewBuilder
+    private var commentsSection: some View {
+        if !comments.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Comments")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button(options.selectedCommentIndices.count == comments.count ? "Clear" : "All") {
+                        if options.selectedCommentIndices.count == comments.count {
+                            options.selectedCommentIndices.removeAll()
+                        } else {
+                            options.selectedCommentIndices = Set(comments.indices)
+                        }
+                    }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("mac-launch-options-comments-toggle-all")
+                }
+
+                ForEach(Array(comments.enumerated()), id: \.offset) { index, comment in
+                    Toggle(isOn: commentBinding(index)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(comment.user?.login ?? "Unknown")
+                                .font(.caption.weight(.medium))
+                            Text(comment.body)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    .toggleStyle(.checkbox)
+                    .accessibilityIdentifier("mac-launch-options-comment-\(index)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var filesSection: some View {
+        if !referencedFiles.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Files")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button(options.selectedFilePaths.count == referencedFiles.count ? "Clear" : "All") {
+                        if options.selectedFilePaths.count == referencedFiles.count {
+                            options.selectedFilePaths.removeAll()
+                        } else {
+                            options.selectedFilePaths = Set(referencedFiles)
+                        }
+                    }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("mac-launch-options-files-toggle-all")
+                }
+
+                ForEach(referencedFiles, id: \.self) { filePath in
+                    Toggle(filePath, isOn: fileBinding(filePath))
+                        .toggleStyle(.checkbox)
+                        .font(.caption.monospaced())
+                        .accessibilityIdentifier("mac-launch-options-file-\(filePath)")
+                }
+            }
+        }
+    }
+
+    private var preambleSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preamble")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextEditor(text: $options.preamble)
+                .frame(minHeight: 90)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.25))
+                )
+                .accessibilityIdentifier("mac-launch-options-preamble-field")
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Cancel") {
+                dismiss()
+            }
+            .accessibilityIdentifier("mac-launch-options-cancel-button")
+
+            Button {
+                Task { await submitOptions() }
+            } label: {
+                if isSubmitting {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Launch", systemImage: "play.fill")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isSubmitting || options.branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityIdentifier("mac-launch-options-submit-button")
+        }
+        .padding(16)
+    }
+
+    private func commentBinding(_ index: Int) -> Binding<Bool> {
+        Binding(
+            get: { options.selectedCommentIndices.contains(index) },
+            set: { isSelected in
+                if isSelected {
+                    options.selectedCommentIndices.insert(index)
+                } else {
+                    options.selectedCommentIndices.remove(index)
+                }
+            }
+        )
+    }
+
+    private func fileBinding(_ filePath: String) -> Binding<Bool> {
+        Binding(
+            get: { options.selectedFilePaths.contains(filePath) },
+            set: { isSelected in
+                if isSelected {
+                    options.selectedFilePaths.insert(filePath)
+                } else {
+                    options.selectedFilePaths.remove(filePath)
+                }
+            }
+        )
+    }
+
+    private func loadSavedAgent() async {
+        guard options.agent == .claude else { return }
+        if let settings = try? await api.getSettings() {
+            options.agent = LaunchAgent.settingValue(settings["launch_agent"])
+        }
+    }
+
+    private func submitOptions() async {
+        guard !isSubmitting else { return }
+        isSubmitting = true
+        await submit(options)
+        isSubmitting = false
     }
 }
 

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -329,26 +329,25 @@ final class MacSidebarStore {
         }
     }
 
-    func launchIssue(api: APIClient, item: MacIssueListItem, detail: IssueDetailResponse?) async throws -> ActiveDeployment {
+    func launchIssue(
+        api: APIClient,
+        item: MacIssueListItem,
+        detail: IssueDetailResponse?,
+        options providedOptions: MacIssueLaunchOptions? = nil
+    ) async throws -> ActiveDeployment {
         await refreshSessions(api: api)
         if let existing = activeSession(for: item) {
             return existing
         }
 
-        let settings = try? await api.getSettings()
-        let agent = LaunchAgent.settingValue(settings?["launch_agent"])
-        let branchName = generateBranchName(issueNumber: item.issue.number, issueTitle: item.issue.title)
-        let workspaceMode: WorkspaceMode = item.repo.localPath?.isEmpty == false ? .worktree : .clone
-        let body = LaunchRequestBody(
-            agent: agent,
-            branchName: branchName,
-            workspaceMode: workspaceMode,
-            selectedCommentIndices: [],
-            selectedFilePaths: [],
-            preamble: nil,
-            forceResume: nil,
-            idempotencyKey: UUID().uuidString
-        )
+        let options: MacIssueLaunchOptions
+        if let providedOptions {
+            options = providedOptions
+        } else {
+            let settings = try? await api.getSettings()
+            options = MacIssueLaunchOptions.defaults(for: item, detail: detail, settings: settings)
+        }
+        let body = options.requestBody(idempotencyKey: UUID().uuidString)
 
         let response = try await api.launch(
             owner: item.repo.owner,
@@ -365,8 +364,8 @@ final class MacSidebarStore {
             id: deploymentId,
             repoId: item.repo.id,
             issueNumber: item.issue.number,
-            branchName: branchName,
-            workspaceMode: workspaceMode,
+            branchName: options.branchName,
+            workspaceMode: options.workspaceMode,
             workspacePath: "",
             linkedPrNumber: nil,
             state: .active,
@@ -422,6 +421,77 @@ final class MacSidebarStore {
         issues.sort { lhs, rhs in
             (lhs.issue.updatedDate ?? .distantPast) > (rhs.issue.updatedDate ?? .distantPast)
         }
+    }
+}
+
+enum MacLaunchResumeBehavior: String, CaseIterable, Identifiable {
+    case automatic
+    case resume
+    case reset
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .automatic: "Auto"
+        case .resume: "Resume"
+        case .reset: "Reset"
+        }
+    }
+
+    var forceResume: Bool? {
+        switch self {
+        case .automatic: nil
+        case .resume: true
+        case .reset: false
+        }
+    }
+
+    static func behavior(forceResume: Bool?) -> MacLaunchResumeBehavior {
+        switch forceResume {
+        case true: .resume
+        case false: .reset
+        case nil: .automatic
+        }
+    }
+}
+
+struct MacIssueLaunchOptions: Equatable {
+    var agent: LaunchAgent
+    var branchName: String
+    var workspaceMode: WorkspaceMode
+    var selectedCommentIndices: Set<Int>
+    var selectedFilePaths: Set<String>
+    var preamble: String
+    var resumeBehavior: MacLaunchResumeBehavior
+
+    static func defaults(
+        for item: MacIssueListItem,
+        detail: IssueDetailResponse?,
+        settings: [String: String]?
+    ) -> MacIssueLaunchOptions {
+        MacIssueLaunchOptions(
+            agent: LaunchAgent.settingValue(settings?["launch_agent"]),
+            branchName: generateBranchName(issueNumber: item.issue.number, issueTitle: item.issue.title),
+            workspaceMode: item.repo.localPath?.isEmpty == false ? .worktree : .clone,
+            selectedCommentIndices: [],
+            selectedFilePaths: [],
+            preamble: "",
+            resumeBehavior: .automatic
+        )
+    }
+
+    func requestBody(idempotencyKey: String?) -> LaunchRequestBody {
+        LaunchRequestBody(
+            agent: agent,
+            branchName: branchName,
+            workspaceMode: workspaceMode,
+            selectedCommentIndices: selectedCommentIndices.sorted(),
+            selectedFilePaths: selectedFilePaths.sorted(),
+            preamble: preamble.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : preamble,
+            forceResume: resumeBehavior.forceResume,
+            idempotencyKey: idempotencyKey
+        )
     }
 }
 

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -307,6 +307,58 @@ final class MacIssueFilterStateTests: XCTestCase {
         ])
     }
 
+    func testMacLaunchOptionsDefaultsUseSettingsLocalPathAndGeneratedBranch() {
+        let repo = Repo(
+            id: 1,
+            owner: "mean-weasel",
+            name: "issuectl",
+            localPath: "/tmp/issuectl",
+            branchPattern: nil,
+            createdAt: "2026-01-01T00:00:00Z"
+        )
+        let item = item(
+            number: 42,
+            repo: repo,
+            title: "Fix launch options",
+            state: "open",
+            assignees: [],
+            author: user("alice"),
+            updatedAt: "2026-05-14T10:00:00.000Z"
+        )
+
+        let options = MacIssueLaunchOptions.defaults(for: item, detail: nil, settings: ["launch_agent": "codex"])
+
+        XCTAssertEqual(options.agent, .codex)
+        XCTAssertEqual(options.workspaceMode, .worktree)
+        XCTAssertEqual(options.branchName, generateBranchName(issueNumber: 42, issueTitle: "Fix launch options"))
+        XCTAssertTrue(options.selectedCommentIndices.isEmpty)
+        XCTAssertTrue(options.selectedFilePaths.isEmpty)
+        XCTAssertEqual(options.resumeBehavior, .automatic)
+    }
+
+    func testMacLaunchOptionsBuildRequestBodyWithExplicitChoices() {
+        let options = MacIssueLaunchOptions(
+            agent: .claude,
+            branchName: "custom-mac-launch",
+            workspaceMode: .clone,
+            selectedCommentIndices: [2, 0],
+            selectedFilePaths: ["Sources/Beta.swift", "Sources/Alpha.swift"],
+            preamble: "Custom Mac preamble",
+            resumeBehavior: .resume
+        )
+
+        let body = options.requestBody(idempotencyKey: "launch-id")
+
+        XCTAssertEqual(body.agent, .claude)
+        XCTAssertEqual(body.branchName, "custom-mac-launch")
+        XCTAssertEqual(body.workspaceMode, .clone)
+        XCTAssertEqual(body.selectedCommentIndices, [0, 2])
+        XCTAssertEqual(body.selectedFilePaths, ["Sources/Alpha.swift", "Sources/Beta.swift"])
+        XCTAssertEqual(body.preamble, "Custom Mac preamble")
+        XCTAssertEqual(body.forceResume, true)
+        XCTAssertEqual(body.idempotencyKey, "launch-id")
+    }
+
     private var repos: [Repo] {
         [
             repo(id: 1, owner: "mean-weasel", name: "issuectl"),

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -223,6 +223,53 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Open alpha issue"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testDefaultIssueLaunchUsesExistingOneClickFlow() {
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        let launchButton = app.buttons["mac-issue-detail-launch-button"]
+        XCTAssertTrue(launchButton.waitForExistence(timeout: 5), app.debugDescription)
+        launchButton.click()
+
+        XCTAssertTrue(app.staticTexts["Session Starting"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["issue-1-open-alpha-issue - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testCustomIssueLaunchOptionsBuildLaunchRequest() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CUSTOM_LAUNCH"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        let branchField = app.textFields["mac-launch-options-branch-field"]
+        XCTAssertTrue(branchField.waitForExistence(timeout: 5), app.debugDescription)
+
+        app.descendants(matching: .any)["mac-launch-options-agent-picker"].radioButtons["Claude Code"].click()
+        app.descendants(matching: .any)["mac-launch-options-workspace-picker"].radioButtons["Clone"].click()
+        app.descendants(matching: .any)["mac-launch-options-resume-picker"].radioButtons["Resume"].click()
+
+        branchField.click()
+        branchField.typeKey("a", modifierFlags: .command)
+        branchField.typeText("custom-mac-launch")
+
+        app.checkBoxes["mac-launch-options-comment-0"].click()
+        app.checkBoxes["mac-launch-options-file-Sources/Alpha.swift"].click()
+
+        let preamble = app.textViews["mac-launch-options-preamble-field"]
+        XCTAssertTrue(preamble.waitForExistence(timeout: 5), app.debugDescription)
+        preamble.click()
+        preamble.typeText("Custom Mac preamble")
+
+        app.buttons["mac-launch-options-submit-button"].click()
+        XCTAssertTrue(app.staticTexts["custom-mac-launch - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
     func testPullRequestFailuresAreRecoverableAndPreserveFilters() {
         app.terminate()
         app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_BETA_PULLS_FAILURE"] = "1"

--- a/docs/goals/mac-ios-parity/notes/T046-next-phase-8a-slice.md
+++ b/docs/goals/mac-ios-parity/notes/T046-next-phase-8a-slice.md
@@ -1,0 +1,32 @@
+# T046 Phase 8A Slice Decision
+
+Decision: approved.
+
+Next worker: T047.
+
+Scope: implement the first Phase 8 launch parity slice by adding a Mac launch options sheet and request-construction path. Keep the existing one-click launch behavior intact while allowing explicit launch agent, workspace mode, branch name, selected comments, selected files, preamble, and resume behavior.
+
+Branch strategy:
+- integration branch: `mac-sidebar-spaces-option-a`
+- worker branch: `mac-parity-phase-8a-launch-options`
+- PR base: `mac-sidebar-spaces-option-a`
+
+Excluded follow-up scope:
+- Embedded terminal window and terminal controls.
+- Active sessions search, repo filters, polling, and terminal preview.
+- Dirty worktree backend checks if they require routes not already exposed to the Mac app.
+
+Allowed files:
+- `apple/IssueCTLMac/Views/MacIssueDetailView.swift`
+- `apple/IssueCTLMac/Views/MacSidebarStore.swift`
+- `apple/IssueCTLMac/App/IssueCTLMacApp.swift`
+- `apple/IssueCTLMacTests/**`
+- `apple/IssueCTLMacUITests/**`
+- `docs/goals/mac-ios-parity/**`
+
+Validation:
+- `git diff --check`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`
+- `pnpm typecheck`
+- `pnpm lint`

--- a/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
+++ b/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
@@ -5,8 +5,7 @@ Result: done.
 Branch: `mac-parity-phase-8a-launch-options`
 Base: `mac-sidebar-spaces-option-a`
 PR: https://github.com/mean-weasel/issuectl/pull/437
-Head: `9df754c1118de5b75dc6acb08c4e1f6d171bdd98`
-PR state: ready for review, mergeable, no GitHub status checks reported.
+PR state: ready for review, mergeable, no GitHub status checks reported on the pushed PR head.
 
 Implemented the first Phase 8 launch parity slice for the Mac app. The issue detail view keeps the existing one-click Launch button and adds a launch options sheet for open issues without active sessions. The sheet lets the user choose agent, workspace mode, branch name, selected comments, referenced files, preamble text, and automatic/resume/reset behavior.
 

--- a/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
+++ b/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
@@ -1,0 +1,41 @@
+# T047 Phase 8A Launch Options
+
+Result: done.
+
+Branch: `mac-parity-phase-8a-launch-options`
+Base: `mac-sidebar-spaces-option-a`
+PR: https://github.com/mean-weasel/issuectl/pull/437
+
+Implemented the first Phase 8 launch parity slice for the Mac app. The issue detail view keeps the existing one-click Launch button and adds a launch options sheet for open issues without active sessions. The sheet lets the user choose agent, workspace mode, branch name, selected comments, referenced files, preamble text, and automatic/resume/reset behavior.
+
+The launch store now accepts optional `MacIssueLaunchOptions`, converts them into the existing shared `LaunchRequestBody`, and still refreshes active sessions before launch so an existing active session is returned instead of creating a duplicate deployment.
+
+Changed files:
+
+- `apple/IssueCTLMac/Views/MacIssueDetailView.swift`
+- `apple/IssueCTLMac/Views/MacSidebarStore.swift`
+- `apple/IssueCTLMac/App/IssueCTLMacApp.swift`
+- `apple/IssueCTLMacTests/MacIssueFilterStateTests.swift`
+- `apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift`
+- `docs/goals/mac-ios-parity/state.yaml`
+
+Acceptance evidence:
+
+- Existing default Launch path is covered by `testDefaultIssueLaunchUsesExistingOneClickFlow`.
+- Custom options request construction is covered by `testCustomIssueLaunchOptionsBuildLaunchRequest`, with the fixture server asserting the posted JSON payload.
+- Launch option defaults and request body sorting/fields are covered by `testMacLaunchOptionsDefaultsUseSettingsLocalPathAndGeneratedBranch` and `testMacLaunchOptionsBuildRequestBodyWithExplicitChoices`.
+- Active-session duplicate prevention remains in `MacSidebarStore.launchIssue` before request construction.
+
+Validation:
+
+- `git diff --check`: pass.
+- `pnpm typecheck`: pass.
+- `pnpm lint`: pass with pre-existing warnings.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 21 tests.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 27 tests.
+
+Excluded follow-up scope:
+
+- Embedded terminal window and controls.
+- Active sessions search/repo filters and polling.
+- Dirty worktree readiness checks.

--- a/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
+++ b/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
@@ -5,7 +5,7 @@ Result: done.
 Branch: `mac-parity-phase-8a-launch-options`
 Base: `mac-sidebar-spaces-option-a`
 PR: https://github.com/mean-weasel/issuectl/pull/437
-Head: `3459f29fc4966adc31047e161b07629fa275a2ea`
+Head: `9df754c1118de5b75dc6acb08c4e1f6d171bdd98`
 PR state: ready for review, mergeable, no GitHub status checks reported.
 
 Implemented the first Phase 8 launch parity slice for the Mac app. The issue detail view keeps the existing one-click Launch button and adds a launch options sheet for open issues without active sessions. The sheet lets the user choose agent, workspace mode, branch name, selected comments, referenced files, preamble text, and automatic/resume/reset behavior.

--- a/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
+++ b/docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md
@@ -5,6 +5,8 @@ Result: done.
 Branch: `mac-parity-phase-8a-launch-options`
 Base: `mac-sidebar-spaces-option-a`
 PR: https://github.com/mean-weasel/issuectl/pull/437
+Head: `3459f29fc4966adc31047e161b07629fa275a2ea`
+PR state: ready for review, mergeable, no GitHub status checks reported.
 
 Implemented the first Phase 8 launch parity slice for the Mac app. The issue detail view keeps the existing one-click Launch button and adds a launch options sheet for open issues without active sessions. The sheet lets the user choose agent, workspace mode, branch name, selected comments, referenced files, preamble text, and automatic/resume/reset behavior.
 
@@ -33,6 +35,7 @@ Validation:
 - `pnpm lint`: pass with pre-existing warnings.
 - `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 21 tests.
 - `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 27 tests.
+- GitHub checks: none reported; local validation is the accepted replacement gate for this PR.
 
 Excluded follow-up scope:
 

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -2351,7 +2351,7 @@ tasks:
   - id: T047
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 8A Mac launch options sheet and request construction while preserving one-click launch defaults."
     inputs:
@@ -2390,7 +2390,47 @@ tasks:
       - "Launch options require shared API/model changes outside allowed files."
       - "Dirty worktree checks require unimplemented backend behavior."
       - "Local validation fails twice for the same unexplained reason."
-    receipt: null
+    receipt:
+      result: done
+      note: "notes/T047-phase-8a-launch-options.md"
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      pr:
+        number: 437
+        url: "https://github.com/mean-weasel/issuectl/pull/437"
+        branch: "mac-parity-phase-8a-launch-options"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        merge_state: "pending push and CI check after receipt commit"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          note: "Passed with pre-existing warnings."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          summary: "21 tests, 0 failures."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          summary: "27 tests, 0 failures."
+      acceptance:
+        - "One-click launch remains available and sends default request values through the existing Launch button."
+        - "Open issue detail exposes an Options launch sheet when no active session exists."
+        - "Options sheet covers agent, workspace mode, branch, comments, referenced files, preamble, and resume/reset behavior."
+        - "Fixture-backed launch route asserts customized LaunchRequestBody payload construction."
+        - "Store still refreshes active sessions before launch and returns an existing session instead of duplicate launching."
+      excluded_follow_up:
+        - "Embedded terminal window and controls."
+        - "Active sessions search/repo filters and polling."
+        - "Dirty worktree readiness checks."
+      summary: "Implemented Phase 8A launch options: Mac issue detail now preserves one-click launch while adding a configurable options sheet wired into LaunchRequestBody with unit and fixture-backed UI coverage."
 
   - id: T999
     type: judge

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -2404,8 +2404,9 @@ tasks:
         url: "https://github.com/mean-weasel/issuectl/pull/437"
         branch: "mac-parity-phase-8a-launch-options"
         base: "mac-sidebar-spaces-option-a"
-        draft: true
-        merge_state: "pending push and CI check after receipt commit"
+        draft: false
+        merge_state: "CLEAN"
+        checks: "No GitHub status checks reported on head 3459f29fc4966adc31047e161b07629fa275a2ea."
       commands:
         - cmd: "git diff --check"
           status: pass

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -2406,7 +2406,7 @@ tasks:
         base: "mac-sidebar-spaces-option-a"
         draft: false
         merge_state: "CLEAN"
-        checks: "No GitHub status checks reported on head 3459f29fc4966adc31047e161b07629fa275a2ea."
+        checks: "No GitHub status checks reported on head 9df754c1118de5b75dc6acb08c4e1f6d171bdd98."
       commands:
         - cmd: "git diff --check"
           status: pass

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -1684,7 +1684,7 @@ tasks:
   - id: T035
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 6D Mac AI parse/batch creation workflow, matching iOS parse behavior where practical while keeping Mac UI native."
     inputs:
@@ -2302,6 +2302,95 @@ tasks:
           - "pnpm typecheck"
           - "pnpm lint with existing warnings only"
       summary: "Marked PR #436 ready, confirmed no GitHub checks were configured, and merged Phase 7C linked PR/issue detail navigation into mac-sidebar-spaces-option-a."
+
+  - id: T046
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose the next safe Mac iOS parity slice after Phase 7 is complete."
+    inputs:
+      - "T045 receipt"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+      - "apple/IssueCTL/Views/Launch/LaunchView.swift"
+      - "Current Mac launch/session implementation"
+    constraints:
+      - "Do not implement."
+      - "Prefer a vertical Phase 8 slice that keeps one-click launch working."
+      - "Define branch/base, allowed files, verification commands, and stop_if conditions for the next Worker."
+    expected_output:
+      - "Decision: approved | blocked | revise_plan."
+      - "Next Worker objective."
+      - "PR branch/base strategy."
+      - "Allowed files and verification commands."
+      - "Risks or excluded follow-up scope."
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      note: "notes/T046-next-phase-8a-slice.md"
+      next_worker: T047
+      worker_objective: "Implement Phase 8A Mac launch options sheet and request construction while preserving one-click launch defaults."
+      branch_strategy:
+        integration_branch: "mac-sidebar-spaces-option-a"
+        worker_branch: "mac-parity-phase-8a-launch-options"
+        worker_pr_base: "mac-sidebar-spaces-option-a"
+      excluded_from_next_slice:
+        - "Embedded terminal window and terminal controls."
+        - "Active sessions search/repo filters and polling."
+        - "Dirty worktree backend checks if they require API routes not already exposed."
+      allowed_files_for_t047:
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMacTests/**"
+        - "apple/IssueCTLMacUITests/**"
+        - "docs/goals/mac-ios-parity/**"
+      summary: "Selected a Phase 8A launch options slice: expose Mac controls for agent, workspace mode, branch, comments/files, preamble, and resume behavior using the existing shared launch request body."
+
+  - id: T047
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: high
+    objective: "Implement Phase 8A Mac launch options sheet and request construction while preserving one-click launch defaults."
+    inputs:
+      - "T046 receipt"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 8"
+      - "apple/IssueCTL/Views/Launch/LaunchView.swift"
+      - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+    constraints:
+      - "Start from a new branch off mac-sidebar-spaces-option-a and open a draft PR before implementation."
+      - "One-click launch must keep current default behavior."
+      - "Use the existing shared LaunchRequestBody shape."
+      - "Do not implement embedded terminal/session filtering in this slice."
+      - "Record branch, PR URL, validation, CI/check status, and merge readiness in the receipt."
+    allowed_files:
+      - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+      - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+      - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+      - "apple/IssueCTLMacTests/**"
+      - "apple/IssueCTLMacUITests/**"
+      - "docs/goals/mac-ios-parity/**"
+    acceptance:
+      - "The existing Launch button still launches with generated branch, saved/default agent, inferred workspace mode, no selected comments/files, no preamble, and nil forceResume."
+      - "Issue detail exposes a launch options sheet for open issues without active sessions."
+      - "The options sheet lets the user choose launch agent, workspace mode, branch name, comment context, referenced file context, preamble, and resume behavior."
+      - "Submitting options sends those choices through LaunchRequestBody."
+      - "Existing active sessions continue to open instead of launching duplicates."
+      - "Fixture-backed UI coverage confirms default launch and customized launch request construction."
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "pnpm typecheck"
+      - "pnpm lint"
+    stop_if:
+      - "Launch options require shared API/model changes outside allowed files."
+      - "Dirty worktree checks require unimplemented backend behavior."
+      - "Local validation fails twice for the same unexplained reason."
+    receipt: null
 
   - id: T999
     type: judge

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -2406,7 +2406,7 @@ tasks:
         base: "mac-sidebar-spaces-option-a"
         draft: false
         merge_state: "CLEAN"
-        checks: "No GitHub status checks reported on head 9df754c1118de5b75dc6acb08c4e1f6d171bdd98."
+        checks: "No GitHub status checks reported on the pushed PR head."
       commands:
         - cmd: "git diff --check"
           status: pass


### PR DESCRIPTION
## Summary

Phase 8A launch parity slice for the Mac app.

- Keeps the existing one-click issue Launch flow intact.
- Adds a Mac launch options sheet for open issues without active sessions.
- Lets the user choose launch agent, workspace mode, branch name, selected comments, referenced files, preamble, and automatic/resume/reset behavior.
- Wires selected options through the existing shared `LaunchRequestBody`.
- Extends the Mac UI fixture server and smoke tests to assert custom launch payload construction.
- Records GoalBuddy T047 receipt in `docs/goals/mac-ios-parity/notes/T047-phase-8a-launch-options.md`.

Excluded follow-up scope remains embedded terminal controls, active session filtering/polling, and dirty worktree readiness checks.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm lint` (passes with pre-existing warnings)
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` (21 tests, 0 failures)
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8a-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` (27 tests, 0 failures)

## CI

GitHub currently reports no status checks on the pushed PR head; local validation above is the recorded replacement gate unless checks appear before merge.
