### PR TITLE
Hide desktop workbench layout controls on compact screens

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -634,24 +634,24 @@ export function WorkbenchShell({
           issuectl<span className={styles.brandDot} />
         </Link>
         <span className={styles.routeLabel}>/workbench</span>
-        <div className={styles.toolbarTools} aria-label="Workbench layout controls">
-          <button
-            type="button"
-            className={styles.resetColumnsButton}
-            aria-label="Reset column widths"
-            title="Reset column widths"
-            onClick={() => {
-              const storedColumnWidths = window.localStorage.getItem(WORKBENCH_COLUMN_WIDTH_STORAGE_KEY);
-              skipNextColumnWidthPersistRef.current =
-                !columnsAreDefault(selection.columnWidths)
-                || (storedColumnWidths !== null && selection.columnWidths !== DEFAULT_WORKBENCH_COLUMN_WIDTHS);
-              window.localStorage.removeItem(WORKBENCH_COLUMN_WIDTH_STORAGE_KEY);
-              dispatch({ type: "resetColumnWidths" });
-            }}
-          >
-            Reset
-          </button>
-          {!compactSidePanesHidden && (
+        {!compactSidePanesHidden && (
+          <div className={styles.toolbarTools} aria-label="Workbench layout controls">
+            <button
+              type="button"
+              className={styles.resetColumnsButton}
+              aria-label="Reset column widths"
+              title="Reset column widths"
+              onClick={() => {
+                const storedColumnWidths = window.localStorage.getItem(WORKBENCH_COLUMN_WIDTH_STORAGE_KEY);
+                skipNextColumnWidthPersistRef.current =
+                  !columnsAreDefault(selection.columnWidths)
+                  || (storedColumnWidths !== null && selection.columnWidths !== DEFAULT_WORKBENCH_COLUMN_WIDTHS);
+                window.localStorage.removeItem(WORKBENCH_COLUMN_WIDTH_STORAGE_KEY);
+                dispatch({ type: "resetColumnWidths" });
+              }}
+            >
+              Reset
+            </button>
             <div className={styles.drawerControls} aria-label="Workbench drawers">
               <button
                 type="button"
@@ -670,8 +670,8 @@ export function WorkbenchShell({
                 Issues
               </button>
             </div>
-          )}
-        </div>
+          </div>
+        )}
         <nav className={styles.topnav} aria-label="Workbench navigation">
           {NAV_ITEMS.map((item) => (
             <button

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -644,7 +644,7 @@ test("keeps compact workbench layouts usable on tablet and mobile", async ({ pag
     const nav = page.getByRole("navigation", { name: "Workbench navigation" });
 
     await expect(page.getByRole("link", { name: "issuectl workbench" })).toBeVisible();
-    await expect(page.getByLabel("Workbench layout controls")).toBeVisible();
+    await expect(page.getByLabel("Workbench layout controls")).toHaveCount(0);
     await expect(nav).toBeVisible();
     await expectNoHorizontalPageScroll(page);
     await expectWorkbenchFitsViewport(page);


### PR DESCRIPTION
## Summary
- audited compact/mobile workbench screenshots and found the desktop-only Reset/layout controls still occupying the mobile header even though side panes and column resizing are hidden
- omit the workbench layout toolbar on compact routes, freeing the top-right header area for navigation and content
- update the compact Playwright regression to assert those desktop layout controls are absent on tablet/mobile widths

## Screenshot evidence
- Before: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-mobile-audit/workbench-settings-393.png`
- After: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-mobile-audit-after/workbench-settings-393.png`
- After: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-mobile-audit-after/workbench-board-393.png`
- After: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-mobile-audit-after/workbench-quick-create-320.png`

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact workbench layouts usable on tablet and mobile|captures workbench QA screenshots"`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- pre-push hook: `pnpm build`

Browser plugin note: Browser is installed, but the required Node REPL JavaScript execution tool was not exposed in this session, so verification used the repository Playwright workflow.
