### PR TITLE
ci: add webkit dynamic workbench coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,8 @@ jobs:
         # Specs hard-fail in CI if canRun() returns false, so a
         # misconfigured token causes a loud failure, not a silent skip.
         run: gh auth status
-      - name: Install Playwright chromium
-        run: pnpm --filter @issuectl/web exec playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: pnpm --filter @issuectl/web exec playwright install --with-deps chromium webkit
       - name: Run mobile UX regression spec
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,6 +157,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test viewport-health.spec.ts --project=mobile-chromium
+      - name: Run compact workbench WebKit dynamic journey
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -30,5 +30,13 @@ export default defineConfig({
       },
       testMatch: /(mobile-ux-patterns|launch-ui|action-sheets|pull-to-refresh|issue-close|viewport-health)\.spec\.ts/,
     },
+    {
+      name: "mobile-webkit",
+      use: {
+        ...devices["iPhone 13"],
+        viewport: { width: 393, height: 852 },
+      },
+      testMatch: /workbench\.spec\.ts/,
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- add a dedicated Playwright mobile-webkit project using the iPhone WebKit device profile
- install WebKit in CI alongside Chromium
- run the compact workbench dynamic journey in WebKit to cover Safari-class focus, history, reload, and terminal-render behavior

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=desktop-chromium --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check