### PR TITLE
ci: add macOS runner smoke workflow

### DIFF
--- a/.github/workflows/macos-runner-smoke.yml
+++ b/.github/workflows/macos-runner-smoke.yml
@@ -1,0 +1,62 @@
+name: Mac Runner Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mac-mini-1:
+    name: mac-mini-1
+    runs-on:
+      group: trusted-macos-e2e
+      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-1]
+    timeout-minutes: 10
+    steps:
+      - name: Cleanup before
+        run: /usr/local/ci/bin/macos-runner-cleanup --json
+      - name: Host proof
+        run: |
+          hostname
+          sw_vers
+          uname -m
+      - name: Healthcheck after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-healthcheck --json
+
+  mac-mini-2:
+    name: mac-mini-2
+    runs-on:
+      group: trusted-macos-e2e
+      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-2]
+    timeout-minutes: 10
+    steps:
+      - name: Cleanup before
+        run: /usr/local/ci/bin/macos-runner-cleanup --json
+      - name: Host proof
+        run: |
+          hostname
+          sw_vers
+          uname -m
+      - name: Healthcheck after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-healthcheck --json
+
+  mac-mini-3:
+    name: mac-mini-3
+    runs-on:
+      group: trusted-macos-e2e
+      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-3]
+    timeout-minutes: 10
+    steps:
+      - name: Cleanup before
+        run: /usr/local/ci/bin/macos-runner-cleanup --json
+      - name: Host proof
+        run: |
+          hostname
+          sw_vers
+          uname -m
+      - name: Healthcheck after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-healthcheck --json


### PR DESCRIPTION
Adds a manual-only workflow_dispatch smoke test for the trusted macOS E2E runner pool. It targets mac-mini-1, mac-mini-2, and mac-mini-3 explicitly and runs machine-owned cleanup plus healthcheck proof on each runner.