### PR TITLE
Silence expected test error logs

### DIFF
--- a/packages/core/src/github/issues-reassign.test.ts
+++ b/packages/core/src/github/issues-reassign.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type Database from "better-sqlite3";
 import { reassignIssue } from "./issues.js";
 import { createTestDb } from "../db/test-helpers.js";
@@ -39,10 +39,21 @@ describe("reassignIssue", () => {
     newRepoId = newRepo.id;
   });
 
+  async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      return await fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
   it("happy path: creates new issue, comments, closes old, returns result without cleanupWarning", async () => {
     const { octokit, create, createComment, update } = makeReassignOctokit();
 
-    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+    const result = await withConsoleWarnSilenced(() =>
+      reassignIssue(db, octokit, oldRepoId, 1, newRepoId)
+    );
 
     // Verify new issue created on target repo with correct title/body
     expect(create).toHaveBeenCalledWith({
@@ -109,7 +120,9 @@ describe("reassignIssue", () => {
     // addComment succeeds (uses createComment), but closeIssue (uses update) fails.
     update.mockRejectedValue(new Error("API rate limit exceeded"));
 
-    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+    const result = await withConsoleWarnSilenced(() =>
+      reassignIssue(db, octokit, oldRepoId, 1, newRepoId)
+    );
 
     // Should NOT throw
     expect(result.newIssueNumber).toBe(42);
@@ -123,7 +136,9 @@ describe("reassignIssue", () => {
 
     createComment.mockRejectedValue(new Error("Forbidden"));
 
-    const result = await reassignIssue(db, octokit, oldRepoId, 1, newRepoId);
+    const result = await withConsoleWarnSilenced(() =>
+      reassignIssue(db, octokit, oldRepoId, 1, newRepoId)
+    );
 
     expect(result.newIssueNumber).toBe(42);
     expect(result.cleanupWarning).toContain("could not be closed");

--- a/packages/core/src/launch/branch.test.ts
+++ b/packages/core/src/launch/branch.test.ts
@@ -22,6 +22,15 @@ beforeEach(() => {
   execFileMock.mockReset();
 });
 
+async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 /* ---------- generateBranchName (pure, no mock needed) ---------- */
 
 describe("generateBranchName", () => {
@@ -112,7 +121,7 @@ describe("getDefaultBranch", () => {
     const err = new Error("ref not found");
     Object.assign(err, { stderr: "fatal: ref not found" });
     execFileMock.mockRejectedValue(err);
-    const branch = await getDefaultBranch("/repo");
+    const branch = await withConsoleWarnSilenced(() => getDefaultBranch("/repo"));
     expect(branch).toBe("origin/main");
   });
 });

--- a/packages/core/src/launch/launch-execute-agents.test.ts
+++ b/packages/core/src/launch/launch-execute-agents.test.ts
@@ -104,6 +104,15 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     db = createTestDb();
   });
 
+  async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      return await fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
   it("allows launch when the prior deployment has ended", async () => {
     const repo = addRepo(db, {
       owner: "acme",
@@ -122,7 +131,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       "UPDATE deployments SET ended_at = datetime('now') WHERE id = ?",
     ).run(prior.id);
 
-    const result = await executeLaunch(db, {} as Octokit, {
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
       owner: "acme",
       repo: "api",
       issueNumber: 42,
@@ -130,7 +139,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       workspaceMode: "existing",
       selectedComments: [],
       selectedFiles: [],
-    });
+    }));
 
     expect(prepareWorkspaceSpy).toHaveBeenCalledTimes(1);
     expect(spawnTtydSpy).toHaveBeenCalledTimes(1);
@@ -167,7 +176,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       "--model gpt-5 --full-auto",
     );
 
-    await executeLaunch(db, {} as Octokit, {
+    await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
       owner: "acme",
       repo: "api",
       issueNumber: 43,
@@ -175,7 +184,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       workspaceMode: "existing",
       selectedComments: [],
       selectedFiles: [],
-    });
+    }));
 
     expect(spawnTtydSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -204,7 +213,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       "--sandbox danger-full-access --ask-for-approval never",
     );
 
-    await executeLaunch(db, {} as Octokit, {
+    await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
       owner: "acme",
       repo: "api",
       issueNumber: 44,
@@ -213,7 +222,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       workspaceMode: "existing",
       selectedComments: [],
       selectedFiles: [],
-    });
+    }));
 
     expect(spawnTtydSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/core/src/launch/launch-execute-rollback.test.ts
+++ b/packages/core/src/launch/launch-execute-rollback.test.ts
@@ -104,6 +104,26 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     db = createTestDb();
   });
 
+  async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      return await fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  async function withConsoleOutputSilenced<T>(fn: () => Promise<T>): Promise<T> {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      return await fn();
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  }
+
   it("rolls back pending deployment when spawnTtyd fails", async () => {
     const repo = addRepo(db, {
       owner: "acme",
@@ -115,7 +135,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     spawnTtydSpy.mockRejectedValueOnce(spawnError);
 
     await expect(
-      executeLaunch(db, {} as Octokit, {
+      withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
         owner: "acme",
         repo: "api",
         issueNumber: 42,
@@ -123,7 +143,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
         workspaceMode: "existing",
         selectedComments: [],
         selectedFiles: [],
-      }),
+      })),
     ).rejects.toThrow("ttyd process failed to start");
 
     // The pending deployment row must have been deleted by the rollback
@@ -136,7 +156,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
 
     // The slot is freed — a second launch for the same issue succeeds
     spawnTtydSpy.mockResolvedValueOnce({ pid: 99999, port: 7700 });
-    const result = await executeLaunch(db, {} as Octokit, {
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
       owner: "acme",
       repo: "api",
       issueNumber: 42,
@@ -144,7 +164,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       workspaceMode: "existing",
       selectedComments: [],
       selectedFiles: [],
-    });
+    }));
     expect(result.ttydPort).toBe(7700);
   });
 
@@ -167,7 +187,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
 
     try {
       await expect(
-        executeLaunch(db, {} as Octokit, {
+        withConsoleOutputSilenced(() => executeLaunch(db, {} as Octokit, {
           owner: "acme",
           repo: "api",
           issueNumber: 42,
@@ -175,7 +195,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
           workspaceMode: "existing",
           selectedComments: [],
           selectedFiles: [],
-        }),
+        })),
         // Must rethrow the original spawn error, not the rollback error
       ).rejects.toThrow("ttyd crashed");
     } finally {
@@ -193,7 +213,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     allocatePortSpy.mockRejectedValueOnce(new Error("no free ports"));
 
     await expect(
-      executeLaunch(db, {} as Octokit, {
+      withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
         owner: "acme",
         repo: "api",
         issueNumber: 42,
@@ -201,7 +221,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
         workspaceMode: "existing",
         selectedComments: [],
         selectedFiles: [],
-      }),
+      })),
     ).rejects.toThrow("no free ports");
 
     // Pending deployment row must be gone after the rollback
@@ -230,7 +250,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       return { pid: 12345, port: 7700 };
     });
 
-    await executeLaunch(db, {} as Octokit, {
+    await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
       owner: "acme",
       repo: "api",
       issueNumber: 42,
@@ -238,7 +258,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       workspaceMode: "existing",
       selectedComments: [],
       selectedFiles: [],
-    });
+    }));
 
     expect(callOrder).toEqual(["reserveTtydPort", "spawnTtyd"]);
     expect(reserveTtydPortSpy).toHaveBeenCalledWith(

--- a/packages/core/src/launch/worktree-status.test.ts
+++ b/packages/core/src/launch/worktree-status.test.ts
@@ -32,11 +32,22 @@ beforeEach(() => {
   branchMocks.isWorkingTreeClean.mockReset();
 });
 
+async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 describe("checkWorktreeStatus", () => {
   it("returns exists: false when directory does not exist", async () => {
     accessMock.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
 
-    const result = await checkWorktreeStatus("/worktrees", "myrepo", 42);
+    const result = await withConsoleWarnSilenced(() =>
+      checkWorktreeStatus("/worktrees", "myrepo", 42)
+    );
     expect(result).toEqual({ exists: false, dirty: false, path: "/worktrees/myrepo-issue-42" });
   });
 
@@ -45,7 +56,9 @@ describe("checkWorktreeStatus", () => {
     execFileMock.mockResolvedValue({ stdout: "", stderr: "" });
     branchMocks.isWorkingTreeClean.mockResolvedValue(true);
 
-    const result = await checkWorktreeStatus("/worktrees", "myrepo", 42);
+    const result = await withConsoleWarnSilenced(() =>
+      checkWorktreeStatus("/worktrees", "myrepo", 42)
+    );
     expect(result).toEqual({ exists: true, dirty: false, path: "/worktrees/myrepo-issue-42" });
   });
 
@@ -54,7 +67,9 @@ describe("checkWorktreeStatus", () => {
     execFileMock.mockResolvedValue({ stdout: "", stderr: "" });
     branchMocks.isWorkingTreeClean.mockResolvedValue(false);
 
-    const result = await checkWorktreeStatus("/worktrees", "myrepo", 42);
+    const result = await withConsoleWarnSilenced(() =>
+      checkWorktreeStatus("/worktrees", "myrepo", 42)
+    );
     expect(result).toEqual({ exists: true, dirty: true, path: "/worktrees/myrepo-issue-42" });
   });
 
@@ -71,7 +86,9 @@ describe("checkWorktreeStatus", () => {
     execFileMock.mockResolvedValue({ stdout: "", stderr: "" });
     branchMocks.isWorkingTreeClean.mockRejectedValue(new Error("git status timed out"));
 
-    const result = await checkWorktreeStatus("/worktrees", "myrepo", 42);
+    const result = await withConsoleWarnSilenced(() =>
+      checkWorktreeStatus("/worktrees", "myrepo", 42)
+    );
     expect(result).toEqual({ exists: true, dirty: true, path: "/worktrees/myrepo-issue-42" });
   });
 });
@@ -100,7 +117,9 @@ describe("resetWorktree", () => {
     rmMock.mockResolvedValue(undefined);
     execFileMock.mockRejectedValue(new Error("git not found"));
 
-    await expect(resetWorktree("/worktrees/myrepo-issue-42", "/repos/myrepo"))
+    await expect(withConsoleWarnSilenced(() =>
+      resetWorktree("/worktrees/myrepo-issue-42", "/repos/myrepo")
+    ))
       .resolves.toBeUndefined();
     expect(rmMock).toHaveBeenCalledWith("/worktrees/myrepo-issue-42", { recursive: true, force: true });
   });

--- a/packages/web/lib/actions/comments.test.ts
+++ b/packages/web/lib/actions/comments.test.ts
@@ -42,6 +42,15 @@ function expectFailure(result: { success: boolean }) {
   return result as { success: false; error: string };
 }
 
+async function withConsoleErrorSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // editComment
 // ---------------------------------------------------------------------------
@@ -105,7 +114,9 @@ describe("editComment action", () => {
 
   it("returns formatted error on API failure", async () => {
     withAuthRetryMock.mockRejectedValueOnce(new Error("API failure"));
-    const result = await editComment("acme", "web", 1, 100, "hello");
+    const result = await withConsoleErrorSilenced(() =>
+      editComment("acme", "web", 1, 100, "hello")
+    );
     expect(expectFailure(result).error).toBe("API failure");
   });
 });
@@ -155,7 +166,9 @@ describe("deleteComment action", () => {
 
   it("returns formatted error on API failure", async () => {
     withAuthRetryMock.mockRejectedValueOnce(new Error("Forbidden"));
-    const result = await deleteComment("acme", "web", 1, 100);
+    const result = await withConsoleErrorSilenced(() =>
+      deleteComment("acme", "web", 1, 100)
+    );
     expect(expectFailure(result).error).toBe("Forbidden");
   });
 });

--- a/packages/web/lib/actions/issues.test.ts
+++ b/packages/web/lib/actions/issues.test.ts
@@ -33,10 +33,17 @@ vi.mock("@/lib/revalidate", () => ({
   revalidateSafely: () => ({ stale: false }),
 }));
 
+const notifyNewIssueMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/push/notifications", () => ({
+  notifyNewIssue: notifyNewIssueMock,
+}));
+
 const { createIssue } = await import("./issues");
 
 beforeEach(() => {
   vi.clearAllMocks();
+  notifyNewIssueMock.mockReset();
   coreMocks.getDb.mockReturnValue({});
   coreMocks.setSetting.mockReset();
   coreMocks.getRepo.mockReturnValue({

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  withConsoleErrorSilenced,
+  withConsoleWarnSilenced,
+} from "../test-utils/console.js";
 
 // vi.mock is hoisted, so we cannot reference a const declared above it.
 // Use vi.hoisted() to create spies before hoisting occurs, then reference them.
@@ -184,7 +188,7 @@ describe("launchIssue", () => {
 
 describe("endSession", () => {
   it("kills ttyd before ending deployment", async () => {
-    const result = await endSession(...ARGS);
+    const result = await withConsoleWarnSilenced(() => endSession(...ARGS));
 
     expect(killTtyd).toHaveBeenCalledWith(42, "issuectl-repo-7");
     expect(coreEndDeployment).toHaveBeenCalled();
@@ -196,7 +200,7 @@ describe("endSession", () => {
       throw Object.assign(new Error("Operation not permitted"), { code: "EPERM" });
     });
 
-    const result = await endSession(...ARGS);
+    const result = await withConsoleWarnSilenced(() => endSession(...ARGS));
 
     // Kill failure must not prevent the DB update.
     expect(coreEndDeployment).toHaveBeenCalled();
@@ -243,7 +247,7 @@ describe("checkSessionAlive", () => {
   it("returns alive when tmux session exists (even if ttyd is dead)", async () => {
     isTmuxSessionAlive.mockReturnValue(true);
 
-    const result = await checkSessionAlive(1);
+    const result = await withConsoleErrorSilenced(() => checkSessionAlive(1));
 
     expect(result).toEqual({ alive: true });
     expect(coreEndDeployment).not.toHaveBeenCalled();
@@ -252,7 +256,7 @@ describe("checkSessionAlive", () => {
   it("ends deployment and returns not alive when tmux session is gone", async () => {
     isTmuxSessionAlive.mockReturnValue(false);
 
-    const result = await checkSessionAlive(1);
+    const result = await withConsoleErrorSilenced(() => checkSessionAlive(1));
 
     expect(result).toEqual({ alive: false });
     expect(coreEndDeployment).toHaveBeenCalled();
@@ -261,7 +265,7 @@ describe("checkSessionAlive", () => {
   it("returns not alive when deployment is already ended", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), endedAt: "2026-01-01" });
 
-    const result = await checkSessionAlive(1);
+    const result = await withConsoleErrorSilenced(() => checkSessionAlive(1));
 
     expect(result).toEqual({ alive: false });
     expect(isTmuxSessionAlive).not.toHaveBeenCalled();
@@ -290,7 +294,7 @@ describe("checkSessionAlive", () => {
       throw new Error("DB locked");
     });
 
-    const result = await checkSessionAlive(1);
+    const result = await withConsoleErrorSilenced(() => checkSessionAlive(1));
 
     expect(result).toEqual({ alive: false, error: "Health check failed" });
   });
@@ -301,7 +305,7 @@ describe("ensureTtyd", () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(true);
 
-    const result = await ensureTtyd(1);
+    const result = await withConsoleErrorSilenced(() => ensureTtyd(1));
 
     expect(result).toEqual({ port: 7700, terminalToken: expect.any(String) });
     expect(respawnTtyd).not.toHaveBeenCalled();
@@ -313,7 +317,7 @@ describe("ensureTtyd", () => {
     isTmuxSessionAlive.mockReturnValue(true);
     respawnTtyd.mockResolvedValue({ pid: 99 });
 
-    const result = await ensureTtyd(1);
+    const result = await withConsoleErrorSilenced(() => ensureTtyd(1));
 
     expect(result).toEqual({ port: 7700, terminalToken: expect.any(String), respawned: true });
     expect(respawnTtyd).toHaveBeenCalledWith(7700, "issuectl-repo-7");
@@ -324,7 +328,7 @@ describe("ensureTtyd", () => {
     isTtydAlive.mockReturnValue(false);
     isTmuxSessionAlive.mockReturnValue(false);
 
-    const result = await ensureTtyd(1);
+    const result = await withConsoleErrorSilenced(() => ensureTtyd(1));
 
     expect(result).toEqual({ alive: false, error: "Terminal session has ended" });
     expect(respawnTtyd).not.toHaveBeenCalled();
@@ -364,7 +368,7 @@ describe("ensureTtyd", () => {
     isTmuxSessionAlive.mockReturnValue(true);
     respawnTtyd.mockRejectedValue(new Error("port conflict"));
 
-    const result = await ensureTtyd(1);
+    const result = await withConsoleErrorSilenced(() => ensureTtyd(1));
 
     // formatErrorForUser passes through Error.message
     expect(result).toEqual({ alive: false, error: "port conflict" });

--- a/packages/web/lib/actions/settings.test.ts
+++ b/packages/web/lib/actions/settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { withConsoleErrorSilenced, withConsoleWarnSilenced } from "../test-utils/console.js";
 
 // vi.mock is hoisted, so we cannot reference a const declared above it.
 // Use vi.hoisted() to create the spy before hoisting occurs, then reference it.
@@ -212,7 +213,7 @@ describe("updateSetting", () => {
       err.code = "SQLITE_BUSY";
       throw err;
     });
-    const result = await updateSetting("branch_pattern", "main");
+    const result = await withConsoleErrorSilenced(() => updateSetting("branch_pattern", "main"));
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/busy|another/i);
   });
@@ -221,7 +222,7 @@ describe("updateSetting", () => {
     setSetting.mockImplementationOnce(() => {
       throw new Error("some unrecognized failure");
     });
-    const result = await updateSetting("branch_pattern", "main");
+    const result = await withConsoleErrorSilenced(() => updateSetting("branch_pattern", "main"));
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/^Failed to update setting:/);
     expect(result.error).toContain("some unrecognized failure");
@@ -231,7 +232,7 @@ describe("updateSetting", () => {
     revalidatePath.mockImplementationOnce(() => {
       throw new Error("revalidation failed");
     });
-    const result = await updateSetting("branch_pattern", "main");
+    const result = await withConsoleWarnSilenced(() => updateSetting("branch_pattern", "main"));
     expect(result.success).toBe(true);
     expect(result.cacheStale).toBe(true);
     expect(fakeDb.settings.get("branch_pattern")).toBe("main");
@@ -282,10 +283,10 @@ describe("updateSettings (batch)", () => {
   });
 
   it("applies all updates in one transaction", async () => {
-    const result = await updateSettings({
+    const result = await withConsoleErrorSilenced(() => updateSettings({
       branch_pattern: "main",
       cache_ttl: "600",
-    });
+    }));
     expect(result.success).toBe(true);
     expect(fakeDb.settings.get("branch_pattern")).toBe("main");
     expect(fakeDb.settings.get("cache_ttl")).toBe("600");
@@ -345,10 +346,10 @@ describe("updateSettings (batch)", () => {
       db.settings.set(key, value);
     });
 
-    const result = await updateSettings({
+    const result = await withConsoleErrorSilenced(() => updateSettings({
       branch_pattern: "main",
       cache_ttl: "600",
-    });
+    }));
 
     expect(result.success).toBe(false);
     // Neither write should survive — the transaction rolls back the first.

--- a/packages/web/lib/actions/uploads.test.ts
+++ b/packages/web/lib/actions/uploads.test.ts
@@ -81,6 +81,15 @@ function validFormData(overrides: Partial<Parameters<typeof makeFormData>[0]> = 
   });
 }
 
+async function withConsoleErrorSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -246,7 +255,7 @@ describe("uploadImage server action", () => {
       new Error("GitHub image upload failed (403): Forbidden"),
     );
 
-    const result = await uploadImage(validFormData());
+    const result = await withConsoleErrorSilenced(() => uploadImage(validFormData()));
 
     expect(result).toMatchObject({
       success: false,
@@ -257,7 +266,7 @@ describe("uploadImage server action", () => {
   it("returns { success: false } when getGhToken throws", async () => {
     getGhTokenMock.mockRejectedValue(new Error("gh auth: not logged in"));
 
-    const result = await uploadImage(validFormData());
+    const result = await withConsoleErrorSilenced(() => uploadImage(validFormData()));
 
     expect(result).toMatchObject({ success: false });
     expect((result as { error: string }).error).toBeTruthy();

--- a/packages/web/lib/api-auth.test.ts
+++ b/packages/web/lib/api-auth.test.ts
@@ -7,6 +7,15 @@ vi.mock("@issuectl/core", () => ({
   getSetting: vi.fn(),
 }));
 
+const loggerMock = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("./logger", () => ({
+  default: loggerMock,
+}));
+
 import { validateApiToken, requireAuth, resetApiTokenCache } from "./api-auth.js";
 import { getDb, getSetting } from "@issuectl/core";
 
@@ -25,6 +34,8 @@ describe("validateApiToken", () => {
     resetApiTokenCache();
     vi.mocked(getDb).mockReturnValue(mockDb);
     vi.mocked(getSetting).mockReset();
+    loggerMock.warn.mockClear();
+    loggerMock.error.mockClear();
   });
 
   it("returns true for a valid bearer token", () => {

--- a/packages/web/lib/network-info.test.ts
+++ b/packages/web/lib/network-info.test.ts
@@ -13,6 +13,15 @@ const { getLanIp, getPublicIp, getLanRedirectUrl, resetForTesting } = await impo
 
 const originalFetch = globalThis.fetch;
 
+async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 describe("getLanIp", () => {
   beforeEach(() => {
     resetForTesting();
@@ -42,7 +51,7 @@ describe("getLanIp", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("no network"));
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getLanIp()).toBe("192.168.1.30");
   });
@@ -57,7 +66,7 @@ describe("getLanIp", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("no network"));
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getLanIp()).toBeNull();
   });
@@ -68,7 +77,7 @@ describe("getLanIp", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("no network"));
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getLanIp()).toBeNull();
   });
@@ -95,7 +104,7 @@ describe("getPublicIp", () => {
     });
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getPublicIp()).toBe("203.0.113.42");
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -112,7 +121,7 @@ describe("getPublicIp", () => {
     });
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getPublicIp()).toBeNull();
   });
@@ -121,7 +130,7 @@ describe("getPublicIp", () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("fetch failed"));
 
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    await withConsoleWarnSilenced(() => refresh());
 
     expect(getPublicIp()).toBeNull();
   });
@@ -159,7 +168,11 @@ describe("getLanRedirectUrl", () => {
       globalThis.fetch = vi.fn().mockRejectedValue(new Error("no network"));
     }
     const { refreshNetworkInfo: refresh } = await import("./network-info.js");
-    await refresh();
+    if (pub) {
+      await refresh();
+    } else {
+      await withConsoleWarnSilenced(() => refresh());
+    }
   }
 
   it("returns null when ISSUECTL_TUNNEL_URL is not set", async () => {

--- a/packages/web/lib/test-utils/console.ts
+++ b/packages/web/lib/test-utils/console.ts
@@ -1,0 +1,19 @@
+import { vi } from "vitest";
+
+export async function withConsoleErrorSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+export async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+  const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}


### PR DESCRIPTION
## Summary
- silence expected console noise in tests that intentionally exercise error paths
- mock structured logger/notification side effects that were writing pino JSON during unrelated tests
- add a small web test utility for scoped console suppression

## Verification
- pnpm test (with captured output scan for remaining expected log noise)
- pnpm lint
- pnpm typecheck
- git diff --check
- push hook pnpm build