### PR TITLE
Mac parity Phase 8D: embedded terminal window

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -323,6 +323,9 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 return !endedDeploymentIds.contains(id)
             }]
         case ("POST", "/api/v1/deployments/2/ensure-ttyd"):
+            if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_TTYD_FAILURE"] == "1" {
+                return ["alive": false, "error": "Fixture terminal unavailable"]
+            }
             return ["port": 7700, "terminalToken": "fixture-terminal-token", "respawned": ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_RESPAWN_TTYD"] == "1"]
         case ("POST", "/api/v1/deployments/8/ensure-ttyd"):
             return ["port": 7701, "terminalToken": "fixture-terminal-token-beta", "respawned": false]

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -797,13 +797,11 @@ struct MacIssueDetailView: View {
         )
     }
 
+    @MainActor
     private func openTerminalAsync(_ session: ActiveDeployment) async {
         errorMessage = nil
-        do {
-            let url = try await store.terminalURL(api: api, session: session)
-            openURL(url)
-        } catch {
-            errorMessage = error.localizedDescription
+        MacTerminalWindowController.open(session: session, store: store, api: api) {
+            activeSession = nil
         }
     }
 }

--- a/apple/IssueCTLMac/Views/MacSessionsView.swift
+++ b/apple/IssueCTLMac/Views/MacSessionsView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import AppKit
+import WebKit
 
 struct MacSessionsView: View {
     @Environment(APIClient.self) private var api
-    @Environment(\.openURL) private var openURL
     @Environment(\.macSidebarTextScale) private var textScale
 
     let store: MacSidebarStore
@@ -271,18 +272,10 @@ struct MacSessionsView: View {
     }
 
     private func openTerminal(_ session: ActiveDeployment) {
-        Task {
-            errorMessage = nil
-            terminalNotice = nil
-            do {
-                let access = try await store.terminalAccess(api: api, session: session)
-                if ProcessInfo.processInfo.environment["ISSUECTL_UI_TESTING"] != "1" {
-                    openURL(access.url)
-                }
-                terminalNotice = access.respawned ? "Terminal respawned on port \(access.port)" : "Terminal opened on port \(access.port)"
-            } catch {
-                errorMessage = error.localizedDescription
-            }
+        errorMessage = nil
+        terminalNotice = nil
+        MacTerminalWindowController.open(session: session, store: store, api: api) {
+            syncRepoSelection()
         }
     }
 
@@ -366,5 +359,276 @@ struct MacSessionsView: View {
             return "All repos"
         }
         return "\(selectedRepoKeys.count) of \(availableRepoKeys.count) repos"
+    }
+}
+
+struct MacTerminalSessionSheet: View {
+    @Environment(APIClient.self) private var api
+
+    let session: ActiveDeployment
+    let store: MacSidebarStore
+    let onEnded: () -> Void
+    let onClose: () -> Void
+
+    @AppStorage("macTerminalFontSize") private var terminalFontSize = 14
+
+    @State private var access: MacTerminalAccess?
+    @State private var isLoading = false
+    @State private var isEnding = false
+    @State private var errorMessage: String?
+    @State private var notice: String?
+
+    private var preferences: MacTerminalPreferences {
+        MacTerminalPreferences(fontSize: terminalFontSize, lineHeight: "1.25")
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            terminalBody
+        }
+        .frame(minWidth: 760, idealWidth: 960, minHeight: 520, idealHeight: 680)
+        .task {
+            if access == nil {
+                await loadTerminal()
+            }
+        }
+        .onChange(of: terminalFontSize) { _, _ in
+            Task { await loadTerminal() }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("\(session.repoFullName) #\(session.issueNumber)")
+                        .font(.headline)
+                        .accessibilityIdentifier("mac-terminal-title")
+                    Text(session.branchName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Label(session.runningDuration, systemImage: "clock")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-terminal-duration")
+
+                Button {
+                    Task { await loadTerminal() }
+                } label: {
+                    Label("Reconnect", systemImage: "arrow.clockwise")
+                }
+                .disabled(isLoading || isEnding)
+                .accessibilityIdentifier("mac-terminal-reconnect-button")
+
+                Button(role: .destructive) {
+                    Task { await endSession() }
+                } label: {
+                    if isEnding {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label("End", systemImage: "stop.circle")
+                    }
+                }
+                .disabled(isEnding)
+                .accessibilityIdentifier("mac-terminal-end-button")
+
+                Button {
+                    onClose()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.borderless)
+                .help("Close")
+                .accessibilityIdentifier("mac-terminal-close-button")
+            }
+
+            HStack(spacing: 10) {
+                Label(access.map { "Port \($0.port)" } ?? "Preparing terminal", systemImage: "terminal")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-terminal-status")
+
+                Spacer()
+
+                Label("Text Size", systemImage: "textformat.size")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Stepper("\(terminalFontSize) pt", value: $terminalFontSize, in: 10...22, step: 1)
+                    .labelsHidden()
+                    .accessibilityLabel("Terminal text size")
+                    .accessibilityValue("\(terminalFontSize) pt")
+                    .accessibilityIdentifier("mac-terminal-text-size-stepper")
+            }
+
+            if let notice {
+                Label(notice, systemImage: "checkmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-terminal-notice")
+            }
+
+            if let errorMessage {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("mac-terminal-error")
+
+                    Button("Retry") {
+                        Task { await loadTerminal() }
+                    }
+                    .controlSize(.small)
+                    .disabled(isLoading)
+                    .accessibilityIdentifier("mac-terminal-retry-button")
+                }
+            }
+        }
+        .padding(14)
+    }
+
+    @ViewBuilder
+    private var terminalBody: some View {
+        if isLoading && access == nil {
+            ProgressView("Opening terminal...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("mac-terminal-loading")
+        } else if let access {
+            MacTerminalWebView(url: access.url)
+                .id(access.url)
+                .accessibilityIdentifier("mac-terminal-webview")
+        } else {
+            ContentUnavailableView("Terminal Not Ready", systemImage: "terminal", description: Text("Reconnect when the session is ready."))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityIdentifier("mac-terminal-unavailable")
+        }
+    }
+
+    @MainActor
+    private func loadTerminal() async {
+        isLoading = true
+        errorMessage = nil
+        notice = nil
+        defer { isLoading = false }
+
+        do {
+            let nextAccess = try await store.terminalAccess(api: api, session: session, preferences: preferences)
+            access = nextAccess
+            notice = nextAccess.respawned ? "Terminal respawned on port \(nextAccess.port)" : "Terminal connected on port \(nextAccess.port)"
+        } catch {
+            access = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func endSession() async {
+        isEnding = true
+        errorMessage = nil
+        defer { isEnding = false }
+
+        do {
+            try await store.endSession(api: api, session: session)
+            onEnded()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct MacTerminalWebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.suppressesIncrementalRendering = false
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsMagnification = true
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        if webView.url != url {
+            webView.load(URLRequest(url: url))
+        }
+    }
+}
+
+@MainActor
+final class MacTerminalWindowController: NSWindowController, NSWindowDelegate {
+    private static var controllers: [Int: MacTerminalWindowController] = [:]
+
+    private let sessionId: Int
+
+    static func open(
+        session: ActiveDeployment,
+        store: MacSidebarStore,
+        api: APIClient,
+        onEnded: @escaping () -> Void
+    ) {
+        if let existing = controllers[session.id] {
+            existing.showWindow(nil)
+            existing.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let controller = MacTerminalWindowController(session: session, store: store, api: api, onEnded: onEnded)
+        controllers[session.id] = controller
+        controller.showWindow(nil)
+        controller.window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private init(
+        session: ActiveDeployment,
+        store: MacSidebarStore,
+        api: APIClient,
+        onEnded: @escaping () -> Void
+    ) {
+        sessionId = session.id
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 680),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "\(session.repoFullName) #\(session.issueNumber) Terminal"
+        window.minSize = NSSize(width: 760, height: 520)
+        window.center()
+
+        super.init(window: window)
+        window.delegate = self
+
+        let content = MacTerminalSessionSheet(
+            session: session,
+            store: store,
+            onEnded: { [weak self] in
+                onEnded()
+                self?.close()
+            },
+            onClose: { [weak self] in
+                self?.close()
+            }
+        )
+        window.contentView = NSHostingView(rootView: content.environment(api))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        Self.controllers[sessionId] = nil
     }
 }

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -403,14 +403,19 @@ final class MacSidebarStore {
         )
     }
 
-    func terminalAccess(api: APIClient, session: ActiveDeployment) async throws -> MacTerminalAccess {
+    func terminalAccess(
+        api: APIClient,
+        session: ActiveDeployment,
+        preferences: MacTerminalPreferences = .default
+    ) async throws -> MacTerminalAccess {
         let result = try await api.ensureTtyd(deploymentId: session.id)
         switch result {
         case .available(let port, let token, let respawned):
             var components = URLComponents(string: "\(api.serverURL)/api/terminal/\(port)/")
             components?.queryItems = [
                 URLQueryItem(name: "terminalToken", value: token),
-                URLQueryItem(name: "lineHeight", value: "1.25"),
+                URLQueryItem(name: "fontSize", value: "\(preferences.fontSize)"),
+                URLQueryItem(name: "lineHeight", value: preferences.lineHeight),
                 URLQueryItem(name: "disableResizeOverlay", value: "true"),
                 URLQueryItem(name: "rendererType", value: "canvas"),
             ]
@@ -522,6 +527,13 @@ struct MacIssueLaunchOptions: Equatable {
             idempotencyKey: idempotencyKey
         )
     }
+}
+
+struct MacTerminalPreferences: Equatable {
+    var fontSize: Int
+    var lineHeight: String
+
+    static let `default` = MacTerminalPreferences(fontSize: 14, lineHeight: "1.25")
 }
 
 struct MacTerminalAccess: Equatable {

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -405,10 +405,40 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Running alpha issue"].waitForNonExistence(timeout: 5), app.debugDescription)
 
         app.buttons["Open terminal for session 2"].click()
-        XCTAssertTrue(app.staticTexts["Terminal opened on port 7700"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.windows["org/alpha #2 Terminal"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-terminal-status"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Terminal connected on port 7700"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-terminal-duration"].exists, app.debugDescription)
+        XCTAssertTrue(app.steppers["mac-terminal-text-size-stepper"].exists, app.debugDescription)
 
-        app.buttons["End session 2"].click()
+        app.buttons["mac-terminal-reconnect-button"].click()
+        XCTAssertTrue(app.staticTexts["Terminal connected on port 7700"].waitForExistence(timeout: 5), app.debugDescription)
+
+        app.buttons["mac-terminal-end-button"].click()
         XCTAssertTrue(app.descendants(matching: .any)["mac-session-row-2"].waitForNonExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testEmbeddedTerminalRespawnAndFailureRecovery() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_RESPAWN_TTYD"] = "1"
+        app.launch()
+
+        selectRootSection("Active")
+        XCTAssertTrue(app.descendants(matching: .any)["mac-session-row-2"].waitForExistence(timeout: 8), app.debugDescription)
+        app.buttons["Open terminal for session 2"].click()
+        XCTAssertTrue(app.staticTexts["Terminal respawned on port 7700"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["mac-terminal-close-button"].click()
+
+        app.terminate()
+        app.launchEnvironment.removeValue(forKey: "ISSUECTL_MAC_UI_FIXTURE_RESPAWN_TTYD")
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_TTYD_FAILURE"] = "1"
+        app.launch()
+
+        selectRootSection("Active")
+        XCTAssertTrue(app.descendants(matching: .any)["mac-session-row-2"].waitForExistence(timeout: 8), app.debugDescription)
+        app.buttons["Open terminal for session 2"].click()
+        XCTAssertTrue(app.descendants(matching: .any)["mac-terminal-error"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-terminal-retry-button"].exists, app.debugDescription)
     }
 
     func testActiveSessionEndFailureKeepsRowAndShowsError() {

--- a/docs/goals/mac-ios-parity/notes/T056-phase-8d-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T056-phase-8d-branch-start.md
@@ -1,0 +1,21 @@
+# T056 Worker Start: Phase 8D Terminal Window
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-8d-terminal-window`
+
+Base: `mac-sidebar-spaces-option-a`
+
+Planned slice:
+
+- Add a native embedded Mac terminal surface opened from issue detail and Active Sessions.
+- Reuse the existing `ensureTtyd` terminal access path and token URL.
+- Add loading, failure, reconnect/respawn, text-size, duration, and end-session controls.
+- Add focused unit/UI coverage and fixture support for deterministic validation.
+
+Out of scope:
+
+- Offline/cache parity beyond existing session cache banner.
+- Notifications and Today extension parity.
+- Per-Space desktop filter behavior.
+- Backend API changes beyond fixture support.

--- a/docs/goals/mac-ios-parity/notes/T056-phase-8d-terminal-window.md
+++ b/docs/goals/mac-ios-parity/notes/T056-phase-8d-terminal-window.md
@@ -1,0 +1,52 @@
+# T056 Phase 8D Terminal Window Receipt
+
+Date: 2026-05-14
+
+## Result
+
+Implemented Phase 8D embedded Mac terminal parity in draft PR #440:
+
+https://github.com/mean-weasel/issuectl/pull/440
+
+Branch: `mac-parity-phase-8d-terminal-window`
+Base: `mac-sidebar-spaces-option-a`
+
+## Scope
+
+- Replaced external browser terminal opening with a native resizable Mac terminal window.
+- Opened the terminal window from both issue detail active-session actions and Active Sessions rows.
+- Backed the window by existing `ensureTtyd` access, terminal token URL, and end-session APIs.
+- Added persisted terminal text size via `@AppStorage("macTerminalFontSize")`.
+- Added terminal loading, connected, respawned, error, retry, reconnect, duration, close, and end-session controls.
+- Added fixture coverage for terminal failure and respawn paths.
+- Added UI coverage for connected, respawned, failure/retry, text-size control, and end-session behavior.
+
+## Changed Files
+
+- `apple/IssueCTLMac/App/IssueCTLMacApp.swift`
+- `apple/IssueCTLMac/Views/MacIssueDetailView.swift`
+- `apple/IssueCTLMac/Views/MacSessionsView.swift`
+- `apple/IssueCTLMac/Views/MacSidebarStore.swift`
+- `apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift`
+- `docs/goals/mac-ios-parity/state.yaml`
+- `docs/goals/mac-ios-parity/notes/T056-phase-8d-terminal-window.md`
+
+## Acceptance Evidence
+
+- Native embedded terminal surface exists as a Mac `NSWindow` hosting a SwiftUI terminal controller with `WKWebView`.
+- Terminal URL includes `terminalToken`, persisted `fontSize`, fixed `lineHeight`, `disableResizeOverlay`, and canvas renderer query parameters.
+- Active Sessions terminal flow opens `org/alpha #2 Terminal`, shows connected status, exposes duration and text-size control, reconnects, and can end the session.
+- Respawn path shows `Terminal respawned on port 7700`.
+- Failure path shows `mac-terminal-error` and `mac-terminal-retry-button`.
+
+## Validation
+
+- `git diff --check`: pass
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with pre-existing warnings
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8d-terminal -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 22 tests, 0 failures
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8d-terminal -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 35 tests, 0 failures
+
+## Residual Gate
+
+T057 owns the PR gate: push the branch, inspect PR #440, check GitHub CI or record no configured checks, dogfood the terminal if possible, mark the PR ready, merge when acceptable, and select the next parity slice.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T056
+active_task: T057
 
 tasks:
   - id: T001
@@ -2827,7 +2827,7 @@ tasks:
   - id: T056
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 8D embedded terminal parity for the Mac app: a native embedded terminal surface from issue detail and Active Sessions backed by ensure-ttyd, with loading/error states, text-size control, reconnect/respawn, visible duration, and end-session control."
     inputs:
@@ -2865,6 +2865,58 @@ tasks:
       - "A backend API contract change is required beyond existing ensure-ttyd/end-session semantics."
       - "Terminal UI automation cannot deterministically observe the embedded surface or controls after two focused attempts."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      note: "notes/T056-phase-8d-terminal-window.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacSessionsView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      pr:
+        number: 440
+        url: "https://github.com/mean-weasel/issuectl/pull/440"
+        branch: "mac-parity-phase-8d-terminal-window"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          note: "Passed with pre-existing warnings."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8d-terminal -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          note: "22 tests, 0 failures."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase8d-terminal -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          note: "35 tests, 0 failures."
+      summary: "Implemented a native Mac terminal window opened from issue detail and Active Sessions, backed by ensure-ttyd with persisted text size, reconnect/respawn handling, loading/error/retry UI, duration, and end-session controls."
+
+  - id: T057
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Gate PR #440 for Phase 8D: inspect the pushed diff, confirm CI or accepted replacement validation, complete a focused dogfood pass if possible, decide merge readiness, and select the next PR-sized parity slice."
+    inputs:
+      - "T056 receipt"
+      - "PR #440"
+      - "Local validation receipts"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md"
+    constraints:
+      - "Do not merge PR #440 until the branch is pushed and CI is green or no checks are configured with replacement validation documented."
+      - "Prefer dogfooding the terminal from Active Sessions on this Mac before merge; if skipped, record the reason and residual risk."
+      - "Do not implement unrelated phases inside the merge gate."
+      - "If merge ready, mark the PR ready before merge unless policy allows merging drafts directly."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "CI or replacement validation status."
+      - "Dogfood result or explicit skipped reason."
+      - "Merge action and next task recommendation."
     receipt: null
 
   - id: T999


### PR DESCRIPTION
## Summary

Phase 8D worker branch for embedded Mac terminal parity.

Planned scope:
- open a native embedded terminal surface from issue detail and Active Sessions
- reuse existing ensure-ttyd token URL handling
- add loading/error, reconnect/respawn, text-size, duration, and end-session controls
- add fixture-backed Mac tests and dogfood evidence before merge

Out of scope:
- offline/cache parity beyond the existing session cache banner
- notifications and Today extension parity
- per-Space desktop filter behavior
- backend API changes beyond test fixtures

## Validation

Not yet run; branch-start PR only.
