### PR TITLE
Reset compact workbench focus from nav

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -217,12 +217,23 @@ export function WorkbenchShell({
   } as CSSProperties;
 
   function selectMode(nextMode: WorkbenchMode, path: string) {
-    dispatch({ type: "selectMode", mode: nextMode });
+    const pathParams = new URLSearchParams(path.split("?")[1] ?? "");
+    if (nextMode === "workbench" && !pathParams.has("issue") && !pathParams.has("deployment")) {
+      dispatch({
+        type: "applyUrlSelection",
+        mode: nextMode,
+        repoId: selectedRepo?.id ?? selection.selectedRepoId,
+        issueNumber: null,
+        deploymentId: null,
+      });
+    } else {
+      dispatch({ type: "selectMode", mode: nextMode });
+    }
     if (sidePaneWidthsApply(nextMode)) {
       setDrawerCollapse({ instances: false, issues: false });
     }
     window.history.pushState(null, "", path);
-    setRepoSetupRequested(new URLSearchParams(path.split("?")[1] ?? "").get("repoSetup") === "1");
+    setRepoSetupRequested(pathParams.get("repoSetup") === "1");
   }
 
   function modePathWithRepo(path: string): string {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -759,6 +759,52 @@ test("keeps compact session entry reachable from the workbench overview", async 
   await expectWorkbenchFitsViewport(page);
 });
 
+test("returns compact issue and terminal focus to the workbench overview", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await page.getByRole("navigation", { name: "Workbench navigation" }).getByRole("button", { name: "Workbench" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByLabel("Compact repo issues")).toBeVisible();
+  await expect(page.getByLabel("Compact active sessions")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toHaveCount(0);
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&deployment=101`);
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await page.getByRole("navigation", { name: "Workbench navigation" }).getByRole("button", { name: "Workbench" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByLabel("Compact active sessions")).toBeVisible();
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toHaveCount(0);
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("captures workbench QA screenshots", async ({ browser }) => {
   if (!tmpDir) throw new Error("Expected workbench e2e tmpDir to be initialized");
   const artifactDir = join(tmpDir, "workbench-artifacts");


### PR DESCRIPTION
## Summary
- Parallel audit finding: compact users can enter issue and terminal focus, but tapping the Workbench nav did not clear stale issue/deployment focus back to the overview.
- Preserve the selected repo while clearing issue/deployment focus when Workbench nav targets a repo-only workbench URL.
- Add compact regression coverage for issue detail -> Workbench overview and terminal -> Workbench overview.

## Parallel audit notes
- Return/switch navigation agent found the stale focus bug.
- Repo switching agent confirmed repo rail selection already clears focus, but noted context clarity as a future improvement.
- Terminal recovery agent found a separate no-ttyd recovery gap for a follow-up PR.

## Screenshot verification
- Issue return overview: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-return-navigation-after/compact-issue-return-overview-393-after.png`
- Terminal return overview: `/var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-return-navigation-after/compact-terminal-return-overview-393-after.png`
- Browser plugin was available, but the Node REPL execution tool was not exposed after discovery, so verification used the repo Playwright CLI fallback.

## Verification
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "returns compact issue and terminal focus to the workbench overview|keeps compact session entry reachable from the workbench overview|keeps compact issue entry reachable from the workbench overview" --project desktop-chromium`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test`
- `git diff --check`
- commit hook: repo `typecheck` and `lint` passed