### PR TITLE
Add local macOS E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,17 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        env:
+          PNPM_CONFIG_SIDE_EFFECTS_CACHE: "false"
+        run: pnpm install --frozen-lockfile
       - name: Rebuild native test dependencies
-        run: pnpm rebuild better-sqlite3
+        env:
+          npm_config_build_from_source: "true"
+        run: |
+          rm -rf node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/build
+          pnpm --filter @issuectl/core rebuild better-sqlite3
+          pnpm --dir packages/core exec node -e "require('better-sqlite3')(':memory:').close()"
       - run: pnpm turbo test
 
   build:
@@ -126,7 +134,17 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        env:
+          PNPM_CONFIG_SIDE_EFFECTS_CACHE: "false"
+        run: pnpm install --frozen-lockfile
+      - name: Rebuild native E2E dependencies
+        env:
+          npm_config_build_from_source: "true"
+        run: |
+          rm -rf node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/build
+          pnpm --filter @issuectl/core rebuild better-sqlite3
+          pnpm --dir packages/core exec node -e "require('better-sqlite3')(':memory:').close()"
       - name: Build core package
         # next dev resolves @issuectl/core via its package.json exports
         # (dist/index.js), so the workspace package must be built before

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Rebuild native test dependencies
+        run: pnpm rebuild better-sqlite3
       - run: pnpm turbo test
 
   build:

--- a/.github/workflows/macos-e2e-local.yml
+++ b/.github/workflows/macos-e2e-local.yml
@@ -1,0 +1,96 @@
+name: Local macOS E2E
+
+on:
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-web:
+    name: Browser E2E on local Mac
+    runs-on: [self-hosted, macOS, ARM64, trusted-macos-e2e, e2e, gui, browser]
+    timeout-minutes: 35
+    steps:
+      - name: Host proof
+        run: |
+          hostname
+          sw_vers
+          uname -m
+          xcodebuild -version
+
+      - name: Healthcheck before
+        run: |
+          RUNNER_HOME="$HOME" \
+          RUNNER_WORK="$HOME/actions-runner/_work" \
+          /usr/local/ci/bin/macos-runner-healthcheck --json
+
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core package
+        run: pnpm turbo build --filter=@issuectl/core
+
+      - name: Verify gh CLI auth
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh auth status
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @issuectl/web exec playwright install chromium webkit
+
+      - name: Run mobile Chromium E2E
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm --filter @issuectl/web exec playwright test \
+            mobile-ux-patterns.spec.ts \
+            launch-ui.spec.ts \
+            viewport-health.spec.ts \
+            --project=mobile-chromium
+
+      - name: Run mobile WebKit E2E
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm --filter @issuectl/web exec playwright test \
+            workbench.spec.ts \
+            mobile-ux-patterns.spec.ts \
+            --project=mobile-webkit
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-local-macos-e2e
+          path: packages/web/playwright-report/
+          retention-days: 7
+
+      - name: Cleanup after
+        if: always()
+        run: |
+          RUNNER_HOME="$HOME" \
+          RUNNER_WORK="$HOME/actions-runner/_work" \
+          /usr/local/ci/bin/macos-runner-cleanup --json
+
+      - name: Healthcheck after
+        if: always()
+        run: |
+          RUNNER_HOME="$HOME" \
+          RUNNER_WORK="$HOME/actions-runner/_work" \
+          /usr/local/ci/bin/macos-runner-healthcheck --json

--- a/.github/workflows/macos-e2e-local.yml
+++ b/.github/workflows/macos-e2e-local.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Rebuild native dependencies
+        run: pnpm rebuild better-sqlite3
+
       - name: Build core package
         run: pnpm turbo build --filter=@issuectl/core
 

--- a/.github/workflows/macos-e2e-local.yml
+++ b/.github/workflows/macos-e2e-local.yml
@@ -24,8 +24,33 @@ jobs:
           sw_vers
           uname -m
           xcodebuild -version
+          {
+            echo "/opt/homebrew/bin"
+            echo "/usr/local/bin"
+          } >> "$GITHUB_PATH"
+
+      - name: Workspace cleanup before
+        working-directory: /
+        run: |
+          set -euo pipefail
+
+          case "${GITHUB_WORKSPACE:-}" in
+            "$HOME/actions-runner/_work/"*)
+              rm -rf "$GITHUB_WORKSPACE"
+              mkdir -p "$GITHUB_WORKSPACE"
+              ;;
+            *)
+              echo "Refusing to clean unexpected GITHUB_WORKSPACE: ${GITHUB_WORKSPACE:-<unset>}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -n "${RUNNER_TEMP:-}" ] && [ -d "$RUNNER_TEMP" ]; then
+            find "$RUNNER_TEMP" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          fi
 
       - name: Healthcheck before
+        working-directory: /
         run: |
           RUNNER_HOME="$HOME" \
           RUNNER_WORK="$HOME/actions-runner/_work" \
@@ -41,13 +66,32 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
+        env:
+          PNPM_CONFIG_SIDE_EFFECTS_CACHE: "false"
         run: pnpm install --frozen-lockfile
 
       - name: Rebuild native dependencies
-        run: pnpm rebuild better-sqlite3
+        env:
+          npm_config_build_from_source: "true"
+        run: |
+          rm -rf node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/build
+          pnpm --filter @issuectl/core rebuild better-sqlite3
+          pnpm --dir packages/core exec node -e "require('better-sqlite3')(':memory:').close()"
 
       - name: Build core package
         run: pnpm turbo build --filter=@issuectl/core
+
+      - name: Ensure gh CLI
+        run: |
+          if ! command -v gh >/dev/null 2>&1; then
+            if command -v brew >/dev/null 2>&1; then
+              brew install gh
+            else
+              echo "gh CLI is required for E2E auth checks, but neither gh nor brew is available" >&2
+              exit 1
+            fi
+          fi
+          gh --version
 
       - name: Verify gh CLI auth
         env:
@@ -84,15 +128,9 @@ jobs:
           path: packages/web/playwright-report/
           retention-days: 7
 
-      - name: Cleanup after
-        if: always()
-        run: |
-          RUNNER_HOME="$HOME" \
-          RUNNER_WORK="$HOME/actions-runner/_work" \
-          /usr/local/ci/bin/macos-runner-cleanup --json
-
       - name: Healthcheck after
         if: always()
+        working-directory: /
         run: |
           RUNNER_HOME="$HOME" \
           RUNNER_WORK="$HOME/actions-runner/_work" \

--- a/packages/web/e2e/mobile-ux-patterns.spec.ts
+++ b/packages/web/e2e/mobile-ux-patterns.spec.ts
@@ -521,19 +521,34 @@ test.describe("Mobile UX regressions — sheet scroll lock", () => {
   }) => {
     if (skipReason) test.skip(true, skipReason);
     await withMobilePage(browser, "/", async (page) => {
-      // Ensure the page is tall enough to scroll, regardless of how many
-      // issues the test DB has.  Inject a spacer if needed.
+      // Ensure the browser's actual scroll root is tall enough to scroll,
+      // regardless of how many issues the test DB has.
       await page.evaluate(() => {
-        if (document.body.scrollHeight <= window.innerHeight) {
+        document.documentElement.style.minHeight = "2200px";
+        document.body.style.minHeight = "2200px";
+
+        if (!document.querySelector("[data-e2e-scroll-spacer]")) {
           const spacer = document.createElement("div");
-          spacer.style.height = "2000px";
+          spacer.dataset.e2eScrollSpacer = "true";
+          spacer.style.display = "block";
+          spacer.style.height = "2200px";
+          spacer.style.flex = "0 0 auto";
+          spacer.style.pointerEvents = "none";
           document.body.appendChild(spacer);
         }
       });
+      await page.waitForFunction(() => {
+        const scroller = document.scrollingElement;
+        return (
+          !!scroller && scroller.scrollHeight - scroller.clientHeight >= 400
+        );
+      });
 
       // Scroll down first.
-      await page.evaluate(() => window.scrollTo(0, 200));
-      const scrollBefore = await page.evaluate(() => window.scrollY);
+      await page.evaluate(() => document.scrollingElement?.scrollTo(0, 200));
+      const scrollBefore = await page.evaluate(
+        () => document.scrollingElement?.scrollTop ?? window.scrollY,
+      );
       expect(scrollBefore).toBeGreaterThan(0);
 
       // Open and close the sheet.
@@ -551,7 +566,10 @@ test.describe("Mobile UX regressions — sheet scroll lock", () => {
       // clearing position:fixed, so we verify the mechanism works
       // by calling scrollTo from the test context.
       const afterClose = await page.evaluate(() => ({
-        scrollable: document.body.scrollHeight > window.innerHeight,
+        scrollable:
+          !!document.scrollingElement &&
+          document.scrollingElement.scrollHeight >
+            document.scrollingElement.clientHeight,
         htmlPos: document.documentElement.style.position,
         bodyPos: document.body.style.position,
       }));
@@ -564,13 +582,19 @@ test.describe("Mobile UX regressions — sheet scroll lock", () => {
       expect(afterClose.scrollable, "page should be scrollable").toBe(true);
 
       // Verify scrollTo works after lock release.
-      await page.evaluate((y) => window.scrollTo(0, y), scrollBefore);
-      await page.waitForTimeout(100);
-      const scrollAfter = await page.evaluate(() => window.scrollY);
-      expect(
-        scrollAfter,
-        "scrollTo should work after lock is released",
-      ).toBe(scrollBefore);
+      await page.evaluate(
+        (y) => document.scrollingElement?.scrollTo(0, y),
+        scrollBefore,
+      );
+      await expect
+        .poll(
+          () =>
+            page.evaluate(
+              () => document.scrollingElement?.scrollTop ?? window.scrollY,
+            ),
+          { message: "scrollTo should work after lock is released" },
+        )
+        .toBe(scrollBefore);
     });
   });
 


### PR DESCRIPTION
## Summary
- add a merge-queue/manual workflow that targets the trusted local macOS runner pool
- run Playwright Chromium/WebKit E2E on real local Macs
- run healthcheck before and cleanup/healthcheck after every job

## Notes
- intentionally does not run on pull_request so public PR code does not execute directly on self-hosted runners
- uses shared labels rather than pinning to one Mac Mini