### PR TITLE
[codex] Add PTY bridge launch skeleton

### DIFF
--- a/packages/core/src/launch/launch-diagnostics.ts
+++ b/packages/core/src/launch/launch-diagnostics.ts
@@ -76,6 +76,18 @@ export function recordTtydSpawned(
   });
 }
 
+export function recordPtyBridgeSpawned(
+  ctx: LaunchDiagnosticContext,
+  data: { deploymentId: number; sessionName: string },
+): void {
+  recordDiagnosticEventSafely(ctx.db, {
+    ...baseEvent(ctx),
+    level: "info",
+    event: "pty.bridge_spawned",
+    ...data,
+  });
+}
+
 export function recordLaunchSpawnFailed(
   ctx: LaunchDiagnosticContext,
   data: { deploymentId: number; sessionName: string; error: unknown },

--- a/packages/core/src/launch/launch-execute-agents.test.ts
+++ b/packages/core/src/launch/launch-execute-agents.test.ts
@@ -21,15 +21,19 @@ vi.mock("./workspace.js", () => ({
   prepareWorkspace: prepareWorkspaceSpy,
 }));
 
-const { verifyTtydSpy, spawnTtydSpy, allocatePortSpy } = vi.hoisted(() => ({
+const { verifyTtydSpy, verifyTmuxSpy, spawnTtydSpy, spawnPtyBridgeSessionSpy, allocatePortSpy } = vi.hoisted(() => ({
   verifyTtydSpy: vi.fn(),
+  verifyTmuxSpy: vi.fn(),
   spawnTtydSpy: vi.fn(async () => ({ pid: 12345, port: 7700 })),
+  spawnPtyBridgeSessionSpy: vi.fn(),
   allocatePortSpy: vi.fn(async () => 7700),
 }));
 
 vi.mock("./ttyd.js", () => ({
   verifyTtyd: verifyTtydSpy,
+  verifyTmux: verifyTmuxSpy,
   spawnTtyd: spawnTtydSpy,
+  spawnPtyBridgeSession: spawnPtyBridgeSessionSpy,
   allocatePort: allocatePortSpy,
   tmuxSessionName: (repo: string, issueNumber: number) =>
     `issuectl-${repo}-${issueNumber}`,
@@ -103,9 +107,12 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
   let db: Database.Database;
 
   beforeEach(() => {
+    delete process.env.ISSUECTL_PTY_BRIDGE;
     prepareWorkspaceSpy.mockClear();
     verifyTtydSpy.mockClear();
+    verifyTmuxSpy.mockClear();
     spawnTtydSpy.mockClear();
+    spawnPtyBridgeSessionSpy.mockClear();
     allocatePortSpy.mockClear();
     reserveTtydPortSpy.mockClear();
     updateTtydInfoSpy.mockClear();
@@ -264,5 +271,60 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       .prepare("SELECT agent FROM deployments WHERE repo_id = ? AND issue_number = ?")
       .get(repo.id, 44) as { agent: string };
     expect(row.agent).toBe("codex");
+  });
+
+  it("records a pty bridge deployment and skips ttyd when the experiment is enabled", async () => {
+    process.env.ISSUECTL_PTY_BRIDGE = "1";
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 45,
+      agent: "codex",
+      branchName: "pty-bridge",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+    }));
+
+    expect(verifyTmuxSpy).toHaveBeenCalledTimes(1);
+    expect(verifyTtydSpy).not.toHaveBeenCalled();
+    expect(allocatePortSpy).not.toHaveBeenCalled();
+    expect(reserveTtydPortSpy).not.toHaveBeenCalled();
+    expect(spawnTtydSpy).not.toHaveBeenCalled();
+    expect(updateTtydInfoSpy).not.toHaveBeenCalled();
+    expect(spawnPtyBridgeSessionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspacePath: "/tmp/fake-workspace",
+        contextFilePath: "/tmp/fake-context.md",
+        agentCommand: expect.stringMatching(/(^|\/)codex$/),
+        agentInputMode: "argument",
+        sessionName: "issuectl-api-45",
+      }),
+    );
+    expect(result.ttydPort).toBeNull();
+
+    const row = db
+      .prepare("SELECT terminal_backend, ttyd_port, ttyd_pid, state FROM deployments WHERE repo_id = ? AND issue_number = ?")
+      .get(repo.id, 45) as { terminal_backend: string; ttyd_port: number | null; ttyd_pid: number | null; state: string };
+    expect(row).toEqual({
+      terminal_backend: "pty_bridge",
+      ttyd_port: null,
+      ttyd_pid: null,
+      state: "active",
+    });
+    expect(recordDiagnosticEventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: "pty.bridge_spawned",
+        deploymentId: result.deploymentId,
+        sessionName: "issuectl-api-45",
+      }),
+    );
   });
 });

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -16,8 +16,8 @@ import {
   type LaunchContext,
 } from "./context.js";
 import type { WorkspaceMode } from "./workspace.js";
-import { verifyTtyd, spawnTtyd, allocatePort, tmuxSessionName } from "./ttyd.js";
-import type { LaunchAgent } from "../types.js";
+import { verifyTtyd, verifyTmux, spawnTtyd, spawnPtyBridgeSession, allocatePort, tmuxSessionName } from "./ttyd.js";
+import type { LaunchAgent, TerminalBackend } from "../types.js";
 import {
   buildLaunchAgentCommand,
   extraArgsSettingForAgent,
@@ -33,6 +33,7 @@ import {
   recordLaunchLabelsFailed,
   recordLaunchRequested,
   recordLaunchSpawnFailed,
+  recordPtyBridgeSpawned,
   recordTtydSpawned,
   recordWorkspacePrepared,
 } from "./launch-diagnostics.js";
@@ -60,7 +61,8 @@ export interface LaunchResult {
   branchName: string;
   workspacePath: string;
   contextFilePath: string;
-  ttydPort: number;
+  terminalBackend: TerminalBackend;
+  ttydPort: number | null;
   /**
    * Set when lifecycle labels (`issuectl:deployed`, `issuectl:in-progress`)
    * could not be applied after the retry budget was exhausted. Launch
@@ -91,8 +93,14 @@ export async function executeLaunch(
     workspaceMode: options.workspaceMode,
   });
 
-  // 0. Verify ttyd is installed
-  verifyTtyd();
+  const terminalBackend: TerminalBackend = process.env.ISSUECTL_PTY_BRIDGE === "1" ? "pty_bridge" : "ttyd";
+
+  // 0. Verify terminal backend prerequisites.
+  if (terminalBackend === "pty_bridge") {
+    verifyTmux();
+  } else {
+    verifyTtyd();
+  }
 
   // 1. Fetch issue detail
   const detail = await getIssueDetail(
@@ -184,6 +192,7 @@ export async function executeLaunch(
       branchName: options.branchName,
       workspaceMode: options.workspaceMode,
       workspacePath: workspace.path,
+      terminalBackend,
       state: "pending",
     });
     recordDeploymentRecorded(diagnosticContext, deployment.id);
@@ -202,35 +211,49 @@ export async function executeLaunch(
     throw err;
   }
 
-  // 9. Spawn ttyd
+  // 9. Spawn terminal backend
   const agentCommand = buildLaunchAgentCommand(
     launchAgent,
     getSetting(db, extraArgsSettingForAgent(launchAgent)),
   );
   console.warn(`[issuectl] launching: ${agentCommand}`);
-  let ttydPort: number;
+  let ttydPort: number | null = null;
   const sessionName = tmuxSessionName(options.repo, options.issueNumber);
   try {
-    const port = await allocatePort(db);
-    // Reserve the port in the DB *before* spawning so concurrent launches
-    // see it and pick a different port (fixes #198 TOCTOU race).
-    reserveTtydPort(db, deployment.id, port);
-    const { pid } = await spawnTtyd({
-      port,
-      workspacePath: workspace.path,
-      contextFilePath,
-      agentCommand,
-      agentInputMode: launchAgent === "codex" ? "argument" : "stdin",
-      sessionName,
-    });
-    updateTtydInfo(db, deployment.id, port, pid);
-    recordTtydSpawned(diagnosticContext, {
-      deploymentId: deployment.id,
-      sessionName,
-      ttydPort: port,
-      ttydPid: pid,
-    });
-    ttydPort = port;
+    if (terminalBackend === "pty_bridge") {
+      spawnPtyBridgeSession({
+        workspacePath: workspace.path,
+        contextFilePath,
+        agentCommand,
+        agentInputMode: launchAgent === "codex" ? "argument" : "stdin",
+        sessionName,
+      });
+      recordPtyBridgeSpawned(diagnosticContext, {
+        deploymentId: deployment.id,
+        sessionName,
+      });
+    } else {
+      const port = await allocatePort(db);
+      // Reserve the port in the DB *before* spawning so concurrent launches
+      // see it and pick a different port (fixes #198 TOCTOU race).
+      reserveTtydPort(db, deployment.id, port);
+      const { pid } = await spawnTtyd({
+        port,
+        workspacePath: workspace.path,
+        contextFilePath,
+        agentCommand,
+        agentInputMode: launchAgent === "codex" ? "argument" : "stdin",
+        sessionName,
+      });
+      updateTtydInfo(db, deployment.id, port, pid);
+      recordTtydSpawned(diagnosticContext, {
+        deploymentId: deployment.id,
+        sessionName,
+        ttydPort: port,
+        ttydPid: pid,
+      });
+      ttydPort = port;
+    }
   } catch (err) {
     recordLaunchSpawnFailed(diagnosticContext, {
       deploymentId: deployment.id,
@@ -287,6 +310,7 @@ export async function executeLaunch(
     branchName: options.branchName,
     workspacePath: workspace.path,
     contextFilePath,
+    terminalBackend,
     ttydPort,
     labelWarning,
   };

--- a/packages/core/src/launch/tmux-session.ts
+++ b/packages/core/src/launch/tmux-session.ts
@@ -1,0 +1,75 @@
+import { execFileSync } from "node:child_process";
+
+export interface SpawnPtyBridgeSessionOptions {
+  workspacePath: string;
+  contextFilePath: string;
+  agentCommand: string;
+  agentInputMode?: "stdin" | "argument";
+  sessionName: string;
+}
+
+export const TMUX_TIMEOUT_MS = 10_000;
+export const TMUX_SESSION_RE = /^[a-zA-Z0-9_-]+$/;
+
+// Detached tmux sessions otherwise start at 80 columns, wider than phones.
+const TMUX_INITIAL_COLUMNS = 40;
+const TMUX_INITIAL_ROWS = 24;
+const AGENT_ENV_RESET =
+  "for name in $(env | awk -F= '/^npm_/ {print $1}'); do unset \"$name\"; done; unset PNPM_SCRIPT_SRC_DIR";
+
+export function createTmuxAgentSession(options: SpawnPtyBridgeSessionOptions): void {
+  const {
+    workspacePath,
+    contextFilePath,
+    agentCommand,
+    agentInputMode = "stdin",
+    sessionName,
+  } = options;
+
+  if (!TMUX_SESSION_RE.test(sessionName)) {
+    throw new Error(
+      `Invalid tmux session name: ${JSON.stringify(sessionName)}. Only alphanumeric, hyphens, and underscores are allowed.`,
+    );
+  }
+
+  const contextInput =
+    agentInputMode === "argument"
+      ? `"$(cat ${shellEscape(contextFilePath)})"`
+      : `< ${shellEscape(contextFilePath)}`;
+  const innerCommand =
+    `${AGENT_ENV_RESET}; cd ${shellEscape(workspacePath)} && ${agentCommand} ${contextInput} ; exit`;
+
+  execFileSync("tmux", [
+    "new-session", "-d",
+    "-x", String(TMUX_INITIAL_COLUMNS),
+    "-y", String(TMUX_INITIAL_ROWS),
+    "-s", sessionName,
+    `bash -lic ${shellEscape(innerCommand)}`,
+  ], { timeout: TMUX_TIMEOUT_MS });
+
+  try {
+    execFileSync("tmux", ["set-option", "-t", sessionName, "status", "off"],
+      { timeout: TMUX_TIMEOUT_MS });
+    // "largest" sizing ensures shared sessions expand to the biggest attached client.
+    execFileSync("tmux", ["set-option", "-t", sessionName, "window-size", "largest"],
+      { timeout: TMUX_TIMEOUT_MS });
+  } catch (err) {
+    killTmuxSession(sessionName);
+    throw err;
+  }
+}
+
+export function killTmuxSession(name: string): void {
+  try {
+    execFileSync("tmux", ["kill-session", "-t", name], {
+      stdio: "ignore",
+      timeout: TMUX_TIMEOUT_MS,
+    });
+  } catch {
+    // best effort
+  }
+}
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/core/src/launch/ttyd-respawn.test.ts
+++ b/packages/core/src/launch/ttyd-respawn.test.ts
@@ -185,7 +185,7 @@ describe("reconcileOrphanedDeployments", () => {
     expect(runSpy).not.toHaveBeenCalled();
   });
 
-  it("only queries deployments that have a ttyd_pid (excludes pending)", () => {
+  it("queries spawned ttyd and pty bridge deployments only", () => {
     execFileSyncSpy.mockReturnValue(Buffer.from(""));
 
     const prepareSpy = vi.fn((sql: string) => {
@@ -202,7 +202,7 @@ describe("reconcileOrphanedDeployments", () => {
       (c: unknown[]) => (c[0] as string).includes("SELECT"),
     );
     expect(selectCall).toBeDefined();
-    expect(selectCall![0]).toContain("ttyd_pid IS NOT NULL");
+    expect(selectCall![0]).toContain("d.ttyd_pid IS NOT NULL OR d.terminal_backend = 'pty_bridge'");
   });
 
   it("logs error and does not throw when query fails", () => {

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -2,6 +2,14 @@ import { execFileSync, spawn } from "node:child_process";
 import net from "node:net";
 import type Database from "better-sqlite3";
 import { recordDiagnosticEventSafely } from "../db/diagnostics.js";
+import {
+  createTmuxAgentSession,
+  killTmuxSession,
+  TMUX_SESSION_RE,
+  TMUX_TIMEOUT_MS,
+  type SpawnPtyBridgeSessionOptions,
+} from "./tmux-session.js";
+export type { SpawnPtyBridgeSessionOptions } from "./tmux-session.js";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -25,18 +33,7 @@ export interface SpawnTtydOptions {
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-function shellEscape(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-const TMUX_TIMEOUT_MS = 10_000;
-const TMUX_SESSION_RE = /^[a-zA-Z0-9_-]+$/;
-// Detached tmux sessions otherwise start at 80 columns, wider than phones.
-const TMUX_INITIAL_COLUMNS = 40;
-const TMUX_INITIAL_ROWS = 24;
 const TTYD_TERMINATION_GRACE_MS = 150;
-const AGENT_ENV_RESET =
-  "for name in $(env | awk -F= '/^npm_/ {print $1}'); do unset \"$name\"; done; unset PNPM_SCRIPT_SRC_DIR";
 
 /**
  * Build a tmux-safe session name from repo + issue number. Dots, colons,
@@ -71,6 +68,22 @@ export function verifyTtyd(): void {
         { cause: err },
       );
     }
+  }
+}
+
+export function verifyTmux(): void {
+  try {
+    execFileSync("which", ["tmux"], { stdio: "ignore" });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    const status = (err as { status?: number }).status;
+    if (code === "ENOENT" || status === 1) {
+      throw new Error("tmux is not installed. Run: brew install tmux", { cause: err });
+    }
+    throw new Error(
+      `Failed to verify tmux installation: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   }
 }
 
@@ -255,45 +268,13 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
     throw new Error("spawnTtyd requires agentCommand");
   }
 
-  if (!TMUX_SESSION_RE.test(sessionName)) {
-    throw new Error(
-      `Invalid tmux session name: ${JSON.stringify(sessionName)}. Only alphanumeric, hyphens, and underscores are allowed.`,
-    );
-  }
-
-  // Build the inner shell command that runs inside tmux. Claude Code accepts
-  // piped context while staying interactive; Codex treats piped stdin as a
-  // non-interactive prompt, so it needs the context as its initial argument.
-  const contextInput =
-    agentInputMode === "argument"
-      ? `"$(cat ${shellEscape(contextFilePath)})"`
-      : `< ${shellEscape(contextFilePath)}`;
-  const innerCommand =
-    `${AGENT_ENV_RESET}; cd ${shellEscape(workspacePath)} && ${command} ${contextInput} ; exit`;
-
-  // Create a detached tmux session that runs the agent command.
-  // This is step 1 of 2 — ttyd will then serve `tmux attach` so
-  // every WebSocket client shares the same terminal view.
-  execFileSync("tmux", [
-    "new-session", "-d",
-    "-x", String(TMUX_INITIAL_COLUMNS),
-    "-y", String(TMUX_INITIAL_ROWS),
-    "-s", sessionName,
-    `bash -lic ${shellEscape(innerCommand)}`,
-  ], { timeout: TMUX_TIMEOUT_MS });
-
-  try {
-    execFileSync("tmux", ["set-option", "-t", sessionName, "status", "off"],
-      { timeout: TMUX_TIMEOUT_MS });
-    // "largest" sizing ensures the session expands to the biggest attached
-    // client instead of shrinking to the smallest — critical for shared
-    // viewing where desktop and mobile connect simultaneously.
-    execFileSync("tmux", ["set-option", "-t", sessionName, "window-size", "largest"],
-      { timeout: TMUX_TIMEOUT_MS });
-  } catch (err) {
-    killTmuxSession(sessionName);
-    throw err;
-  }
+  createTmuxAgentSession({
+    workspacePath,
+    contextFilePath,
+    agentCommand: command,
+    agentInputMode,
+    sessionName,
+  });
 
   // Bind to loopback only — the Next.js custom server proxies
   // terminal traffic through same-origin routes (/api/terminal/{port}),
@@ -325,6 +306,10 @@ export async function spawnTtyd(options: SpawnTtydOptions): Promise<{ pid: numbe
   }
 
   return { pid: child.pid, port };
+}
+
+export function spawnPtyBridgeSession(options: SpawnPtyBridgeSessionOptions): void {
+  createTmuxAgentSession(options);
 }
 
 /* ------------------------------------------------------------------ */
@@ -373,16 +358,6 @@ export async function respawnTtyd(
   return { pid: child.pid };
 }
 
-/** Best-effort cleanup of a tmux session. */
-function killTmuxSession(name: string): void {
-  try {
-    execFileSync("tmux", ["kill-session", "-t", name], {
-      stdio: "ignore",
-      timeout: TMUX_TIMEOUT_MS,
-    });
-  } catch { /* best effort */ }
-}
-
 /* ------------------------------------------------------------------ */
 /*  reconcileOrphanedDeployments                                       */
 /* ------------------------------------------------------------------ */
@@ -403,7 +378,7 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
          FROM deployments d
          JOIN repos r ON r.id = d.repo_id
          WHERE d.ended_at IS NULL
-           AND d.ttyd_pid IS NOT NULL`,
+           AND (d.ttyd_pid IS NOT NULL OR d.terminal_backend = 'pty_bridge')`,
       )
       .all() as typeof rows;
   } catch (err) {

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
   getRepo.mockReturnValue({ id: 1, owner: "owner", name: "repo" });
   executeLaunch.mockResolvedValue({
     deploymentId: 123,
+    terminalBackend: "ttyd",
     ttydPort: 7700,
     labelWarning: null,
   });
@@ -82,6 +83,7 @@ describe("POST /api/v1/launch/[owner]/[repo]/[number]", () => {
     expect(json).toMatchObject({
       success: true,
       deploymentId: 123,
+      terminalBackend: "ttyd",
       ttydPort: 7700,
       correlationId: expect.any(String),
     });
@@ -96,6 +98,7 @@ describe("POST /api/v1/launch/[owner]/[repo]/[number]", () => {
     withIdempotency.mockResolvedValue({
       correlationId: "cached-correlation-id",
       deploymentId: 456,
+      terminalBackend: "ttyd",
       ttydPort: 7800,
       labelWarning: null,
     });
@@ -111,9 +114,32 @@ describe("POST /api/v1/launch/[owner]/[repo]/[number]", () => {
       success: true,
       correlationId: "cached-correlation-id",
       deploymentId: 456,
+      terminalBackend: "ttyd",
       ttydPort: 7800,
     });
     expect(executeLaunch).not.toHaveBeenCalled();
+  });
+
+  it("returns the terminal backend selected by core", async () => {
+    executeLaunch.mockResolvedValue({
+      deploymentId: 456,
+      terminalBackend: "pty_bridge",
+      ttydPort: null,
+      labelWarning: null,
+    });
+
+    const response = await POST(makeRequest({ ...baseBody, agent: "codex" }), {
+      params,
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({
+      success: true,
+      deploymentId: 456,
+      terminalBackend: "pty_bridge",
+      ttydPort: null,
+    });
   });
 
   it("rejects an invalid launch agent", async () => {

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
@@ -121,6 +121,7 @@ export async function POST(
       return {
         correlationId,
         deploymentId: r.deploymentId,
+        terminalBackend: r.terminalBackend,
         ttydPort: r.ttydPort,
         labelWarning: r.labelWarning ?? null,
       };
@@ -133,6 +134,7 @@ export async function POST(
       success: true,
       correlationId: result.correlationId,
       deploymentId: result.deploymentId,
+      terminalBackend: result.terminalBackend,
       ttydPort: result.ttydPort,
       ...(result.labelWarning ? { labelWarning: result.labelWarning } : {}),
     });

--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -11,7 +11,7 @@ import { WorkspaceModeSelector } from "@/components/launch/WorkspaceModeSelector
 import { BodyText } from "@/components/detail/BodyText";
 import { generateBranchName } from "@/lib/branch";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
-import type { WorkbenchDeployment, WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
+import type { TerminalBackend, WorkbenchDeployment, WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
 import type { WorkbenchSectionCollapseState, WorkbenchSectionId } from "./workbench-state";
 import {
   addIssueComment,
@@ -564,7 +564,9 @@ export function IssueFocus({
                     forceResume,
                     idempotencyKey: newIdempotencyKey(),
                   });
-                  if (!result.success || result.deploymentId === undefined || result.ttydPort === undefined) {
+                  const terminalBackend = result.terminalBackend ?? "ttyd";
+                  const missingTtydPort = terminalBackend === "ttyd" && typeof result.ttydPort !== "number";
+                  if (!result.success || result.deploymentId === undefined || missingTtydPort) {
                     setLaunchMessage(result.error ?? "Launch failed");
                     return;
                   }
@@ -575,7 +577,8 @@ export function IssueFocus({
                     branchName,
                     workspaceMode,
                     deploymentId: result.deploymentId,
-                    ttydPort: result.ttydPort,
+                    terminalBackend,
+                    ttydPort: result.ttydPort ?? null,
                   });
                   setLaunchMessage("Launch started");
                   onSessionLaunched(deployment);
@@ -725,6 +728,7 @@ function deploymentFromLaunch({
   branchName,
   workspaceMode,
   deploymentId,
+  terminalBackend,
   ttydPort,
 }: {
   repo: WorkbenchRepo;
@@ -733,7 +737,8 @@ function deploymentFromLaunch({
   branchName: string;
   workspaceMode: WorkspaceMode;
   deploymentId: number;
-  ttydPort: number;
+  terminalBackend: TerminalBackend;
+  ttydPort: number | null;
 }): WorkbenchDeployment {
   return {
     id: deploymentId,
@@ -747,6 +752,7 @@ function deploymentFromLaunch({
     state: "active",
     launchedAt: new Date().toISOString(),
     endedAt: null,
+    terminalBackend,
     ttydPort,
     ttydPid: null,
     idleSince: null,

--- a/packages/web/components/workbench/workbench-api.ts
+++ b/packages/web/components/workbench/workbench-api.ts
@@ -1,5 +1,5 @@
 import type { LaunchAgent, Priority, WorkspaceMode } from "@issuectl/core";
-import type { WorkbenchDeployment, WorkbenchPayload } from "./workbench-types";
+import type { TerminalBackend, WorkbenchDeployment, WorkbenchPayload } from "./workbench-types";
 
 export class WorkbenchApiError extends Error {
   constructor(
@@ -274,7 +274,8 @@ export type LaunchIssueRequest = {
 export type LaunchIssueResult = {
   success?: boolean;
   deploymentId?: number;
-  ttydPort?: number;
+  terminalBackend?: TerminalBackend;
+  ttydPort?: number | null;
   error?: string;
   labelWarning?: string;
 };


### PR DESCRIPTION
## Summary

Adds the first feature-flagged PTY bridge launch path behind `ISSUECTL_PTY_BRIDGE=1`. Core now records `pty_bridge` deployments without allocating or spawning ttyd, creates the tmux-backed agent session directly, and emits a `pty.bridge_spawned` diagnostics event.

The launch API and workbench response plumbing now carry `terminalBackend` so PTY bridge sessions are created with `ttydPort: null` and attach through the existing PTY terminal path. Startup reconciliation also scans PTY bridge deployments so missing tmux sessions do not remain as phantom active sessions after restart.

## Validation

- `pnpm --dir packages/core test -- launch-execute-agents.test.ts ttyd-respawn.test.ts`
- `pnpm --dir packages/web test -- app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/core lint`
- `pnpm --dir packages/web lint`
- Commit hook: repo typecheck and lint
- Pre-push hook: repo build