### PR TITLE
Mac parity phase 8C: launch readiness

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -250,6 +250,22 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["repos": [repo, betaRepo]]
         case ("GET", "/api/v1/worktrees"):
             return ["worktrees": worktrees]
+        case ("GET", "/api/v1/worktrees/status"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_STATUS_FAILURE"] == "1" {
+                return ["error": "Fixture worktree status failed"]
+            }
+            let dirty = ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_DIRTY_WORKTREE"] == "1"
+            return [
+                "exists": true,
+                "dirty": dirty,
+                "path": "/tmp/issuectl-worktrees/org-alpha-1",
+            ]
+        case ("POST", "/api/v1/worktrees/reset"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_RESET_FAILURE"] == "1" {
+                return ["success": false, "error": "Fixture reset failed"]
+            }
+            resetWorktreeCalled = true
+            return ["success": true, "error": NSNull()]
         case ("POST", "/api/v1/worktrees/cleanup"):
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_CLEANUP_FAILURE"] == "1" {
                 return ["success": false, "error": "Fixture cleanup failed"]
@@ -321,6 +337,9 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             return ["success": true, "error": NSNull()]
         case ("POST", "/api/v1/launch/org/alpha/1"):
             let payload = jsonBody(from: request)
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_LAUNCH_FAILURE"] == "1" {
+                return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture launch failed", "label_warning": NSNull()]
+            }
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CUSTOM_LAUNCH"] == "1" {
                 let selectedComments = payload["selectedCommentIndices"] as? [Int] ?? []
                 let selectedFiles = payload["selectedFilePaths"] as? [String] ?? []
@@ -333,6 +352,20 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                       payload["forceResume"] as? Bool == true else {
                     return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture custom launch assertion failed", "label_warning": NSNull()]
                 }
+            }
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_DIRTY_RESUME_LAUNCH"] == "1",
+               payload["forceResume"] as? Bool != true {
+                return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture dirty resume assertion failed", "label_warning": NSNull()]
+            }
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_RESET_THEN_LAUNCH"] == "1" {
+                guard resetWorktreeCalled,
+                      payload["forceResume"] as? Bool == false else {
+                    return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture reset launch assertion failed", "label_warning": NSNull()]
+                }
+            }
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CLONE_LAUNCH"] == "1",
+               payload["workspaceMode"] as? String != "clone" {
+                return ["success": false, "deployment_id": NSNull(), "ttyd_port": NSNull(), "error": "Fixture clone launch assertion failed", "label_warning": NSNull()]
             }
             let deploymentId = 700 + launchedDeployments.count
             launchedDeployments.append(launchedDeployment(id: deploymentId, payload: payload))
@@ -612,7 +645,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "id": 1,
             "owner": "org",
             "name": "alpha",
-            "local_path": "/tmp/issuectl-alpha",
+            "local_path": ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_NO_LOCAL_PATH"] == "1" ? NSNull() : "/tmp/issuectl-alpha",
             "branch_pattern": "jeremy/{slug}",
             "created_at": isoDate,
         ]
@@ -669,6 +702,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
     nonisolated(unsafe) private static var pullMergeMethod: String?
     nonisolated(unsafe) private static var launchedDeployments: [[String: Any]] = []
     nonisolated(unsafe) private static var endedDeploymentIds: Set<Int> = []
+    nonisolated(unsafe) private static var resetWorktreeCalled = false
     nonisolated(unsafe) private static var detailComments: [[String: Any]] = [
         commentFixture(id: 101, body: "Alice **own** comment", author: "alice"),
         commentFixture(id: 102, body: "Bob comment with missing image ![Missing image](https://issuectl-ui-test.local/fixtures/missing.png)", author: "bob"),

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -754,7 +754,8 @@ struct MacIssueDetailView: View {
         }
     }
 
-    private func launchIssue(options: MacIssueLaunchOptions?, openTerminalWhenReady: Bool) async {
+    @discardableResult
+    private func launchIssue(options: MacIssueLaunchOptions?, openTerminalWhenReady: Bool) async -> Bool {
         isLaunching = true
         errorMessage = nil
         defer { isLaunching = false }
@@ -766,8 +767,10 @@ struct MacIssueDetailView: View {
             if openTerminalWhenReady, session.ttydPort != nil {
                 await openTerminalAsync(session)
             }
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -837,16 +840,23 @@ private struct MacLaunchOptionsSheet: View {
 
     let item: MacIssueListItem
     let detail: IssueDetailResponse?
-    let submit: (MacIssueLaunchOptions) async -> Void
+    let submit: (MacIssueLaunchOptions) async -> Bool
 
     @State private var options: MacIssueLaunchOptions
     @State private var isSubmitting = false
+    @State private var isCheckingWorktree = false
+    @State private var isResettingWorktree = false
+    @State private var worktreeStatus: WorktreeStatusResponse?
+    @State private var worktreeStatusError: String?
+    @State private var resetMessage: String?
+    @State private var resetErrorMessage: String?
+    @State private var launchErrorMessage: String?
 
     init(
         item: MacIssueListItem,
         detail: IssueDetailResponse?,
         initialOptions: MacIssueLaunchOptions,
-        submit: @escaping (MacIssueLaunchOptions) async -> Void
+        submit: @escaping (MacIssueLaunchOptions) async -> Bool
     ) {
         self.item = item
         self.detail = detail
@@ -871,11 +881,12 @@ private struct MacLaunchOptionsSheet: View {
                 VStack(alignment: .leading, spacing: 16) {
                     agentSection
                     workspaceSection
+                    readinessSection
                     branchSection
                     resumeSection
+                    preambleSection
                     commentsSection
                     filesSection
-                    preambleSection
                 }
                 .padding(16)
             }
@@ -884,7 +895,16 @@ private struct MacLaunchOptionsSheet: View {
             footer
         }
         .frame(width: 520, height: 620)
-        .task { await loadSavedAgent() }
+        .task {
+            await loadSavedAgent()
+            await refreshWorktreeStatusIfNeeded()
+        }
+        .onChange(of: options.workspaceMode) {
+            Task { await refreshWorktreeStatusIfNeeded() }
+        }
+        .onChange(of: options.resumeBehavior) {
+            launchErrorMessage = nil
+        }
     }
 
     private var header: some View {
@@ -927,12 +947,129 @@ private struct MacLaunchOptionsSheet: View {
             .accessibilityIdentifier("mac-launch-options-workspace-picker")
 
             if item.repo.localPath?.isEmpty != false, options.workspaceMode == .worktree {
-                Label("This repo has no local path; clone mode is usually safer.", systemImage: "exclamationmark.triangle")
+                Label("This repo has no local path, so launch will use clone mode unless a path is configured.", systemImage: "exclamationmark.triangle")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("mac-launch-options-workspace-warning")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var readinessSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Readiness")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if options.workspaceMode == .worktree, item.repo.localPath?.isEmpty != false {
+                readinessLabel(
+                    "Worktree mode needs a local repo path. Clone mode is available for this launch.",
+                    systemImage: "arrow.down.doc",
+                    color: .orange,
+                    identifier: "mac-launch-options-fallback-explanation"
+                )
+            } else if options.workspaceMode == .worktree {
+                if isCheckingWorktree {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Checking worktree status...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("mac-launch-options-readiness-checking")
+                } else if let worktreeStatusError {
+                    readinessLabel(
+                        "Could not check worktree status: \(worktreeStatusError). Clone mode remains available.",
+                        systemImage: "wifi.exclamationmark",
+                        color: .orange,
+                        identifier: "mac-launch-options-worktree-status-error"
+                    )
+                } else if let worktreeStatus, worktreeStatus.isDirty {
+                    dirtyWorktreeCard(path: worktreeStatus.path)
+                } else if let worktreeStatus, worktreeStatus.exists {
+                    readinessLabel(
+                        "Worktree is clean at \(worktreeStatus.path).",
+                        systemImage: "checkmark.circle",
+                        color: .green,
+                        identifier: "mac-launch-options-readiness-summary"
+                    )
+                } else {
+                    readinessLabel(
+                        "No existing issue worktree was found. Launch can create one from the local repo.",
+                        systemImage: "plus.circle",
+                        color: .secondary,
+                        identifier: "mac-launch-options-readiness-summary"
+                    )
+                }
+            } else {
+                readinessLabel(
+                    options.workspaceMode == .clone ? "Clone mode will create a fresh checkout for this issue." : "Existing mode will use the configured local checkout.",
+                    systemImage: options.workspaceMode == .clone ? "arrow.down.doc" : "folder",
+                    color: .secondary,
+                    identifier: "mac-launch-options-readiness-summary"
+                )
+            }
+
+            if let resetMessage {
+                readinessLabel(resetMessage, systemImage: "checkmark.circle", color: .green, identifier: "mac-launch-options-reset-message")
+            }
+
+            if let resetErrorMessage {
+                readinessLabel(resetErrorMessage, systemImage: "exclamationmark.triangle", color: .red, identifier: "mac-launch-options-reset-error")
+            }
+
+            if let launchErrorMessage {
+                readinessLabel(launchErrorMessage, systemImage: "exclamationmark.triangle", color: .red, identifier: "mac-launch-options-submit-error")
+            }
+        }
+    }
+
+    private func readinessLabel(_ text: String, systemImage: String, color: Color, identifier: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption)
+            .foregroundStyle(color)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityIdentifier(identifier)
+    }
+
+    private func dirtyWorktreeCard(path: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            readinessLabel(
+                "Existing changes were found in \(path). Choose whether to discard them or resume with them.",
+                systemImage: "exclamationmark.triangle",
+                color: .orange,
+                identifier: "mac-launch-options-dirty-worktree-warning"
+            )
+
+            HStack {
+                Button {
+                    Task { await resetWorktree() }
+                } label: {
+                    if isResettingWorktree {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("Discard & Start Fresh", systemImage: "arrow.counterclockwise")
+                    }
+                }
+                .disabled(isResettingWorktree || isSubmitting)
+                .accessibilityIdentifier("mac-launch-options-reset-worktree-button")
+
+                Button {
+                    options.resumeBehavior = .resume
+                    resetMessage = "Launch will resume with the existing worktree changes."
+                    resetErrorMessage = nil
+                    launchErrorMessage = nil
+                } label: {
+                    Label("Resume with Changes", systemImage: "arrow.forward.circle")
+                }
+                .disabled(isResettingWorktree || isSubmitting)
+                .accessibilityIdentifier("mac-launch-options-resume-dirty-button")
+            }
+            .controlSize(.small)
         }
     }
 
@@ -1065,10 +1202,23 @@ private struct MacLaunchOptionsSheet: View {
                 }
             }
             .buttonStyle(.borderedProminent)
-            .disabled(isSubmitting || options.branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .disabled(!canSubmit)
             .accessibilityIdentifier("mac-launch-options-submit-button")
         }
         .padding(16)
+    }
+
+    private var canSubmit: Bool {
+        guard !isSubmitting,
+              !isCheckingWorktree,
+              !isResettingWorktree,
+              !options.branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        if options.workspaceMode == .worktree, worktreeStatus?.isDirty == true, options.resumeBehavior != .resume {
+            return false
+        }
+        return true
     }
 
     private func commentBinding(_ index: Int) -> Binding<Bool> {
@@ -1107,8 +1257,71 @@ private struct MacLaunchOptionsSheet: View {
     private func submitOptions() async {
         guard !isSubmitting else { return }
         isSubmitting = true
-        await submit(options)
+        launchErrorMessage = nil
+        var launchOptions = options
+        if launchOptions.workspaceMode == .worktree, item.repo.localPath?.isEmpty != false {
+            launchOptions.workspaceMode = .clone
+        }
+        let didLaunch = await submit(launchOptions)
+        if !didLaunch {
+            launchErrorMessage = "Launch failed. Adjust the options and try again."
+        }
         isSubmitting = false
+    }
+
+    private func refreshWorktreeStatusIfNeeded() async {
+        resetMessage = nil
+        resetErrorMessage = nil
+        launchErrorMessage = nil
+        worktreeStatus = nil
+        worktreeStatusError = nil
+
+        guard options.workspaceMode == .worktree,
+              item.repo.localPath?.isEmpty == false else {
+            return
+        }
+
+        isCheckingWorktree = true
+        defer { isCheckingWorktree = false }
+        do {
+            worktreeStatus = try await api.checkWorktreeStatus(
+                owner: item.repo.owner,
+                repo: item.repo.name,
+                issueNumber: item.issue.number
+            )
+        } catch {
+            worktreeStatusError = error.localizedDescription
+        }
+    }
+
+    private func resetWorktree() async {
+        guard !isResettingWorktree else { return }
+        isResettingWorktree = true
+        resetMessage = nil
+        resetErrorMessage = nil
+        launchErrorMessage = nil
+        defer { isResettingWorktree = false }
+
+        do {
+            let response = try await api.resetWorktree(
+                owner: item.repo.owner,
+                repo: item.repo.name,
+                issueNumber: item.issue.number
+            )
+            guard response.success else {
+                resetErrorMessage = response.error ?? "Could not reset worktree."
+                return
+            }
+            options.resumeBehavior = .reset
+            worktreeStatus = WorktreeStatusResponse(
+                exists: true,
+                dirty: false,
+                path: worktreeStatus?.path ?? item.repo.localPath ?? ""
+            )
+            resetMessage = "Worktree reset. Launch will start from a clean checkout."
+        } catch {
+            resetErrorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -257,17 +257,123 @@ final class MacSidebarSmokeTests: XCTestCase {
         branchField.typeKey("a", modifierFlags: .command)
         branchField.typeText("custom-mac-launch")
 
-        app.checkBoxes["mac-launch-options-comment-0"].click()
-        app.checkBoxes["mac-launch-options-file-Sources/Alpha.swift"].click()
-
         let preamble = app.textViews["mac-launch-options-preamble-field"]
         XCTAssertTrue(preamble.waitForExistence(timeout: 5), app.debugDescription)
         preamble.click()
         preamble.typeText("Custom Mac preamble")
 
+        app.checkBoxes["mac-launch-options-comment-0"].click()
+        app.checkBoxes["mac-launch-options-file-Sources/Alpha.swift"].click()
+
         app.buttons["mac-launch-options-submit-button"].click()
         XCTAssertTrue(app.staticTexts["custom-mac-launch - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
         XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
+    func testLaunchOptionsDirtyWorktreeCanResumeWithChanges() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_DIRTY_WORKTREE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_DIRTY_RESUME_LAUNCH"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-dirty-worktree-warning"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.buttons["mac-launch-options-submit-button"].isEnabled, app.debugDescription)
+
+        app.buttons["mac-launch-options-resume-dirty-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-reset-message"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-launch-options-submit-button"].click()
+
+        XCTAssertTrue(app.staticTexts["issue-1-open-alpha-issue - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
+    func testLaunchOptionsDirtyWorktreeCanResetBeforeLaunch() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_DIRTY_WORKTREE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_RESET_THEN_LAUNCH"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-dirty-worktree-warning"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-launch-options-reset-worktree-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-reset-message"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-readiness-summary"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-launch-options-submit-button"].click()
+        XCTAssertTrue(app.staticTexts["issue-1-open-alpha-issue - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
+    func testLaunchOptionsWorktreeStatusFailureCanFallbackToClone() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_STATUS_FAILURE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CLONE_LAUNCH"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-worktree-status-error"].waitForExistence(timeout: 5), app.debugDescription)
+        app.descendants(matching: .any)["mac-launch-options-workspace-picker"].radioButtons["Clone"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-readiness-summary"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-launch-options-submit-button"].click()
+
+        XCTAssertTrue(app.staticTexts["issue-1-open-alpha-issue - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
+    func testLaunchOptionsNoLocalPathFallsBackToClone() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_NO_LOCAL_PATH"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_ASSERT_CLONE_LAUNCH"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        let workspacePicker = app.descendants(matching: .any)["mac-launch-options-workspace-picker"]
+        XCTAssertTrue(workspacePicker.waitForExistence(timeout: 5), app.debugDescription)
+        workspacePicker.radioButtons["Worktree"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-fallback-explanation"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-launch-options-submit-button"].click()
+
+        XCTAssertTrue(app.staticTexts["issue-1-open-alpha-issue - terminal preparing"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-issue-detail-error-message"].exists, app.debugDescription)
+    }
+
+    func testLaunchOptionsFailuresRemainRecoverable() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_LAUNCH_FAILURE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_WORKTREE_RESET_FAILURE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_DIRTY_WORKTREE"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        app.buttons["mac-issue-detail-launch-options-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-dirty-worktree-warning"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-launch-options-reset-worktree-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-reset-error"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-launch-options-resume-dirty-button"].click()
+        app.buttons["mac-launch-options-submit-button"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-launch-options-submit-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-launch-options-submit-button"].exists, app.debugDescription)
     }
 
     func testActiveSessionsFiltersPreviewNavigationOpenAndEnd() {

--- a/docs/goals/mac-ios-parity/notes/T053-phase-8c-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T053-phase-8c-branch-start.md
@@ -1,0 +1,9 @@
+# T053 Phase 8C Branch Start
+
+Branch: `mac-parity-phase-8c-readiness`
+
+Base: `mac-sidebar-spaces-option-a`
+
+Scope: Phase 8C launch readiness and dirty-worktree parity.
+
+Draft PR will be opened after this branch-start receipt commit so GitHub has a head commit to compare.

--- a/docs/goals/mac-ios-parity/notes/T053-phase-8c-readiness.md
+++ b/docs/goals/mac-ios-parity/notes/T053-phase-8c-readiness.md
@@ -1,0 +1,51 @@
+# T053 Phase 8C Launch Readiness
+
+## Result
+
+Implemented Phase 8C launch readiness parity on `mac-parity-phase-8c-readiness` for draft PR #439 into `mac-sidebar-spaces-option-a`.
+
+## Product Changes
+
+- Added a Mac launch options readiness panel that checks worktree status before launch.
+- Shows clear clone/worktree readiness messaging for clean worktrees, missing local repo paths, status-check failures, clone mode, and existing-checkout mode.
+- Detects dirty worktrees and blocks ambiguous worktree launch until the user explicitly chooses a recovery path.
+- Added dirty-worktree actions:
+  - `Discard & Start Fresh` calls the reset worktree API, records reset progress/error state, and launches with reset semantics.
+  - `Resume with Changes` launches with explicit resume semantics.
+- Converts a manually selected worktree launch to clone mode when the repo has no local path, while keeping a visible fallback explanation in the sheet.
+- Keeps launch failures visible inside the options sheet so the user can adjust options and retry without losing context.
+- Preserved one-click default launch and the existing custom launch options flow.
+- Extended Mac UI fixtures with worktree status/reset routes, dirty/no-local-path/status-failure/reset-failure/launch-failure modes, and launch payload assertions.
+
+## Acceptance Evidence
+
+- One-click launch still works through the default button path.
+- Dirty worktree UI is fixture-backed and confirmed for both reset-before-launch and resume-with-changes.
+- Reset-before-launch asserts the reset endpoint is called before launch and the launch payload sends `forceResume == false`.
+- Resume-with-changes asserts the launch payload sends `forceResume == true`.
+- Missing local path fallback shows a visible explanation and asserts the launch payload uses clone mode.
+- Worktree status failure shows a recoverable error and supports switching to clone mode.
+- Reset failure and launch failure remain visible in the launch options sheet with the submit button still available for recovery.
+
+## Validation
+
+- PASS: `git diff --check`
+- PASS: `pnpm typecheck`
+- PASS: `pnpm lint`
+  - Existing warnings only; no lint errors.
+- PASS: `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`
+  - 22 tests passed.
+- PASS: Focused launch readiness UI tests:
+  - `testCustomIssueLaunchOptionsBuildLaunchRequest`
+  - `testLaunchOptionsDirtyWorktreeCanResumeWithChanges`
+  - `testLaunchOptionsDirtyWorktreeCanResetBeforeLaunch`
+  - `testLaunchOptionsWorktreeStatusFailureCanFallbackToClone`
+  - `testLaunchOptionsNoLocalPathFallsBackToClone`
+  - `testLaunchOptionsFailuresRemainRecoverable`
+- PASS: `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`
+  - 34 tests passed.
+
+## Residual Scope
+
+- Embedded terminal WKWebView and terminal text-size/reconnect/respawn controls remain excluded from this slice per T052.
+- PR #439 still needs push, ready-for-review transition, check inspection, and merge or accepted no-check replacement validation.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: null
+active_task: T054
 
 tasks:
   - id: T001
@@ -2682,7 +2682,7 @@ tasks:
   - id: T053
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 8C Mac launch readiness parity: local path checks, clone/worktree fallback explanation, dirty-worktree detection, discard/reset and resume choices, progress state, and recoverable launch/reset failures."
     inputs:
@@ -2722,6 +2722,57 @@ tasks:
       - "Readiness requires backend/API changes outside allowed files."
       - "Existing-session reset/new flow requires broader navigation or terminal redesign."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      note: "notes/T053-phase-8c-readiness.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      pr:
+        number: 439
+        url: "https://github.com/mean-weasel/issuectl/pull/439"
+        branch: "mac-parity-phase-8c-readiness"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        merge_state: "not_checked_after_implementation"
+        checks: "Pending push and ready-for-review transition."
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          warnings: "Existing lint warnings only; no errors."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          summary: "22 tests passed"
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          summary: "34 tests passed"
+      acceptance_evidence:
+        - "One-click launch remains covered by testDefaultIssueLaunchUsesExistingOneClickFlow."
+        - "Dirty worktree reset and resume are fixture-backed and assert reset/launch payload behavior."
+        - "No-local-path worktree fallback shows a visible explanation and asserts clone launch payload."
+        - "Worktree status failure is visible and recoverable by switching to clone mode."
+        - "Reset and launch failures remain visible in the launch options sheet with retry controls still present."
+      summary: "Implemented Phase 8C Mac launch readiness parity: worktree status checks, dirty-worktree reset/resume decisions, local-path clone fallback, status/reset/launch failure recovery, fixture routes, and full Mac smoke coverage."
+
+  - id: T054
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: low
+    objective: "Push Phase 8C PR #439, mark it ready, inspect GitHub checks, and merge into mac-sidebar-spaces-option-a if green or if no-check replacement validation is accepted."
+    inputs:
+      - "PR #439"
+      - "T053 receipt"
+    constraints:
+      - "Do not implement product changes."
+      - "Do not merge red CI without an explicit recorded exception."
+      - "Record CI or replacement validation used for the merge gate."
+      - "Record head SHA and merge commit SHA if merged."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary

Phase 8C launch readiness parity slice for the Mac app.

Planned scope:

- Add local path/worktree readiness checks to Mac launch options.
- Show visible clone/worktree fallback explanations when worktree mode is unavailable or status is unknown.
- Detect dirty worktree state before launch.
- Support dirty-worktree choices: discard/start fresh via worktree reset, or resume with changes via `forceResume`.
- Preserve one-click launch and existing Options launch behavior.
- Add progress and recoverable failure states for launch readiness/reset.

Excluded follow-up scope: embedded terminal WKWebView, terminal text-size controls, reconnect/respawn controls, and terminal-window dogfood pass.

## Acceptance Criteria

- One-click launch still works with defaults.
- Existing session opens instead of launching duplicate work unless a reset/new flow is explicitly chosen.
- Mac launch options show local path/clone fallback readiness with visible explanation when worktree mode is unavailable or unknown.
- Dirty worktree state is detected before launch.
- Dirty worktree choices support discard/start fresh and resume with changes, and the selected behavior is reflected in launch/reset API calls.
- Launch and reset progress/failure states are visible and recoverable.
- Fixture-backed UI coverage confirms dirty detection, reset, resume, fallback explanation, and failure recovery.

## Planned Validation

- `git diff --check`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8c-dd -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`
- `pnpm typecheck`
- `pnpm lint`
