### PR TITLE
fix: preserve quick create state across workbench modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
+      - name: Run compact workbench WebKit cross-mode quick create persistence
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact quick create drafts across cross-mode navigation in WebKit"
       - name: Run compact workbench WebKit terminal recovery
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/components/workbench/QuickCreateFocus.tsx
+++ b/packages/web/components/workbench/QuickCreateFocus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ParsedIssuesResponse } from "@issuectl/core";
 import { CandidateIssuesSection, DraftFallback, QuickCreateResults } from "./QuickCreateSections";
 import {
@@ -21,6 +21,16 @@ type Props = {
   selectedRepo: WorkbenchPayload["repos"][number] | null;
 };
 
+const QUICK_CREATE_INPUT_STORAGE_KEY = "issuectl.workbench.quickCreate.input";
+const QUICK_CREATE_DRAFT_STORAGE_KEY = "issuectl.workbench.quickCreate.draft";
+const DEFAULT_DRAFT: DraftState = {
+  id: null,
+  title: "",
+  body: "",
+  priority: "normal",
+  labels: "",
+};
+
 export function QuickCreateFocus({ repos, selectedRepo }: Props) {
   const defaultRepoKey = repoKey(selectedRepo) ?? repoKey(repos[0]) ?? "";
   const repoOptions = useMemo(() => repos.map((repo) => ({
@@ -30,21 +40,23 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
     owner: repo.owner,
     repo: repo.name,
   })), [repos]);
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(readStoredInput);
   const [parseStatus, setParseStatus] = useState<"idle" | "parsing" | "creating">("idle");
   const [cards, setCards] = useState<CandidateIssue[]>([]);
   const [result, setResult] = useState<QuickCreateResult | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [draft, setDraft] = useState<DraftState>({
-    id: null,
-    title: "",
-    body: "",
-    priority: "normal",
-    labels: "",
-  });
+  const [draft, setDraft] = useState<DraftState>(readStoredDraft);
   const [draftMessage, setDraftMessage] = useState<string | null>(null);
 
   const acceptedCount = cards.filter((card) => card.accepted).length;
+
+  useEffect(() => {
+    writeStoredValue(QUICK_CREATE_INPUT_STORAGE_KEY, input);
+  }, [input]);
+
+  useEffect(() => {
+    writeStoredValue(QUICK_CREATE_DRAFT_STORAGE_KEY, JSON.stringify(draft));
+  }, [draft]);
 
   async function handleParse() {
     setParseStatus("parsing");
@@ -223,4 +235,45 @@ export function QuickCreateFocus({ repos, selectedRepo }: Props) {
   function updateCard(id: string, patch: Partial<CandidateIssue>) {
     setCards((current) => current.map((card) => card.id === id ? { ...card, ...patch } : card));
   }
+}
+
+function readStoredInput(): string {
+  try {
+    return window.localStorage.getItem(QUICK_CREATE_INPUT_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function readStoredDraft(): DraftState {
+  try {
+    const raw = window.localStorage.getItem(QUICK_CREATE_DRAFT_STORAGE_KEY);
+    if (!raw) return DEFAULT_DRAFT;
+    const parsed = JSON.parse(raw) as Partial<DraftState>;
+    return {
+      id: typeof parsed.id === "string" ? parsed.id : null,
+      title: typeof parsed.title === "string" ? parsed.title : "",
+      body: typeof parsed.body === "string" ? parsed.body : "",
+      priority: isDraftPriority(parsed.priority) ? parsed.priority : "normal",
+      labels: typeof parsed.labels === "string" ? parsed.labels : "",
+    };
+  } catch {
+    return DEFAULT_DRAFT;
+  }
+}
+
+function writeStoredValue(key: string, value: string): void {
+  try {
+    if (value) {
+      window.localStorage.setItem(key, value);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Persistence is a convenience; the form remains usable if storage is unavailable.
+  }
+}
+
+function isDraftPriority(value: unknown): value is DraftState["priority"] {
+  return value === "low" || value === "normal" || value === "high";
 }

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1649,6 +1649,49 @@ test("preserves compact repo-scoped mode while switching repos from deep links",
   await expectWorkbenchFitsViewport(page);
 });
 
+test("preserves compact quick create drafts across cross-mode navigation in WebKit", async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.route("**/api/v1/pulls/mean-weasel/**", async (route) => {
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ pulls: [], fromCache: false, cachedAt: null }),
+    });
+  });
+  await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ port: 7701, terminalToken: "terminal-token-101" }),
+    });
+  });
+  await mockTerminalPage(page, 7701, "terminal-token-101");
+
+  await page.goto(`${baseUrl}/workbench/quick-create?repo=mean-weasel%2Fissuectl`);
+  await page.getByLabel("Parse text").fill("Fix compact cross-mode quick create persistence");
+  await page.getByLabel("Draft title").fill("Preserve compact quick create draft");
+  await page.getByLabel("Draft body").fill("Do not lose in-progress work when switching workbench modes.");
+  await page.getByLabel("Draft labels").fill("ux, workbench");
+
+  await clickNavAndExpect(page, "PRs", "/workbench/prs", true);
+  await clickNavAndExpect(page, "Settings", "/workbench/settings", true);
+  await clickNavAndExpect(page, "Workbench", "/workbench", true);
+  await page
+    .getByLabel("Compact active sessions")
+    .getByLabel("Session #447")
+    .getByRole("button", { name: "Open terminal" })
+    .click();
+  await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
+  await clickNavAndExpect(page, "Quick Create", "/workbench/quick-create", true);
+
+  await expect(page.getByLabel("Parse text")).toHaveValue("Fix compact cross-mode quick create persistence");
+  await expect(page.getByLabel("Draft title")).toHaveValue("Preserve compact quick create draft");
+  await expect(page.getByLabel("Draft body")).toHaveValue("Do not lose in-progress work when switching workbench modes.");
+  await expect(page.getByLabel("Draft labels")).toHaveValue("ux, workbench");
+  await expectCompactWorkbenchViewport(page);
+});
+
 test("keeps compact issue mutations and session navigation coherent end to end", async ({ page }) => {
   await page.setViewportSize({ width: 393, height: 852 });
   const requests: Array<{ method: string; url: string; body: unknown }> = [];


### PR DESCRIPTION
## Summary
- persist unsaved Quick Create parse text and fallback draft fields across workbench mode changes
- add compact WebKit cross-mode journey through PRs, settings, overview, terminal, and back to Quick Create
- add the new cross-mode quick-create regression to E2E CI

## Verification
- git diff --check
- pnpm --dir packages/web lint (passes; existing max-lines warning in workbench.test.ts)
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact quick create drafts across cross-mode navigation in WebKit"
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact quick create drafts across cross-mode navigation in WebKit|keeps compact issue mutations and session navigation coherent end to end"

## Audit note
Highest-value T030 issue found: Quick Create kept parse/draft form state inside the mounted component only, so compact users could lose in-progress work while moving through PRs, settings, overview, and terminal workflows.