### PR TITLE
ci: set runner paths in mac smoke workflow

### DIFF
--- a/.github/workflows/macos-runner-smoke.yml
+++ b/.github/workflows/macos-runner-smoke.yml
@@ -11,6 +11,9 @@ jobs:
     name: mac-mini-1
     runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-1]
     timeout-minutes: 10
+    env:
+      RUNNER_HOME: /Users/neonwatty
+      RUNNER_WORK: /Users/neonwatty/actions-runner/_work
     steps:
       - name: Cleanup before
         run: /usr/local/ci/bin/macos-runner-cleanup --json
@@ -27,6 +30,9 @@ jobs:
     name: mac-mini-2
     runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-2]
     timeout-minutes: 10
+    env:
+      RUNNER_HOME: /Users/jeremywatt
+      RUNNER_WORK: /Users/jeremywatt/actions-runner/_work
     steps:
       - name: Cleanup before
         run: /usr/local/ci/bin/macos-runner-cleanup --json
@@ -43,6 +49,9 @@ jobs:
     name: mac-mini-3
     runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, mac-mini-3]
     timeout-minutes: 10
+    env:
+      RUNNER_HOME: /Users/jeremywatt
+      RUNNER_WORK: /Users/jeremywatt/actions-runner/_work
     steps:
       - name: Cleanup before
         run: /usr/local/ci/bin/macos-runner-cleanup --json


### PR DESCRIPTION
Sets per-runner RUNNER_HOME and RUNNER_WORK for the manual Mac Runner Smoke workflow so the machine-owned cleanup and healthcheck scripts validate the actual runner user directories.