### PR TITLE
ci: add WebKit command sheet coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
+      - name: Run command sheet WebKit scroll lock
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-webkit --grep "body is scroll-locked when command sheet is open"
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         ...devices["iPhone 13"],
         viewport: { width: 393, height: 852 },
       },
-      testMatch: /workbench\.spec\.ts/,
+      testMatch: /(workbench|mobile-ux-patterns)\.spec\.ts/,
     },
   ],
 });


### PR DESCRIPTION
## Summary
- include the mobile UX regression spec in the mobile WebKit Playwright project
- add a CI WebKit run for the command sheet scroll-lock regression

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "body is scroll-locked when command sheet is open"
- pnpm --dir packages/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-webkit --grep "body is scroll-locked when command sheet is open"
- pnpm --dir packages/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-chromium --grep "body is scroll-locked when command sheet is open"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check

## Notes
- I audited the existing swipe-to-dismiss coverage first, but WebKit rejects the synthetic `Touch` constructor used by that Chromium test. The PR therefore pins the highest-value WebKit-safe command sheet path: open sheet + body/html scroll lock.
- A committed screenshot attachment was also tested and removed because local WebKit hung while capturing it; the functional browser assertion is stable and CI-safe.