### PR TITLE
Fix board terminal launch and proxy auth

### DIFF
--- a/packages/core/src/launch/launch-agent-command.ts
+++ b/packages/core/src/launch/launch-agent-command.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { execFileSync } from "node:child_process";
 import { getSetting } from "../db/settings.js";
 import type { LaunchAgent } from "../types.js";
 
@@ -58,17 +59,26 @@ export function buildLaunchAgentCommand(
   agent: LaunchAgent,
   rawExtraArgs: string | undefined,
 ): string {
+  const command = resolveLaunchAgentBinary(agent);
   const extraArgs = rawExtraArgs?.trim() ?? "";
-  if (extraArgs === "") return agent;
+  if (extraArgs === "") return command;
   if (DANGEROUS_METACHARS.test(extraArgs)) {
     console.warn(
       `[issuectl] ${extraArgsSettingForAgent(agent)} contains unexpected shell metacharacters; falling back to plain '${agent}'. Re-save the value in Settings to re-validate. Got: ${JSON.stringify(extraArgs)}`,
     );
-    return agent;
+    return command;
   }
-  return `${agent} ${extraArgs}`;
+  return `${command} ${extraArgs}`;
 }
 
 export function buildClaudeCommand(rawExtraArgs: string | undefined): string {
   return buildLaunchAgentCommand("claude", rawExtraArgs);
+}
+
+function resolveLaunchAgentBinary(agent: LaunchAgent): string {
+  try {
+    return execFileSync("which", [agent], { encoding: "utf8" }).trim() || agent;
+  } catch {
+    return agent;
+  }
 }

--- a/packages/core/src/launch/launch-execute-agents.test.ts
+++ b/packages/core/src/launch/launch-execute-agents.test.ts
@@ -156,7 +156,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       expect.objectContaining({
         port: 7700,
         workspacePath: "/tmp/fake-workspace",
-        agentCommand: "claude",
+        agentCommand: expect.stringMatching(/(^|\/)claude$/),
         agentInputMode: "stdin",
         sessionName: "issuectl-api-42",
       }),
@@ -208,7 +208,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
 
     expect(spawnTtydSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentCommand: "codex --model gpt-5 --full-auto",
+        agentCommand: expect.stringMatching(/(^|\/)codex --model gpt-5 --full-auto$/),
         agentInputMode: "argument",
       }),
     );
@@ -256,7 +256,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
 
     expect(spawnTtydSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentCommand: "codex --sandbox danger-full-access --ask-for-approval never",
+        agentCommand: expect.stringMatching(/(^|\/)codex --sandbox danger-full-access --ask-for-approval never$/),
         agentInputMode: "argument",
       }),
     );

--- a/packages/core/src/launch/launch.test.ts
+++ b/packages/core/src/launch/launch.test.ts
@@ -13,74 +13,74 @@ describe("buildClaudeCommand", () => {
   });
 
   it("returns 'claude' for undefined", () => {
-    expect(buildClaudeCommand(undefined)).toBe("claude");
+    expect(buildClaudeCommand(undefined)).toMatch(/(^|\/)claude$/);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("returns 'claude' for empty string", () => {
-    expect(buildClaudeCommand("")).toBe("claude");
+    expect(buildClaudeCommand("")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("returns 'claude' for whitespace-only string", () => {
-    expect(buildClaudeCommand("   ")).toBe("claude");
+    expect(buildClaudeCommand("   ")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("appends trimmed extra args for a normal value", () => {
-    expect(buildClaudeCommand("--dangerously-skip-permissions")).toBe(
-      "claude --dangerously-skip-permissions",
+    expect(buildClaudeCommand("--dangerously-skip-permissions")).toMatch(
+      /(^|\/)claude --dangerously-skip-permissions$/,
     );
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("appends multiple args", () => {
-    expect(buildClaudeCommand("--verbose --model opus")).toBe("claude --verbose --model opus");
+    expect(buildClaudeCommand("--verbose --model opus")).toMatch(/(^|\/)claude --verbose --model opus$/);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("trims surrounding whitespace before composing", () => {
-    expect(buildClaudeCommand("  --verbose  ")).toBe("claude --verbose");
+    expect(buildClaudeCommand("  --verbose  ")).toMatch(/(^|\/)claude --verbose$/);
   });
 
   it("falls back to 'claude' and warns on semicolon (tampered DB)", () => {
-    expect(buildClaudeCommand("--foo; rm -rf /")).toBe("claude");
+    expect(buildClaudeCommand("--foo; rm -rf /")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/metacharacters/i);
   });
 
   it("falls back on backtick", () => {
-    expect(buildClaudeCommand("`evil`")).toBe("claude");
+    expect(buildClaudeCommand("`evil`")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on $ variable", () => {
-    expect(buildClaudeCommand("--append $HOME")).toBe("claude");
+    expect(buildClaudeCommand("--append $HOME")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on && operator", () => {
-    expect(buildClaudeCommand("--foo && --bar")).toBe("claude");
+    expect(buildClaudeCommand("--foo && --bar")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on pipe", () => {
-    expect(buildClaudeCommand("--foo | cat")).toBe("claude");
+    expect(buildClaudeCommand("--foo | cat")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on redirect", () => {
-    expect(buildClaudeCommand("--foo > out.txt")).toBe("claude");
+    expect(buildClaudeCommand("--foo > out.txt")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on newline (injection attempt)", () => {
-    expect(buildClaudeCommand("--foo\nrm -rf /")).toBe("claude");
+    expect(buildClaudeCommand("--foo\nrm -rf /")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("falls back on parentheses", () => {
-    expect(buildClaudeCommand("(echo hi)")).toBe("claude");
+    expect(buildClaudeCommand("(echo hi)")).toMatch(/(^|\/)claude$/);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });
@@ -97,17 +97,17 @@ describe("buildLaunchAgentCommand", () => {
   });
 
   it("builds a plain codex command with no args", () => {
-    expect(buildLaunchAgentCommand("codex", undefined)).toBe("codex");
+    expect(buildLaunchAgentCommand("codex", undefined)).toMatch(/(^|\/)codex$/);
   });
 
   it("appends codex args", () => {
-    expect(buildLaunchAgentCommand("codex", "--model gpt-5 --full-auto")).toBe(
-      "codex --model gpt-5 --full-auto",
+    expect(buildLaunchAgentCommand("codex", "--model gpt-5 --full-auto")).toMatch(
+      /(^|\/)codex --model gpt-5 --full-auto$/,
     );
   });
 
   it("falls back to plain codex for dangerous stored args", () => {
-    expect(buildLaunchAgentCommand("codex", "--model gpt-5; rm -rf /")).toBe("codex");
+    expect(buildLaunchAgentCommand("codex", "--model gpt-5; rm -rf /")).toMatch(/(^|\/)codex$/);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("codex_extra_args"));
   });
 });

--- a/packages/core/src/launch/ttyd-spawn.test.ts
+++ b/packages/core/src/launch/ttyd-spawn.test.ts
@@ -67,6 +67,7 @@ describe("spawnTtyd", () => {
     expect(tmuxCmd).toContain("/home/user/project");
     expect(tmuxCmd).toContain("/tmp/ctx.md");
     expect(tmuxCmd).toContain("claude --dangerously-skip-permissions");
+    expect(tmuxCmd).toContain("unset PNPM_SCRIPT_SRC_DIR");
     expect(tmuxCmd).toContain("< ");
     expect(tmuxCmd).toContain("; exit");
 

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -35,6 +35,8 @@ const TMUX_SESSION_RE = /^[a-zA-Z0-9_-]+$/;
 const TMUX_INITIAL_COLUMNS = 40;
 const TMUX_INITIAL_ROWS = 24;
 const TTYD_TERMINATION_GRACE_MS = 150;
+const AGENT_ENV_RESET =
+  "for name in $(env | awk -F= '/^npm_/ {print $1}'); do unset \"$name\"; done; unset PNPM_SCRIPT_SRC_DIR";
 
 /**
  * Build a tmux-safe session name from repo + issue number. Dots, colons,
@@ -267,7 +269,7 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
       ? `"$(cat ${shellEscape(contextFilePath)})"`
       : `< ${shellEscape(contextFilePath)}`;
   const innerCommand =
-    `cd ${shellEscape(workspacePath)} && ${command} ${contextInput} ; exit`;
+    `${AGENT_ENV_RESET}; cd ${shellEscape(workspacePath)} && ${command} ${contextInput} ; exit`;
 
   // Create a detached tmux session that runs the agent command.
   // This is step 1 of 2 — ttyd will then serve `tmux attach` so

--- a/packages/web/app/api/terminal/[port]/[...path]/route.ts
+++ b/packages/web/app/api/terminal/[port]/[...path]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidTerminalPort, proxyHttpRequest } from "@/lib/terminal-proxy";
-import { validateTerminalToken } from "@/lib/terminal-auth";
+import { terminalTokenFromRequest, validateTerminalToken } from "@/lib/terminal-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +14,8 @@ export async function GET(
   if (!isValidTerminalPort(port)) {
     return new NextResponse("Not Found", { status: 404 });
   }
-  if (!validateTerminalToken(request.nextUrl.searchParams.get("terminalToken"), port)) {
+  const terminalToken = terminalTokenFromRequest(request.nextUrl, port, request.headers.get("referer"));
+  if (!validateTerminalToken(terminalToken, port)) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 

--- a/packages/web/app/api/terminal/[port]/route.ts
+++ b/packages/web/app/api/terminal/[port]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidTerminalPort, proxyHttpRequest, rewriteHtml } from "@/lib/terminal-proxy";
-import { validateTerminalToken } from "@/lib/terminal-auth";
+import { terminalTokenFromRequest, validateTerminalToken } from "@/lib/terminal-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +14,7 @@ export async function GET(
   if (!isValidTerminalPort(port)) {
     return new NextResponse("Not Found", { status: 404 });
   }
-  const terminalToken = request.nextUrl.searchParams.get("terminalToken");
+  const terminalToken = terminalTokenFromRequest(request.nextUrl, port, request.headers.get("referer"));
   if (!validateTerminalToken(terminalToken, port)) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
@@ -27,7 +27,7 @@ export async function GET(
       const rewritten = rewriteHtml(upstream.body.toString("utf-8"), port, terminalToken ?? undefined);
       return new NextResponse(rewritten, {
         status: upstream.status,
-        headers: { "content-type": contentType },
+        headers: { "content-type": contentType, "referrer-policy": "same-origin" },
       });
     }
 

--- a/packages/web/lib/terminal-auth.test.ts
+++ b/packages/web/lib/terminal-auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("@issuectl/core", () => ({
   getActiveDeploymentByPort: mockGetActiveDeploymentByPort,
 }));
 
-import { createTerminalToken, validateTerminalToken } from "./terminal-auth.js";
+import { createTerminalToken, terminalTokenFromRequest, validateTerminalToken } from "./terminal-auth.js";
 
 describe("terminal auth tokens", () => {
   beforeEach(() => {
@@ -51,5 +51,49 @@ describe("terminal auth tokens", () => {
     mockGetDeploymentById.mockReturnValue({ id: 7, endedAt: "2026-04-28", ttydPort: 7700 });
 
     expect(validateTerminalToken(token, 7700)).toBe(false);
+  });
+});
+
+describe("terminalTokenFromRequest", () => {
+  it("returns the direct terminal token when present", () => {
+    const url = new URL("http://localhost:3000/api/terminal/7700/token?terminalToken=direct");
+
+    expect(terminalTokenFromRequest(url, 7700, null)).toBe("direct");
+  });
+
+  it("falls back to an authenticated same-origin terminal frame referer", () => {
+    const url = new URL("http://localhost:3000/api/terminal/7700/token");
+
+    expect(
+      terminalTokenFromRequest(
+        url,
+        7700,
+        "http://localhost:3000/api/terminal/7700/?terminalToken=from-frame",
+      ),
+    ).toBe("from-frame");
+  });
+
+  it("rejects referers for a different terminal port", () => {
+    const url = new URL("http://localhost:3000/api/terminal/7700/token");
+
+    expect(
+      terminalTokenFromRequest(
+        url,
+        7700,
+        "http://localhost:3000/api/terminal/7701/?terminalToken=wrong-port",
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects cross-origin referers", () => {
+    const url = new URL("http://localhost:3000/api/terminal/7700/token");
+
+    expect(
+      terminalTokenFromRequest(
+        url,
+        7700,
+        "http://example.com/api/terminal/7700/?terminalToken=cross-origin",
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/web/lib/terminal-auth.ts
+++ b/packages/web/lib/terminal-auth.ts
@@ -102,3 +102,22 @@ export function validateTerminalToken(token: string | null | undefined, port: nu
     return false;
   }
 }
+
+export function terminalTokenFromRequest(
+  url: URL,
+  port: number,
+  referer: string | null,
+): string | null {
+  const token = url.searchParams.get("terminalToken");
+  if (token) return token;
+  if (!referer) return null;
+
+  try {
+    const refererUrl = new URL(referer, url.origin);
+    if (refererUrl.origin !== url.origin) return null;
+    if (!refererUrl.pathname.startsWith(`/api/terminal/${port}/`)) return null;
+    return refererUrl.searchParams.get("terminalToken");
+  } catch {
+    return null;
+  }
+}

--- a/packages/web/lib/terminal-proxy.test.ts
+++ b/packages/web/lib/terminal-proxy.test.ts
@@ -85,6 +85,8 @@ describe("rewriteHtml", () => {
   it("injects a WebSocket token patch when terminalToken is present", () => {
     const result = rewriteHtml("<html><head></head><body></body></html>", 7701, "abc123");
     expect(result).toContain("window.WebSocket=AuthWebSocket");
+    expect(result).toContain("window.fetch=function");
+    expect(result).toContain("XMLHttpRequest.prototype.open=function");
     expect(result).toContain("abc123");
   });
 });

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -39,8 +39,39 @@ export function rewriteHtml(html: string, port: number, terminalToken?: string):
   const token = terminalToken;
   const encodedToken = token ? encodeURIComponent(token) : "";
   const tokenQuery = encodedToken ? `?terminalToken=${encodedToken}` : "";
-  const wsPatch = terminalToken
-    ? `<script>(()=>{const token=${JSON.stringify(token)};const port=${JSON.stringify(port)};const Native=window.WebSocket;function AuthWebSocket(url,protocols){try{const u=new URL(url,window.location.href);if(u.origin===window.location.origin&&u.pathname.startsWith("/api/terminal/"+port+"/")&&!u.searchParams.has("terminalToken")){u.searchParams.set("terminalToken",token);url=u.toString();}}catch{}return protocols===undefined?new Native(url):new Native(url,protocols)}AuthWebSocket.prototype=Native.prototype;Object.setPrototypeOf(AuthWebSocket,Native);window.WebSocket=AuthWebSocket;})();</script>`
+  const browserApiPatch = terminalToken
+    ? `<script>${[
+        "(()=>{",
+        `const token=${JSON.stringify(token)};`,
+        `const port=${JSON.stringify(port)};`,
+        "function authUrl(url){",
+        "const u=new URL(url,window.location.href);",
+        "if(u.origin===window.location.origin&&u.pathname.startsWith('/api/terminal/'+port+'/')&&!u.searchParams.has('terminalToken'))u.searchParams.set('terminalToken',token);",
+        "return u;",
+        "}",
+        "const NativeWebSocket=window.WebSocket;",
+        "function AuthWebSocket(url,protocols){",
+        "try{url=authUrl(url).toString();}catch{}",
+        "return protocols===undefined?new NativeWebSocket(url):new NativeWebSocket(url,protocols);",
+        "}",
+        "AuthWebSocket.prototype=NativeWebSocket.prototype;",
+        "Object.setPrototypeOf(AuthWebSocket,NativeWebSocket);",
+        "window.WebSocket=AuthWebSocket;",
+        "const nativeFetch=window.fetch;",
+        "window.fetch=function(input,init){",
+        "try{",
+        "if(input instanceof Request){input=new Request(authUrl(input.url).toString(),input);}",
+        "else{input=authUrl(input).toString();}",
+        "}catch{}",
+        "return nativeFetch.call(this,input,init);",
+        "};",
+        "const nativeOpen=XMLHttpRequest.prototype.open;",
+        "XMLHttpRequest.prototype.open=function(method,url,...rest){",
+        "try{url=authUrl(url).toString();}catch{}",
+        "return nativeOpen.call(this,method,url,...rest);",
+        "};",
+        "})();",
+      ].join("")}</script>`
     : "";
   const rewritten = html
     .replace(/(href|src|action)="\/(?!\/)/g, `$1="${prefix}/`)
@@ -55,8 +86,8 @@ export function rewriteHtml(html: string, port: number, terminalToken?: string):
         },
       )
     : rewritten;
-  if (!wsPatch) return withToken;
+  if (!browserApiPatch) return withToken;
   return withToken.includes("</head>")
-    ? withToken.replace("</head>", `${wsPatch}</head>`)
-    : `${wsPatch}${withToken}`;
+    ? withToken.replace("</head>", `${browserApiPatch}</head>`)
+    : `${browserApiPatch}${withToken}`;
 }


### PR DESCRIPTION
## Summary
- resolve launch agent binaries before starting tmux so web-launched Codex sessions survive the server environment
- clear inherited npm/pnpm lifecycle env vars before running agents in tmux
- keep terminal proxy auth attached to ttyd runtime fetch/XHR/WebSocket calls so the workbench terminal renders instead of showing unavailable

## Verification
- pnpm --dir packages/core typecheck
- pnpm --dir packages/core lint
- pnpm --dir packages/core test
- pnpm --dir packages/core test:integration -- codex-ttyd.integration.test.ts
- pnpm --dir packages/core build
- pnpm --dir packages/web test -- terminal-auth.test.ts terminal-proxy.test.ts
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- git diff --check
- manual launch: deployment 110 rendered the terminal iframe, /token?terminalToken=... returned 200, websocket connected, and terminal frames flowed
