### PR TITLE
Mac parity Phase 11A: Today attention section

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		5C8B076C5D41EB2832394E74 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9961C2183D56ACC7E5650E0 /* Issue.swift */; };
 		5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */; };
 		9D4E0A6C52F14F3A9B8C7D22 /* MacPullRequestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A0E9C4D2B4F68852C3D11 /* MacPullRequestsView.swift */; };
+		9E8D7C6B5A4938271605F4E3 /* MacTodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8D7C6B5A4938271605F4E2 /* MacTodayView.swift */; };
 		5F5DEDA652F31AC394A5A596 /* DraftWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FAC416FAB2ACA469E0EC6F /* DraftWorkflowTests.swift */; };
 		62580655D91E8E7A9A7950B1 /* NetworkErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */; };
 		62A88EE9440FC6032A029F78 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB04FB5543994CCE2DE041E /* KeychainService.swift */; };
@@ -287,6 +288,7 @@
 		0FA58C21063864ADB4BAC822 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		134385CA01429770C742CD89 /* MacSidebarRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarRootView.swift; sourceTree = "<group>"; };
 		7F1A0E9C4D2B4F68852C3D11 /* MacPullRequestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPullRequestsView.swift; sourceTree = "<group>"; };
+		9E8D7C6B5A4938271605F4E2 /* MacTodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTodayView.swift; sourceTree = "<group>"; };
 		13760098C8ED1658B27AD54B /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		15319A8AF148A10DF82FE6DD /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
@@ -710,6 +712,7 @@
 				134385CA01429770C742CD89 /* MacSidebarRootView.swift */,
 				E04E7DE3BF0A6826FE986B1D /* MacSidebarStore.swift */,
 				49CDE37EDB8F4EA3712FE68E /* MacSidebarTextScale.swift */,
+				9E8D7C6B5A4938271605F4E2 /* MacTodayView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1305,6 +1308,7 @@
 				BFC0A82D9CCFD653415A4A82 /* MacSidebarRootView.swift in Sources */,
 				22B99716E42E20F0DA147C5B /* MacSidebarStore.swift in Sources */,
 				ABD4FEB7F53690ECF6E60CDC /* MacSidebarTextScale.swift in Sources */,
+				9E8D7C6B5A4938271605F4E3 /* MacTodayView.swift in Sources */,
 				B4AF2A85F0768942BCD81D8C /* NetworkMonitor.swift in Sources */,
 				D9E454235B1E43451B1B9597 /* NotificationPreferences.swift in Sources */,
 				3F98C9896C5653D619ABA40F /* OfflineCacheStore.swift in Sources */,

--- a/apple/IssueCTLMac/Views/MacDraftsView.swift
+++ b/apple/IssueCTLMac/Views/MacDraftsView.swift
@@ -670,7 +670,7 @@ private struct DraftRow: View {
     }
 }
 
-private struct DirectIssueCreateSheet: View {
+struct DirectIssueCreateSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let repos: [Repo]

--- a/apple/IssueCTLMac/Views/MacSidebarRootView.swift
+++ b/apple/IssueCTLMac/Views/MacSidebarRootView.swift
@@ -222,6 +222,8 @@ struct MacSidebarRootView: View {
 
             Group {
                 switch selectedSection {
+                case .today:
+                    MacTodayView(store: store)
                 case .issues:
                     MacIssuesView(store: store, filterState: issueFilterState)
                 case .pullRequests:
@@ -377,6 +379,7 @@ struct MacSidebarRootView: View {
 }
 
 private enum MacSidebarSection: String, CaseIterable, Identifiable {
+    case today
     case issues
     case pullRequests
     case drafts
@@ -386,6 +389,7 @@ private enum MacSidebarSection: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
+        case .today: "Today"
         case .issues: "Issues"
         case .pullRequests: "PRs"
         case .drafts: "Drafts"
@@ -395,6 +399,7 @@ private enum MacSidebarSection: String, CaseIterable, Identifiable {
 
     var systemImage: String {
         switch self {
+        case .today: "smallcircle.filled.circle"
         case .issues: "list.bullet"
         case .pullRequests: "arrow.triangle.merge"
         case .drafts: "doc.text"

--- a/apple/IssueCTLMac/Views/MacTodayView.swift
+++ b/apple/IssueCTLMac/Views/MacTodayView.swift
@@ -1,0 +1,445 @@
+import SwiftUI
+
+enum MacTodayAttentionKind: Equatable {
+    case pull
+    case issue
+    case session
+
+    var title: String {
+        switch self {
+        case .pull: "PR"
+        case .issue: "Issue"
+        case .session: "Session"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .pull: "arrow.triangle.merge"
+        case .issue: "smallcircle.filled.circle"
+        case .session: "terminal"
+        }
+    }
+}
+
+struct MacTodayAttentionItem: Identifiable, Equatable {
+    let id: String
+    let kind: MacTodayAttentionKind
+    let repoFullName: String
+    let number: Int
+    let title: String
+    let subtitle: String
+    let isAttention: Bool
+}
+
+struct MacTodayProjection: Equatable {
+    let activeSessionCount: Int
+    let reviewPullCount: Int
+    let issueCount: Int
+    let items: [MacTodayAttentionItem]
+
+    var subtitle: String {
+        let count = items.count
+        return count == 1 ? "1 item needs attention" : "\(count) items need attention"
+    }
+}
+
+enum MacTodayModel {
+    static func project(
+        issues: [MacIssueListItem],
+        pulls: [MacPullRequestListItem],
+        sessions: [ActiveDeployment],
+        searchText: String,
+        currentUserLogin: String?
+    ) -> MacTodayProjection {
+        let assignedIssues = todayIssues(issues, currentUserLogin: currentUserLogin)
+        let reviewPulls = pulls
+            .filter { needsReviewAttention($0.pull) }
+            .sorted { sortPull($0.pull, before: $1.pull) }
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        let issueItems = assignedIssues
+            .filter { query.isEmpty || matches(query: query, title: $0.issue.title, body: $0.issue.body, repoFullName: $0.repoFullName, number: $0.issue.number) }
+            .prefix(4)
+            .map { item in
+                MacTodayAttentionItem(
+                    id: "issue-\(item.id)",
+                    kind: .issue,
+                    repoFullName: item.repoFullName,
+                    number: item.issue.number,
+                    title: item.issue.title,
+                    subtitle: issueSubtitle(item.issue),
+                    isAttention: item.issue.labels.contains { $0.name.lowercased().contains("block") }
+                )
+            }
+
+        let pullItems = reviewPulls
+            .filter { query.isEmpty || matches(query: query, title: $0.pull.title, body: $0.pull.body, repoFullName: $0.repoFullName, number: $0.pull.number) }
+            .prefix(4)
+            .map { item in
+                MacTodayAttentionItem(
+                    id: "pull-\(item.id)",
+                    kind: .pull,
+                    repoFullName: item.repoFullName,
+                    number: item.pull.number,
+                    title: item.pull.title,
+                    subtitle: pullSubtitle(item.pull),
+                    isAttention: item.pull.checksStatus == "failure"
+                )
+            }
+
+        let sessionItems: [MacTodayAttentionItem] = query.isEmpty ? sessions.prefix(3).map { session in
+            MacTodayAttentionItem(
+                id: "session-\(session.id)",
+                kind: .session,
+                repoFullName: session.repoFullName,
+                number: session.issueNumber,
+                title: session.branchName,
+                subtitle: "\(session.workspaceMode.rawValue) - \(session.runningDuration)",
+                isAttention: false
+            )
+        } : []
+
+        return MacTodayProjection(
+            activeSessionCount: sessions.filter(\.isActive).count,
+            reviewPullCount: reviewPulls.count,
+            issueCount: assignedIssues.count,
+            items: Array((pullItems + issueItems + sessionItems).prefix(8))
+        )
+    }
+
+    static func needsReviewAttention(_ pull: GitHubPull) -> Bool {
+        pull.isOpen && (pull.checksStatus == "failure" || pull.checksStatus == "pending")
+    }
+
+    private static func todayIssues(_ issues: [MacIssueListItem], currentUserLogin: String?) -> [MacIssueListItem] {
+        let openIssues = issues.filter(\.issue.isOpen)
+        guard let currentUserLogin else { return openIssues }
+        return openIssues.filter { item in
+            (item.issue.assignees ?? []).contains { $0.login == currentUserLogin }
+        }
+    }
+
+    private static func matches(query: String, title: String, body: String?, repoFullName: String, number: Int) -> Bool {
+        [
+            title,
+            body ?? "",
+            repoFullName,
+            "#\(number)",
+            "\(number)",
+        ]
+        .joined(separator: " ")
+        .lowercased()
+        .contains(query)
+    }
+
+    private static func issueSubtitle(_ issue: GitHubIssue) -> String {
+        if issue.labels.contains(where: { $0.name.lowercased().contains("block") }) {
+            return "Blocked"
+        }
+        if let assignees = issue.assignees, !assignees.isEmpty {
+            return "Assigned"
+        }
+        return "Open"
+    }
+
+    private static func pullSubtitle(_ pull: GitHubPull) -> String {
+        switch pull.checksStatus {
+        case "failure": "Failing checks"
+        case "pending": "Pending checks"
+        default: "Needs review"
+        }
+    }
+
+    private static func sortPull(_ lhs: GitHubPull, before rhs: GitHubPull) -> Bool {
+        let lhsIndex = pullSortIndex(lhs)
+        let rhsIndex = pullSortIndex(rhs)
+        if lhsIndex != rhsIndex { return lhsIndex < rhsIndex }
+        return lhs.number < rhs.number
+    }
+
+    private static func pullSortIndex(_ pull: GitHubPull) -> Int {
+        switch pull.checksStatus {
+        case "failure": 0
+        case "pending": 1
+        default: 2
+        }
+    }
+}
+
+struct MacTodayView: View {
+    @Environment(APIClient.self) private var api
+    @Environment(NetworkMonitor.self) private var network
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let store: MacSidebarStore
+
+    @State private var pulls: [MacPullRequestListItem] = []
+    @State private var isLoadingPulls = false
+    @State private var pullsFromCache = false
+    @State private var pullsCachedAt: String?
+    @State private var errorMessage: String?
+    @State private var searchText = ""
+    @State private var selectedIssue: MacIssueListItem?
+    @State private var selectedPull: MacPullRequestListItem?
+    @State private var isShowingQuickCreate = false
+
+    private var projection: MacTodayProjection {
+        MacTodayModel.project(
+            issues: store.issues,
+            pulls: pulls,
+            sessions: store.sessions,
+            searchText: searchText,
+            currentUserLogin: store.currentUserLogin
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controls
+
+            if isLoadingPulls && pulls.isEmpty && store.issues.isEmpty {
+                ProgressView("Loading today...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if projection.items.isEmpty {
+                ContentUnavailableView(emptyTitle, systemImage: "checkmark.circle", description: Text(emptyDescription))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityIdentifier("mac-today-empty-state")
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(projection.items) { item in
+                            Button {
+                                open(item)
+                            } label: {
+                                MacTodayAttentionRow(item: item)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("mac-today-row-\(item.kind.title.lowercased())-\(item.repoFullName)-\(item.number)")
+
+                            Divider()
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                }
+            }
+        }
+        .task { await loadPulls(refresh: false) }
+        .onChange(of: store.repos.count) { _, _ in
+            Task { await loadPulls(refresh: false) }
+        }
+        .sheet(item: $selectedIssue) { item in
+            MacIssueDetailView(item: item, store: store)
+        }
+        .sheet(item: $selectedPull) { item in
+            MacPullRequestDetailView(item: item, store: store)
+        }
+        .sheet(isPresented: $isShowingQuickCreate) {
+            DirectIssueCreateSheet(repos: store.repos) { repo, title, body, priority, labels in
+                _ = try await store.createIssue(api: api, title: title, body: body, priority: priority, repo: repo, labels: labels)
+                await loadPulls(refresh: true)
+            } loadLabels: { repo in
+                try await api.repoLabels(owner: repo.owner, repo: repo.name)
+            }
+        }
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(projection.subtitle)
+                    .font(.macSidebar(size: 12, weight: .semibold, scale: textScale))
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("mac-today-subtitle")
+
+                Spacer()
+
+                Button {
+                    isShowingQuickCreate = true
+                } label: {
+                    Label("New Issue", systemImage: "square.and.pencil")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(store.repos.isEmpty)
+                .accessibilityIdentifier("mac-today-new-issue-button")
+
+                Button {
+                    Task {
+                        await store.load(api: api, refresh: true)
+                        await loadPulls(refresh: true)
+                    }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(store.isLoading || isLoadingPulls)
+                .accessibilityLabel("Refresh Today")
+                .accessibilityIdentifier("mac-today-refresh-button")
+            }
+
+            HStack(spacing: 8) {
+                metric(value: projection.activeSessionCount, label: "Active", id: "mac-today-metric-sessions")
+                metric(value: projection.reviewPullCount, label: "Review", id: "mac-today-metric-prs")
+                metric(value: projection.issueCount, label: store.currentUserLogin == nil ? "Issues" : "Mine", id: "mac-today-metric-issues")
+            }
+
+            TextField("Search issues and PRs", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("mac-today-search-field")
+
+            if isShowingCachedData || !network.isConnected {
+                Label(cacheMessage, systemImage: "wifi.slash")
+                    .font(.macSidebar(size: 11, scale: textScale))
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("mac-today-cache-banner")
+            }
+
+            if let errorMessage {
+                MacRecoveryBanner(
+                    message: errorMessage,
+                    actionTitle: "Retry",
+                    isActionDisabled: isLoadingPulls
+                ) {
+                    Task { await loadPulls(refresh: true) }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private func metric(value: Int, label: String, id: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(value)")
+                .font(.macSidebar(size: 18, weight: .semibold, scale: textScale))
+            Text(label)
+                .font(.macSidebar(size: 10, scale: textScale))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+        .accessibilityIdentifier(id)
+    }
+
+    private var emptyTitle: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Queue Clear" : "No Matches"
+    }
+
+    private var emptyDescription: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "No reviews, assigned issues, or active sessions need attention."
+            : "No Today issues or pull requests match the current search."
+    }
+
+    private var isShowingCachedData: Bool {
+        store.issuesFromCache || store.sessionsFromCache || pullsFromCache
+    }
+
+    private var cacheMessage: String {
+        guard let oldest = [store.issuesCachedAt, store.sessionsCachedAt, pullsCachedAt]
+            .compactMap({ $0 })
+            .compactMap(parseIssueCTLDate)
+            .min()
+        else {
+            return "Showing cached today data"
+        }
+
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return "Showing cached today data from \(formatter.localizedString(for: oldest, relativeTo: Date()))"
+    }
+
+    private func open(_ item: MacTodayAttentionItem) {
+        switch item.kind {
+        case .issue:
+            selectedIssue = store.issues.first { $0.repoFullName == item.repoFullName && $0.issue.number == item.number }
+        case .pull:
+            selectedPull = pulls.first { $0.repoFullName == item.repoFullName && $0.pull.number == item.number }
+        case .session:
+            if let session = store.sessions.first(where: { $0.repoFullName == item.repoFullName && $0.issueNumber == item.number }) {
+                MacTerminalWindowController.open(session: session, store: store, api: api) {}
+            }
+        }
+    }
+
+    private func loadPulls(refresh: Bool) async {
+        guard !store.repos.isEmpty else { return }
+        isLoadingPulls = true
+        errorMessage = nil
+        defer { isLoadingPulls = false }
+
+        var loadedPulls: [MacPullRequestListItem] = []
+        var cachedDates: [Date] = []
+        var didUseCache = false
+        var failures: [String] = []
+
+        for (index, repo) in store.repos.enumerated() {
+            do {
+                let response = try await api.pulls(owner: repo.owner, repo: repo.name, refresh: refresh)
+                loadedPulls.append(contentsOf: response.pulls.map { pull in
+                    MacPullRequestListItem(pull: pull, repo: repo, repoIndex: index)
+                })
+                didUseCache = didUseCache || response.fromCache
+                if let cachedAt = response.cachedAt, let date = parseIssueCTLDate(cachedAt) {
+                    cachedDates.append(date)
+                }
+            } catch {
+                failures.append("\(repo.fullName): \(error.localizedDescription)")
+            }
+        }
+
+        pulls = loadedPulls
+        pullsFromCache = didUseCache
+        pullsCachedAt = cachedDates.min().map { sharedISO8601Formatter.string(from: $0) }
+        if !failures.isEmpty {
+            errorMessage = "Some PRs failed to load: \(failures.joined(separator: "; "))"
+        }
+    }
+}
+
+private struct MacTodayAttentionRow: View {
+    @Environment(\.macSidebarTextScale) private var textScale
+
+    let item: MacTodayAttentionItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: item.kind.iconName)
+                .font(.macSidebar(size: 15, weight: .semibold, scale: textScale))
+                .foregroundStyle(item.isAttention ? .orange : .secondary)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(item.kind.title)
+                        .font(.macSidebar(size: 10, weight: .semibold, scale: textScale))
+                        .foregroundStyle(.secondary)
+                    Text("\(item.repoFullName) #\(item.number)")
+                        .font(.macSidebar(size: 10, scale: textScale))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                Text(item.title)
+                    .font(.macSidebar(size: 12, weight: .semibold, scale: textScale))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+
+                Text(item.subtitle)
+                    .font(.macSidebar(size: 10, scale: textScale))
+                    .foregroundStyle(item.isAttention ? .orange : .secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 4)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+    }
+}

--- a/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
+++ b/apple/IssueCTLMacTests/MacIssueFilterStateTests.swift
@@ -444,6 +444,56 @@ final class MacIssueFilterStateTests: XCTestCase {
         ])
     }
 
+    func testMacTodayProjectionBuildsMetricsAttentionAndSearch() {
+        let blockingIssue = item(
+            number: 9,
+            repo: repos[0],
+            title: "Blocked login",
+            state: "open",
+            assignees: [user("alice")],
+            author: user("bob"),
+            updatedAt: "2026-05-14T10:00:00.000Z",
+            labels: [GitHubLabel(name: "blocked", color: "ff9900", description: nil)]
+        )
+        let otherIssue = item(
+            number: 10,
+            repo: repos[1],
+            title: "Other assigned",
+            state: "open",
+            assignees: [user("carol")],
+            author: user("bob"),
+            updatedAt: "2026-05-14T10:00:00.000Z"
+        )
+        let pulls = [
+            pullItem(number: 4, repo: repos[0], title: "Failing review", state: "open", merged: false, author: "alice", checksStatus: "failure", createdAt: "2026-05-14T09:00:00.000Z", updatedAt: "2026-05-14T09:00:00.000Z"),
+            pullItem(number: 5, repo: repos[0], title: "Passing cleanup", state: "open", merged: false, author: "alice", checksStatus: "success", createdAt: "2026-05-14T09:00:00.000Z", updatedAt: "2026-05-14T09:00:00.000Z"),
+        ]
+
+        let projection = MacTodayModel.project(
+            issues: [blockingIssue, otherIssue],
+            pulls: pulls,
+            sessions: [session(owner: "mean-weasel", repo: "issuectl", issueNumber: 2)],
+            searchText: "",
+            currentUserLogin: "alice"
+        )
+
+        XCTAssertEqual(projection.activeSessionCount, 1)
+        XCTAssertEqual(projection.reviewPullCount, 1)
+        XCTAssertEqual(projection.issueCount, 1)
+        XCTAssertEqual(projection.items.map(\.kind), [.pull, .issue, .session])
+        XCTAssertTrue(projection.items[1].isAttention)
+
+        let searchProjection = MacTodayModel.project(
+            issues: [blockingIssue, otherIssue],
+            pulls: pulls,
+            sessions: [session(owner: "mean-weasel", repo: "issuectl", issueNumber: 2)],
+            searchText: "failing",
+            currentUserLogin: "alice"
+        )
+
+        XCTAssertEqual(searchProjection.items.map(\.title), ["Failing review"])
+    }
+
     func testMacLaunchOptionsDefaultsUseSettingsLocalPathAndGeneratedBranch() {
         let repo = Repo(
             id: 1,
@@ -568,14 +618,15 @@ final class MacIssueFilterStateTests: XCTestCase {
         state: String,
         assignees: [GitHubUser],
         author: GitHubUser,
-        updatedAt: String
+        updatedAt: String,
+        labels: [GitHubLabel] = []
     ) -> MacIssueListItem {
         let issue = GitHubIssue(
             number: number,
             title: title,
             body: "Issue body",
             state: state,
-            labels: [],
+            labels: labels,
             assignees: assignees,
             user: author,
             commentCount: 0,

--- a/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
+++ b/apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift
@@ -171,6 +171,39 @@ final class MacSidebarSmokeTests: XCTestCase {
         app.typeKey(.escape, modifierFlags: [])
     }
 
+    func testTodayAttentionSectionShowsMetricsSearchAndNavigation() {
+        selectRootSection("Today")
+
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-metric-sessions"].waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-metric-prs"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-metric-issues"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-row-pr-org/alpha-10"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-row-issue-org/alpha-2"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-row-session-org/alpha-2"].waitForExistence(timeout: 5), app.debugDescription)
+
+        let search = app.textFields["mac-today-search-field"]
+        XCTAssertTrue(search.waitForExistence(timeout: 5), app.debugDescription)
+        search.click()
+        search.typeText("migration")
+        XCTAssertTrue(app.descendants(matching: .any)["mac-today-row-pr-org/alpha-11"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.descendants(matching: .any)["mac-today-row-issue-org/alpha-2"].exists, app.debugDescription)
+
+        let pullRow = app.descendants(matching: .any)["mac-today-row-pr-org/alpha-11"]
+        openPullRequest(pullRow)
+        XCTAssertTrue(app.buttons["mac-pr-detail-done-button"].waitForExistence(timeout: 5), app.debugDescription)
+    }
+
+    func testTodayQuickCreateOpensDirectIssueFlow() {
+        selectRootSection("Today")
+
+        let newIssueButton = app.buttons["mac-today-new-issue-button"]
+        XCTAssertTrue(newIssueButton.waitForExistence(timeout: 8), app.debugDescription)
+        newIssueButton.click()
+
+        let titleField = app.textFields["mac-quick-create-title-field"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), app.debugDescription)
+    }
+
     func testPullRequestDetailActionsSucceedAndRefresh() {
         selectRootSection("PRs")
         openPullRequest(prRow("org/alpha", 10))

--- a/docs/goals/mac-ios-parity/notes/T069-phase-11a-branch-start.md
+++ b/docs/goals/mac-ios-parity/notes/T069-phase-11a-branch-start.md
@@ -1,0 +1,9 @@
+# T069 Phase 11A Branch Start
+
+Date: 2026-05-14
+
+Branch: `mac-parity-phase-11a-today-attention`
+
+Base: `mac-sidebar-spaces-option-a`
+
+Objective: implement the compact Mac Today / Attention sidebar section selected by T068.

--- a/docs/goals/mac-ios-parity/notes/T069-phase-11a-today-attention.md
+++ b/docs/goals/mac-ios-parity/notes/T069-phase-11a-today-attention.md
@@ -1,0 +1,45 @@
+# T069 Phase 11A Today Attention
+
+Date: 2026-05-14
+
+## Result
+
+Result: `done`
+
+PR: https://github.com/mean-weasel/issuectl/pull/446
+
+Branch: `mac-parity-phase-11a-today-attention`
+
+Base: `mac-sidebar-spaces-option-a`
+
+## Changes
+
+- Added a first-class `Today` section to the Mac sidebar section picker and collapsed rail.
+- Added `MacTodayView`, a compact sidebar-native attention surface with metrics, search, attention rows, quick create, and cache/offline state.
+- Reused existing Mac issue detail, PR detail, terminal open, and direct issue creation surfaces.
+- Made `DirectIssueCreateSheet` reusable outside the Drafts section.
+- Added projection coverage for Today counts, attention ordering, blocking issue state, and search filtering.
+- Added UI coverage for Today metrics/search/navigation and quick create entry.
+
+## Acceptance Evidence
+
+- Mac sidebar now includes `Today` in expanded and collapsed section controls.
+- Metrics expose active sessions, review-needed PRs, and assigned/open issues.
+- Attention rows include review-needed PRs, assigned issues, and active sessions from fixture data.
+- PR and issue rows open existing Mac detail sheets; session rows use existing terminal open behavior.
+- Search filters loaded Today issues and PRs by text and preserves PR navigation.
+- Quick create opens the existing direct issue creation flow from Today.
+- Cached/offline indicators are wired from issue, PR, and session cache metadata.
+
+## Validation
+
+- `git diff --check`: pass
+- `pnpm typecheck`: pass
+- `pnpm lint`: pass with existing warnings only
+- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`: pass
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests`: pass, 29 tests
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayAttentionSectionShowsMetricsSearchAndNavigation -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayQuickCreateOpensDirectIssueFlow`: pass, 2 tests
+
+## Notes
+
+This is the compact-first Phase 11 implementation. It intentionally does not add a separate full Today window.

--- a/docs/goals/mac-ios-parity/state.yaml
+++ b/docs/goals/mac-ios-parity/state.yaml
@@ -63,7 +63,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T069
+active_task: T070
 
 tasks:
   - id: T001
@@ -3585,7 +3585,7 @@ tasks:
   - id: T069
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Phase 11A compact Mac Today / Attention sidebar section with metrics, attention rows, search, quick navigation, quick create, and cached/offline indicators."
     inputs:
@@ -3629,6 +3629,61 @@ tasks:
       - "Reusing the direct issue creation sheet requires a broad extraction beyond a small access-level change."
       - "Stable UI navigation cannot be tested without brittle menu-bar automation."
       - "The fixture server lacks enough issue/PR/session data and cannot be extended inside the allowed file set."
+    receipt:
+      result: done
+      full_outcome_complete: false
+      note: "notes/T069-phase-11a-today-attention.md"
+      pr:
+        number: 446
+        url: "https://github.com/mean-weasel/issuectl/pull/446"
+        branch: "mac-parity-phase-11a-today-attention"
+        base: "mac-sidebar-spaces-option-a"
+        draft: true
+        checks: "Pending after push."
+      changed_files:
+        - "apple/IssueCTL.xcodeproj/project.pbxproj"
+        - "apple/IssueCTLMac/Views/MacDraftsView.swift"
+        - "apple/IssueCTLMac/Views/MacSidebarRootView.swift"
+        - "apple/IssueCTLMac/Views/MacTodayView.swift"
+        - "apple/IssueCTLMacTests/MacIssueFilterStateTests.swift"
+        - "apple/IssueCTLMacUITests/MacSidebarSmokeTests.swift"
+      acceptance_evidence:
+        - "Mac sidebar includes Today in expanded and collapsed controls."
+        - "Today metrics cover active sessions, review-needed PRs, and assigned/open issues."
+        - "Fixture-backed attention rows cover PRs, issues, and active sessions."
+        - "Rows reuse existing Mac PR detail, issue detail, and terminal open behavior."
+        - "Search filters Today issues and PRs while preserving PR navigation."
+        - "Quick create opens the existing direct issue creation sheet."
+        - "Cache/offline indicator is wired from issue, PR, and session metadata."
+      validation:
+        - "git diff --check: pass"
+        - "pnpm typecheck: pass"
+        - "pnpm lint: pass with existing warnings only"
+        - "IssueCTLMac build: pass"
+        - "IssueCTLMacTests/MacIssueFilterStateTests: 29 tests passed"
+        - "Focused Today UI tests: 2 tests passed"
+      summary: "Added a compact Mac Today sidebar section with metrics, attention rows, search, quick create, existing detail/session navigation, cache/offline state, and deterministic unit/UI coverage."
+
+  - id: T070
+    type: judge
+    assignee: Judge
+    status: active
+    reasoning_hint: high
+    objective: "Review PR #446 Phase 11A Today attention section for acceptance coverage, GitHub check state, merge readiness, and whether Phase 11 needs a follow-up slice before final audit."
+    inputs:
+      - "T069 receipt"
+      - "https://github.com/mean-weasel/issuectl/pull/446"
+      - "docs/specs/2026-05-14-mac-ios-parity-plan.md Phase 11"
+    constraints:
+      - "Do not implement product code unless the review finds a small board/receipt-only correction is required."
+      - "Merge only if PR checks are green, or if no checks are configured and local validation from T069 is accepted as replacement evidence."
+      - "If merge-ready, mark the PR ready, merge into mac-sidebar-spaces-option-a, record the merge commit, and choose final audit or a Phase 11 follow-up."
+      - "Do not mark the overall goal complete unless the final audit task has actually completed."
+    expected_output:
+      - "Decision: merge_ready | changes_required | blocked."
+      - "PR check state and local replacement validation."
+      - "Merge result or required fixes."
+      - "Next task recommendation: final audit or Phase 11 follow-up."
     receipt: null
 
   - id: T999
@@ -3658,10 +3713,11 @@ checks:
   dirty_fingerprint: unknown
   last_verification:
     result: pass
-    task: T066
+    task: T069
     commands:
       - "git diff --check"
       - "pnpm typecheck"
       - "pnpm lint"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
-      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase10a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests/testMacNotificationUnavailableProjectionDocumentsDeferredPath -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testSettingsShowsNotificationUnavailableState"
+      - "xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayAttentionSectionShowsMetricsSearchAndNavigation -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayQuickCreateOpensDirectIssueFlow"


### PR DESCRIPTION
## Summary
- add compact Mac Today/Attention sidebar section
- surface metrics, attention rows, search, quick navigation, quick create, and cache/offline state
- reuse existing Mac issue detail, PR detail, terminal, and direct issue creation surfaces
- record Phase 11A GoalBuddy evidence

## Acceptance Criteria
- Mac sidebar has a Today section in expanded and collapsed controls
- metrics cover sessions, review PRs, and assigned/open issues
- attention rows cover review-needed PRs, assigned issues, and active sessions from fixture data
- rows navigate to existing Mac detail/session surfaces
- search filters issues and PRs and preserves PR navigation
- quick create opens existing direct issue flow
- cached/offline indicators are wired from underlying response metadata

## Validation
- `git diff --check`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings only)
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacTests/MacIssueFilterStateTests` (29 tests)
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTLMac -destination 'platform=macOS' -derivedDataPath /tmp/issuectl-phase11a-mac -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayAttentionSectionShowsMetricsSearchAndNavigation -only-testing:IssueCTLMacUITests/MacSidebarSmokeTests/testTodayQuickCreateOpensDirectIssueFlow` (2 tests)
