### PR TITLE
Clean Next build warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,14 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    plugins: { "@next/next": nextPlugin },
+    settings: {
+      next: {
+        rootDir: "packages/web/",
+      },
+    },
+  },
+  {
     ignores: ["**/dist/", "**/.next/", "**/.turbo/"],
   },
   {
@@ -33,8 +41,17 @@ export default tseslint.config(
   },
   {
     // Next.js plugin for web package
-    files: ["packages/web/**/*.{ts,tsx}"],
-    plugins: { "@next/next": nextPlugin },
-    rules: { ...nextPlugin.configs.recommended.rules },
+    files: [
+      "packages/web/**/*.{ts,tsx}",
+      "app/**/*.{ts,tsx}",
+      "components/**/*.{ts,tsx}",
+      "lib/**/*.{ts,tsx}",
+    ],
+    rules: {
+      ...nextPlugin.configs.recommended.rules,
+      // issuectl uses only the App Router; there is no pages directory
+      // for this legacy Pages Router rule to inspect.
+      "@next/next/no-html-link-for-pages": "off",
+    },
   },
 );

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -39,6 +39,14 @@ const appVersion = resolveVersion();
 
 const nextConfig: NextConfig = {
   experimental: {
+    serverActions: {
+      // Next.js defaults to 1 MB for server action request bodies.
+      // Image uploads from mobile phones are typically 3-8 MB, so the
+      // default silently rejects them before the action code runs. This
+      // matches the explicit 10 MB limit enforced in useImageUpload and
+      // the uploadImage server action.
+      bodySizeLimit: "10mb",
+    },
     // Keep Next.js 15's default of 0 seconds for the client Router
     // Cache on dynamic pages. This ensures mutations (create issue,
     // add comment, close issue) are immediately visible when
@@ -47,14 +55,6 @@ const nextConfig: NextConfig = {
     staleTimes: {
       dynamic: 0,
     },
-  },
-  serverActions: {
-    // Next.js defaults to 1 MB for server action request bodies.
-    // Image uploads from mobile phones are typically 3-8 MB, so the
-    // default silently rejects them before the action code runs. This
-    // matches the explicit 10 MB limit enforced in useImageUpload and
-    // the uploadImage server action.
-    bodySizeLimit: "10mb",
   },
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,


### PR DESCRIPTION
## Summary
- move `serverActions.bodySizeLimit` under `experimental` for Next 15
- register the Next ESLint plugin globally so `next build` can detect it
- keep Next recommended rules scoped to the web package and disable the pages-router-only `no-html-link-for-pages` rule for this App Router app

## Verification
- `pnpm --filter @issuectl/web build`
- `pnpm --filter @issuectl/web lint`
- `TURBO_FORCE=true pnpm lint`
- `pnpm typecheck`
- pre-push `turbo build`

## Notes
- The original Next build warnings for the invalid `serverActions` key and undetected Next ESLint plugin are gone.
