### PR TITLE
Add feature-flagged PTY bridge terminal

### DIFF
--- a/.github/workflows/macos-runner-smoke.yml
+++ b/.github/workflows/macos-runner-smoke.yml
@@ -15,8 +15,6 @@ jobs:
       RUNNER_HOME: /Users/neonwatty
       RUNNER_WORK: /Users/neonwatty/actions-runner/_work
     steps:
-      - name: Cleanup before
-        run: /usr/local/ci/bin/macos-runner-cleanup --json
       - name: Host proof
         run: |
           hostname
@@ -25,6 +23,9 @@ jobs:
       - name: Healthcheck after
         if: always()
         run: /usr/local/ci/bin/macos-runner-healthcheck --json
+      - name: Cleanup after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-cleanup --json
 
   mac-mini-2:
     name: mac-mini-2
@@ -34,8 +35,6 @@ jobs:
       RUNNER_HOME: /Users/jeremywatt
       RUNNER_WORK: /Users/jeremywatt/actions-runner/_work
     steps:
-      - name: Cleanup before
-        run: /usr/local/ci/bin/macos-runner-cleanup --json
       - name: Host proof
         run: |
           hostname
@@ -44,6 +43,9 @@ jobs:
       - name: Healthcheck after
         if: always()
         run: /usr/local/ci/bin/macos-runner-healthcheck --json
+      - name: Cleanup after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-cleanup --json
 
   mac-mini-3:
     name: mac-mini-3
@@ -53,8 +55,6 @@ jobs:
       RUNNER_HOME: /Users/jeremywatt
       RUNNER_WORK: /Users/jeremywatt/actions-runner/_work
     steps:
-      - name: Cleanup before
-        run: /usr/local/ci/bin/macos-runner-cleanup --json
       - name: Host proof
         run: |
           hostname
@@ -63,3 +63,6 @@ jobs:
       - name: Healthcheck after
         if: always()
         run: /usr/local/ci/bin/macos-runner-healthcheck --json
+      - name: Cleanup after
+        if: always()
+        run: /usr/local/ci/bin/macos-runner-cleanup --json

--- a/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/app.js
+++ b/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/app.js
@@ -1,0 +1,542 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });

--- a/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/index.html
+++ b/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/styles.css
+++ b/docs/goals/pty-bridge-terminal-experiment/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/pty-bridge-terminal-experiment/goal.md
+++ b/docs/goals/pty-bridge-terminal-experiment/goal.md
@@ -1,0 +1,110 @@
+# PTY Bridge Terminal Experiment
+
+## Objective
+
+Turn `docs/specs/2026-05-21-pty-bridge-terminal-design.md` into a concrete, verified implementation sequence for feature-flagged experimentation with an xterm.js + node-pty terminal bridge, while preserving ttyd as the default backend and tmux as the durable issue launch session.
+
+## Original Request
+
+Use GoalBuddy prep to break the PTY bridge terminal design into concrete implementation tasks.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: issuectl maintainers and agents debugging unreliable Codex/Claude issue launch terminal sessions
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: the current tranche is complete when the repo has Phase 0 terminal diagnostics and the first feature-flagged PTY bridge slice planned or implemented with strong verification, without regressing current ttyd-backed launch/session behavior.
+- Goal oracle: diagnostics and tests can distinguish where terminal launch/attach failures happen across the existing ttyd backend and the new experimental PTY bridge path, while default ttyd behavior remains green.
+- Likely misfire: attempting a broad ttyd replacement before validating the design, recording backend state, protecting rollback, and improving current diagnostics.
+- Blind spots considered: native `node-pty` dependency risk, token transport, multi-client write policy, DB naming, active ttyd session compatibility, Apple client parity, and live side-effecting test boundaries.
+- Existing plan facts:
+  - Keep tmux as the source of truth.
+  - Keep ttyd as the default backend during experimentation.
+  - Add Phase 0 telemetry to the current ttyd path before or alongside the bridge.
+  - Add a terminal backend abstraction and record backend per deployment.
+  - Build the PTY bridge as an additive feature-flagged path.
+  - Route each active deployment according to the backend recorded at launch.
+  - Do not log raw terminal input/output, tokens, context files, command strings, or environment variables.
+
+## Goal Oracle
+
+The oracle for this GoalBuddy tranche is:
+
+`A verified implementation plan and first safe work packages exist for the PTY bridge experiment, starting with current ttyd telemetry and backend abstraction, with tests proving existing ttyd launch/session behavior remains green and diagnostics can localize terminal attach failures without recording terminal content.`
+
+This is not a completion claim for full ttyd removal. The full migration remains intentionally phased.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Validate and operationalize the design doc into the first implementation tranche:
+
+1. Baseline current ttyd terminal telemetry in the diagnostics journal.
+2. Prepare backend abstraction and schema/API contracts without changing the default backend.
+3. Define the first PTY bridge MVP slice behind a feature flag.
+4. Keep rollback simple and existing ttyd deployments usable.
+
+## Non-Negotiable Constraints
+
+- Do not replace tmux in this tranche.
+- Do not make PTY bridge the default backend in this tranche.
+- Do not remove ttyd paths while dual-path rollout is still needed.
+- Do not log raw terminal input, raw terminal output, terminal tokens, context file contents, command strings, or environment variables.
+- Existing ttyd launch/session behavior and tests must remain green.
+- Active deployments must route by the backend recorded at launch.
+- Live side-effecting tests must remain explicitly opt-in and restricted to the approved issuectl test repos.
+- No implementation work should proceed without a bounded Worker task with explicit `allowed_files`, verification commands, and stop conditions.
+
+## Stop Rule
+
+Stop only when a final Judge or PM audit proves the current tranche is complete against the oracle.
+
+Do not stop after plan validation if a safe local Worker task can be activated.
+
+Do not mark the full migration complete after Phase 0 telemetry or the first PTY bridge slice. This goal is about executing the first safe tranche of the experiment.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. A good task is the largest safe useful slice.
+
+For this goal, useful slices should produce behavior or enforceable contracts:
+
+- diagnostics emitted and queryable
+- backend stored and returned through APIs
+- feature flag selected but default unchanged
+- PTY bridge attach path proven behind the flag
+- parity tests proving ttyd remains unaffected
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/pty-bridge-terminal-experiment/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/pty-bridge-terminal-experiment/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Compare the active task to `docs/specs/2026-05-21-pty-bridge-terminal-design.md`.
+5. Preserve the design's tmux-first and feature-flagged rollout constraints.
+6. Work only on the active board task.
+7. Assign Scout, Judge, Worker, or PM according to the task.
+8. Write a compact task receipt.
+9. Update the board.
+10. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+11. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the current tranche oracle and records whether the tranche, not the full migration, is complete.

--- a/docs/goals/pty-bridge-terminal-experiment/state.yaml
+++ b/docs/goals/pty-bridge-terminal-experiment/state.yaml
@@ -1,0 +1,733 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "PTY Bridge Terminal Experiment"
+  slug: "pty-bridge-terminal-experiment"
+  kind: existing_plan
+  tranche: "Operationalize the xterm.js + node-pty bridge design into the first feature-flagged implementation tranche, starting with ttyd telemetry and backend contracts."
+  status: done
+  oracle:
+    signal: "A verified first tranche improves current ttyd terminal diagnostics, preserves default ttyd behavior, and prepares a rollback-safe feature-flagged PTY bridge path while keeping tmux as the durable session layer."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Receipts and verification commands show current ttyd launch/session tests remain green, diagnostics can localize terminal attach failures, and the next PTY bridge slice is bounded behind a non-default backend flag."
+  intake:
+    original_request: "Use GoalBuddy prep to break the PTY bridge terminal design into concrete implementation tasks."
+    interpreted_outcome: "The repo has a GoalBuddy board that can drive the first safe tranche of feature-flagged PTY bridge terminal work."
+    input_shape: existing_plan
+    audience: "issuectl maintainers and future agents debugging unreliable launch terminal sessions"
+    authority: requested
+    proof_type: test
+    completion_proof: "A final audit proves the first implementation tranche is complete against the design doc and does not regress ttyd-backed sessions."
+    likely_misfire: "Replacing ttyd broadly before validating telemetry, backend persistence, rollback, and tmux-preserving PTY attach behavior."
+    blind_spots_considered:
+      - "Native node-pty dependency and packaging risk"
+      - "Token transport and websocket auth"
+      - "Multi-client write policy"
+      - "DB schema naming while ttyd fields still exist"
+      - "Active ttyd deployment compatibility"
+      - "Apple client parity"
+      - "Live side-effecting test boundaries"
+      - "Avoiding terminal input/output capture in logs"
+    existing_plan_facts:
+      - "Design doc: docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+      - "Keep tmux as the durable session layer."
+      - "Keep ttyd as the default backend during experimentation."
+      - "Add Phase 0 telemetry for the current ttyd path."
+      - "Add a backend abstraction and record backend per deployment."
+      - "Build PTY bridge as an additive feature-flagged path."
+      - "Route deployments by the backend recorded at launch."
+      - "Do not log raw terminal input/output, tokens, context files, command strings, or environment variables."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/pty-bridge-terminal-experiment/"
+    command: "npx goalbuddy board docs/goals/pty-bridge-terminal-experiment"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Validate the PTY bridge design against current terminal code, diagnostics, schema, and tests, then identify the largest safe first Worker slice."
+    inputs:
+      - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+      - "packages/core/src/launch/launch.ts"
+      - "packages/core/src/launch/ttyd.ts"
+      - "packages/core/src/launch/launch-diagnostics.ts"
+      - "packages/core/src/db/diagnostics.ts"
+      - "packages/core/src/db/deployments.ts"
+      - "packages/web/lib/ensure-ttyd.ts"
+      - "packages/web/lib/terminal-websocket.ts"
+      - "packages/web/lib/terminal-proxy.ts"
+      - "packages/web/components/workbench/TerminalFocus.tsx"
+      - "packages/web/e2e/terminal-*.spec.ts"
+      - "packages/web/e2e/codex-workbench-live.spec.ts"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not run live side-effecting tests."
+      - "Preserve the design decision to keep tmux as durable session source."
+      - "Identify exact current tests and new tests needed for Phase 0 telemetry."
+    expected_output:
+      - "Evidence-backed map of current ttyd diagnostic gaps."
+      - "Recommended first Worker objective."
+      - "allowed_files for the first Worker."
+      - "verify commands for the first Worker."
+      - "stop_if conditions for the first Worker."
+      - "Risks that require Judge review before PTY bridge implementation."
+    receipt:
+      result: done
+      summary: "Validated the PTY bridge design against current ttyd/tmux code, diagnostics, schema, and tests. The largest safe first Worker slice is Phase 0 diagnostics for the current ttyd attach/proxy path: journal terminal open/token/proxy/websocket/first-output/backpressure/close/respawn events without changing default ttyd behavior or adding node-pty."
+      evidence:
+        - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+        - "packages/web/lib/ensure-ttyd.ts:20"
+        - "packages/web/lib/ensure-ttyd.ts:53"
+        - "packages/web/lib/ensure-ttyd.ts:93"
+        - "packages/web/lib/terminal-lifecycle.ts:32"
+        - "packages/web/lib/terminal-lifecycle.ts:96"
+        - "packages/web/lib/terminal-websocket.ts:37"
+        - "packages/web/lib/terminal-websocket.ts:73"
+        - "packages/web/lib/terminal-websocket.ts:90"
+        - "packages/web/lib/terminal-websocket.ts:177"
+        - "packages/web/lib/terminal-websocket.ts:249"
+        - "packages/web/components/workbench/TerminalFocus.tsx:73"
+        - "packages/web/components/workbench/workbench-api.ts:84"
+        - "packages/web/lib/actions/launch-ensure-ttyd.test.ts:86"
+        - "packages/web/lib/terminal-proxy.test.ts:15"
+        - "packages/web/lib/terminal-auth.test.ts:17"
+        - "packages/web/e2e/codex-workbench-live.spec.ts:395"
+      findings:
+        - "Current diagnostics cover launch and explicit ensure-ttyd outcomes, but not all terminal attach/proxy lifecycle events."
+        - "The WebSocket bridge already tracks frames, bytes, drops, and backpressure in web logs; those are not journaled with deployment/issue context."
+        - "The implicit proxy respawn path in terminal-lifecycle logs respawn and tmux-dead outcomes, but does not write diagnostic events like ensure-ttyd does."
+        - "TerminalFocus/checkTerminalProxy turns proxy failures into UI strings, but there is no durable server-side terminal proxy probe event."
+        - "Existing tests already cover ensure-ttyd diagnostics, token validation, proxy HTML rewriting, and live Codex workbench behavior; Phase 0 should extend those rather than introduce node-pty."
+      recommended_worker:
+        objective: "Add Phase 0 diagnostics journal events for current ttyd terminal open, token issuance/failure, proxy probe success/failure, WebSocket connect/first-output/backpressure/close, and implicit respawn/tmux-missing paths without changing terminal behavior."
+        allowed_files:
+          - "packages/web/lib/ensure-ttyd.ts"
+          - "packages/web/lib/terminal-lifecycle.ts"
+          - "packages/web/lib/terminal-websocket.ts"
+          - "packages/web/lib/terminal-proxy.ts"
+          - "packages/web/app/api/terminal/[port]/route.ts"
+          - "packages/web/lib/terminal-diagnostics.ts"
+          - "packages/web/lib/terminal-diagnostics.test.ts"
+          - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+          - "packages/web/lib/terminal-proxy.test.ts"
+          - "packages/web/lib/terminal-auth.test.ts"
+        verify:
+          - "git diff --check"
+          - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts"
+          - "pnpm --dir packages/web typecheck"
+        stop_if:
+          - "Need to add node-pty or xterm dependencies."
+          - "Need to change the default backend away from ttyd."
+          - "Need to log terminal input/output, tokens, context, command strings, or env."
+          - "Need schema changes before Judge approves backend contracts."
+          - "The diagnostics cannot be correlated to deployment/issue without broad DB changes."
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate Scout's recommendation and choose the first largest safe Worker slice for the PTY bridge experiment tranche."
+    inputs:
+      - "T001 receipt"
+      - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+      - "Goal oracle and non-negotiable constraints"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject any slice that changes the default terminal backend away from ttyd."
+      - "Reject any slice that logs raw terminal input/output, tokens, context, command strings, or env."
+      - "Prefer Phase 0 telemetry or backend-contract work before PTY bridge behavior unless Scout proves the bridge slice is safer."
+    expected_output:
+      - "Decision: approved, revise, or blocked."
+      - "Exact Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+      - "Whether a follow-up Judge is required before node-pty dependency introduction."
+    receipt:
+      result: done
+      decision: "approved"
+      summary: "Approve Scout's Phase 0 current-ttyd diagnostics slice as the largest safe first Worker package. It improves evidence for the launch/session failures the PTY bridge experiment is meant to address, does not introduce node-pty or xterm, does not alter default ttyd behavior, and preserves the later backend-contract and PTY dependency gates."
+      rationale:
+        - "The current failure mode needs better terminal attach/proxy lifecycle evidence before adding a second terminal backend."
+        - "The proposed slice is additive diagnostics only and can be verified with existing web unit tests plus a new focused helper test."
+        - "No schema or native dependency changes are required for this first package."
+        - "The no-secret constraint is enforceable by a terminal diagnostics helper that allowlists safe aggregate fields."
+      worker:
+        objective: "Add Phase 0 diagnostics journal events for current ttyd terminal open, token issuance/failure, proxy probe success/failure, WebSocket connect/first-output/backpressure/close, and implicit respawn/tmux-missing paths without changing terminal behavior."
+        allowed_files:
+          - "packages/web/lib/ensure-ttyd.ts"
+          - "packages/web/lib/terminal-lifecycle.ts"
+          - "packages/web/lib/terminal-websocket.ts"
+          - "packages/web/lib/terminal-proxy.ts"
+          - "packages/web/app/api/terminal/[port]/route.ts"
+          - "packages/web/lib/terminal-diagnostics.ts"
+          - "packages/web/lib/terminal-diagnostics.test.ts"
+          - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+          - "packages/web/lib/terminal-proxy.test.ts"
+          - "packages/web/lib/terminal-auth.test.ts"
+        verify:
+          - "git diff --check"
+          - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts"
+          - "pnpm --dir packages/web typecheck"
+        stop_if:
+          - "Need to add node-pty or xterm dependencies."
+          - "Need to change the default backend away from ttyd."
+          - "Need to log terminal input/output, tokens, context, command strings, or env."
+          - "Need schema changes before Judge approves backend contracts."
+          - "The diagnostics cannot be correlated to deployment/issue without broad DB changes."
+      follow_up_gate: "A follow-up Judge remains required before node-pty or xterm dependency introduction."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Add Phase 0 diagnostics journal events for current ttyd terminal open, token issuance/failure, proxy probe success/failure, WebSocket connect/first-output/backpressure/close, and implicit respawn/tmux-missing paths without changing terminal behavior."
+    allowed_files:
+      - "packages/web/lib/ensure-ttyd.ts"
+      - "packages/web/lib/terminal-lifecycle.ts"
+      - "packages/web/lib/terminal-websocket.ts"
+      - "packages/web/lib/terminal-proxy.ts"
+      - "packages/web/app/api/terminal/[port]/route.ts"
+      - "packages/web/lib/terminal-diagnostics.ts"
+      - "packages/web/lib/terminal-diagnostics.test.ts"
+      - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+      - "packages/web/lib/terminal-proxy.test.ts"
+      - "packages/web/lib/terminal-auth.test.ts"
+    verify:
+      - "git diff --check"
+      - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The slice would change the default backend away from ttyd."
+      - "The slice would log terminal input/output, tokens, context, command strings, or env."
+      - "Need schema changes before Judge approves backend contracts."
+      - "Existing ttyd launch/session tests fail twice with different root causes."
+      - "Implementation requires adding node-pty before Judge explicitly approves that dependency boundary."
+    receipt:
+      result: done
+      summary: "Implemented Phase 0 diagnostics for the current ttyd attach/proxy path without changing terminal behavior or introducing node-pty/xterm. Added a terminal diagnostics helper that enriches events with deployment/issue/repo context and allowlists only aggregate diagnostic data."
+      changed_files:
+        - "packages/web/lib/terminal-diagnostics.ts"
+        - "packages/web/lib/terminal-diagnostics.test.ts"
+        - "packages/web/lib/ensure-ttyd.ts"
+        - "packages/web/lib/terminal-lifecycle.ts"
+        - "packages/web/lib/terminal-websocket.ts"
+        - "packages/web/app/api/terminal/[port]/route.ts"
+        - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+        - "packages/web/lib/terminal-proxy.test.ts"
+      events_added:
+        - "terminal.open_requested"
+        - "terminal.token_issued"
+        - "terminal.token_failed"
+        - "terminal.proxy_probe_succeeded"
+        - "terminal.proxy_probe_failed"
+        - "terminal.ws_connected"
+        - "terminal.first_output_seen"
+        - "terminal.backpressure_start"
+        - "terminal.backpressure_clear"
+        - "terminal.ws_closed"
+        - "terminal.ws_upstream_error"
+        - "terminal.ws_client_error"
+        - "terminal.respawn_started"
+        - "terminal.respawned"
+        - "terminal.respawn_failed"
+        - "terminal.tmux_missing"
+        - "terminal.tmux_check_failed"
+        - "terminal.auth_failed"
+        - "terminal.port_invalid"
+        - "terminal.unavailable"
+      safety:
+        - "No terminal input/output frames are written to diagnostics."
+        - "No terminal tokens, context files, command strings, or environment variables are recorded."
+        - "Diagnostic event data is allowlisted to aggregate numeric/boolean counters."
+        - "ttyd remains the default and only implemented terminal backend."
+      verification:
+        - command: "git diff --check"
+          result: pass
+        - command: "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts"
+          result: pass
+          details: "4 files passed, 35 tests passed"
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+        - command: "pnpm --dir packages/web lint"
+          result: pass
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web lint"
+          status: pass
+
+  - id: T004
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the first Worker slice and decide whether the next tranche should be backend schema/contracts or PTY bridge MVP."
+    inputs:
+      - "T003 receipt"
+      - "Current diff"
+      - "Last verification output"
+      - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject progression to node-pty if current ttyd diagnostics or rollback boundaries are weak."
+    expected_output:
+      - "Decision: proceed_to_backend_contracts | proceed_to_pty_mvp | revise_first_slice | blocked."
+      - "Exact next Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+    receipt:
+      result: done
+      decision: "proceed_to_backend_contracts"
+      summary: "The Phase 0 telemetry slice is verified and additive. The next safest slice is terminal backend persistence and ttyd-compatible ensure-terminal contracts. PTY MVP remains deferred until the repo can record backend per deployment and route future attach behavior by that persisted value."
+      evidence:
+        - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+        - "packages/core/src/db/schema.ts"
+        - "packages/core/src/db/migrations.ts"
+        - "packages/core/src/db/deployments.ts"
+        - "packages/core/src/types.ts"
+        - "packages/web/lib/ensure-ttyd.ts"
+      rationale:
+        - "The design requires active deployments to route by the backend recorded at launch."
+        - "Existing ttyd deployments need a default backend value without migration risk."
+        - "A typed ensure-terminal contract can be introduced while preserving the current ensure-ttyd route and UI behavior."
+        - "The node-pty/xterm dependency boundary should stay behind a later Judge gate."
+      worker:
+        objective: "Add terminal backend persistence and ttyd-compatible ensure-terminal contracts while keeping ttyd as the only/default runtime backend."
+        allowed_files:
+          - "packages/core/src/types.ts"
+          - "packages/core/src/index.ts"
+          - "packages/core/src/db/schema.ts"
+          - "packages/core/src/db/migrations.ts"
+          - "packages/core/src/db/deployments.ts"
+          - "packages/core/src/data/unified-list-test-helpers.ts"
+          - "packages/core/src/db/schema-deployments.test.ts"
+          - "packages/core/src/db/schema-invariants.test.ts"
+          - "packages/core/src/db/schema.test.ts"
+          - "packages/core/src/db/deployments-ttyd.test.ts"
+          - "packages/web/lib/ensure-ttyd.ts"
+          - "packages/web/lib/ensure-terminal.ts"
+          - "packages/web/lib/ensure-terminal.test.ts"
+          - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+        verify:
+          - "git diff --check"
+          - "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/ensure-terminal.test.ts"
+          - "pnpm --dir packages/core typecheck"
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/core lint"
+          - "pnpm --dir packages/web lint"
+        stop_if:
+          - "Need to add node-pty or xterm dependencies."
+          - "Need to make pty_bridge selectable before PTY runtime support exists."
+          - "Need to migrate active sessions or rewrite ttyd_port/ttyd_pid semantics."
+          - "Need files outside allowed_files."
+          - "Existing ttyd launch/session behavior changes."
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Add terminal backend persistence and ttyd-compatible ensure-terminal contracts while keeping ttyd as the only/default runtime backend."
+    allowed_files:
+      - "packages/core/src/types.ts"
+      - "packages/core/src/index.ts"
+      - "packages/core/src/db/schema.ts"
+      - "packages/core/src/db/migrations.ts"
+      - "packages/core/src/db/deployments.ts"
+      - "packages/core/src/data/unified-list-test-helpers.ts"
+      - "packages/core/src/db/schema-deployments.test.ts"
+      - "packages/core/src/db/schema-invariants.test.ts"
+      - "packages/core/src/db/schema.test.ts"
+      - "packages/core/src/db/deployments-ttyd.test.ts"
+      - "packages/web/lib/ensure-ttyd.ts"
+      - "packages/web/lib/ensure-terminal.ts"
+      - "packages/web/lib/ensure-terminal.test.ts"
+      - "packages/web/lib/actions/launch-ensure-ttyd.test.ts"
+    verify:
+      - "git diff --check"
+      - "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/ensure-terminal.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core lint"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The slice would migrate or break active ttyd deployments."
+      - "The slice would require node-pty before the dependency boundary is approved."
+      - "The slice would make pty_bridge selectable before PTY runtime support exists."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      summary: "Added terminal backend persistence and a ttyd-compatible ensure-terminal contract while preserving ttyd as the only runtime backend."
+      changed_files:
+        - "packages/core/src/types.ts"
+        - "packages/core/src/index.ts"
+        - "packages/core/src/db/schema.ts"
+        - "packages/core/src/db/migrations.ts"
+        - "packages/core/src/db/deployments.ts"
+        - "packages/core/src/data/unified-list-test-helpers.ts"
+        - "packages/core/src/db/schema-deployments.test.ts"
+        - "packages/core/src/db/schema-invariants.test.ts"
+        - "packages/core/src/db/schema.test.ts"
+        - "packages/core/src/db/deployments-ttyd.test.ts"
+        - "packages/web/lib/ensure-terminal.ts"
+        - "packages/web/lib/ensure-terminal.test.ts"
+      details:
+        - "Schema version advanced to 16 with deployments.terminal_backend TEXT NOT NULL DEFAULT 'ttyd'."
+        - "Deployment rows now map terminalBackend as 'ttyd' | 'pty_bridge'."
+        - "recordDeployment defaults terminalBackend to ttyd and can persist pty_bridge for future gated slices."
+        - "ensureTerminalForDeployment returns a discriminated ttyd response and refuses pty_bridge rows until the runtime exists."
+        - "No xterm/node-pty dependencies were added and no runtime backend selection was enabled."
+      verification:
+        - command: "git diff --check"
+          result: pass
+        - command: "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          result: pass
+          details: "4 files passed, 46 tests passed"
+        - command: "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/ensure-terminal.test.ts"
+          result: pass
+          details: "2 files passed, 13 tests passed"
+        - command: "pnpm --dir packages/core typecheck"
+          result: pass
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+        - command: "pnpm --dir packages/core lint"
+          result: pass
+        - command: "pnpm --dir packages/web lint"
+          result: pass
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/ensure-terminal.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/core typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+        - command: "pnpm --dir packages/core lint"
+          status: pass
+        - command: "pnpm --dir packages/web lint"
+          status: pass
+
+  - id: T006
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Make the dependency and architecture go/no-go decision before any node-pty/xterm PTY bridge MVP work."
+    inputs:
+      - "Done receipts"
+      - "Current package manifests"
+      - "Current verification"
+      - "Design doc open questions"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Explicitly evaluate native dependency risk, rollback, security, and test coverage."
+    expected_output:
+      - "Decision: approve_pty_mvp | defer_pty_mvp | blocked."
+      - "Dependency acceptance criteria."
+      - "Exact PTY bridge MVP Worker objective if approved."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+    receipt:
+      result: done
+      decision: "approve_pty_mvp"
+      summary: "Approve a narrow PTY bridge MVP slice now that Phase 0 telemetry and terminal_backend persistence are in place. The approval is conditional: the bridge must remain non-default, feature-flagged, tmux-preserving, and routed only by a deployment's persisted backend."
+      dependency_acceptance_criteria:
+        - "Add xterm/node-pty dependencies only to packages/web."
+        - "Keep ttyd as the default for all launches unless an explicit non-default experiment path records terminalBackend='pty_bridge'."
+        - "Do not migrate active deployments between backends."
+        - "Killing a PTY attach process must not kill tmux."
+        - "Diagnostics must record lifecycle/counter data only, never terminal input/output, tokens, command strings, context, or env."
+        - "Rollback must be disabling the experiment flag for new sessions while existing ttyd deployments keep working."
+      worker:
+        objective: "Implement the first PTY bridge MVP path behind a non-default experiment flag: xterm client component, server websocket attach route for persisted pty_bridge deployments, node-pty tmux attach lifecycle, and diagnostics, while leaving ttyd UI/launch behavior unchanged by default."
+        allowed_files:
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "packages/web/package.json"
+          - "packages/web/server.ts"
+          - "packages/web/lib/pty-terminal-websocket.ts"
+          - "packages/web/lib/pty-terminal-websocket.test.ts"
+          - "packages/web/lib/ensure-terminal.ts"
+          - "packages/web/lib/ensure-terminal.test.ts"
+          - "packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts"
+          - "packages/web/lib/terminal-auth.ts"
+          - "packages/web/lib/terminal-auth.test.ts"
+          - "packages/web/components/workbench/PtyTerminal.tsx"
+          - "packages/web/components/workbench/PtyTerminal.module.css"
+          - "packages/web/components/workbench/TerminalFocus.tsx"
+          - "packages/web/components/workbench/WorkbenchShell.tsx"
+          - "packages/web/components/workbench/workbench-api.ts"
+          - "packages/web/components/workbench/workbench-types.ts"
+          - "packages/web/components/workbench/WorkbenchShell.module.css"
+        verify:
+          - "git diff --check"
+          - "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/web lint"
+        stop_if:
+          - "Need to make pty_bridge the default backend."
+          - "Need to remove or rewrite ttyd paths."
+          - "Need to log terminal input/output, tokens, command strings, context, or env."
+          - "Need to replace tmux as the durable session layer."
+          - "Native dependency install/build fails twice."
+          - "The slice cannot keep rollback to an experiment flag."
+
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Implement the first PTY bridge MVP path behind a non-default experiment flag: xterm client component, server websocket attach route for persisted pty_bridge deployments, node-pty tmux attach lifecycle, and diagnostics, while leaving ttyd UI/launch behavior unchanged by default."
+    allowed_files:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "packages/web/package.json"
+      - "packages/web/server.ts"
+      - "packages/web/lib/pty-terminal-websocket.ts"
+      - "packages/web/lib/pty-terminal-websocket.test.ts"
+      - "packages/web/lib/ensure-terminal.ts"
+      - "packages/web/lib/ensure-terminal.test.ts"
+      - "packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts"
+      - "packages/web/lib/terminal-auth.ts"
+      - "packages/web/lib/terminal-auth.test.ts"
+      - "packages/web/components/workbench/PtyTerminal.tsx"
+      - "packages/web/components/workbench/PtyTerminal.module.css"
+      - "packages/web/components/workbench/TerminalFocus.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.tsx"
+      - "packages/web/components/workbench/workbench-api.ts"
+      - "packages/web/components/workbench/workbench-types.ts"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+    verify:
+      - "git diff --check"
+      - "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "T006 did not approve PTY MVP."
+      - "Need files outside allowed_files."
+      - "The bridge would replace tmux as durable session layer."
+      - "The bridge would become default."
+      - "The bridge would log raw terminal content or secrets."
+      - "Rollback requires DB surgery."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      summary: "Implemented the first PTY bridge MVP path behind the non-default ISSUECTL_PTY_BRIDGE=1 experiment flag while preserving ttyd as the default and keeping tmux as the durable session layer."
+      changed_files:
+        - "packages/web/package.json"
+        - "pnpm-lock.yaml"
+        - "packages/web/server.ts"
+        - "packages/web/lib/pty-terminal-websocket.ts"
+        - "packages/web/lib/pty-terminal-websocket.test.ts"
+        - "packages/web/lib/ensure-terminal.ts"
+        - "packages/web/lib/ensure-terminal.test.ts"
+        - "packages/web/lib/terminal-auth.ts"
+        - "packages/web/lib/terminal-auth.test.ts"
+        - "packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/PtyTerminal.module.css"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.tsx"
+        - "packages/web/components/workbench/workbench-api.ts"
+        - "packages/web/components/workbench/workbench-types.ts"
+      details:
+        - "Added @xterm/xterm, @xterm/addon-fit, and node-pty to packages/web."
+        - "Added PTY token creation/validation bound to deploymentId and backend='pty_bridge'."
+        - "Added /api/terminal/pty/:deploymentId/ws server upgrade routing."
+        - "Added node-pty attach to tmux attach-session for persisted pty_bridge deployments only."
+        - "Closing the websocket kills only the attach PTY process, not tmux."
+        - "Added PTY diagnostics for attach requested/attached/failed, auth failure, websocket connected/closed/error, first output, resize, backpressure, process exit, and tmux missing."
+        - "Added an xterm client component rendered only when ensure returns pty_bridge metadata."
+      safety:
+        - "ttyd remains the default; no launch path was changed to select pty_bridge by default."
+        - "PTY metadata is returned only for persisted pty_bridge deployments and only when ISSUECTL_PTY_BRIDGE=1."
+        - "Existing ttyd iframe/proxy path remains available."
+        - "Diagnostics record aggregate lifecycle/counter data only, not terminal input/output, tokens, commands, context, or env."
+      verification:
+        - command: "git diff --check"
+          result: pass
+        - command: "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+          result: pass
+          details: "3 files passed, 20 tests passed"
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+        - command: "pnpm --dir packages/web lint"
+          result: pass
+        - command: "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          result: pass
+          details: "4 files passed, 46 tests passed"
+        - command: "pnpm --dir packages/core typecheck"
+          result: pass
+        - command: "pnpm --dir packages/core lint"
+          result: pass
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web lint"
+          status: pass
+        - command: "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/core typecheck"
+          status: pass
+        - command: "pnpm --dir packages/core lint"
+          status: pass
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the current PTY bridge experiment tranche is complete against the oracle."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+      - "Goal oracle"
+    constraints:
+      - "Read-only."
+      - "Reject completion if only planning exists and a required safe Worker remains queued."
+      - "Reject completion if ttyd default behavior lacks verification."
+      - "Reject completion if diagnostics or backend contracts could log terminal content or secrets."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false for the current tranche"
+      - "Evidence mapping to each tranche requirement."
+      - "Missing evidence or next task if not complete."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      scope: "current tranche, not full ttyd removal"
+      evidence:
+        - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+        - "packages/web/lib/terminal-diagnostics.ts"
+        - "packages/web/lib/ensure-ttyd.ts"
+        - "packages/web/lib/terminal-websocket.ts"
+        - "packages/web/app/api/terminal/[port]/route.ts"
+        - "packages/core/src/db/schema.ts"
+        - "packages/core/src/db/migrations.ts"
+        - "packages/core/src/db/deployments.ts"
+        - "packages/web/lib/ensure-terminal.ts"
+        - "packages/web/lib/terminal-auth.ts"
+        - "packages/web/lib/pty-terminal-websocket.ts"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "T003 receipt"
+        - "T005 receipt"
+        - "T007 receipt"
+      mapping:
+        - requirement: "Baseline current ttyd terminal telemetry in the diagnostics journal."
+          proof: "T003 added terminal.open_requested, token, proxy probe, websocket, first-output, backpressure, close/error, respawn, tmux-missing, auth, invalid-port, and unavailable diagnostics with aggregate-only data and focused tests."
+          status: complete
+        - requirement: "Prepare backend abstraction/schema/API contracts without changing the default backend."
+          proof: "T005 added deployments.terminal_backend defaulting to ttyd, typed terminalBackend mapping, recordDeployment defaulting to ttyd, and ensureTerminalForDeployment while tests prove schema/default behavior."
+          status: complete
+        - requirement: "Define or implement the first PTY bridge MVP slice behind a feature flag."
+          proof: "T006 approved the dependency boundary; T007 added @xterm/xterm, @xterm/addon-fit, node-pty, PTY token validation, /api/terminal/pty/:deploymentId/ws routing, node-pty tmux attach, and xterm rendering only for persisted pty_bridge deployments when ISSUECTL_PTY_BRIDGE=1."
+          status: complete
+        - requirement: "Keep rollback simple and existing ttyd deployments usable."
+          proof: "No launch path was changed to make pty_bridge default; ttyd remains the default schema value and existing iframe/proxy route remains in place. Disabling ISSUECTL_PTY_BRIDGE prevents PTY attach metadata and websocket handling."
+          status: complete
+        - requirement: "Keep tmux as the durable session layer."
+          proof: "The PTY bridge uses node-pty only to run tmux attach-session; websocket cleanup kills the attach PTY only and does not end tmux."
+          status: complete
+        - requirement: "Do not log terminal input/output, tokens, context, commands, or env."
+          proof: "Terminal diagnostics helper and PTY diagnostics record lifecycle/counter fields only; token values are not written to diagnostics, and PTY input/output is only forwarded over websocket."
+          status: complete
+        - requirement: "Existing ttyd launch/session behavior and tests remain green."
+          proof: "Focused ttyd diagnostics tests, web tests/typecheck/lint, and core schema/type/lint checks passed after all slices."
+          status: complete
+      verification:
+        - command: "git diff --check"
+          result: pass
+        - command: "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+          result: pass
+          details: "3 files passed, 20 tests passed"
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+        - command: "pnpm --dir packages/web lint"
+          result: pass
+        - command: "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+          result: pass
+          details: "4 files passed, 46 tests passed"
+        - command: "pnpm --dir packages/core typecheck"
+          result: pass
+        - command: "pnpm --dir packages/core lint"
+          result: pass
+      summary: "The current GoalBuddy tranche is complete: ttyd diagnostics, backend persistence/contracts, and a non-default feature-flagged PTY bridge MVP path are implemented and verified. The full migration and ttyd cleanup remain intentionally out of scope."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    commands:
+      - "git diff --check"
+      - "pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/ensure-terminal.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core lint"
+      - "pnpm --dir packages/web lint"
+      - "pnpm --dir packages/web test -- --run lib/ensure-terminal.test.ts lib/terminal-auth.test.ts lib/pty-terminal-websocket.test.ts"
+      - "pnpm --dir packages/web lint"

--- a/docs/specs/2026-05-21-pty-bridge-terminal-design.md
+++ b/docs/specs/2026-05-21-pty-bridge-terminal-design.md
@@ -1,0 +1,514 @@
+# xterm.js + PTY Bridge Terminal Design
+
+**Date:** 2026-05-21
+**Status:** Proposed
+**Motivation:** Improve launch-session stability and diagnostics by experimenting with an issuectl-owned terminal bridge instead of relying on ttyd as the browser terminal server.
+
+## Summary
+
+issuectl has consistent trouble getting issue launch terminal sessions up, attached, and recoverable. The current architecture has improved substantially: tmux is now the durable session layer, ttyd is treated as a disposable web frontend, the web server proxies ttyd through same-origin routes, and the diagnostics journal records launch and reconnect lifecycle events. Even with those improvements, the terminal interaction boundary is still largely owned by ttyd. That limits what issuectl can observe when the UI fails to attach, when ttyd accepts a process but the browser never sees output, or when websocket/proxy failures occur after launch activation.
+
+This design proposes a feature-flagged experiment that keeps tmux as the durable work session but replaces ttyd, for opted-in launches, with:
+
+- xterm.js in the browser
+- a server-side WebSocket endpoint owned by issuectl
+- node-pty attaching to `tmux attach-session -t <sessionName>`
+
+The core rule is:
+
+```text
+Keep tmux as the source of truth. Replace ttyd as the browser/PTY bridge.
+```
+
+This gives issuectl much richer terminal telemetry without changing the most important stability invariant: closing, reloading, or crashing the browser terminal must not kill the agent session.
+
+## Current Architecture
+
+Today a launch flows through `executeLaunch` in `packages/core/src/launch/launch.ts`.
+
+1. Record `launch.requested`.
+2. Verify `ttyd` and `tmux`.
+3. Fetch issue detail, write context, and prepare the workspace.
+4. Insert a deployment row as `pending`.
+5. Allocate and reserve a ttyd port.
+6. `spawnTtyd` creates a detached tmux session running the agent command.
+7. `spawnTtyd` starts `ttyd -W -i 127.0.0.1 -p <port> -q tmux attach-session -t <session>`.
+8. The deployment row gets `ttyd_port` and `ttyd_pid`.
+9. The deployment is activated.
+
+Relevant files:
+
+- `packages/core/src/launch/launch.ts`
+- `packages/core/src/launch/ttyd.ts`
+- `packages/core/src/db/deployments.ts`
+- `packages/core/src/launch/launch-diagnostics.ts`
+
+Workbench opens terminals through `TerminalFocus`:
+
+1. Call `/api/v1/deployments/:id/ensure-ttyd`.
+2. Ensure ttyd is alive, or respawn ttyd if tmux is still alive.
+3. Create a short-lived terminal token.
+4. Probe `/api/terminal/:port/`.
+5. Render an iframe pointed at the proxied ttyd page.
+
+Relevant files:
+
+- `packages/web/components/workbench/TerminalFocus.tsx`
+- `packages/web/lib/ensure-ttyd.ts`
+- `packages/web/lib/terminal-auth.ts`
+- `packages/web/lib/terminal-proxy.ts`
+- `packages/web/lib/terminal-websocket.ts`
+- `packages/web/server.ts`
+
+The important existing invariant is that tmux is the liveness signal. ttyd may exit when all browser clients disconnect; issuectl can respawn it and reattach to the same tmux session.
+
+## Telemetry Today
+
+The diagnostics journal already records useful lifecycle events:
+
+- `launch.requested`
+- `workspace.prepared`
+- `deployment.recorded`
+- `ttyd.spawned`
+- `deployment.activated`
+- `launch.spawn_failed`
+- `launch.activation_failed`
+- `ensure_ttyd.alive`
+- `ensure_ttyd.respawned`
+- `ensure_ttyd.failed`
+- `reconcile.tmux_missing`
+- `liveness.tmux_missing`
+
+The CLI can inspect those events through:
+
+```sh
+pnpm --dir packages/cli exec issuectl diag list --limit 50
+pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>
+pnpm --dir packages/cli exec issuectl diag show --issue <owner>/<repo>#<issue-number>
+```
+
+This is a good base, but several high-value terminal states still live outside the diagnostics journal.
+
+## Current Diagnostic Gaps
+
+The current ttyd path is difficult to debug in these areas:
+
+- `spawnTtyd` only checks that the ttyd PID survives for 300ms. It does not prove ttyd accepted HTTP, websocket, or first terminal output.
+- ttyd child-process `error` handlers log to raw logs, not the diagnostics journal.
+- The proxy websocket path records structured web logs for connect/close/backpressure, but those are not consistently journaled with deployment and issue IDs.
+- Browser probe failures collapse into UI strings such as "Terminal proxy returned 502" without a durable attempt ID or terminal lifecycle event.
+- Upgrade failures such as auth rejection, invalid port, upstream socket errors, and backpressure are hard to correlate from `diag show`.
+- Activation failure is journaled, but an already-open tmux/ttyd pair may need manual cleanup.
+- ttyd owns the terminal protocol boundary, so issuectl cannot directly observe first output, input activity timestamps, resize behavior, PTY exit, or attach process lifecycle.
+
+## Options Considered
+
+### Option 1: Full ttyd Replacement
+
+Replace ttyd immediately with xterm.js and a server PTY bridge for all launches.
+
+Pros:
+
+- Removes the ttyd dependency quickly.
+- Gives issuectl complete control over terminal UI, auth, resize, backpressure, and telemetry.
+- Simplifies same-origin terminal serving by removing ttyd HTML rewriting and iframe proxying.
+
+Cons:
+
+- Highest risk to launch-session stability.
+- Current DB fields, tests, UI, diagnostics, and routes are ttyd-shaped.
+- A broad replacement could accidentally weaken the tmux durability model.
+- Rollback would be harder if active deployments are migrated in place.
+
+Decision: not recommended.
+
+### Option 2: Telemetry-Only ttyd Improvements
+
+Keep ttyd and add more diagnostics around the existing proxy, respawn, and browser attach flow.
+
+Pros:
+
+- Lowest behavior risk.
+- Creates a baseline for current instability.
+- Immediately improves diagnostics for existing users.
+
+Cons:
+
+- Does not remove the opaque ttyd terminal boundary.
+- Still leaves issuectl dependent on ttyd HTML, websocket protocol, and process behavior.
+- Cannot expose the same quality of PTY lifecycle telemetry as an owned bridge.
+
+Decision: useful Phase 0, but not enough by itself.
+
+### Option 3: Feature-Flagged Dual Path
+
+Keep ttyd as the default backend and add an experimental `pty_bridge` backend for new opted-in deployments. Preserve tmux as the durable session and have node-pty attach to tmux.
+
+Pros:
+
+- Preserves existing launch/session behavior for normal users.
+- Allows per-session rollback by choosing the backend at launch time.
+- Lets both paths run side by side while tests and diagnostics prove parity.
+- Provides the telemetry benefits of owning the browser/PTY boundary.
+
+Cons:
+
+- Temporarily duplicates terminal attach, ensure, UI, and testing paths.
+- Requires native `node-pty` dependency management.
+- Requires careful schema/API naming while old `ttyd_*` fields still exist.
+
+Decision: recommended.
+
+## Recommended Architecture
+
+Add a terminal backend abstraction with at least two implementations:
+
+```ts
+type TerminalBackend = "ttyd" | "pty_bridge";
+```
+
+The default remains `ttyd`. The PTY bridge is enabled through an env flag or setting, then recorded per deployment when the launch is created.
+
+### Durable Session Layer
+
+Do not replace tmux in the first implementation.
+
+Launch should still create a detached tmux session running the selected agent command. The PTY bridge should attach to that existing session:
+
+```sh
+tmux attach-session -t <sessionName>
+```
+
+This preserves:
+
+- browser navigation persistence
+- web app restart recovery
+- shared session viewing
+- session previews through tmux capture
+- reconciliation through tmux liveness
+- end-session cleanup semantics
+
+### Browser Terminal
+
+Replace the iframe path only for `pty_bridge` deployments.
+
+Add a React terminal component that uses:
+
+- `@xterm/xterm`
+- `@xterm/addon-fit`
+- optionally `@xterm/addon-web-links`
+
+Client protocol:
+
+```ts
+// client -> server
+{ type: "input"; data: string }
+{ type: "resize"; cols: number; rows: number }
+
+// server -> client
+{ type: "ready" }
+{ type: "output"; data: string }
+{ type: "exit"; code?: number; signal?: string }
+{ type: "error"; message: string }
+```
+
+The client must not log terminal input or output. It may record aggregate counters and lifecycle events.
+
+### Server PTY Bridge
+
+Add a WebSocket upgrade route such as:
+
+```text
+/api/terminal/pty/:deploymentId/ws
+```
+
+The handler should:
+
+1. Validate the terminal token.
+2. Load the active deployment.
+3. Check that the deployment backend is `pty_bridge`.
+4. Derive the tmux session name from repo and issue number.
+5. Verify tmux is alive.
+6. Spawn a node-pty child process for `tmux attach-session -t <sessionName>`.
+7. Pipe xterm input to the PTY.
+8. Pipe PTY output to the browser.
+9. Apply backpressure protections.
+10. On websocket close, kill only the attach PTY, not tmux.
+
+This belongs beside the existing websocket bridge:
+
+- Current ttyd bridge: `packages/web/lib/terminal-websocket.ts`
+- New PTY bridge: `packages/web/lib/pty-terminal-websocket.ts`
+
+The custom server in `packages/web/server.ts` can continue to own WebSocket upgrade routing.
+
+### Backend Compatibility
+
+The first version should keep the existing `ttyd_port` and `ttyd_pid` columns. For PTY bridge deployments they can be null.
+
+Add only the minimum schema needed:
+
+- `deployments.terminal_backend TEXT NOT NULL DEFAULT 'ttyd'`
+
+Longer term, after ttyd is removed, rename or replace ttyd-specific fields with neutral terminal metadata. Do not do that in the experimental phase.
+
+### API Shape
+
+Rename concepts without breaking the ttyd path:
+
+- `ensureTtydForDeployment` becomes or delegates to `ensureTerminalForDeployment`.
+- The response includes backend-specific attach metadata.
+- TTYD deployments return `{ backend: "ttyd", port, terminalToken }`.
+- PTY bridge deployments return `{ backend: "pty_bridge", deploymentId, terminalToken, wsUrl }`.
+
+Existing active ttyd deployments must continue to open through the old port route until they end.
+
+## Diagnostics Design
+
+Diagnostics are a first-class acceptance criterion. The PTY bridge should not log raw terminal input, raw terminal output, context file contents, command strings, environment variables, or terminal tokens.
+
+Safe events:
+
+| Event | When |
+| --- | --- |
+| `terminal.open_requested` | Browser asks to open any terminal backend |
+| `terminal.token_issued` | A terminal token is created |
+| `terminal.token_failed` | Token creation fails |
+| `terminal.proxy_probe_succeeded` | Browser/server probe succeeds for ttyd |
+| `terminal.proxy_probe_failed` | Browser/server probe fails for ttyd |
+| `pty.bridge_attach_requested` | PTY websocket attach starts |
+| `pty.bridge_attached` | node-pty attach process is ready |
+| `pty.bridge_attach_failed` | Attach fails before ready |
+| `pty.ws_connected` | Browser websocket accepted |
+| `pty.first_output_seen` | First PTY output reaches server |
+| `pty.resize` | Terminal size changes, sampled or rate-limited |
+| `pty.backpressure_start` | Client buffering exceeds threshold |
+| `pty.backpressure_clear` | Backpressure episode ends |
+| `pty.ws_closed` | Browser websocket closes |
+| `pty.process_exit` | Attach PTY exits |
+| `pty.tmux_missing` | Deployment is active but tmux session is gone |
+| `pty.auth_failed` | Auth fails, with reason category only |
+
+Useful fields:
+
+- `correlationId`
+- `deploymentId`
+- `owner`
+- `repo`
+- `issueNumber`
+- `sessionName`
+- `status`
+- `message`
+- `data.backend`
+- `data.durationMs`
+- `data.cols`
+- `data.rows`
+- `data.bytesToClient`
+- `data.bytesFromClient`
+- `data.framesToClient`
+- `data.framesFromClient`
+- `data.closeReason`
+- `data.exitCode`
+- `data.signal`
+
+For privacy, client identity should be coarse. If a client IP is recorded, hash it or record only a category such as `local`, `lan`, or `remote`.
+
+## Security
+
+### Terminal Tokens
+
+Current terminal tokens are signed with the API token, include a port, and expire after 10 minutes. For the PTY bridge:
+
+- token payload should bind to `deploymentId`, `backend`, and expiration
+- token validation should confirm the deployment is active
+- token validation should confirm the deployment backend matches the requested route
+- token should not be written to diagnostics or logs
+
+Prefer moving token transport away from query strings when practical. A short-lived one-time ticket endpoint or WebSocket subprotocol would reduce URL/referrer exposure. Query-string compatibility is acceptable for the initial experiment if tokens remain short-lived and redacted from logs.
+
+### Multi-Client Attach
+
+tmux supports multiple clients. The PTY bridge should preserve this, but write access needs an explicit policy.
+
+Initial policy:
+
+- multiple clients may attach
+- all authenticated clients may write, matching current ttyd behavior
+- diagnostics record active attach count
+
+Future policy:
+
+- consider read-only secondary viewers
+- consider focus ownership for write access
+
+### Process Ownership
+
+The web server will own node-pty attach children. It must track them and kill them on:
+
+- websocket close
+- auth/deployment invalidation
+- end session
+- server shutdown
+
+Killing an attach PTY must not kill the tmux session unless the user explicitly ends the session.
+
+### Backpressure
+
+The current websocket bridge tracks frames, bytes, dropped frames, and backpressure. The PTY bridge must keep equivalent protections so a slow browser cannot grow memory unbounded.
+
+## Phased Plan
+
+### Phase 0: Baseline Current ttyd Telemetry
+
+Before building the bridge, add journal events to the current path:
+
+- terminal open requested
+- token issued/failed
+- proxy HEAD success/failure
+- websocket connect/close
+- upstream websocket open/error/close
+- first output frame seen
+- backpressure start/clear
+- respawn start/success/failure
+- tmux missing
+
+This gives a before/after comparison and helps debug current launch failures immediately.
+
+### Phase 1: Terminal Backend Abstraction
+
+Add:
+
+- `terminal_backend` deployment field
+- backend selection setting or env flag
+- shared `ensureTerminalForDeployment`
+- shared terminal token model
+- API response that can describe ttyd or PTY bridge attach metadata
+
+Keep ttyd as default.
+
+### Phase 2: PTY Bridge MVP
+
+Add:
+
+- xterm.js terminal component
+- `/api/terminal/pty/:deploymentId/ws` upgrade handling
+- node-pty attach to existing tmux sessions
+- resize/input/output protocol
+- PTY diagnostics
+- attach cleanup on websocket close
+
+Do not remove ttyd.
+
+### Phase 3: Dual-Path Rollout
+
+Allow opt-in per environment, repo, or launch session.
+
+Requirements:
+
+- active ttyd deployments continue using ttyd
+- active PTY bridge deployments continue using PTY bridge
+- switching the default affects only new deployments
+- rollback is a setting/env change, not a DB migration
+
+### Phase 4: Default Switch
+
+Switch new deployments to PTY bridge only after:
+
+- parity tests pass
+- live Codex workbench E2E passes on PTY bridge
+- diagnostics show attach failures are lower or easier to diagnose
+- manual dogfooding confirms mobile and desktop terminal behavior
+
+### Phase 5: ttyd Cleanup
+
+Remove ttyd after a rollback window:
+
+- remove ttyd install requirement
+- remove ttyd HTTP proxy routes
+- remove ttyd respawn code
+- remove port allocation
+- rename/remove ttyd-specific DB fields
+- update docs and diagnostics event names
+
+## Acceptance Criteria
+
+The experiment is successful only if these are true:
+
+- Closing the terminal UI does not end the agent session.
+- Browser refresh and workbench navigation can reattach to the same tmux session.
+- Server restart does not lose the durable session.
+- Two browser clients can attach to the same session and see shared state.
+- End Session kills attach PTYs, kills tmux, marks deployment ended, and removes UI session state.
+- PTY bridge failures do not kill tmux unless the user explicitly ends the session.
+- Existing ttyd deployments remain usable while the dual path exists.
+- Diagnostics distinguish ttyd backend failures from PTY bridge failures.
+- Diagnostics can identify whether a failure happened before tmux creation, after tmux creation, during attach, before first output, during websocket transport, or during cleanup.
+- No raw terminal input or output is recorded.
+
+## Test Plan
+
+### Unit Tests
+
+- backend selection from env/setting
+- deployment backend persistence
+- terminal token validation for ttyd vs PTY bridge
+- invalid token, expired token, wrong backend, ended deployment
+- PTY protocol message parsing
+- resize validation and clamping
+- liveness uses tmux, not bridge PID
+
+### Integration Tests
+
+- launch creates tmux before terminal attach
+- pending deployment rolls back if tmux creation fails
+- PTY attach failure does not kill tmux
+- end session kills tmux and active attach PTYs
+- startup reconciliation marks tmux-missing deployments ended
+
+### Web Tests
+
+- `ensureTerminalForDeployment` returns ttyd metadata for ttyd deployments
+- `ensureTerminalForDeployment` returns PTY metadata for PTY bridge deployments
+- TerminalFocus renders iframe for ttyd
+- TerminalFocus renders xterm component for PTY bridge
+- reconnect after navigation reuses the same deployment/session
+- terminal unavailable states remain actionable
+
+### E2E Tests
+
+Mirror existing terminal coverage for the PTY bridge:
+
+- terminal persistence across navigation
+- raw respawn/reconnect equivalent, now attach-process restart
+- shared terminal clients
+- stale tmux reconciliation
+- end-session cleanup
+- opt-in live Codex workbench E2E using `ISSUECTL_LIVE_CODEX_WORKBENCH_E2E=1`
+
+Keep current ttyd E2E tests while the dual path exists.
+
+## Rollback
+
+Rollback must be simple:
+
+1. Set default backend back to `ttyd`.
+2. Existing PTY bridge deployments continue until ended or can be ended manually.
+3. Existing ttyd deployments are unaffected.
+4. No DB surgery is required.
+5. Do not migrate active sessions between backends.
+
+If the PTY bridge has a severe bug, disabling new PTY bridge launches should be enough to stabilize the product while preserving active tmux sessions.
+
+## Open Questions
+
+- Should PTY bridge be selected by env flag only, by settings UI, or both?
+- Should secondary browser clients be read-only in the first bridge implementation?
+- Should terminal tokens move to one-time websocket tickets during Phase 2, or remain compatible with current signed query tokens until Phase 4?
+- Should diagnostics journal schema add neutral `terminalBackend` / `terminalPid` fields, or keep backend-specific details inside `data_json` during the experiment?
+- Should PTY bridge live in `packages/web` only, or should terminal backend abstractions move into `packages/core` for Apple client parity?
+
+## Recommendation
+
+Proceed with the feature-flagged dual path.
+
+Start with Phase 0 telemetry because it improves current debugging immediately and gives us a baseline. Then implement the PTY bridge as an additive backend that attaches to tmux. This approach gives issuectl much better observability at the terminal boundary while preserving the durable-session architecture that already fixed the worst ttyd persistence failure mode.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^22.14.0",
     "eslint": "^10.2.0",
     "husky": "^9.1.7",
+    "node-gyp": "^12.3.0",
     "prettier": "^3.5.3",
     "semantic-release": "^25.0.3",
     "tsup": "^8.4.0",
@@ -48,5 +49,14 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.3"
+  },
+  "pnpm": {
+    "packageExtensions": {
+      "node-pty@*": {
+        "dependencies": {
+          "node-gyp": "^12.3.0"
+        }
+      }
+    }
   }
 }

--- a/packages/core/src/data/unified-list-test-helpers.ts
+++ b/packages/core/src/data/unified-list-test-helpers.ts
@@ -51,6 +51,7 @@ export function makeDeployment(issueNumber: number, ended = false): Deployment {
     workspacePath: `/tmp/${issueNumber}`,
     linkedPrNumber: null,
     state: "active",
+    terminalBackend: "ttyd",
     launchedAt: "2026-04-01T00:00:00Z",
     endedAt: ended ? "2026-04-02T00:00:00Z" : null,
     ttydPort: null,

--- a/packages/core/src/db/deployments-ttyd.test.ts
+++ b/packages/core/src/db/deployments-ttyd.test.ts
@@ -40,6 +40,23 @@ describe("reserveTtydPort", () => {
     const updated = getDeploymentById(db, dep.id);
     expect(updated!.ttydPort).toBe(7700);
     expect(updated!.ttydPid).toBeNull();
+    expect(updated!.terminalBackend).toBe("ttyd");
+  });
+
+  it("persists an explicit terminal backend", () => {
+    const dep = recordDeployment(db, {
+      repoId,
+      issueNumber: 1,
+      branchName: "issue-1",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+      terminalBackend: "pty_bridge",
+    });
+
+    const updated = getDeploymentById(db, dep.id);
+    expect(updated!.terminalBackend).toBe("pty_bridge");
+    expect(updated!.ttydPort).toBeNull();
+    expect(updated!.ttydPid).toBeNull();
   });
 
   it("makes the reserved port visible to concurrent allocatePort calls (#198)", () => {

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import type { Deployment, DeploymentState, LaunchAgent } from "../types.js";
+import type { Deployment, DeploymentState, LaunchAgent, TerminalBackend } from "../types.js";
 
 type DeploymentRow = {
   id: number;
@@ -11,6 +11,7 @@ type DeploymentRow = {
   workspace_path: string;
   linked_pr_number: number | null;
   state: string;
+  terminal_backend: string;
   launched_at: string;
   ended_at: string | null;
   ttyd_port: number | null;
@@ -29,6 +30,7 @@ function rowToDeployment(row: DeploymentRow): Deployment {
     workspacePath: row.workspace_path,
     linkedPrNumber: row.linked_pr_number,
     state: (row.state as DeploymentState) ?? "active",
+    terminalBackend: (row.terminal_backend as TerminalBackend | undefined) ?? "ttyd",
     launchedAt: row.launched_at,
     endedAt: row.ended_at,
     ttydPort: row.ttyd_port,
@@ -46,6 +48,7 @@ export function recordDeployment(
     workspaceMode: Deployment["workspaceMode"];
     workspacePath: string;
     agent?: LaunchAgent;
+    terminalBackend?: TerminalBackend;
     /**
      * Optional initial state. Defaults to "active" for callers that want
      * the legacy one-shot write. The launch flow passes "pending" so the
@@ -58,15 +61,18 @@ export function recordDeployment(
 ): Deployment {
   const state: DeploymentState = deployment.state ?? "active";
   const agent: LaunchAgent = deployment.agent ?? "claude";
+  const terminalBackend: TerminalBackend = deployment.terminalBackend ?? "ttyd";
   const result = db
     .prepare(
-      `INSERT INTO deployments (repo_id, issue_number, agent, branch_name, workspace_mode, workspace_path, state)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO deployments (
+        repo_id, issue_number, agent, terminal_backend, branch_name, workspace_mode, workspace_path, state
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       deployment.repoId,
       deployment.issueNumber,
       agent,
+      terminalBackend,
       deployment.branchName,
       deployment.workspaceMode,
       deployment.workspacePath,

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -329,6 +329,22 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 16,
+    up(db) {
+      const { c } = db
+        .prepare(
+          "SELECT COUNT(*) as c FROM sqlite_master WHERE type = 'table' AND name = 'deployments'",
+        )
+        .get() as { c: number };
+      if (c === 0) return;
+
+      db.exec(`
+        ALTER TABLE deployments ADD COLUMN terminal_backend TEXT NOT NULL DEFAULT 'ttyd'
+          CHECK (terminal_backend IN ('ttyd', 'pty_bridge'));
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/core/src/db/schema-deployments.test.ts
+++ b/packages/core/src/db/schema-deployments.test.ts
@@ -7,7 +7,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
   it("initSchema on a fresh DB produces the current schema version", () => {
     const db = createRawTestDb();
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
   });
 
   it("fresh schema includes the drafts table", () => {
@@ -38,6 +38,16 @@ describe("schema v5 — drafts and issue_metadata", () => {
     const agentCol = cols.find((c) => c.name === "agent");
     expect(agentCol).toBeDefined();
     expect(agentCol?.dflt_value).toContain("claude");
+  });
+
+  it("fresh deployments schema includes terminal backend defaulting to ttyd", () => {
+    const db = createTestDb();
+    const cols = db
+      .prepare("PRAGMA table_info(deployments)")
+      .all() as { name: string; dflt_value: string | null }[];
+    const terminalBackendCol = cols.find((c) => c.name === "terminal_backend");
+    expect(terminalBackendCol).toBeDefined();
+    expect(terminalBackendCol?.dflt_value).toContain("ttyd");
   });
 
   it("drafts table enforces the priority CHECK constraint", () => {
@@ -83,7 +93,7 @@ describe("schema v5 — drafts and issue_metadata", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     const drafts = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'drafts'",
@@ -103,6 +113,9 @@ describe("schema v5 — drafts and issue_metadata", () => {
     const stateCol = cols.find((c) => c.name === "state");
     expect(stateCol).toBeDefined();
     expect(stateCol?.dflt_value).toContain("active");
+    const terminalBackendCol = cols.find((c) => c.name === "terminal_backend");
+    expect(terminalBackendCol).toBeDefined();
+    expect(terminalBackendCol?.dflt_value).toContain("ttyd");
   });
 });
 
@@ -171,7 +184,7 @@ describe("schema v8 — deployments FK cascade", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
 
     // Pre-existing row should have been copied over with its state intact
     const row = db
@@ -254,7 +267,7 @@ describe("schema v9 — live deployment unique index", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     // Row id=1 (older duplicate) → ended. id=2 (most recent live) → live.
     // id=3 (historic ended) → still ended, untouched.
     const live = db

--- a/packages/core/src/db/schema-invariants.test.ts
+++ b/packages/core/src/db/schema-invariants.test.ts
@@ -134,7 +134,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
       runMigrations(db);
     }).not.toThrow();
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
 
     // Verify the dedupe ran and the index now exists.
     const live = db
@@ -164,7 +164,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
 
   it("v10 migration creates github_accessible_repos with expected columns", () => {
     const db = createTestDb();
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
 
     const cols = db
       .prepare("PRAGMA table_info(github_accessible_repos)")
@@ -179,7 +179,7 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
     expect(pkCols).toEqual(["name", "owner"]);
   });
 
-  it("v12 to v15 migration adds deployment agent, default settings, push devices, and diagnostics", () => {
+  it("v12 to v16 migration adds deployment agent, default settings, push devices, diagnostics, and terminal backend", () => {
     const db = createRawTestDb();
     db.exec(`
       CREATE TABLE schema_version (version INTEGER NOT NULL);
@@ -215,11 +215,12 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     const deployment = db
-      .prepare("SELECT agent FROM deployments WHERE id = 1")
-      .get() as { agent: string };
+      .prepare("SELECT agent, terminal_backend FROM deployments WHERE id = 1")
+      .get() as { agent: string; terminal_backend: string };
     expect(deployment.agent).toBe("claude");
+    expect(deployment.terminal_backend).toBe("ttyd");
     expect(
       (db.prepare("SELECT value FROM settings WHERE key = 'launch_agent'").get() as { value: string })
         .value,
@@ -230,6 +231,9 @@ describe("initSchema does not deadlock against pre-existing duplicate live deplo
     ).toBe("");
     expect(() =>
       db.prepare("UPDATE deployments SET agent = 'unknown' WHERE id = 1").run(),
+    ).toThrow();
+    expect(() =>
+      db.prepare("UPDATE deployments SET terminal_backend = 'unknown' WHERE id = 1").run(),
     ).toThrow();
     const pushDeviceCols = db
       .prepare("PRAGMA table_info(push_devices)")

--- a/packages/core/src/db/schema.test.ts
+++ b/packages/core/src/db/schema.test.ts
@@ -38,13 +38,13 @@ describe("initSchema", () => {
 
   it("sets schema_version to 15", () => {
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
   });
 
   it("is idempotent — calling twice does not error or change version", () => {
     initSchema(db);
     initSchema(db);
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
   });
 });
 
@@ -61,7 +61,7 @@ describe("runMigrations", () => {
     const db = createRawTestDb();
     initSchema(db);
     runMigrations(db);
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
   });
 
   it("migrates v1 schema through v9 and drops claude_aliases", () => {
@@ -77,7 +77,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -101,7 +101,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     db.prepare("INSERT INTO deployments (repo_id, issue_number, branch_name, workspace_mode, workspace_path, launched_at, ended_at) VALUES (1, 1, 'b', 'existing', '/x', '2025-01-01', NULL)").run();
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
@@ -144,7 +144,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claude_aliases'")
       .all();
@@ -175,7 +175,7 @@ describe("runMigrations", () => {
 
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(15);
+    expect(getSchemaVersion(db)).toBe(16);
     const cols = db
       .prepare("PRAGMA table_info(diagnostic_events)")
       .all() as { name: string; pk: number }[];

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 16;
 
 const CREATE_TABLES = `
   CREATE TABLE IF NOT EXISTS repos (
@@ -30,6 +30,8 @@ const CREATE_TABLES = `
     linked_pr_number INTEGER,
     state            TEXT NOT NULL DEFAULT 'active'
                      CHECK (state IN ('pending', 'active')),
+    terminal_backend TEXT NOT NULL DEFAULT 'ttyd'
+                     CHECK (terminal_backend IN ('ttyd', 'pty_bridge')),
     launched_at      TEXT NOT NULL DEFAULT (datetime('now')),
     ended_at         TEXT,
     ttyd_port        INTEGER,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type {
   Deployment,
   DeploymentState,
   LaunchAgent,
+  TerminalBackend,
   CacheEntry,
   Draft,
   DraftInput,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -29,6 +29,7 @@ import type { GitHubIssue } from "./github/types.js";
 
 export type DeploymentState = "pending" | "active";
 export type LaunchAgent = "claude" | "codex";
+export type TerminalBackend = "ttyd" | "pty_bridge";
 
 export type Deployment = {
   id: number;
@@ -47,6 +48,7 @@ export type Deployment = {
    * only the rollback path in executeLaunch sees them.
    */
   state: DeploymentState;
+  terminalBackend?: TerminalBackend;
   launchedAt: string;
   endedAt: string | null;
   ttydPort: number | null;

--- a/packages/web/app/api/terminal/[port]/route.ts
+++ b/packages/web/app/api/terminal/[port]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidTerminalPort, proxyHttpRequest, rewriteHtml } from "@/lib/terminal-proxy";
 import { terminalTokenFromRequest, validateTerminalToken } from "@/lib/terminal-auth";
+import { recordTerminalEventForPort } from "@/lib/terminal-diagnostics";
 
 export const dynamic = "force-dynamic";
 
@@ -12,15 +13,36 @@ export async function GET(
   const port = Number(portStr);
 
   if (!isValidTerminalPort(port)) {
+    recordTerminalEventForPort(port, {
+      level: "warn",
+      event: "terminal.port_invalid",
+      source: "web.terminal-route",
+      status: "not_found",
+    });
     return new NextResponse("Not Found", { status: 404 });
   }
   const terminalToken = terminalTokenFromRequest(request.nextUrl, port, request.headers.get("referer"));
   if (!validateTerminalToken(terminalToken, port)) {
+    recordTerminalEventForPort(port, {
+      level: "warn",
+      event: "terminal.auth_failed",
+      source: "web.terminal-route",
+      status: "unauthorized",
+    });
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
   try {
     const upstream = await proxyHttpRequest(port, "/");
+    recordTerminalEventForPort(port, {
+      level: upstream.status >= 400 ? "warn" : "info",
+      event: upstream.status >= 400
+        ? "terminal.proxy_probe_failed"
+        : "terminal.proxy_probe_succeeded",
+      source: "web.terminal-route",
+      status: String(upstream.status),
+      data: { statusCode: upstream.status },
+    });
     const contentType = upstream.headers["content-type"] ?? "";
 
     if (contentType.includes("text/html")) {
@@ -37,6 +59,12 @@ export async function GET(
     });
   } catch (err) {
     console.error(`[issuectl] HTTP proxy error for port ${port}:`, err);
+    recordTerminalEventForPort(port, {
+      level: "error",
+      event: "terminal.proxy_probe_failed",
+      source: "web.terminal-route",
+      message: err instanceof Error ? err.message : String(err),
+    });
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("ECONNREFUSED")) {
       return new NextResponse("Terminal not available", { status: 502 });

--- a/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/ensure-ttyd/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
-import { ensureTtydForDeployment } from "@/lib/ensure-ttyd";
+import { ensureTerminalForDeployment } from "@/lib/ensure-terminal";
 import log from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -18,11 +18,11 @@ export async function POST(
     return NextResponse.json({ alive: false, error: "Invalid deployment ID" }, { status: 400 });
   }
 
-  const result = await ensureTtydForDeployment(deploymentId);
-  if ("respawned" in result && result.respawned) {
+  const result = await ensureTerminalForDeployment(deploymentId);
+  if (result.backend === "ttyd" && "respawned" in result && result.respawned) {
     log.info({ msg: "ttyd_respawned", deploymentId, port: result.port });
   }
-  if (result.alive === false && result.error) {
+  if ("alive" in result && result.alive === false && result.error) {
     log.error({ msg: "ensure_ttyd_failed", deploymentId, error: result.error });
   }
   return NextResponse.json(result);

--- a/packages/web/components/workbench/PtyTerminal.module.css
+++ b/packages/web/components/workbench/PtyTerminal.module.css
@@ -1,0 +1,17 @@
+.terminal {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: #111;
+}
+
+.terminal :global(.xterm) {
+  height: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.terminal :global(.xterm-viewport) {
+  scrollbar-width: thin;
+}

--- a/packages/web/components/workbench/PtyTerminal.tsx
+++ b/packages/web/components/workbench/PtyTerminal.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import styles from "./PtyTerminal.module.css";
+
+type Props = {
+  wsUrl: string;
+  title: string;
+  onError: (message: string) => void;
+};
+
+type ServerMessage =
+  | { type: "ready" }
+  | { type: "output"; data: string }
+  | { type: "exit"; code?: number; signal?: string }
+  | { type: "error"; message: string };
+
+export function PtyTerminal({ wsUrl, title, onError }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const terminal = new Terminal({
+      cursorBlink: true,
+      convertEol: true,
+      fontFamily: "var(--paper-mono), ui-monospace, SFMono-Regular, Menlo, monospace",
+      fontSize: 13,
+      theme: {
+        background: "#111111",
+        foreground: "#f2f0e8",
+        cursor: "#f2f0e8",
+      },
+    });
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(container);
+
+    const ws = new WebSocket(toAbsoluteWsUrl(wsUrl));
+    const disposables = [
+      terminal.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "input", data }));
+        }
+      }),
+    ];
+
+    function fitAndReport() {
+      try {
+        fitAddon.fit();
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "resize", cols: terminal.cols, rows: terminal.rows }));
+        }
+      } catch {
+        // xterm can briefly have no measurable container while React lays out.
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(fitAndReport);
+    resizeObserver.observe(container);
+
+    ws.addEventListener("open", fitAndReport);
+    ws.addEventListener("message", (event) => {
+      const message = parseServerMessage(event.data);
+      if (!message) return;
+      if (message.type === "output") {
+        terminal.write(message.data);
+      } else if (message.type === "exit") {
+        terminal.writeln("");
+        terminal.writeln(`[terminal attach exited${message.code === undefined ? "" : `: ${message.code}`}]`);
+      } else if (message.type === "error") {
+        onError(message.message);
+      }
+    });
+    ws.addEventListener("close", (event) => {
+      if (event.code !== 1000 && event.code !== 1005) {
+        onError("PTY terminal connection closed.");
+      }
+    });
+    ws.addEventListener("error", () => onError("PTY terminal connection failed."));
+
+    return () => {
+      resizeObserver.disconnect();
+      for (const disposable of disposables) disposable.dispose();
+      terminal.dispose();
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close(1000, "component unmounted");
+      }
+    };
+  }, [onError, wsUrl]);
+
+  return <div ref={containerRef} className={styles.terminal} role="application" aria-label={title} />;
+}
+
+function toAbsoluteWsUrl(path: string): string {
+  if (path.startsWith("ws://") || path.startsWith("wss://")) return path;
+  const base = new URL(path, window.location.href);
+  base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+  return base.toString();
+}
+
+function parseServerMessage(data: unknown): ServerMessage | null {
+  if (typeof data !== "string") return null;
+  try {
+    const parsed = JSON.parse(data) as Partial<ServerMessage>;
+    if (parsed.type === "ready") return { type: "ready" };
+    if (parsed.type === "output" && typeof parsed.data === "string") return parsed as ServerMessage;
+    if (parsed.type === "exit") return parsed as ServerMessage;
+    if (parsed.type === "error" && typeof parsed.message === "string") return parsed as ServerMessage;
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/packages/web/components/workbench/TerminalFocus.tsx
+++ b/packages/web/components/workbench/TerminalFocus.tsx
@@ -7,6 +7,7 @@ import {
   isStaleEnsureTtydResult,
   terminalProxyUrl,
 } from "./workbench-api";
+import { PtyTerminal } from "./PtyTerminal";
 import type { WorkbenchDeployment, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
 
@@ -38,25 +39,33 @@ export function TerminalFocus({
     port: number | null;
     token: string | null;
     src: string | null;
+    backend: "ttyd" | "pty_bridge" | null;
+    wsUrl: string | null;
     error: string | null;
   }>({
-    status: deployment.ttydPort ? "loading" : "error",
+    status: deployment.ttydPort || deployment.terminalBackend === "pty_bridge" ? "loading" : "error",
     port: deployment.ttydPort,
     token: null,
     src: null,
-    error: deployment.ttydPort ? null : "Reconnect this session to open the terminal.",
+    backend: deployment.terminalBackend ?? "ttyd",
+    wsUrl: null,
+    error: deployment.ttydPort || deployment.terminalBackend === "pty_bridge"
+      ? null
+      : "Reconnect this session to open the terminal.",
   });
   const [retryAttempt, setRetryAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     const controller = new AbortController();
-    if (!deployment.ttydPort) {
+    if (!deployment.ttydPort && deployment.terminalBackend !== "pty_bridge") {
       setTerminal({
         status: "error",
         port: null,
         token: null,
         src: null,
+        backend: deployment.terminalBackend ?? "ttyd",
+        wsUrl: null,
         error: "Reconnect this session to open the terminal.",
       });
       return;
@@ -67,12 +76,26 @@ export function TerminalFocus({
       port: deployment.ttydPort,
       token: null,
       src: null,
+      backend: deployment.terminalBackend ?? "ttyd",
+      wsUrl: null,
       error: null,
     });
 
     ensureDeploymentTtyd(deployment.id)
       .then(async (result) => {
         if (cancelled) return;
+        if ("wsUrl" in result) {
+          setTerminal({
+            status: "ready",
+            port: null,
+            token: result.terminalToken,
+            src: null,
+            backend: "pty_bridge",
+            wsUrl: result.wsUrl,
+            error: null,
+          });
+          return;
+        }
         if (!("port" in result) || !result.terminalToken) {
           if (isStaleEnsureTtydResult(result)) {
             onDeploymentStale(deployment.id);
@@ -83,6 +106,8 @@ export function TerminalFocus({
             port: deployment.ttydPort,
             token: null,
             src: null,
+            backend: deployment.terminalBackend ?? "ttyd",
+            wsUrl: null,
             error: "error" in result && result.error
               ? result.error
               : "Terminal auth token could not be created.",
@@ -98,6 +123,8 @@ export function TerminalFocus({
             port: result.port,
             token: result.terminalToken,
             src: null,
+            backend: "ttyd",
+            wsUrl: null,
             error: proxy.error,
           });
           return;
@@ -108,6 +135,8 @@ export function TerminalFocus({
           port: result.port,
           token: result.terminalToken,
           src: terminalProxyUrl(result.port, result.terminalToken),
+          backend: "ttyd",
+          wsUrl: null,
           error: null,
         });
       })
@@ -119,6 +148,8 @@ export function TerminalFocus({
           port: deployment.ttydPort,
           token: null,
           src: null,
+          backend: deployment.terminalBackend ?? "ttyd",
+          wsUrl: null,
           error: err instanceof Error ? err.message : "Terminal is not available.",
         });
       });
@@ -127,7 +158,7 @@ export function TerminalFocus({
       cancelled = true;
       controller.abort();
     };
-  }, [deployment.id, deployment.ttydPort, onDeploymentStale, retryAttempt]);
+  }, [deployment.id, deployment.terminalBackend, deployment.ttydPort, onDeploymentStale, retryAttempt]);
 
   async function reconnectTerminal() {
     await onReconnect(deployment);
@@ -150,7 +181,15 @@ export function TerminalFocus({
           Back to overview
         </button>
       </header>
-      {terminal.status === "ready" && terminal.src ? (
+      {terminal.status === "ready" && terminal.backend === "pty_bridge" && terminal.wsUrl ? (
+        <div className={styles.terminalFrame}>
+          <PtyTerminal
+            title={`Terminal for issue ${deployment.issueNumber}`}
+            wsUrl={terminal.wsUrl}
+            onError={(error) => setTerminal((current) => ({ ...current, status: "error", error }))}
+          />
+        </div>
+      ) : terminal.status === "ready" && terminal.src ? (
         <iframe
           className={styles.terminalFrame}
           title={`Terminal for issue ${deployment.issueNumber}`}

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -345,6 +345,10 @@ export function WorkbenchShell({
     setSessionRowErrors((current) => withoutKey(current, deployment.id));
     try {
       const result = await ensureDeploymentTtyd(deployment.id);
+      if ("wsUrl" in result) {
+        selectDeployment(deployment.id);
+        return;
+      }
       if (!("port" in result)) {
         if (isStaleEnsureTtydResult(result)) {
           removeDeployment(deployment.id);

--- a/packages/web/components/workbench/workbench-api.ts
+++ b/packages/web/components/workbench/workbench-api.ts
@@ -49,13 +49,21 @@ export async function fetchWorkbench({
 
 export type EnsureTtydResult =
   | {
+      backend?: "ttyd";
       port: number;
       terminalToken: string;
       respawned?: boolean;
     }
   | {
+      backend: "pty_bridge";
+      deploymentId: number;
+      terminalToken: string;
+      wsUrl: string;
+    }
+  | {
       alive: false;
       error?: string;
+      backend?: "ttyd" | "pty_bridge";
     };
 
 const STALE_DEPLOYMENT_ERRORS = [
@@ -68,7 +76,7 @@ export function isStaleDeploymentError(message: string | undefined): boolean {
 }
 
 export function isStaleEnsureTtydResult(result: EnsureTtydResult): boolean {
-  return !("port" in result) && isStaleDeploymentError(result.error);
+  return !("port" in result) && !("wsUrl" in result) && isStaleDeploymentError(result.error);
 }
 
 export async function ensureDeploymentTtyd(deploymentId: number): Promise<EnsureTtydResult> {

--- a/packages/web/components/workbench/workbench-types.ts
+++ b/packages/web/components/workbench/workbench-types.ts
@@ -26,7 +26,11 @@ export type WorkbenchUser = {
 
 export type WorkbenchPreview = SessionPreview;
 
-export type WorkbenchDeployment = (Deployment & { owner: string; repoName: string }) | ActiveDeploymentWithRepo;
+export type TerminalBackend = "ttyd" | "pty_bridge";
+
+export type WorkbenchDeployment =
+  | (Deployment & { owner: string; repoName: string; terminalBackend?: TerminalBackend })
+  | (ActiveDeploymentWithRepo & { terminalBackend?: TerminalBackend });
 
 export type WorkbenchIssueSummary = {
   number: number;

--- a/packages/web/lib/actions/launch-ensure-ttyd.test.ts
+++ b/packages/web/lib/actions/launch-ensure-ttyd.test.ts
@@ -5,6 +5,7 @@ const revalidatePath = vi.hoisted(() => vi.fn());
 vi.mock("next/cache", () => ({ revalidatePath }));
 
 const getDb = vi.hoisted(() => vi.fn());
+const getActiveDeploymentByPort = vi.hoisted(() => vi.fn());
 const getDeploymentById = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
 const getSetting = vi.hoisted(() => vi.fn());
@@ -17,6 +18,7 @@ const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
+  getActiveDeploymentByPort: (...args: unknown[]) => getActiveDeploymentByPort(...args),
   getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
   getRepoById: (...args: unknown[]) => getRepoById(...args),
   getSetting: (...args: unknown[]) => getSetting(...args),
@@ -58,6 +60,7 @@ function makeRepoRecord() {
 
 beforeEach(() => {
   getDb.mockReset();
+  getActiveDeploymentByPort.mockReset();
   getDeploymentById.mockReset();
   getRepoById.mockReset();
   getSetting.mockReset();
@@ -69,6 +72,7 @@ beforeEach(() => {
   recordDiagnosticEventSafely.mockReset();
 
   getDb.mockReturnValue({ prepare: vi.fn() });
+  getActiveDeploymentByPort.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
   getDeploymentById.mockReturnValue(makeDeployment(42));
   getRepoById.mockReturnValue(makeRepoRecord());
   getSetting.mockReturnValue("test-api-token");
@@ -100,6 +104,15 @@ describe("ensureTtyd", () => {
         ttydPid: 42,
       }),
     );
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: "terminal.token_issued",
+        deploymentId: 1,
+        ttydPort: 7700,
+        ttydPid: 42,
+      }),
+    );
   });
 
   it("respawns ttyd when dead but tmux alive", async () => {
@@ -122,6 +135,18 @@ describe("ensureTtyd", () => {
         sessionName: "issuectl-repo-7",
         ttydPort: 7700,
         ttydPid: 99,
+      }),
+    );
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: "terminal.respawned",
+        owner: "owner",
+        repo: "repo",
+        deploymentId: 1,
+        ttydPort: 7700,
+        ttydPid: 99,
+        data: { oldPid: 42, newPid: 99 },
       }),
     );
   });

--- a/packages/web/lib/ensure-terminal.test.ts
+++ b/packages/web/lib/ensure-terminal.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDb = vi.hoisted(() => vi.fn());
+const getDeploymentById = vi.hoisted(() => vi.fn());
+const ensureTtydForDeployment = vi.hoisted(() => vi.fn());
+const createPtyTerminalToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
+}));
+
+vi.mock("./ensure-ttyd", () => ({
+  ensureTtydForDeployment: (...args: unknown[]) => ensureTtydForDeployment(...args),
+}));
+
+vi.mock("./terminal-auth", () => ({
+  createPtyTerminalToken: (...args: unknown[]) => createPtyTerminalToken(...args),
+}));
+
+import { ensureTerminalForDeployment } from "./ensure-terminal.js";
+
+const db = { prepare: vi.fn() };
+
+beforeEach(() => {
+  getDb.mockReset();
+  getDeploymentById.mockReset();
+  ensureTtydForDeployment.mockReset();
+
+  getDb.mockReturnValue(db);
+  getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "ttyd" });
+  createPtyTerminalToken.mockReturnValue("pty-token");
+  delete process.env.ISSUECTL_PTY_BRIDGE;
+});
+
+describe("ensureTerminalForDeployment", () => {
+  it("returns invalid deployment ID without touching the DB", async () => {
+    await expect(ensureTerminalForDeployment(0)).resolves.toEqual({
+      alive: false,
+      error: "Invalid deployment ID",
+    });
+    expect(getDb).not.toHaveBeenCalled();
+    expect(ensureTtydForDeployment).not.toHaveBeenCalled();
+  });
+
+  it("wraps ttyd success with the backend discriminator", async () => {
+    ensureTtydForDeployment.mockResolvedValue({ port: 7700, terminalToken: "token" });
+
+    await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
+      backend: "ttyd",
+      port: 7700,
+      terminalToken: "token",
+    });
+  });
+
+  it("passes through ttyd failures", async () => {
+    ensureTtydForDeployment.mockResolvedValue({ alive: false, error: "Terminal session has ended" });
+
+    await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
+      alive: false,
+      error: "Terminal session has ended",
+    });
+  });
+
+  it("does not route pty_bridge deployments through ttyd when the experiment flag is disabled", async () => {
+    getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "pty_bridge" });
+
+    await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
+      alive: false,
+      backend: "pty_bridge",
+      error: "PTY bridge terminal backend is not implemented yet",
+    });
+    expect(ensureTtydForDeployment).not.toHaveBeenCalled();
+  });
+
+  it("returns PTY bridge attach metadata when the experiment flag is enabled", async () => {
+    process.env.ISSUECTL_PTY_BRIDGE = "1";
+    getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "pty_bridge" });
+
+    await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
+      backend: "pty_bridge",
+      deploymentId: 1,
+      terminalToken: "pty-token",
+      wsUrl: "/api/terminal/pty/1/ws?terminalToken=pty-token",
+    });
+    expect(ensureTtydForDeployment).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/lib/ensure-terminal.ts
+++ b/packages/web/lib/ensure-terminal.ts
@@ -1,0 +1,50 @@
+import { getDb, getDeploymentById } from "@issuectl/core";
+import { ensureTtydForDeployment, type EnsureTtydResult } from "./ensure-ttyd";
+import { createPtyTerminalToken } from "./terminal-auth";
+
+type TerminalBackend = "ttyd" | "pty_bridge";
+type DeploymentWithTerminalBackend = ReturnType<typeof getDeploymentById> & {
+  terminalBackend?: TerminalBackend;
+};
+
+export type EnsureTerminalResult =
+  | ({ backend: "ttyd" } & Extract<EnsureTtydResult, { port: number }>)
+  | { backend: "pty_bridge"; deploymentId: number; terminalToken: string; wsUrl: string }
+  | { alive: false; error?: string; backend?: TerminalBackend };
+
+export async function ensureTerminalForDeployment(
+  deploymentId: number,
+): Promise<EnsureTerminalResult> {
+  if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
+    return { alive: false, error: "Invalid deployment ID" };
+  }
+
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId) as DeploymentWithTerminalBackend;
+    if (deployment?.terminalBackend === "pty_bridge") {
+      const terminalToken = createPtyTerminalToken(deploymentId);
+      if (terminalToken && process.env.ISSUECTL_PTY_BRIDGE === "1") {
+        return {
+          backend: "pty_bridge",
+          deploymentId,
+          terminalToken,
+          wsUrl: `/api/terminal/pty/${deploymentId}/ws?terminalToken=${encodeURIComponent(terminalToken)}`,
+        };
+      }
+      return {
+        alive: false,
+        backend: "pty_bridge",
+        error: "PTY bridge terminal backend is not implemented yet",
+      };
+    }
+  } catch {
+    // Let the existing ttyd ensure path keep its current error handling.
+  }
+
+  const result = await ensureTtydForDeployment(deploymentId);
+  if ("port" in result) {
+    return { backend: "ttyd", ...result };
+  }
+  return result;
+}

--- a/packages/web/lib/ensure-ttyd.ts
+++ b/packages/web/lib/ensure-ttyd.ts
@@ -12,6 +12,7 @@ import {
   recordDiagnosticEventSafely,
 } from "@issuectl/core";
 import { createTerminalToken } from "./terminal-auth";
+import { recordTerminalEventForDeployment } from "./terminal-diagnostics";
 
 export type EnsureTtydResult =
   | { port: number; terminalToken: string; respawned?: true; alive?: never; error?: never }
@@ -49,6 +50,11 @@ export async function ensureTtydForDeployment(
       return { alive: false, error: "No terminal process configured" };
     }
     const port = deployment.ttydPort;
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "info",
+      event: "terminal.open_requested",
+      source: "web.ensure-ttyd",
+    });
 
     if (isTtydAlive(deployment.ttydPid)) {
       recordDiagnosticEventSafely(db, {
@@ -62,6 +68,12 @@ export async function ensureTtydForDeployment(
       });
       const terminalToken = createTerminalToken(deploymentId, port);
       if (!terminalToken) {
+        recordTerminalEventForDeployment(db, deployment, {
+          level: "error",
+          event: "terminal.token_failed",
+          source: "web.ensure-ttyd",
+          message: "Terminal auth token could not be created",
+        });
         recordDiagnosticEventSafely(db, {
           level: "error",
           event: "ensure_ttyd.failed",
@@ -74,6 +86,11 @@ export async function ensureTtydForDeployment(
         });
         return { alive: false, error: "Terminal auth token could not be created" };
       }
+      recordTerminalEventForDeployment(db, deployment, {
+        level: "info",
+        event: "terminal.token_issued",
+        source: "web.ensure-ttyd",
+      });
       return { port, terminalToken };
     }
 
@@ -93,6 +110,12 @@ export async function ensureTtydForDeployment(
     const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
     if (!isTmuxSessionAlive(sessionName)) {
       endDeployment(db, deploymentId);
+      recordTerminalEventForDeployment(db, deployment, {
+        level: "warn",
+        event: "terminal.tmux_missing",
+        source: "web.ensure-ttyd",
+        message: "Terminal session has ended",
+      }, repo);
       recordDiagnosticEventSafely(db, {
         level: "error",
         event: "ensure_ttyd.failed",
@@ -109,6 +132,7 @@ export async function ensureTtydForDeployment(
 
     const { pid } = await respawnTtyd(port, sessionName);
     updateTtydInfo(db, deploymentId, port, pid);
+    const respawnedDeployment = { ...deployment, ttydPid: pid };
     recordDiagnosticEventSafely(db, {
       level: "info",
       event: "ensure_ttyd.respawned",
@@ -121,8 +145,20 @@ export async function ensureTtydForDeployment(
       ttydPort: port,
       ttydPid: pid,
     });
+    recordTerminalEventForDeployment(db, respawnedDeployment, {
+      level: "info",
+      event: "terminal.respawned",
+      source: "web.ensure-ttyd",
+      data: { oldPid: deployment.ttydPid, newPid: pid },
+    }, repo);
     const terminalToken = createTerminalToken(deploymentId, port);
     if (!terminalToken) {
+      recordTerminalEventForDeployment(db, respawnedDeployment, {
+        level: "error",
+        event: "terminal.token_failed",
+        source: "web.ensure-ttyd",
+        message: "Terminal auth token could not be created",
+      }, repo);
       recordDiagnosticEventSafely(db, {
         level: "error",
         event: "ensure_ttyd.failed",
@@ -138,6 +174,11 @@ export async function ensureTtydForDeployment(
       });
       return { alive: false, error: "Terminal auth token could not be created" };
     }
+    recordTerminalEventForDeployment(db, respawnedDeployment, {
+      level: "info",
+      event: "terminal.token_issued",
+      source: "web.ensure-ttyd",
+    }, repo);
     return { port, terminalToken, respawned: true };
   } catch (err) {
     console.error("[issuectl] ensureTtydForDeployment failed:", deploymentId, err);

--- a/packages/web/lib/pty-terminal-websocket.test.ts
+++ b/packages/web/lib/pty-terminal-websocket.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { isPtyBridgeEnabled, parsePtyClientMessage } from "./pty-terminal-websocket.js";
+
+describe("isPtyBridgeEnabled", () => {
+  beforeEach(() => {
+    delete process.env.ISSUECTL_PTY_BRIDGE;
+  });
+
+  it("requires the explicit experiment flag", () => {
+    expect(isPtyBridgeEnabled()).toBe(false);
+    process.env.ISSUECTL_PTY_BRIDGE = "1";
+    expect(isPtyBridgeEnabled()).toBe(true);
+  });
+});
+
+describe("parsePtyClientMessage", () => {
+  it("parses input messages", () => {
+    expect(parsePtyClientMessage(Buffer.from(JSON.stringify({ type: "input", data: "ls\n" })))).toEqual({
+      type: "input",
+      data: "ls\n",
+    });
+  });
+
+  it("clamps resize dimensions", () => {
+    expect(parsePtyClientMessage(Buffer.from(JSON.stringify({ type: "resize", cols: 999, rows: 1 })))).toEqual({
+      type: "resize",
+      cols: 240,
+      rows: 5,
+    });
+  });
+
+  it("rejects malformed or oversized input", () => {
+    expect(parsePtyClientMessage(Buffer.from("{"))).toBeNull();
+    expect(parsePtyClientMessage(Buffer.from(JSON.stringify({ type: "input", data: "x".repeat(70_000) })))).toBeNull();
+  });
+});

--- a/packages/web/lib/pty-terminal-websocket.ts
+++ b/packages/web/lib/pty-terminal-websocket.ts
@@ -1,0 +1,315 @@
+import { IncomingMessage } from "node:http";
+import { Duplex } from "node:stream";
+import { WebSocketServer, WebSocket } from "ws";
+import { spawn, type IPty } from "node-pty";
+import {
+  getDb,
+  getDeploymentById,
+  getRepoById,
+  isTmuxSessionAlive,
+  recordDiagnosticEventSafely,
+  tmuxSessionName,
+} from "@issuectl/core";
+import log from "./logger";
+import { validatePtyTerminalToken } from "./terminal-auth";
+
+const ptyWss = new WebSocketServer({ noServer: true });
+ptyWss.on("error", (err) => log.error({ err, msg: "pty_wss_error" }));
+
+const MAX_INPUT_CHARS = 64 * 1024;
+const MIN_COLS = 20, MAX_COLS = 240, MIN_ROWS = 5, MAX_ROWS = 80;
+const BACKPRESSURE_BYTES = 1024 * 1024;
+
+let activePtyWsConnections = 0;
+
+type PtyClientMessage =
+  | { type: "input"; data: string }
+  | { type: "resize"; cols: number; rows: number };
+
+type PtyStats = {
+  deploymentId: number; framesToClient: number; framesFromClient: number;
+  bytesToClient: number; bytesFromClient: number; peakBuffered: number;
+  backpressureDrops: number; backpressureShedding: boolean;
+  firstOutputSeen: boolean; connectedAt: number;
+};
+
+export function activePtyWsCount(): number {
+  return activePtyWsConnections;
+}
+
+export function isPtyBridgeEnabled(): boolean {
+  return process.env.ISSUECTL_PTY_BRIDGE === "1";
+}
+
+export function parsePtyClientMessage(raw: WebSocket.RawData): PtyClientMessage | null {
+  const text = raw.toString();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const message = parsed as Record<string, unknown>;
+  if (message.type === "input" && typeof message.data === "string") {
+    if (message.data.length > MAX_INPUT_CHARS) return null;
+    return { type: "input", data: message.data };
+  }
+  if (message.type === "resize") {
+    const cols = clampDimension(message.cols, MIN_COLS, MAX_COLS);
+    const rows = clampDimension(message.rows, MIN_ROWS, MAX_ROWS);
+    if (!cols || !rows) return null;
+    return { type: "resize", cols, rows };
+  }
+  return null;
+}
+
+export async function handlePtyUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  deploymentId: number,
+): Promise<void> {
+  if (!isPtyBridgeEnabled()) {
+    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (!validatePtyTerminalToken(url.searchParams.get("terminalToken"), deploymentId)) {
+    recordPtyEvent(deploymentId, "warn", "pty.auth_failed", { status: "unauthorized" });
+    socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
+  const context = loadPtyContext(deploymentId);
+  if (!context.ok) {
+    recordPtyEvent(deploymentId, "error", "pty.bridge_attach_failed", {
+      status: context.status,
+      message: context.message,
+    });
+    socket.write(`HTTP/1.1 ${context.httpStatus} ${context.status}\r\n\r\n`);
+    socket.destroy();
+    return;
+  }
+
+  recordPtyEvent(deploymentId, "info", "pty.bridge_attach_requested", { sessionName: context.sessionName });
+
+  ptyWss.handleUpgrade(req, socket, head, (clientWs) => {
+    activePtyWsConnections++;
+    const stats = createStats(deploymentId);
+    let attachPty: IPty | null = null;
+    let cleanedUp = false;
+
+    try {
+      attachPty = spawn("tmux", ["attach-session", "-t", context.sessionName], {
+        name: "xterm-256color",
+        cols: 80,
+        rows: 24,
+        cwd: context.workspacePath,
+        env: buildPtyEnv(),
+      });
+    } catch (err) {
+      recordPtyEvent(deploymentId, "error", "pty.bridge_attach_failed", { message: err instanceof Error ? err.message : String(err) });
+      activePtyWsConnections--;
+      clientWs.close(1011, "attach failed");
+      return;
+    }
+
+    recordPtyEvent(deploymentId, "info", "pty.ws_connected", { data: { activeWs: activePtyWsConnections } });
+    recordPtyEvent(deploymentId, "info", "pty.bridge_attached");
+    safeSend(clientWs, { type: "ready" });
+
+    attachPty.onData((data) => {
+      if (!stats.firstOutputSeen) {
+        stats.firstOutputSeen = true;
+        recordPtyEvent(deploymentId, "info", "pty.first_output_seen");
+      }
+      if (shouldDropForBackpressure(clientWs, stats)) return;
+      stats.framesToClient++;
+      stats.bytesToClient += Buffer.byteLength(data);
+      safeSend(clientWs, { type: "output", data });
+    });
+
+    attachPty.onExit(({ exitCode, signal }) => {
+      recordPtyEvent(deploymentId, "info", "pty.process_exit", { data: { exitCode, signal: signal ?? undefined } });
+      safeSend(clientWs, { type: "exit", code: exitCode, signal });
+      cleanup("pty_exit");
+      clientWs.close();
+    });
+
+    clientWs.on("message", (raw) => {
+      const message = parsePtyClientMessage(raw);
+      if (!message || !attachPty) return;
+      if (message.type === "input") {
+        stats.framesFromClient++;
+        stats.bytesFromClient += Buffer.byteLength(message.data);
+        attachPty.write(message.data);
+      } else {
+        attachPty.resize(message.cols, message.rows);
+        recordPtyEvent(deploymentId, "debug", "pty.resize", { data: { cols: message.cols, rows: message.rows } });
+      }
+    });
+
+    clientWs.on("close", () => cleanup("client_close"));
+    clientWs.on("error", (err) => {
+      recordPtyEvent(deploymentId, "error", "pty.ws_error", { message: err instanceof Error ? err.message : String(err) });
+      cleanup("client_error");
+    });
+
+    function cleanup(reason: string) {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      activePtyWsConnections--;
+      if (attachPty) attachPty.kill();
+      recordPtyClose(deploymentId, reason, stats);
+    }
+  });
+}
+
+function loadPtyContext(deploymentId: number):
+  | { ok: true; sessionName: string; workspacePath: string }
+  | { ok: false; httpStatus: number; status: string; message: string } {
+  const db = getDb();
+  const deployment = getDeploymentById(db, deploymentId);
+  if (!deployment || deployment.endedAt !== null) {
+    return { ok: false, httpStatus: 404, status: "not_found", message: "Deployment not found" };
+  }
+  if ((deployment as { terminalBackend?: string }).terminalBackend !== "pty_bridge") {
+    return { ok: false, httpStatus: 404, status: "wrong_backend", message: "Deployment is not PTY bridge backed" };
+  }
+  const repo = getRepoById(db, deployment.repoId);
+  if (!repo) return { ok: false, httpStatus: 404, status: "repo_missing", message: "Repository not found" };
+  const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+  if (!isTmuxSessionAlive(sessionName)) {
+    recordPtyEvent(deploymentId, "warn", "pty.tmux_missing", { sessionName });
+    return { ok: false, httpStatus: 410, status: "tmux_missing", message: "tmux session is gone" };
+  }
+  return { ok: true, sessionName, workspacePath: deployment.workspacePath };
+}
+
+function buildPtyEnv(): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/sbin:/sbin",
+    COLORTERM: "truecolor",
+    SHELL: process.env.SHELL ?? "/bin/zsh",
+    TERM: "xterm-256color",
+  };
+}
+
+function createStats(deploymentId: number): PtyStats {
+  return {
+    deploymentId,
+    framesToClient: 0,
+    framesFromClient: 0,
+    bytesToClient: 0,
+    bytesFromClient: 0,
+    peakBuffered: 0,
+    backpressureDrops: 0,
+    backpressureShedding: false,
+    firstOutputSeen: false,
+    connectedAt: Date.now(),
+  };
+}
+
+function shouldDropForBackpressure(clientWs: WebSocket, stats: PtyStats): boolean {
+  const buffered = clientWs.bufferedAmount;
+  if (buffered > stats.peakBuffered) stats.peakBuffered = buffered;
+  if (buffered <= BACKPRESSURE_BYTES) {
+    if (stats.backpressureShedding) {
+      stats.backpressureShedding = false;
+      recordPtyEvent(stats.deploymentId, "warn", "pty.backpressure_clear", { data: { backpressureDrops: stats.backpressureDrops } });
+    }
+    return false;
+  }
+  if (!stats.backpressureShedding) {
+    stats.backpressureShedding = true;
+    recordPtyEvent(stats.deploymentId, "warn", "pty.backpressure_start", { data: { bufferedBytes: buffered } });
+  }
+  stats.backpressureDrops++;
+  return true;
+}
+
+function safeSend(clientWs: WebSocket, payload: Record<string, unknown>): void {
+  if (clientWs.readyState !== WebSocket.OPEN) return;
+  clientWs.send(JSON.stringify(payload));
+}
+
+function recordPtyClose(deploymentId: number, reason: string, stats: PtyStats): void {
+  recordPtyEvent(deploymentId, "info", "pty.ws_closed", {
+    status: reason,
+    data: {
+      activeWs: activePtyWsConnections,
+      backpressureDrops: stats.backpressureDrops,
+      bytesFromClient: stats.bytesFromClient,
+      bytesToClient: stats.bytesToClient,
+      durationMs: Date.now() - stats.connectedAt,
+      framesFromClient: stats.framesFromClient,
+      framesToClient: stats.framesToClient,
+      peakBuffered: stats.peakBuffered,
+    },
+  });
+}
+
+function recordPtyEvent(
+  deploymentId: number,
+  level: "debug" | "info" | "warn" | "error",
+  event: string,
+  input: { sessionName?: string; status?: string; message?: string; data?: Record<string, unknown> } = {},
+): void {
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    const repo = deployment ? getRepoById(db, deployment.repoId) : undefined;
+    recordDiagnosticEventSafely(db, {
+      level,
+      event,
+      source: "web.pty-terminal",
+      owner: repo?.owner,
+      repo: repo?.name,
+      issueNumber: deployment?.issueNumber,
+      deploymentId,
+      sessionName: input.sessionName,
+      status: input.status,
+      message: input.message,
+      data: sanitizePtyData(input.data),
+    });
+  } catch {
+    // Diagnostics should not break terminal attach behavior.
+  }
+}
+
+function sanitizePtyData(data: Record<string, unknown> | undefined): Record<string, number | boolean | string> | null {
+  if (!data) return null;
+  const safe: Record<string, number | boolean | string> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!SAFE_PTY_DATA_KEYS.has(key)) continue;
+    if (typeof value === "number" && Number.isFinite(value)) safe[key] = value;
+    if (typeof value === "boolean") safe[key] = value;
+    if (typeof value === "string" && key === "signal") safe[key] = value;
+  }
+  return Object.keys(safe).length ? safe : null;
+}
+
+const SAFE_PTY_DATA_KEYS = new Set([
+  "activeWs",
+  "backpressureDrops",
+  "bufferedBytes",
+  "bytesFromClient",
+  "bytesToClient",
+  "cols",
+  "durationMs",
+  "exitCode",
+  "framesFromClient",
+  "framesToClient",
+  "peakBuffered",
+  "rows",
+  "signal",
+]);
+
+function clampDimension(value: unknown, min: number, max: number): number | null {
+  if (!Number.isFinite(value)) return null;
+  return Math.max(min, Math.min(max, Math.floor(value as number)));
+}

--- a/packages/web/lib/terminal-auth.test.ts
+++ b/packages/web/lib/terminal-auth.test.ts
@@ -12,7 +12,13 @@ vi.mock("@issuectl/core", () => ({
   getActiveDeploymentByPort: mockGetActiveDeploymentByPort,
 }));
 
-import { createTerminalToken, terminalTokenFromRequest, validateTerminalToken } from "./terminal-auth.js";
+import {
+  createPtyTerminalToken,
+  createTerminalToken,
+  terminalTokenFromRequest,
+  validatePtyTerminalToken,
+  validateTerminalToken,
+} from "./terminal-auth.js";
 
 describe("terminal auth tokens", () => {
   beforeEach(() => {
@@ -22,6 +28,7 @@ describe("terminal auth tokens", () => {
       id: 7,
       endedAt: null,
       ttydPort: 7700,
+      terminalBackend: "ttyd",
     });
     mockGetActiveDeploymentByPort.mockReturnValue({ id: 7 });
   });
@@ -51,6 +58,44 @@ describe("terminal auth tokens", () => {
     mockGetDeploymentById.mockReturnValue({ id: 7, endedAt: "2026-04-28", ttydPort: 7700 });
 
     expect(validateTerminalToken(token, 7700)).toBe(false);
+  });
+});
+
+describe("pty terminal auth tokens", () => {
+  beforeEach(() => {
+    mockGetDb.mockReturnValue("fake-db");
+    mockGetSetting.mockReturnValue("test-secret");
+    mockGetDeploymentById.mockReturnValue({
+      id: 7,
+      endedAt: null,
+      ttydPort: null,
+      terminalBackend: "pty_bridge",
+    });
+  });
+
+  it("creates and validates a deployment-bound PTY token", () => {
+    const token = createPtyTerminalToken(7);
+
+    expect(token).toEqual(expect.any(String));
+    expect(validatePtyTerminalToken(token, 7)).toBe(true);
+  });
+
+  it("rejects a PTY token for a different deployment", () => {
+    const token = createPtyTerminalToken(7);
+
+    expect(validatePtyTerminalToken(token, 8)).toBe(false);
+  });
+
+  it("rejects a PTY token for a ttyd deployment", () => {
+    const token = createPtyTerminalToken(7);
+    mockGetDeploymentById.mockReturnValue({
+      id: 7,
+      endedAt: null,
+      ttydPort: 7700,
+      terminalBackend: "ttyd",
+    });
+
+    expect(validatePtyTerminalToken(token, 7)).toBe(false);
   });
 });
 

--- a/packages/web/lib/terminal-auth.ts
+++ b/packages/web/lib/terminal-auth.ts
@@ -13,6 +13,7 @@ type TerminalTokenPayload = {
   deploymentId: number;
   port: number;
   exp: number;
+  backend?: "ttyd" | "pty_bridge";
 };
 
 function base64UrlEncode(input: string): string {
@@ -45,6 +46,24 @@ export function createTerminalToken(deploymentId: number, port: number): string 
     return `${encoded}.${sign(encoded, secret)}`;
   } catch (err) {
     log.error({ err, msg: "terminal_token_create_failed", deploymentId, port });
+    return null;
+  }
+}
+
+export function createPtyTerminalToken(deploymentId: number): string | null {
+  try {
+    const secret = getTerminalSecret();
+    if (!secret) return null;
+    const payload: TerminalTokenPayload = {
+      deploymentId,
+      port: 0,
+      backend: "pty_bridge",
+      exp: Date.now() + TOKEN_TTL_MS,
+    };
+    const encoded = base64UrlEncode(JSON.stringify(payload));
+    return `${encoded}.${sign(encoded, secret)}`;
+  } catch (err) {
+    log.error({ err, msg: "pty_terminal_token_create_failed", deploymentId });
     return null;
   }
 }
@@ -99,6 +118,32 @@ export function validateTerminalToken(token: string | null | undefined, port: nu
     return activeByPort?.id === deployment.id;
   } catch (err) {
     log.error({ err, msg: "terminal_token_validate_failed", port });
+    return false;
+  }
+}
+
+export function validatePtyTerminalToken(
+  token: string | null | undefined,
+  deploymentId: number,
+): boolean {
+  if (!token) return false;
+  try {
+    const payload = parseToken(token);
+    if (
+      !payload ||
+      payload.backend !== "pty_bridge" ||
+      payload.deploymentId !== deploymentId ||
+      payload.exp < Date.now()
+    ) {
+      return false;
+    }
+
+    const db = getDb();
+    const deployment = getDeploymentById(db, deploymentId);
+    return deployment?.endedAt === null
+      && (deployment as { terminalBackend?: string }).terminalBackend === "pty_bridge";
+  } catch (err) {
+    log.error({ err, msg: "pty_terminal_token_validate_failed", deploymentId });
     return false;
   }
 }

--- a/packages/web/lib/terminal-diagnostics.test.ts
+++ b/packages/web/lib/terminal-diagnostics.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDb = vi.hoisted(() => vi.fn());
+const getActiveDeploymentByPort = vi.hoisted(() => vi.fn());
+const getRepoById = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getActiveDeploymentByPort: (...args: unknown[]) => getActiveDeploymentByPort(...args),
+  getRepoById: (...args: unknown[]) => getRepoById(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+}));
+
+import {
+  recordTerminalEventForDeployment,
+  recordTerminalEventForPort,
+  sanitizeTerminalDiagnosticData,
+} from "./terminal-diagnostics.js";
+
+const db = { prepare: vi.fn() } as unknown as Parameters<
+  typeof recordTerminalEventForDeployment
+>[0];
+const deployment = {
+  id: 123,
+  repoId: 9,
+  issueNumber: 483,
+  ttydPort: 7700,
+  ttydPid: 456,
+};
+const repo = {
+  id: 9,
+  owner: "issuectl-tests",
+  name: "issuectl-alpha",
+  localPath: "/tmp/repo",
+  branchPattern: null,
+  createdAt: "2026-05-21T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  getDb.mockReset();
+  getActiveDeploymentByPort.mockReset();
+  getRepoById.mockReset();
+  recordDiagnosticEventSafely.mockReset();
+
+  getDb.mockReturnValue(db);
+  getActiveDeploymentByPort.mockReturnValue(deployment);
+  getRepoById.mockReturnValue(repo);
+});
+
+describe("sanitizeTerminalDiagnosticData", () => {
+  it("keeps aggregate numeric and boolean fields only", () => {
+    expect(
+      sanitizeTerminalDiagnosticData({
+        bytesOut: 42,
+        framesOut: 3,
+        activeWs: true,
+        token: "secret",
+        command: "pnpm dev",
+        output: "terminal output",
+        env: { GH_TOKEN: "secret" },
+        bufferedBytes: Number.NaN,
+      }),
+    ).toEqual({
+      activeWs: true,
+      bytesOut: 42,
+      framesOut: 3,
+    });
+  });
+
+  it("returns null when no safe fields remain", () => {
+    expect(sanitizeTerminalDiagnosticData({ token: "secret" })).toBeNull();
+  });
+});
+
+describe("recordTerminalEventForPort", () => {
+  it("records deployment and issue context for an active terminal port", () => {
+    recordTerminalEventForPort(7700, {
+      level: "info",
+      event: "terminal.ws_closed",
+      source: "web.terminal-websocket",
+      status: "client_close",
+      data: { bytesOut: 100, token: "secret" },
+    });
+
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, {
+      level: "info",
+      event: "terminal.ws_closed",
+      source: "web.terminal-websocket",
+      status: "client_close",
+      owner: "issuectl-tests",
+      repo: "issuectl-alpha",
+      issueNumber: 483,
+      deploymentId: 123,
+      ttydPort: 7700,
+      ttydPid: 456,
+      data: { bytesOut: 100 },
+    });
+  });
+
+  it("records port-only context when no active deployment exists", () => {
+    getActiveDeploymentByPort.mockReturnValue(undefined);
+
+    recordTerminalEventForPort(7701, {
+      level: "warn",
+      event: "terminal.port_invalid",
+      source: "web.terminal-route",
+    });
+
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, {
+      level: "warn",
+      event: "terminal.port_invalid",
+      source: "web.terminal-route",
+      ttydPort: 7701,
+      data: null,
+    });
+  });
+
+  it("does not throw when diagnostics storage is unavailable", () => {
+    getDb.mockImplementation(() => {
+      throw new Error("db unavailable");
+    });
+
+    expect(() =>
+      recordTerminalEventForPort(7700, {
+        level: "info",
+        event: "terminal.ws_connected",
+        source: "web.terminal-websocket",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("recordTerminalEventForDeployment", () => {
+  it("uses an explicit repo without doing a repo lookup", () => {
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "info",
+      event: "terminal.token_issued",
+      source: "web.ensure-ttyd",
+    }, repo);
+
+    expect(getRepoById).not.toHaveBeenCalled();
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      owner: "issuectl-tests",
+      repo: "issuectl-alpha",
+      issueNumber: 483,
+      deploymentId: 123,
+      ttydPort: 7700,
+      ttydPid: 456,
+    }));
+  });
+});

--- a/packages/web/lib/terminal-diagnostics.ts
+++ b/packages/web/lib/terminal-diagnostics.ts
@@ -1,0 +1,111 @@
+import {
+  getActiveDeploymentByPort,
+  getDb,
+  getRepoById,
+  recordDiagnosticEventSafely,
+  type DiagnosticLevel,
+} from "@issuectl/core";
+
+type Database = ReturnType<typeof getDb>;
+type RepoRecord = NonNullable<ReturnType<typeof getRepoById>>;
+type TerminalDeployment = {
+  id: number;
+  repoId: number;
+  issueNumber: number;
+  ttydPort?: number | null;
+  ttydPid?: number | null;
+};
+
+type TerminalDiagnosticInput = {
+  level: DiagnosticLevel;
+  event: string;
+  source: string;
+  status?: string;
+  message?: string;
+  data?: Record<string, unknown> | null;
+};
+
+const SAFE_DATA_KEYS = new Set([
+  "activeWs",
+  "backpressureDrops",
+  "bufferedBytes",
+  "bytesOut",
+  "dropped",
+  "droppedDuringEpisode",
+  "durationMs",
+  "framesIn",
+  "framesOut",
+  "newPid",
+  "oldPid",
+  "peakBuffered",
+  "pendingMessages",
+  "statusCode",
+  "uptimeSec",
+]);
+
+export function sanitizeTerminalDiagnosticData(
+  data: Record<string, unknown> | null | undefined,
+): Record<string, number | boolean> | null {
+  if (!data) return null;
+  const safe: Record<string, number | boolean> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!SAFE_DATA_KEYS.has(key)) continue;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      safe[key] = value;
+    } else if (typeof value === "boolean") {
+      safe[key] = value;
+    }
+  }
+  return Object.keys(safe).length > 0 ? safe : null;
+}
+
+export function recordTerminalEventForPort(
+  port: number,
+  input: TerminalDiagnosticInput,
+): void {
+  try {
+    const db = getDb();
+    const ttydPort = Number.isInteger(port) ? port : undefined;
+    const deployment = ttydPort === undefined
+      ? undefined
+      : getActiveDeploymentByPort(db, ttydPort);
+    if (!deployment) {
+      recordDiagnosticEventSafely(db, {
+        ...input,
+        ttydPort,
+        data: sanitizeTerminalDiagnosticData(input.data),
+      });
+      return;
+    }
+    recordTerminalEventForDeployment(db, deployment, input);
+  } catch {
+    // Diagnostics must never break terminal attach/proxy behavior.
+  }
+}
+
+export function recordTerminalEventForDeployment(
+  db: Database,
+  deployment: TerminalDeployment,
+  input: TerminalDiagnosticInput,
+  repo?: RepoRecord,
+): void {
+  let resolvedRepo = repo;
+  if (!resolvedRepo) {
+    try {
+      resolvedRepo = getRepoById(db, deployment.repoId);
+    } catch {
+      resolvedRepo = undefined;
+    }
+  }
+
+  recordDiagnosticEventSafely(db, {
+    ...input,
+    owner: resolvedRepo?.owner,
+    repo: resolvedRepo?.name,
+    issueNumber: deployment.issueNumber,
+    deploymentId: deployment.id,
+    ttydPort: deployment.ttydPort ?? undefined,
+    ttydPid: deployment.ttydPid ?? undefined,
+    data: sanitizeTerminalDiagnosticData(input.data),
+  });
+}

--- a/packages/web/lib/terminal-lifecycle.ts
+++ b/packages/web/lib/terminal-lifecycle.ts
@@ -10,6 +10,7 @@ import {
   updateTtydInfo,
 } from "@issuectl/core";
 import log from "./logger";
+import { recordTerminalEventForDeployment } from "./terminal-diagnostics";
 
 const PORT_MIN = 7700;
 const PORT_MAX = 7799;
@@ -46,6 +47,12 @@ export async function ensureTtydRunning(port: number): Promise<boolean> {
 
   if (!deployment.ttydPid) {
     log.warn({ msg: "ttyd_no_pid_recorded", port, deploymentId: deployment.id });
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "warn",
+      event: "terminal.unavailable",
+      source: "web.terminal-lifecycle",
+      message: "No ttyd PID recorded",
+    });
     return false;
   }
 
@@ -71,6 +78,12 @@ async function doRespawn(
   const repo = getRepoById(db, deployment.repoId);
   if (!repo) {
     log.warn({ msg: "ttyd_respawn_no_repo", port, deploymentId: deployment.id, repoId: deployment.repoId });
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "error",
+      event: "terminal.respawn_failed",
+      source: "web.terminal-lifecycle",
+      message: "Repository not found",
+    });
     return false;
   }
 
@@ -80,6 +93,12 @@ async function doRespawn(
     sessionAlive = isTmuxSessionAlive(sessionName);
   } catch (err) {
     log.error({ msg: "ttyd_tmux_check_failed", port, deploymentId: deployment.id, sessionName, err });
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "error",
+      event: "terminal.tmux_check_failed",
+      source: "web.terminal-lifecycle",
+      message: err instanceof Error ? err.message : String(err),
+    }, repo);
     return false;
   }
 
@@ -90,10 +109,21 @@ async function doRespawn(
       log.debug({ msg: "ttyd_end_deployment_skipped", deploymentId: deployment.id, err });
     }
     log.info({ msg: "ttyd_session_dead", port, deploymentId: deployment.id, sessionName });
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "warn",
+      event: "terminal.tmux_missing",
+      source: "web.terminal-lifecycle",
+      message: "Terminal session has ended",
+    }, repo);
     return false;
   }
 
   try {
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "info",
+      event: "terminal.respawn_started",
+      source: "web.terminal-lifecycle",
+    }, repo);
     const result = await respawnTtyd(port, sessionName);
     updateTtydInfo(db, deployment.id, port, result.pid);
     log.info({
@@ -104,9 +134,21 @@ async function doRespawn(
       newPid: result.pid,
       sessionName,
     });
+    recordTerminalEventForDeployment(db, { ...deployment, ttydPid: result.pid }, {
+      level: "info",
+      event: "terminal.respawned",
+      source: "web.terminal-lifecycle",
+      data: { oldPid: deployment.ttydPid, newPid: result.pid },
+    }, repo);
     return true;
   } catch (err) {
     log.error({ msg: "ttyd_respawn_failed", port, deploymentId: deployment.id, err });
+    recordTerminalEventForDeployment(db, deployment, {
+      level: "error",
+      event: "terminal.respawn_failed",
+      source: "web.terminal-lifecycle",
+      message: err instanceof Error ? err.message : String(err),
+    }, repo);
     return false;
   }
 }

--- a/packages/web/lib/terminal-proxy.test.ts
+++ b/packages/web/lib/terminal-proxy.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetActiveDeploymentByPort = vi.hoisted(() => vi.fn());
 const mockGetDb = vi.hoisted(() => vi.fn(() => "fake-db"));
+const mockGetRepoById = vi.hoisted(() => vi.fn());
+const mockRecordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: mockGetDb,
   getActiveDeploymentByPort: mockGetActiveDeploymentByPort,
+  getRepoById: mockGetRepoById,
+  recordDiagnosticEventSafely: mockRecordDiagnosticEventSafely,
   getDeploymentById: vi.fn(),
   getSetting: vi.fn(),
 }));

--- a/packages/web/lib/terminal-websocket.ts
+++ b/packages/web/lib/terminal-websocket.ts
@@ -5,6 +5,7 @@ import { registerPort, unregisterPort, recordPtyOutput } from "./idle-registry";
 import log from "./logger";
 import { ensureTtydRunning, isValidTerminalPort } from "./terminal-lifecycle";
 import { validateTerminalToken } from "./terminal-auth";
+import { recordTerminalEventForPort } from "./terminal-diagnostics";
 
 const wss = new WebSocketServer({ noServer: true });
 wss.on("error", (err) => {
@@ -31,6 +32,7 @@ interface WsStats {
   backpressureDrops: number;
   backpressureShedding: boolean;
   backpressureEpisodeDrops: number;
+  firstOutputSeen: boolean;
   readonly connectedAt: number;
 }
 
@@ -42,12 +44,14 @@ export async function handleUpgrade(
 ): Promise<void> {
   const url = new URL(req.url ?? "/", "http://localhost");
   if (!validateTerminalToken(url.searchParams.get("terminalToken"), port)) {
+    recordTerminalEventForPort(port, { level: "warn", event: "terminal.auth_failed", source: "web.terminal-websocket", status: "unauthorized" });
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;
   }
 
   if (!isValidTerminalPort(port)) {
+    recordTerminalEventForPort(port, { level: "warn", event: "terminal.port_invalid", source: "web.terminal-websocket", status: "not_found" });
     socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
     socket.destroy();
     return;
@@ -55,6 +59,7 @@ export async function handleUpgrade(
 
   const alive = await ensureTtydRunning(port);
   if (!alive) {
+    recordTerminalEventForPort(port, { level: "error", event: "terminal.unavailable", source: "web.terminal-websocket", status: "bad_gateway" });
     socket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
     socket.destroy();
     return;
@@ -71,6 +76,7 @@ export async function handleUpgrade(
     const stats = createStats(port, clientIp);
 
     log.info({ msg: "ws_connect", port, clientIp, activeWs: _activeWsCount });
+    recordTerminalEventForPort(port, { level: "info", event: "terminal.ws_connected", source: "web.terminal-websocket", data: { activeWs: _activeWsCount } });
 
     const tickTimer = setInterval(() => logTick(stats), TICK_INTERVAL_MS);
     const protocols = req.headers["sec-websocket-protocol"]?.split(",").map((s) => s.trim());
@@ -114,12 +120,20 @@ export async function handleUpgrade(
     });
     upstream.on("error", (err) => {
       log.error({ err, msg: "ws_upstream_error", port, clientIp, bufferedMsgs: pendingClientMsgs.length });
+      recordTerminalEventForPort(port, {
+        level: "error",
+        event: "terminal.ws_upstream_error",
+        source: "web.terminal-websocket",
+        message: err instanceof Error ? err.message : String(err),
+        data: { pendingMessages: pendingClientMsgs.length },
+      });
       cleanup("upstream_error");
       if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
       upstream.terminate();
     });
     clientWs.on("error", (err) => {
       log.error({ err, msg: "ws_client_error", port, clientIp });
+      recordTerminalEventForPort(port, { level: "error", event: "terminal.ws_client_error", source: "web.terminal-websocket", message: err instanceof Error ? err.message : String(err) });
       cleanup("client_error");
       upstream.terminate();
     });
@@ -138,6 +152,7 @@ function createStats(port: number, clientIp: string): WsStats {
     backpressureDrops: 0,
     backpressureShedding: false,
     backpressureEpisodeDrops: 0,
+    firstOutputSeen: false,
     connectedAt: Date.now(),
   };
 }
@@ -150,6 +165,10 @@ function forwardFromUpstream(
 ) {
   stats.framesFromTtyd++;
   recordPtyOutput(stats.port, Date.now());
+  if (!stats.firstOutputSeen) {
+    stats.firstOutputSeen = true;
+    recordTerminalEventForPort(stats.port, { level: "info", event: "terminal.first_output_seen", source: "web.terminal-websocket" });
+  }
   if (clientWs.readyState !== WebSocket.OPEN) {
     stats.droppedFrames++;
     return;
@@ -186,6 +205,10 @@ function shouldDropForBackpressure(clientWs: WebSocket, stats: WsStats): boolean
         clientIp: stats.clientIp,
         droppedDuringEpisode: stats.backpressureEpisodeDrops,
       });
+      recordTerminalEventForPort(stats.port, {
+        level: "warn", event: "terminal.backpressure_clear", source: "web.terminal-websocket",
+        data: { droppedDuringEpisode: stats.backpressureEpisodeDrops },
+      });
       stats.backpressureEpisodeDrops = 0;
     }
     return false;
@@ -193,6 +216,7 @@ function shouldDropForBackpressure(clientWs: WebSocket, stats: WsStats): boolean
   if (!stats.backpressureShedding) {
     stats.backpressureShedding = true;
     log.warn({ msg: "ws_backpressure_start", port: stats.port, clientIp: stats.clientIp, bufferedBytes: buffered });
+    recordTerminalEventForPort(stats.port, { level: "warn", event: "terminal.backpressure_start", source: "web.terminal-websocket", data: { bufferedBytes: buffered } });
   }
   stats.backpressureDrops++;
   stats.backpressureEpisodeDrops++;
@@ -247,12 +271,13 @@ function logTick(stats: WsStats) {
 }
 
 function logClose(reason: string, stats: WsStats, activeWs: number) {
+  const uptimeSec = (Date.now() - stats.connectedAt) / 1000;
   log.info({
     msg: "ws_close",
     reason,
     port: stats.port,
     clientIp: stats.clientIp,
-    uptimeSec: ((Date.now() - stats.connectedAt) / 1000).toFixed(1),
+    uptimeSec: uptimeSec.toFixed(1),
     framesIn: stats.framesFromTtyd,
     framesOut: stats.framesToClient,
     bytesOut: stats.bytesToClient,
@@ -260,5 +285,22 @@ function logClose(reason: string, stats: WsStats, activeWs: number) {
     dropped: stats.droppedFrames,
     backpressureDrops: stats.backpressureDrops,
     activeWs,
+  });
+  recordTerminalEventForPort(stats.port, {
+    level: "info",
+    event: "terminal.ws_closed",
+    source: "web.terminal-websocket",
+    status: reason,
+    data: {
+      activeWs,
+      backpressureDrops: stats.backpressureDrops,
+      bytesOut: stats.bytesToClient,
+      dropped: stats.droppedFrames,
+      durationMs: Math.round(uptimeSec * 1000),
+      framesIn: stats.framesFromTtyd,
+      framesOut: stats.framesToClient,
+      peakBuffered: stats.peakBufferedAmount,
+      uptimeSec: Number(uptimeSec.toFixed(1)),
+    },
   });
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,7 +16,10 @@
   "dependencies": {
     "@issuectl/core": "workspace:*",
     "@serwist/next": "^9.5.7",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "next": "^15.3.0",
+    "node-pty": "^1.1.0",
     "pino": "^10.3.1",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -3,10 +3,12 @@ import type { Duplex } from "node:stream";
 import next from "next";
 import log, { logPath } from "./lib/logger";
 import { handleUpgrade, activeWsCount } from "./lib/terminal-proxy";
+import { handlePtyUpgrade, activePtyWsCount } from "./lib/pty-terminal-websocket";
 import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./lib/network-info.js";
 import { startIdleChecker, stopIdleChecker } from "./lib/idle-checker";
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
+const PTY_TERMINAL_WS_RE = /^\/api\/terminal\/pty\/(\d+)\/ws/;
 const SENSITIVE_QUERY_PARAMS = new Set(["terminalToken"]);
 
 const dev = process.argv.includes("--dev");
@@ -147,6 +149,20 @@ interceptUpgradeRegistrations("addListener");
 // Our terminal handler runs first (prepend). It marks the socket so
 // any later upgrade listeners (Next.js HMR, etc.) are no-ops.
 server.prependListener("upgrade", (req: IncomingMessage, socket: Duplex & { [HANDLED]?: boolean }, head: Buffer) => {
+  const ptyMatch = req.url?.match(PTY_TERMINAL_WS_RE);
+  if (ptyMatch) {
+    const deploymentId = Number(ptyMatch[1]);
+    socket[HANDLED] = true;
+    handlePtyUpgrade(req, socket, head, deploymentId).catch((err) => {
+      log.error({ err, msg: "pty_terminal_upgrade_failed", deploymentId });
+      if (!socket.destroyed) {
+        socket.write("HTTP/1.1 500 Internal Server Error\r\n\r\n");
+        socket.destroy();
+      }
+    });
+    return;
+  }
+
   const match = req.url?.match(TERMINAL_WS_RE);
   if (match) {
     const terminalPort = Number(match[1]);
@@ -175,6 +191,7 @@ function heartbeat(): void {
     heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
     rssMB: Math.round(mem.rss / 1024 / 1024),
     activeWs: activeWsCount(),
+    activePtyWs: activePtyWsCount(),
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: 3974ceeb2e6c136e707f65e5a109f70b
+
 importers:
 
   .:
@@ -35,6 +37,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      node-gyp:
+        specifier: ^12.3.0
+        version: 12.3.0
       prettier:
         specifier: ^3.5.3
         version: 3.8.1
@@ -105,9 +110,18 @@ importers:
       '@serwist/next':
         specifier: ^9.5.7
         version: 9.5.7(next@15.5.14(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       next:
         specifier: ^15.3.0
         version: 15.5.14(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -768,6 +782,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1458,6 +1476,16 @@ packages:
   '@vitest/utils@4.1.3':
     resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1643,6 +1671,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   clean-stack@5.3.0:
     resolution: {integrity: sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==}
@@ -1954,6 +1986,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2303,6 +2338,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   issue-parser@7.0.1:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
@@ -2703,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2761,12 +2804,28 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -3101,6 +3160,10 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -3473,6 +3536,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
@@ -3807,6 +3874,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3860,6 +3932,10 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -4437,6 +4513,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5098,6 +5178,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
+  abbrev@4.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5256,6 +5342,8 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   clean-stack@5.3.0:
     dependencies:
@@ -5606,6 +5694,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   extend@3.0.2: {}
 
   fake-indexeddb@6.2.5: {}
@@ -5929,6 +6019,8 @@ snapshots:
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  isexe@4.0.0: {}
 
   issue-parser@7.0.1:
     dependencies:
@@ -6492,6 +6584,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
@@ -6549,6 +6645,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@7.1.1: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -6556,7 +6654,29 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
+  node-gyp@12.3.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.15
+      tinyglobby: 0.2.15
+      undici: 6.25.0
+      which: 6.0.1
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+      node-gyp: 12.3.0
+
   node-releases@2.0.37: {}
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -6808,6 +6928,8 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -7300,6 +7422,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   temp-dir@3.0.0: {}
 
   tempy@3.2.0:
@@ -7590,6 +7720,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -7632,6 +7766,8 @@ snapshots:
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
## Summary
- add the PTY bridge design doc and GoalBuddy execution board
- add ttyd terminal diagnostics events for attach/proxy/websocket lifecycle
- add terminal_backend persistence and backend-aware ensure-terminal contracts
- add a non-default ISSUECTL_PTY_BRIDGE=1 xterm.js + node-pty tmux attach path

## Verification
- git diff --check
- pnpm --dir packages/core test -- --run src/db/schema-deployments.test.ts src/db/schema-invariants.test.ts src/db/schema.test.ts src/db/deployments-ttyd.test.ts
- pnpm --dir packages/web test -- --run lib/actions/launch-ensure-ttyd.test.ts lib/terminal-proxy.test.ts lib/terminal-auth.test.ts lib/terminal-diagnostics.test.ts lib/ensure-terminal.test.ts lib/pty-terminal-websocket.test.ts
- pnpm typecheck
- pnpm lint
- pre-push pnpm build

## Notes
- ttyd remains the default backend.
- PTY attach metadata is only returned for persisted pty_bridge deployments when ISSUECTL_PTY_BRIDGE=1.
- websocket cleanup kills only the PTY attach process, not tmux.
- diagnostics record lifecycle/counter data only, not terminal input/output or tokens.