### PR TITLE
Refactor workbench inline styles

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -36,10 +36,7 @@ export function BoardFocus({ repos, deployments, onSelectIssue }: Props) {
         {visibleIssues} {runningOnly ? "running" : "open"} issues across {repos.length} tracked repositories.
       </p>
 
-      <div
-        aria-label="Board controls"
-        style={{ display: "flex", gap: 10, flexWrap: "wrap", margin: "18px 0" }}
-      >
+      <div aria-label="Board controls" className={styles.boardControls}>
         <button
           type="button"
           className={runningOnly ? styles.primaryButton : styles.secondaryButton}
@@ -73,20 +70,11 @@ export function BoardFocus({ repos, deployments, onSelectIssue }: Props) {
             <section
               key={repo.id}
               aria-label={`Board column ${repo.owner}/${repo.name}`}
-              style={{
-                minWidth: 190,
-                display: "grid",
-                alignContent: "start",
-                gap: 10,
-                padding: 12,
-                border: "1px solid var(--paper-line)",
-                borderRadius: "var(--paper-radius-md)",
-                background: "rgba(255, 255, 255, 0.18)",
-              }}
+              className={styles.boardColumn}
             >
               <header>
-                <h2 style={{ margin: 0, fontSize: 18 }}>{repo.owner}/{repo.name}</h2>
-                <p className={styles.muted} style={{ margin: "4px 0 0" }}>
+                <h2>{repo.owner}/{repo.name}</h2>
+                <p className={`${styles.muted} ${styles.boardColumnMeta}`}>
                   {issues.length} {runningOnly ? "running" : "open"}
                 </p>
               </header>

--- a/packages/web/components/workbench/QuickCreateFocus.tsx
+++ b/packages/web/components/workbench/QuickCreateFocus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type CSSProperties } from "react";
+import { useMemo, useState } from "react";
 import type { BatchCreateResult, ParsedIssue, ParsedIssuesResponse, Priority } from "@issuectl/core";
 import type { WorkbenchPayload } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
@@ -28,13 +28,6 @@ type Props = {
   repos: WorkbenchPayload["repos"];
   selectedRepo: WorkbenchPayload["repos"][number] | null;
 };
-
-const rowStyle = {
-  display: "flex",
-  alignItems: "center",
-  gap: "10px",
-  flexWrap: "wrap",
-} satisfies CSSProperties;
 
 export function QuickCreateFocus({ repos, selectedRepo }: Props) {
   const defaultRepoKey = repoKey(selectedRepo) ?? repoKey(repos[0]) ?? "";
@@ -190,15 +183,14 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
           Parse text
           <textarea
             aria-label="Parse text"
-            className={styles.workbenchInput}
-            style={{ minHeight: 132, resize: "vertical" }}
+            className={`${styles.workbenchInput} ${styles.quickCreateParseInput}`}
             value={input}
             onChange={(event) => setInput(event.target.value)}
             placeholder="Fix login timeout in issuectl. Also add keyboard shortcuts to the workbench."
             disabled={parseStatus !== "idle"}
           />
         </label>
-        <div style={rowStyle}>
+        <div className={styles.quickCreateRow}>
           <button
             type="button"
             className={styles.primaryButton}
@@ -214,19 +206,15 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
       </section>
 
       {cards.length > 0 && (
-        <section aria-label="Candidate issues" style={{ display: "grid", gap: "10px" }}>
+        <section aria-label="Candidate issues" className={styles.quickCreateCandidates}>
           {cards.map((card, index) => (
             <article
               key={card.id}
               aria-label={`Candidate issue ${index + 1}`}
               data-state={card.accepted ? "accepted" : "rejected"}
               className={styles.quickCreateCard}
-              style={{
-                opacity: card.accepted ? 1 : 0.64,
-                borderColor: card.accepted ? "var(--paper-accent)" : "var(--paper-line)",
-              }}
             >
-              <div style={{ ...rowStyle, justifyContent: "space-between" }}>
+              <div className={`${styles.quickCreateRow} ${styles.quickCreateSplitRow}`}>
                 <strong>{card.accepted ? "accepted" : "rejected"}</strong>
                 <button
                   type="button"
@@ -268,8 +256,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
                 Body
                 <textarea
                   aria-label={`Candidate ${index + 1} body`}
-                  className={styles.workbenchInput}
-                  style={{ minHeight: 84, resize: "vertical" }}
+                  className={`${styles.workbenchInput} ${styles.quickCreateCandidateBody}`}
                   value={card.body}
                   onChange={(event) => updateCard(card.id, { body: event.target.value })}
                 />
@@ -294,7 +281,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
             {result.created} created, {result.drafted} drafted, {result.failed} failed
           </strong>
           {result.results.map((item) => (
-            <div key={item.id} style={rowStyle}>
+            <div key={item.id} className={styles.quickCreateRow}>
               <span>{item.success ? "created" : "failed"}</span>
               <span>{item.owner && item.repo ? `${item.owner}/${item.repo}` : "draft"}</span>
               {item.issueNumber ? <span>#{item.issueNumber}</span> : null}
@@ -323,8 +310,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
           Draft body
           <textarea
             aria-label="Draft body"
-            className={styles.workbenchInput}
-            style={{ minHeight: 86, resize: "vertical" }}
+            className={`${styles.workbenchInput} ${styles.quickCreateDraftBody}`}
             value={draft.body}
             onChange={(event) => setDraft((current) => ({ ...current, body: event.target.value }))}
           />
@@ -352,7 +338,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
             placeholder="bug, workbench"
           />
         </label>
-        <div style={rowStyle}>
+        <div className={styles.quickCreateRow}>
           <button type="button" className={styles.primaryButton} onClick={handleSaveDraft} disabled={!draft.title.trim()}>
             Save draft
           </button>

--- a/packages/web/components/workbench/SettingsFocus.tsx
+++ b/packages/web/components/workbench/SettingsFocus.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import type { WorkbenchSectionCollapseState, WorkbenchSectionId } from "./workbench-state";
 import type { WorkbenchHealth, WorkbenchPayload, WorkbenchSettings, WorkbenchUser } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
@@ -97,23 +97,23 @@ export function SettingsFocus({ payload, collapsedSections, onToggleSection, onS
       >
         <dl className={styles.settingsSummaryGrid}>
           <div>
-            <dt style={labelStyle}>Server</dt>
+            <dt>Server</dt>
             <dd>{health.ok ? "ok" : "unavailable"}</dd>
           </div>
           <div>
-            <dt style={labelStyle}>User</dt>
+            <dt>User</dt>
             <dd>{user.login ?? user.error ?? "unknown"}</dd>
           </div>
           <div>
-            <dt style={labelStyle}>Tracked repos</dt>
+            <dt>Tracked repos</dt>
             <dd>{payload.repos.length}</dd>
           </div>
           <div>
-            <dt style={labelStyle}>Version</dt>
+            <dt>Version</dt>
             <dd>{health.version ?? "unknown"}</dd>
           </div>
         </dl>
-        {health.error && <p role="alert" style={errorStyle}>{health.error}</p>}
+        {health.error && <p role="alert" className={styles.workbenchError}>{health.error}</p>}
       </SettingsSection>
 
       <SettingsSection
@@ -151,8 +151,8 @@ export function SettingsFocus({ payload, collapsedSections, onToggleSection, onS
         </button>
       </SettingsSection>
 
-      {status && <p role="status" style={statusStyle}>{status}</p>}
-      {error && <p role="alert" style={errorStyle}>{error}</p>}
+      {status && <p role="status" className={styles.workbenchStatus}>{status}</p>}
+      {error && <p role="alert" className={styles.workbenchError}>{error}</p>}
     </div>
   );
 }
@@ -177,7 +177,7 @@ function SettingsSection({
   children: ReactNode;
 }) {
   return (
-    <section className={styles.collapsibleSection} style={sectionStyle}>
+    <section className={`${styles.collapsibleSection} ${styles.settingsSection}`}>
       <button
         type="button"
         className={styles.collapsibleHeader}
@@ -190,7 +190,7 @@ function SettingsSection({
         <span aria-hidden="true">v</span>
       </button>
       <div id={id} className={styles.collapsibleBody} aria-label={bodyLabel} hidden={collapsed}>
-        <h2 style={headingStyle}>{title}</h2>
+        <h2>{title}</h2>
         {children}
       </div>
     </section>
@@ -240,35 +240,3 @@ function readApiToken(): string | null {
   return window.localStorage.getItem("issuectl.apiToken")
     ?? window.localStorage.getItem("issuectlApiToken");
 }
-
-const sectionStyle = {
-  display: "grid",
-  gap: 12,
-  marginTop: 22,
-  padding: 16,
-  border: "1px solid var(--paper-line)",
-  borderRadius: "var(--paper-radius-md)",
-  background: "rgba(255, 255, 255, 0.2)",
-} satisfies CSSProperties;
-
-const headingStyle = {
-  fontFamily: "var(--paper-serif)",
-  fontSize: 20,
-  fontWeight: 500,
-} satisfies CSSProperties;
-
-const labelStyle = {
-  color: "var(--paper-ink-muted)",
-  font: "700 10px var(--paper-mono)",
-  textTransform: "uppercase",
-} satisfies CSSProperties;
-
-const statusStyle = {
-  marginTop: 14,
-  color: "var(--paper-accent)",
-} satisfies CSSProperties;
-
-const errorStyle = {
-  marginTop: 14,
-  color: "#9f1d12",
-} satisfies CSSProperties;

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1243,8 +1243,43 @@
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.settingsSummaryGrid dt {
+  color: var(--paper-ink-muted);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
 .settingsFormGrid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settingsSection {
+  display: grid;
+  gap: 12px;
+  margin-top: 22px;
+  padding: 16px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.settingsSection h2 {
+  font-family: var(--paper-serif);
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.workbenchStatus,
+.workbenchError {
+  margin-top: 14px;
+}
+
+.workbenchStatus {
+  color: var(--paper-accent);
+}
+
+.workbenchError {
+  color: #9f1d12;
 }
 
 .workbenchField {
@@ -1293,11 +1328,58 @@
   background: rgba(255, 255, 255, 0.22);
 }
 
+.quickCreateCard[data-state="accepted"] {
+  border-color: var(--paper-accent);
+}
+
+.quickCreateCard[data-state="rejected"] {
+  border-color: var(--paper-line);
+  opacity: 0.64;
+}
+
+.quickCreateRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.quickCreateSplitRow {
+  justify-content: space-between;
+}
+
+.quickCreateCandidates {
+  display: grid;
+  gap: 10px;
+}
+
+.quickCreateParseInput {
+  min-height: 132px;
+  resize: vertical;
+}
+
+.quickCreateCandidateBody {
+  min-height: 84px;
+  resize: vertical;
+}
+
+.quickCreateDraftBody {
+  min-height: 86px;
+  resize: vertical;
+}
+
 .boardFocus {
   max-width: none;
   width: 100%;
   min-height: 100%;
   overflow: hidden;
+}
+
+.boardControls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 18px 0;
 }
 
 .boardScroll {
@@ -1309,6 +1391,26 @@
   overflow-x: auto;
   overscroll-behavior-x: contain;
   padding-bottom: 12px;
+}
+
+.boardColumn {
+  min-width: 190px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.boardColumn h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.boardColumnMeta {
+  margin: 4px 0 0;
 }
 
 .focusInner h1 {


### PR DESCRIPTION
## Summary
- move remaining inline styling in Board, Quick Create, and Settings workbench focus views into WorkbenchShell.module.css
- keep existing workbench behavior and selectors intact

## Verification
- pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/web lint
- PLAYWRIGHT_HTML_OPEN=never pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium --grep "compact|captures workbench QA screenshots|shows cross-repo board|semantic|Quick Create|Settings" --output=/tmp/issuectl-style-cleanup-smoke
- git push pre-push build hook passed

## Notes
- Lint still reports the existing warning-only baseline for file length and explicit any.
- Browser plugin was listed, but its required browser execution tool was not exposed in this session, so rendered validation used Playwright.