### PR TITLE
fix: reconcile stale workbench refresh selections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact degraded refresh states usable in WebKit"
+      - name: Run compact workbench WebKit stale refresh reconciliation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "reconciles compact stale overview data after refresh in WebKit"
       - name: Run command sheet WebKit scroll lock
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/components/workbench/workbench-state.ts
+++ b/packages/web/components/workbench/workbench-state.ts
@@ -94,12 +94,31 @@ export function workbenchReducer(
 ): WorkbenchSelectionState {
   switch (action.type) {
     case "payloadLoaded": {
-      const repoIds = new Set(action.payload.repos.map((repo) => repo.id));
+      const repos = action.payload.repos;
+      const repoIds = new Set(repos.map((repo) => repo.id));
+      const retainedRepoId = state.selectedRepoId && repoIds.has(state.selectedRepoId)
+        ? state.selectedRepoId
+        : null;
+      const selectedDeployment = state.selectedDeploymentId === null
+        ? null
+        : action.payload.deployments.find((deployment) => deployment.id === state.selectedDeploymentId)
+          ?? repos.flatMap((repo) => repo.deployments).find((deployment) => deployment.id === state.selectedDeploymentId)
+          ?? null;
+      const selectedRepoId = selectedDeployment?.repoId ?? retainedRepoId ?? repos[0]?.id ?? null;
+      const selectedRepo = repos.find((repo) => repo.id === selectedRepoId) ?? null;
+      const selectedIssueNumber =
+        !selectedDeployment
+        && retainedRepoId === selectedRepoId
+        && state.selectedIssueNumber !== null
+        && selectedRepo?.issues.some((issue) => issue.number === state.selectedIssueNumber)
+          ? state.selectedIssueNumber
+          : null;
+
       return {
         ...state,
-        selectedRepoId: state.selectedRepoId && repoIds.has(state.selectedRepoId)
-          ? state.selectedRepoId
-          : action.payload.repos[0]?.id ?? null,
+        selectedRepoId,
+        selectedIssueNumber,
+        selectedDeploymentId: selectedDeployment?.id ?? null,
       };
     }
     case "selectRepo":

--- a/packages/web/components/workbench/workbench.test.ts
+++ b/packages/web/components/workbench/workbench.test.ts
@@ -42,6 +42,75 @@ describe("workbench state", () => {
     expect(next.mode).toBe("workbench");
   });
 
+  it("clears stale issue selection when refreshed payload removes the issue", () => {
+    const payload = payloadFixture();
+    const selectedIssue = workbenchReducer(createWorkbenchState(payload), {
+      type: "selectIssue",
+      issueNumber: 512,
+    });
+    const refreshedPayload = {
+      ...payload,
+      repos: payload.repos.map((repo) =>
+        repo.id === 1
+          ? { ...repo, issues: repo.issues.filter((issue) => issue.number !== 512) }
+          : repo,
+      ),
+    };
+
+    const next = workbenchReducer(selectedIssue, { type: "payloadLoaded", payload: refreshedPayload });
+
+    expect(next.selectedRepoId).toBe(1);
+    expect(next.selectedIssueNumber).toBeNull();
+    expect(next.selectedDeploymentId).toBeNull();
+  });
+
+  it("clears stale issue selection when refreshed payload replaces the selected repo", () => {
+    const payload = payloadFixture();
+    const selectedIssue = workbenchReducer(createWorkbenchState(payload), {
+      type: "selectIssue",
+      issueNumber: 512,
+    });
+    const refreshedPayload = {
+      ...payload,
+      repos: [
+        {
+          ...repo(5, "replacement", 0),
+          issues: [{ ...issue(512, "Replacement repo issue"), hasActiveDeployment: false }],
+        },
+        ...payload.repos.filter((item) => item.id !== 1),
+      ],
+    };
+
+    const next = workbenchReducer(selectedIssue, { type: "payloadLoaded", payload: refreshedPayload });
+
+    expect(next.selectedRepoId).toBe(5);
+    expect(next.selectedIssueNumber).toBeNull();
+    expect(next.selectedDeploymentId).toBeNull();
+  });
+
+  it("clears stale deployment selection when refreshed payload removes the deployment", () => {
+    const payload = payloadFixture();
+    const selectedDeployment = workbenchReducer(createWorkbenchState(payload), {
+      type: "selectDeployment",
+      deploymentId: 101,
+      repoId: 1,
+    });
+    const refreshedPayload = {
+      ...payload,
+      repos: payload.repos.map((repo) =>
+        repo.id === 1
+          ? { ...repo, deployments: repo.deployments.filter((deployment) => deployment.id !== 101) }
+          : repo,
+      ),
+    };
+
+    const next = workbenchReducer(selectedDeployment, { type: "payloadLoaded", payload: refreshedPayload });
+
+    expect(next.selectedRepoId).toBe(1);
+    expect(next.selectedIssueNumber).toBeNull();
+    expect(next.selectedDeploymentId).toBeNull();
+  });
+
   it("uses live deployment counts for rail badges", () => {
     const payload = payloadFixture();
 

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1542,6 +1542,44 @@ test("keeps compact degraded refresh states usable in WebKit", async ({ page }) 
   await expectCompactWorkbenchViewport(page);
 });
 
+test("reconciles compact stale overview data after refresh in WebKit", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  seedWorkbenchRepos(dbPath);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByLabel("Repo health summary")).toContainText("4");
+  await expect(page.getByLabel("Repo health summary")).toContainText("issues loaded");
+  await expect(page.getByLabel("Compact repo issues").getByLabel("Issue #512")).toBeVisible();
+
+  const refreshedPayload = workbenchPayload();
+  refreshedPayload.repos[0] = {
+    ...refreshedPayload.repos[0],
+    issues: refreshedPayload.repos[0].issues.filter((issue) => issue.number !== 512),
+    deployments: refreshedPayload.repos[0].deployments.slice(0, 1),
+    badgeCount: 1,
+    deployedCount: 1,
+  };
+
+  await page.route("**/api/v1/workbench", async (route) => {
+    expect(route.request().method()).toBe("GET");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(refreshedPayload),
+    });
+  });
+
+  await page.getByRole("button", { name: "Refresh workbench data" }).click();
+  await expect(page.getByRole("button", { name: "Refresh workbench data" })).toBeEnabled();
+  await expect(page.getByLabel("Repo health summary")).toContainText("3");
+  await expect(page.getByLabel("Repo health summary")).toContainText("1");
+  await expect(page.getByLabel("Repo health summary")).toContainText("active sessions");
+  await expect(page.getByLabel("Compact repo issues").getByLabel("Issue #512")).toHaveCount(0);
+  await expect(page.getByLabel("Compact repo issues").getByLabel("Issue #447")).toBeVisible();
+  await expectCompactWorkbenchViewport(page);
+});
+
 test("keeps compact workbench context visible while switching focus", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {


### PR DESCRIPTION
## Summary
- clear stale selected issue/session state when refreshed workbench payloads remove or replace the selected data
- add reducer coverage for removed issues, replaced repos, and removed deployments
- add mobile WebKit compact refresh coverage and CI step for stale overview reconciliation

## Verification
- git diff --check
- pnpm --dir packages/web lint (passes; existing max-lines warning in workbench.test.ts)
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "reconciles compact stale overview data after refresh in WebKit"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "reconciles compact stale overview data after refresh in WebKit|keeps compact degraded refresh states usable in WebKit"

## Audit note
Highest-value T020 issue found: payload refresh reconciled selected repo existence, but left selected issue/deployment ids intact even when refreshed data removed that item or replaced the repo. That could surface stale or wrong detail/action state after data changed.