### PR TITLE
Show compact workbench keyboard focus

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -352,6 +352,11 @@
   background: var(--paper-bg);
 }
 
+.focusPane:focus {
+  outline: 2px solid color-mix(in srgb, var(--paper-accent) 62%, transparent);
+  outline-offset: -3px;
+}
+
 .columnResizeHandle {
   position: relative;
   z-index: 2;

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1141,6 +1141,63 @@ test("keeps compact session entry reachable from the workbench overview", async 
   await expectWorkbenchFitsViewport(page);
 });
 
+test("keeps compact keyboard focus visible after issue and terminal shortcut activation", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench`);
+  await expectFocusedWorkbenchPaneVisible(page);
+
+  const issueShortcut = page.getByLabel("Compact repo issues")
+    .getByLabel("Issue #512")
+    .getByRole("button", { name: "Open issue" });
+  await issueShortcut.focus();
+  await expect(issueShortcut).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expectFocusedWorkbenchPaneVisible(page);
+  await expectCompactWorkbenchViewport(page);
+
+  const workbenchNav = page
+    .getByRole("navigation", { name: "Workbench navigation" })
+    .getByRole("button", { name: "Workbench", exact: true });
+  await workbenchNav.focus();
+  await expect(workbenchNav).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expectFocusedWorkbenchPaneVisible(page);
+
+  const terminalShortcut = page.getByLabel("Compact active sessions")
+    .getByLabel("Session #447")
+    .getByRole("button", { name: "Open terminal" });
+  await terminalShortcut.focus();
+  await expect(terminalShortcut).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await expectFocusedWorkbenchPaneVisible(page);
+  await expectCompactWorkbenchViewport(page);
+});
+
 test("recovers compact unavailable terminal sessions without showing the sessions pane", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   const unavailableRepos = workbenchPayload().repos;
@@ -2993,7 +3050,7 @@ test("moves focus into workbench focus after repo issue session and mode changes
 
   await page.getByRole("button", { name: "mean-weasel/issuectl" }).click();
   await expect(page.getByLabel("Workbench focus")).toBeFocused();
-  await page.getByLabel("Issue #512").click();
+  await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
   await expect(page.getByLabel("Workbench focus")).toBeFocused();
 
@@ -3227,6 +3284,20 @@ async function expectNoHorizontalPageScroll(page: import("@playwright/test").Pag
 async function expectCompactWorkbenchViewport(page: import("@playwright/test").Page) {
   await expectNoHorizontalPageScroll(page);
   await expectWorkbenchFitsViewport(page);
+}
+
+async function expectFocusedWorkbenchPaneVisible(page: import("@playwright/test").Page) {
+  const focus = page.getByLabel("Workbench focus");
+  await expect(focus).toBeFocused();
+  const outline = await focus.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    return {
+      style: style.outlineStyle,
+      width: Number.parseFloat(style.outlineWidth),
+    };
+  });
+  expect(outline.style).not.toBe("none");
+  expect(outline.width).toBeGreaterThanOrEqual(2);
 }
 
 async function expectWorkbenchFitsViewport(page: import("@playwright/test").Page) {


### PR DESCRIPTION
## Summary
- add a visible focus outline to the workbench focus pane when compact keyboard workflows programmatically move focus there
- add Playwright keyboard coverage for compact issue and terminal shortcut activation
- scope an existing focus test selector to the repo issue pane to avoid hidden compact shortcut ambiguity

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact keyboard focus visible after issue and terminal shortcut activation" --project desktop-chromium
- ISSUECTL_WORKBENCH_KEYBOARD_ARTIFACT_DIR=/tmp/issuectl-workbench-keyboard pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact keyboard focus visible after issue and terminal shortcut activation" --project desktop-chromium
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "keeps compact keyboard focus visible after issue and terminal shortcut activation|moves focus into workbench focus after repo issue session and mode changes|keeps compact issue entry reachable from the workbench overview|keeps compact session entry reachable from the workbench overview|recovers compact unavailable terminal sessions without showing the sessions pane" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check

## Screenshot artifacts
- /tmp/issuectl-workbench-keyboard/compact-keyboard-issue-focus.png
- /tmp/issuectl-workbench-keyboard/compact-keyboard-terminal-focus.png