### PR TITLE
ci: add WebKit compact terminal recovery coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
+      - name: Run compact workbench WebKit terminal recovery
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "recovers compact unavailable terminal sessions without showing the sessions pane"
       - name: Run command sheet WebKit scroll lock
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a dedicated mobile WebKit CI step for compact terminal unavailable/reconnect recovery
- cover the unavailable terminal state, hidden sessions pane on compact screens, reconnect action, and restored terminal iframe

## Audit notes
- Existing WebKit checks now cover happy-path issue/session navigation, issue mutations, terminal rendering, history/reload, and command sheet scroll lock.
- The highest-value remaining recovery gap was terminal unavailable/reconnect because it combines compact failure UI, recovery action, and restored terminal access.

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "recovers compact unavailable terminal sessions without showing the sessions pane"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "recovers compact unavailable terminal sessions without showing the sessions pane"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check