### PR TITLE
ci: use label matching for mac runner smoke

### DIFF
--- a/.github/workflows/macos-runner-smoke.yml
+++ b/.github/workflows/macos-runner-smoke.yml
@@ -9,9 +9,7 @@ permissions:
 jobs:
   mac-mini-1:
     name: mac-mini-1
-    runs-on:
-      group: trusted-macos-e2e
-      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-1]
+    runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-1]
     timeout-minutes: 10
     steps:
       - name: Cleanup before
@@ -27,9 +25,7 @@ jobs:
 
   mac-mini-2:
     name: mac-mini-2
-    runs-on:
-      group: trusted-macos-e2e
-      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-2]
+    runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-2]
     timeout-minutes: 10
     steps:
       - name: Cleanup before
@@ -45,9 +41,7 @@ jobs:
 
   mac-mini-3:
     name: mac-mini-3
-    runs-on:
-      group: trusted-macos-e2e
-      labels: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-3]
+    runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-3]
     timeout-minutes: 10
     steps:
       - name: Cleanup before


### PR DESCRIPTION
Updates the manual Mac Runner Smoke workflow to target the trusted macOS runners by labels only. The previous group+labels form queued indefinitely even though the runners were online and in the trusted group.