### PR TITLE
Expose compact terminal recovery actions

### DIFF
--- a/packages/web/components/workbench/TerminalFocus.tsx
+++ b/packages/web/components/workbench/TerminalFocus.tsx
@@ -13,10 +13,24 @@ import styles from "./WorkbenchShell.module.css";
 type Props = {
   deployment: WorkbenchDeployment;
   repo: WorkbenchRepo | null;
+  pending: boolean;
+  rowError?: string;
+  onReconnect: (deployment: WorkbenchDeployment) => Promise<void> | void;
+  onEnd: (deployment: WorkbenchDeployment) => void;
+  onBackToOverview: () => void;
   onDeploymentStale: (deploymentId: number) => void;
 };
 
-export function TerminalFocus({ deployment, repo, onDeploymentStale }: Props) {
+export function TerminalFocus({
+  deployment,
+  repo,
+  pending,
+  rowError,
+  onReconnect,
+  onEnd,
+  onBackToOverview,
+  onDeploymentStale,
+}: Props) {
   const issue = repo?.issues.find((item) => item.number === deployment.issueNumber);
   const title = issue?.title ?? "Issue session";
   const [terminal, setTerminal] = useState<{
@@ -115,6 +129,11 @@ export function TerminalFocus({ deployment, repo, onDeploymentStale }: Props) {
     };
   }, [deployment.id, deployment.ttydPort, onDeploymentStale, retryAttempt]);
 
+  async function reconnectTerminal() {
+    await onReconnect(deployment);
+    setRetryAttempt((current) => current + 1);
+  }
+
   return (
     <div className={styles.terminalFocus}>
       <header className={styles.terminalHeader}>
@@ -143,15 +162,39 @@ export function TerminalFocus({ deployment, repo, onDeploymentStale }: Props) {
         <div className={styles.terminalUnavailable} role="alert">
           <h2>Terminal unavailable</h2>
           <p>{terminal.error}</p>
-          {deployment.ttydPort && (
+          <div className={styles.terminalRecoveryActions}>
             <button
               type="button"
               className={styles.secondaryButton}
-              onClick={() => setRetryAttempt((current) => current + 1)}
+              disabled={pending}
+              onClick={reconnectTerminal}
             >
-              Reconnect terminal
+              Reconnect session
             </button>
-          )}
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={onBackToOverview}
+            >
+              Back to overview
+            </button>
+            <details className={styles.endDetails}>
+              <summary>End</summary>
+              <div className={styles.confirmBox}>
+                <strong>End session?</strong>
+                <button
+                  type="button"
+                  onClick={(event) => event.currentTarget.closest("details")?.removeAttribute("open")}
+                >
+                  Cancel
+                </button>
+                <button type="button" disabled={pending} onClick={() => onEnd(deployment)}>
+                  End session
+                </button>
+              </div>
+            </details>
+          </div>
+          {rowError && <p className={styles.rowError}>{rowError}</p>}
         </div>
       )}
     </div>

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -973,6 +973,24 @@
   font-weight: 500;
 }
 
+.terminalRecoveryActions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+.terminalRecoveryActions .secondaryButton {
+  min-height: 44px;
+  margin-top: 0;
+}
+
+.terminalRecoveryActions .endDetails summary {
+  min-height: 44px;
+  padding: 0 14px;
+}
+
 .deploymentList {
   display: grid;
   gap: 8px;

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -203,7 +203,10 @@ export function WorkbenchShell({
   }, [selection.mode, selection.selectedDeploymentId, selection.selectedIssueNumber, selection.selectedRepoId]);
 
   const selectedRepo = resolveSelectedRepo(payload, selection);
-  const selectedDeployment = resolveSelectedDeployment(payload, selection);
+  const selectedDeployment = selection.selectedDeploymentId === null
+    ? null
+    : selectedRepo?.deployments.find((deployment) => deployment.id === selection.selectedDeploymentId)
+      ?? resolveSelectedDeployment(payload, selection);
   const selectedIssue = selectedRepo?.issues.find((issue) => issue.number === selection.selectedIssueNumber) ?? null;
   const reassignTargets = payload?.repos.filter((repo) => repo.id !== selectedRepo?.id) ?? [];
   const hideSidePanes = !sidePaneWidthsApply(selection.mode);
@@ -779,6 +782,8 @@ export function WorkbenchShell({
             repoSetupRequested={repoSetupRequested}
             collapsedSections={selection.collapsedSections}
             sessionsHidden={!compactSidePanesHidden && drawerCollapse.instances}
+            pendingDeploymentId={pendingDeploymentId}
+            sessionRowErrors={sessionRowErrors}
             onToggleSection={toggleSection}
             onShowSessions={() => setDrawerCollapse((current) => ({ ...current, instances: false }))}
             onRetry={() => {
@@ -794,6 +799,11 @@ export function WorkbenchShell({
             onGlobalIssueSelected={selectGlobalIssue}
             onSessionLaunched={addLaunchedSession}
             onDeploymentStale={removeDeployment}
+            onReconnectDeployment={reconnectDeployment}
+            onEndSession={endSession}
+            onBackToOverview={() => {
+              selectMode("workbench", selectedRepo ? workbenchRepoUrl(selectedRepo) : "/workbench");
+            }}
             onJumpToSession={selectDeployment}
             onRepoUpdated={updateRepo}
             onRepoAdded={addRepo}
@@ -863,6 +873,8 @@ function FocusContent({
   repoSetupRequested,
   collapsedSections,
   sessionsHidden,
+  pendingDeploymentId,
+  sessionRowErrors,
   onToggleSection,
   onShowSessions,
   onRetry,
@@ -874,6 +886,9 @@ function FocusContent({
   onGlobalIssueSelected,
   onSessionLaunched,
   onDeploymentStale,
+  onReconnectDeployment,
+  onEndSession,
+  onBackToOverview,
   onJumpToSession,
   onRepoUpdated,
   onRepoAdded,
@@ -892,6 +907,8 @@ function FocusContent({
   repoSetupRequested: boolean;
   collapsedSections: WorkbenchSectionCollapseState;
   sessionsHidden: boolean;
+  pendingDeploymentId: number | null;
+  sessionRowErrors: Record<number, string>;
   onToggleSection: (section: WorkbenchSectionId) => void;
   onShowSessions: () => void;
   onRetry: () => void;
@@ -903,6 +920,9 @@ function FocusContent({
   onGlobalIssueSelected: (repoId: number, issueNumber: number) => void;
   onSessionLaunched: (deployment: WorkbenchDeployment) => void;
   onDeploymentStale: (deploymentId: number) => void;
+  onReconnectDeployment: (deployment: WorkbenchDeployment) => void;
+  onEndSession: (deployment: WorkbenchDeployment) => void;
+  onBackToOverview: () => void;
   onJumpToSession: (deploymentId: number) => void;
   onRepoUpdated: (repo: WorkbenchRepo) => void;
   onRepoAdded: (repo: WorkbenchRepo) => void;
@@ -1034,7 +1054,18 @@ function FocusContent({
   }
 
   if (mode === "workbench" && selectedDeployment) {
-    return <TerminalFocus deployment={selectedDeployment} repo={selectedRepo} onDeploymentStale={onDeploymentStale} />;
+    return (
+      <TerminalFocus
+        deployment={selectedDeployment}
+        repo={selectedRepo}
+        pending={pendingDeploymentId === selectedDeployment.id}
+        rowError={sessionRowErrors[selectedDeployment.id]}
+        onReconnect={onReconnectDeployment}
+        onEnd={onEndSession}
+        onBackToOverview={onBackToOverview}
+        onDeploymentStale={onDeploymentStale}
+      />
+    );
   }
 
   if (mode === "workbench" && selectedRepo) {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -759,6 +759,49 @@ test("keeps compact session entry reachable from the workbench overview", async 
   await expectWorkbenchFitsViewport(page);
 });
 
+test("recovers compact unavailable terminal sessions without showing the sessions pane", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  const unavailableRepos = workbenchPayload().repos;
+  unavailableRepos[0] = {
+    ...unavailableRepos[0],
+    deployments: unavailableRepos[0].deployments.map((deployment) =>
+      deployment.id === 101
+        ? { ...deployment, ttydPort: null, ttydPid: null }
+        : deployment,
+    ),
+  };
+  seedWorkbenchRepos(dbPath, unavailableRepos);
+  let ensureTtydCalls = 0;
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    ensureTtydCalls += 1;
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&deployment=101`);
+
+  await expect(page.getByRole("heading", { name: "Terminal unavailable" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reconnect session" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Back to overview" })).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+
+  await page.getByRole("button", { name: "Reconnect session" }).click();
+
+  await expect.poll(() => ensureTtydCalls).toBeGreaterThanOrEqual(1);
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await expect(page.frameLocator('iframe[title="Terminal for issue 447"]').getByText("terminal ready")).toBeVisible();
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("returns compact issue and terminal focus to the workbench overview", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -2234,7 +2277,7 @@ test("shows terminal reconnect after terminal auth failure", async ({ page }) =>
   await expect(page.getByRole("heading", { name: "Terminal unavailable" })).toBeVisible();
   expect(attempts).toBeGreaterThanOrEqual(1);
   allowSuccess = true;
-  await page.getByRole("button", { name: "Reconnect terminal" }).click();
+  await page.getByRole("button", { name: "Reconnect session" }).click();
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
 });
 
@@ -2269,19 +2312,19 @@ test("reconnects a session and shows a Workbench terminal error when the proxy r
   await expect(sessions.nth(0)).toContainText("#447");
   await expect(sessions.nth(1)).toContainText("#486");
   await expect(sessions.nth(2)).toContainText("#498");
-  await expect(page.getByLabel("Session #486")).toHaveAttribute("data-status", "error");
-  await expect(page.getByLabel("Session #486")).toContainText("Error: preview failed");
+  await expect(sessions.nth(1)).toHaveAttribute("data-status", "error");
+  await expect(sessions.nth(1)).toContainText("Error: preview failed");
 
-  await page.getByLabel("Session #447").getByRole("button").first().click();
+  await sessions.nth(0).getByRole("button").first().click();
 
   await expect(page.getByRole("heading", { name: /#447/ })).toBeVisible();
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toHaveCount(0);
   const terminalAlert = page.getByRole("alert").filter({ hasText: "Terminal unavailable" });
   await expect(terminalAlert).toBeVisible();
   await expect(terminalAlert).toContainText("Terminal proxy returned 401: Unauthorized");
-  await expect(page.getByRole("button", { name: "Reconnect terminal" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reconnect session" })).toBeVisible();
 
-  await page.getByLabel("Session #486").getByRole("button", { name: "Reconnect" }).click();
+  await sessions.nth(1).getByRole("button", { name: "Reconnect" }).click();
   await expect(page.getByRole("heading", { name: /#486/ })).toBeVisible();
   await expect(page.locator('iframe[title="Terminal for issue 486"]')).toHaveAttribute(
     "src",
@@ -2765,8 +2808,8 @@ function repo(id: number, name: string, deploymentCount: number): {
     state: "active";
     launchedAt: string;
     endedAt: null;
-    ttydPort: number;
-    ttydPid: number;
+    ttydPort: number | null;
+    ttydPid: number | null;
     idleSince: null;
     owner: string;
     repoName: string;


### PR DESCRIPTION
## Summary
- expose reconnect, back-to-overview, and end controls when a compact terminal detail opens without an active ttyd port
- keep same-port terminal retry behavior working after auth/proxy failures
- add compact Playwright coverage for unavailable terminal recovery without showing the sessions pane

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "recovers compact unavailable terminal sessions without showing the sessions pane|keeps compact session entry reachable from the workbench overview|shows terminal reconnect after terminal auth failure" --project desktop-chromium
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "recovers compact unavailable terminal sessions without showing the sessions pane|shows terminal reconnect after terminal auth failure|reconnects a session and shows a Workbench terminal error when the proxy rejects the token" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
- Playwright screenshots inspected: /var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-terminal-recovery-after/compact-terminal-recovery-393-after.png and compact-terminal-reconnected-393-after.png