### PR TITLE
test: add WebKit compact failure state coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "recovers compact unavailable terminal sessions without showing the sessions pane"
+      - name: Run compact workbench WebKit failure states
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact empty and service failure states stable in WebKit"
       - name: Run command sheet WebKit scroll lock
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1379,6 +1379,113 @@ test("keeps compact failure empty and stale workbench states inside the viewport
   await expectCompactWorkbenchViewport(page);
 });
 
+test("keeps compact empty and service failure states stable in WebKit", async ({ browser }) => {
+  async function withFreshMobilePage(fn: (page: import("@playwright/test").Page) => Promise<void>): Promise<void> {
+    const context = await browser.newContext({
+      viewport: { width: 393, height: 852 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    await context.addInitScript((token) => {
+      window.localStorage.setItem("issuectl.apiToken", token);
+    }, apiToken);
+    const page = await context.newPage();
+    try {
+      await fn(page);
+    } finally {
+      await context.close();
+    }
+  }
+
+  seedWorkbenchRepos(dbPath, []);
+  await withFreshMobilePage(async (page) => {
+    await page.goto(`${baseUrl}/workbench`);
+    await expect(page.getByRole("heading", { name: "No tracked repositories" })).toBeVisible();
+    await expect(page.getByLabel("Workbench focus").getByRole("button", { name: "Add repository" })).toBeVisible();
+    await expectCompactWorkbenchViewport(page);
+  });
+
+  seedWorkbenchRepos(dbPath);
+  await withFreshMobilePage(async (page) => {
+    await page.route("**/api/v1/pulls/mean-weasel/issuectl**", async (route) => {
+      expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "GitHub checks are temporarily unavailable for this repository." }),
+      });
+    });
+    await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
+    await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+    await expect(page.locator('[role="alert"]').filter({ hasText: "GitHub checks are temporarily unavailable" })).toBeVisible();
+    await expect(page.getByText("Select a pull request to open details in this focus pane.")).toBeVisible();
+    await expectCompactWorkbenchViewport(page);
+  });
+
+  await withFreshMobilePage(async (page) => {
+    await page.route("**/api/v1/settings", async (route) => {
+      expect(route.request().method()).toBe("GET");
+      expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Settings service is temporarily unavailable." }),
+      });
+    });
+    await page.route("**/api/v1/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, version: "test-version", timestamp: "2026-05-16T16:00:00.000Z" }),
+      });
+    });
+    await page.route("**/api/v1/user", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ login: null, error: "GitHub user unavailable" }),
+      });
+    });
+    await page.goto(`${baseUrl}/workbench/settings?repo=mean-weasel%2Fissuectl`);
+    await expect(page.getByRole("heading", { name: "Workbench settings" })).toBeVisible();
+    await expect(page.locator('[role="alert"]').filter({ hasText: "Settings service is temporarily unavailable" })).toBeVisible();
+    await expectCompactWorkbenchViewport(page);
+  });
+
+  await withFreshMobilePage(async (page) => {
+    await page.route("**/api/v1/parse", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Parser service is temporarily unavailable." }),
+      });
+    });
+    await page.goto(`${baseUrl}/workbench/quick-create?repo=mean-weasel%2Fissuectl`);
+    await page.getByLabel("Parse text").fill("Turn this outage note into an issue");
+    await page.getByRole("button", { name: "Parse", exact: true }).click();
+    await expect(page.locator('[role="alert"]').filter({ hasText: "Parser service is temporarily unavailable" })).toBeVisible();
+    await expectCompactWorkbenchViewport(page);
+  });
+
+  await withFreshMobilePage(async (page) => {
+    await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ alive: false, error: "Terminal session has ended" }),
+      });
+    });
+    await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&deployment=101`);
+    await expect(page.getByLabel("Session #447")).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+    await expectCompactWorkbenchViewport(page);
+  });
+});
+
 test("keeps compact workbench context visible while switching focus", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {


### PR DESCRIPTION
## Summary
- add a mobile WebKit regression test for compact empty and service failure states
- add a dedicated CI step for that WebKit failure-state coverage

## Audit notes
- The existing broad compact failure-state test showed a WebKit-only delayed-navigation race when several states shared one page.
- This new test isolates each failure mode in a fresh mobile context and covers empty repos, PR service error, settings service error, parse error, and ended terminal fallback.

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "keeps compact empty and service failure states stable in WebKit"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact empty and service failure states stable in WebKit"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
