### PR TITLE
fix: keep compact workbench refresh usable during degraded network

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact empty and service failure states stable in WebKit"
+      - name: Run compact workbench WebKit degraded refresh states
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact degraded refresh states usable in WebKit"
       - name: Run command sheet WebKit scroll lock
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/app/workbench/[mode]/page.tsx
+++ b/packages/web/app/workbench/[mode]/page.tsx
@@ -4,7 +4,6 @@ import { generateApiToken, getDb } from "@issuectl/core";
 import { WorkbenchShell } from "@/components/workbench/WorkbenchShell";
 import type { WorkbenchMode } from "@/components/workbench/workbench-state";
 import { getWorkbenchPayload } from "@/lib/workbench-data";
-import { refreshWorkbenchPayload } from "../actions";
 import styles from "../WorkbenchPage.module.css";
 
 export const metadata: Metadata = {
@@ -35,7 +34,6 @@ export default async function WorkbenchSubpathPage({ params }: Props) {
     <div className={styles.page}>
       <WorkbenchShell
         initialPayload={await getWorkbenchPayload()}
-        onRefreshPayload={refreshWorkbenchPayload}
         initialMode={modeToWorkbenchMode(mode)}
         apiToken={apiToken}
       />

--- a/packages/web/app/workbench/page.tsx
+++ b/packages/web/app/workbench/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { generateApiToken, getDb } from "@issuectl/core";
 import { WorkbenchShell } from "@/components/workbench/WorkbenchShell";
 import { getWorkbenchPayload } from "@/lib/workbench-data";
-import { refreshWorkbenchPayload } from "./actions";
 import styles from "./WorkbenchPage.module.css";
 
 export const metadata: Metadata = {
@@ -17,7 +16,6 @@ export default async function WorkbenchPage() {
     <div className={styles.page}>
       <WorkbenchShell
         initialPayload={await getWorkbenchPayload()}
-        onRefreshPayload={refreshWorkbenchPayload}
         initialMode="workbench"
         apiToken={apiToken}
       />

--- a/packages/web/components/workbench/RepoOverviewFocus.tsx
+++ b/packages/web/components/workbench/RepoOverviewFocus.tsx
@@ -6,6 +6,8 @@ type Props = {
   repo: WorkbenchRepo;
   health: WorkbenchHealth;
   onRefresh: () => void;
+  refreshPending: boolean;
+  refreshError: string | null;
   onSelectDeployment: (deploymentId: number) => void;
   onSelectIssue: (issueNumber: number) => void;
   onOpenRepoSetup: () => void;
@@ -15,6 +17,8 @@ export function RepoOverviewFocus({
   repo,
   health,
   onRefresh,
+  refreshPending,
+  refreshError,
   onSelectDeployment,
   onSelectIssue,
   onOpenRepoSetup,
@@ -58,13 +62,32 @@ export function RepoOverviewFocus({
       )}
 
       <div className={styles.overviewActions}>
-        <button type="button" className={styles.primaryButton} onClick={onRefresh}>
-          Refresh
+        <button
+          type="button"
+          className={styles.primaryButton}
+          onClick={onRefresh}
+          disabled={refreshPending}
+          aria-label={refreshPending ? "Refreshing workbench data" : "Refresh workbench data"}
+        >
+          {refreshPending ? "Refreshing" : "Refresh"}
         </button>
         <button type="button" className={styles.secondaryButton} disabled>
           New shell unavailable
         </button>
       </div>
+
+      {refreshPending && (
+        <p className={styles.refreshStatus} role="status">
+          Refreshing workbench data...
+        </p>
+      )}
+
+      {refreshError && (
+        <div className={styles.notice} role="alert">
+          <strong>Refresh failed</strong>
+          <p>{refreshError}</p>
+        </div>
+      )}
 
       {repo.deployments.length > 0 && (
         <section className={styles.overviewSessionShortcuts} aria-label="Compact active sessions">

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1474,6 +1474,11 @@
   color: var(--paper-ink);
 }
 
+.primaryButton:disabled {
+  opacity: 0.72;
+  cursor: progress;
+}
+
 .emptyActions {
   display: flex;
   gap: 10px;
@@ -1539,6 +1544,12 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.refreshStatus {
+  margin-top: 10px;
+  color: var(--paper-ink-muted);
+  font: 12px var(--paper-mono);
 }
 
 .overviewSessionShortcuts,

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -85,6 +85,10 @@ export function WorkbenchShell({
       ? { status: "loaded", data: initialPayload, error: null }
       : { status: "loading", data: null, error: null },
   );
+  const [refreshState, setRefreshState] = useState<{ pending: boolean; error: string | null }>({
+    pending: false,
+    error: null,
+  });
   const [sessionSortMode, setSessionSortMode] = useState<SessionSortMode>("running first");
   const [issueFilter, setIssueFilter] = useState<IssueQueueFilter>("open");
   const [pendingDeploymentId, setPendingDeploymentId] = useState<number | null>(null);
@@ -107,27 +111,36 @@ export function WorkbenchShell({
 
   const load = useCallback(() => {
     const controller = new AbortController();
-    setLoadState((current) =>
-      current.status === "loaded" ? current : { status: "loading", data: null, error: null },
-    );
+    const refreshingExistingData = loadState.status === "loaded";
+    if (refreshingExistingData) {
+      setRefreshState({ pending: true, error: null });
+    } else {
+      setLoadState({ status: "loading", data: null, error: null });
+    }
     const request = onRefreshPayload
       ? onRefreshPayload()
       : fetchWorkbench({ signal: controller.signal });
     request
       .then((data) => {
         setLoadState({ status: "loaded", data, error: null });
+        setRefreshState({ pending: false, error: null });
         dispatch({ type: "payloadLoaded", payload: data });
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : "Unable to load workbench";
+        if (refreshingExistingData) {
+          setRefreshState({ pending: false, error: message });
+          return;
+        }
         setLoadState({
           status: "error",
           data: null,
-          error: err instanceof Error ? err.message : "Unable to load workbench",
+          error: message,
         });
       });
     return controller;
-  }, [onRefreshPayload]);
+  }, [loadState.status, onRefreshPayload]);
 
   useEffect(() => {
     if (initialPayload) {
@@ -841,6 +854,8 @@ export function WorkbenchShell({
             onRefresh={() => {
               load();
             }}
+            refreshPending={refreshState.pending}
+            refreshError={refreshState.error}
             onIssueUpdated={updateIssue}
             onIssueReassigned={focusReassignedIssue}
             onSelectDeployment={selectDeployment}
@@ -928,6 +943,8 @@ function FocusContent({
   onShowSessions,
   onRetry,
   onRefresh,
+  refreshPending,
+  refreshError,
   onIssueUpdated,
   onIssueReassigned,
   onSelectDeployment,
@@ -962,6 +979,8 @@ function FocusContent({
   onShowSessions: () => void;
   onRetry: () => void;
   onRefresh: () => void;
+  refreshPending: boolean;
+  refreshError: string | null;
   onIssueUpdated: (repoId: number, issueNumber: number, patch: Partial<WorkbenchIssueSummary>) => void;
   onIssueReassigned: (result: { owner: string; repo: string; issueNumber: number }) => void;
   onSelectDeployment: (deploymentId: number) => void;
@@ -1123,6 +1142,8 @@ function FocusContent({
         repo={selectedRepo}
         health={loadState.data.health}
         onRefresh={onRefresh}
+        refreshPending={refreshPending}
+        refreshError={refreshError}
         onSelectDeployment={onSelectDeployment}
         onSelectIssue={onSelectIssue}
         onOpenRepoSetup={onOpenRepoSetup}

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1486,6 +1486,62 @@ test("keeps compact empty and service failure states stable in WebKit", async ({
   });
 });
 
+test("keeps compact degraded refresh states usable in WebKit", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  seedWorkbenchRepos(dbPath);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+
+  let releaseRefresh!: () => void;
+  let markRefreshStarted!: () => void;
+  const refreshStarted = new Promise<void>((resolve) => {
+    markRefreshStarted = resolve;
+  });
+  let refreshCalls = 0;
+  await page.route("**/api/v1/workbench", async (route) => {
+    refreshCalls += 1;
+    expect(route.request().method()).toBe("GET");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+
+    if (refreshCalls === 1) {
+      markRefreshStarted();
+      await new Promise<void>((resolve) => {
+        releaseRefresh = resolve;
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(workbenchPayload()),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Workbench refresh is temporarily unavailable." }),
+    });
+  });
+
+  await page.getByRole("button", { name: "Refresh workbench data" }).click();
+  await refreshStarted;
+  await expect(page.getByRole("button", { name: "Refreshing workbench data" })).toBeDisabled();
+  await expect(page.getByText("Refreshing workbench data...")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expectCompactWorkbenchViewport(page);
+
+  releaseRefresh();
+  await expect(page.getByRole("button", { name: "Refresh workbench data" })).toBeEnabled();
+  await expect(page.getByText("Refreshing workbench data...")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Refresh workbench data" }).click();
+  await expect(page.locator('[role="alert"]').filter({ hasText: "Refresh failed" })).toBeVisible();
+  await expect(page.getByText("Workbench refresh is temporarily unavailable.")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Refresh workbench data" })).toBeEnabled();
+  await expectCompactWorkbenchViewport(page);
+});
+
 test("keeps compact workbench context visible while switching focus", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {


### PR DESCRIPTION
## Summary
- keep existing workbench data visible while a compact refresh is pending or fails
- move refresh to the authenticated client workbench API so degraded network behavior is deterministic and testable
- add mobile WebKit coverage plus a dedicated CI step for compact degraded refresh states

## Audit notes
- Highest-value degraded-network issue found: refreshing a loaded workbench gave no pending feedback and could replace a usable overview with the full unavailable state on refresh failure.
- The fix keeps stale data usable, disables the refresh button while pending, and shows an inline refresh failure alert.

## Acceptance criteria
- Slow refresh path shows an inline pending state and keeps the compact overview visible.
- Failed refresh path shows an inline error and keeps stale overview data and actions usable.
- Mobile WebKit viewport remains stable in both states.

## Verification
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "keeps compact degraded refresh states usable in WebKit"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact degraded refresh states usable in WebKit"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=desktop-chromium --grep "refreshes server-loaded workbench content"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- git diff --check
