### PR TITLE
ci: add WebKit compact workbench mutation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
+      - name: Run compact workbench WebKit issue mutation and terminal navigation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
       - name: Run command sheet WebKit scroll lock
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a dedicated mobile WebKit CI step for compact issue mutations and terminal navigation
- cover priority update, comment add, jump-to-session, terminal iframe render, and return-to-overview in Safari/WebKit-like mobile automation

## Audit notes
- Existing WebKit coverage already covered one long history/reload journey plus command-sheet scroll lock.
- The highest-value remaining gap was the compact issue action surface feeding into active session/terminal navigation, because that path exercises issue mutation controls and terminal access in one stable browser test.

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check