### PR TITLE
Expose compact session entry from workbench overview

### DIFF
--- a/packages/web/components/workbench/RepoOverviewFocus.tsx
+++ b/packages/web/components/workbench/RepoOverviewFocus.tsx
@@ -1,10 +1,12 @@
-import type { WorkbenchHealth, WorkbenchRepo } from "./workbench-types";
+import { previewForDeployment } from "./workbench-selectors";
+import type { WorkbenchDeployment, WorkbenchHealth, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
 
 type Props = {
   repo: WorkbenchRepo;
   health: WorkbenchHealth;
   onRefresh: () => void;
+  onSelectDeployment: (deploymentId: number) => void;
   onSelectIssue: (issueNumber: number) => void;
   onOpenRepoSetup: () => void;
 };
@@ -13,6 +15,7 @@ export function RepoOverviewFocus({
   repo,
   health,
   onRefresh,
+  onSelectDeployment,
   onSelectIssue,
   onOpenRepoSetup,
 }: Props) {
@@ -63,14 +66,30 @@ export function RepoOverviewFocus({
         </button>
       </div>
 
+      {repo.deployments.length > 0 && (
+        <section className={styles.overviewSessionShortcuts} aria-label="Compact active sessions">
+          <h2>Active sessions</h2>
+          <div className={styles.overviewShortcutList}>
+            {repo.deployments.map((deployment) => (
+              <OverviewSessionCard
+                key={deployment.id}
+                deployment={deployment}
+                repo={repo}
+                onSelectDeployment={onSelectDeployment}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
       {repo.issues.length > 0 && (
         <section className={styles.overviewIssueShortcuts} aria-label="Compact repo issues">
           <h2>Repo issues</h2>
-          <div className={styles.overviewIssueList}>
+          <div className={styles.overviewShortcutList}>
             {repo.issues.map((issue) => {
               const status = issue.state === "closed" ? "closed" : issue.hasActiveDeployment ? "running" : "open";
               return (
-                <article key={issue.number} className={styles.overviewIssueCard} aria-label={`Issue #${issue.number}`}>
+                <article key={issue.number} className={styles.overviewShortcutCard} aria-label={`Issue #${issue.number}`}>
                   <div>
                     <strong>#{issue.number}</strong>
                     <span>{status}</span>
@@ -87,5 +106,34 @@ export function RepoOverviewFocus({
         </section>
       )}
     </div>
+  );
+}
+
+function OverviewSessionCard({
+  deployment,
+  repo,
+  onSelectDeployment,
+}: {
+  deployment: WorkbenchDeployment;
+  repo: WorkbenchRepo;
+  onSelectDeployment: (deploymentId: number) => void;
+}) {
+  const issue = repo.issues.find((item) => item.number === deployment.issueNumber);
+  const preview = previewForDeployment(deployment, repo.previews);
+  const status = preview?.status ?? "running";
+  const runtimeLabel = deployment.idleSince ? "idle" : "running";
+  return (
+    <article className={styles.overviewShortcutCard} aria-label={`Session #${deployment.issueNumber}`}>
+      <div>
+        <strong>#{deployment.issueNumber}</strong>
+        <span>{deployment.agent}</span>
+        <span>{status}</span>
+      </div>
+      <h3>{issue?.title ?? "Issue session"}</h3>
+      <p>{deployment.branchName} - {runtimeLabel}</p>
+      <button type="button" onClick={() => onSelectDeployment(deployment.id)}>
+        Open terminal
+      </button>
+    </article>
   );
 }

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1513,22 +1513,24 @@
   flex-wrap: wrap;
 }
 
+.overviewSessionShortcuts,
 .overviewIssueShortcuts {
   display: none;
 }
 
+.overviewSessionShortcuts h2,
 .overviewIssueShortcuts h2 {
   font-family: var(--paper-serif);
   font-size: 20px;
   font-weight: 500;
 }
 
-.overviewIssueList {
+.overviewShortcutList {
   display: grid;
   gap: 10px;
 }
 
-.overviewIssueCard {
+.overviewShortcutCard {
   min-width: 0;
   display: grid;
   gap: 8px;
@@ -1538,7 +1540,7 @@
   background: rgba(255, 255, 255, 0.22);
 }
 
-.overviewIssueCard div {
+.overviewShortcutCard div {
   min-width: 0;
   display: flex;
   gap: 6px;
@@ -1548,7 +1550,7 @@
   font: 11px var(--paper-mono);
 }
 
-.overviewIssueCard h3 {
+.overviewShortcutCard h3 {
   min-width: 0;
   color: var(--paper-ink);
   font-family: var(--paper-serif);
@@ -1558,7 +1560,14 @@
   overflow-wrap: anywhere;
 }
 
-.overviewIssueCard button {
+.overviewShortcutCard p {
+  min-width: 0;
+  color: var(--paper-ink-muted);
+  font: 12px var(--paper-mono);
+  overflow-wrap: anywhere;
+}
+
+.overviewShortcutCard button {
   justify-self: start;
   min-height: 36px;
   padding: 0 12px;
@@ -1765,6 +1774,7 @@
     padding: 22px 16px;
   }
 
+  .overviewSessionShortcuts,
   .overviewIssueShortcuts {
     max-width: 620px;
     display: grid;

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -778,6 +778,7 @@ export function WorkbenchShell({
             }}
             onIssueUpdated={updateIssue}
             onIssueReassigned={focusReassignedIssue}
+            onSelectDeployment={selectDeployment}
             onSelectIssue={selectIssue}
             onGlobalIssueSelected={selectGlobalIssue}
             onSessionLaunched={addLaunchedSession}
@@ -857,6 +858,7 @@ function FocusContent({
   onRefresh,
   onIssueUpdated,
   onIssueReassigned,
+  onSelectDeployment,
   onSelectIssue,
   onGlobalIssueSelected,
   onSessionLaunched,
@@ -885,6 +887,7 @@ function FocusContent({
   onRefresh: () => void;
   onIssueUpdated: (repoId: number, issueNumber: number, patch: Partial<WorkbenchIssueSummary>) => void;
   onIssueReassigned: (result: { owner: string; repo: string; issueNumber: number }) => void;
+  onSelectDeployment: (deploymentId: number) => void;
   onSelectIssue: (issueNumber: number) => void;
   onGlobalIssueSelected: (repoId: number, issueNumber: number) => void;
   onSessionLaunched: (deployment: WorkbenchDeployment) => void;
@@ -1029,6 +1032,7 @@ function FocusContent({
         repo={selectedRepo}
         health={loadState.data.health}
         onRefresh={onRefresh}
+        onSelectDeployment={onSelectDeployment}
         onSelectIssue={onSelectIssue}
         onOpenRepoSetup={onOpenRepoSetup}
       />

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -732,6 +732,33 @@ test("keeps compact issue entry reachable from the workbench overview", async ({
   await expectWorkbenchFitsViewport(page);
 });
 
+test("keeps compact session entry reachable from the workbench overview", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench`);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
+  const compactSessions = page.getByLabel("Compact active sessions");
+  await expect(compactSessions).toBeVisible();
+  await expect(compactSessions.getByLabel("Session #447")).toBeVisible();
+  await compactSessions.getByLabel("Session #447").getByRole("button", { name: "Open terminal" }).click();
+  await expect(page).toHaveURL(/deployment=101/);
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await expect(page.frameLocator('iframe[title="Terminal for issue 447"]').getByText("terminal ready")).toBeVisible();
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("captures workbench QA screenshots", async ({ browser }) => {
   if (!tmpDir) throw new Error("Expected workbench e2e tmpDir to be initialized");
   const artifactDir = join(tmpDir, "workbench-artifacts");


### PR DESCRIPTION
## Summary
- Audit finding: compact `/workbench` hides the active-session side pane, leaving only an active-session count on the default overview and no direct terminal entry point.
- Add compact-only active-session shortcuts to the repo overview so mobile users can open terminals directly from `/workbench`.
- Reuse the compact overview shortcut styling for both sessions and issues, keeping desktop unchanged.

## Screenshot verification
- Captured compact overview active-session shortcuts: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-session-entry-audit-after/compact-overview-sessions-393-after.png`
- Captured compact terminal after opening session #447: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-session-entry-audit-after/compact-overview-terminal-393-after.png`
- Browser plugin was available, but the Node REPL execution tool was not exposed after tool discovery, so verification used the repo Playwright CLI fallback.

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact session entry reachable from the workbench overview|keeps compact issue entry reachable from the workbench overview|keeps compact workbench layouts usable on tablet and mobile" --project desktop-chromium`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- push hook: `turbo run build` passed