### PR TITLE
Expose compact issue entry from workbench overview

### DIFF
--- a/packages/web/components/workbench/RepoOverviewFocus.tsx
+++ b/packages/web/components/workbench/RepoOverviewFocus.tsx
@@ -5,6 +5,7 @@ type Props = {
   repo: WorkbenchRepo;
   health: WorkbenchHealth;
   onRefresh: () => void;
+  onSelectIssue: (issueNumber: number) => void;
   onOpenRepoSetup: () => void;
 };
 
@@ -12,6 +13,7 @@ export function RepoOverviewFocus({
   repo,
   health,
   onRefresh,
+  onSelectIssue,
   onOpenRepoSetup,
 }: Props) {
   return (
@@ -60,6 +62,30 @@ export function RepoOverviewFocus({
           New shell unavailable
         </button>
       </div>
+
+      {repo.issues.length > 0 && (
+        <section className={styles.overviewIssueShortcuts} aria-label="Compact repo issues">
+          <h2>Repo issues</h2>
+          <div className={styles.overviewIssueList}>
+            {repo.issues.map((issue) => {
+              const status = issue.state === "closed" ? "closed" : issue.hasActiveDeployment ? "running" : "open";
+              return (
+                <article key={issue.number} className={styles.overviewIssueCard} aria-label={`Issue #${issue.number}`}>
+                  <div>
+                    <strong>#{issue.number}</strong>
+                    <span>{status}</span>
+                    <span>{issue.priority}</span>
+                  </div>
+                  <h3>{issue.title}</h3>
+                  <button type="button" onClick={() => onSelectIssue(issue.number)}>
+                    Open issue
+                  </button>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1513,6 +1513,63 @@
   flex-wrap: wrap;
 }
 
+.overviewIssueShortcuts {
+  display: none;
+}
+
+.overviewIssueShortcuts h2 {
+  font-family: var(--paper-serif);
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.overviewIssueList {
+  display: grid;
+  gap: 10px;
+}
+
+.overviewIssueCard {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.overviewIssueCard div {
+  min-width: 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--paper-ink-muted);
+  font: 11px var(--paper-mono);
+}
+
+.overviewIssueCard h3 {
+  min-width: 0;
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.overviewIssueCard button {
+  justify-self: start;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--paper-ink);
+  font-family: var(--paper-serif);
+  font-style: italic;
+}
+
 .secondaryButton:disabled {
   opacity: 0.62;
   cursor: default;
@@ -1706,6 +1763,13 @@
     width: 100%;
     box-sizing: border-box;
     padding: 22px 16px;
+  }
+
+  .overviewIssueShortcuts {
+    max-width: 620px;
+    display: grid;
+    gap: 12px;
+    margin-top: 22px;
   }
 
   .issueFocusGrid,

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -778,6 +778,7 @@ export function WorkbenchShell({
             }}
             onIssueUpdated={updateIssue}
             onIssueReassigned={focusReassignedIssue}
+            onSelectIssue={selectIssue}
             onGlobalIssueSelected={selectGlobalIssue}
             onSessionLaunched={addLaunchedSession}
             onDeploymentStale={removeDeployment}
@@ -856,6 +857,7 @@ function FocusContent({
   onRefresh,
   onIssueUpdated,
   onIssueReassigned,
+  onSelectIssue,
   onGlobalIssueSelected,
   onSessionLaunched,
   onDeploymentStale,
@@ -883,6 +885,7 @@ function FocusContent({
   onRefresh: () => void;
   onIssueUpdated: (repoId: number, issueNumber: number, patch: Partial<WorkbenchIssueSummary>) => void;
   onIssueReassigned: (result: { owner: string; repo: string; issueNumber: number }) => void;
+  onSelectIssue: (issueNumber: number) => void;
   onGlobalIssueSelected: (repoId: number, issueNumber: number) => void;
   onSessionLaunched: (deployment: WorkbenchDeployment) => void;
   onDeploymentStale: (deploymentId: number) => void;
@@ -1026,6 +1029,7 @@ function FocusContent({
         repo={selectedRepo}
         health={loadState.data.health}
         onRefresh={onRefresh}
+        onSelectIssue={onSelectIssue}
         onOpenRepoSetup={onOpenRepoSetup}
       />
     );

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -703,6 +703,35 @@ test("keeps compact issue action controls readable and ordered", async ({ page }
   await expectWorkbenchFitsViewport(page);
 });
 
+test("keeps compact issue entry reachable from the workbench overview", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench`);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
+  const compactIssues = page.getByLabel("Compact repo issues");
+  await expect(compactIssues).toBeVisible();
+  await expect(compactIssues.getByLabel("Issue #512")).toBeVisible();
+  await compactIssues.getByLabel("Issue #512").getByRole("button", { name: "Open issue" }).click();
+  await expect(page).toHaveURL(/issue=512/);
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  const issueActions = page.getByLabel("Issue actions");
+  await expect(issueActions).toBeVisible();
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("captures workbench QA screenshots", async ({ browser }) => {
   if (!tmpDir) throw new Error("Expected workbench e2e tmpDir to be initialized");
   const artifactDir = join(tmpDir, "workbench-artifacts");


### PR DESCRIPTION
## Summary
- Audit finding: compact `/workbench` hides the repo issue side pane, but the default repo overview did not provide an issue-entry path even though it tells users to select a session or issue.
- Add compact-only repo issue shortcuts to the overview so mobile users can open issue detail/actions without first navigating to a separate Issues view.
- Add a regression covering the compact overview -> issue #512 -> issue actions path with no horizontal overflow.

## Screenshot verification
- Captured compact overview issue shortcuts: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-issue-entry-audit-after/compact-overview-issues-393-after.png`
- Captured compact issue actions scrolled into view: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-issue-entry-audit-after/compact-overview-issue-detail-393-after.png`
- Browser plugin was available, but the runtime execution tool was not exposed in this session, so verification used the repo Playwright CLI fallback.

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact issue entry reachable from the workbench overview|keeps compact issue action controls readable and ordered|keeps compact workbench layouts usable on tablet and mobile" --project desktop-chromium`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- push hook: `turbo run build` passed