### PR TITLE
[codex] add live Codex workbench E2E coverage

### DIFF
--- a/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/app.js
+++ b/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/app.js
@@ -1,0 +1,542 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });

--- a/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/index.html
+++ b/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/styles.css
+++ b/docs/goals/codex-workbench-live-e2e/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/codex-workbench-live-e2e/goal.md
+++ b/docs/goals/codex-workbench-live-e2e/goal.md
@@ -1,0 +1,92 @@
+# Live Codex Workbench E2E Coverage
+
+## Objective
+
+Add a guarded live end-to-end test tranche that proves an issue can be created in an approved issuectl test repo, launched with Codex through the workbench, kept reachable while navigating away and back, and cleaned up without touching non-test repositories.
+
+## Original Request
+
+Make a detailed GoalBuddy prep plan for live Codex workbench E2E coverage, restricted to the two issuectl test repos for issue creation, terminal session launch, and cleanup.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl maintainers and future agents debugging launch/session regressions
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: A checked-in live E2E spec or equivalent verified test harness exists, is guarded by an explicit allowlist of only `mean-weasel/issuectl-test-repo` and `mean-weasel/issuectl-test-repo-2`, and demonstrates issue creation, Codex launch, terminal persistence across navigation, return-to-session, and cleanup.
+- Goal oracle: A live or safely skippable test command proves the guarded workflow end to end, plus static assertions prove no non-allowlisted repo can be used for create/launch/cleanup.
+- Likely misfire: Adding more mocked workbench tests or isolated ttyd tests while still missing the real integrated path that failed manually.
+- Blind spots considered: GitHub side effects, stale service workers, local server lifecycle, real Codex prerequisites, cleanup on failure, accidental repo targeting, CI suitability, and flaky timing around ttyd/tmux.
+- Existing plan facts: The test should be restricted to the two issuectl test repos; it should cover issue creation, terminal session launch, navigating away to another issue/view, returning to the session, and closing/cleanup.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A guarded live E2E command creates a uniquely-marked issue only in an allowlisted issuectl test repo, launches Codex, verifies the workbench terminal/session remains reachable across navigation and reload/return, ends the session, closes the created issue, and leaves no live deployment/tmux/ttyd residue; if prerequisites are absent, the test skips before side effects.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing mocked UI test, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Implement the missing integrated coverage safely. Start by validating the current test harness and selecting the lowest-risk insertion point. Then add the guarded live E2E path, run the strongest feasible local verification, and audit the cleanup and allowlist protections.
+
+## Non-Negotiable Constraints
+
+- Issue creation, Codex terminal launch, cleanup, and issue closing may target only `mean-weasel/issuectl-test-repo` or `mean-weasel/issuectl-test-repo-2`.
+- The test must fail or skip before side effects when a repo is outside the allowlist.
+- Created issues must use a unique test marker and cleanup must only close allowlisted issues with that marker.
+- Cleanup must be best-effort in `afterEach`/`afterAll` style paths so failures do not leave active sessions or open test issues.
+- The test must not run against production or arbitrary repos by default.
+- The implementation must preserve existing unit, integration, and mocked workbench coverage rather than replacing it.
+- No implementation work should proceed without a bounded Worker task with explicit allowed files and verification commands.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/codex-workbench-live-e2e/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/codex-workbench-live-e2e/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the allowlist, side-effect boundaries, cleanup proof, and live-test oracle before making changes.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/codex-workbench-live-e2e/state.yaml
+++ b/docs/goals/codex-workbench-live-e2e/state.yaml
@@ -1,0 +1,372 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "Live Codex Workbench E2E Coverage"
+  slug: "codex-workbench-live-e2e"
+  kind: specific
+  tranche: "Add guarded live E2E coverage for issue creation, Codex workbench launch, terminal persistence across navigation, return-to-session, and cleanup."
+  status: done
+  oracle:
+    signal: "A guarded live E2E command creates a marked issue in an allowlisted issuectl test repo, launches Codex, verifies terminal/session persistence across navigation and return, ends the session, closes the issue, and leaves no live deployment/tmux/ttyd residue."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Receipt-backed test output plus static/behavioral evidence that only mean-weasel/issuectl-test-repo and mean-weasel/issuectl-test-repo-2 can be targeted for side effects."
+  intake:
+    original_request: "Make a detailed GoalBuddy prep plan for live Codex workbench E2E coverage restricted to the two issuectl test repos."
+    interpreted_outcome: "The repo has a safe, guarded live E2E test for the real Codex workbench launch/session lifecycle."
+    input_shape: specific
+    audience: "issuectl maintainers and future debugging agents"
+    authority: requested
+    proof_type: test
+    completion_proof: "A final audit shows the live E2E harness and verification evidence satisfy the oracle without permitting non-test repo side effects."
+    likely_misfire: "Adding only mocked UI or isolated terminal tests while leaving the real integrated launch/session path untested."
+    blind_spots_considered:
+      - "GitHub issue creation and cleanup side effects"
+      - "Accidental non-test repository targeting"
+      - "Local Codex, ttyd, tmux, gh, and auth prerequisites"
+      - "Server lifecycle and stale browser/service-worker state"
+      - "Failure cleanup for deployments, tmux sessions, ttyd listeners, and created issues"
+      - "Flakiness around terminal readiness and navigation timing"
+      - "Whether this should be default CI, opt-in CI, or local/manual only"
+    existing_plan_facts:
+      - "Allowed repos are mean-weasel/issuectl-test-repo and mean-weasel/issuectl-test-repo-2 only."
+      - "The workflow must create a uniquely-marked test issue."
+      - "The workflow must launch the issue using Codex."
+      - "The workflow must verify terminal/session reachability after navigating to a different issue or view and returning."
+      - "The workflow must close/end the session and clean up the created issue."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/codex-workbench-live-e2e/"
+    command: "npx goalbuddy board docs/goals/codex-workbench-live-e2e"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Map the current launch, workbench, terminal, and E2E test harness paths relevant to a guarded live Codex workflow."
+    inputs:
+      - "packages/web/e2e/"
+      - "packages/web/playwright.config.ts"
+      - "packages/web/lib/actions/launch*.test.ts"
+      - "packages/core/src/launch/*"
+      - "packages/core/src/db/deployments*"
+      - "Existing diagnostics journal docs and tests"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not create GitHub issues or launch sessions."
+      - "Identify existing helpers, gaps, and prerequisite checks with file-path evidence."
+    expected_output:
+      - "Recommended test file or harness location."
+      - "Existing helpers that should be reused."
+      - "Exact live workflow steps and cleanup requirements."
+      - "Risks and prerequisite gates."
+      - "Candidate Worker allowed_files, verify commands, and stop conditions."
+    receipt:
+      result: done
+      summary: "Mapped the current harness. Modern workbench UI coverage is mocked in workbench.spec.ts; the old real launch-flow spec is stale; real terminal websocket coverage requires the custom server.ts harness, not npx next dev."
+      evidence:
+        - "packages/web/e2e/workbench.spec.ts:3328"
+        - "packages/web/e2e/workbench.spec.ts:3036"
+        - "packages/web/e2e/launch-flow.spec.ts:9"
+        - "packages/web/server.ts:147"
+        - "packages/web/lib/terminal-proxy.ts:1"
+        - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts:1"
+        - "packages/web/app/api/v1/deployments/[id]/end/route.ts:1"
+        - "packages/core/src/launch/launch.ts:205"
+        - "packages/core/src/launch/codex-ttyd.integration.test.ts:147"
+      findings:
+        - "Recommended location: add a new opt-in live spec under packages/web/e2e, e.g. codex-workbench-live.spec.ts, rather than extending the large mocked workbench.spec.ts."
+        - "The live spec should start node --import tsx server.ts --dev with PORT and ISSUECTL_DB_PATH so terminal websocket upgrades go through server.ts."
+        - "Existing helpers to reuse or copy: isolated DB setup using initSchema/runMigrations/generateApiToken, process-group server cleanup, gh-auth prerequisite checks, ttyd/tmux/codex prerequisite checks, and created-issue cleanup patterns."
+        - "The workflow should create a uniquely-marked GitHub issue in an allowlisted test repo, seed/track that repo in the isolated DB, launch via /api/v1/launch with agent=codex and workspaceMode=clone, open /workbench?repo=...&deployment=..., verify iframe/token/websocket-visible terminal content, navigate away to an issue/view and return, then end via /api/v1/deployments/:id/end and close the issue."
+        - "Cleanup must include best-effort deployment end, tmux kill using tmuxSessionName(repo, issueNumber), ttyd listener kill by recorded PID/port, created issue close, server process group shutdown, and temp DB/worktree removal."
+        - "Live verification should be opt-in/skippable before side effects unless prerequisites and an explicit live-test env flag are present."
+      candidate_worker:
+        objective: "Add an opt-in guarded live Codex workbench E2E spec plus script/config hooks needed to run it without default CI side effects."
+        allowed_files:
+          - "packages/web/e2e/codex-workbench-live.spec.ts"
+          - "packages/web/playwright.config.ts"
+          - "packages/web/package.json"
+          - "README.md"
+          - "AGENTS.md"
+          - "CLAUDE.md"
+          - "docs/**/*.md"
+        verify:
+          - "git diff --check"
+          - "pnpm --dir packages/web test -- --run packages/web/lib/actions/launch.test.ts packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+          - "pnpm --dir packages/web exec playwright test packages/web/e2e/codex-workbench-live.spec.ts --project=desktop-chromium"
+        stop_if:
+          - "The live spec cannot skip before side effects when prerequisites or the live env flag are missing."
+          - "Any create/launch/end/cleanup path can target a repo outside mean-weasel/issuectl-test-repo or mean-weasel/issuectl-test-repo-2."
+          - "The real terminal path cannot use packages/web/server.ts."
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the Scout plan and choose the largest safe Worker slice for implementing guarded live E2E coverage."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle and non-negotiable constraints"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject any plan that can create, launch, close, or clean up outside the allowlisted repos."
+      - "Prefer a vertical slice that proves the real integration path while keeping risky side effects gated and cleanup-first."
+    expected_output:
+      - "Decision: approved, revise, or blocked."
+      - "Exact Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+      - "Whether the live test should be opt-in, tagged, skipped by default, or CI-gated."
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "The Scout plan targets the missing real integration path and uses opt-in prerequisite gates before side effects. The first Worker should implement the guarded live spec plus minimal script/docs, with no default CI side effects."
+      worker_objective: "Add an opt-in guarded live Codex workbench E2E spec that starts the custom web server, creates a marked issue only in the explicit test-repo allowlist, launches Codex, verifies terminal persistence across navigation/return, and performs best-effort cleanup."
+      allowed_files:
+        - "packages/web/e2e/codex-workbench-live.spec.ts"
+        - "packages/web/package.json"
+        - "docs/workflows/live-codex-workbench-e2e.md"
+      verify:
+        - "git diff --check"
+        - "pnpm --dir packages/web test -- --run packages/web/lib/actions/launch.test.ts packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+        - "pnpm --dir packages/web exec playwright test packages/web/e2e/codex-workbench-live.spec.ts --project=desktop-chromium"
+      stop_if:
+        - "The spec can create, launch, end, close, or clean up a repo outside mean-weasel/issuectl-test-repo or mean-weasel/issuectl-test-repo-2."
+        - "The spec cannot skip before side effects when ISSUECTL_LIVE_CODEX_WORKBENCH_E2E is not enabled."
+        - "The custom server.ts harness cannot be used for the live terminal websocket path."
+        - "Need to modify launch/core implementation to make the test pass."
+      live_test_policy: "Skipped by default; run locally or in an explicitly configured job only with ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 and ISSUECTL_LIVE_CODEX_WORKBENCH_REPO set to one of the two allowlisted repos."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Add an opt-in guarded live Codex workbench E2E spec that starts the custom web server, creates a marked issue only in the explicit test-repo allowlist, launches Codex, verifies terminal persistence across navigation/return, and performs best-effort cleanup."
+    allowed_files:
+      - "packages/web/e2e/codex-workbench-live.spec.ts"
+      - "packages/web/package.json"
+      - "docs/workflows/live-codex-workbench-e2e.md"
+    verify:
+      - "git diff --check"
+      - "pnpm --dir packages/web test -- --run packages/web/lib/actions/launch.test.ts packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+      - "pnpm --dir packages/web exec playwright test packages/web/e2e/codex-workbench-live.spec.ts --project=desktop-chromium"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The test would target a repo outside the explicit allowlist."
+      - "Cleanup cannot be made best-effort and narrowly scoped to marked test artifacts."
+      - "Prerequisite handling is ambiguous."
+      - "Verification fails twice with different root causes."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/e2e/codex-workbench-live.spec.ts"
+        - "packages/web/package.json"
+        - "docs/workflows/live-codex-workbench-e2e.md"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- --run lib/actions/launch.test.ts lib/actions/launch-ensure-ttyd.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web exec playwright test e2e/codex-workbench-live.spec.ts --project=desktop-chromium"
+          status: pass
+          note: "Default non-side-effect mode: allowlist assertion passed; live workflow skipped before side effects."
+        - cmd: "pnpm --dir packages/web test:e2e:live-codex-workbench"
+          status: pass
+          note: "Default non-side-effect mode: allowlist assertion passed; live workflow skipped before side effects."
+      summary: "Added an opt-in live Codex workbench E2E spec, package script, and workflow doc. The spec hard-gates side effects with ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1, restricts target repos to the two allowlisted issuectl test repos, starts the custom server.ts harness, and includes best-effort cleanup for deployments, tmux/ttyd, created marked issues, server, DB, and worktrees."
+
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: default
+    objective: "Add or update developer documentation for running the guarded live Codex workbench E2E test, if Judge or Worker determines docs are required."
+    allowed_files:
+      - "CLAUDE.md"
+      - "AGENTS.md"
+      - "README.md"
+      - "docs/**/*.md"
+      - "packages/web/package.json"
+      - "package.json"
+    verify:
+      - "git diff --check"
+      - "Run the relevant docs/script smoke command selected by the active Worker, if any."
+    stop_if:
+      - "No docs or script changes are needed after T003."
+      - "Need to edit implementation files beyond the allowed documentation/script scope."
+    receipt:
+      result: blocked
+      summary: "No separate documentation Worker is needed because T003 added docs/workflows/live-codex-workbench-e2e.md and a package script in the same approved implementation slice."
+
+  - id: T005
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit side-effect safety before any live verification that creates issues or launches Codex."
+    inputs:
+      - "T003 receipt or current diff"
+      - "Allowlist implementation"
+      - "Cleanup paths"
+    constraints:
+      - "Read-only."
+      - "Do not run live side-effecting tests."
+      - "Reject live verification if allowlist, marker, or cleanup proof is weak."
+    expected_output:
+      - "approved_for_live_verification: true | false"
+      - "Safety gaps, if any."
+      - "Exact live verification command if approved."
+    receipt:
+      result: done
+      decision: approved_for_live_verification
+      approved_for_live_verification: true
+      full_outcome_complete: false
+      rationale: "The spec skips before side effects without ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1, asserts the repo allowlist before DB setup, issue creation, issue close, deployment cleanup, and the main live launch path, and closes only issues whose current title starts with the test marker."
+      safety_evidence:
+        - "packages/web/e2e/codex-workbench-live.spec.ts:21"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:24"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:67"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:164"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:187"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:241"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:378"
+      exact_live_verification_command: "ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 ISSUECTL_LIVE_CODEX_WORKBENCH_REPO=mean-weasel/issuectl-test-repo-2 pnpm --dir packages/web test:e2e:live-codex-workbench"
+      note: "If prerequisites are absent, the live test may skip before side effects. Any non-allowlisted repo must fail before side effects rather than skip silently."
+
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Run the approved verification commands and record whether the live E2E oracle passes, skips safely, or exposes follow-up defects."
+    allowed_files:
+      - "docs/goals/codex-workbench-live-e2e/state.yaml"
+      - "docs/goals/codex-workbench-live-e2e/notes/**"
+    verify:
+      - "Run non-side-effecting test/lint commands selected by T003/T005."
+      - "Run the live side-effecting command only if T005 approves it and prerequisites are present."
+    stop_if:
+      - "T005 has not approved live verification."
+      - "The command would target a non-allowlisted repo."
+      - "Cleanup fails and manual intervention is required."
+    receipt:
+      result: done
+      changed_files:
+        - "docs/goals/codex-workbench-live-e2e/state.yaml"
+      commands:
+        - cmd: "ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 ISSUECTL_LIVE_CODEX_WORKBENCH_REPO=mean-weasel/issuectl-test-repo-2 pnpm --dir packages/web test:e2e:live-codex-workbench"
+          status: pass
+          summary: "2 passed in 1.0m on the fresh completion audit: allowlist assertion passed; live test created marked issues, launched Codex, returned/reconnected to terminal, ended session, and cleaned up."
+        - cmd: "gh issue list --repo mean-weasel/issuectl-test-repo-2 --state all --search '\"[issuectl-e2e-live]\" in:title' --limit 30 --json number,title,state,closedAt,url"
+          status: pass
+          summary: "Marked live issues from the fresh successful run (#11 and #12) are CLOSED; earlier marked issues are also CLOSED."
+        - cmd: "tmux has-session -t issuectl-issuectl-test-repo-2-11; tmux has-session -t issuectl-issuectl-test-repo-2-12"
+          status: pass
+          summary: "Both fresh successful-run issue sessions are absent after cleanup."
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web test:e2e:live-codex-workbench"
+          status: pass
+          summary: "Default non-side-effect mode still passes allowlist assertion and skips live workflow before side effects."
+      summary: "Verified the live oracle on mean-weasel/issuectl-test-repo-2 and confirmed cleanup of the created marked issues and their tmux sessions."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the live Codex workbench E2E coverage satisfies the original restricted-repo outcome."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "Goal oracle"
+    constraints:
+      - "Read-only."
+      - "Reject completion if required Worker work is still queued or active."
+      - "Reject completion if only mocked coverage exists."
+      - "Reject completion if allowlist or cleanup proof is incomplete."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Evidence mapping to each workflow step."
+      - "Missing evidence or next task if not complete."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      evidence:
+        - "packages/web/e2e/codex-workbench-live.spec.ts"
+        - "packages/web/package.json"
+        - "docs/workflows/live-codex-workbench-e2e.md"
+        - "T003 verification receipt"
+        - "T005 safety audit receipt"
+        - "T006 live verification receipt"
+      mapping:
+        - requirement: "Issue creation restricted to the two issuectl test repos."
+          proof: "ALLOWED_E2E_REPOS plus assertAllowedRepo before createMarkedIssue; allowlist test rejects mean-weasel/issuectl and accepts both allowed repos."
+        - requirement: "Codex terminal launch restricted to the two issuectl test repos."
+          proof: "Main live path asserts repo allowlist before API launch; successful live run used mean-weasel/issuectl-test-repo-2."
+        - requirement: "Terminal remains reachable after navigating to another issue and returning."
+          proof: "Successful live Playwright run clicked a second marked issue, returned to the deployment URL, reconnected when needed, and observed the terminal iframe/websocket."
+        - requirement: "Session can be ended and cleanup is narrow."
+          proof: "Fresh successful live run ended the session, closed marked issues #11/#12, and tmux has-session returned absent for both successful-run issue sessions."
+        - requirement: "No default CI/live side effects."
+          proof: "Default package script run without ISSUECTL_LIVE_CODEX_WORKBENCH_E2E passed allowlist assertion and skipped the live workflow."
+      summary: "The original GoalBuddy outcome is satisfied: the repo now has guarded live Codex workbench E2E coverage with explicit two-repo side-effect boundaries, docs, script, passing default-safe verification, and a successful allowlisted live oracle run."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T006
+    commands:
+      - "git diff --check"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web test:e2e:live-codex-workbench"
+      - "ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 ISSUECTL_LIVE_CODEX_WORKBENCH_REPO=mean-weasel/issuectl-test-repo-2 pnpm --dir packages/web test:e2e:live-codex-workbench"

--- a/docs/workflows/live-codex-workbench-e2e.md
+++ b/docs/workflows/live-codex-workbench-e2e.md
@@ -1,0 +1,18 @@
+# Live Codex Workbench E2E
+
+`packages/web/e2e/codex-workbench-live.spec.ts` covers the real workbench launch path with GitHub, Codex, ttyd, tmux, and the custom `packages/web/server.ts` terminal proxy.
+
+It is skipped by default. To run it intentionally:
+
+```sh
+ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 \
+ISSUECTL_LIVE_CODEX_WORKBENCH_REPO=mean-weasel/issuectl-test-repo-2 \
+pnpm --dir packages/web test:e2e:live-codex-workbench
+```
+
+Allowed repositories are only:
+
+- `mean-weasel/issuectl-test-repo`
+- `mean-weasel/issuectl-test-repo-2`
+
+The test creates uniquely marked issues, launches one with Codex, verifies the terminal remains reachable after navigating to another issue and returning, ends the session, and closes the marked issues. It refuses non-allowlisted repositories before side effects and performs best-effort cleanup for deployments, ttyd/tmux, issues, the dev server, and temporary worktrees.

--- a/packages/web/e2e/codex-workbench-live.spec.ts
+++ b/packages/web/e2e/codex-workbench-live.spec.ts
@@ -1,0 +1,477 @@
+import { expect, test } from "@playwright/test";
+import { execFile, execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import Database from "better-sqlite3";
+import {
+  addRepo,
+  generateApiToken,
+  initSchema,
+  runMigrations,
+  tmuxSessionName,
+} from "@issuectl/core";
+
+const execFileAsync = promisify(execFile);
+
+const WEB_ROOT = join(import.meta.dirname, "..");
+const TEST_PORT = Number(process.env.ISSUECTL_LIVE_CODEX_WORKBENCH_PORT ?? 3862);
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+const LIVE_ENABLED = process.env.ISSUECTL_LIVE_CODEX_WORKBENCH_E2E === "1";
+const DEFAULT_REPO = "mean-weasel/issuectl-test-repo-2";
+const TARGET_REPO_REF = process.env.ISSUECTL_LIVE_CODEX_WORKBENCH_REPO ?? DEFAULT_REPO;
+const ALLOWED_E2E_REPOS = new Set([
+  "mean-weasel/issuectl-test-repo",
+  "mean-weasel/issuectl-test-repo-2",
+]);
+const ISSUE_TITLE_PREFIX = "[issuectl-e2e-live]";
+
+type RepoRef = {
+  owner: string;
+  repo: string;
+  ref: string;
+};
+
+type CreatedIssue = {
+  number: number;
+  title: string;
+};
+
+type DeploymentRow = {
+  ended_at: string | null;
+  ttyd_port: number | null;
+  ttyd_pid: number | null;
+};
+
+let tmpDir: string | undefined;
+let dbPath: string | undefined;
+let apiToken = "";
+let server: ChildProcess | undefined;
+let skipReason: string | undefined;
+let createdIssues: CreatedIssue[] = [];
+let deploymentId: number | undefined;
+let deploymentRepo: RepoRef | undefined;
+let deploymentIssueNumber: number | undefined;
+
+function parseRepoRef(raw: string): RepoRef {
+  const [owner, repo, extra] = raw.split("/");
+  if (!owner || !repo || extra) {
+    throw new Error(
+      `Invalid ISSUECTL_LIVE_CODEX_WORKBENCH_REPO: ${JSON.stringify(raw)}. Use owner/repo.`,
+    );
+  }
+  return { owner, repo, ref: `${owner}/${repo}` };
+}
+
+function assertAllowedRepo(repoRef: RepoRef): void {
+  if (!ALLOWED_E2E_REPOS.has(repoRef.ref)) {
+    throw new Error(
+      `Refusing live Codex workbench E2E side effects for ${repoRef.ref}. ` +
+      `Allowed repos: ${[...ALLOWED_E2E_REPOS].join(", ")}`,
+    );
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function canRun(repoRef: RepoRef): Promise<{ ok: true } | { ok: false; reason: string }> {
+  if (!LIVE_ENABLED) {
+    return {
+      ok: false,
+      reason: "Set ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 to run live side-effecting coverage.",
+    };
+  }
+
+  try {
+    assertAllowedRepo(repoRef);
+  } catch (err) {
+    throw err;
+  }
+
+  for (const bin of ["gh", "git", "codex", "ttyd", "tmux"] as const) {
+    try {
+      await execFileAsync("which", [bin]);
+    } catch {
+      return { ok: false, reason: `${bin} is not installed` };
+    }
+  }
+
+  try {
+    await execFileAsync("gh", ["auth", "token"]);
+  } catch {
+    return { ok: false, reason: "gh auth not configured" };
+  }
+
+  try {
+    await execFileAsync("gh", ["repo", "view", repoRef.ref, "--json", "name"]);
+  } catch {
+    return { ok: false, reason: `gh cannot access ${repoRef.ref}` };
+  }
+
+  return { ok: true };
+}
+
+function createTestDb(path: string, repoRef: RepoRef, worktreeDir: string): string {
+  assertAllowedRepo(repoRef);
+  const db = new Database(path);
+  try {
+    initSchema(db);
+    runMigrations(db);
+    const insertSetting = db.prepare(
+      "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+    );
+    for (const [key, value] of [
+      ["branch_pattern", "issue-{number}-{slug}"],
+      ["cache_ttl", "0"],
+      ["worktree_dir", worktreeDir],
+      ["launch_agent", "codex"],
+      ["codex_extra_args", "--sandbox danger-full-access --ask-for-approval never"],
+    ] as const) {
+      insertSetting.run(key, value);
+    }
+    addRepo(db, {
+      owner: repoRef.owner,
+      name: repoRef.repo,
+      branchPattern: "issue-{number}-{slug}",
+    });
+    return generateApiToken(db);
+  } finally {
+    db.close();
+  }
+}
+
+async function waitForServer(url: string, token: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/api/v1/workbench`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) return;
+      lastError = new Error(`Server returned ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw lastError instanceof Error ? lastError : new Error("Server timeout");
+}
+
+async function createMarkedIssue(repoRef: RepoRef, suffix: string): Promise<CreatedIssue> {
+  assertAllowedRepo(repoRef);
+  const title = `${ISSUE_TITLE_PREFIX} ${suffix} ${Date.now()}`;
+  const { stdout } = await execFileAsync("gh", [
+    "issue",
+    "create",
+    "--repo",
+    repoRef.ref,
+    "--title",
+    title,
+    "--body",
+    [
+      "Created by packages/web/e2e/codex-workbench-live.spec.ts.",
+      "This issue is safe to close automatically.",
+    ].join("\n\n"),
+  ]);
+  const match = stdout.match(/\/issues\/(\d+)/);
+  if (!match) {
+    throw new Error(`Could not parse issue number from gh output: ${stdout}`);
+  }
+  return { number: Number(match[1]), title };
+}
+
+async function closeMarkedIssue(repoRef: RepoRef, issue: CreatedIssue): Promise<void> {
+  assertAllowedRepo(repoRef);
+  let title = "";
+  try {
+    const result = await execFileAsync("gh", [
+      "issue",
+      "view",
+      String(issue.number),
+      "--repo",
+      repoRef.ref,
+      "--json",
+      "title",
+      "--jq",
+      ".title",
+    ]);
+    title = result.stdout.trim();
+  } catch {
+    return;
+  }
+  if (!title.startsWith(ISSUE_TITLE_PREFIX)) return;
+  await execFileAsync("gh", [
+    "issue",
+    "close",
+    String(issue.number),
+    "--repo",
+    repoRef.ref,
+    "--reason",
+    "not planned",
+  ]).catch(() => undefined);
+}
+
+async function apiPost(path: string, body: unknown): Promise<Response> {
+  return fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function readDeployment(id: number): DeploymentRow | undefined {
+  if (!dbPath) return undefined;
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare(
+      "SELECT ended_at, ttyd_port, ttyd_pid FROM deployments WHERE id = ?",
+    ).get(id) as DeploymentRow | undefined;
+  } finally {
+    db.close();
+  }
+}
+
+async function cleanupDeployment(): Promise<void> {
+  if (!deploymentRepo || !deploymentIssueNumber) return;
+  assertAllowedRepo(deploymentRepo);
+
+  if (deploymentId) {
+    await apiPost(`/api/v1/deployments/${deploymentId}/end`, {
+      owner: deploymentRepo.owner,
+      repo: deploymentRepo.repo,
+      issueNumber: deploymentIssueNumber,
+    }).catch(() => undefined);
+  }
+
+  const row = deploymentId ? readDeployment(deploymentId) : undefined;
+  if (row?.ttyd_pid) {
+    try {
+      process.kill(row.ttyd_pid, "SIGTERM");
+    } catch {
+      // Already gone.
+    }
+  }
+
+  try {
+    execFileSync("tmux", [
+      "kill-session",
+      "-t",
+      tmuxSessionName(deploymentRepo.repo, deploymentIssueNumber),
+    ], { stdio: "ignore" });
+  } catch {
+    // Already gone.
+  }
+}
+
+async function stopServer(): Promise<void> {
+  if (!server?.pid) return;
+  const killGroup = (signal: NodeJS.Signals) => {
+    try {
+      process.kill(-server!.pid!, signal);
+    } catch {
+      try {
+        server?.kill(signal);
+      } catch {
+        // Already gone.
+      }
+    }
+  };
+  const killTimeout = setTimeout(() => killGroup("SIGKILL"), 5_000);
+  killGroup("SIGTERM");
+  await new Promise<void>((resolve) => {
+    if (!server || server.exitCode !== null) {
+      resolve();
+      return;
+    }
+    server.once("close", () => resolve());
+  });
+  clearTimeout(killTimeout);
+}
+
+async function expectTerminalReady(
+  page: import("@playwright/test").Page,
+  issueNumber: number,
+  seenConsoleMessages: string[],
+): Promise<void> {
+  const iframe = page.locator(`iframe[title="Terminal for issue ${issueNumber}"]`);
+  try {
+    await iframe.waitFor({ state: "visible", timeout: 15_000 });
+  } catch {
+    const reconnect = page.getByRole("button", { name: "Reconnect session" });
+    if (await reconnect.isVisible().catch(() => false)) {
+      await reconnect.click();
+    }
+  }
+  await expect(iframe).toBeVisible({ timeout: 90_000 });
+  await expect(iframe).toHaveAttribute("src", /\/api\/terminal\/\d+\/\?terminalToken=/);
+  await expect.poll(
+    async () => seenConsoleMessages.some((message) =>
+      message.includes("[ttyd] websocket connection opened"),
+    ),
+    { timeout: 90_000, message: "ttyd websocket should open" },
+  ).toBe(true);
+}
+
+test.beforeAll(async () => {
+  const repoRef = parseRepoRef(TARGET_REPO_REF);
+  if (LIVE_ENABLED) {
+    assertAllowedRepo(repoRef);
+  }
+
+  const check = await canRun(repoRef);
+  if (!check.ok) {
+    skipReason = check.reason;
+    return;
+  }
+
+  tmpDir = mkdtempSync(join(tmpdir(), "issuectl-live-codex-workbench-"));
+  dbPath = join(tmpDir, "issuectl.db");
+  apiToken = createTestDb(dbPath, repoRef, join(tmpDir, "worktrees"));
+
+  server = spawn(process.execPath, ["--import", "tsx", "server.ts", "--dev"], {
+    cwd: WEB_ROOT,
+    env: {
+      ...process.env,
+      ISSUECTL_DB_PATH: dbPath,
+      NEXT_DIST_DIR: join(tmpDir, ".next"),
+      NEXT_PRIVATE_SKIP_SETUP: "1",
+      PORT: String(TEST_PORT),
+    },
+    stdio: "pipe",
+    detached: true,
+  });
+
+  let serverOutput = "";
+  server.stdout?.on("data", (chunk: Buffer) => {
+    serverOutput = `${serverOutput}${chunk.toString()}`.slice(-4_000);
+  });
+  server.stderr?.on("data", (chunk: Buffer) => {
+    serverOutput = `${serverOutput}${chunk.toString()}`.slice(-4_000);
+  });
+
+  await waitForServer(BASE_URL, apiToken, 90_000).catch((err) => {
+    throw new Error(`${err.message}\n${serverOutput}`);
+  });
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    await cleanupDeployment();
+  }
+});
+
+test.afterAll(async () => {
+  const repoRef = parseRepoRef(TARGET_REPO_REF);
+  await cleanupDeployment();
+  for (const issue of [...createdIssues].reverse()) {
+    await closeMarkedIssue(repoRef, issue);
+  }
+  await stopServer();
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+  deploymentId = undefined;
+  deploymentRepo = undefined;
+  deploymentIssueNumber = undefined;
+  createdIssues = [];
+});
+
+test("allowlist rejects non-test repositories before side effects", () => {
+  expect(() => assertAllowedRepo(parseRepoRef("mean-weasel/issuectl"))).toThrow(
+    /Refusing live Codex workbench E2E side effects/,
+  );
+  for (const allowed of ALLOWED_E2E_REPOS) {
+    expect(() => assertAllowedRepo(parseRepoRef(allowed))).not.toThrow();
+  }
+});
+
+test("creates a test issue, launches Codex, returns to the running terminal, and cleans up", async ({ page }) => {
+  test.setTimeout(300_000);
+  if (skipReason) test.skip(true, skipReason);
+
+  const repoRef = parseRepoRef(TARGET_REPO_REF);
+  assertAllowedRepo(repoRef);
+  deploymentRepo = repoRef;
+
+  const primaryIssue = await createMarkedIssue(repoRef, "primary");
+  createdIssues.push(primaryIssue);
+  deploymentIssueNumber = primaryIssue.number;
+
+  const otherIssue = await createMarkedIssue(repoRef, "navigation-target");
+  createdIssues.push(otherIssue);
+
+  const launchRes = await apiPost(
+    `/api/v1/launch/${repoRef.owner}/${repoRef.repo}/${primaryIssue.number}`,
+    {
+      agent: "codex",
+      branchName: `issue-${primaryIssue.number}-live-codex-workbench-e2e`,
+      workspaceMode: "clone",
+      selectedCommentIndices: [],
+      selectedFilePaths: [],
+      preamble: "Live E2E: keep the Codex terminal session open for workbench persistence verification.",
+      forceResume: false,
+      idempotencyKey: `live-codex-${Date.now()}`,
+    },
+  );
+  expect(launchRes.status).toBe(200);
+  const launchJson = await launchRes.json() as {
+    success: boolean;
+    deploymentId: number;
+    ttydPort: number;
+  };
+  expect(launchJson.success).toBe(true);
+  deploymentId = launchJson.deploymentId;
+  expect(readDeployment(deploymentId)?.ttyd_pid).toBeGreaterThan(0);
+
+  const consoleMessages: string[] = [];
+  page.on("console", (message) => {
+    consoleMessages.push(message.text());
+  });
+  await page.addInitScript((token) => {
+    window.localStorage.setItem("issuectl.apiToken", token);
+  }, apiToken);
+
+  const repoParam = encodeURIComponent(repoRef.ref);
+  const deploymentUrl = `${BASE_URL}/workbench?repo=${repoParam}&deployment=${deploymentId}`;
+  await page.goto(deploymentUrl, { waitUntil: "networkidle" });
+  await expect(page.getByLabel("Workbench context")).toContainText(
+    `${repoRef.ref} #${primaryIssue.number} terminal`,
+  );
+  await expectTerminalReady(page, primaryIssue.number, consoleMessages);
+
+  await page.goto(`${BASE_URL}/workbench?repo=${repoParam}`, { waitUntil: "networkidle" });
+  await page
+    .getByRole("complementary", { name: "Repo issues" })
+    .getByLabel(`Issue #${otherIssue.number}`)
+    .click();
+  await expect(page.getByRole("heading", {
+    name: new RegExp(`#${otherIssue.number}.*${escapeRegExp(otherIssue.title)}`),
+  })).toBeVisible({ timeout: 30_000 });
+
+  consoleMessages.length = 0;
+  await page.goto(deploymentUrl, { waitUntil: "networkidle" });
+  await expect(page).toHaveURL(new RegExp(`deployment=${deploymentId}$`));
+  await expect(page.getByLabel("Workbench context")).toContainText(
+    `${repoRef.ref} #${primaryIssue.number} terminal`,
+  );
+  await expectTerminalReady(page, primaryIssue.number, consoleMessages);
+
+  const session = page.getByLabel(`Session #${primaryIssue.number}`);
+  await session.getByText("End", { exact: true }).click();
+  await expect(session.getByText("End session?")).toBeVisible();
+  await session.getByRole("button", { name: "End session" }).click();
+  await expect(page.getByLabel(`Session #${primaryIssue.number}`)).toHaveCount(0, { timeout: 30_000 });
+  await expect.poll(() => readDeployment(deploymentId!)?.ended_at ?? null, {
+    timeout: 30_000,
+  }).not.toBeNull();
+
+  await closeMarkedIssue(repoRef, otherIssue);
+  await closeMarkedIssue(repoRef, primaryIssue);
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint app/ components/ lib/",
     "dev": "node --import tsx server.ts --dev",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:live-codex-workbench": "playwright test e2e/codex-workbench-live.spec.ts --project=desktop-chromium"
   },
   "dependencies": {
     "@issuectl/core": "workspace:*",


### PR DESCRIPTION
## Summary

Adds a guarded live Playwright E2E spec for the real Codex workbench launch/session path. The test creates marked issues only in the two approved issuectl test repositories, launches Codex through the workbench, verifies the terminal remains reachable after navigating away and returning, ends the session, and cleans up issues, deployments, ttyd, tmux, temp DB, and worktrees.

Also adds a package script, workflow documentation, and the GoalBuddy board/receipt for the completed tranche.

## Safety

- Live side effects are skipped unless `ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1` is set.
- Repo side effects are explicitly restricted to `mean-weasel/issuectl-test-repo` and `mean-weasel/issuectl-test-repo-2`.
- Cleanup closes only marked test issues whose current title starts with `[issuectl-e2e-live]`.

## Verification

- `git diff --check`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web test -- --run lib/actions/launch.test.ts lib/actions/launch-ensure-ttyd.test.ts`
- `pnpm --dir packages/web test:e2e:live-codex-workbench`
- `ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1 ISSUECTL_LIVE_CODEX_WORKBENCH_REPO=mean-weasel/issuectl-test-repo-2 pnpm --dir packages/web test:e2e:live-codex-workbench`
- pre-commit typecheck/lint
- pre-push build

Fresh live cleanup evidence: marked issues `#11` and `#12` were closed, and tmux sessions `issuectl-issuectl-test-repo-2-11` and `issuectl-issuectl-test-repo-2-12` were absent after cleanup.