### PR TITLE
Mac parity Phase 9A: cache and offline visibility

### DIFF
--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -490,9 +490,9 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 "error": NSNull(),
             ]
         case ("GET", "/api/v1/issues/org/alpha"):
-            return ["issues": issues, "from_cache": false, "cached_at": NSNull()]
+            return issuesResponse(issues)
         case ("GET", "/api/v1/issues/org/beta"):
-            return ["issues": betaIssues, "from_cache": false, "cached_at": NSNull()]
+            return issuesResponse(betaIssues)
         case ("GET", "/api/v1/pulls/org/alpha"):
             if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_PULLS_FAILURE"] == "1" {
                 return ["error": "Fixture pulls failed"]
@@ -1016,9 +1016,7 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
                 ],
             ],
             "referencedFiles": ["Sources/Alpha.swift"],
-            "fromCache": false,
-            "cachedAt": NSNull(),
-        ]
+        ].merging(cacheMetadata()) { _, new in new }
     }
 
     private static func runningIssueDetail() -> [String: Any] {
@@ -1132,6 +1130,18 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
 
     private static var isoDate: String {
         "2026-05-14T00:00:00Z"
+    }
+
+    private static func cacheMetadata() -> [String: Any] {
+        let isCached = ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_CACHED_DATA"] == "1"
+        return [
+            "from_cache": isCached,
+            "cached_at": isCached ? isoDate : NSNull(),
+        ]
+    }
+
+    private static func issuesResponse(_ issues: [[String: Any]]) -> [String: Any] {
+        ["issues": issues].merging(cacheMetadata()) { _, new in new }
     }
 
     private static func jsonData(_ object: Any) -> Data {

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -67,6 +67,9 @@ struct MacIssueDetailView: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 10)
                     Divider()
+                    if let detail {
+                        cacheIndicator(for: detail)
+                    }
 
                     ScrollView {
                         VStack(alignment: .leading, spacing: 18) {
@@ -685,6 +688,28 @@ struct MacIssueDetailView: View {
             }
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    @ViewBuilder
+    private func cacheIndicator(for detail: IssueDetailResponse) -> some View {
+        if detail.fromCache {
+            Label(MacCacheIndicatorModel.cachedBannerText(kind: "issue detail", cachedAt: detail.cachedAt), systemImage: "externaldrive.badge.clock")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.orange.opacity(0.10))
+                .accessibilityIdentifier("mac-issue-detail-cached-banner")
+        } else if let updatedText = MacCacheIndicatorModel.updatedText(cachedAt: detail.cachedAt) {
+            Text(updatedText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .accessibilityIdentifier("mac-issue-detail-cache-age")
         }
     }
 

--- a/apple/IssueCTLMac/Views/MacIssuesView.swift
+++ b/apple/IssueCTLMac/Views/MacIssuesView.swift
@@ -247,6 +247,18 @@ struct MacIssuesView: View {
                     .accessibilityIdentifier("mac-issues-load-more-button")
                 }
             }
+
+            if store.issuesFromCache {
+                Label(MacCacheIndicatorModel.cachedBannerText(kind: "issues", cachedAt: store.issuesCachedAt), systemImage: "externaldrive.badge.clock")
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("mac-issues-cached-banner")
+            } else if let updatedText = MacCacheIndicatorModel.updatedText(cachedAt: store.issuesCachedAt) {
+                Text(updatedText)
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-issues-cache-age")
+            }
         }
         .padding(12)
     }

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MacSidebarRootView: View {
     @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
     @Environment(SidebarChromeState.self) private var chrome
     @Environment(MacSidebarPreferences.self) private var preferences
     @Environment(MacSidebarDisplayPreferences.self) private var displayPreferences
@@ -193,6 +194,9 @@ struct MacSidebarRootView: View {
     private var dashboard: some View {
         VStack(spacing: 0) {
             dashboardToolbar
+            if !network.isConnected {
+                offlineBanner
+            }
             if let errorMessage = store.errorMessage {
                 MacRecoveryBanner(
                     message: errorMessage,
@@ -232,6 +236,22 @@ struct MacSidebarRootView: View {
         .task {
             await store.load(api: api, refresh: false)
         }
+    }
+
+    private var offlineBanner: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Label("Offline - showing cached data when available", systemImage: "wifi.slash")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 14)
+        .padding(.bottom, 10)
+        .accessibilityIdentifier("mac-sidebar-offline-banner")
     }
 
     private var dashboardToolbar: some View {

--- a/apple/IssueCTLMac/Views/MacSidebarStore.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarStore.swift
@@ -7,6 +7,8 @@ final class MacSidebarStore {
     private(set) var drafts: [Draft] = []
     private(set) var sessions: [ActiveDeployment] = []
     private(set) var sessionPreviewsByPort: [Int: SessionPreview] = [:]
+    private(set) var issuesFromCache = false
+    private(set) var issuesCachedAt: String?
     private(set) var sessionsFromCache = false
     private(set) var sessionsCachedAt: String?
     private(set) var sessionPreviewError: String?
@@ -28,6 +30,8 @@ final class MacSidebarStore {
         drafts = []
         sessions = []
         sessionPreviewsByPort = [:]
+        issuesFromCache = false
+        issuesCachedAt = nil
         sessionsFromCache = false
         sessionsCachedAt = nil
         sessionPreviewError = nil
@@ -57,6 +61,8 @@ final class MacSidebarStore {
 
             var loadedIssues: [MacIssueListItem] = []
             var issueFailures: [String] = []
+            var cachedIssueDates: [Date] = []
+            var didUseCachedIssues = false
 
             for (index, repo) in loadedRepos.enumerated() {
                 do {
@@ -64,6 +70,10 @@ final class MacSidebarStore {
                     loadedIssues.append(contentsOf: response.issues.map { issue in
                         MacIssueListItem(issue: issue, repo: repo, repoIndex: index)
                     })
+                    didUseCachedIssues = didUseCachedIssues || response.fromCache
+                    if let cachedAt = response.cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                        cachedIssueDates.append(date)
+                    }
                 } catch {
                     issueFailures.append("\(repo.fullName): \(error.localizedDescription)")
                 }
@@ -73,6 +83,8 @@ final class MacSidebarStore {
             issues = loadedIssues.sorted { lhs, rhs in
                 (lhs.issue.updatedDate ?? .distantPast) > (rhs.issue.updatedDate ?? .distantPast)
             }
+            issuesFromCache = didUseCachedIssues
+            issuesCachedAt = cachedIssueDates.min().map { sharedISO8601Formatter.string(from: $0) }
             drafts = try await draftsResult.drafts
             let loadedSessions = try await sessionsResult
             sessions = loadedSessions.deployments
@@ -534,6 +546,45 @@ struct MacTerminalPreferences: Equatable {
     var lineHeight: String
 
     static let `default` = MacTerminalPreferences(fontSize: 14, lineHeight: "1.25")
+}
+
+enum MacCacheIndicatorModel {
+    static func cacheAgeText(cachedAt: String?, now: Date = Date()) -> String? {
+        guard let cachedAt, let date = parseIssueCTLDate(cachedAt) else { return nil }
+        return cacheAgeText(cachedAt: date, now: now)
+    }
+
+    static func cacheAgeText(cachedAt date: Date, now: Date = Date()) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(date)))
+        if seconds < 60 {
+            return "just now"
+        }
+
+        let minutes = seconds / 60
+        if minutes < 60 {
+            return "\(minutes)m ago"
+        }
+
+        let hours = minutes / 60
+        if hours < 24 {
+            return "\(hours)h ago"
+        }
+
+        let days = hours / 24
+        return "\(days)d ago"
+    }
+
+    static func cachedBannerText(kind: String, cachedAt: String?, now: Date = Date()) -> String {
+        if let age = cacheAgeText(cachedAt: cachedAt, now: now) {
+            return "Showing cached \(kind) from \(age)"
+        }
+        return "Showing cached \(kind)"
+    }
+
+    static func updatedText(cachedAt: String?, now: Date = Date()) -> String? {
+        guard let age = cacheAgeText(cachedAt: cachedAt, now: now) else { return nil }
+        return "Updated \(age)"
+    }
 }
 
 struct MacTerminalAccess: Equatable {

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -239,6 +239,42 @@ final class MacIssueFilterStateTests: XCTestCase {
         }
     }
 
+    func testMacCacheIndicatorFormatsAgeBuckets() {
+        let now = Date(timeIntervalSince1970: 3_600)
+
+        XCTAssertEqual(
+            MacCacheIndicatorModel.cacheAgeText(cachedAt: Date(timeIntervalSince1970: 3_575), now: now),
+            "just now"
+        )
+        XCTAssertEqual(
+            MacCacheIndicatorModel.cacheAgeText(cachedAt: Date(timeIntervalSince1970: 3_000), now: now),
+            "10m ago"
+        )
+        XCTAssertEqual(
+            MacCacheIndicatorModel.cacheAgeText(cachedAt: Date(timeIntervalSince1970: 0), now: now),
+            "1h ago"
+        )
+        XCTAssertEqual(
+            MacCacheIndicatorModel.cacheAgeText(cachedAt: Date(timeIntervalSince1970: -86_400), now: now),
+            "1d ago"
+        )
+    }
+
+    func testMacCacheIndicatorBuildsBannerAndUpdatedCopy() {
+        let now = Date(timeIntervalSince1970: 3_600)
+        let cachedAt = "1970-01-01T00:50:00Z"
+
+        XCTAssertEqual(
+            MacCacheIndicatorModel.cachedBannerText(kind: "issues", cachedAt: cachedAt, now: now),
+            "Showing cached issues from 10m ago"
+        )
+        XCTAssertEqual(
+            MacCacheIndicatorModel.updatedText(cachedAt: cachedAt, now: now),
+            "Updated 10m ago"
+        )
+        XCTAssertNil(MacCacheIndicatorModel.updatedText(cachedAt: nil, now: now))
+    }
+
     func testMacParseReviewStateAutoSelectsConfidentRepoAndAcceptedIssues() {
         let state = MacParseReviewState(parsedIssues: [
             parsedIssue(id: "parsed-1", owner: "mean-weasel", repo: "issuectl", confidence: 0.9),

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -80,6 +80,21 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testIssueCacheAndOfflineIndicators() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_CACHED_DATA"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE"] = "1"
+        app.launch()
+
+        XCTAssertTrue(issueRow("org/alpha", 1).waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-sidebar-offline-banner"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issues-cached-banner"].waitForExistence(timeout: 5), app.debugDescription)
+
+        issueRow("org/alpha", 1).click()
+        XCTAssertTrue(app.buttons["mac-issue-detail-edit-button"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-cached-banner"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testPullRequestListFiltersPaginatesAndOpensDetail() {
         selectRootSection("PRs")
 

--- a/apple/IssueCTLShared/Services/NetworkMonitor.swift
+++ b/apple/IssueCTLShared/Services/NetworkMonitor.swift
@@ -38,6 +38,11 @@ final class NetworkMonitor {
     }
 
     init() {
+        if ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE"] == "1" {
+            isConnected = false
+            connectionType = .unknown
+            return
+        }
         startMonitoring()
     }
 

--- a/docs/goals/mac-ios-parity/notes/T059-phase-9a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T059-phase-9a-branch-start.md
@@ -1,0 +1,22 @@
+# T059 Phase 9A Branch Start
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-9a-cache-visibility`
+Base: `mac-sidebar-spaces-option-a`
+
+Objective: implement the Phase 9A Mac cache/offline visibility slice selected by T058.
+
+Initial scope:
+
+- Offline/network status banner in the Mac sidebar.
+- Issue list cached-data and cache-age indicators.
+- Issue detail cached-data and cache-age indicators.
+- Deterministic cache/offline UI and formatting tests.
+
+Excluded from this branch:
+
+- Offline action queue and replay.
+- Queue settings management.
+- Notifications.
+- Today/Attention surface.

--- a/docs/goals/mac-ios-parity/notes/T059-phase-9a-cache-visibility.md
+++ b/docs/goals/mac-ios-parity/notes/T059-phase-9a-cache-visibility.md
@@ -1,0 +1,39 @@
+# T059 Phase 9A Cache Visibility
+
+Date: 2026-05-14
+
+## Result
+
+`done`
+
+Implemented the Phase 9A Mac cache/offline visibility slice in PR #441.
+
+https://github.com/mean-weasel/issuectl/pull/441
+
+## Changes
+
+- Added an offline banner to the Mac sidebar using the shared `NetworkMonitor`.
+- Added deterministic fixture support for offline and cached Mac UI test launches.
+- Surfaced cached issue list and issue detail indicators with cache-age copy.
+- Added cache-age formatting helpers for Mac issue surfaces.
+- Preserved existing PR and session cache banners; no PR/session surface behavior changed.
+
+## Excluded Scope
+
+- Offline mutation queue and replay.
+- Queue settings management.
+- Notifications.
+- Today/Attention surface.
+
+## Validation
+
+- `git diff --check` passed.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed with existing warnings only.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` passed: 24 tests, 0 failures.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueCacheAndOfflineIndicators` passed: 1 test, 0 failures.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests` passed: 36 tests, 0 failures.
+
+## Residual Risk
+
+This slice verifies deterministic cached/offline UI with fixtures. Real outage dogfood is still useful before the broader Phase 9 offline queue/replay work, but no network outage or queue behavior was part of this PR-sized slice.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T059
+active_task: T060
 
 tasks:
   - id: T001
@@ -2979,7 +2979,7 @@ tasks:
   - id: T059
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 9A Mac cache/offline visibility: show network/offline status in the Mac sidebar, surface cached-data and cache-age indicators for issue list and issue detail, preserve existing PR/session cache banners, and add deterministic tests for cache age formatting and cached/offline UI."
     inputs:
@@ -3024,6 +3024,64 @@ tasks:
       - "NetworkMonitor cannot be observed in the Mac sidebar without broader coordinator architecture changes."
       - "Offline queue/replay work becomes necessary to make the visibility slice coherent."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      full_outcome_complete: false
+      note: "notes/T059-phase-9a-cache-visibility.md"
+      changed_files:
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacIssuesView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarRootView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarStore.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+        - "apple/IssueCTLShared/Services/NetworkMonitor.swift"
+      pr:
+        number: 441
+        url: "https://github.com/mean-weasel/issuectl/pull/441"
+        branch: "mac-parity-phase-9a-cache-visibility"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass
+          note: "Passed with existing warnings only."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          summary: "24 tests, 0 failures."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueCacheAndOfflineIndicators"
+          status: pass
+          summary: "1 test, 0 failures."
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          summary: "36 tests, 0 failures."
+      summary: "Implemented Mac sidebar offline visibility and cached issue list/detail cache-age indicators with deterministic unit and UI coverage."
+
+  - id: T060
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #441 Phase 9A cache/offline visibility for acceptance criteria coverage, GitHub check state, merge readiness, and the next Phase 9 slice."
+    inputs:
+      - "T059 receipt"
+      - "PR #441 diff and GitHub checks"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 9"
+    constraints:
+      - "Do not implement product changes unless merge-gate validation reveals a small required fix."
+      - "Do not merge red CI without an explicit recorded exception and replacement validation."
+      - "Record no-checks state if GitHub has no configured checks for this branch."
+      - "If merge-ready, mark the PR ready, merge into mac-sidebar-spaces-option-a, record the merge commit, and choose the next safe PR-sized slice."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "GitHub check state and local replacement validation."
+      - "Merge commit SHA if merged."
+      - "Next PR-sized Phase 9 worker task if safe local work remains."
     receipt: null
 
   - id: T999
@@ -3053,12 +3111,11 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: pass
-    task: T026
+    task: T059
     commands:
       - "git diff --check"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-build -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-phase5c-tests -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLMacTests"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -derivedDataPath /tmp/issuectl-ios-phase5c-tests -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test -only-testing:IssueCTLTests/APIClientExtensionTests"
-      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -derivedDataPath /tmp/issuectl-mac-ui-derived -destination 'platform=macOS,arch=arm64' test -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
       - "pnpm typecheck"
       - "pnpm lint"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueCacheAndOfflineIndicators"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"


### PR DESCRIPTION
## Summary

Phase 9A Mac cache/offline visibility slice.

## Acceptance Criteria

- Mac sidebar shows network/offline status when the local network/server state is unavailable.
- Issue list surfaces cached-data and cache-age indicators from existing API metadata.
- Issue detail surfaces cached-data and cache-age indicators from existing API metadata.
- Existing PR/session cached banners continue to work.
- Deterministic tests cover cache age formatting and cached/offline UI.

## Validation

- [ ] git diff --check
- [ ] pnpm typecheck
- [ ] pnpm lint
- [ ] MacIssueFilterStateTests
- [ ] MacSidebarSmokeTests

## Excluded

- Offline action queue and replay
- Queue settings management
- Notifications
- Today/Attention surface