### PR TITLE
Mac parity Phase 9C: offline queue hardening

### DIFF
--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -500,8 +500,8 @@ struct MacSettingsView: View {
         GroupBox("Offline Queue") {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Image(systemName: offlineSync.failedCount > 0 ? "exclamationmark.arrow.triangle.2.circlepath" : "arrow.triangle.2.circlepath")
-                    Text("\(offlineSync.pendingCount) pending, \(offlineSync.failedCount) failed")
+                    Image(systemName: MacOfflineQueueSummaryProjection(pendingCount: offlineSync.pendingCount, failedCount: offlineSync.failedCount).iconName)
+                    Text(MacOfflineQueueSummaryProjection(pendingCount: offlineSync.pendingCount, failedCount: offlineSync.failedCount).text)
                         .accessibilityIdentifier("mac-settings-offline-queue-summary")
 
                     Spacer()
@@ -551,6 +551,7 @@ struct MacSettingsView: View {
                 }
             }
         }
+        .accessibilityIdentifier("mac-settings-offline-queue-section")
     }
 
     private var staleWorktrees: [WorktreeInfo] {
@@ -1151,21 +1152,25 @@ private struct MacOfflineQueueRow: View {
     let action: QueuedOfflineAction
     let onRemove: () -> Void
 
+    private var projection: MacOfflineQueueActionProjection {
+        MacOfflineQueueActionProjection(action: action)
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
-            Image(systemName: iconName)
-                .foregroundStyle(statusColor)
+            Image(systemName: projection.iconName)
+                .foregroundStyle(projection.statusColor)
                 .frame(width: 18)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(title)
+                Text(projection.title)
                     .font(.subheadline.weight(.medium))
-                Text(detail)
+                Text(projection.detail)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
 
-                if let lastError = action.lastError, !lastError.isEmpty {
+                if let lastError = projection.lastError {
                     Text(lastError)
                         .font(.caption)
                         .foregroundStyle(.orange)
@@ -1184,10 +1189,29 @@ private struct MacOfflineQueueRow: View {
             .help("Remove queued action")
             .accessibilityIdentifier("mac-settings-offline-queue-remove-\(action.id)")
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(projection.accessibilityLabel)
         .accessibilityIdentifier("mac-settings-offline-queue-row-\(action.id)")
     }
+}
 
-    private var title: String {
+struct MacOfflineQueueSummaryProjection: Equatable {
+    let pendingCount: Int
+    let failedCount: Int
+
+    var text: String {
+        "\(pendingCount) pending, \(failedCount) failed"
+    }
+
+    var iconName: String {
+        failedCount > 0 ? "exclamationmark.arrow.triangle.2.circlepath" : "arrow.triangle.2.circlepath"
+    }
+}
+
+struct MacOfflineQueueActionProjection: Equatable {
+    let action: QueuedOfflineAction
+
+    var title: String {
         switch action.kind {
         case .issueComment(let comment):
             "Comment on \(comment.owner)/\(comment.repo)#\(comment.issueNumber)"
@@ -1196,12 +1220,26 @@ private struct MacOfflineQueueRow: View {
         }
     }
 
-    private var detail: String {
+    var detail: String {
         let status = action.status.rawValue
         return "\(status) - queued \(action.createdAt)"
     }
 
-    private var iconName: String {
+    var lastError: String? {
+        guard let lastError = action.lastError, !lastError.isEmpty else {
+            return nil
+        }
+        return lastError
+    }
+
+    var accessibilityLabel: String {
+        if let lastError {
+            return "\(title), \(detail), \(lastError)"
+        }
+        return "\(title), \(detail)"
+    }
+
+    var iconName: String {
         switch action.status {
         case .pending:
             "clock.arrow.circlepath"
@@ -1212,7 +1250,7 @@ private struct MacOfflineQueueRow: View {
         }
     }
 
-    private var statusColor: Color {
+    var statusColor: Color {
         switch action.status {
         case .pending:
             .secondary

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -221,6 +221,98 @@ final class MacIssueFilterStateTests: XCTestCase {
         XCTAssertThrowsError(try MacRepoNameInput.parse("mean-weasel/issuectl/extra"))
     }
 
+    func testMacOfflineQueueSummaryAndRowsExposeActionDetails() {
+        let pendingSummary = MacOfflineQueueSummaryProjection(pendingCount: 2, failedCount: 0)
+        XCTAssertEqual(pendingSummary.text, "2 pending, 0 failed")
+        XCTAssertEqual(pendingSummary.iconName, "arrow.triangle.2.circlepath")
+
+        let failedSummary = MacOfflineQueueSummaryProjection(pendingCount: 1, failedCount: 1)
+        XCTAssertEqual(failedSummary.text, "1 pending, 1 failed")
+        XCTAssertEqual(failedSummary.iconName, "exclamationmark.arrow.triangle.2.circlepath")
+
+        let comment = MacOfflineQueueActionProjection(action: queuedComment(status: .pending))
+        XCTAssertEqual(comment.title, "Comment on org/alpha#1")
+        XCTAssertTrue(comment.detail.contains("pending - queued 2026-05-14T00:00:00Z"))
+        XCTAssertNil(comment.lastError)
+        XCTAssertEqual(comment.iconName, "clock.arrow.circlepath")
+
+        let failedState = MacOfflineQueueActionProjection(action: queuedState(status: .failed, lastError: "GitHub rejected the state change"))
+        XCTAssertEqual(failedState.title, "Close org/alpha#1")
+        XCTAssertEqual(failedState.lastError, "GitHub rejected the state change")
+        XCTAssertEqual(failedState.iconName, "exclamationmark.triangle")
+        XCTAssertTrue(failedState.accessibilityLabel.contains("GitHub rejected the state change"))
+    }
+
+    func testMacOfflineSyncServiceReplaysAndControlsQueue() async throws {
+        let store = OfflineActionQueueStore(defaults: defaults)
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "alpha",
+            issueNumber: 1,
+            body: "Queued from Mac",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        store.enqueueIssueState(
+            owner: "org",
+            repo: "alpha",
+            issueNumber: 1,
+            state: "closed",
+            comment: "Close from Mac",
+            id: "state-1",
+            now: Date(timeIntervalSince1970: 1)
+        )
+        let client = MacOfflineQueueFakeClient(
+            commentResponses: [.success(IssueCommentResponse(success: true, commentId: 501, error: nil))],
+            stateResponses: [.success(IssueStateResponse(success: true, commentPosted: true, error: nil))]
+        )
+        let service = OfflineSyncService(store: store, client: client)
+
+        let result = await service.syncPendingActions()
+
+        XCTAssertEqual(result.attempted, 2)
+        XCTAssertEqual(result.completed, 2)
+        XCTAssertEqual(result.failed, 0)
+        XCTAssertTrue(store.allActions().isEmpty)
+        XCTAssertEqual(client.requests, [
+            .comment(owner: "org", repo: "alpha", number: 1, body: "Queued from Mac"),
+            .state(owner: "org", repo: "alpha", number: 1, state: "closed", comment: "Close from Mac"),
+        ])
+    }
+
+    func testMacOfflineSyncRetryClearAndRemoveControlsMutateQueue() throws {
+        let store = OfflineActionQueueStore(defaults: defaults)
+        store.enqueueIssueComment(
+            owner: "org",
+            repo: "alpha",
+            issueNumber: 1,
+            body: "Queued from Mac",
+            id: "comment-1",
+            now: Date(timeIntervalSince1970: 0)
+        )
+        store.markFailed(id: "comment-1", error: "network unavailable", now: Date(timeIntervalSince1970: 1))
+        let service = OfflineSyncService(store: store, client: MacOfflineQueueFakeClient())
+
+        service.retryFailedActions()
+
+        XCTAssertEqual(service.pendingCount, 1)
+        XCTAssertEqual(service.failedCount, 0)
+        XCTAssertEqual(store.allActions().first?.lastError, "network unavailable")
+
+        store.markFailed(id: "comment-1", error: "still offline", now: Date(timeIntervalSince1970: 2))
+        service.refreshCounts()
+        XCTAssertEqual(service.failedCount, 1)
+
+        service.clearFailedActions()
+        XCTAssertTrue(service.actions.isEmpty)
+
+        service.enqueueIssueState(owner: "org", repo: "alpha", issueNumber: 1, state: "open")
+        let actionID = try XCTUnwrap(service.actions.first?.id)
+        service.removeAction(id: actionID)
+
+        XCTAssertTrue(service.actions.isEmpty)
+    }
+
     func testMacImageAttachmentProcessorPreparesFixtureJPEGData() async throws {
         let data = try await MacImageAttachmentProcessor.preparedJPEGData(from: MacImageAttachmentProcessor.fixturePNGData)
 
@@ -578,5 +670,86 @@ final class MacIssueFilterStateTests: XCTestCase {
             owner: owner,
             repoName: repo
         )
+    }
+
+    private func queuedComment(status: OfflineActionStatus, lastError: String? = nil) -> QueuedOfflineAction {
+        QueuedOfflineAction(
+            id: "comment-1",
+            kind: .issueComment(IssueCommentOfflineAction(
+                owner: "org",
+                repo: "alpha",
+                issueNumber: 1,
+                body: "Queued from Mac"
+            )),
+            status: status,
+            retryCount: status == .failed ? 1 : 0,
+            lastError: lastError,
+            createdAt: "2026-05-14T00:00:00Z",
+            updatedAt: "2026-05-14T00:00:00Z"
+        )
+    }
+
+    private func queuedState(status: OfflineActionStatus, lastError: String? = nil) -> QueuedOfflineAction {
+        QueuedOfflineAction(
+            id: "state-1",
+            kind: .issueState(IssueStateOfflineAction(
+                owner: "org",
+                repo: "alpha",
+                issueNumber: 1,
+                state: "closed",
+                comment: "Close from Mac"
+            )),
+            status: status,
+            retryCount: status == .failed ? 1 : 0,
+            lastError: lastError,
+            createdAt: "2026-05-14T00:00:00Z",
+            updatedAt: "2026-05-14T00:00:00Z"
+        )
+    }
+}
+
+private enum MacOfflineQueueFakeRequest: Equatable {
+    case comment(owner: String, repo: String, number: Int, body: String)
+    case state(owner: String, repo: String, number: Int, state: String, comment: String?)
+}
+
+@MainActor
+private final class MacOfflineQueueFakeClient: OfflineIssueCommentPosting, OfflineIssueStateUpdating {
+    private var commentResponses: [Result<IssueCommentResponse, Error>]
+    private var stateResponses: [Result<IssueStateResponse, Error>]
+    private(set) var requests: [MacOfflineQueueFakeRequest] = []
+
+    init(
+        commentResponses: [Result<IssueCommentResponse, Error>] = [],
+        stateResponses: [Result<IssueStateResponse, Error>] = []
+    ) {
+        self.commentResponses = commentResponses
+        self.stateResponses = stateResponses
+    }
+
+    func commentOnIssue(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueCommentRequestBody
+    ) async throws -> IssueCommentResponse {
+        requests.append(.comment(owner: owner, repo: repo, number: number, body: body.body))
+        guard !commentResponses.isEmpty else {
+            return IssueCommentResponse(success: true, commentId: nil, error: nil)
+        }
+        return try commentResponses.removeFirst().get()
+    }
+
+    func updateIssueState(
+        owner: String,
+        repo: String,
+        number: Int,
+        body: IssueStateRequestBody
+    ) async throws -> IssueStateResponse {
+        requests.append(.state(owner: owner, repo: repo, number: number, state: body.state, comment: body.comment))
+        guard !stateResponses.isEmpty else {
+            return IssueStateResponse(success: true, commentPosted: nil, error: nil)
+        }
+        return try stateResponses.removeFirst().get()
     }
 }

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -875,6 +875,22 @@ final class MacSidebarSmokeTests: XCTestCase {
         app.buttons["Cancel"].click()
     }
 
+    func testSettingsShowsSeededOfflineQueue() {
+        app.terminate()
+        app.launchEnvironment["ISSUECTL_MAC_UI_FIXTURE_OFFLINE_QUEUE"] = "1"
+        app.launch()
+
+        openSettings()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-offline-queue-summary"].waitForExistence(timeout: 5), app.debugDescription)
+        let removeQueuedAction = app.buttons
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "mac-settings-offline-queue-remove-"))
+            .firstMatch
+        XCTAssertTrue(removeQueuedAction.waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.buttons["mac-settings-offline-queue-sync-button"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-settings-offline-queue-empty"].exists, app.debugDescription)
+    }
+
     func testSettingsShowsConnectionAndSavesAdvancedSettings() {
         openSettings()
 

--- a/docs/goals/mac-ios-parity/notes/T063-phase-9c-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T063-phase-9c-branch-start.md
@@ -1,0 +1,13 @@
+# T063 Phase 9C Branch Start
+
+Date: 2026-05-14
+
+## Branch
+
+- Branch: `mac-parity-phase-9c-offline-queue-hardening`
+- Base: `mac-sidebar-spaces-option-a`
+- Base commit: `cf30ca4`
+
+## Scope
+
+Add deterministic Mac-specific evidence for offline queue visibility/actions and replay behavior before moving to Phase 10 notifications.

--- a/docs/goals/mac-ios-parity/notes/T063-phase-9c-offline-queue-hardening.md
+++ b/docs/goals/mac-ios-parity/notes/T063-phase-9c-offline-queue-hardening.md
@@ -1,0 +1,43 @@
+# T063 Phase 9C Offline Queue Hardening
+
+Date: 2026-05-14
+
+## Result
+
+Implemented Phase 9C Mac offline queue hardening on `mac-parity-phase-9c-offline-queue-hardening`.
+
+PR: https://github.com/mean-weasel/issuectl/pull/443
+Base: `mac-sidebar-spaces-option-a`
+Head before receipt commit: `f1e62caadfe9821d58f130818a7f4e0cb9661c9d`
+GitHub checks: none reported
+Merge state: `CLEAN`
+
+## Changes
+
+- Added Mac offline queue summary and row projection types so queue rendering, status icons, detail text, last error display, and accessibility labels have deterministic unit coverage.
+- Added stable accessibility identifiers and labels around Mac settings offline queue rows and controls.
+- Added Mac unit coverage for queue summary/row projections, queue replay through `OfflineSyncService`, retry/clear/remove behavior, and FIFO comment/state replay requests.
+- Added a Mac UI fixture path that seeds a queued offline comment and verifies the Settings offline queue summary, sync button, and remove action are visible.
+
+## Acceptance Evidence
+
+- Mac settings queue visibility is covered by `MacSidebarSmokeTests/testSettingsShowsSeededOfflineQueue`.
+- Sync, retry failed, clear failed, and remove controls are covered by `MacIssueFilterStateTests/testMacOfflineSyncServiceReplaysAndControlsQueue` and `testMacOfflineSyncRetryClearAndRemoveControlsMutateQueue`.
+- Queued Mac issue comment and state replay is covered by `testMacOfflineSyncServiceReplaysAndControlsQueue`.
+- Failed action detail projection is covered by `testMacOfflineQueueSummaryAndRowsExposeActionDetails`.
+- Non-queueable Mac issue/PR actions remain outside this slice; the full Mac smoke suite continued to cover existing issue/PR action behavior without queue regressions.
+
+## Dogfood
+
+Real stop-web/restart-web dogfood was not performed in this run because the local web server may be serving the user's current machine session. Replacement evidence used the deterministic Mac UI fixture (`ISSUECTL_MAC_UI_FIXTURE_OFFLINE_QUEUE=1`) plus shared offline sync replay tests. A manual dogfood pass remains appropriate before turning this from draft to merge-ready if the user wants real server interruption evidence.
+
+## Validation
+
+- `git diff --check`: pass
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings only
+- Focused Phase 9C Mac tests: 3 Mac unit tests and 1 Mac UI test passed
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: 27 tests passed
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9c-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests`: 8 tests passed
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests`: 38 tests passed
+

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T063
+active_task: T064
 
 tasks:
   - id: T001
@@ -3264,7 +3264,7 @@ tasks:
   - id: T063
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 9C Mac offline queue hardening and dogfood evidence: add deterministic Mac-specific coverage for queue visibility/actions and replay behavior, improve settings accessibility for queue rows if needed, and record dogfood steps for stopping/restarting the local web server."
     inputs:
@@ -3311,6 +3311,64 @@ tasks:
       - "Replay verification requires destructive real GitHub operations instead of local fixture behavior."
       - "Dogfood requires credentials or machine state not available in this run."
       - "Local validation fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      full_outcome_complete: false
+      note: "notes/T063-phase-9c-offline-queue-hardening.md"
+      pr:
+        number: 443
+        url: "https://github.com/mean-weasel/issuectl/pull/443"
+        branch: "mac-parity-phase-9c-offline-queue-hardening"
+        base: "mac-sidebar-spaces-option-a"
+        head_sha_before_receipt: "f1e62caadfe9821d58f130818a7f4e0cb9661c9d"
+        draft: true
+        merge_state: "CLEAN"
+        checks: "No checks reported."
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      acceptance_evidence:
+        - "Mac settings queue visibility covered by MacSidebarSmokeTests/testSettingsShowsSeededOfflineQueue."
+        - "Sync, retry failed, clear failed, and remove controls covered by MacIssueFilterStateTests queue tests."
+        - "Queued Mac comment and state replay covered by MacOfflineSyncService replay test."
+        - "Failed queued action visible details covered by MacOfflineQueueActionProjection tests."
+        - "Full Mac sidebar smoke suite continued to cover non-queueable issue/PR action behavior."
+      dogfood:
+        status: replacement_evidence
+        note: "Real stop-web/restart-web dogfood was not performed to avoid disrupting the user's local machine session; deterministic UI fixture and sync replay tests are recorded as replacement evidence."
+      validation:
+        - "git diff --check: pass"
+        - "pnpm typecheck: pass"
+        - "pnpm lint: pass with existing warnings only"
+        - "Focused Phase 9C Mac tests: 3 unit tests and 1 UI test passed"
+        - "IssueCTLMacTests/MacIssueFilterStateTests: 27 tests passed"
+        - "IssueCTLTests/OfflineSyncServiceTests: 8 tests passed"
+        - "IssueCTLMacUITests/MacSidebarSmokeTests: 38 tests passed"
+      summary: "Added deterministic Mac offline queue projections, accessibility hooks, unit replay/control coverage, and a seeded Settings queue UI test in draft PR #443."
+
+  - id: T064
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #443 Phase 9C offline queue hardening for acceptance coverage, dogfood replacement adequacy, GitHub check state, merge readiness, and the next Phase 10 notification slice."
+    inputs:
+      - "T063 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/443"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 9 and Phase 10"
+    constraints:
+      - "Do not implement."
+      - "Decide whether replacement evidence is sufficient or real stop-web dogfood is required before merge."
+      - "Merge only if PR checks are green, or if no checks are configured and local validation from T063 is accepted as replacement evidence."
+      - "If merge-ready, mark the PR ready, merge into mac-sidebar-spaces-option-a, record the merge commit, and choose the next safe PR-sized slice."
+      - "Do not mark the overall goal complete."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "PR check state and local replacement validation."
+      - "Dogfood adequacy decision."
+      - "Merge result or required fixes."
+      - "Next PR-sized parity task."
     receipt: null
 
   - id: T999
@@ -3340,11 +3398,12 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: pass
-    task: T061
+    task: T063
     commands:
       - "git diff --check"
       - "pnpm typecheck"
       - "pnpm lint"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9b-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9b-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineQueueSummaryAndRowsExposeActionDetails -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineSyncServiceReplaysAndControlsQueue -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineSyncRetryClearAndRemoveControlsMutateQueue -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsSeededOfflineQueue"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9c-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"


### PR DESCRIPTION
## Summary
- harden Mac offline queue visibility/actions and replay coverage
- add deterministic Mac settings seeded queue UI coverage
- record Phase 9C validation and dogfood replacement evidence in GoalBuddy

## Validation
- git diff --check
- pnpm typecheck
- pnpm lint (existing warnings only)
- focused Phase 9C Mac tests: 3 unit tests and 1 UI test passed
- IssueCTLMacTests/MacIssueFilterStateTests: 27 tests passed
- IssueCTLTests/OfflineSyncServiceTests: 8 tests passed
- IssueCTLMacUITests/MacSidebarSmokeTests: 38 tests passed

## Dogfood
- real stop-web/restart-web dogfood was skipped to avoid disrupting the active local dev server on :3847
- replacement evidence: deterministic seeded queue UI fixture plus shared offline sync replay tests