### PR TITLE
Skip splash overlay on workbench routes

### DIFF
--- a/packages/web/components/ui/SplashOverlay.tsx
+++ b/packages/web/components/ui/SplashOverlay.tsx
@@ -1,10 +1,18 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import styles from "./SplashOverlay.module.css";
 
 export function SplashOverlay() {
+  const pathname = usePathname();
   const version = process.env.NEXT_PUBLIC_APP_VERSION || "dev";
 
+  if (pathname?.startsWith("/workbench")) {
+    return null;
+  }
+
   return (
-    <div className={styles.overlay} aria-hidden="true">
+    <div className={styles.overlay} aria-hidden="true" data-testid="splash-overlay">
       <div className={styles.logoMark}>ic</div>
       <div className={styles.title}>issuectl</div>
       <div className={styles.version}>v{version}</div>

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2286,6 +2286,8 @@ async function mockTerminalPage(
 }
 
 async function expectNoWorkbenchSplash(page: import("@playwright/test").Page) {
+  await expect(page.getByTestId("splash-overlay")).toHaveCount(0);
+  await expect(page.getByLabel("Loading workbench")).toHaveCount(0);
   await expect(page.getByText("Opening workbench")).toHaveCount(0);
   await expect(page.getByText("Preparing repositories, sessions, and issue queues.")).toHaveCount(0);
 }


### PR DESCRIPTION
## Summary
- audited workbench QA screenshots and found the global splash overlay could remain over ready workbench views on direct/subroute loads
- skip the app splash overlay for `/workbench` routes so the workbench content is immediately inspectable
- add Playwright regression checks that screenshot-ready workbench flows have no global splash or workbench loading shell

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "captures workbench QA screenshots|keeps compact workbench layouts usable on tablet and mobile"`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- pre-push hook: `pnpm build`
