### PR TITLE
Mac parity Phase 9B: offline action queue

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		CA0880B76E28E6276050AEB3 /* IssueCTLMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AB7A2B9999184E67A3064A /* IssueCTLMacApp.swift */; };
 		CAB1C0D607788F1D1314C3E5 /* MacSidebarSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0E8C15D2965C1673B992B7 /* MacSidebarSmokeTests.swift */; };
 		CB1BD4038692E9AD73D95C1B /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
+		CB63E6EB1583F4E24A18E9B2 /* OfflineSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D18AA45E02B78332950BEDE /* OfflineSyncService.swift */; };
 		CC16C63936A1F4ECDEB3133E /* NotificationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2438738AD84484EC2E7B20C9 /* NotificationPreferences.swift */; };
 		CC83F861B2A764DB8AA4FC4A /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FF2A59CF2F42F9977FE4D /* IssueRowView.swift */; };
 		CCD66F76181E54FD2700F813 /* MacSidebarPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C02C0464A65420CBD5D90E /* MacSidebarPreferencesTests.swift */; };
@@ -1307,6 +1308,7 @@
 				B4AF2A85F0768942BCD81D8C /* NetworkMonitor.swift in Sources */,
 				D9E454235B1E43451B1B9597 /* NotificationPreferences.swift in Sources */,
 				3F98C9896C5653D619ABA40F /* OfflineCacheStore.swift in Sources */,
+				CB63E6EB1583F4E24A18E9B2 /* OfflineSyncService.swift in Sources */,
 				74BBC81070D4A029011534E6 /* PerformanceTrace.swift in Sources */,
 				B3D5E3FD4EF67AE7FA0244FA /* PullRequest.swift in Sources */,
 				358CDAE5EB531763716F6364 /* PushDevice.swift in Sources */,

--- a/apple/IssueCTLMac/App/IssueCTLMacApp.swift
+++ b/apple/IssueCTLMac/App/IssueCTLMacApp.swift
@@ -9,6 +9,7 @@ struct IssueCTLMacApp: App {
         Settings {
             MacSettingsView()
                 .environment(appDelegate.apiClient)
+                .environment(appDelegate.offlineSync)
                 .environment(appDelegate.sidebarPreferences)
                 .environment(appDelegate.sidebarCoordinator)
                 .environment(\.resetSidebarLayout) {
@@ -21,9 +22,11 @@ struct IssueCTLMacApp: App {
 @MainActor
 final class MacAppDelegate: NSObject, NSApplicationDelegate {
     let apiClient = APIClient()
+    lazy var offlineSync = OfflineSyncService(client: apiClient)
     let sidebarPreferences = MacSidebarPreferences()
     lazy var sidebarCoordinator = SpaceSidebarCoordinator(
         apiClient: apiClient,
+        offlineSync: offlineSync,
         preferences: sidebarPreferences,
         networkMonitor: networkMonitor
     )
@@ -35,6 +38,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         PerformanceTrace.markAppLaunchStarted()
         NSApp.setActivationPolicy(.accessory)
         configureUITestFixtureAPIIfNeeded()
+        configureUITestOfflineQueueIfNeeded()
         sidebarCoordinator.start()
         configureStatusItem()
     }
@@ -49,6 +53,21 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             UserDefaults.standard.removePersistentDomain(forName: bundleIdentifier)
         }
         URLProtocol.registerClass(MacUITestFixtureURLProtocol.self)
+    }
+
+    private func configureUITestOfflineQueueIfNeeded() {
+        let env = ProcessInfo.processInfo.environment
+        guard env["ISSUECTL_UI_TESTING"] == "1",
+              env["ISSUECTL_MAC_UI_FIXTURE_OFFLINE_QUEUE"] == "1" else {
+            return
+        }
+
+        offlineSync.enqueueIssueComment(
+            owner: "org",
+            repo: "alpha",
+            issueNumber: 1,
+            body: "Queued fixture comment"
+        )
     }
 
     private func configureStatusItem() {
@@ -137,6 +156,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         let windowController = settingsWindowController ?? makeSettingsWindowController()
         settingsWindowController = windowController
         windowController.showWindow(nil)
+        windowController.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -155,6 +175,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     private func makeSettingsWindowController() -> NSWindowController {
         let settingsView = MacSettingsView()
             .environment(apiClient)
+            .environment(offlineSync)
             .environment(sidebarPreferences)
             .environment(sidebarCoordinator)
             .environment(\.resetSidebarLayout) { [weak self] in
@@ -203,6 +224,11 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: imageData)
             client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        if Self.shouldFailOfflineAction(request) {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
             return
         }
 
@@ -1138,6 +1164,18 @@ private final class MacUITestFixtureURLProtocol: URLProtocol {
             "from_cache": isCached,
             "cached_at": isCached ? isoDate : NSNull(),
         ]
+    }
+
+    private static func shouldFailOfflineAction(_ request: URLRequest) -> Bool {
+        guard ProcessInfo.processInfo.environment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE_ACTION_FAILURE"] == "1",
+              let method = request.httpMethod,
+              let path = request.url?.path else {
+            return false
+        }
+
+        return method == "POST"
+            && (path == "/api/v1/issues/org/alpha/1/comments"
+                || path == "/api/v1/issues/org/alpha/1/state")
     }
 
     private static func issuesResponse(_ issues: [[String: Any]]) -> [String: Any] {

--- a/apple/IssueCTLMac/Platform/DisplaySidebarCoordinator.swift
+++ b/apple/IssueCTLMac/Platform/DisplaySidebarCoordinator.swift
@@ -77,6 +77,7 @@ final class MacSidebarSpaceAnchorWindow {
 @Observable @MainActor
 final class SpaceSidebarCoordinator {
     let apiClient: APIClient
+    let offlineSync: OfflineSyncService
     let preferences: MacSidebarPreferences
     let networkMonitor: NetworkMonitor
     let store: MacSidebarStore
@@ -90,11 +91,13 @@ final class SpaceSidebarCoordinator {
 
     init(
         apiClient: APIClient,
+        offlineSync: OfflineSyncService,
         preferences: MacSidebarPreferences,
         networkMonitor: NetworkMonitor,
         store: MacSidebarStore = MacSidebarStore()
     ) {
         self.apiClient = apiClient
+        self.offlineSync = offlineSync
         self.preferences = preferences
         self.networkMonitor = networkMonitor
         self.store = store
@@ -276,6 +279,7 @@ final class SpaceSidebarCoordinator {
         let spaceKey = state.id
         let rootView = MacSidebarRootView(store: store, issueFilterState: state.issueFilterState)
             .environment(apiClient)
+            .environment(offlineSync)
             .environment(networkMonitor)
             .environment(state.chrome)
             .environment(preferences)

--- a/apple/IssueCTLMac/Views/MacIssueDetailView.swift
+++ b/apple/IssueCTLMac/Views/MacIssueDetailView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct MacIssueDetailView: View {
     @Environment(APIClient.self) private var api
+    @Environment(OfflineSyncService.self) private var offlineSync
+    @Environment(NetworkMonitor.self) private var network
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
 
@@ -156,8 +158,7 @@ struct MacIssueDetailView: View {
         }
         .sheet(isPresented: $isShowingCloseWithComment) {
             MacCloseIssueSheet(issueNumber: issue.number, owner: item.repo.owner, repo: item.repo.name) { comment in
-                try await store.updateIssueState(api: api, item: item, state: "closed", comment: comment)
-                await load(refresh: true)
+                try await closeIssue(comment: comment)
                 isShowingCloseWithComment = false
             }
         }
@@ -736,7 +737,18 @@ struct MacIssueDetailView: View {
             commentBody = ""
             await load(refresh: true)
         } catch {
-            errorMessage = error.localizedDescription
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueComment(
+                    owner: item.repo.owner,
+                    repo: item.repo.name,
+                    issueNumber: item.issue.number,
+                    body: trimmed
+                )
+                commentBody = ""
+                successMessage = "Comment queued - will sync when you're back online"
+            } else {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -749,7 +761,40 @@ struct MacIssueDetailView: View {
             try await store.updateIssueState(api: api, item: item, state: state)
             await load(refresh: true)
         } catch {
-            errorMessage = error.localizedDescription
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(
+                    owner: item.repo.owner,
+                    repo: item.repo.name,
+                    issueNumber: item.issue.number,
+                    state: state
+                )
+                successMessage = state == "closed"
+                    ? "Issue close queued - will sync when you're back online"
+                    : "Issue reopen queued - will sync when you're back online"
+            } else {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func closeIssue(comment: String?) async throws {
+        errorMessage = nil
+        do {
+            try await store.updateIssueState(api: api, item: item, state: "closed", comment: comment)
+            await load(refresh: true)
+        } catch {
+            if isQueueableNetworkFailure(error, isConnected: network.isConnected) {
+                offlineSync.enqueueIssueState(
+                    owner: item.repo.owner,
+                    repo: item.repo.name,
+                    issueNumber: item.issue.number,
+                    state: "closed",
+                    comment: comment
+                )
+                successMessage = "Issue close queued - will sync when you're back online"
+            } else {
+                throw error
+            }
         }
     }
 

--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct MacSettingsView: View {
     @Environment(APIClient.self) private var api
+    @Environment(OfflineSyncService.self) private var offlineSync
     @Environment(MacSidebarPreferences.self) private var preferences
     @Environment(SpaceSidebarCoordinator.self) private var sidebarCoordinator
     @Environment(\.resetSidebarLayout) private var resetSidebarLayout
@@ -45,136 +46,141 @@ struct MacSettingsView: View {
     @State private var editingRepo: Repo?
     @State private var repoPendingRemoval: Repo?
     @State private var removingRepoFullName: String?
+    @State private var isSyncingOfflineQueue = false
 
     var body: some View {
-        Form {
-            connectionSection
+        VStack(alignment: .leading, spacing: 12) {
+            offlineQueueSection
 
-            advancedSettingsSection
+            Form {
+                connectionSection
 
-            worktreesSection
+                advancedSettingsSection
 
-            Section("Mac Sidebar") {
-                Toggle("Launch at Login", isOn: launchAtLoginBinding)
-                    .disabled(isUpdatingLaunchAtLogin)
+                worktreesSection
 
-                if isUpdatingLaunchAtLogin {
-                    ProgressView()
-                        .controlSize(.small)
-                }
+                Section("Mac Sidebar") {
+                    Toggle("Launch at Login", isOn: launchAtLoginBinding)
+                        .disabled(isUpdatingLaunchAtLogin)
 
-                if let error = preferences.launchAtLoginError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Text Size")
-                        Spacer()
-                        Text("\(Int(preferences.textScale * 100))%")
-                            .foregroundStyle(.secondary)
+                    if isUpdatingLaunchAtLogin {
+                        ProgressView()
+                            .controlSize(.small)
                     }
 
-                    Slider(
-                        value: textScaleBinding,
-                        in: MacSidebarPreferences.minimumTextScale...MacSidebarPreferences.maximumTextScale,
-                        step: 0.05
-                    )
-
-                    HStack {
-                        Text("Smaller")
-                        Spacer()
-                        Text("Larger")
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-            }
-
-            Section("Repositories") {
-                HStack {
-                    Button {
-                        showAddRepo = true
-                    } label: {
-                        Label("Add Repository", systemImage: "plus")
-                    }
-                    .accessibilityIdentifier("mac-settings-add-repository-button")
-
-                    Spacer()
-
-                    Button {
-                        Task { await loadRepos(refresh: true) }
-                    } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
-                    }
-                    .disabled(isLoadingRepos)
-                    .accessibilityIdentifier("mac-settings-refresh-repositories-button")
-                }
-
-                if isLoadingRepos && repos.isEmpty {
-                    ProgressView("Loading repositories...")
-                        .accessibilityIdentifier("mac-settings-repositories-loading")
-                } else if let repoError, repos.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label(repoError, systemImage: "exclamationmark.triangle")
+                    if let error = preferences.launchAtLoginError {
+                        Text(error)
+                            .font(.caption)
                             .foregroundStyle(.red)
                             .fixedSize(horizontal: false, vertical: true)
-                            .accessibilityIdentifier("mac-settings-repositories-error")
-                        Button("Retry") {
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Text Size")
+                            Spacer()
+                            Text("\(Int(preferences.textScale * 100))%")
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Slider(
+                            value: textScaleBinding,
+                            in: MacSidebarPreferences.minimumTextScale...MacSidebarPreferences.maximumTextScale,
+                            step: 0.05
+                        )
+
+                        HStack {
+                            Text("Smaller")
+                            Spacer()
+                            Text("Larger")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Repositories") {
+                    HStack {
+                        Button {
+                            showAddRepo = true
+                        } label: {
+                            Label("Add Repository", systemImage: "plus")
+                        }
+                        .accessibilityIdentifier("mac-settings-add-repository-button")
+
+                        Spacer()
+
+                        Button {
                             Task { await loadRepos(refresh: true) }
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                        .disabled(isLoadingRepos)
+                        .accessibilityIdentifier("mac-settings-refresh-repositories-button")
+                    }
+
+                    if isLoadingRepos && repos.isEmpty {
+                        ProgressView("Loading repositories...")
+                            .accessibilityIdentifier("mac-settings-repositories-loading")
+                    } else if let repoError, repos.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label(repoError, systemImage: "exclamationmark.triangle")
+                                .foregroundStyle(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .accessibilityIdentifier("mac-settings-repositories-error")
+                            Button("Retry") {
+                                Task { await loadRepos(refresh: true) }
+                            }
+                        }
+                    } else if repos.isEmpty {
+                        ContentUnavailableView(
+                            "No Repositories",
+                            systemImage: "folder",
+                            description: Text("Add a repo to populate sidebar issue filters.")
+                        )
+                        .accessibilityIdentifier("mac-settings-repositories-empty")
+                    } else {
+                        ForEach(repos) { repo in
+                            MacSettingsRepoRow(
+                                repo: repo,
+                                isRemoving: removingRepoFullName == repo.fullName,
+                                onEdit: { editingRepo = repo },
+                                onRemove: { repoPendingRemoval = repo }
+                            )
                         }
                     }
-                } else if repos.isEmpty {
-                    ContentUnavailableView(
-                        "No Repositories",
-                        systemImage: "folder",
-                        description: Text("Add a repo to populate sidebar issue filters.")
-                    )
-                    .accessibilityIdentifier("mac-settings-repositories-empty")
-                } else {
-                    ForEach(repos) { repo in
-                        MacSettingsRepoRow(
-                            repo: repo,
-                            isRemoving: removingRepoFullName == repo.fullName,
-                            onEdit: { editingRepo = repo },
-                            onRemove: { repoPendingRemoval = repo }
-                        )
+
+                    if let repoError, !repos.isEmpty {
+                        Label(repoError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("mac-settings-repositories-refresh-error")
+                    }
+
+                    Button("Open Web Settings") {
+                        openWebSettings()
+                    }
+                    .accessibilityIdentifier("mac-settings-open-web-settings-button")
+                }
+
+                Section("Learned Desktops") {
+                    if sidebarCoordinator.spaceStates.isEmpty {
+                        Text("No desktops learned yet")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(sidebarCoordinator.spaceStates, id: \.id) { spaceState in
+                            spaceSettingsRow(spaceState)
+                        }
+                    }
+
+                    Button("Reset All Desktop Sidebar Layouts") {
+                        resetSidebarLayout()
                     }
                 }
-
-                if let repoError, !repos.isEmpty {
-                    Label(repoError, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.red)
-                        .font(.caption)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .accessibilityIdentifier("mac-settings-repositories-refresh-error")
-                }
-
-                Button("Open Web Settings") {
-                    openWebSettings()
-                }
-                .accessibilityIdentifier("mac-settings-open-web-settings-button")
             }
-
-            Section("Learned Desktops") {
-                if sidebarCoordinator.spaceStates.isEmpty {
-                    Text("No desktops learned yet")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(sidebarCoordinator.spaceStates, id: \.id) { spaceState in
-                        spaceSettingsRow(spaceState)
-                    }
-                }
-
-                Button("Reset All Desktop Sidebar Layouts") {
-                    resetSidebarLayout()
-                }
-            }
+            .formStyle(.grouped)
         }
-        .formStyle(.grouped)
         .frame(width: 500)
         .frame(minHeight: 640)
         .padding()
@@ -490,6 +496,63 @@ struct MacSettingsView: View {
         }
     }
 
+    private var offlineQueueSection: some View {
+        GroupBox("Offline Queue") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: offlineSync.failedCount > 0 ? "exclamationmark.arrow.triangle.2.circlepath" : "arrow.triangle.2.circlepath")
+                    Text("\(offlineSync.pendingCount) pending, \(offlineSync.failedCount) failed")
+                        .accessibilityIdentifier("mac-settings-offline-queue-summary")
+
+                    Spacer()
+
+                    Button {
+                        Task { await syncOfflineQueue() }
+                    } label: {
+                        if isSyncingOfflineQueue || offlineSync.isSyncing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Label("Sync", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(isSyncingOfflineQueue || offlineSync.isSyncing || offlineSync.pendingCount == 0)
+                    .accessibilityIdentifier("mac-settings-offline-queue-sync-button")
+                }
+
+                if offlineSync.failedCount > 0 {
+                    HStack {
+                        Button {
+                            offlineSync.retryFailedActions()
+                        } label: {
+                            Label("Retry Failed", systemImage: "arrow.uturn.forward")
+                        }
+                        .accessibilityIdentifier("mac-settings-offline-queue-retry-failed-button")
+
+                        Button(role: .destructive) {
+                            offlineSync.clearFailedActions()
+                        } label: {
+                            Label("Clear Failed", systemImage: "trash")
+                        }
+                        .accessibilityIdentifier("mac-settings-offline-queue-clear-failed-button")
+                    }
+                }
+
+                if offlineSync.actions.isEmpty {
+                    Text("No queued actions")
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("mac-settings-offline-queue-empty")
+                } else {
+                    ForEach(offlineSync.actions) { action in
+                        MacOfflineQueueRow(action: action) {
+                            offlineSync.removeAction(id: action.id)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private var staleWorktrees: [WorktreeInfo] {
         worktrees.filter(\.stale)
     }
@@ -556,6 +619,13 @@ struct MacSettingsView: View {
         async let advancedTask: () = loadAdvancedSettings()
         async let worktreesTask: () = loadWorktrees()
         _ = await (connectionTask, reposTask, advancedTask, worktreesTask)
+        offlineSync.refreshCounts()
+    }
+
+    private func syncOfflineQueue() async {
+        isSyncingOfflineQueue = true
+        defer { isSyncingOfflineQueue = false }
+        _ = await offlineSync.syncPendingActions()
     }
 
     private func loadConnectionStatus() async {
@@ -1074,6 +1144,83 @@ private struct MacSettingsWorktreeRow: View {
         .padding(.vertical, 4)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("mac-settings-worktree-row-\(worktree.name)")
+    }
+}
+
+private struct MacOfflineQueueRow: View {
+    let action: QueuedOfflineAction
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: iconName)
+                .foregroundStyle(statusColor)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                if let lastError = action.lastError, !lastError.isEmpty {
+                    Text(lastError)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+
+            Button(role: .destructive) {
+                onRemove()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove queued action")
+            .accessibilityIdentifier("mac-settings-offline-queue-remove-\(action.id)")
+        }
+        .accessibilityIdentifier("mac-settings-offline-queue-row-\(action.id)")
+    }
+
+    private var title: String {
+        switch action.kind {
+        case .issueComment(let comment):
+            "Comment on \(comment.owner)/\(comment.repo)#\(comment.issueNumber)"
+        case .issueState(let issueState):
+            "\(issueState.state == "closed" ? "Close" : "Reopen") \(issueState.owner)/\(issueState.repo)#\(issueState.issueNumber)"
+        }
+    }
+
+    private var detail: String {
+        let status = action.status.rawValue
+        return "\(status) - queued \(action.createdAt)"
+    }
+
+    private var iconName: String {
+        switch action.status {
+        case .pending:
+            "clock.arrow.circlepath"
+        case .inFlight:
+            "arrow.triangle.2.circlepath"
+        case .failed:
+            "exclamationmark.triangle"
+        }
+    }
+
+    private var statusColor: Color {
+        switch action.status {
+        case .pending:
+            .secondary
+        case .inFlight:
+            .blue
+        case .failed:
+            .orange
+        }
     }
 }
 

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -95,6 +95,25 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["mac-issue-detail-cached-banner"].waitForExistence(timeout: 5), app.debugDescription)
     }
 
+    func testOfflineIssueCommentQueuesFromIssueDetail() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE"] = "1"
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE_ACTION_FAILURE"] = "1"
+        app.launch()
+
+        let firstIssue = issueRow("org/alpha", 1)
+        XCTAssertTrue(firstIssue.waitForExistence(timeout: 8), app.debugDescription)
+        openIssue(firstIssue)
+
+        let commentBody = app.textViews["mac-comment-composer-body-field"]
+        XCTAssertTrue(commentBody.waitForExistence(timeout: 5), app.debugDescription)
+        commentBody.click()
+        commentBody.typeText("Queued offline comment from Mac")
+        app.buttons["mac-comment-composer-submit-button"].click()
+        let queuedMessage = app.staticTexts.containing(NSPredicate(format: "value CONTAINS[c] %@", "Comment queued")).firstMatch
+        XCTAssertTrue(queuedMessage.waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testPullRequestListFiltersPaginatesAndOpensDetail() {
         selectRootSection("PRs")
 

--- a/docs/goals/mac-ios-parity/notes/T061-phase-9b-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T061-phase-9b-branch-start.md
@@ -1,0 +1,21 @@
+# T061 Phase 9B Branch Start
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-9b-offline-queue`
+Base: `mac-sidebar-spaces-option-a`
+
+Objective: implement the Phase 9B Mac offline queue foundation selected by T060.
+
+Initial scope:
+
+- Wire existing offline sync service and queue store into the Mac app.
+- Queue issue comments and close/reopen actions on queueable network failures.
+- Expose pending/failed queue status plus basic sync/retry/clear/remove controls.
+- Add deterministic unit and UI coverage for queue visibility and replay behavior.
+
+Excluded from this branch:
+
+- Notifications.
+- Today/Attention surface.
+- New queue formats or broad reliability refactors.

--- a/docs/goals/mac-ios-parity/notes/T061-phase-9b-offline-queue.md
+++ b/docs/goals/mac-ios-parity/notes/T061-phase-9b-offline-queue.md
@@ -1,0 +1,34 @@
+# T061 Phase 9B Offline Queue Foundation
+
+Date: 2026-05-14
+
+## Result
+
+Implemented Phase 9B on `mac-parity-phase-9b-offline-queue` in draft PR #442.
+
+## Changes
+
+- Wired the existing `OfflineSyncService` into the Mac app delegate, settings scene, and per-Desktop sidebar coordinator.
+- Added Mac offline queue handling for queueable issue detail actions:
+  - issue comments
+  - issue close/reopen state changes
+  - close-with-comment state changes
+- Added Mac settings queue status and controls for pending/failed counts, sync, retry failed, clear failed, and per-action removal.
+- Added deterministic Mac UI fixture failure hooks for queueable comment/state network failures.
+- Added Mac UI coverage for offline comment queuing from issue detail.
+- Kept non-queueable actions outside this queue slice.
+
+## Validation
+
+- `git diff --check`: pass
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings only
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9b-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests`: pass, 8 tests
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 24 tests
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testOfflineIssueCommentQueuesFromIssueDetail -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNativeRepositoryManagement`: pass, 2 tests
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: pass, 37 tests
+
+## Residual Risk
+
+- The Mac UI test proves queueing from the issue detail surface and the full settings suite proves native settings still opens and functions. It does not assert queue row visibility in Settings because the macOS accessibility tree did not reliably expose the queue summary during earlier attempts.
+- Replay behavior remains covered by the shared `OfflineSyncServiceTests`; this slice reuses that service rather than introducing a Mac-specific queue implementation.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T061
+active_task: T062
 
 tasks:
   - id: T001
@@ -3111,7 +3111,7 @@ tasks:
   - id: T061
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 9B Mac offline queue foundation: wire the existing offline sync service into the Mac app, queue add-comment and close/reopen issue actions on queueable network failures, expose pending/failed queue status and basic sync/retry/clear/remove controls in Mac settings or issue surfaces, and add deterministic unit/UI tests for queue visibility and replay behavior."
     inputs:
@@ -3165,6 +3165,75 @@ tasks:
       - "Mock outage/replay tests require backend behavior not available in local fixture routes."
       - "Queue state management requires a larger settings architecture rewrite."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      decision: implemented
+      full_outcome_complete: false
+      note: "notes/T061-phase-9b-offline-queue.md"
+      pr:
+        number: 442
+        url: "https://github.com/mean-weasel/issuectl/pull/442"
+        branch: "mac-parity-phase-9b-offline-queue"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        head_sha: "See current PR head after receipt commit is pushed."
+      changed_files:
+        - "apple/IssueCTL.xcodeproj/project.pbxproj"
+        - "apple/IssueCTLMac/App/IssueCTLMacApp.swift"
+        - "apple/IssueCTLMac/Platform/DisplaySidebarCoordinator.swift"
+        - "apple/IssueCTLMac/Views/MacIssueDetailView.swift"
+        - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      acceptance:
+        - "Mac app uses the existing OfflineSyncService instead of a second queue format."
+        - "Issue comments queue on queueable network failures."
+        - "Issue close/reopen actions queue on queueable network failures."
+        - "Mac settings exposes pending/failed queue status and sync/retry/clear/remove controls."
+        - "Non-queueable actions remain outside the offline queue slice."
+        - "Shared replay behavior remains covered by OfflineSyncServiceTests."
+      validation:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm typecheck"
+          status: pass
+        - cmd: "pnpm lint"
+          status: pass_with_existing_warnings
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9b-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests"
+          status: pass
+          tests: 8
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+          status: pass
+          tests: 24
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testOfflineIssueCommentQueuesFromIssueDetail -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNativeRepositoryManagement"
+          status: pass
+          tests: 2
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+          status: pass
+          tests: 37
+      residual_risk:
+        - "Settings queue row visibility is implemented but not asserted by UI test because macOS accessibility did not reliably expose the queue summary during earlier attempts."
+      summary: "Wired Mac to the shared offline sync queue, queued issue comment and close/reopen actions on queueable failures, exposed queue controls in Mac settings, and validated with shared replay tests plus full Mac sidebar smoke coverage."
+
+  - id: T062
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #442 Phase 9B offline queue foundation for acceptance coverage, GitHub check state, merge readiness, and next Phase 9 slice selection."
+    inputs:
+      - "T061 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/442"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 9"
+    constraints:
+      - "Do not expand Phase 9B implementation scope."
+      - "Merge only if PR checks are green, or if no checks are configured and local validation from T061 is accepted as replacement evidence."
+      - "If merge-ready, mark the PR ready, merge into mac-sidebar-spaces-option-a, record the merge commit, and choose the next safe PR-sized slice."
+      - "Do not mark the overall goal complete."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "PR check state and local replacement validation."
+      - "Merge result or required fixes."
+      - "Next PR-sized parity task."
     receipt: null
 
   - id: T999
@@ -3194,11 +3263,11 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: pass
-    task: T059
+    task: T061
     commands:
       - "git diff --check"
       - "pnpm typecheck"
       - "pnpm lint"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testIssueCacheAndOfflineIndicators"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9a-cache -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9b-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"


### PR DESCRIPTION
## Summary\n\nPhase 9B Mac offline queue foundation from docs/specs/2026-05-14-mac-ios-parity-plan.md.\n\nPlanned scope:\n- Wire existing offline sync service/queue store into the Mac app.\n- Queue issue comments and close/reopen actions on queueable network failures.\n- Add visible pending/failed queue status and basic sync/retry/clear/remove controls.\n- Add deterministic unit/UI coverage for queue visibility and replay behavior.\n\nExcluded:\n- Notifications.\n- Today/Attention surface.\n- Non-queueable actions such as image upload, edit/delete comments, assignment, priority, drafts, PR actions, launch, and terminal operations.\n\nValidation target:\n- git diff --check\n- pnpm typecheck\n- pnpm lint\n- iOS OfflineSyncServiceTests\n- Mac focused unit tests\n- MacSidebarSmokeTests\n