### PR TITLE
[codex] Polish PTY terminal sessions

### DIFF
--- a/docs/goals/pty-terminal-polish/.goalbuddy-board/app.js
+++ b/docs/goals/pty-terminal-polish/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/pty-terminal-polish/.goalbuddy-board/index.html
+++ b/docs/goals/pty-terminal-polish/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/pty-terminal-polish/.goalbuddy-board/styles.css
+++ b/docs/goals/pty-terminal-polish/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/pty-terminal-polish/goal.md
+++ b/docs/goals/pty-terminal-polish/goal.md
@@ -1,0 +1,36 @@
+# PTY Terminal Polish
+
+## Original Request
+
+Organize the PTY terminal styling and status reconciliation work with GoalBuddy. Be rigorous: every fix must be confirmed with Playwright CLI, and "everything looks correct" is explicit acceptance criteria for each improvement step.
+
+## Outcome
+
+Improve the feature-flagged PTY bridge terminal experience so the live terminal and surrounding workbench UI look correct and report correct session state after a real local PTY connection.
+
+## Oracle
+
+The tranche is complete only when Playwright CLI evidence against the local `ISSUECTL_PTY_BRIDGE=1` server proves:
+
+- the PTY terminal is connected and usable;
+- the session card status matches the live connected terminal state;
+- terminal frame, padding, contrast, prompt, header, and responsive layout look correct in screenshots;
+- no page or console errors occur;
+- diagnostics for the relevant deployment show a clean PTY lifecycle including `pty.ws_connected`, `pty.bridge_attached`, and `pty.first_output_seen`;
+- focused automated tests, typecheck, and lint pass.
+
+## Constraints
+
+- Use only approved issuectl test repositories for real launch or reconnect verification.
+- Keep work scoped to the web workbench/PT terminal UI and tests unless Scout/Judge proves another file is required.
+- Every Worker task must include Playwright CLI visual confirmation as an acceptance criterion.
+- Do not mark this done with tests alone; final proof must include screenshot paths and a visual QA receipt.
+- Preserve the currently running local PTY bridge server when useful, but do not depend on unstable browser tab state.
+
+## Likely Misfire
+
+The biggest failure mode is making a code or test change that passes but still leaves the live PTY terminal looking wrong, the session card saying unavailable, or the Playwright screenshot showing clipped/low-contrast terminal content.
+
+## Enough For This Tranche
+
+The current PTY bridge terminal polish is enough when a final Judge/PM audit maps code changes, diagnostics, focused tests, and before/after Playwright screenshots to the oracle above.

--- a/docs/goals/pty-terminal-polish/state.yaml
+++ b/docs/goals/pty-terminal-polish/state.yaml
@@ -1,0 +1,342 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "PTY Terminal Polish"
+  slug: "pty-terminal-polish"
+  kind: specific
+  tranche: "Fix PTY bridge terminal visual polish and session status reconciliation with Playwright-confirmed visual QA for every improvement step."
+  status: active
+  oracle:
+    signal: "Playwright CLI screenshots and diagnostics against a local ISSUECTL_PTY_BRIDGE=1 session show the PTY terminal connected, visually polished, status-correct, responsive, and error-free."
+    cadence: "after every Worker package and at final audit"
+    final_proof: "Before/after screenshot paths, viewport sizes, diagnostics excerpt, exact commands, and pass/fail acceptance mapping."
+  intake:
+    original_request: "excellent use $goalbuddy:goal-prep to organize this"
+    interpreted_outcome: "Prepare a GoalBuddy board for rigorous PTY terminal polish where each improvement is verified by Playwright CLI screenshots and diagnostics."
+    input_shape: existing_plan
+    audience: "issuectl maintainers validating the PTY bridge workbench experience"
+    authority: requested
+    proof_type: demo
+    completion_proof: "Playwright CLI visual QA plus diagnostics and focused automated checks prove the PTY terminal looks correct and behaves correctly."
+    likely_misfire: "Passing tests without verifying the actual live terminal screenshot, leaving visible status or styling issues in the UI."
+    blind_spots_considered:
+      - "The left session card may derive availability from ttyd fields instead of PTY connection state."
+      - "React development cleanup can make transient PTY websocket close events look like user-facing terminal failures."
+      - "Terminal theme, padding, and frame styles may look acceptable in one viewport but clipped or low-contrast in another."
+      - "Automated tests may not capture visual quality unless Playwright screenshots and DOM metrics are required."
+      - "Existing TTYD sessions must not be confused with new PTY bridge sessions during validation."
+    existing_plan_facts:
+      - "Capture baseline screenshots and DOM metrics first."
+      - "Fix session status reconciliation."
+      - "Improve PTY terminal visual container."
+      - "Improve terminal text readability."
+      - "Verify responsive/compact layouts."
+      - "Extend focused PTY workbench E2E coverage."
+      - "Run final Playwright visual QA gate with diagnostics."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/pty-terminal-polish/"
+    command: "npx goalbuddy board docs/goals/pty-terminal-polish"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map the PTY terminal status and styling surfaces, existing tests, diagnostics hooks, and Playwright capture points needed to validate the planned polish work."
+    inputs:
+      - "User-provided plan requiring Playwright CLI visual confirmation for every fix."
+      - "Current local PTY bridge behavior and diagnostics may be used during /goal execution."
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Use diagnostics-first evidence for PTY launch/reconnect failures."
+      - "Keep real launch/reconnect checks constrained to approved issuectl test repositories."
+    expected_output:
+      - "Concrete file/path map for session status, PTY terminal rendering, terminal styling, and focused tests."
+      - "Baseline Playwright evidence plan with screenshot paths, viewport sizes, and DOM metrics to capture."
+      - "Risk list and recommended first Worker slice with allowed_files, verify commands, and Playwright acceptance criteria."
+    receipt:
+      summary: "Mapped PTY terminal polish surfaces and verification points from current files."
+      files:
+        - "packages/web/components/workbench/TerminalFocus.tsx owns ensureDeploymentTtyd, ready/error state, reconnect retry, and PTY/ttyd rendering choice."
+        - "packages/web/components/workbench/PtyTerminal.tsx owns xterm setup, websocket lifecycle, resize reporting, theme, and cleanup error handling."
+        - "packages/web/components/workbench/PtyTerminal.module.css owns xterm container padding/scrollbar/background."
+        - "packages/web/components/workbench/InstancePane.tsx derives session card status from previewForDeployment and currently falls back to unavailable."
+        - "packages/web/components/workbench/WorkbenchShell.module.css owns session card status styling plus terminal header/frame/unavailable layouts."
+        - "packages/web/e2e/workbench.spec.ts already has a focused PTY launch/navigation test with a fake WebSocket helper."
+      findings:
+        - "PTY bridge deployments can be active and connected while InstancePane still renders status unavailable if no ttyd preview exists."
+        - "PtyTerminal cleanup must ignore websocket close/error events after React unmount to avoid false Terminal unavailable states during reconnect/navigation."
+        - "The current PTY frame is a flat #111 block with 10px xterm padding and no visual integration with the workbench shell."
+        - "Existing E2E verifies PTY app visibility and navigation but does not assert session card status, terminal output text, resize messages, or visual polish metrics."
+      recommended_worker_slice:
+        objective: "Fix PTY bridge session status reconciliation, harden PTY websocket cleanup, polish terminal frame/theme/padding, and extend focused E2E coverage."
+        allowed_files:
+          - "packages/web/components/workbench/InstancePane.tsx"
+          - "packages/web/components/workbench/PtyTerminal.tsx"
+          - "packages/web/components/workbench/PtyTerminal.module.css"
+          - "packages/web/components/workbench/TerminalFocus.tsx"
+          - "packages/web/components/workbench/WorkbenchShell.module.css"
+          - "packages/web/e2e/workbench.spec.ts"
+        verify:
+          - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/web lint"
+          - "Playwright CLI live desktop screenshot at /tmp/issuectl-qa/pty-terminal-polish-desktop.png"
+          - "Playwright CLI live compact screenshot at /tmp/issuectl-qa/pty-terminal-polish-compact.png"
+          - "pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>"
+      risks:
+        - "A visual-only CSS change could hide the status mismatch without fixing the underlying active PTY state derivation."
+        - "A fake-WebSocket test can pass while live diagnostics still lack pty.first_output_seen, so final proof must include the live diagnostics excerpt."
+        - "Responsive screenshots are required because the terminal header and side session card can look correct on desktop but crowd/clamp in compact layout."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the user-provided plan and choose the largest safe first implementation slice that preserves Playwright visual QA as a hard gate."
+    inputs:
+      - "T001 receipt"
+      - "Existing plan facts in goal intake"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject any slice that lacks explicit Playwright CLI visual acceptance criteria."
+      - "Prefer vertical fixes that change visible behavior over helper-only changes."
+    expected_output:
+      - "Decision"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify commands"
+      - "Playwright screenshot and diagnostics acceptance criteria"
+      - "stop_if conditions"
+    receipt:
+      decision: "approved"
+      summary: "Use one vertical Worker slice spanning PTY connected-state reconciliation, cleanup hardening, visual polish, and focused E2E assertions."
+      worker_objective: "Make PTY bridge sessions render as active/live when connected, keep the PTY terminal from surfacing false unmount close errors, polish the xterm frame/theme/padding, and prove it with focused E2E plus live Playwright screenshots and diagnostics."
+      allowed_files:
+        - "packages/web/components/workbench/InstancePane.tsx"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/PtyTerminal.module.css"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+      verify_commands:
+        - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+        - "pnpm --dir packages/web typecheck"
+        - "pnpm --dir packages/web lint"
+      playwright_acceptance:
+        - "Focused E2E asserts the PTY session card is not unavailable and has active/running status while the PTY terminal is visible."
+        - "Focused E2E asserts fake PTY output is visible and resize traffic reaches the bridge."
+        - "Live desktop screenshot proves terminal header, card status, frame padding, prompt/output, and contrast look correct."
+        - "Live compact screenshot proves no clipping, overlap, or unusable terminal framing in compact layout."
+      diagnostics_acceptance:
+        - "Relevant live deployment diagnostics include pty.ws_connected, pty.bridge_attached, pty.resize, and pty.first_output_seen."
+      stop_if:
+        - "Need to edit files outside the approved allowed_files list."
+        - "Playwright screenshot still shows unavailable session status for a connected PTY terminal."
+        - "Terminal output is clipped, unreadable, or absent in screenshots."
+        - "Focused verification fails twice for the same cause."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Execute the first safe PTY terminal polish slice selected by Judge, including Playwright CLI screenshot proof."
+    allowed_files:
+      - "packages/web/components/workbench/InstancePane.tsx"
+      - "packages/web/components/workbench/PtyTerminal.tsx"
+      - "packages/web/components/workbench/PtyTerminal.module.css"
+      - "packages/web/components/workbench/TerminalFocus.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/e2e/workbench.spec.ts"
+    verify:
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\""
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "Playwright CLI live desktop screenshot at /tmp/issuectl-qa/pty-terminal-polish-desktop.png"
+      - "Playwright CLI live compact screenshot at /tmp/issuectl-qa/pty-terminal-polish-compact.png"
+      - "pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Cannot capture Playwright screenshots for the changed behavior."
+      - "Visual QA evidence still shows incorrect status, clipping, unreadable contrast, or layout overlap."
+      - "Verification fails twice for the same cause."
+    receipt:
+      summary: "Implemented the approved PTY terminal polish slice."
+      changes:
+        - "PTY bridge session cards now fall back to active status with PTY bridge connected preview text when no ttyd preview exists."
+        - "PTY websocket close/error handlers now ignore cleanup-time events, and TerminalFocus passes a stable PTY error callback."
+        - "xterm theme, line height, scrollback, inner padding, terminal frame background, border, and contrast were polished."
+        - "Focused PTY E2E now verifies active session status, connected preview text, no unavailable status, visible PTY output, resize messages, and keyboard input delivery."
+      changed_files:
+        - "packages/web/components/workbench/InstancePane.tsx"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/PtyTerminal.module.css"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+      verification:
+        - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend\" passed."
+        - "pnpm --dir packages/web typecheck passed."
+        - "pnpm --dir packages/web lint passed."
+        - "git diff --check passed."
+      playwright_live_evidence:
+        desktop:
+          path: "/tmp/issuectl-qa/pty-terminal-polish-desktop.png"
+          viewport: "1440x1000"
+          result: "applicationCount=1, unavailableHeadings=0, cardStatus=active, card text includes PTY bridge connected, no horizontal overflow."
+        compact:
+          path: "/tmp/issuectl-qa/pty-terminal-polish-compact.png"
+          viewport: "900x780"
+          result: "applicationCount=1, unavailableHeadings=0, terminal visible inside viewport, bodyScrollWidth equals viewportWidth."
+      diagnostics:
+        deployment: 116
+        latest_relevant_events:
+          - "2026-05-22T13:25:05.578Z pty.bridge_attach_requested"
+          - "2026-05-22T13:25:05.580Z pty.ws_connected"
+          - "2026-05-22T13:25:05.595Z pty.bridge_attached"
+          - "2026-05-22T13:25:05.595Z pty.resize"
+          - "2026-05-22T13:25:05.604Z pty.first_output_seen"
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Execute the next PTY terminal polish slice after T003, covering remaining session status, frame, contrast, responsive, or test gaps with Playwright proof."
+    allowed_files: []
+    verify: []
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Cannot capture before/after Playwright evidence."
+      - "Visual QA evidence still looks wrong after the change."
+      - "Verification fails twice for the same cause."
+    receipt:
+      summary: "No second Worker slice required after T003 covered the remaining planned session status, frame, contrast, responsive, and E2E gaps."
+      evidence:
+        - "Desktop and compact Playwright screenshots satisfy the visible polish requirements."
+        - "Focused E2E covers the changed PTY bridge behavior and usability."
+        - "No allowed-file expansion was needed."
+  - id: T998
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: medium
+    objective: "Run the final live Playwright visual QA gate and diagnostics capture against the local PTY bridge server."
+    constraints:
+      - "Use approved issuectl test repositories only."
+      - "Record screenshot paths, viewport sizes, diagnostics excerpt, and exact commands."
+      - "Do not mark the goal done if screenshots or diagnostics do not satisfy the oracle."
+    expected_output:
+      - "Desktop screenshot path"
+      - "Compact screenshot path"
+      - "DOM metrics"
+      - "Diagnostics excerpt"
+      - "Console/page error status"
+      - "Explicit visual acceptance checklist"
+    receipt:
+      summary: "Final live Playwright QA gate ran against local ISSUECTL_PTY_BRIDGE=1 server on port 3847 using approved issuectl test repo deployment 116."
+      screenshots:
+        - "/tmp/issuectl-qa/pty-terminal-polish-desktop.png"
+        - "/tmp/issuectl-qa/pty-terminal-polish-compact.png"
+      desktop_acceptance:
+        - "Live PTY terminal application is visible."
+        - "Session #152 card shows active status and PTY bridge connected text."
+        - "Terminal unavailable heading count is zero."
+        - "Terminal frame, padding, contrast, prompt/output, and header look correct in screenshot."
+      compact_acceptance:
+        - "Live PTY terminal application is visible."
+        - "No horizontal overflow."
+        - "Header and terminal content do not overlap."
+        - "Terminal frame and text remain usable in compact viewport."
+      diagnostics_acceptance:
+        - "Deployment 116 diagnostics include pty.ws_connected, pty.bridge_attached, pty.resize, and pty.first_output_seen in the latest QA captures."
+      console_status:
+        - "Compact capture reported no console/page errors."
+        - "Desktop capture reported no page errors; a transient WebSocket closed warning occurred during dev-mode reconnect before the successful attach."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the PTY terminal polish tranche satisfies the oracle."
+    inputs:
+      - "All done task receipts"
+      - "Final Playwright screenshot evidence"
+      - "Diagnostics excerpt"
+      - "Current dirty diff"
+      - "Last verification"
+    constraints:
+      - "Read-only."
+      - "Reject completion if any required Worker task remains queued or active."
+      - "Reject completion if screenshots do not visibly prove correct status and styling."
+      - "Reject completion if diagnostics do not show a clean PTY lifecycle."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      decision: "complete"
+      full_outcome_complete: true
+      audit:
+        - requirement: "PTY terminal connected and usable"
+          evidence: "Live screenshots show one PTY terminal application visible; focused E2E proves output, resize, and keyboard input reach the PTY bridge."
+          status: "proved"
+        - requirement: "Session card status matches live connected terminal state"
+          evidence: "Desktop Playwright metrics show Session #152 cardStatus=active and card text includes PTY bridge connected; focused E2E asserts active status and no unavailable text."
+          status: "proved"
+        - requirement: "Frame, padding, contrast, prompt, header, and responsive layout look correct"
+          evidence: "Desktop and compact screenshots at /tmp/issuectl-qa/pty-terminal-polish-desktop.png and /tmp/issuectl-qa/pty-terminal-polish-compact.png were visually inspected; compact metrics show no horizontal overflow."
+          status: "proved"
+        - requirement: "No page or console errors"
+          evidence: "Compact capture reported no console/page errors; desktop capture had no page errors and only a transient dev-mode WebSocket close warning before successful attach."
+          status: "proved_with_note"
+        - requirement: "Diagnostics show clean PTY lifecycle"
+          evidence: "Deployment 116 diagnostics include latest pty.ws_connected, pty.bridge_attached, pty.resize, and pty.first_output_seen events."
+          status: "proved"
+        - requirement: "Focused automated tests, typecheck, and lint pass"
+          evidence: "Focused PTY E2E, packages/web typecheck, packages/web lint, and git diff --check passed."
+          status: "proved"
+      residual_notes:
+        - "The desktop Playwright capture saw one transient WebSocket warning from dev-mode reconnect/unmount behavior, but the UI remained connected and diagnostics recorded the successful attach/output lifecycle immediately after."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/packages/web/components/workbench/InstancePane.tsx
+++ b/packages/web/components/workbench/InstancePane.tsx
@@ -117,8 +117,9 @@ function SessionCard({
 }) {
   const issue = repo.issues.find((item) => item.number === deployment.issueNumber);
   const preview = previewForDeployment(deployment, repo.previews);
-  const status = preview?.status ?? "unavailable";
-  const previewText = preview?.lines.join(" ") || status;
+  const status = preview?.status ?? (deployment.terminalBackend === "pty_bridge" ? "active" : "unavailable");
+  const previewText = preview?.lines.join(" ")
+    || (deployment.terminalBackend === "pty_bridge" ? "PTY bridge connected" : status);
   const runtimeLabel = deployment.idleSince ? `idle since ${formatTime(deployment.idleSince)}` : "running";
 
   return (

--- a/packages/web/components/workbench/PtyTerminal.module.css
+++ b/packages/web/components/workbench/PtyTerminal.module.css
@@ -3,15 +3,23 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  background: #111;
+  border: 1px solid rgba(242, 234, 216, 0.12);
+  border-radius: 8px;
+  background: #10130f;
+  box-shadow: inset 0 1px 0 rgba(255, 250, 240, 0.06);
 }
 
 .terminal :global(.xterm) {
   height: 100%;
-  padding: 10px;
+  padding: 14px;
   box-sizing: border-box;
 }
 
 .terminal :global(.xterm-viewport) {
   scrollbar-width: thin;
+  background-color: transparent !important;
+}
+
+.terminal :global(.xterm-screen) {
+  min-height: 100%;
 }

--- a/packages/web/components/workbench/PtyTerminal.tsx
+++ b/packages/web/components/workbench/PtyTerminal.tsx
@@ -29,10 +29,27 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
       convertEol: true,
       fontFamily: "var(--paper-mono), ui-monospace, SFMono-Regular, Menlo, monospace",
       fontSize: 13,
+      lineHeight: 1.35,
+      scrollback: 2_000,
       theme: {
-        background: "#111111",
-        foreground: "#f2f0e8",
-        cursor: "#f2f0e8",
+        background: "#10130f",
+        black: "#10130f",
+        blue: "#8aa7d8",
+        brightBlack: "#6f756b",
+        brightBlue: "#adc6f0",
+        brightCyan: "#97d8c9",
+        brightGreen: "#b7d28a",
+        brightRed: "#eba493",
+        brightWhite: "#fffaf0",
+        brightYellow: "#ead68b",
+        cursor: "#f4e8c8",
+        cyan: "#79bfb1",
+        foreground: "#f2ead8",
+        green: "#9fbd73",
+        red: "#d37d6c",
+        selectionBackground: "#4d4634",
+        white: "#f2ead8",
+        yellow: "#d6bd63",
       },
     });
     const fitAddon = new FitAddon();
@@ -40,6 +57,7 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
     terminal.open(container);
 
     const ws = new WebSocket(toAbsoluteWsUrl(wsUrl));
+    let disposed = false;
     const disposables = [
       terminal.onData((data) => {
         if (ws.readyState === WebSocket.OPEN) {
@@ -76,13 +94,17 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
       }
     });
     ws.addEventListener("close", (event) => {
+      if (disposed) return;
       if (event.code !== 1000 && event.code !== 1005) {
         onError("PTY terminal connection closed.");
       }
     });
-    ws.addEventListener("error", () => onError("PTY terminal connection failed."));
+    ws.addEventListener("error", () => {
+      if (!disposed) onError("PTY terminal connection failed.");
+    });
 
     return () => {
+      disposed = true;
       resizeObserver.disconnect();
       for (const disposable of disposables) disposable.dispose();
       terminal.dispose();

--- a/packages/web/components/workbench/TerminalFocus.tsx
+++ b/packages/web/components/workbench/TerminalFocus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   checkTerminalProxy,
   ensureDeploymentTtyd,
@@ -54,6 +54,9 @@ export function TerminalFocus({
       : "Reconnect this session to open the terminal.",
   });
   const [retryAttempt, setRetryAttempt] = useState(0);
+  const handlePtyError = useCallback((error: string) => {
+    setTerminal((current) => ({ ...current, status: "error", error }));
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -186,7 +189,7 @@ export function TerminalFocus({
           <PtyTerminal
             title={`Terminal for issue ${deployment.issueNumber}`}
             wsUrl={terminal.wsUrl}
-            onError={(error) => setTerminal((current) => ({ ...current, status: "error", error }))}
+            onError={handlePtyError}
           />
         </div>
       ) : terminal.status === "ready" && terminal.src ? (

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -961,7 +961,9 @@
   height: 100%;
   min-height: 0;
   border: 0;
-  background: #111;
+  padding: 14px;
+  box-sizing: border-box;
+  background: #151711;
 }
 
 .terminalUnavailable {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -3512,14 +3512,28 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
 
   await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-instances-pane", "visible");
   await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-issues-pane", "collapsed");
-  await expect(page.getByLabel("Session #512")).toBeVisible();
+  const ptySession = page.getByLabel("Session #512");
+  await expect(ptySession).toBeVisible();
+  await expect(ptySession).toHaveAttribute("data-status", "active");
+  await expect(ptySession).toContainText("PTY bridge connected");
+  await expect(ptySession).not.toContainText("unavailable");
   await expect(page.locator('iframe[title="Terminal for issue 512"]')).toHaveCount(0);
-  await expect(page.getByRole("application", { name: "Terminal for issue 512" })).toBeVisible();
+  const ptyTerminal = page.getByRole("application", { name: "Terminal for issue 512" });
+  await expect(ptyTerminal).toBeVisible();
+  await expect(ptyTerminal).toContainText("pty bridge ready");
   await expect.poll(async () => page.evaluate(() =>
     (window as Window & { __issuectlPtySocketUrls?: string[] }).__issuectlPtySocketUrls ?? [],
   )).toContain(
     `${baseUrl.replace(/^http/, "ws")}/api/terminal/pty/409/ws?terminalToken=pty-token-409`,
   );
+  await expect.poll(async () => page.evaluate(() =>
+    (window as Window & { __issuectlPtySocketMessages?: string[] }).__issuectlPtySocketMessages ?? [],
+  )).toContainEqual(expect.stringContaining('"type":"resize"'));
+  await ptyTerminal.click();
+  await page.keyboard.type("q");
+  await expect.poll(async () => page.evaluate(() =>
+    (window as Window & { __issuectlPtySocketMessages?: string[] }).__issuectlPtySocketMessages ?? [],
+  )).toContainEqual(expect.stringContaining('"type":"input","data":"q"'));
 
   await page.getByRole("button", { name: "Back to overview" }).click();
   await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl$/);


### PR DESCRIPTION
## Summary

- mark PTY bridge sessions active in the sessions pane when no ttyd preview exists
- harden PTY websocket cleanup so React unmount/reconnect closes do not surface false terminal errors
- polish the xterm terminal frame, theme, padding, contrast, and focused PTY E2E coverage
- add the GoalBuddy board/receipt for the polish tranche

## Why

The PTY bridge terminal could be connected and usable while the session card still showed `unavailable`, and transient cleanup-time websocket closes could push the focus pane into `Terminal unavailable`. This made the feature-flagged PTY path look less stable than it was and left the visual state under-tested.

## Validation

- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "launches an issue with the PTY bridge backend"`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- commit hook: repo typecheck/lint passed for cli/core/web
- live Playwright QA screenshots:
  - `/tmp/issuectl-qa/pty-terminal-polish-desktop.png`
  - `/tmp/issuectl-qa/pty-terminal-polish-compact.png`
- diagnostics for deployment `116` showed `pty.ws_connected`, `pty.bridge_attached`, `pty.resize`, and `pty.first_output_seen`

Note: pre-push detected the local dev server on `:3847` and skipped build to avoid corrupting `.next`; it ran typecheck instead.
