### PR TITLE
Show compact workbench context

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -39,13 +39,18 @@
 }
 
 .routeLabel {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 32vw;
   padding: 5px 8px;
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-sm);
   color: var(--paper-ink-muted);
   background: rgba(255, 255, 255, 0.22);
   font: 12px var(--paper-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .topnav {
@@ -1702,6 +1707,7 @@
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-areas:
       "brand tools"
+      "context context"
       "nav nav";
     align-items: center;
     row-gap: 6px;
@@ -1718,6 +1724,12 @@
     justify-self: end;
     max-width: 100%;
     overflow-x: auto;
+  }
+
+  .routeLabel {
+    grid-area: context;
+    display: block;
+    max-width: 100%;
   }
 
   .drawerControls {

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -208,6 +208,12 @@ export function WorkbenchShell({
     : selectedRepo?.deployments.find((deployment) => deployment.id === selection.selectedDeploymentId)
       ?? resolveSelectedDeployment(payload, selection);
   const selectedIssue = selectedRepo?.issues.find((issue) => issue.number === selection.selectedIssueNumber) ?? null;
+  const contextLabel = workbenchContextLabel({
+    mode: selection.mode,
+    repo: selectedRepo,
+    issue: selectedIssue,
+    deployment: selectedDeployment,
+  });
   const reassignTargets = payload?.repos.filter((repo) => repo.id !== selectedRepo?.id) ?? [];
   const hideSidePanes = !sidePaneWidthsApply(selection.mode);
   const compactSidePanesHidden = compactLayout || hideSidePanes;
@@ -647,7 +653,9 @@ export function WorkbenchShell({
         <Link href="/workbench" className={styles.brand} aria-label="issuectl workbench">
           issuectl<span className={styles.brandDot} />
         </Link>
-        <span className={styles.routeLabel}>/workbench</span>
+        <span className={styles.routeLabel} aria-label="Workbench context" title={contextLabel}>
+          {contextLabel}
+        </span>
         {!compactSidePanesHidden && (
           <div className={styles.toolbarTools} aria-label="Workbench layout controls">
             <button
@@ -1274,6 +1282,28 @@ function modeFromPath(pathname: string): WorkbenchMode {
   if (pathname.endsWith("/quick-create")) return "quickCreate";
   if (pathname.endsWith("/settings")) return "settings";
   return "workbench";
+}
+
+function workbenchContextLabel({
+  mode,
+  repo,
+  issue,
+  deployment,
+}: {
+  mode: WorkbenchMode;
+  repo: WorkbenchRepo | null;
+  issue: WorkbenchIssueSummary | null;
+  deployment: WorkbenchDeployment | null;
+}): string {
+  if (mode === "globalIssues") return "Issues";
+  if (mode === "board") return "Board";
+  if (mode === "pullRequests") return repo ? `${repo.owner}/${repo.name} PRs` : "PRs";
+  if (mode === "quickCreate") return repo ? `${repo.owner}/${repo.name} quick create` : "Quick Create";
+  if (mode === "settings") return repo ? `${repo.owner}/${repo.name} settings` : "Settings";
+  if (repo && deployment) return `${repo.owner}/${repo.name} #${deployment.issueNumber} terminal`;
+  if (repo && issue) return `${repo.owner}/${repo.name} #${issue.number}`;
+  if (repo) return `${repo.owner}/${repo.name}`;
+  return "Workbench";
 }
 
 function titleForMode(mode: WorkbenchMode): string {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -802,6 +802,44 @@ test("recovers compact unavailable terminal sessions without showing the session
   await expectWorkbenchFitsViewport(page);
 });
 
+test("keeps compact workbench context visible while switching focus", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl");
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #512");
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&deployment=101`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #447 terminal");
+
+  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fbugdrop$/);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/bugdrop");
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("returns compact issue and terminal focus to the workbench overview", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {


### PR DESCRIPTION
## Summary
- replace the static workbench route chip with a derived context label for repo, issue, terminal, and mode states
- keep the context label visible on compact workbench screens with truncation instead of hiding it
- add compact Playwright coverage for context updates across overview, issue, terminal, and repo switch flows

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact workbench context visible while switching focus|returns compact issue and terminal focus to the workbench overview|keeps compact workbench layouts usable on tablet and mobile" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
- Playwright screenshot inspected: /var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-context-clarity-after/compact-context-terminal-393-after.png