### PR TITLE
Preserve compact repo-scoped workbench modes

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -252,11 +252,18 @@ export function WorkbenchShell({
   }
 
   function selectRepo(repoId: number) {
-    dispatch({ type: "selectRepo", repoId });
-    setDrawerCollapse({ instances: false, issues: false });
     const repo = payload?.repos.find((item) => item.id === repoId) ?? null;
-    window.history.pushState(null, "", repo ? workbenchRepoUrl(repo) : "/workbench");
-    setRepoSetupRequested(false);
+    const nextMode = repoScopedMode(selection.mode) ? selection.mode : "workbench";
+    dispatch({
+      type: "applyUrlSelection",
+      mode: nextMode,
+      repoId,
+      issueNumber: null,
+      deploymentId: null,
+    });
+    setDrawerCollapse({ instances: false, issues: false });
+    window.history.pushState(null, "", repo ? workbenchRepoModeUrl(repo, nextMode, repoSetupRequested) : "/workbench");
+    setRepoSetupRequested(nextMode === "settings" && repoSetupRequested);
   }
 
   function openRepoSetup() {
@@ -1273,6 +1280,30 @@ function workbenchIssueUrl(repo: Pick<WorkbenchRepo, "owner" | "name">, issueNum
 
 function workbenchDeploymentUrl(deployment: Pick<WorkbenchDeployment, "owner" | "repoName" | "id">): string {
   return `/workbench?repo=${encodeURIComponent(`${deployment.owner}/${deployment.repoName}`)}&deployment=${deployment.id}`;
+}
+
+function workbenchRepoModeUrl(
+  repo: Pick<WorkbenchRepo, "owner" | "name">,
+  mode: WorkbenchMode,
+  repoSetupRequested: boolean,
+): string {
+  const repoParam = `repo=${encodeURIComponent(`${repo.owner}/${repo.name}`)}`;
+  if (mode === "pullRequests") {
+    return `/workbench/prs?${repoParam}`;
+  }
+  if (mode === "quickCreate") {
+    return `/workbench/quick-create?${repoParam}`;
+  }
+  if (mode === "settings") {
+    return repoSetupRequested
+      ? `/workbench/settings?repoSetup=1&${repoParam}`
+      : `/workbench/settings?${repoParam}`;
+  }
+  return workbenchRepoUrl(repo);
+}
+
+function repoScopedMode(mode: WorkbenchMode): boolean {
+  return mode === "pullRequests" || mode === "quickCreate" || mode === "settings";
 }
 
 function modeFromPath(pathname: string): WorkbenchMode {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -840,6 +840,37 @@ test("keeps compact workbench context visible while switching focus", async ({ p
   await expectWorkbenchFitsViewport(page);
 });
 
+test("preserves compact repo-scoped mode while switching repos from deep links", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/pulls/mean-weasel/**", async (route) => {
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ pulls: [], fromCache: false, cachedAt: null }),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl PRs");
+  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
+  await expect(page).toHaveURL(/\/workbench\/prs\?repo=mean-weasel%2Fbugdrop$/);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/bugdrop PRs");
+  await expect(
+    page
+      .getByRole("navigation", { name: "Workbench navigation" })
+      .getByRole("button", { name: "PRs", exact: true }),
+  ).toHaveAttribute("aria-current", "page");
+
+  await page.goto(`${baseUrl}/workbench/settings?repoSetup=1&repo=mean-weasel%2Fissuectl`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl settings");
+  await page.getByRole("button", { name: "mean-weasel/web" }).click();
+  await expect(page).toHaveURL(/\/workbench\/settings\?repoSetup=1&repo=mean-weasel%2Fweb$/);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/web settings");
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+});
+
 test("returns compact issue and terminal focus to the workbench overview", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -1083,8 +1114,12 @@ test("supports top nav modes and collapses side panes for global modes", async (
 
 test("preserves selected repo across global mode reloads", async ({ page }) => {
   await gotoWorkbenchWithRetry(page);
-  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
-  await expect(page).toHaveURL(/repo=mean-weasel%2Fbugdrop/);
+  const bugdropRepo = page.getByRole("button", { name: "mean-weasel/bugdrop" });
+  await expect(bugdropRepo).toBeVisible();
+  await expect(async () => {
+    await bugdropRepo.click();
+    await expect(page).toHaveURL(/repo=mean-weasel%2Fbugdrop/, { timeout: 1_000 });
+  }).toPass();
   const nav = page.getByRole("navigation", { name: "Workbench navigation" });
 
   await nav.getByRole("button", { name: "Settings", exact: true }).click();
@@ -2422,8 +2457,8 @@ async function clickNavAndExpect(page: import("@playwright/test").Page, label: s
   const workbench = page.getByRole("main", { name: "Workbench" });
   if (collapsed) {
     await expect(workbench).toHaveAttribute("data-side-panes", "collapsed");
-    await expect(page.getByLabel("Active sessions")).toHaveCount(0);
-    await expect(page.getByLabel("Repo issues")).toHaveCount(0);
+    await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
+    await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
     const workbenchBox = await workbench.boundingBox();
     const repoRailBox = await page.getByLabel("Repositories").boundingBox();
     const focusBox = await page.getByLabel("Workbench focus").boundingBox();
@@ -2435,8 +2470,8 @@ async function clickNavAndExpect(page: import("@playwright/test").Page, label: s
     );
   } else {
     await expect(workbench).toHaveAttribute("data-side-panes", "visible");
-    await expect(page.getByLabel("Active sessions")).toBeVisible();
-    await expect(page.getByLabel("Repo issues")).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Active sessions" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Repo issues" })).toBeVisible();
   }
 }
 


### PR DESCRIPTION
## Summary
- keep repo switching inside repo-scoped workbench modes instead of dropping compact users back to the workbench overview
- preserve PRs, Quick Create, Settings, and Settings repo setup URLs when changing repos from the rail
- add compact deep-link coverage for repo switching in PRs and Settings setup, and tighten existing pane selectors

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "preserves compact repo-scoped mode while switching repos from deep links|keeps compact workbench context visible while switching focus|preserves selected repo across global mode reloads|supports top nav modes and collapses side panes for global modes" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
- Playwright screenshot inspected: /var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-deeplink-repo-context-after/compact-settings-repo-switch-393-after.png