### PR TITLE
Fix compact issue mutation failure recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
+      - name: Run compact workbench WebKit issue mutation failure recovery
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutation failures visible and recoverable in WebKit"
       - name: Run compact workbench WebKit cross-mode quick create persistence
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { LaunchAgent, Priority, WorkspaceMode } from "@issuectl/core";
 import { AgentSelector } from "@/components/launch/AgentSelector";
@@ -74,6 +74,7 @@ export function IssueFocus({
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [reassignedIssue, setReassignedIssue] = useState<ReassignResult | null>(null);
+  const actionAlertRef = useRef<HTMLParagraphElement | null>(null);
   const [agent, setAgent] = useState<LaunchAgent>("codex");
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>(() => defaultWorkspaceMode(repo));
   const [branchName, setBranchName] = useState(() => defaultBranchName(repo, issue));
@@ -133,6 +134,12 @@ export function IssueFocus({
     setSelectedComments(detail.comments.map((_, index) => index));
     setSelectedFiles(detail.referencedFiles);
   }, [detail?.comments, detail?.issue.number, detail?.referencedFiles]);
+
+  useEffect(() => {
+    if (error && status !== "error") {
+      actionAlertRef.current?.focus();
+    }
+  }, [error, status]);
 
   useEffect(() => {
     let cancelled = false;
@@ -227,7 +234,6 @@ export function IssueFocus({
           Issue detail failed to load: {error}
         </p>
       )}
-      {error && status !== "error" && <p className={styles.issueFocusError}>{error}</p>}
       {actionMessage && <p className={styles.issueFocusNotice} role="status">{actionMessage}</p>}
 
       <section className={styles.issueFocusBody} aria-label="Issue body">
@@ -302,6 +308,11 @@ export function IssueFocus({
       </div>
 
       <section className={styles.issueActionGrid} aria-label="Issue actions">
+        {error && status !== "error" && (
+          <p ref={actionAlertRef} className={styles.issueFocusError} role="alert" tabIndex={-1}>
+            {error}
+          </p>
+        )}
         <div className={styles.issueActionGroup} aria-label="Metadata actions">
           <h2>Metadata</h2>
           <label>

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1196,6 +1196,10 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.issueActionGrid > .issueFocusError {
+  grid-column: 1 / -1;
+}
+
 .issueActionGroup {
   padding: 12px;
   border: 1px solid var(--paper-line);

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1787,6 +1787,63 @@ test("keeps compact issue mutations and session navigation coherent end to end",
   expect(requests.some((item) => item.url.includes("/deployments/101/ensure-ttyd") && item.method === "POST")).toBe(true);
 });
 
+test("keeps compact issue mutation failures visible and recoverable in WebKit", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  const requests: Array<{ method: string; url: string; body: unknown }> = [];
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    const request = route.request();
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512/priority", async (route) => {
+    const request = route.request();
+    const body = await request.postDataJSON();
+    requests.push({ method: request.method(), url: request.url(), body });
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    expect(request.method()).toBe("PUT");
+    expect(body).toEqual({ priority: "normal" });
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Priority API unavailable" }),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+
+  const issueActions = page.getByLabel("Issue actions");
+  await issueActions.getByLabel("Priority").selectOption("normal");
+
+  const alert = page.getByRole("alert").filter({ hasText: "priority failed: Priority API unavailable" });
+  await expect(alert).toBeVisible();
+  await expect(alert).toBeFocused();
+  await expect(alert).toBeInViewport();
+  await expect(issueActions.getByLabel("Priority")).toHaveValue("high");
+  await expect(page.getByLabel("Workbench focus")).toContainText("high");
+  await expectCompactWorkbenchViewport(page);
+  await testInfo.attach("compact-issue-mutation-failure-recovery", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+
+  expect(requests).toEqual([{
+    method: "PUT",
+    url: expect.stringContaining("/api/v1/issues/mean-weasel/issuectl/512/priority"),
+    body: { priority: "normal" },
+  }]);
+});
+
 test("preserves compact issue and terminal context across keyboard navigation history and reload", async ({ page }, testInfo) => {
   await page.setViewportSize({ width: 393, height: 852 });
   const requests: Array<{ method: string; url: string; body: unknown }> = [];


### PR DESCRIPTION
## Summary\n- move issue action failures into the Issue actions region as a focused role=alert message\n- keep failed compact mutations recoverable without changing selected issue state\n- add mobile WebKit regression coverage and CI step for mutation failure recovery\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --dir packages/core build\n- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutation failures visible and recoverable in WebKit"\n- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutation failures visible and recoverable in WebKit|keeps compact issue mutations and session navigation coherent end to end"\n- pnpm --dir packages/web typecheck\n- pnpm --dir packages/web lint\n- pnpm --dir packages/web test\n- git diff --check\n- pnpm turbo build\n