### PR TITLE
Validate PTY bridge workbench handoff

### DIFF
--- a/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/app.js
+++ b/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/index.html
+++ b/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/styles.css
+++ b/docs/goals/pty-bridge-workbench-e2e/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/pty-bridge-workbench-e2e/goal.md
+++ b/docs/goals/pty-bridge-workbench-e2e/goal.md
@@ -1,0 +1,89 @@
+# PTY Bridge Workbench E2E
+
+## Objective
+
+Plan and execute the next focused tranche for the feature-flagged PTY bridge experiment: prove that a workbench issue launch using `ISSUECTL_PTY_BRIDGE=1` creates, displays, attaches to, preserves, and closes a PTY bridge terminal session correctly.
+
+## Original Request
+
+"plan it out with $goalbuddy:goal-prep" for the next PTY bridge client-side slice after PR #497 merged.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl maintainers debugging launch/session reliability
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: Focused automated tests and a local manual walkthrough demonstrate that a workbench issue launch with `terminalBackend: "pty_bridge"` and `ttydPort: null` routes through the PTY websocket path, remains usable across issue navigation, and records useful diagnostics.
+- Goal oracle: Run the targeted web/core tests plus a local flagged manual launch walkthrough and diagnostics inspection.
+- Likely misfire: Adding more type or helper coverage while never proving the workbench launch-to-terminal handoff actually works with `ttydPort: null`.
+- Blind spots considered: Existing PTY bridge server skeleton may work in isolation while the workbench UI rejects null ports, stale deployment state, terminal recovery, or navigation persistence.
+- Existing plan facts: PR #497 merged the server/core PTY bridge launch skeleton and response plumbing; next tranche should focus on workbench tests and local manual verification.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`With ISSUECTL_PTY_BRIDGE=1, a workbench launch can be tested and manually exercised from issue launch through PTY terminal attachment, navigation away/back, close/recovery behavior, and diagnostics journal inspection without falling back to ttyd assumptions.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Complete the client-side and local verification slice for the PTY bridge experiment. The expected path is: map existing workbench terminal tests, add the missing focused coverage for PTY bridge launch/session behavior, run targeted checks, then perform a local flagged manual launch walkthrough and inspect diagnostics.
+
+## Non-Negotiable Constraints
+
+- Keep the experiment gated by `ISSUECTL_PTY_BRIDGE=1`.
+- Do not remove or weaken the existing ttyd path.
+- Restrict any real issue creation, terminal session launch, and cleanup used by tests to the approved issuectl test repositories.
+- Use diagnostics-first debugging for launch, terminal, ttyd, tmux, session, or workbench failures.
+- Keep implementation slices bounded and verified before expanding scope.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/pty-bridge-workbench-e2e/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/pty-bridge-workbench-e2e/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Work only on the active board task.
+5. Assign Scout, Judge, Worker, or PM according to the task.
+6. Write a compact task receipt.
+7. Update the board.
+8. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+9. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/pty-bridge-workbench-e2e/state.yaml
+++ b/docs/goals/pty-bridge-workbench-e2e/state.yaml
@@ -1,0 +1,290 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "PTY Bridge Workbench E2E"
+  slug: "pty-bridge-workbench-e2e"
+  kind: specific
+  tranche: "Prove the feature-flagged PTY bridge workbench launch and terminal handoff path with focused tests plus local manual diagnostics."
+  status: done
+  oracle:
+    signal: "With ISSUECTL_PTY_BRIDGE=1, a workbench launch routes through PTY websocket attach, survives navigation, supports close/recovery behavior, and leaves diagnostics that explain the lifecycle."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Targeted tests pass and a local manual walkthrough receipt maps launch, attach, navigation, close/recovery, and diagnostics back to the oracle."
+  intake:
+    original_request: "plan it out with $goalbuddy:goal-prep"
+    interpreted_outcome: "Prepare a GoalBuddy board for the next PTY bridge client-side/end-to-end verification tranche."
+    input_shape: specific
+    audience: "issuectl maintainers debugging launch/session reliability"
+    authority: requested
+    proof_type: test
+    completion_proof: "Focused automated tests and local flagged manual walkthrough prove PTY bridge workbench launch/session behavior."
+    likely_misfire: "Stopping at response plumbing or type coverage without proving the workbench launch-to-terminal handoff works with null ttyd ports."
+    blind_spots_considered:
+      - "Workbench launch may create a deployment but not route TerminalFocus through PTY websocket attach."
+      - "Session persistence across issue navigation may still assume ttyd ports."
+      - "Close/recovery paths may not record enough diagnostics for failed PTY attach."
+      - "Manual launch tests must remain constrained to approved issuectl test repositories."
+    existing_plan_facts:
+      - "PR #497 merged the feature-flagged core/server launch skeleton."
+      - "The next risk is client-side handoff and local manual verification."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://127.0.0.1:41737/pty-bridge-workbench-e2e/"
+    command: "npx goalbuddy board docs/goals/pty-bridge-workbench-e2e"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Map existing workbench launch, terminal focus, PTY websocket, diagnostics, and E2E test coverage relevant to PTY bridge launch/session behavior."
+    inputs:
+      - "PR #497 merged behavior and current repository files."
+      - "Workbench launch and terminal components."
+      - "Existing web/core tests and E2E specs."
+      - "Diagnostics journal CLI instructions in AGENTS.md."
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Prefer concrete file-path evidence and existing test names."
+      - "Do not launch real issue sessions during Scout."
+    expected_output:
+      - "Coverage map for launch result, deployment creation, TerminalFocus PTY attach, navigation persistence, close/recovery, and diagnostics."
+      - "Identified gaps and risk ranking."
+      - "Candidate Worker slices with likely allowed_files and verification commands."
+    receipt:
+      result: done
+      summary: "Mapped PTY bridge launch/session coverage. Core launch and ensure-terminal unit paths exist, and ttyd workbench launch/navigation E2E exists, but no workbench E2E proves a launch result with terminalBackend=pty_bridge and ttydPort=null routes through PTY websocket attach or survives navigation."
+      evidence:
+        - "packages/core/src/launch/launch-execute-agents.test.ts"
+        - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts"
+        - "packages/web/lib/ensure-terminal.test.ts"
+        - "packages/web/lib/terminal-auth.test.ts"
+        - "packages/web/lib/pty-terminal-websocket.ts"
+        - "packages/web/components/workbench/IssueFocus.tsx"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/e2e/workbench.spec.ts"
+      gaps:
+        - "No E2E coverage for launch response terminalBackend=pty_bridge with ttydPort=null."
+        - "No workbench E2E assertion that TerminalFocus renders the xterm PTY application instead of a ttyd iframe."
+        - "No workbench E2E assertion that PTY deployment selection survives issue navigation away and back."
+        - "No workbench E2E close-path coverage for PTY bridge launched sessions."
+      candidate_worker_slices:
+        - "Add a focused workbench E2E PTY bridge launch/session test in packages/web/e2e/workbench.spec.ts."
+        - "Later run a local manual flagged launch and diagnostics inspection against approved issuectl test repositories."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose the largest safe first Worker slice for PTY bridge workbench automated coverage."
+    inputs:
+      - "T001 receipt"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Prefer a vertical behavior test slice over helper-only coverage."
+      - "Reject any slice that requires real issue launch outside the approved issuectl test repositories."
+    expected_output:
+      - "Decision"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify commands"
+      - "stop_if conditions"
+      - "Deferred follow-up tasks"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "The largest safe first slice is test-only and vertical: prove the workbench handles a PTY bridge launch result end to end in the mocked E2E harness. This targets the highest-risk handoff without real issue side effects."
+      worker_task: T003
+      allowed_files:
+        - "packages/web/e2e/workbench.spec.ts"
+      verify:
+        - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+        - "pnpm --dir packages/web typecheck"
+        - "pnpm --dir packages/web lint"
+      stop_if:
+        - "Need files outside packages/web/e2e/workbench.spec.ts."
+        - "Playwright cannot mock the PTY websocket attach deterministically in this harness."
+        - "The test would require real issue creation or launch outside approved issuectl test repositories."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Add a focused workbench E2E test proving a PTY bridge launch response creates a null-port deployment, renders the PTY terminal application through websocket attach, survives issue navigation away/back, and can be ended."
+    allowed_files:
+      - "packages/web/e2e/workbench.spec.ts"
+    verify:
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The test requires real issue creation or launch outside approved issuectl test repositories."
+      - "Playwright cannot mock the PTY websocket attach deterministically in this harness."
+      - "Verification fails twice for the same cause."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/e2e/workbench.spec.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+      summary: "Added a focused mocked workbench E2E that launches issue #512 with terminalBackend=pty_bridge and ttydPort=null, verifies no ttyd iframe is used, verifies the PTY terminal application opens with the expected websocket URL, navigates away/back through issue and session state, and ends the session from the active sessions pane."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Run a local feature-flagged manual launch walkthrough and diagnostics inspection for the PTY bridge path."
+    allowed_files:
+      - "docs/goals/pty-bridge-workbench-e2e/state.yaml"
+      - "docs/goals/pty-bridge-workbench-e2e/notes/**"
+    verify:
+      - "ISSUECTL_PTY_BRIDGE=1 local web launch walkthrough against an approved issuectl test repository"
+      - "pnpm --dir packages/cli exec issuectl diag list --limit 50"
+      - "pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>"
+    stop_if:
+      - "No approved issuectl test repository is available."
+      - "The walkthrough would create or mutate issues outside the approved test repositories."
+      - "A launch/session failure occurs and diagnostics are insufficient to localize the first impossible transition."
+    receipt:
+      result: done
+      changed_files:
+        - "docs/goals/pty-bridge-workbench-e2e/state.yaml"
+      commands:
+        - cmd: "ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/cli exec issuectl web --port 3897"
+          status: pass
+        - cmd: "POST /api/v1/launch/mean-weasel/issuectl-test-repo/169"
+          status: pass
+        - cmd: "POST /api/v1/deployments/115/ensure-ttyd"
+          status: pass
+        - cmd: "Node websocket attach to /api/terminal/pty/115/ws"
+          status: pass
+        - cmd: "pnpm --dir packages/cli exec issuectl diag show --deployment 115"
+          status: pass
+      summary: "Ran the flagged PTY bridge walkthrough against approved test repo mean-weasel/issuectl-test-repo#169. The first deployment 114 localized a node-pty attach failure to posix_spawnp failed because the packaged macOS spawn-helper was not executable. After local chmod validation, deployment 115 launched with terminalBackend=pty_bridge and ttydPort=null, ensure returned a PTY websocket URL, websocket attach saw ready plus terminal output, diagnostics recorded pty.bridge_attach_requested, pty.ws_connected, pty.bridge_attached, pty.first_output_seen, pty.ws_closed, and pty.process_exit, then deployments 114 and 115 were ended and the test tmux session was killed."
+      deployment_ids:
+        failed_attach: 114
+        passed_attach: 115
+      issue: "mean-weasel/issuectl-test-repo#169"
+      correlation_ids:
+        failed_attach: "c0429211-3419-4094-93d3-9a7365bb7417"
+        passed_attach: "47fdeb00-1844-460e-80a7-b3a72cc74660"
+      follow_up_needed: "Add a source-level guard so PTY bridge attach fixes or reports non-executable node-pty spawn-helper before spawning."
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Make PTY bridge attach self-heal non-executable node-pty macOS spawn-helper permissions and cover the guard with focused tests."
+    allowed_files:
+      - "packages/web/lib/pty-terminal-websocket.ts"
+      - "packages/web/lib/pty-terminal-websocket.test.ts"
+      - "packages/web/lib/node-pty-spawn-helper.ts"
+      - "packages/web/lib/pty-diagnostics-sanitize.ts"
+    verify:
+      - "pnpm --dir packages/web test -- pty-terminal-websocket"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need dependency or lockfile changes."
+      - "Need files outside allowed_files."
+      - "The guard cannot be tested without invoking real node-pty native spawning."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/pty-terminal-websocket.ts"
+        - "packages/web/lib/node-pty-spawn-helper.ts"
+        - "packages/web/lib/pty-diagnostics-sanitize.ts"
+        - "packages/web/lib/pty-terminal-websocket.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test -- pty-terminal-websocket"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+        - cmd: "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+          status: pass
+      summary: "Added a macOS node-pty spawn-helper guard before PTY attach. The guard resolves node-pty's packaged spawn-helper, chmods it to 0755 when the executable bit is missing, logs the self-heal, and is covered without invoking native PTY spawning. Split the sanitizer out so pty-terminal-websocket.ts stays under the 300-line lint limit."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the PTY bridge workbench E2E tranche satisfies the oracle."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "Manual walkthrough diagnostics note if created"
+    constraints:
+      - "Read-only."
+      - "Reject completion if required Worker work is still queued or active."
+      - "Reject completion if tests pass but no manual flagged launch/diagnostics proof exists."
+      - "Reject completion if the PTY path still falls back to ttyd assumptions."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "The tranche satisfies the oracle. Automated coverage proves the PTY bridge workbench launch response renders the PTY terminal, preserves session navigation, and ends the session. Manual flagged diagnostics on approved test repo mean-weasel/issuectl-test-repo#169 proved launch through websocket attach and cleanup. The discovered node-pty spawn-helper install hazard now has a focused self-healing source guard and tests."
+      evidence:
+        - "T003 mocked workbench E2E passed."
+        - "T004 deployment 115 diagnostics recorded launch.requested, workspace.prepared, deployment.recorded, pty.bridge_spawned, deployment.activated, pty.bridge_attach_requested, pty.ws_connected, pty.bridge_attached, pty.first_output_seen, pty.ws_closed, and pty.process_exit."
+        - "T005 unit/typecheck/lint/focused E2E passed."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T005
+    commands:
+      - "pnpm --dir packages/web test -- pty-terminal-websocket"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -3442,6 +3442,104 @@ test("checks worktree status and launches an issue with selected context", async
   await page.goto("about:blank");
 });
 
+test("launches an issue with the PTY bridge backend and keeps the terminal session navigable", async ({ page }) => {
+  await installFakePtyWebSocket(page);
+  await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
+    expect(route.request().method()).toBe("GET");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(issueDetailFixture()),
+    });
+  });
+  await page.route("**/api/v1/worktrees/status?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ exists: true, dirty: false, path: "/tmp/issuectl-512" }),
+    });
+  });
+  await page.route("**/api/v1/launch/mean-weasel/issuectl/512", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    const body = await route.request().postDataJSON();
+    const { idempotencyKey, ...withoutNonce } = body;
+    expect(withoutNonce).toEqual({
+      agent: "codex",
+      branchName: "issue-512-desktop-instance-manager-workbench",
+      workspaceMode: "worktree",
+      selectedCommentIndices: [0],
+      selectedFilePaths: ["packages/web/app/workbench/page.tsx"],
+      preamble: "Investigate workbench implementation",
+      forceResume: false,
+    });
+    expect(typeof idempotencyKey).toBe("string");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        deploymentId: 409,
+        terminalBackend: "pty_bridge",
+        ttydPort: null,
+      }),
+    });
+  });
+  await page.route("**/api/v1/deployments/409/ensure-ttyd", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        backend: "pty_bridge",
+        deploymentId: 409,
+        terminalToken: "pty-token-409",
+        wsUrl: "/api/terminal/pty/409/ws?terminalToken=pty-token-409",
+      }),
+    });
+  });
+  await expectJsonRequest(page, "**/api/v1/deployments/409/end", "POST", {
+    owner: "mean-weasel",
+    repo: "issuectl",
+    issueNumber: 512,
+  });
+
+  await gotoWorkbenchWithRetry(page);
+  await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await page.getByRole("button", { name: "Launch issue" }).click();
+
+  await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-instances-pane", "visible");
+  await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-issues-pane", "collapsed");
+  await expect(page.getByLabel("Session #512")).toBeVisible();
+  await expect(page.locator('iframe[title="Terminal for issue 512"]')).toHaveCount(0);
+  await expect(page.getByRole("application", { name: "Terminal for issue 512" })).toBeVisible();
+  await expect.poll(async () => page.evaluate(() =>
+    (window as Window & { __issuectlPtySocketUrls?: string[] }).__issuectlPtySocketUrls ?? [],
+  )).toContain(
+    `${baseUrl.replace(/^http/, "ws")}/api/terminal/pty/409/ws?terminalToken=pty-token-409`,
+  );
+
+  await page.getByRole("button", { name: "Back to overview" }).click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
+  await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await page.goBack();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #512").click();
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl&deployment=409$/);
+  await expect(page.getByRole("application", { name: "Terminal for issue 512" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Back to overview" }).click();
+  const launchedSession = page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #512");
+  await launchedSession.getByText("End", { exact: true }).click();
+  await launchedSession.getByRole("button", { name: "End session" }).click();
+  await expect(page.getByLabel("Session #512")).toHaveCount(0);
+  await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);
+  await page.goto("about:blank");
+});
+
 test("defaults launches to fresh clone when a repo has no local path", async ({ page }) => {
   await page.route("**/api/v1/issues/mean-weasel/web/440", async (route) => {
     expect(route.request().method()).toBe("GET");
@@ -3688,6 +3786,61 @@ async function terminalFrameViewportState(page: import("@playwright/test").Page,
     return rect.top >= 0 && rect.left >= 0 && rect.bottom <= window.innerHeight && rect.right <= window.innerWidth
       ? "visible-in-viewport"
       : `offscreen:${Math.round(rect.left)},${Math.round(rect.top)},${Math.round(rect.right)},${Math.round(rect.bottom)}`;
+  });
+}
+
+async function installFakePtyWebSocket(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    const state = window as Window & {
+      __issuectlPtySocketUrls?: string[];
+      __issuectlPtySocketMessages?: string[];
+    };
+    state.__issuectlPtySocketUrls = [];
+    state.__issuectlPtySocketMessages = [];
+
+    class FakePtyWebSocket extends EventTarget {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+
+      readonly url: string;
+      readonly protocol = "";
+      readonly extensions = "";
+      readonly binaryType = "blob";
+      bufferedAmount = 0;
+      readyState = FakePtyWebSocket.CONNECTING;
+
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        state.__issuectlPtySocketUrls?.push(this.url);
+        queueMicrotask(() => {
+          this.readyState = FakePtyWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.dispatchEvent(new MessageEvent("message", {
+            data: JSON.stringify({ type: "ready" }),
+          }));
+          this.dispatchEvent(new MessageEvent("message", {
+            data: JSON.stringify({ type: "output", data: "pty bridge ready\r\n" }),
+          }));
+        });
+      }
+
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        state.__issuectlPtySocketMessages?.push(typeof data === "string" ? data : "[binary]");
+      }
+
+      close(code = 1000) {
+        this.readyState = FakePtyWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close", { code }));
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FakePtyWebSocket,
+    });
   });
 }
 

--- a/packages/web/lib/node-pty-spawn-helper.ts
+++ b/packages/web/lib/node-pty-spawn-helper.ts
@@ -1,0 +1,53 @@
+import { accessSync, chmodSync, constants } from "node:fs";
+import { createRequire } from "node:module";
+import { arch as osArch, platform as osPlatform } from "node:os";
+import { dirname, join } from "node:path";
+import log from "./logger";
+
+const require = createRequire(import.meta.url);
+const checkedSpawnHelpers = new Set<string>();
+
+export function ensureNodePtySpawnHelperExecutable(options: {
+  helperPath?: string | null;
+  platform?: string;
+  arch?: string;
+  resolveNodePty?: () => string;
+  access?: typeof accessSync;
+  chmod?: typeof chmodSync;
+  resetCache?: boolean;
+} = {}): boolean {
+  const helperPath = options.helperPath ?? nodePtySpawnHelperPath(
+    options.platform ?? osPlatform(),
+    options.arch ?? osArch(),
+    options.resolveNodePty ?? (() => require.resolve("node-pty")),
+  );
+  if (!helperPath) return false;
+  if (options.resetCache) checkedSpawnHelpers.delete(helperPath);
+  if (checkedSpawnHelpers.has(helperPath)) return false;
+
+  const access = options.access ?? accessSync;
+  const chmod = options.chmod ?? chmodSync;
+  try {
+    access(helperPath, constants.X_OK);
+    checkedSpawnHelpers.add(helperPath);
+    return false;
+  } catch {
+    chmod(helperPath, 0o755);
+    access(helperPath, constants.X_OK);
+    checkedSpawnHelpers.add(helperPath);
+    log.warn({ msg: "node_pty_spawn_helper_chmod", helperPath });
+    return true;
+  }
+}
+
+function nodePtySpawnHelperPath(
+  platformName: string,
+  archName: string,
+  resolveNodePty: () => string,
+): string | null {
+  if (platformName !== "darwin") return null;
+  if (archName !== "arm64" && archName !== "x64") return null;
+  const nodePtyEntry = resolveNodePty();
+  const packageRoot = dirname(dirname(nodePtyEntry));
+  return join(packageRoot, "prebuilds", `darwin-${archName}`, "spawn-helper");
+}

--- a/packages/web/lib/pty-diagnostics-sanitize.ts
+++ b/packages/web/lib/pty-diagnostics-sanitize.ts
@@ -1,0 +1,27 @@
+export function sanitizePtyData(data: Record<string, unknown> | undefined): Record<string, number | boolean | string> | null {
+  if (!data) return null;
+  const safe: Record<string, number | boolean | string> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!SAFE_PTY_DATA_KEYS.has(key)) continue;
+    if (typeof value === "number" && Number.isFinite(value)) safe[key] = value;
+    if (typeof value === "boolean") safe[key] = value;
+    if (typeof value === "string" && key === "signal") safe[key] = value;
+  }
+  return Object.keys(safe).length ? safe : null;
+}
+
+const SAFE_PTY_DATA_KEYS = new Set([
+  "activeWs",
+  "backpressureDrops",
+  "bufferedBytes",
+  "bytesFromClient",
+  "bytesToClient",
+  "cols",
+  "durationMs",
+  "exitCode",
+  "framesFromClient",
+  "framesToClient",
+  "peakBuffered",
+  "rows",
+  "signal",
+]);

--- a/packages/web/lib/pty-terminal-websocket.test.ts
+++ b/packages/web/lib/pty-terminal-websocket.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { ensureNodePtySpawnHelperExecutable } from "./node-pty-spawn-helper.js";
 import { isPtyBridgeEnabled, parsePtyClientMessage } from "./pty-terminal-websocket.js";
 
 describe("isPtyBridgeEnabled", () => {
@@ -32,5 +33,46 @@ describe("parsePtyClientMessage", () => {
   it("rejects malformed or oversized input", () => {
     expect(parsePtyClientMessage(Buffer.from("{"))).toBeNull();
     expect(parsePtyClientMessage(Buffer.from(JSON.stringify({ type: "input", data: "x".repeat(70_000) })))).toBeNull();
+  });
+});
+
+describe("ensureNodePtySpawnHelperExecutable", () => {
+  it("chmods a non-executable macOS spawn helper once", () => {
+    const calls: string[] = [];
+    const access = () => {
+      calls.push("access");
+      if (calls.length === 1) throw new Error("not executable");
+    };
+    const chmod = (_path: unknown, mode: string | number) => {
+      calls.push(`chmod:${Number(mode).toString(8)}`);
+    };
+
+    expect(ensureNodePtySpawnHelperExecutable({
+      helperPath: "/tmp/node-pty/prebuilds/darwin-arm64/spawn-helper",
+      access,
+      chmod,
+      resetCache: true,
+    })).toBe(true);
+    expect(ensureNodePtySpawnHelperExecutable({
+      helperPath: "/tmp/node-pty/prebuilds/darwin-arm64/spawn-helper",
+      access,
+      chmod,
+    })).toBe(false);
+    expect(calls).toEqual(["access", "chmod:755", "access"]);
+  });
+
+  it("skips non-macOS platforms", () => {
+    expect(ensureNodePtySpawnHelperExecutable({
+      platform: "linux",
+      arch: "arm64",
+      resolveNodePty: () => "/tmp/node-pty/lib/index.js",
+      access: () => {
+        throw new Error("should not access");
+      },
+      chmod: () => {
+        throw new Error("should not chmod");
+      },
+      resetCache: true,
+    })).toBe(false);
   });
 });

--- a/packages/web/lib/pty-terminal-websocket.ts
+++ b/packages/web/lib/pty-terminal-websocket.ts
@@ -11,6 +11,8 @@ import {
   tmuxSessionName,
 } from "@issuectl/core";
 import log from "./logger";
+import { sanitizePtyData } from "./pty-diagnostics-sanitize";
+import { ensureNodePtySpawnHelperExecutable } from "./node-pty-spawn-helper";
 import { validatePtyTerminalToken } from "./terminal-auth";
 
 const ptyWss = new WebSocketServer({ noServer: true });
@@ -104,6 +106,7 @@ export async function handlePtyUpgrade(
     let cleanedUp = false;
 
     try {
+      ensureNodePtySpawnHelperExecutable();
       attachPty = spawn("tmux", ["attach-session", "-t", context.sessionName], {
         name: "xterm-256color",
         cols: 80,
@@ -280,34 +283,6 @@ function recordPtyEvent(
     // Diagnostics should not break terminal attach behavior.
   }
 }
-
-function sanitizePtyData(data: Record<string, unknown> | undefined): Record<string, number | boolean | string> | null {
-  if (!data) return null;
-  const safe: Record<string, number | boolean | string> = {};
-  for (const [key, value] of Object.entries(data)) {
-    if (!SAFE_PTY_DATA_KEYS.has(key)) continue;
-    if (typeof value === "number" && Number.isFinite(value)) safe[key] = value;
-    if (typeof value === "boolean") safe[key] = value;
-    if (typeof value === "string" && key === "signal") safe[key] = value;
-  }
-  return Object.keys(safe).length ? safe : null;
-}
-
-const SAFE_PTY_DATA_KEYS = new Set([
-  "activeWs",
-  "backpressureDrops",
-  "bufferedBytes",
-  "bytesFromClient",
-  "bytesToClient",
-  "cols",
-  "durationMs",
-  "exitCode",
-  "framesFromClient",
-  "framesToClient",
-  "peakBuffered",
-  "rows",
-  "signal",
-]);
 
 function clampDimension(value: unknown, min: number, max: number): number | null {
   if (!Number.isFinite(value)) return null;


### PR DESCRIPTION
## Summary
- add a focused workbench E2E for PTY bridge launches with null ttyd ports, PTY terminal rendering, navigation persistence, and end-session cleanup
- add a macOS node-pty spawn-helper executable guard before PTY attach, with focused unit coverage
- record the GoalBuddy plan/receipt and manual diagnostics for the PTY bridge validation tranche

## Manual diagnostics
- deployment 114 localized the first attach failure to `pty.bridge_attach_failed` / `posix_spawnp failed`
- after validating the spawn-helper permission fix, deployment 115 recorded `pty.ws_connected`, `pty.bridge_attached`, `pty.first_output_seen`, `pty.ws_closed`, and `pty.process_exit`
- test deployments 114 and 115 were ended, and the test tmux session was cleaned up

## Verification
- `pnpm --dir packages/web test -- pty-terminal-websocket`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "launches an issue with the PTY bridge backend"`
- commit hook: repo typecheck/lint
- pre-push hook: repo build
- GoalBuddy state checker passed
