### PR TITLE
Stabilize compact issue session workflow

### DIFF
--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -636,7 +636,7 @@ function actionSuccessMessage(name: string): string {
     case "comment":
       return "Comment added";
     case "priority":
-      return "Priority saved";
+      return "Priority updated";
     case "labels":
       return "Label updated";
     case "assignees":

--- a/packages/web/components/workbench/TerminalFocus.tsx
+++ b/packages/web/components/workbench/TerminalFocus.tsx
@@ -146,6 +146,9 @@ export function TerminalFocus({
           <span>{deployment.agent}</span>
           <span>{deployment.branchName}</span>
         </div>
+        <button type="button" className={styles.secondaryButton} onClick={onBackToOverview}>
+          Back to overview
+        </button>
       </header>
       {terminal.status === "ready" && terminal.src ? (
         <iframe
@@ -170,13 +173,6 @@ export function TerminalFocus({
               onClick={reconnectTerminal}
             >
               Reconnect session
-            </button>
-            <button
-              type="button"
-              className={styles.secondaryButton}
-              onClick={onBackToOverview}
-            >
-              Back to overview
             </button>
             <details className={styles.endDetails}>
               <summary>End</summary>

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1804,6 +1804,27 @@
     padding: 22px 16px;
   }
 
+  .terminalHeader {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 10px;
+    padding: 22px 16px;
+  }
+
+  .terminalHeader h1 {
+    overflow-wrap: anywhere;
+  }
+
+  .terminalHeader .secondaryButton {
+    justify-self: start;
+    margin-top: 0;
+  }
+
+  .terminalMeta {
+    flex-wrap: wrap;
+  }
+
   .overviewSessionShortcuts,
   .overviewIssueShortcuts {
     max-width: 620px;

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -871,6 +871,101 @@ test("preserves compact repo-scoped mode while switching repos from deep links",
   await expectWorkbenchFitsViewport(page);
 });
 
+test("keeps compact issue mutations and session navigation coherent end to end", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  const requests: Array<{ method: string; url: string; body: unknown }> = [];
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    const request = route.request();
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512/priority", async (route) => {
+    const request = route.request();
+    const body = await request.postDataJSON();
+    requests.push({ method: request.method(), url: request.url(), body });
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    expect(request.method()).toBe("PUT");
+    expect(body).toEqual({ priority: "normal" });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, priority: "normal" }),
+    });
+  });
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512/comments", async (route) => {
+    const request = route.request();
+    const body = await request.postDataJSON();
+    requests.push({ method: request.method(), url: request.url(), body });
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    expect(request.method()).toBe("POST");
+    expect(body).toEqual({ body: "Compact workflow comment" });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, commentId: 9901 }),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    const request = route.request();
+    requests.push({ method: request.method(), url: request.url(), body: request.postData() });
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    expect(request.method()).toBe("POST");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #512");
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
+
+  const issueActions = page.getByLabel("Issue actions");
+  await expect(issueActions).toBeVisible();
+  await issueActions.getByLabel("Priority").selectOption("normal");
+  await expect(page.getByRole("status")).toContainText("Priority updated");
+  await expect(page.getByLabel("Workbench focus")).toContainText("#512 Desktop instance manager workbench");
+  await expect(page.getByLabel("Workbench focus")).toContainText("normal");
+
+  await issueActions.getByLabel("Comment", { exact: true }).fill("Compact workflow comment");
+  await issueActions.getByRole("button", { name: "Add comment" }).click();
+  await expect(page.getByRole("status")).toContainText("Comment added");
+  await expect(issueActions.getByLabel("Comment", { exact: true })).toHaveValue("");
+
+  await page.getByLabel("Issue detail metadata").getByRole("button", { name: "Jump to session" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl&deployment=101$/);
+  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #447 terminal");
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await expect(page.frameLocator('iframe[title="Terminal for issue 447"]').getByText("terminal ready")).toBeVisible();
+
+  await page.getByRole("button", { name: "Back to overview" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await expect(page.getByLabel("Compact active sessions")).toBeVisible();
+  await expect(page.getByLabel("Compact repo issues")).toBeVisible();
+  await expect(page.getByLabel("Issue #512")).toContainText("normal");
+  await expectNoHorizontalPageScroll(page);
+  await expectWorkbenchFitsViewport(page);
+
+  expect(requests.some((item) => item.url.includes("/priority") && item.method === "PUT")).toBe(true);
+  expect(requests.some((item) => item.url.includes("/comments") && item.method === "POST")).toBe(true);
+  expect(requests.some((item) => item.url.includes("/deployments/101/ensure-ttyd") && item.method === "POST")).toBe(true);
+});
+
 test("returns compact issue and terminal focus to the workbench overview", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -2086,7 +2181,7 @@ test("loads issue detail and calls issue mutation endpoints", async ({ page }) =
   await expect(page.getByRole("status")).toContainText("Title saved");
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench renamed" })).toBeVisible();
   await issueActions.getByLabel("Priority").selectOption("normal");
-  await expect(page.getByRole("status")).toContainText("Priority saved");
+  await expect(page.getByRole("status")).toContainText("Priority updated");
   await expect(page.getByLabel("Issue #512")).toContainText("normal");
   await expect(preamble).toHaveValue("Keep this launch context");
   await expect(issueActions.getByLabel("Comment", { exact: true })).toHaveValue("");
@@ -2120,7 +2215,7 @@ test("loads issue detail and calls issue mutation endpoints", async ({ page }) =
   await expect(page.getByRole("heading", { name: "#612 Reassigned issue #612" })).toBeVisible();
   await page.getByRole("button", { name: "mean-weasel/issuectl" }).click();
   await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Closed 1" }).click();
-  await expect(page.getByLabel("Issue #512")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512")).toBeVisible();
 });
 
 test("empty repositories add action opens repo setup", async ({ page }) => {
@@ -2215,7 +2310,7 @@ test("checks worktree status and launches an issue with selected context", async
   });
 
   await gotoWorkbenchWithRetry(page);
-  await page.getByLabel("Issue #512").click();
+  await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Codex", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Claude Code", { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary
- add an integrated compact workbench regression for issue priority/comment actions, jumping to the linked terminal session, and returning to overview
- make terminal focus expose Back to overview from the active terminal header and wrap compact terminal headers so the action stays visible
- align issue priority mutation status copy with the tested user feedback and scope ambiguous issue selectors to the repo issue pane

## Screenshot evidence
- inspected terminal state: /var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-compact-issue-session-after/compact-issue-session-terminal-393-after.png
- inspected overview state: /var/folders/wt/nn4g5swd3gd139y9r6yw6x_80000gn/T/issuectl-workbench-compact-issue-session-after/compact-issue-session-overview-393-after.png

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact issue mutations and session navigation coherent end to end" --project desktop-chromium
- ISSUECTL_KEEP_WORKBENCH_ARTIFACTS=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact issue mutations and session navigation coherent end to end" --project desktop-chromium
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact issue mutations and session navigation coherent end to end|loads issue detail and calls issue mutation endpoints|checks worktree status and launches an issue with selected context|keeps compact session entry reachable from the workbench overview|recovers compact unavailable terminal sessions without showing the sessions pane" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
- pre-push hook: turbo build across @issuectl/cli, @issuectl/core, @issuectl/web
