### PR TITLE
fix: preserve compact workbench overview scroll

### DIFF
--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -96,6 +96,7 @@ export function WorkbenchShell({
   const [resizingColumn, setResizingColumn] = useState<WorkbenchColumnKey | null>(null);
   const skipNextColumnWidthPersistRef = useRef(false);
   const focusPaneRef = useRef<HTMLElement | null>(null);
+  const compactOverviewScrollRef = useRef<Record<number, number>>({});
   const dragRef = useRef<{
     column: WorkbenchColumnKey;
     startX: number;
@@ -198,9 +199,23 @@ export function WorkbenchShell({
 
   useEffect(() => {
     const focusPane = focusPaneRef.current;
-    focusPane?.scrollTo({ top: 0, left: 0 });
+    const shouldRestoreOverviewScroll =
+      compactLayout
+      && selection.mode === "workbench"
+      && selection.selectedIssueNumber === null
+      && selection.selectedDeploymentId === null;
+    const top = shouldRestoreOverviewScroll
+      ? compactOverviewScrollRef.current[overviewScrollKey(selection.selectedRepoId)] ?? 0
+      : 0;
+    focusPane?.scrollTo({ top, left: 0 });
     focusPane?.focus({ preventScroll: true });
-  }, [selection.mode, selection.selectedDeploymentId, selection.selectedIssueNumber, selection.selectedRepoId]);
+  }, [
+    compactLayout,
+    selection.mode,
+    selection.selectedDeploymentId,
+    selection.selectedIssueNumber,
+    selection.selectedRepoId,
+  ]);
 
   const selectedRepo = resolveSelectedRepo(payload, selection);
   const selectedDeployment = selection.selectedDeploymentId === null
@@ -226,6 +241,7 @@ export function WorkbenchShell({
   } as CSSProperties;
 
   function selectMode(nextMode: WorkbenchMode, path: string) {
+    rememberCompactOverviewScroll();
     const pathParams = new URLSearchParams(path.split("?")[1] ?? "");
     if (nextMode === "workbench" && !pathParams.has("issue") && !pathParams.has("deployment")) {
       dispatch({
@@ -252,6 +268,7 @@ export function WorkbenchShell({
   }
 
   function selectRepo(repoId: number) {
+    rememberCompactOverviewScroll();
     const repo = payload?.repos.find((item) => item.id === repoId) ?? null;
     const nextMode = repoScopedMode(selection.mode) ? selection.mode : "workbench";
     dispatch({
@@ -271,6 +288,7 @@ export function WorkbenchShell({
   }
 
   function selectDeployment(deploymentId: number, deploymentOverride?: WorkbenchDeployment) {
+    rememberCompactOverviewScroll();
     const deployment = deploymentOverride
       ?? payload?.deployments.find((item) => item.id === deploymentId)
       ?? selectedRepo?.deployments.find((item) => item.id === deploymentId)
@@ -282,6 +300,7 @@ export function WorkbenchShell({
   }
 
   function selectIssue(issueNumber: number) {
+    rememberCompactOverviewScroll();
     dispatch({ type: "selectIssue", issueNumber });
     setDrawerCollapse((current) => ({ ...current, instances: true, issues: false }));
     window.history.pushState(null, "", selectedRepo ? workbenchIssueUrl(selectedRepo, issueNumber) : "/workbench");
@@ -289,6 +308,7 @@ export function WorkbenchShell({
   }
 
   function selectGlobalIssue(repoId: number, issueNumber: number) {
+    rememberCompactOverviewScroll();
     dispatch({ type: "selectRepo", repoId });
     dispatch({ type: "selectIssue", issueNumber });
     setDrawerCollapse({ instances: false, issues: false });
@@ -573,6 +593,20 @@ export function WorkbenchShell({
         error: null,
       };
     });
+  }
+
+  function rememberCompactOverviewScroll() {
+    const focusPane = focusPaneRef.current;
+    if (
+      !compactLayout
+      || !focusPane
+      || selection.mode !== "workbench"
+      || selection.selectedIssueNumber !== null
+      || selection.selectedDeploymentId !== null
+    ) {
+      return;
+    }
+    compactOverviewScrollRef.current[overviewScrollKey(selection.selectedRepoId)] = focusPane.scrollTop;
   }
 
   function toggleSection(section: WorkbenchSectionId) {
@@ -1188,6 +1222,10 @@ function withoutKey(record: Record<number, string>, key: number): Record<number,
 function columnsAreDefault(widths: Record<WorkbenchColumnKey, number>): boolean {
   return widths.instances === DEFAULT_WORKBENCH_COLUMN_WIDTHS.instances
     && widths.issues === DEFAULT_WORKBENCH_COLUMN_WIDTHS.issues;
+}
+
+function overviewScrollKey(repoId: number | null): number {
+  return repoId ?? 0;
 }
 
 type UrlSelection = {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1198,6 +1198,52 @@ test("keeps compact keyboard focus visible after issue and terminal shortcut act
   await expectCompactWorkbenchViewport(page);
 });
 
+test("restores compact overview scroll after opening an issue detail", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench`);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  const focus = page.getByLabel("Workbench focus");
+  await expect(focus).toBeFocused();
+  await focus.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect.poll(() => focus.evaluate((element) => element.scrollTop)).toBeGreaterThan(150);
+
+  const issueShortcut = page.getByLabel("Compact repo issues")
+    .getByLabel("Issue #512")
+    .getByRole("button", { name: "Open issue" });
+  await issueShortcut.scrollIntoViewIfNeeded();
+  const overviewScroll = await focus.evaluate((element) => element.scrollTop);
+  expect(overviewScroll).toBeGreaterThan(150);
+
+  await issueShortcut.click();
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expectFocusedWorkbenchPaneVisible(page);
+  await expect.poll(() => focus.evaluate((element) => element.scrollTop)).toBe(0);
+
+  await page
+    .getByRole("navigation", { name: "Workbench navigation" })
+    .getByRole("button", { name: "Workbench", exact: true })
+    .click();
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expectFocusedWorkbenchPaneVisible(page);
+  await expect.poll(() => focus.evaluate((element) => element.scrollTop)).toBeGreaterThanOrEqual(overviewScroll - 2);
+  await expect(page.getByLabel("Compact repo issues").getByLabel("Issue #512")).toBeVisible();
+  await expectCompactWorkbenchViewport(page);
+});
+
 test("recovers compact unavailable terminal sessions without showing the sessions pane", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   const unavailableRepos = workbenchPayload().repos;


### PR DESCRIPTION
## Summary
- preserve compact workbench overview scroll when opening issue/session/detail views and returning to overview
- keep detail views starting at the top with focus returned to the workbench focus pane
- add Playwright coverage for the compact scroll restoration path

## Verification
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "restores compact overview scroll after opening an issue detail" --project desktop-chromium
- ISSUECTL_WORKBENCH_SCROLL_ARTIFACT_DIR=/tmp/issuectl-workbench-scroll pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "restores compact overview scroll after opening an issue detail" --project desktop-chromium
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --grep "restores compact overview scroll after opening an issue detail|keeps compact keyboard focus visible after issue and terminal shortcut activation|keeps compact issue entry reachable from the workbench overview|keeps compact session entry reachable from the workbench overview|returns compact issue and terminal focus to the workbench overview|keeps compact issue mutations and session navigation coherent end to end" --project desktop-chromium
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check

## Screenshot artifacts
- /tmp/issuectl-workbench-scroll/compact-scroll-issue-detail-top.png
- /tmp/issuectl-workbench-scroll/compact-scroll-overview-restored.png