### PR TITLE
[codex] add terminal diagnostics UI

### DIFF
--- a/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/app.js
+++ b/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/index.html
+++ b/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/styles.css
+++ b/docs/goals/terminal-session-diagnostics-ui/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/terminal-session-diagnostics-ui/goal.md
+++ b/docs/goals/terminal-session-diagnostics-ui/goal.md
@@ -1,0 +1,38 @@
+# Terminal Session Diagnostics UI
+
+## Original Request
+
+Plan the next slice for adding lightweight terminal diagnostics and session status visibility to the workbench.
+
+## Outcome
+
+Add a small, useful diagnostics/status surface for issue launch terminal sessions so maintainers can quickly see whether a session is using TTYD or the PTY bridge, understand the current attach/connection state, and jump to or copy the right diagnostics command when something goes wrong.
+
+## Oracle
+
+The tranche is complete only when current evidence proves:
+
+- terminal/session UI shows the backend clearly: `TTYD` or `PTY bridge`;
+- a live PTY bridge session shows a correct connected/attached status while usable;
+- TTYD sessions still render with a correct backend/status indicator;
+- the UI exposes a low-friction diagnostics affordance for the relevant deployment ID, such as copying `issuectl diag show --deployment <id>`;
+- diagnostics-first debugging remains documented and aligned with `AGENTS.md`;
+- focused automated tests cover PTY and TTYD status display plus diagnostics command behavior;
+- Playwright evidence against a local server proves the UI is visible, readable, and not cluttered in desktop and compact layouts;
+- manual QA against the approved issuectl test repos confirms launch, navigate away/back, reconnect, and close behavior still works.
+
+## Constraints
+
+- Keep PTY bridge feature-flagged behind `ISSUECTL_PTY_BRIDGE=1`.
+- Restrict real issue launch/manual QA to the approved issuectl test repositories.
+- Prefer the smallest read-only diagnostics surface before building a full diagnostics browser.
+- Do not add a new backend API unless Scout proves the workbench cannot get enough useful state from existing deployment data, terminal lifecycle state, and copyable CLI commands.
+- Preserve TTYD as the default path unless a separate rollout decision changes it.
+
+## Likely Misfire
+
+The likely wrong solution is overbuilding a diagnostics dashboard before proving that a compact backend/status/command affordance helps real debugging. Another likely miss is showing static backend labels without proving they match live terminal connection state in Playwright and diagnostics.
+
+## Enough For This Tranche
+
+This tranche is enough when a maintainer launching a test issue can immediately tell which terminal backend is active, whether the terminal is connected/attached, and what diagnostics command to run for the deployment, with tests and Playwright evidence proving the behavior.

--- a/docs/goals/terminal-session-diagnostics-ui/state.yaml
+++ b/docs/goals/terminal-session-diagnostics-ui/state.yaml
@@ -1,0 +1,350 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "Terminal Session Diagnostics UI"
+  slug: "terminal-session-diagnostics-ui"
+  kind: specific
+  tranche: "Add lightweight terminal backend/status and diagnostics affordances for issue launch sessions."
+  status: done
+  oracle:
+    signal: "Workbench UI, focused tests, Playwright screenshots, and diagnostics journal evidence prove terminal backend/status visibility and deployment diagnostics command affordance work for PTY bridge and TTYD sessions."
+    cadence: "after Scout, after each Worker slice, and at final audit"
+    final_proof: "Changed files, focused test commands, Playwright screenshot paths, manual QA notes, diagnostics excerpt, and requirement-by-requirement acceptance mapping."
+  intake:
+    original_request: "Okay plan it out."
+    interpreted_outcome: "Prepare a GoalBuddy execution board for a lightweight terminal/session diagnostics UI in the issuectl workbench."
+    input_shape: specific
+    audience: "issuectl maintainers debugging launch terminal sessions"
+    authority: requested
+    proof_type: demo
+    completion_proof: "Playwright plus diagnostics evidence proves the UI clearly displays backend/status and exposes the correct deployment diagnostics command."
+    likely_misfire: "Overbuilding a diagnostics dashboard or adding static labels that do not reflect real PTY/TTYD session state."
+    blind_spots_considered:
+      - "The workbench may not currently expose diagnostics journal records to the browser."
+      - "A copyable CLI command may be enough for this tranche without adding a backend diagnostics API."
+      - "TTYD remains the default path, so status UI must not imply PTY bridge is always active."
+      - "Compact layout can become cluttered if diagnostics metadata is placed in the wrong terminal surface."
+      - "Manual QA must stay constrained to issuectl test repos."
+    existing_plan_facts:
+      - "Start with backend badge, deployment ID, connection state, and Copy diagnostics command."
+      - "Avoid a full diagnostics browser unless a Scout/Judge pass proves it is necessary."
+      - "Keep PTY bridge feature-flagged behind ISSUECTL_PTY_BRIDGE=1."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: running
+    url: "http://goalbuddy.localhost:41737/terminal-session-diagnostics-ui/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/docs/goals/terminal-session-diagnostics-ui"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: medium
+    objective: "Map existing terminal backend/status data, diagnostics journal access paths, UI insertion points, and tests needed for a lightweight terminal diagnostics surface."
+    inputs:
+      - "Goal charter in docs/goals/terminal-session-diagnostics-ui/goal.md"
+      - "Current workbench terminal/session implementation"
+      - "Diagnostics-first instructions in AGENTS.md"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not add a diagnostics API unless evidence proves one is required."
+      - "Keep real launch/manual QA scoped to issuectl test repos."
+    expected_output:
+      - "File/path map for terminal focus, session card, diagnostics CLI/API, and tests."
+      - "Recommendation on whether copy diagnostics command is enough or a read-only API is needed."
+      - "Proposed smallest vertical Worker slice with allowed_files, verification commands, Playwright acceptance criteria, and stop_if conditions."
+    receipt:
+      summary: "Mapped terminal diagnostics UI inputs and verified the first slice can avoid backend API work."
+      file_map:
+        - "packages/web/components/workbench/TerminalFocus.tsx owns terminal loading/ready/error state, backend selection, ensureDeploymentTtyd calls, reconnect, and terminal header rendering."
+        - "packages/web/components/workbench/PtyTerminal.tsx owns PTY websocket lifecycle and can report connecting, connected, attached, first output, closed, and error states to TerminalFocus."
+        - "packages/web/components/workbench/InstancePane.tsx already exposes session card backend-adjacent state through deployment.terminalBackend and preview fallback text."
+        - "packages/web/components/workbench/WorkbenchShell.module.css owns terminal header/frame/unavailable styling and is the right place for a compact status strip."
+        - "packages/web/components/workbench/workbench-api.ts already returns backend-specific ensure results and exposes deployment IDs to client code."
+        - "packages/web/e2e/workbench.spec.ts already has focused TTYD and PTY launch/navigation tests that can be extended for backend/status/diagnostics command assertions."
+        - "AGENTS.md and CLAUDE.md already document diagnostics-first CLI commands, including diag show --deployment <id>."
+      diagnostics_paths:
+        - "No browser diagnostics API currently exists, but it is not required for the first tranche because the UI can provide the exact local CLI command for the deployment ID."
+        - "The diagnostics journal remains available through pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>."
+      recommendation:
+        decision: "no_new_backend_api_for_first_slice"
+        rationale: "TerminalFocus already knows deployment ID, backend, loading/ready/error state, and row errors; PtyTerminal can report PTY lifecycle state directly. A copyable CLI command satisfies the low-friction diagnostics affordance without overbuilding."
+      proposed_worker_slice:
+        objective: "Add a compact terminal diagnostics/status strip in TerminalFocus, report PTY lifecycle state from PtyTerminal, show backend/deployment/status, and provide a copy diagnostics command affordance."
+        allowed_files:
+          - "packages/web/components/workbench/TerminalFocus.tsx"
+          - "packages/web/components/workbench/PtyTerminal.tsx"
+          - "packages/web/components/workbench/WorkbenchShell.module.css"
+          - "packages/web/e2e/workbench.spec.ts"
+        verify:
+          - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/web lint"
+          - "Playwright live desktop screenshot proving backend/status/diagnostics strip is visible and readable."
+          - "Playwright live compact screenshot proving the strip does not clutter or overflow."
+        acceptance:
+          - "TTYD launch test sees backend label TTYD, ready status, deployment ID, and a diagnostics command containing deployment 409."
+          - "PTY bridge launch test sees backend label PTY bridge, attached/first output state, deployment ID, and a diagnostics command containing deployment 409."
+          - "Copy diagnostics command button writes pnpm --dir packages/cli exec issuectl diag show --deployment <id> to clipboard or exposes the command visibly when clipboard is unavailable."
+        stop_if:
+          - "A new diagnostics reader API appears necessary."
+          - "Files outside allowed_files are needed."
+          - "The UI cannot fit in compact layout without larger workbench layout changes."
+          - "Focused tests cannot cover both TTYD and PTY bridge behavior."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate Scout findings and choose the smallest useful implementation slice that satisfies the oracle without overbuilding."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle and constraints"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject any slice that lacks focused tests and Playwright visual acceptance criteria."
+      - "Reject backend API work unless Scout proves it is necessary."
+    expected_output:
+      - "Decision"
+      - "Worker objective"
+      - "allowed_files"
+      - "verify commands"
+      - "Playwright screenshot/DOM acceptance criteria"
+      - "Manual QA checklist"
+      - "stop_if conditions"
+    receipt:
+      decision: "approved"
+      summary: "Approve the no-new-API vertical slice. It satisfies the oracle's first useful diagnostic affordance while avoiding a full diagnostics browser."
+      worker_objective: "Add a compact terminal diagnostics/status strip in TerminalFocus, wire PTY lifecycle state from PtyTerminal, show backend/deployment/status, and expose a copy diagnostics command affordance."
+      allowed_files:
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+      verify_commands:
+        - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+        - "pnpm --dir packages/web typecheck"
+        - "pnpm --dir packages/web lint"
+      playwright_acceptance:
+        - "Desktop screenshot shows backend, deployment ID, lifecycle/status, and diagnostics command affordance without obscuring the terminal."
+        - "Compact screenshot shows the same strip readable without horizontal overflow or header/content overlap."
+      manual_qa_checklist:
+        - "Launch PTY bridge session in an approved issuectl test repo."
+        - "Confirm backend/status/deployment ID appear while terminal is usable."
+        - "Copy diagnostics command and verify it targets the deployment ID."
+        - "Navigate away/back, reconnect, and close session."
+      stop_if:
+        - "Need files outside allowed_files."
+        - "Need backend diagnostics API."
+        - "Focused tests fail twice for the same cause."
+        - "Playwright evidence shows compact layout clutter or overflow."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement the Judge-approved smallest vertical terminal diagnostics/status UI slice."
+    allowed_files:
+      - "packages/web/components/workbench/TerminalFocus.tsx"
+      - "packages/web/components/workbench/PtyTerminal.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/e2e/workbench.spec.ts"
+    verify:
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Need a new backend diagnostics API that Judge did not approve."
+      - "Focused tests cannot prove both PTY and TTYD display behavior."
+      - "Playwright screenshots show clutter, overlap, unreadable metadata, or incorrect backend/status."
+      - "Verification fails twice for the same cause."
+    receipt:
+      summary: "Implemented the compact terminal diagnostics/status strip for TTYD and PTY bridge sessions."
+      changed_files:
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/components/workbench/PtyTerminal.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+      implementation:
+        - "TerminalFocus now shows backend, deployment ID, lifecycle/status, and a copyable diagnostics CLI command."
+        - "PtyTerminal reports lifecycle states: connecting, connected, attached, first_output, closed, and error."
+        - "The diagnostics strip uses responsive wrapping so compact layouts do not clip the command or issue title."
+        - "Focused workbench E2E coverage now asserts TTYD and PTY bridge labels, statuses, deployment command text, and clipboard copy behavior."
+      verification:
+        - "PASS pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/web lint"
+      playwright_evidence:
+        - "Desktop: /tmp/issuectl-terminal-diagnostics-desktop-v2.png"
+        - "Compact: /tmp/issuectl-terminal-diagnostics-compact-v2.png"
+      diagnostics_evidence:
+        - "pnpm --dir packages/cli exec issuectl diag show --deployment 117 shows deployment.recorded, pty.bridge_spawned, deployment.activated, pty.ws_connected, pty.bridge_attached, and pty.first_output_seen for mean-weasel/issuectl-test-repo#137."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Execute a follow-up slice only if T003 leaves a proven oracle gap, such as missing compact layout polish or missing diagnostics API read path."
+    allowed_files: []
+    verify: []
+    stop_if:
+      - "No proven oracle gap remains after T003."
+      - "Need files outside allowed_files."
+      - "Playwright evidence does not improve after the change."
+    receipt:
+      summary: "Skipped follow-up worker slice because T003 closed the proven UI/test gaps without requiring a backend diagnostics API."
+      no_gap_reason:
+        - "Focused tests cover both backend display paths and diagnostics command copy behavior."
+        - "Playwright CLI screenshots show desktop and compact layouts are readable after responsive polish."
+        - "Live diagnostics evidence confirms the displayed deployment command targets a real approved test-repo PTY bridge deployment."
+  - id: T998
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: medium
+    objective: "Run final local verification, Playwright visual QA, diagnostics check, and manual QA checklist against approved issuectl test repos."
+    constraints:
+      - "Use ISSUECTL_PTY_BRIDGE=1 for PTY bridge manual QA."
+      - "Keep launch testing scoped to approved issuectl test repos."
+      - "Record screenshot paths, commands, diagnostics excerpts, and manual QA notes."
+    expected_output:
+      - "Verification command results"
+      - "Desktop and compact screenshot paths"
+      - "Diagnostics excerpt"
+      - "Manual QA checklist result"
+      - "Explicit oracle acceptance mapping"
+    receipt:
+      summary: "Final PM verification and live QA passed against the approved issuectl test repo."
+      verification_commands:
+        - "PASS pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/web lint"
+        - "PASS git diff --check"
+      playwright_evidence:
+        - "Desktop terminal view: /tmp/issuectl-terminal-diagnostics-desktop-v2.png"
+        - "Compact terminal view: /tmp/issuectl-terminal-diagnostics-compact-v2.png"
+        - "After close overview: /tmp/issuectl-terminal-diagnostics-after-close-desktop.png"
+        - "Live QA ended screenshot: /tmp/issuectl-terminal-diagnostics-live-qa-ended.png"
+      diagnostics_excerpt:
+        deployment: 117
+        issue: "mean-weasel/issuectl-test-repo#137"
+        command: "pnpm --dir packages/cli exec issuectl diag show --deployment 117"
+        events:
+          - "deployment.recorded"
+          - "pty.bridge_spawned"
+          - "deployment.activated"
+          - "pty.bridge_attach_requested"
+          - "pty.ws_connected"
+          - "pty.bridge_attached"
+          - "pty.first_output_seen"
+          - "pty.ws_closed"
+          - "pty.process_exit"
+      manual_qa:
+        scope: "Approved test repo only: mean-weasel/issuectl-test-repo#137, deployment 117."
+        result: pass
+        checklist:
+          - "Opened live PTY bridge terminal and confirmed backend/status/deployment ID."
+          - "Copied diagnostics command and verified clipboard text exactly matched deployment 117."
+          - "Navigated back to overview and returned to the active session."
+          - "Clicked Reconnect and confirmed the terminal reattached and remained visible."
+          - "Closed the session and confirmed Session #137 was removed while Session #152 remained."
+      docs_alignment:
+        - "AGENTS.md still documents diagnostics-first debugging and diag show --deployment <deployment-id>."
+        - "TerminalFocus uses the same workspace CLI form: pnpm --dir packages/cli exec issuectl diag show --deployment <id>."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the terminal diagnostics UI tranche satisfies the oracle."
+    inputs:
+      - "All task receipts"
+      - "Current diff"
+      - "Verification results"
+      - "Playwright evidence"
+      - "Manual QA notes"
+    constraints:
+      - "Read-only."
+      - "Reject completion if any Worker task remains queued without a receipt explaining why it is unnecessary."
+      - "Reject completion if PTY and TTYD behavior are not both covered."
+      - "Reject completion if Playwright evidence is missing or only indirect."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      decision: complete
+      full_outcome_complete: true
+      oracle_mapping:
+        - requirement: "UI shows backend clearly: TTYD or PTY bridge."
+          evidence: "TerminalFocus renders backendLabel; focused TTYD and PTY tests assert TTYD and PTY bridge; desktop/compact screenshots show PTY bridge."
+          result: proven
+        - requirement: "Live PTY bridge session shows correct connected/attached status while usable."
+          evidence: "Live deployment 117 showed PTY first output seen while terminal was visible; diagnostics showed pty.ws_connected, pty.bridge_attached, and pty.first_output_seen."
+          result: proven
+        - requirement: "TTYD sessions render with correct backend/status indicator."
+          evidence: "Focused TTYD launch test asserts TTYD, Deployment #409, TTYD ready, and iframe terminal visibility."
+          result: proven
+        - requirement: "UI exposes low-friction diagnostics affordance for deployment ID."
+          evidence: "Focused tests and live QA verify the visible/copyable command pnpm --dir packages/cli exec issuectl diag show --deployment <id>."
+          result: proven
+        - requirement: "Diagnostics-first debugging remains documented and aligned with AGENTS.md."
+          evidence: "AGENTS.md includes Diagnostics-first debugging and diag show --deployment <deployment-id>; TerminalFocus command uses the same CLI path."
+          result: proven
+        - requirement: "Focused automated tests cover PTY and TTYD status display plus diagnostics command behavior."
+          evidence: "The two focused Playwright tests passed and assert backend labels, status text, deployment command text, and clipboard copy behavior."
+          result: proven
+        - requirement: "Playwright evidence against local server proves visible/readable/not cluttered desktop and compact layouts."
+          evidence: "/tmp/issuectl-terminal-diagnostics-desktop-v2.png and /tmp/issuectl-terminal-diagnostics-compact-v2.png inspected after fixing compact wrapping."
+          result: proven
+        - requirement: "Manual QA against approved issuectl test repos confirms launch, navigate away/back, reconnect, and close behavior."
+          evidence: "Browser-driven live QA passed against mean-weasel/issuectl-test-repo#137, deployment 117; post-close screenshot shows Session #137 removed."
+          result: proven
+      missing_evidence: []
+      next_task: null
+
+checks:
+  dirty_fingerprint: "terminal diagnostics UI changes plus GoalBuddy board"
+  last_verification:
+    result: "pass"
+    task: T998
+    commands:
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "git diff --check"

--- a/packages/web/components/workbench/PtyTerminal.tsx
+++ b/packages/web/components/workbench/PtyTerminal.tsx
@@ -9,7 +9,10 @@ type Props = {
   wsUrl: string;
   title: string;
   onError: (message: string) => void;
+  onLifecycle?: (state: PtyLifecycleState) => void;
 };
+
+export type PtyLifecycleState = "connecting" | "connected" | "attached" | "first_output" | "closed" | "error";
 
 type ServerMessage =
   | { type: "ready" }
@@ -17,7 +20,7 @@ type ServerMessage =
   | { type: "exit"; code?: number; signal?: string }
   | { type: "error"; message: string };
 
-export function PtyTerminal({ wsUrl, title, onError }: Props) {
+export function PtyTerminal({ wsUrl, title, onError, onLifecycle }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -58,6 +61,8 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
 
     const ws = new WebSocket(toAbsoluteWsUrl(wsUrl));
     let disposed = false;
+    let sawOutput = false;
+    onLifecycle?.("connecting");
     const disposables = [
       terminal.onData((data) => {
         if (ws.readyState === WebSocket.OPEN) {
@@ -80,27 +85,41 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
     const resizeObserver = new ResizeObserver(fitAndReport);
     resizeObserver.observe(container);
 
-    ws.addEventListener("open", fitAndReport);
+    ws.addEventListener("open", () => {
+      onLifecycle?.("connected");
+      fitAndReport();
+    });
     ws.addEventListener("message", (event) => {
       const message = parseServerMessage(event.data);
       if (!message) return;
-      if (message.type === "output") {
+      if (message.type === "ready") {
+        onLifecycle?.("attached");
+      } else if (message.type === "output") {
         terminal.write(message.data);
+        if (!sawOutput) {
+          sawOutput = true;
+          onLifecycle?.("first_output");
+        }
       } else if (message.type === "exit") {
         terminal.writeln("");
         terminal.writeln(`[terminal attach exited${message.code === undefined ? "" : `: ${message.code}`}]`);
       } else if (message.type === "error") {
+        onLifecycle?.("error");
         onError(message.message);
       }
     });
     ws.addEventListener("close", (event) => {
       if (disposed) return;
+      onLifecycle?.("closed");
       if (event.code !== 1000 && event.code !== 1005) {
         onError("PTY terminal connection closed.");
       }
     });
     ws.addEventListener("error", () => {
-      if (!disposed) onError("PTY terminal connection failed.");
+      if (!disposed) {
+        onLifecycle?.("error");
+        onError("PTY terminal connection failed.");
+      }
     });
 
     return () => {
@@ -112,7 +131,7 @@ export function PtyTerminal({ wsUrl, title, onError }: Props) {
         ws.close(1000, "component unmounted");
       }
     };
-  }, [onError, wsUrl]);
+  }, [onError, onLifecycle, wsUrl]);
 
   return <div ref={containerRef} className={styles.terminal} role="application" aria-label={title} />;
 }

--- a/packages/web/components/workbench/TerminalFocus.tsx
+++ b/packages/web/components/workbench/TerminalFocus.tsx
@@ -7,9 +7,22 @@ import {
   isStaleEnsureTtydResult,
   terminalProxyUrl,
 } from "./workbench-api";
-import { PtyTerminal } from "./PtyTerminal";
+import { PtyTerminal, type PtyLifecycleState } from "./PtyTerminal";
 import type { WorkbenchDeployment, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
+
+type TerminalLifecycle = PtyLifecycleState | "ready" | "respawned";
+
+type TerminalState = {
+  status: "loading" | "ready" | "error";
+  port: number | null;
+  token: string | null;
+  src: string | null;
+  backend: "ttyd" | "pty_bridge" | null;
+  wsUrl: string | null;
+  error: string | null;
+  lifecycle: TerminalLifecycle | null;
+};
 
 type Props = {
   deployment: WorkbenchDeployment;
@@ -34,15 +47,7 @@ export function TerminalFocus({
 }: Props) {
   const issue = repo?.issues.find((item) => item.number === deployment.issueNumber);
   const title = issue?.title ?? "Issue session";
-  const [terminal, setTerminal] = useState<{
-    status: "loading" | "ready" | "error";
-    port: number | null;
-    token: string | null;
-    src: string | null;
-    backend: "ttyd" | "pty_bridge" | null;
-    wsUrl: string | null;
-    error: string | null;
-  }>({
+  const [terminal, setTerminal] = useState<TerminalState>({
     status: deployment.ttydPort || deployment.terminalBackend === "pty_bridge" ? "loading" : "error",
     port: deployment.ttydPort,
     token: null,
@@ -52,11 +57,17 @@ export function TerminalFocus({
     error: deployment.ttydPort || deployment.terminalBackend === "pty_bridge"
       ? null
       : "Reconnect this session to open the terminal.",
+    lifecycle: deployment.ttydPort || deployment.terminalBackend === "pty_bridge" ? "connecting" : "error",
   });
   const [retryAttempt, setRetryAttempt] = useState(0);
+  const [diagnosticsCopied, setDiagnosticsCopied] = useState(false);
   const handlePtyError = useCallback((error: string) => {
     setTerminal((current) => ({ ...current, status: "error", error }));
   }, []);
+  const handlePtyLifecycle = useCallback((state: PtyLifecycleState) => {
+    setTerminal((current) => ({ ...current, lifecycle: state }));
+  }, []);
+  const diagnosticsCommand = diagnosticsCommandForDeployment(deployment.id);
 
   useEffect(() => {
     let cancelled = false;
@@ -70,6 +81,7 @@ export function TerminalFocus({
         backend: deployment.terminalBackend ?? "ttyd",
         wsUrl: null,
         error: "Reconnect this session to open the terminal.",
+        lifecycle: "error",
       });
       return;
     }
@@ -82,7 +94,9 @@ export function TerminalFocus({
       backend: deployment.terminalBackend ?? "ttyd",
       wsUrl: null,
       error: null,
+      lifecycle: "connecting",
     });
+    setDiagnosticsCopied(false);
 
     ensureDeploymentTtyd(deployment.id)
       .then(async (result) => {
@@ -96,6 +110,7 @@ export function TerminalFocus({
             backend: "pty_bridge",
             wsUrl: result.wsUrl,
             error: null,
+            lifecycle: "connecting",
           });
           return;
         }
@@ -114,6 +129,7 @@ export function TerminalFocus({
             error: "error" in result && result.error
               ? result.error
               : "Terminal auth token could not be created.",
+            lifecycle: "error",
           });
           return;
         }
@@ -129,6 +145,7 @@ export function TerminalFocus({
             backend: "ttyd",
             wsUrl: null,
             error: proxy.error,
+            lifecycle: "error",
           });
           return;
         }
@@ -141,6 +158,7 @@ export function TerminalFocus({
           backend: "ttyd",
           wsUrl: null,
           error: null,
+          lifecycle: result.respawned ? "respawned" : "ready",
         });
       })
       .catch((err: unknown) => {
@@ -154,6 +172,7 @@ export function TerminalFocus({
           backend: deployment.terminalBackend ?? "ttyd",
           wsUrl: null,
           error: err instanceof Error ? err.message : "Terminal is not available.",
+          lifecycle: "error",
         });
       });
 
@@ -166,6 +185,15 @@ export function TerminalFocus({
   async function reconnectTerminal() {
     await onReconnect(deployment);
     setRetryAttempt((current) => current + 1);
+  }
+
+  async function copyDiagnosticsCommand() {
+    try {
+      await navigator.clipboard.writeText(diagnosticsCommand);
+      setDiagnosticsCopied(true);
+    } catch {
+      setDiagnosticsCopied(false);
+    }
   }
 
   return (
@@ -184,12 +212,22 @@ export function TerminalFocus({
           Back to overview
         </button>
       </header>
+      <section className={styles.terminalDiagnostics} aria-label="Terminal diagnostics">
+        <span className={styles.diagnosticBadge}>{backendLabel(terminal.backend ?? deployment.terminalBackend)}</span>
+        <span>Deployment #{deployment.id}</span>
+        <span>{terminalStateLabel(terminal)}</span>
+        <code>{diagnosticsCommand}</code>
+        <button type="button" className={styles.secondaryButton} onClick={() => void copyDiagnosticsCommand()}>
+          {diagnosticsCopied ? "Copied" : "Copy diagnostics command"}
+        </button>
+      </section>
       {terminal.status === "ready" && terminal.backend === "pty_bridge" && terminal.wsUrl ? (
         <div className={styles.terminalFrame}>
           <PtyTerminal
             title={`Terminal for issue ${deployment.issueNumber}`}
             wsUrl={terminal.wsUrl}
             onError={handlePtyError}
+            onLifecycle={handlePtyLifecycle}
           />
         </div>
       ) : terminal.status === "ready" && terminal.src ? (
@@ -237,4 +275,26 @@ export function TerminalFocus({
       )}
     </div>
   );
+}
+
+function diagnosticsCommandForDeployment(deploymentId: number): string {
+  return `pnpm --dir packages/cli exec issuectl diag show --deployment ${deploymentId}`;
+}
+
+function backendLabel(backend: "ttyd" | "pty_bridge" | null | undefined): string {
+  return backend === "pty_bridge" ? "PTY bridge" : "TTYD";
+}
+
+function terminalStateLabel(terminal: TerminalState): string {
+  if (terminal.status === "error") return "Terminal error";
+  if (terminal.backend === "pty_bridge") {
+    if (terminal.lifecycle === "first_output") return "PTY first output seen";
+    if (terminal.lifecycle === "attached") return "PTY attached";
+    if (terminal.lifecycle === "connected") return "PTY websocket connected";
+    if (terminal.lifecycle === "closed") return "PTY websocket closed";
+    if (terminal.lifecycle === "error") return "PTY error";
+    return "PTY connecting";
+  }
+  if (terminal.status === "ready") return terminal.lifecycle === "respawned" ? "TTYD respawned" : "TTYD ready";
+  return "TTYD connecting";
 }

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -938,7 +938,7 @@
   height: 100%;
   min-height: 0;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
 }
 
 .terminalHeader {
@@ -950,10 +950,59 @@
   border-bottom: 1px solid var(--paper-line);
 }
 
+.terminalHeader > div {
+  min-width: 0;
+}
+
 .terminalHeader h1 {
   font-family: var(--paper-serif);
   font-size: 24px;
   font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.terminalDiagnostics {
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--paper-line);
+  background: rgba(255, 255, 255, 0.24);
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.terminalDiagnostics code {
+  max-width: min(100%, 560px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 4px 6px;
+  border: 1px solid rgba(61, 55, 43, 0.16);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.36);
+  color: var(--paper-ink);
+  font-family: var(--paper-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+.terminalDiagnostics .secondaryButton {
+  min-height: 32px;
+  margin-top: 0;
+  margin-left: auto;
+  font-size: 13px;
+}
+
+.diagnosticBadge {
+  padding: 3px 7px;
+  border: 1px solid rgba(42, 111, 75, 0.28);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(42, 111, 75, 0.08);
+  color: var(--paper-ink);
+  font-weight: 700;
 }
 
 .terminalFrame {
@@ -1855,6 +1904,21 @@
 
   .terminalMeta {
     flex-wrap: wrap;
+  }
+
+  .terminalDiagnostics {
+    padding: 10px 16px;
+  }
+
+  .terminalDiagnostics code {
+    width: 100%;
+    max-width: none;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .terminalDiagnostics .secondaryButton {
+    margin-left: 0;
   }
 
   .overviewSessionShortcuts,

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -3326,6 +3326,7 @@ test("empty repositories add action opens repo setup", async ({ page }) => {
 });
 
 test("checks worktree status and launches an issue with selected context", async ({ page }) => {
+  await installClipboardCapture(page);
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
     expect(route.request().method()).toBe("GET");
     await route.fulfill({
@@ -3437,12 +3438,24 @@ test("checks worktree status and launches an issue with selected context", async
     "src",
     /\/api\/terminal\/7790\/\?terminalToken=terminal-token-409$/,
   );
+  const diagnostics = page.getByLabel("Terminal diagnostics");
+  await expect(diagnostics).toBeVisible();
+  await expect(diagnostics).toContainText("TTYD");
+  await expect(diagnostics).toContainText("Deployment #409");
+  await expect(diagnostics).toContainText("TTYD ready");
+  await expect(diagnostics).toContainText("pnpm --dir packages/cli exec issuectl diag show --deployment 409");
+  await diagnostics.getByRole("button", { name: "Copy diagnostics command" }).click();
+  await expect(diagnostics.getByRole("button", { name: "Copied" })).toBeVisible();
+  await expect.poll(async () => page.evaluate(() =>
+    (window as Window & { __issuectlCopiedText?: string }).__issuectlCopiedText ?? "",
+  )).toBe("pnpm --dir packages/cli exec issuectl diag show --deployment 409");
   await expect(page.locator('iframe[title="Terminal for issue 512"]')).toBeVisible();
   await expect.poll(async () => terminalFrameViewportState(page, "512")).toEqual("visible-in-viewport");
   await page.goto("about:blank");
 });
 
 test("launches an issue with the PTY bridge backend and keeps the terminal session navigable", async ({ page }) => {
+  await installClipboardCapture(page);
   await installFakePtyWebSocket(page);
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
     expect(route.request().method()).toBe("GET");
@@ -3521,6 +3534,17 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
   const ptyTerminal = page.getByRole("application", { name: "Terminal for issue 512" });
   await expect(ptyTerminal).toBeVisible();
   await expect(ptyTerminal).toContainText("pty bridge ready");
+  const diagnostics = page.getByLabel("Terminal diagnostics");
+  await expect(diagnostics).toBeVisible();
+  await expect(diagnostics).toContainText("PTY bridge");
+  await expect(diagnostics).toContainText("Deployment #409");
+  await expect(diagnostics).toContainText("PTY first output seen");
+  await expect(diagnostics).toContainText("pnpm --dir packages/cli exec issuectl diag show --deployment 409");
+  await diagnostics.getByRole("button", { name: "Copy diagnostics command" }).click();
+  await expect(diagnostics.getByRole("button", { name: "Copied" })).toBeVisible();
+  await expect.poll(async () => page.evaluate(() =>
+    (window as Window & { __issuectlCopiedText?: string }).__issuectlCopiedText ?? "",
+  )).toBe("pnpm --dir packages/cli exec issuectl diag show --deployment 409");
   await expect.poll(async () => page.evaluate(() =>
     (window as Window & { __issuectlPtySocketUrls?: string[] }).__issuectlPtySocketUrls ?? [],
   )).toContain(
@@ -3800,6 +3824,19 @@ async function terminalFrameViewportState(page: import("@playwright/test").Page,
     return rect.top >= 0 && rect.left >= 0 && rect.bottom <= window.innerHeight && rect.right <= window.innerWidth
       ? "visible-in-viewport"
       : `offscreen:${Math.round(rect.left)},${Math.round(rect.top)},${Math.round(rect.right)},${Math.round(rect.bottom)}`;
+  });
+}
+
+async function installClipboardCapture(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          (window as Window & { __issuectlCopiedText?: string }).__issuectlCopiedText = text;
+        },
+      },
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Adds a compact terminal diagnostics/status strip to the workbench terminal view so maintainers can immediately see the active backend, deployment ID, connection state, and the diagnostics CLI command for the session.

## Details

- Shows `TTYD` or `PTY bridge` plus deployment ID and terminal lifecycle status in `TerminalFocus`.
- Wires PTY bridge lifecycle events from `PtyTerminal` into the terminal view.
- Adds a copy diagnostics command affordance using `pnpm --dir packages/cli exec issuectl diag show --deployment <id>`.
- Keeps the surface small and responsive, with desktop and compact Playwright evidence recorded in the GoalBuddy board.
- Adds focused workbench E2E assertions for TTYD and PTY bridge status display plus diagnostics command copy behavior.

## Validation

- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend"`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- Live browser QA against `mean-weasel/issuectl-test-repo#137`, deployment `117`: open, copy diagnostics command, navigate away/back, reconnect, and close.
