### PR TITLE
Mac parity Phase 10A: notification unavailable copy

### DIFF
--- a/apple/IssueCTLMac/Views/MacSettingsView.swift
+++ b/apple/IssueCTLMac/Views/MacSettingsView.swift
@@ -59,6 +59,8 @@ struct MacSettingsView: View {
 
                 worktreesSection
 
+                notificationsSection
+
                 Section("Mac Sidebar") {
                     Toggle("Launch at Login", isOn: launchAtLoginBinding)
                         .disabled(isUpdatingLaunchAtLogin)
@@ -493,6 +495,33 @@ struct MacSettingsView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var notificationsSection: some View {
+        let projection = MacNotificationUnavailableProjection()
+
+        return Section("Notifications") {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: projection.iconName)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(projection.title)
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityIdentifier("mac-settings-notifications-title")
+                    Text(projection.message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("mac-settings-notifications-message")
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(projection.accessibilityLabel)
+            .accessibilityIdentifier("mac-settings-notifications-unavailable")
         }
     }
 
@@ -1259,6 +1288,16 @@ struct MacOfflineQueueActionProjection: Equatable {
         case .failed:
             .orange
         }
+    }
+}
+
+struct MacNotificationUnavailableProjection: Equatable {
+    let title = "Notifications are iOS-only for now"
+    let message = "Mac push registration is deferred while backend platform support is tracked in issue #444."
+    let iconName = "bell.slash"
+
+    var accessibilityLabel: String {
+        "\(title), \(message)"
     }
 }
 

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -243,6 +243,15 @@ final class MacIssueFilterStateTests: XCTestCase {
         XCTAssertTrue(failedState.accessibilityLabel.contains("GitHub rejected the state change"))
     }
 
+    func testMacNotificationUnavailableProjectionDocumentsDeferredPath() {
+        let projection = MacNotificationUnavailableProjection()
+
+        XCTAssertEqual(projection.title, "Notifications are iOS-only for now")
+        XCTAssertEqual(projection.iconName, "bell.slash")
+        XCTAssertTrue(projection.message.contains("issue #444"))
+        XCTAssertTrue(projection.accessibilityLabel.contains("backend platform support"))
+    }
+
     func testMacOfflineSyncServiceReplaysAndControlsQueue() async throws {
         let store = OfflineActionQueueStore(defaults: defaults)
         store.enqueueIssueComment(

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -891,6 +891,17 @@ final class MacSidebarSmokeTests: XCTestCase {
         XCTAssertFalse(app.descendants(matching: .any)["mac-settings-offline-queue-empty"].exists, app.debugDescription)
     }
 
+    func testSettingsShowsNotificationUnavailableState() {
+        openSettings()
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-notifications-unavailable"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-notifications-title"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-settings-notifications-message"].waitForExistence(timeout: 3), app.debugDescription)
+        XCTAssertFalse(app.switches["notifications-idle-terminals-toggle"].exists, app.debugDescription)
+        XCTAssertFalse(app.switches["notifications-new-issues-toggle"].exists, app.debugDescription)
+        XCTAssertFalse(app.switches["notifications-merged-prs-toggle"].exists, app.debugDescription)
+    }
+
     func testSettingsShowsConnectionAndSavesAdvancedSettings() {
         openSettings()
 

--- a/docs/goals/mac-ios-parity/notes/T066-phase-10a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T066-phase-10a-branch-start.md
@@ -1,0 +1,9 @@
+# T066 Phase 10A Branch Start
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-10a-notification-copy`
+Base: `mac-sidebar-spaces-option-a`
+
+Objective: add Mac settings copy for deferred/iOS-only notification support, prove no broken Mac notification toggles are exposed, and record validation before merge.
+

--- a/docs/goals/mac-ios-parity/notes/T066-phase-10a-notification-copy.md
+++ b/docs/goals/mac-ios-parity/notes/T066-phase-10a-notification-copy.md
@@ -1,0 +1,40 @@
+# T066 Phase 10A Notification Copy
+
+Date: 2026-05-14
+
+## Result
+
+Result: `done`
+
+PR: https://github.com/mean-weasel/issuectl/pull/445
+
+Branch: `mac-parity-phase-10a-notification-copy`
+
+Base: `mac-sidebar-spaces-option-a`
+
+## Changes
+
+- Added a Mac Settings `Notifications` section with an unavailable-state row.
+- Added a stable `MacNotificationUnavailableProjection` for title, body, icon, and accessibility copy.
+- Added unit coverage proving the unavailable-state copy and issue #444 reference are stable.
+- Added Mac UI coverage proving the Settings notification unavailable state is visible and iOS notification toggles are not exposed on Mac.
+
+## Acceptance Evidence
+
+- Mac settings includes a Notifications section that says notifications are iOS-only for now.
+- Backend/platform follow-up is linked through issue #444 in the unavailable-state copy and in this receipt.
+- No notification preference toggles are exposed in the Mac settings UI.
+- `MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath` covers title, body, icon, issue reference, and accessibility text.
+- `MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState` covers Settings visibility and absence of notification toggles.
+
+## Validation
+
+- `git diff --check`: pass
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings only
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 28 tests
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState`: pass, 2 tests
+
+## Notes
+
+Real macOS push notification registration remains deferred to https://github.com/mean-weasel/issuectl/issues/444. This slice intentionally does not change backend notification schema/API behavior, APNs topic configuration, entitlements, or remote notification delegate wiring.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T066
+active_task: T067
 
 tasks:
   - id: T001
@@ -3437,7 +3437,7 @@ tasks:
   - id: T066
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: medium
     objective: "Implement Phase 10A Mac notification unavailable settings copy: add a Mac settings Notifications section that clearly states push notifications are iOS-only/deferred on Mac and exposes no broken notification toggles."
     inputs:
@@ -3473,6 +3473,55 @@ tasks:
       - "Adding the copy requires a broad settings architecture rewrite."
       - "The UI cannot expose stable assertions without brittle accessibility behavior."
       - "Product direction changes to require real macOS push implementation immediately."
+    receipt:
+      result: done
+      full_outcome_complete: false
+      note: "notes/T066-phase-10a-notification-copy.md"
+      pr:
+        number: 445
+        url: "https://github.com/mean-weasel/issuectl/pull/445"
+        branch: "mac-parity-phase-10a-notification-copy"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending after push."
+      changed_files:
+        - "apple/IssueCTLMac/Views/MacSettingsView.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      acceptance_evidence:
+        - "Mac settings includes a Notifications section with iOS-only/deferred copy."
+        - "Unavailable-state copy and receipt link backend/platform issue #444."
+        - "Mac settings exposes no notification preference toggles."
+        - "MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath proves unavailable-state title/body/icon are stable."
+        - "MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState proves the settings surface is visible and notification toggles are absent."
+      validation:
+        - "git diff --check: pass"
+        - "pnpm typecheck: pass"
+        - "pnpm lint: pass with existing warnings only"
+        - "IssueCTLMacTests/MacIssueFilterStateTests: 28 tests passed"
+        - "Focused notification unit/UI tests: 2 tests passed"
+      summary: "Added explicit Mac notification unavailable copy in Settings, with projection and UI coverage proving no broken notification toggles are exposed."
+
+  - id: T067
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #445 Phase 10A notification copy for acceptance coverage, GitHub check state, merge readiness, and the next safe parity slice."
+    inputs:
+      - "T066 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/445"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 10 and Phase 11"
+    constraints:
+      - "Do not implement product code unless the review finds a small board/receipt-only correction is required."
+      - "Merge only if PR checks are green, or if no checks are configured and local validation from T066 is accepted as replacement evidence."
+      - "If merge-ready, mark the PR ready, merge into mac-sidebar-spaces-option-a, record the merge commit, and choose the next safe PR-sized slice."
+      - "Do not mark the overall goal complete."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "PR check state and local replacement validation."
+      - "Merge result or required fixes."
+      - "Next PR-sized parity task."
     receipt: null
 
   - id: T999
@@ -3502,12 +3551,10 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: pass
-    task: T063
+    task: T066
     commands:
       - "git diff --check"
       - "pnpm typecheck"
       - "pnpm lint"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineQueueSummaryAndRowsExposeActionDetails -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineSyncServiceReplaysAndControlsQueue -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacOfflineSyncRetryClearAndRemoveControlsMutateQueue -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsSeededOfflineQueue"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/issuectl-phase9c-ios -only-testing:IssueCTLTests/OfflineSyncServiceTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase9c-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState"


### PR DESCRIPTION
## Summary
- add a Mac Settings Notifications section for the deferred/iOS-only notification path
- keep Mac push registration controls unavailable instead of exposing broken toggles
- record Phase 10A GoalBuddy evidence and link backend/platform follow-up issue #444

## Acceptance Criteria
- Mac settings includes a Notifications section with unavailable/deferred copy
- backend/platform follow-up is linked through issue #444
- no notification preference toggles are exposed on Mac
- unit/projection coverage proves unavailable-state title/body/icon are stable
- Mac UI coverage verifies the settings surface and absence of toggles

## Validation
- `git diff --check`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings only)
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` (28 tests)
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState` (2 tests)

## Notes
- Real macOS push notification registration remains deferred to #444.
