### PR TITLE
Fix compact dense issue detail layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutation failures visible and recoverable in WebKit"
+      - name: Run compact workbench WebKit dense issue detail content
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact dense issue detail content readable in WebKit"
       - name: Run compact workbench WebKit cross-mode quick create persistence
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1023,6 +1023,7 @@
 }
 
 .deploymentRow div {
+  min-width: 0;
   display: grid;
   gap: 3px;
 }
@@ -1033,8 +1034,10 @@
 }
 
 .deploymentRow span {
+  min-width: 0;
   color: var(--paper-ink-muted);
   font-size: 12px;
+  overflow-wrap: anywhere;
 }
 
 .issueFocus {
@@ -1053,6 +1056,7 @@
   font-family: var(--paper-serif);
   font-size: 30px;
   font-weight: 500;
+  overflow-wrap: anywhere;
 }
 
 .issueFocusMeta {
@@ -1087,6 +1091,8 @@
 }
 
 .issueLabels span {
+  min-width: 0;
+  max-width: 100%;
   min-height: 22px;
   display: inline-grid;
   place-items: center;
@@ -1096,6 +1102,8 @@
   background: rgba(255, 255, 255, 0.42);
   color: var(--paper-ink);
   font: 11px var(--paper-mono);
+  overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .issueFocusNotice,
@@ -1143,7 +1151,9 @@
 }
 
 .issueDetailSections .collapsibleBody {
+  min-width: 0;
   padding: 14px;
+  overflow-wrap: anywhere;
 }
 
 .issueDetailSections .issueFocusGrid {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -1844,6 +1844,97 @@ test("keeps compact issue mutation failures visible and recoverable in WebKit", 
   }]);
 });
 
+test("keeps compact dense issue detail content readable in WebKit", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  const longToken = "supercalifragilisticexpialidocious-workbench-regression-without-natural-breaks";
+  const denseRepos = workbenchPayload().repos;
+  denseRepos[0] = {
+    ...denseRepos[0],
+    issues: denseRepos[0].issues.map((issue) => issue.number === 512
+      ? {
+        ...issue,
+        title: `Audit ${longToken} compact overflow when many controls stay visible`,
+        labels: [
+          { name: longToken, color: "ffffff", description: null },
+          { name: "dense-content", color: "ffffff", description: null },
+        ],
+      }
+      : issue),
+    deployments: denseRepos[0].deployments.map((deployment) => deployment.id === 101
+      ? {
+        ...deployment,
+        branchName: `issue-447-${longToken}`,
+      }
+      : deployment),
+  };
+  seedWorkbenchRepos(dbPath, denseRepos);
+
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const detail = issueDetailFixture();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...detail,
+        issue: {
+          ...detail.issue,
+          title: `Audit ${longToken} compact overflow when many controls stay visible`,
+          body: `This issue includes ${longToken} in body text plus ordinary prose.`,
+          labels: [
+            { name: longToken, color: "ffffff", description: null },
+            { name: "dense-content", color: "ffffff", description: null },
+          ],
+        },
+        comments: [{
+          ...detail.comments[0],
+          body: `Existing comment with ${longToken} and enough surrounding words to wrap.`,
+        }],
+        deployments: detail.deployments.map((deployment) => deployment.id === 101
+          ? {
+            ...deployment,
+            branchName: `issue-447-${longToken}`,
+          }
+          : deployment),
+        linkedPRs: [{
+          ...detail.linkedPRs[0],
+          title: `Fix ${longToken} pull request overflow`,
+        }],
+        referencedFiles: [
+          `packages/web/components/workbench/${longToken}/IssueFocus.tsx`,
+          `packages/web/components/workbench/${longToken}/WorkbenchShell.module.css`,
+        ],
+      }),
+    });
+  });
+  await page.route("**/api/v1/worktrees/status?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ exists: true, dirty: false, path: `/tmp/${longToken}` }),
+    });
+  });
+
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
+  await expect(page.getByRole("heading", { name: new RegExp(`^#512 Audit ${longToken}`) })).toBeVisible();
+  await expect(page.getByLabel("Issue labels").getByText(longToken, { exact: true })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Issue body" })).toContainText(longToken);
+  await expect(page.getByLabel("Issue detail metadata", { exact: true })).toContainText(longToken);
+  await expect(page.getByLabel("Issue comments", { exact: true })).toContainText(longToken);
+  await expect(page.getByLabel("Issue context", { exact: true })).toContainText(longToken);
+
+  await expectCompactWorkbenchViewport(page);
+  await expectLocatorWithinViewport(page.getByLabel("Issue labels").getByText(longToken, { exact: true }), 393);
+  await expectLocatorWithinViewport(page.getByRole("button", { name: "Launch issue" }), 393);
+  await testInfo.attach("compact-dense-issue-detail", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
 test("preserves compact issue and terminal context across keyboard navigation history and reload", async ({ page }, testInfo) => {
   await page.setViewportSize({ width: 393, height: 852 });
   const requests: Array<{ method: string; url: string; body: unknown }> = [];


### PR DESCRIPTION
## Summary
- keep compact issue detail labels, headers, deployment metadata, and collapsible content wrapping inside mobile viewport constraints
- add a deterministic mobile WebKit dense-content regression with long title, labels, comments, referenced files, and session branch data
- add the new dense-content regression to CI

## Verification
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact dense issue detail content readable in WebKit" (red before CSS fix: long label right edge reached ~584px in a 393px viewport)
- pnpm --dir packages/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact dense issue detail content readable in WebKit|keeps compact issue mutation failures visible and recoverable in WebKit"
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- pnpm --dir packages/web exec playwright test --list --project=mobile-webkit --grep "keeps compact dense issue detail content readable in WebKit"
- git diff --check
- commit hook: turbo typecheck and turbo lint
- push hook: turbo build

Refs #483