### PR TITLE
Split oversized workbench modules

### DIFF
--- a/packages/web/components/workbench/InstancePane.tsx
+++ b/packages/web/components/workbench/InstancePane.tsx
@@ -1,8 +1,7 @@
 import type { WorkbenchDeployment, WorkbenchRepo } from "./workbench-types";
+import { previewForDeployment, sortDeploymentSessions } from "./workbench-selectors";
 import {
   type SessionSortMode,
-  previewForDeployment,
-  sortDeploymentSessions,
 } from "./workbench-state";
 import styles from "./WorkbenchShell.module.css";
 

--- a/packages/web/components/workbench/IssueQueuePane.tsx
+++ b/packages/web/components/workbench/IssueQueuePane.tsx
@@ -1,9 +1,7 @@
 import type { WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
+import { deploymentForIssue, filterIssueQueue, issueQueueCounts } from "./workbench-selectors";
 import {
   type IssueQueueFilter,
-  deploymentForIssue,
-  filterIssueQueue,
-  issueQueueCounts,
 } from "./workbench-state";
 import styles from "./WorkbenchShell.module.css";
 

--- a/packages/web/components/workbench/PullRequestsFocus.tsx
+++ b/packages/web/components/workbench/PullRequestsFocus.tsx
@@ -1,111 +1,22 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  checksSummary,
+  errorMessage,
+  linkedIssueNumber,
+  requestJson,
+  type ListResponse,
+  type PullDetail,
+  type PullSummary,
+} from "./pull-requests-data";
+import { cardStyle, fieldStyle, panelStyle, rowStyle, textareaStyle } from "./pull-requests-styles";
 import type { WorkbenchPayload } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
 
 type Props = {
   selectedRepo: WorkbenchPayload["repos"][number] | null;
 };
-
-type ChecksStatus = "success" | "failure" | "pending" | null;
-
-type PullSummary = {
-  number: number;
-  title: string;
-  body: string | null;
-  state: "open" | "closed";
-  draft: boolean;
-  merged: boolean;
-  user: { login: string; avatarUrl: string } | null;
-  headRef: string;
-  baseRef: string;
-  additions: number;
-  deletions: number;
-  changedFiles: number;
-  createdAt: string;
-  updatedAt: string;
-  mergedAt: string | null;
-  closedAt: string | null;
-  htmlUrl: string;
-  checksStatus?: ChecksStatus;
-};
-
-type PullDetail = {
-  pull: PullSummary;
-  checks: Array<{
-    name: string;
-    status: string;
-    conclusion: string | null;
-    htmlUrl: string | null;
-  }>;
-  files: Array<{
-    filename: string;
-    status: string;
-    additions: number;
-    deletions: number;
-  }>;
-  linkedIssue: {
-    number: number;
-    title: string;
-    state: "open" | "closed";
-    htmlUrl: string;
-  } | null;
-  reviews: Array<{
-    id: number;
-    state: string;
-    body: string;
-    user: { login: string; avatarUrl: string } | null;
-  }>;
-};
-
-type ListResponse = {
-  pulls: PullSummary[];
-  fromCache?: boolean;
-  cachedAt?: string | null;
-};
-
-const panelStyle = {
-  display: "grid",
-  gap: "16px",
-  maxWidth: "980px",
-} satisfies CSSProperties;
-
-const rowStyle = {
-  display: "flex",
-  alignItems: "center",
-  gap: "10px",
-  flexWrap: "wrap",
-} satisfies CSSProperties;
-
-const cardStyle = {
-  display: "grid",
-  gap: "12px",
-  padding: "14px",
-  border: "1px solid var(--paper-line)",
-  borderRadius: "var(--paper-radius-md)",
-  background: "rgba(255, 255, 255, 0.22)",
-} satisfies CSSProperties;
-
-const fieldStyle = {
-  display: "grid",
-  gap: "7px",
-  color: "var(--paper-ink-muted)",
-  font: "700 10px var(--paper-mono)",
-  textTransform: "uppercase",
-} satisfies CSSProperties;
-
-const textareaStyle = {
-  minHeight: "82px",
-  padding: "8px 10px",
-  border: "1px solid var(--paper-line)",
-  borderRadius: "var(--paper-radius-sm)",
-  background: "rgba(255, 255, 255, 0.28)",
-  color: "var(--paper-ink)",
-  font: "14px var(--paper-serif)",
-  textTransform: "none",
-  resize: "vertical",
-} satisfies CSSProperties;
 
 export function PullRequestsFocus({ selectedRepo }: Props) {
   const [pulls, setPulls] = useState<PullSummary[]>([]);
@@ -359,48 +270,4 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
       </section>
     </div>
   );
-}
-
-async function requestJson<T>(path: string, init: RequestInit): Promise<T> {
-  const headers = new Headers(init.headers);
-  headers.set("Accept", "application/json");
-  if (init.body) headers.set("Content-Type", "application/json");
-  const token = readApiToken();
-  if (token) headers.set("Authorization", `Bearer ${token}`);
-
-  const response = await fetch(path, { ...init, headers });
-  const body = await response.json().catch(() => undefined);
-  if (!response.ok) {
-    const message =
-      body && typeof body === "object" && "error" in body && typeof body.error === "string"
-        ? body.error
-        : `Pull request request failed with ${response.status}`;
-    throw new Error(message);
-  }
-  return body as T;
-}
-
-function linkedIssueNumber(body: string | null): number | null {
-  if (!body) return null;
-  const match = body.match(/(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/i);
-  return match ? Number(match[1]) : null;
-}
-
-function checksSummary(checks: PullDetail["checks"]): string {
-  if (checks.length === 0) return "none";
-  const failed = checks.filter((check) => check.conclusion === "failure").length;
-  const pending = checks.filter((check) => check.status !== "completed").length;
-  if (failed > 0) return `${failed} failing`;
-  if (pending > 0) return `${pending} pending`;
-  return "success";
-}
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback;
-}
-
-function readApiToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return window.localStorage.getItem("issuectl.apiToken")
-    ?? window.localStorage.getItem("issuectlApiToken");
 }

--- a/packages/web/components/workbench/QuickCreateFocus.tsx
+++ b/packages/web/components/workbench/QuickCreateFocus.tsx
@@ -1,28 +1,20 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { BatchCreateResult, ParsedIssue, ParsedIssuesResponse, Priority } from "@issuectl/core";
+import type { ParsedIssuesResponse } from "@issuectl/core";
+import { CandidateIssuesSection, DraftFallback, QuickCreateResults } from "./QuickCreateSections";
+import {
+  errorMessage,
+  repoKey,
+  requestJson,
+  toCandidateIssues,
+  unwrapParsedResponse,
+  type CandidateIssue,
+  type DraftState,
+  type QuickCreateResult,
+} from "./quick-create-data";
 import type { WorkbenchPayload } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
-
-type CandidateIssue = {
-  id: string;
-  title: string;
-  body: string;
-  owner: string;
-  repo: string;
-  labels: string[];
-  accepted: boolean;
-  originalText: string;
-};
-
-type DraftState = {
-  id: string | null;
-  title: string;
-  body: string;
-  priority: Priority;
-  labels: string;
-};
 
 type Props = {
   repos: WorkbenchPayload["repos"];
@@ -41,7 +33,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
   const [input, setInput] = useState("");
   const [parseStatus, setParseStatus] = useState<"idle" | "parsing" | "creating">("idle");
   const [cards, setCards] = useState<CandidateIssue[]>([]);
-  const [result, setResult] = useState<BatchCreateResult | null>(null);
+  const [result, setResult] = useState<QuickCreateResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [draft, setDraft] = useState<DraftState>({
     id: null,
@@ -79,7 +71,7 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
     setParseStatus("creating");
     setError(null);
     try {
-      const response = await requestJson<BatchCreateResult>("/api/v1/parse/create", {
+      const response = await requestJson<QuickCreateResult>("/api/v1/parse/create", {
         method: "POST",
         body: JSON.stringify({
           issues: cards.map((card) => ({
@@ -205,157 +197,24 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
         </div>
       </section>
 
-      {cards.length > 0 && (
-        <section aria-label="Candidate issues" className={styles.quickCreateCandidates}>
-          {cards.map((card, index) => (
-            <article
-              key={card.id}
-              aria-label={`Candidate issue ${index + 1}`}
-              data-state={card.accepted ? "accepted" : "rejected"}
-              className={styles.quickCreateCard}
-            >
-              <div className={`${styles.quickCreateRow} ${styles.quickCreateSplitRow}`}>
-                <strong>{card.accepted ? "accepted" : "rejected"}</strong>
-                <button
-                  type="button"
-                  className={styles.secondaryButton}
-                  onClick={() => updateCard(card.id, { accepted: !card.accepted })}
-                >
-                  {card.accepted ? "Reject" : "Accept"}
-                </button>
-              </div>
-              <label className={styles.workbenchField}>
-                Title
-                <input
-                  aria-label={`Candidate ${index + 1} title`}
-                  className={styles.workbenchInput}
-                  value={card.title}
-                  onChange={(event) => updateCard(card.id, { title: event.target.value })}
-                />
-              </label>
-              <label className={styles.workbenchField}>
-                Repository
-                <select
-                  aria-label={`Candidate ${index + 1} repository`}
-                  className={styles.workbenchInput}
-                  value={card.owner && card.repo ? `${card.owner}/${card.repo}` : ""}
-                  onChange={(event) => {
-                    const [owner = "", repo = ""] = event.target.value.split("/");
-                    updateCard(card.id, { owner, repo });
-                  }}
-                >
-                  <option value="">Save as draft</option>
-                  {repoOptions.map((repo) => (
-                    <option key={repo.key} value={repo.key}>
-                      {repo.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className={styles.workbenchField}>
-                Body
-                <textarea
-                  aria-label={`Candidate ${index + 1} body`}
-                  className={`${styles.workbenchInput} ${styles.quickCreateCandidateBody}`}
-                  value={card.body}
-                  onChange={(event) => updateCard(card.id, { body: event.target.value })}
-                />
-              </label>
-              {card.originalText && <p className={styles.muted}>{card.originalText}</p>}
-            </article>
-          ))}
-          <button
-            type="button"
-            className={styles.primaryButton}
-            onClick={handleCreateAccepted}
-            disabled={acceptedCount === 0 || parseStatus !== "idle"}
-          >
-            {parseStatus === "creating" ? "Creating..." : "Create accepted issues"}
-          </button>
-        </section>
-      )}
-
-      {result && (
-        <section aria-label="Quick create results" className={styles.quickCreateCard}>
-          <strong>
-            {result.created} created, {result.drafted} drafted, {result.failed} failed
-          </strong>
-          {result.results.map((item) => (
-            <div key={item.id} className={styles.quickCreateRow}>
-              <span>{item.success ? "created" : "failed"}</span>
-              <span>{item.owner && item.repo ? `${item.owner}/${item.repo}` : "draft"}</span>
-              {item.issueNumber ? <span>#{item.issueNumber}</span> : null}
-              {item.draftId ? <span>draft {item.draftId}</span> : null}
-              {item.error ? <span role="alert">{item.error}</span> : null}
-            </div>
-          ))}
-        </section>
-      )}
-
-      <section aria-label="Draft fallback" className={styles.quickCreateCard}>
-        <div>
-          <h2>Draft fallback</h2>
-          <p className={styles.muted}>Save unclear work locally, revise it, then assign it to the selected repo.</p>
-        </div>
-        <label className={styles.workbenchField}>
-          Draft title
-          <input
-            aria-label="Draft title"
-            className={styles.workbenchInput}
-            value={draft.title}
-            onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
-          />
-        </label>
-        <label className={styles.workbenchField}>
-          Draft body
-          <textarea
-            aria-label="Draft body"
-            className={`${styles.workbenchInput} ${styles.quickCreateDraftBody}`}
-            value={draft.body}
-            onChange={(event) => setDraft((current) => ({ ...current, body: event.target.value }))}
-          />
-        </label>
-        <label className={styles.workbenchField}>
-          Priority
-          <select
-            aria-label="Draft priority"
-            className={styles.workbenchInput}
-            value={draft.priority}
-            onChange={(event) => setDraft((current) => ({ ...current, priority: event.target.value as Priority }))}
-          >
-            <option value="low">low</option>
-            <option value="normal">normal</option>
-            <option value="high">high</option>
-          </select>
-        </label>
-        <label className={styles.workbenchField}>
-          Assign labels
-          <input
-            aria-label="Draft labels"
-            className={styles.workbenchInput}
-            value={draft.labels}
-            onChange={(event) => setDraft((current) => ({ ...current, labels: event.target.value }))}
-            placeholder="bug, workbench"
-          />
-        </label>
-        <div className={styles.quickCreateRow}>
-          <button type="button" className={styles.primaryButton} onClick={handleSaveDraft} disabled={!draft.title.trim()}>
-            Save draft
-          </button>
-          <button type="button" className={styles.secondaryButton} onClick={handleUpdateDraft} disabled={!draft.id}>
-            Update draft
-          </button>
-          <button
-            type="button"
-            className={styles.secondaryButton}
-            onClick={handleAssignDraft}
-            disabled={!draft.id || !selectedRepo}
-          >
-            Assign draft
-          </button>
-        </div>
-        {draftMessage && <p role="status">{draftMessage}</p>}
-      </section>
+      <CandidateIssuesSection
+        cards={cards}
+        repoOptions={repoOptions}
+        acceptedCount={acceptedCount}
+        parseStatus={parseStatus}
+        onUpdateCard={updateCard}
+        onCreateAccepted={handleCreateAccepted}
+      />
+      <QuickCreateResults result={result} />
+      <DraftFallback
+        draft={draft}
+        draftMessage={draftMessage}
+        selectedRepo={selectedRepo}
+        onDraftChange={(patch) => setDraft((current) => ({ ...current, ...patch }))}
+        onSaveDraft={handleSaveDraft}
+        onUpdateDraft={handleUpdateDraft}
+        onAssignDraft={handleAssignDraft}
+      />
 
       {error && <p role="alert" className={styles.issueFocusError}>{error}</p>}
     </div>
@@ -364,67 +223,4 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
   function updateCard(id: string, patch: Partial<CandidateIssue>) {
     setCards((current) => current.map((card) => card.id === id ? { ...card, ...patch } : card));
   }
-}
-
-function toCandidateIssues(parsed: ParsedIssuesResponse, defaultRepoKey: string): CandidateIssue[] {
-  const order = new Map(parsed.suggestedOrder.map((id, index) => [id, index]));
-  return [...parsed.issues]
-    .sort((a, b) => (order.get(a.id) ?? 999) - (order.get(b.id) ?? 999))
-    .map((issue) => toCandidateIssue(issue, defaultRepoKey));
-}
-
-function toCandidateIssue(issue: ParsedIssue, defaultRepoKey: string): CandidateIssue {
-  const [defaultOwner = "", defaultRepo = ""] = defaultRepoKey.split("/");
-  return {
-    id: issue.id,
-    title: issue.title,
-    body: issue.body,
-    owner: issue.repoOwner ?? defaultOwner,
-    repo: issue.repoName ?? defaultRepo,
-    labels: issue.suggestedLabels,
-    accepted: true,
-    originalText: issue.originalText,
-  };
-}
-
-function repoKey(repo: WorkbenchPayload["repos"][number] | null | undefined): string | null {
-  return repo ? `${repo.owner}/${repo.name}` : null;
-}
-
-function unwrapParsedResponse(body: { parsed: ParsedIssuesResponse } | ParsedIssuesResponse): ParsedIssuesResponse {
-  return "parsed" in body ? body.parsed : body;
-}
-
-async function requestJson<T>(path: string, init: RequestInit): Promise<T> {
-  const headers = new Headers(init.headers);
-  headers.set("Accept", "application/json");
-  if (init.body) headers.set("Content-Type", "application/json");
-  const token = readApiToken();
-  if (token) headers.set("Authorization", `Bearer ${token}`);
-
-  const response = await fetch(path, { ...init, headers });
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch {
-    body = undefined;
-  }
-  if (!response.ok) {
-    throw new Error(
-      body && typeof body === "object" && "error" in body && typeof body.error === "string"
-        ? body.error
-        : `Request failed with ${response.status}`,
-    );
-  }
-  return body as T;
-}
-
-function readApiToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return window.localStorage.getItem("issuectl.apiToken")
-    ?? window.localStorage.getItem("issuectlApiToken");
-}
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback;
 }

--- a/packages/web/components/workbench/QuickCreateSections.tsx
+++ b/packages/web/components/workbench/QuickCreateSections.tsx
@@ -1,0 +1,215 @@
+import type { Priority } from "@issuectl/core";
+import type { CandidateIssue, DraftState, QuickCreateResult, RepoOption } from "./quick-create-data";
+import type { WorkbenchPayload } from "./workbench-types";
+import styles from "./WorkbenchShell.module.css";
+
+type CandidateIssuesProps = {
+  cards: CandidateIssue[];
+  repoOptions: RepoOption[];
+  acceptedCount: number;
+  parseStatus: "idle" | "parsing" | "creating";
+  onUpdateCard: (id: string, patch: Partial<CandidateIssue>) => void;
+  onCreateAccepted: () => void;
+};
+
+type DraftFallbackProps = {
+  draft: DraftState;
+  draftMessage: string | null;
+  selectedRepo: WorkbenchPayload["repos"][number] | null;
+  onDraftChange: (patch: Partial<DraftState>) => void;
+  onSaveDraft: () => void;
+  onUpdateDraft: () => void;
+  onAssignDraft: () => void;
+};
+
+export function CandidateIssuesSection({
+  cards,
+  repoOptions,
+  acceptedCount,
+  parseStatus,
+  onUpdateCard,
+  onCreateAccepted,
+}: CandidateIssuesProps) {
+  if (cards.length === 0) return null;
+
+  return (
+    <section aria-label="Candidate issues" className={styles.quickCreateCandidates}>
+      {cards.map((card, index) => (
+        <article
+          key={card.id}
+          aria-label={`Candidate issue ${index + 1}`}
+          data-state={card.accepted ? "accepted" : "rejected"}
+          className={styles.quickCreateCard}
+        >
+          <div className={`${styles.quickCreateRow} ${styles.quickCreateSplitRow}`}>
+            <strong>{card.accepted ? "accepted" : "rejected"}</strong>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => onUpdateCard(card.id, { accepted: !card.accepted })}
+            >
+              {card.accepted ? "Reject" : "Accept"}
+            </button>
+          </div>
+          <CandidateFields card={card} index={index} repoOptions={repoOptions} onUpdateCard={onUpdateCard} />
+        </article>
+      ))}
+      <button
+        type="button"
+        className={styles.primaryButton}
+        onClick={onCreateAccepted}
+        disabled={acceptedCount === 0 || parseStatus !== "idle"}
+      >
+        {parseStatus === "creating" ? "Creating..." : "Create accepted issues"}
+      </button>
+    </section>
+  );
+}
+
+export function QuickCreateResults({ result }: { result: QuickCreateResult | null }) {
+  if (!result) return null;
+
+  return (
+    <section aria-label="Quick create results" className={styles.quickCreateCard}>
+      <strong>
+        {result.created} created, {result.drafted} drafted, {result.failed} failed
+      </strong>
+      {result.results.map((item) => (
+        <div key={item.id} className={styles.quickCreateRow}>
+          <span>{item.success ? "created" : "failed"}</span>
+          <span>{item.owner && item.repo ? `${item.owner}/${item.repo}` : "draft"}</span>
+          {item.issueNumber ? <span>#{item.issueNumber}</span> : null}
+          {item.draftId ? <span>draft {item.draftId}</span> : null}
+          {item.error ? <span role="alert">{item.error}</span> : null}
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export function DraftFallback({
+  draft,
+  draftMessage,
+  selectedRepo,
+  onDraftChange,
+  onSaveDraft,
+  onUpdateDraft,
+  onAssignDraft,
+}: DraftFallbackProps) {
+  return (
+    <section aria-label="Draft fallback" className={styles.quickCreateCard}>
+      <div>
+        <h2>Draft fallback</h2>
+        <p className={styles.muted}>Save unclear work locally, revise it, then assign it to the selected repo.</p>
+      </div>
+      <label className={styles.workbenchField}>
+        Draft title
+        <input
+          aria-label="Draft title"
+          className={styles.workbenchInput}
+          value={draft.title}
+          onChange={(event) => onDraftChange({ title: event.target.value })}
+        />
+      </label>
+      <label className={styles.workbenchField}>
+        Draft body
+        <textarea
+          aria-label="Draft body"
+          className={`${styles.workbenchInput} ${styles.quickCreateDraftBody}`}
+          value={draft.body}
+          onChange={(event) => onDraftChange({ body: event.target.value })}
+        />
+      </label>
+      <label className={styles.workbenchField}>
+        Priority
+        <select
+          aria-label="Draft priority"
+          className={styles.workbenchInput}
+          value={draft.priority}
+          onChange={(event) => onDraftChange({ priority: event.target.value as Priority })}
+        >
+          <option value="low">low</option>
+          <option value="normal">normal</option>
+          <option value="high">high</option>
+        </select>
+      </label>
+      <label className={styles.workbenchField}>
+        Assign labels
+        <input
+          aria-label="Draft labels"
+          className={styles.workbenchInput}
+          value={draft.labels}
+          onChange={(event) => onDraftChange({ labels: event.target.value })}
+          placeholder="bug, workbench"
+        />
+      </label>
+      <div className={styles.quickCreateRow}>
+        <button type="button" className={styles.primaryButton} onClick={onSaveDraft} disabled={!draft.title.trim()}>
+          Save draft
+        </button>
+        <button type="button" className={styles.secondaryButton} onClick={onUpdateDraft} disabled={!draft.id}>
+          Update draft
+        </button>
+        <button type="button" className={styles.secondaryButton} onClick={onAssignDraft} disabled={!draft.id || !selectedRepo}>
+          Assign draft
+        </button>
+      </div>
+      {draftMessage && <p role="status">{draftMessage}</p>}
+    </section>
+  );
+}
+
+function CandidateFields({
+  card,
+  index,
+  repoOptions,
+  onUpdateCard,
+}: {
+  card: CandidateIssue;
+  index: number;
+  repoOptions: RepoOption[];
+  onUpdateCard: (id: string, patch: Partial<CandidateIssue>) => void;
+}) {
+  return (
+    <>
+      <label className={styles.workbenchField}>
+        Title
+        <input
+          aria-label={`Candidate ${index + 1} title`}
+          className={styles.workbenchInput}
+          value={card.title}
+          onChange={(event) => onUpdateCard(card.id, { title: event.target.value })}
+        />
+      </label>
+      <label className={styles.workbenchField}>
+        Repository
+        <select
+          aria-label={`Candidate ${index + 1} repository`}
+          className={styles.workbenchInput}
+          value={card.owner && card.repo ? `${card.owner}/${card.repo}` : ""}
+          onChange={(event) => {
+            const [owner = "", repo = ""] = event.target.value.split("/");
+            onUpdateCard(card.id, { owner, repo });
+          }}
+        >
+          <option value="">Save as draft</option>
+          {repoOptions.map((repo) => (
+            <option key={repo.key} value={repo.key}>
+              {repo.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.workbenchField}>
+        Body
+        <textarea
+          aria-label={`Candidate ${index + 1} body`}
+          className={`${styles.workbenchInput} ${styles.quickCreateCandidateBody}`}
+          value={card.body}
+          onChange={(event) => onUpdateCard(card.id, { body: event.target.value })}
+        />
+      </label>
+      {card.originalText && <p className={styles.muted}>{card.originalText}</p>}
+    </>
+  );
+}

--- a/packages/web/components/workbench/RepoRail.tsx
+++ b/packages/web/components/workbench/RepoRail.tsx
@@ -1,5 +1,5 @@
 import type { WorkbenchRepo } from "./workbench-types";
-import { compactRepoInitials, repoRailBadgeCount } from "./workbench-state";
+import { compactRepoInitials, repoRailBadgeCount } from "./workbench-selectors";
 import styles from "./WorkbenchShell.module.css";
 
 type Props = {

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -25,6 +25,10 @@ import { TerminalFocus } from "./TerminalFocus";
 import { endDeploymentSession, ensureDeploymentTtyd, fetchWorkbench, isStaleEnsureTtydResult } from "./workbench-api";
 import type { WorkbenchDeployment, WorkbenchIssueSummary, WorkbenchPayload, WorkbenchRepo, WorkbenchSettings } from "./workbench-types";
 import {
+  selectedDeployment as resolveSelectedDeployment,
+  selectedRepo as resolveSelectedRepo,
+} from "./workbench-selectors";
+import {
   type IssueQueueFilter,
   type SessionSortMode,
   type WorkbenchColumnKey,
@@ -35,8 +39,6 @@ import {
   WORKBENCH_COLUMN_WIDTH_LIMITS,
   WORKBENCH_COLUMN_WIDTH_STORAGE_KEY,
   type WorkbenchMode,
-  selectedDeployment as resolveSelectedDeployment,
-  selectedRepo as resolveSelectedRepo,
   sidePaneWidthsApply,
   workbenchReducer,
 } from "./workbench-state";

--- a/packages/web/components/workbench/pull-requests-data.ts
+++ b/packages/web/components/workbench/pull-requests-data.ts
@@ -1,0 +1,100 @@
+export type ChecksStatus = "success" | "failure" | "pending" | null;
+
+export type PullSummary = {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  draft: boolean;
+  merged: boolean;
+  user: { login: string; avatarUrl: string } | null;
+  headRef: string;
+  baseRef: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  createdAt: string;
+  updatedAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+  htmlUrl: string;
+  checksStatus?: ChecksStatus;
+};
+
+export type PullDetail = {
+  pull: PullSummary;
+  checks: Array<{
+    name: string;
+    status: string;
+    conclusion: string | null;
+    htmlUrl: string | null;
+  }>;
+  files: Array<{
+    filename: string;
+    status: string;
+    additions: number;
+    deletions: number;
+  }>;
+  linkedIssue: {
+    number: number;
+    title: string;
+    state: "open" | "closed";
+    htmlUrl: string;
+  } | null;
+  reviews: Array<{
+    id: number;
+    state: string;
+    body: string;
+    user: { login: string; avatarUrl: string } | null;
+  }>;
+};
+
+export type ListResponse = {
+  pulls: PullSummary[];
+  fromCache?: boolean;
+  cachedAt?: string | null;
+};
+
+export async function requestJson<T>(path: string, init: RequestInit): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set("Accept", "application/json");
+  if (init.body) headers.set("Content-Type", "application/json");
+  const token = readApiToken();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const response = await fetch(path, { ...init, headers });
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `Pull request request failed with ${response.status}`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+export function linkedIssueNumber(body: string | null): number | null {
+  if (!body) return null;
+  const match = body.match(/(?:closes|fixes|resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+export function checksSummary(checks: PullDetail["checks"]): string {
+  if (checks.length === 0) return "none";
+  const failed = checks.filter((check) => check.conclusion === "failure").length;
+  const pending = checks.filter((check) => check.status !== "completed").length;
+  if (failed > 0) return `${failed} failing`;
+  if (pending > 0) return `${pending} pending`;
+  return "success";
+}
+
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+function readApiToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem("issuectl.apiToken")
+    ?? window.localStorage.getItem("issuectlApiToken");
+}

--- a/packages/web/components/workbench/pull-requests-styles.ts
+++ b/packages/web/components/workbench/pull-requests-styles.ts
@@ -1,0 +1,43 @@
+import type { CSSProperties } from "react";
+
+export const panelStyle = {
+  display: "grid",
+  gap: "16px",
+  maxWidth: "980px",
+} satisfies CSSProperties;
+
+export const rowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "10px",
+  flexWrap: "wrap",
+} satisfies CSSProperties;
+
+export const cardStyle = {
+  display: "grid",
+  gap: "12px",
+  padding: "14px",
+  border: "1px solid var(--paper-line)",
+  borderRadius: "var(--paper-radius-md)",
+  background: "rgba(255, 255, 255, 0.22)",
+} satisfies CSSProperties;
+
+export const fieldStyle = {
+  display: "grid",
+  gap: "7px",
+  color: "var(--paper-ink-muted)",
+  font: "700 10px var(--paper-mono)",
+  textTransform: "uppercase",
+} satisfies CSSProperties;
+
+export const textareaStyle = {
+  minHeight: "82px",
+  padding: "8px 10px",
+  border: "1px solid var(--paper-line)",
+  borderRadius: "var(--paper-radius-sm)",
+  background: "rgba(255, 255, 255, 0.28)",
+  color: "var(--paper-ink)",
+  font: "14px var(--paper-serif)",
+  textTransform: "none",
+  resize: "vertical",
+} satisfies CSSProperties;

--- a/packages/web/components/workbench/quick-create-data.ts
+++ b/packages/web/components/workbench/quick-create-data.ts
@@ -1,0 +1,96 @@
+import type { BatchCreateResult, ParsedIssue, ParsedIssuesResponse, Priority } from "@issuectl/core";
+import type { WorkbenchPayload } from "./workbench-types";
+
+export type CandidateIssue = {
+  id: string;
+  title: string;
+  body: string;
+  owner: string;
+  repo: string;
+  labels: string[];
+  accepted: boolean;
+  originalText: string;
+};
+
+export type DraftState = {
+  id: string | null;
+  title: string;
+  body: string;
+  priority: Priority;
+  labels: string;
+};
+
+export type RepoOption = {
+  id: number;
+  key: string;
+  label: string;
+  owner: string;
+  repo: string;
+};
+
+export type QuickCreateResult = BatchCreateResult;
+
+export function toCandidateIssues(parsed: ParsedIssuesResponse, defaultRepoKey: string): CandidateIssue[] {
+  const order = new Map(parsed.suggestedOrder.map((id, index) => [id, index]));
+  return [...parsed.issues]
+    .sort((a, b) => (order.get(a.id) ?? 999) - (order.get(b.id) ?? 999))
+    .map((issue) => toCandidateIssue(issue, defaultRepoKey));
+}
+
+export function repoKey(repo: WorkbenchPayload["repos"][number] | null | undefined): string | null {
+  return repo ? `${repo.owner}/${repo.name}` : null;
+}
+
+export function unwrapParsedResponse(
+  body: { parsed: ParsedIssuesResponse } | ParsedIssuesResponse,
+): ParsedIssuesResponse {
+  return "parsed" in body ? body.parsed : body;
+}
+
+export async function requestJson<T>(path: string, init: RequestInit): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set("Accept", "application/json");
+  if (init.body) headers.set("Content-Type", "application/json");
+  const token = readApiToken();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const response = await fetch(path, { ...init, headers });
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+  if (!response.ok) {
+    throw new Error(
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `Request failed with ${response.status}`,
+    );
+  }
+  return body as T;
+}
+
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+function toCandidateIssue(issue: ParsedIssue, defaultRepoKey: string): CandidateIssue {
+  const [defaultOwner = "", defaultRepo = ""] = defaultRepoKey.split("/");
+  return {
+    id: issue.id,
+    title: issue.title,
+    body: issue.body,
+    owner: issue.repoOwner ?? defaultOwner,
+    repo: issue.repoName ?? defaultRepo,
+    labels: issue.suggestedLabels,
+    accepted: true,
+    originalText: issue.originalText,
+  };
+}
+
+function readApiToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem("issuectl.apiToken")
+    ?? window.localStorage.getItem("issuectlApiToken");
+}

--- a/packages/web/components/workbench/workbench-selectors.ts
+++ b/packages/web/components/workbench/workbench-selectors.ts
@@ -1,0 +1,123 @@
+import type {
+  WorkbenchDeployment,
+  WorkbenchIssueSummary,
+  WorkbenchPayload,
+  WorkbenchPreview,
+  WorkbenchRepo,
+} from "./workbench-types";
+import type { IssueQueueFilter, SessionSortMode, WorkbenchSelectionState } from "./workbench-state";
+
+const PREVIEW_STATUS_RANK: Record<WorkbenchPreview["status"], number> = {
+  active: 0,
+  error: 1,
+  unavailable: 2,
+  idle: 3,
+};
+
+export function selectedRepo(
+  payload: WorkbenchPayload | null,
+  state: WorkbenchSelectionState,
+): WorkbenchRepo | null {
+  if (!payload || state.selectedRepoId === null) return null;
+  return payload.repos.find((repo) => repo.id === state.selectedRepoId) ?? null;
+}
+
+export function selectedDeployment(
+  payload: WorkbenchPayload | null,
+  state: WorkbenchSelectionState,
+): WorkbenchDeployment | null {
+  if (!payload || state.selectedDeploymentId === null) return null;
+  return payload.deployments.find((deployment) => deployment.id === state.selectedDeploymentId) ?? null;
+}
+
+export function sortDeploymentSessions(
+  deployments: WorkbenchDeployment[],
+  previews: Record<string, WorkbenchPreview>,
+  sortMode: SessionSortMode,
+): WorkbenchDeployment[] {
+  return [...deployments].sort((left, right) => {
+    if (sortMode === "recent") {
+      return compareTimestampDesc(left.launchedAt, right.launchedAt) || compareDeploymentTie(left, right);
+    }
+
+    if (sortMode === "kind") {
+      return compareDeploymentTie(left, right);
+    }
+
+    return (
+      previewRank(left, previews) - previewRank(right, previews)
+      || compareTimestampDesc(left.launchedAt, right.launchedAt)
+      || compareDeploymentTie(left, right)
+    );
+  });
+}
+
+export function previewForDeployment(
+  deployment: WorkbenchDeployment,
+  previews: Record<string, WorkbenchPreview>,
+): WorkbenchPreview | null {
+  if (deployment.ttydPort === null) return null;
+  return previews[String(deployment.ttydPort)] ?? null;
+}
+
+export function issueQueueCounts(repo: WorkbenchRepo): Record<IssueQueueFilter, number> {
+  return {
+    open: repo.issues.filter((issue) => issue.state === "open").length,
+    running: repo.issues.filter((issue) => issue.state === "open" && issue.hasActiveDeployment).length,
+    closed: repo.issues.filter((issue) => issue.state === "closed").length,
+  };
+}
+
+export function filterIssueQueue(
+  issues: WorkbenchIssueSummary[],
+  filter: IssueQueueFilter,
+): WorkbenchIssueSummary[] {
+  return issues.filter((issue) => {
+    if (filter === "closed") return issue.state === "closed";
+    if (filter === "running") return issue.state === "open" && issue.hasActiveDeployment;
+    return issue.state === "open";
+  });
+}
+
+export function deploymentForIssue(
+  repo: WorkbenchRepo,
+  issueNumber: number,
+): WorkbenchDeployment | null {
+  return repo.deployments.find((deployment) => deployment.issueNumber === issueNumber) ?? null;
+}
+
+export function repoRailBadgeCount(repo: WorkbenchRepo): number {
+  return repo.deployments.length;
+}
+
+export function compactRepoInitials(name: string): string {
+  const cleaned = name.replace(/[^a-zA-Z0-9]+/g, " ").trim();
+  if (!cleaned) return "?";
+  if (cleaned.length <= 3 && !cleaned.includes(" ")) {
+    return cleaned.toUpperCase();
+  }
+
+  const chunks = cleaned.match(/issue|bug|drop|ctl|api|web|app|server|client|[a-zA-Z0-9]+/gi)
+    ?? [cleaned];
+  if (chunks.length > 1) {
+    return chunks.slice(0, 2).map((chunk) => chunk[0]).join("").toUpperCase();
+  }
+
+  return cleaned.slice(0, 2).toUpperCase();
+}
+
+function previewRank(
+  deployment: WorkbenchDeployment,
+  previews: Record<string, WorkbenchPreview>,
+): number {
+  const preview = previewForDeployment(deployment, previews);
+  return preview ? PREVIEW_STATUS_RANK[preview.status] : PREVIEW_STATUS_RANK.unavailable;
+}
+
+function compareTimestampDesc(left: string, right: string): number {
+  return Date.parse(right) - Date.parse(left);
+}
+
+function compareDeploymentTie(left: WorkbenchDeployment, right: WorkbenchDeployment): number {
+  return left.issueNumber - right.issueNumber || left.id - right.id;
+}

--- a/packages/web/components/workbench/workbench-state.ts
+++ b/packages/web/components/workbench/workbench-state.ts
@@ -1,10 +1,4 @@
-import type {
-  WorkbenchDeployment,
-  WorkbenchIssueSummary,
-  WorkbenchPayload,
-  WorkbenchPreview,
-  WorkbenchRepo,
-} from "./workbench-types";
+import type { WorkbenchPayload } from "./workbench-types";
 
 export type WorkbenchMode =
   | "workbench"
@@ -57,13 +51,6 @@ export const DEFAULT_WORKBENCH_SECTION_COLLAPSE_STATE: WorkbenchSectionCollapseS
   issueLaunchOptions: false,
   settingsHealth: false,
   settingsLaunchDefaults: false,
-};
-
-const PREVIEW_STATUS_RANK: Record<WorkbenchPreview["status"], number> = {
-  active: 0,
-  error: 1,
-  unavailable: 2,
-  idle: 3,
 };
 
 export type WorkbenchAction =
@@ -212,114 +199,6 @@ export function clampWorkbenchColumnWidths(widths: Partial<WorkbenchColumnWidths
 
 export function sidePaneWidthsApply(mode: WorkbenchMode): boolean {
   return mode !== "globalIssues" && mode !== "board" && mode !== "settings";
-}
-
-export function selectedRepo(
-  payload: WorkbenchPayload | null,
-  state: WorkbenchSelectionState,
-): WorkbenchRepo | null {
-  if (!payload || state.selectedRepoId === null) return null;
-  return payload.repos.find((repo) => repo.id === state.selectedRepoId) ?? null;
-}
-
-export function selectedDeployment(
-  payload: WorkbenchPayload | null,
-  state: WorkbenchSelectionState,
-): WorkbenchDeployment | null {
-  if (!payload || state.selectedDeploymentId === null) return null;
-  return payload.deployments.find((deployment) => deployment.id === state.selectedDeploymentId) ?? null;
-}
-
-export function sortDeploymentSessions(
-  deployments: WorkbenchDeployment[],
-  previews: Record<string, WorkbenchPreview>,
-  sortMode: SessionSortMode,
-): WorkbenchDeployment[] {
-  return [...deployments].sort((left, right) => {
-    if (sortMode === "recent") {
-      return compareTimestampDesc(left.launchedAt, right.launchedAt) || compareDeploymentTie(left, right);
-    }
-
-    if (sortMode === "kind") {
-      return compareDeploymentTie(left, right);
-    }
-
-    return (
-      previewRank(left, previews) - previewRank(right, previews)
-      || compareTimestampDesc(left.launchedAt, right.launchedAt)
-      || compareDeploymentTie(left, right)
-    );
-  });
-}
-
-export function previewForDeployment(
-  deployment: WorkbenchDeployment,
-  previews: Record<string, WorkbenchPreview>,
-): WorkbenchPreview | null {
-  if (deployment.ttydPort === null) return null;
-  return previews[String(deployment.ttydPort)] ?? null;
-}
-
-export function issueQueueCounts(repo: WorkbenchRepo): Record<IssueQueueFilter, number> {
-  return {
-    open: repo.issues.filter((issue) => issue.state === "open").length,
-    running: repo.issues.filter((issue) => issue.state === "open" && issue.hasActiveDeployment).length,
-    closed: repo.issues.filter((issue) => issue.state === "closed").length,
-  };
-}
-
-export function filterIssueQueue(
-  issues: WorkbenchIssueSummary[],
-  filter: IssueQueueFilter,
-): WorkbenchIssueSummary[] {
-  return issues.filter((issue) => {
-    if (filter === "closed") return issue.state === "closed";
-    if (filter === "running") return issue.state === "open" && issue.hasActiveDeployment;
-    return issue.state === "open";
-  });
-}
-
-export function deploymentForIssue(
-  repo: WorkbenchRepo,
-  issueNumber: number,
-): WorkbenchDeployment | null {
-  return repo.deployments.find((deployment) => deployment.issueNumber === issueNumber) ?? null;
-}
-
-export function repoRailBadgeCount(repo: WorkbenchRepo): number {
-  return repo.deployments.length;
-}
-
-export function compactRepoInitials(name: string): string {
-  const cleaned = name.replace(/[^a-zA-Z0-9]+/g, " ").trim();
-  if (!cleaned) return "?";
-  if (cleaned.length <= 3 && !cleaned.includes(" ")) {
-    return cleaned.toUpperCase();
-  }
-
-  const chunks = cleaned.match(/issue|bug|drop|ctl|api|web|app|server|client|[a-zA-Z0-9]+/gi)
-    ?? [cleaned];
-  if (chunks.length > 1) {
-    return chunks.slice(0, 2).map((chunk) => chunk[0]).join("").toUpperCase();
-  }
-
-  return cleaned.slice(0, 2).toUpperCase();
-}
-
-function previewRank(
-  deployment: WorkbenchDeployment,
-  previews: Record<string, WorkbenchPreview>,
-): number {
-  const preview = previewForDeployment(deployment, previews);
-  return preview ? PREVIEW_STATUS_RANK[preview.status] : PREVIEW_STATUS_RANK.unavailable;
-}
-
-function compareTimestampDesc(left: string, right: string): number {
-  return Date.parse(right) - Date.parse(left);
-}
-
-function compareDeploymentTie(left: WorkbenchDeployment, right: WorkbenchDeployment): number {
-  return left.issueNumber - right.issueNumber || left.id - right.id;
 }
 
 function clampColumnWidth(column: WorkbenchColumnKey, value: number | undefined): number {

--- a/packages/web/components/workbench/workbench.test.ts
+++ b/packages/web/components/workbench/workbench.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from "vitest";
 import type { WorkbenchPayload, WorkbenchRepo } from "./workbench-types";
 import {
-  DEFAULT_WORKBENCH_COLUMN_WIDTHS,
-  WORKBENCH_COLUMN_WIDTH_LIMITS,
-  clampWorkbenchColumnWidths,
   compactRepoInitials,
-  createWorkbenchState,
   filterIssueQueue,
   issueQueueCounts,
   repoRailBadgeCount,
   selectedRepo,
-  sidePaneWidthsApply,
   sortDeploymentSessions,
+} from "./workbench-selectors";
+import {
+  DEFAULT_WORKBENCH_COLUMN_WIDTHS,
+  WORKBENCH_COLUMN_WIDTH_LIMITS,
+  clampWorkbenchColumnWidths,
+  createWorkbenchState,
+  sidePaneWidthsApply,
   workbenchReducer,
 } from "./workbench-state";
 


### PR DESCRIPTION
## Summary
- split Quick Create UI/data helpers into smaller workbench modules
- split Pull Requests API/types/style helpers out of the focus component
- move workbench selector helpers out of reducer state module
- remove workbench max-lines lint warnings for QuickCreateFocus, PullRequestsFocus, and workbench-state

## Verification
- pnpm --filter @issuectl/web typecheck
- pnpm --filter @issuectl/web lint
- pnpm --filter @issuectl/web test -- components/workbench/workbench.test.ts
- PLAYWRIGHT_HTML_OPEN=never pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium --grep "quick create|pull request|compact|semantic" --output=/tmp/issuectl-file-size-cleanup-smoke
- git push pre-push build hook passed

## Notes
- Lint still reports pre-existing warnings in non-workbench files and core tests.