### PR TITLE
Order compact issue title action after its field

### DIFF
--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -322,6 +322,14 @@ export function IssueFocus({
               <option value="low">low</option>
             </select>
           </label>
+          <label>
+            Issue title
+            <input
+              value={titleDraft}
+              disabled={pendingAction !== null || status !== "loaded"}
+              onChange={(event) => setTitleDraft(event.currentTarget.value)}
+            />
+          </label>
           <button
             type="button"
             disabled={pendingAction !== null || status !== "loaded" || !titleChanged}
@@ -334,14 +342,6 @@ export function IssueFocus({
           >
             Save title
           </button>
-          <label>
-            Issue title
-            <input
-              value={titleDraft}
-              disabled={pendingAction !== null || status !== "loaded"}
-              onChange={(event) => setTitleDraft(event.currentTarget.value)}
-            />
-          </label>
         </div>
 
         <div className={styles.issueActionGroup} aria-label="Comment actions">

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -671,6 +671,38 @@ test("keeps compact workbench layouts usable on tablet and mobile", async ({ pag
   }
 });
 
+test("keeps compact issue action controls readable and ordered", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+
+  const issueActions = page.getByLabel("Issue actions");
+  await expect(issueActions.getByLabel("Metadata actions")).toBeVisible();
+  const titleInput = issueActions.getByLabel("Issue title");
+  const saveTitleButton = issueActions.getByRole("button", { name: "Save title" });
+  await expect(titleInput).toHaveValue("Desktop instance manager workbench");
+  await expect(saveTitleButton).toBeDisabled();
+  await expectVerticallyBefore(titleInput, saveTitleButton);
+  await titleInput.fill("Desktop instance manager workbench renamed");
+  await expect(saveTitleButton).toBeEnabled();
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("captures workbench QA screenshots", async ({ browser }) => {
   if (!tmpDir) throw new Error("Expected workbench e2e tmpDir to be initialized");
   const artifactDir = join(tmpDir, "workbench-artifacts");
@@ -2264,6 +2296,17 @@ async function expectNoBoxOverlap(
     && firstBox!.y < secondBox!.y + secondBox!.height
     && firstBox!.y + firstBox!.height > secondBox!.y;
   expect(overlaps).toBe(false);
+}
+
+async function expectVerticallyBefore(
+  first: import("@playwright/test").Locator,
+  second: import("@playwright/test").Locator,
+) {
+  const firstBox = await first.boundingBox();
+  const secondBox = await second.boundingBox();
+  expect(firstBox).not.toBeNull();
+  expect(secondBox).not.toBeNull();
+  expect(firstBox!.y + firstBox!.height).toBeLessThanOrEqual(secondBox!.y);
 }
 
 async function mockTerminalPage(


### PR DESCRIPTION
## Summary
- audited compact issue detail/action workflows and found the Metadata action group put `Save title` above the `Issue title` field
- move `Save title` below the title input so the mobile form reads as field -> action
- add a compact Playwright regression that asserts the issue title field appears before the save button and remains usable without horizontal overflow

## Screenshot evidence
- Before: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-issue-actions-audit/issue-actions-393-before.png`
- After: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-issue-actions-audit-after/issue-actions-section-393-after.png`

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact issue action controls readable and ordered|loads issue detail and calls issue mutation endpoints|keeps compact workbench layouts usable on tablet and mobile" --project desktop-chromium`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- pre-push hook: `pnpm build`

Browser plugin note: Browser is installed, but the required runtime execution tool was not exposed in this session, so verification used the repository Playwright workflow.
