### PR TITLE
docs: record workbench goal completion

### DIFF
--- a/docs/goals/workbench/notes/T030-finish-development-branch.md
+++ b/docs/goals/workbench/notes/T030-finish-development-branch.md
@@ -1,0 +1,66 @@
+# T030 Finish Development Branch
+
+Result: done
+
+Full outcome complete: true
+
+## Final Branch Status
+
+- Implementation branch: `workbench-aggregate-and-shell`
+- Implementation PR: https://github.com/mean-weasel/issuectl/pull/448
+- Merge commit: `e5273f8ea4dde8e47860060b8f75912db4f072ee`
+- Merge time: 2026-05-17T07:58:01Z
+- Merge method: GitHub merge queue, squash merge
+
+## Local Verification
+
+Passed before PR creation:
+
+- `git diff --check`
+- `pnpm --filter @issuectl/web typecheck`
+- `pnpm --filter @issuectl/web test -- components/workbench/workbench.test.ts app/api/v1/workbench/route.test.ts`
+- `pnpm --filter @issuectl/web test:e2e -- e2e/workbench.spec.ts --project=desktop-chromium`
+- `pnpm --filter @issuectl/web lint`
+- `pnpm --filter @issuectl/web test`
+
+Also passed during commit hooks:
+
+- `pnpm turbo typecheck`
+- `pnpm turbo lint`
+
+## Review And CI
+
+- Code review: `~/.codex/skills/codex-review/scripts/codex-review --full-access` completed with no accepted/actionable findings.
+- PR checks passed on PR #448:
+  - Detect changes
+  - Typecheck
+  - Lint
+  - Test
+  - Build
+  - E2E Web (mobile UX + launch UI)
+  - Build + UI Smoke
+  - Build Mac App
+  - Physical iPhone Preview Smoke
+- Merge queue checks passed for PR #448:
+  - CI
+  - iOS
+  - iOS Physical Preview
+  - macOS
+
+## Completion Audit
+
+The original objective was to implement the desktop-first `/workbench` dashboard from `docs/superpowers/plans/2026-05-16-workbench.md`, preserve existing app behavior, and verify the repo-scoped issue/session manager through tests, Playwright, CLI screenshot artifacts, PR review, green CI, and merge criteria.
+
+Evidence:
+
+- Product references: `docs/mockups/workbench.html`, `docs/superpowers/plans/2026-05-16-workbench.md`
+- Implementation: `/workbench` routes, workbench components, aggregate API, workbench data helper, and workbench tests merged in PR #448.
+- API-backed behavior: covered by route tests, reducer tests, and `packages/web/e2e/workbench.spec.ts`.
+- Responsive QA and CLI screenshots: `docs/qa/workbench-validation.md` and `docs/qa/workbench-artifacts`.
+- Named plain shells: intentionally disabled for v1 by T020; T021-T025 and T028 were skipped with receipts.
+- PR/CI/merge: PR #448 passed PR checks, passed merge-queue checks, and merged to `main`.
+
+Remaining follow-up tasks:
+
+- Named plain shells can be handled as a separate future goal if desired.
+- The documented skipped empty-repository long-suite Playwright case can be revisited as a test-harness improvement, but its isolated acceptance check passed and it is not blocking the v1 workbench goal.

--- a/docs/goals/workbench/state.yaml
+++ b/docs/goals/workbench/state.yaml
@@ -5,7 +5,7 @@ goal:
   slug: "workbench"
   kind: existing_plan
   tranche: "Implement /workbench from docs/superpowers/plans/2026-05-16-workbench.md through safe verified PR batches."
-  status: active
+  status: complete
   intake:
     original_request: "Use docs/superpowers/plans/2026-05-16-workbench.md to prepare a GoalBuddy board for implementing /workbench."
     interpreted_outcome: "/workbench is implemented as the repo-scoped issue/session manager described by the mockup and plan, with automated tests, Playwright artifact proof, PR review, green CI, and final audit."
@@ -60,7 +60,7 @@ visual_board:
     command: "npx goalbuddy extend github-projects"
     missing: []
 
-active_task: T030
+active_task: null
 
 tasks:
   - id: T001
@@ -1172,7 +1172,7 @@ tasks:
   - id: T030
     type: pm
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: default
     objective: "Finish the development branch after final audit using superpowers:finishing-a-development-branch."
     inputs:
@@ -1184,11 +1184,36 @@ tasks:
       - "Final branch status."
       - "Merged PR summary."
       - "Remaining follow-up tasks, if any."
-    receipt: null
+    receipt:
+      result: done
+      note: "notes/T030-finish-development-branch.md"
+      summary: "Finished the /workbench development branch: PR #448 passed local verification, Codex review, PR CI, merge-queue CI, and merged to main at e5273f8ea4dde8e47860060b8f75912db4f072ee."
+      evidence:
+        - "https://github.com/mean-weasel/issuectl/pull/448"
+        - "docs/goals/workbench/notes/T030-finish-development-branch.md"
+        - "docs/qa/workbench-validation.md"
+        - "docs/qa/workbench-artifacts"
+      verification:
+        - "git diff --check"
+        - "pnpm --filter @issuectl/web typecheck"
+        - "pnpm --filter @issuectl/web test -- components/workbench/workbench.test.ts app/api/v1/workbench/route.test.ts"
+        - "pnpm --filter @issuectl/web test:e2e -- e2e/workbench.spec.ts --project=desktop-chromium"
+        - "pnpm --filter @issuectl/web lint"
+        - "pnpm --filter @issuectl/web test"
+        - "PR #448 checks: Detect changes, Typecheck, Lint, Test, Build, E2E Web, Build + UI Smoke, Build Mac App, Physical iPhone Preview Smoke"
+        - "Merge queue checks for PR #448: CI, iOS, iOS Physical Preview, macOS"
+      full_outcome_complete: true
+      next_task: null
 
 checks:
   dirty_fingerprint: unknown
   last_verification:
-    result: unknown
-    task: null
-    commands: []
+    result: pass
+    task: T030
+    commands:
+      - "git diff --check"
+      - "pnpm --filter @issuectl/web typecheck"
+      - "pnpm --filter @issuectl/web test -- components/workbench/workbench.test.ts app/api/v1/workbench/route.test.ts"
+      - "pnpm --filter @issuectl/web test:e2e -- e2e/workbench.spec.ts --project=desktop-chromium"
+      - "pnpm --filter @issuectl/web lint"
+      - "pnpm --filter @issuectl/web test"


### PR DESCRIPTION
## Summary
- Mark the Workbench GoalBuddy board complete after PR #448 merged.
- Add the T030 final branch receipt with local verification, PR CI, merge-queue CI, and merge evidence.

## Test Plan
- [x] `git diff --check`
- [x] Inspected `docs/goals/workbench/state.yaml` for no active/queued tasks and `full_outcome_complete: true`.
