### PR TITLE
[codex] Harden PTY bridge tmux cleanup

### DIFF
--- a/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/app.js
+++ b/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/index.html
+++ b/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/styles.css
+++ b/docs/goals/pty-bridge-rollout-hardening/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/pty-bridge-rollout-hardening/goal.md
+++ b/docs/goals/pty-bridge-rollout-hardening/goal.md
@@ -1,0 +1,39 @@
+# PTY Bridge Rollout Hardening
+
+## Original Request
+
+Use GoalBuddy to plan the next PTY bridge stabilization slice after the terminal diagnostics UI landed.
+
+## Outcome
+
+Harden the feature-flagged PTY bridge path so maintainers can confidently keep experimenting with it for issue launch terminal sessions. The next tranche should use the diagnostics journal and workbench UI evidence to identify and fix the highest-value stability gaps around launch, attach, reconnect, stale session cleanup, and close behavior.
+
+## Oracle
+
+The tranche is complete only when current evidence proves:
+
+- PTY bridge remains feature-flagged behind `ISSUECTL_PTY_BRIDGE=1`;
+- real launch and manual QA stay restricted to the approved issuectl test repositories;
+- diagnostics journal events make PTY launch, attach, reconnect, close, and stale cleanup outcomes explainable without raw log spelunking first;
+- the workbench can recover clearly from failed PTY attach/reconnect attempts without leaving misleading active sessions;
+- stale or missing PTY/tmux processes are reconciled consistently with visible session state;
+- focused automated tests cover the selected hardening behavior, including at least one failure or stale-session path;
+- Playwright or CLI evidence against a local server proves the hardened behavior in the UI and diagnostics journal;
+- final audit maps every changed behavior to diagnostics evidence and user-visible state.
+
+## Constraints
+
+- Keep TTYD as the default path unless a separate rollout decision changes it.
+- Keep PTY bridge behind `ISSUECTL_PTY_BRIDGE=1`.
+- Do not launch real sessions outside the approved issuectl test repositories.
+- Use the diagnostics journal first when investigating session failures.
+- Prefer a narrow, behavior-changing stabilization slice over broad rewrites or architecture churn.
+- Do not add a full diagnostics browser unless Scout/Judge evidence shows the compact diagnostics UI and CLI workflow are insufficient.
+
+## Likely Misfire
+
+The likely wrong solution is to add more labels or tests around already-working happy paths while leaving the actual instability modes unexplained. Another likely miss is to paper over PTY attach/reconnect failures in the UI without recording enough diagnostics to debug the next failure quickly.
+
+## Enough For This Tranche
+
+This tranche is enough when one high-value PTY bridge reliability gap is selected from current evidence, fixed end-to-end, and proven through focused tests plus local browser/diagnostics evidence against an approved test repo.

--- a/docs/goals/pty-bridge-rollout-hardening/state.yaml
+++ b/docs/goals/pty-bridge-rollout-hardening/state.yaml
@@ -1,0 +1,403 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "PTY Bridge Rollout Hardening"
+  slug: "pty-bridge-rollout-hardening"
+  kind: specific
+  tranche: "Use diagnostics-led evidence to pick and fix the next highest-value PTY bridge stability gap."
+  status: done
+  oracle:
+    signal: "Focused tests, diagnostics journal timelines, and local workbench QA prove a selected PTY bridge failure/recovery/stale-session behavior is hardened end-to-end."
+    cadence: "after Scout, after Judge slice selection, after each Worker slice, and at final audit"
+    final_proof: "Changed files, verification commands, diagnostics excerpts, Playwright/local QA evidence, and requirement-by-requirement acceptance mapping."
+  intake:
+    original_request: "do this"
+    interpreted_outcome: "Prepare a GoalBuddy board for the next PTY bridge rollout hardening slice."
+    input_shape: specific
+    audience: "issuectl maintainers debugging and stabilizing issue launch terminal sessions"
+    authority: requested
+    proof_type: demo
+    completion_proof: "A behavior-changing PTY bridge hardening slice is verified by tests, diagnostics journal evidence, and local QA against approved test repos."
+    likely_misfire: "Polishing happy-path labels or adding generic tests without improving a real PTY bridge instability mode."
+    blind_spots_considered:
+      - "The next failure mode should be selected from current diagnostics and tests, not assumed from memory."
+      - "Reconnect semantics may differ between PTY bridge and TTYD and need explicit UI/diagnostics proof."
+      - "Stale cleanup may involve tmux, PTY process, websocket, deployment state, or a combination."
+      - "Manual QA must remain constrained to approved issuectl test repositories."
+      - "TTYD must remain default while PTY bridge experimentation stays feature-flagged."
+    existing_plan_facts:
+      - "Terminal diagnostics UI PR #501 merged and exposes backend, status, deployment ID, and copy diagnostics command."
+      - "Use diagnostics-first debugging before raw web logs for terminal/session failures."
+      - "Next likely area is PTY bridge rollout hardening: failure recovery, reconnect semantics, and stale session cleanup."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: unknown
+  worker: unknown
+  judge: unknown
+
+visual_board:
+  selected: local
+  local:
+    status: running
+    url: "http://goalbuddy.localhost:41737/pty-bridge-rollout-hardening/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/docs/goals/pty-bridge-rollout-hardening"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: high
+    objective: "Map current PTY bridge launch, attach, reconnect, close, stale cleanup, diagnostics events, and tests to identify the highest-value hardening slice."
+    inputs:
+      - "docs/goals/pty-bridge-rollout-hardening/goal.md"
+      - "AGENTS.md diagnostics-first instructions"
+      - "Current PTY bridge, workbench terminal, deployment, reconcile/liveness, diagnostics, and E2E test implementation"
+      - "Recent diagnostics journal entries from approved issuectl test repo sessions"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not launch real sessions outside approved issuectl test repositories."
+      - "Use diagnostics journal before raw web logs when investigating launch/session behavior."
+      - "Keep PTY bridge feature-flagged."
+    expected_output:
+      - "File/path map for PTY bridge lifecycle, reconnect, close, stale cleanup, diagnostics journal events, and tests."
+      - "Evidence-backed ranking of 2-3 candidate hardening slices."
+      - "One recommended largest-safe Worker slice with allowed_files, verification commands, Playwright/local QA criteria, diagnostics evidence, and stop_if conditions."
+    receipt:
+      summary: "Mapped PTY bridge lifecycle paths and identified PTY tmux cleanup/liveness as the highest-value hardening slice."
+      file_map:
+        - "packages/core/src/launch/launch.ts selects terminal_backend from ISSUECTL_PTY_BRIDGE, records pty_bridge deployments without ttyd_port/ttyd_pid, spawns tmux through spawnPtyBridgeSession, and records pty.bridge_spawned/deployment.activated."
+        - "packages/core/src/launch/ttyd.ts reconciles active deployments whose tmux session is gone, including pty_bridge deployments, and killTtyd kills tmux only when called with a PID."
+        - "packages/core/src/launch/tmux-session.ts owns createTmuxAgentSession and killTmuxSession; killTmuxSession is currently not exported through @issuectl/core."
+        - "packages/web/lib/ensure-terminal.ts returns PTY websocket metadata when ISSUECTL_PTY_BRIDGE=1 but does not check tmux liveness or end stale PTY deployments first."
+        - "packages/web/lib/pty-terminal-websocket.ts checks tmux liveness at websocket attach, records pty.tmux_missing and pty.bridge_attach_failed, but does not end the stale deployment."
+        - "packages/web/app/api/v1/deployments/[id]/end/route.ts only calls killTtyd when deployment.ttydPid exists; PTY bridge deployments have no ttydPid, so their tmux sessions are not killed on end."
+        - "packages/web/components/workbench/WorkbenchShell.tsx removes stale sessions only when ensureDeploymentTtyd returns an alive:false result whose error matches stale-session helpers."
+        - "packages/web/e2e/workbench.spec.ts covers PTY happy path, stale TTYD reconnect removal, terminal auth failure, and end-session UI removal, but not PTY stale tmux cleanup or PTY end tmux cleanup."
+        - "packages/web/lib/ensure-terminal.test.ts covers feature flag routing but not stale PTY tmux."
+        - "packages/web/lib/pty-terminal-websocket.test.ts covers flag and parser behavior but not attach failures."
+      diagnostics_observations:
+        - "Recent deployment 117 for mean-weasel/issuectl-test-repo#137 shows pty.bridge_spawned, deployment.activated, repeated pty.bridge_attach_requested/ws_connected/bridge_attached/first_output_seen, pty.ws_closed, pty.process_exit, and one pty.auth_failed."
+        - "Diagnostics already make happy-path attach explainable, but end-session cleanup is not represented by a PTY-specific event."
+      candidate_slices:
+        - rank: 1
+          name: "PTY tmux liveness and end cleanup"
+          evidence: "PTY deployments intentionally have no ttydPid, while end routes and legacy server actions only kill tmux through killTtyd when a PID exists. ensureTerminalForDeployment also returns PTY attach metadata without checking tmux liveness first."
+          payoff: "Prevents ended PTY sessions from leaving agent tmux sessions running and makes stale PTY sessions disappear through the same stale-session UI path as TTYD."
+        - rank: 2
+          name: "PTY websocket attach failure UI diagnostics"
+          evidence: "pty-terminal-websocket records pty.bridge_attach_failed and pty.tmux_missing, but the browser only sees websocket closed/failed after ensure has already made the terminal look ready."
+          payoff: "Would improve user-visible failure messages for bad tokens, missing tmux, or node-pty spawn errors."
+        - rank: 3
+          name: "PTY reconnect concurrency/backpressure telemetry"
+          evidence: "Diagnostics show repeated quick attach/close cycles and many resize events; reconnect is usable but can be noisy."
+          payoff: "Could reduce diagnostics noise, but less directly tied to misleading active sessions than stale cleanup."
+      recommended_worker_slice:
+        objective: "Harden PTY bridge tmux liveness and cleanup: ensure PTY reconnect/open checks tmux before returning attach metadata, stale PTY deployments are ended with diagnostics, and ending a PTY session kills its tmux session even without a ttydPid."
+        allowed_files:
+          - "packages/core/src/index.ts"
+          - "packages/core/src/launch/tmux-session.ts"
+          - "packages/web/lib/ensure-terminal.ts"
+          - "packages/web/lib/ensure-terminal.test.ts"
+          - "packages/web/app/api/v1/deployments/[id]/end/route.ts"
+          - "packages/web/e2e/workbench.spec.ts"
+          - "docs/goals/pty-bridge-rollout-hardening/state.yaml"
+        verify:
+          - "pnpm --dir packages/web test -- lib/ensure-terminal.test.ts"
+          - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+          - "pnpm --dir packages/core typecheck"
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/web lint"
+        diagnostics_required:
+          - "A stale PTY ensure path records a PTY-specific tmux-missing diagnostic and ends the deployment."
+          - "PTY end path records or can be inferred from endpoint behavior and leaves no active tmux session."
+        stop_if:
+          - "Need to change PTY bridge rollout default."
+          - "Need real launch outside approved issuectl test repos."
+          - "Need a full diagnostics browser."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate Scout findings and choose the largest safe behavior-changing PTY bridge hardening slice."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle and constraints"
+    constraints:
+      - "Read-only."
+      - "Reject pure label/test-only slices unless Scout proves no behavior gap exists."
+      - "Reject broad rewrites or rollout-default changes."
+      - "Require focused tests and diagnostics journal evidence for the chosen slice."
+    expected_output:
+      - "Decision"
+      - "Chosen hardening behavior"
+      - "Worker objective"
+      - "allowed_files"
+      - "verify commands"
+      - "Playwright/local QA acceptance criteria"
+      - "diagnostics evidence required"
+      - "stop_if conditions"
+    receipt:
+      decision: "approved"
+      chosen_hardening_behavior: "PTY tmux liveness and cleanup"
+      summary: "Approve the Scout-recommended behavior-changing slice. It directly addresses misleading active sessions and leaked PTY tmux sessions without changing rollout defaults."
+      worker_objective: "Harden PTY bridge tmux liveness and cleanup: ensure PTY reconnect/open checks tmux before returning attach metadata, stale PTY deployments are ended with diagnostics, and ending a PTY session kills its tmux session even without a ttydPid."
+      allowed_files:
+        - "packages/core/src/index.ts"
+        - "packages/core/src/launch/tmux-session.ts"
+        - "packages/web/lib/ensure-terminal.ts"
+        - "packages/web/lib/ensure-terminal.test.ts"
+        - "packages/web/lib/actions/launch.ts"
+        - "packages/web/lib/actions/launch.test.ts"
+        - "packages/web/app/api/v1/deployments/[id]/end/route.ts"
+        - "packages/web/app/api/v1/deployments/[id]/end/route.test.ts"
+        - "packages/web/e2e/workbench.spec.ts"
+        - "docs/goals/pty-bridge-rollout-hardening/state.yaml"
+      verify_commands:
+        - "pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'"
+        - "pnpm --dir packages/core build"
+        - "ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+        - "pnpm --dir packages/core typecheck"
+        - "pnpm --dir packages/web typecheck"
+        - "pnpm --dir packages/web lint"
+      acceptance:
+        - "PTY bridge remains feature-flagged behind ISSUECTL_PTY_BRIDGE=1."
+        - "PTY ensure/reconnect checks tmux liveness before issuing websocket metadata."
+        - "Missing PTY tmux ends the deployment and returns a stale-session-compatible alive:false response."
+        - "Ending a PTY bridge deployment kills the tmux session even when ttydPid is null."
+        - "Focused tests cover PTY happy path plus stale/end cleanup behavior."
+      diagnostics_evidence_required:
+        - "Stale PTY tmux path records a diagnostic event containing deployment ID, issue, repo, session name, and a terminal-session-ended message."
+      stop_if:
+        - "Need files outside allowed_files."
+        - "Need a backend diagnostics browser."
+        - "Need to change TTYD default or PTY feature flag semantics."
+        - "Verification fails twice for the same cause."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Harden PTY bridge tmux liveness and cleanup according to the T002 Judge receipt."
+    allowed_files:
+      - "packages/core/src/index.ts"
+      - "packages/core/src/launch/tmux-session.ts"
+      - "packages/web/lib/ensure-terminal.ts"
+      - "packages/web/lib/ensure-terminal.test.ts"
+      - "packages/web/lib/actions/launch.ts"
+      - "packages/web/lib/actions/launch.test.ts"
+      - "packages/web/app/api/v1/deployments/[id]/end/route.ts"
+      - "packages/web/app/api/v1/deployments/[id]/end/route.test.ts"
+      - "packages/web/e2e/workbench.spec.ts"
+      - "docs/goals/pty-bridge-rollout-hardening/state.yaml"
+    verify:
+      - "pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'"
+      - "pnpm --dir packages/core build"
+      - "ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Judge has not approved a concrete behavior-changing slice."
+      - "Need files outside allowed_files."
+      - "Need to change PTY bridge rollout default."
+      - "Need to launch real sessions outside approved issuectl test repositories."
+      - "Verification fails twice for the same cause."
+    receipt:
+      summary: "Hardened PTY bridge tmux liveness and cleanup without changing the rollout default."
+      behavior_changes:
+        - "PTY ensure/reconnect now checks the deployment tmux session before issuing websocket attach metadata."
+        - "Missing PTY tmux returns stale-session-compatible alive:false with backend pty_bridge and ends the deployment idempotently."
+        - "The stale PTY ensure path records pty.tmux_missing diagnostics with owner, repo, issue, deployment ID, session name, and terminal-session-ended message."
+        - "Deployment end routes and legacy server action end paths now kill PTY tmux sessions even when ttydPid is null."
+        - "The API end route records pty.tmux_killed diagnostics for PTY bridge session cleanup."
+      files_changed:
+        - "packages/core/src/index.ts"
+        - "packages/web/lib/ensure-terminal.ts"
+        - "packages/web/lib/ensure-terminal.test.ts"
+        - "packages/web/lib/actions/launch.ts"
+        - "packages/web/lib/actions/launch.test.ts"
+        - "packages/web/app/api/v1/deployments/[id]/end/route.ts"
+        - "packages/web/app/api/v1/deployments/[id]/end/route.test.ts"
+        - "packages/web/e2e/workbench.spec.ts"
+        - "docs/goals/pty-bridge-rollout-hardening/state.yaml"
+      verification:
+        - "PASS pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts' (3 files, 24 tests)"
+        - "PASS pnpm --dir packages/core build"
+        - "PASS ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\" (3 tests)"
+        - "PASS pnpm --dir packages/core typecheck"
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/web lint"
+      diagnostics_evidence:
+        - "Unit test asserts pty.tmux_missing is recorded by web.ensure-terminal with deployment ID, issue, repo, session name, and Terminal session has ended."
+        - "Route unit test asserts pty.tmux_killed is recorded by web.end-session for PTY bridge end cleanup."
+      playwright_evidence:
+        - "Stale PTY reconnect test verifies real ensure endpoint returns alive:false/backend pty_bridge/error Terminal session has ended and removes Session #447."
+        - "PTY end test verifies real end endpoint returns 200, removes Session #498, and fake tmux log contains kill-session -t issuectl-issuectl-498."
+        - "Existing PTY happy path remains green and verifies PTY bridge terminal rendering, diagnostics copy text, websocket URL, and keyboard send."
+  - id: T004
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the Worker slice against the oracle and decide whether another hardening slice is required before final audit."
+    inputs:
+      - "T003 receipt"
+      - "Current diff"
+      - "Verification output"
+      - "Diagnostics evidence"
+    constraints:
+      - "Read-only."
+      - "Do not approve completion if diagnostics or UI evidence is missing."
+      - "If another high-value instability remains in scope, queue the next largest safe Worker slice."
+    expected_output:
+      - "approved | needs_followup"
+      - "remaining oracle gaps"
+      - "next Worker slice if needed"
+    receipt:
+      decision: "approved"
+      summary: "T003 satisfies the approved PTY tmux liveness and cleanup slice. No additional Worker slice is required before final audit."
+      oracle_mapping:
+        - "PTY bridge remains feature-flagged; the real Playwright PTY ensure coverage runs with ISSUECTL_PTY_BRIDGE=1."
+        - "PTY ensure/reconnect now checks tmux liveness before issuing websocket metadata."
+        - "Missing PTY tmux returns stale-session-compatible alive:false and removes the session from the workbench."
+        - "Ending a PTY bridge deployment kills the tmux session despite ttydPid being null."
+        - "Diagnostics are covered by pty.tmux_missing and pty.tmux_killed assertions in focused tests."
+      residual_risk:
+        - "This slice does not add richer websocket attach failure UI diagnostics; that remains a separate lower-ranked follow-up."
+        - "Manual QA against a live approved test repo was not needed for this code slice because the Playwright harness exercised the real ensure/end API endpoints with controlled tmux behavior."
+      next: "Run final audit and prepare PR-ready summary."
+  - id: T998
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: medium
+    objective: "Run final local verification, diagnostics journal check, and approved-test-repo QA for the hardened behavior."
+    constraints:
+      - "Use ISSUECTL_PTY_BRIDGE=1 for PTY bridge QA."
+      - "Keep real launch/manual QA scoped to approved issuectl test repositories."
+      - "Record commands, diagnostics excerpts, screenshots or browser evidence, and explicit oracle mapping."
+    expected_output:
+      - "Verification command results"
+      - "Diagnostics journal excerpt"
+      - "Playwright/local QA evidence"
+      - "Manual QA checklist result"
+      - "Explicit oracle acceptance mapping"
+    receipt:
+      verification_commands:
+        - "PASS pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'"
+        - "PASS pnpm --dir packages/core build"
+        - "PASS ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+        - "PASS pnpm --dir packages/core typecheck"
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/web lint"
+        - "PASS git diff --check"
+      diagnostics_journal_coverage:
+        - "Stale reconnect path records pty.tmux_missing with deployment, issue, repo, session name, and Terminal session has ended."
+        - "PTY end path records pty.tmux_killed with deployment, issue, repo, and session name."
+      playwright_local_qa:
+        - "Real ensure endpoint with ISSUECTL_PTY_BRIDGE=1 returned alive:false/backend pty_bridge/error Terminal session has ended and the workbench removed the stale PTY session."
+        - "Real end endpoint returned 200 for a PTY deployment with null ttydPid, removed the session row, and the fake tmux command log proved kill-session ran."
+        - "Existing PTY launch/navigation happy path still rendered the xterm-backed terminal, diagnostics panel, copy diagnostics command, websocket URL, resize message, and keyboard input."
+      oracle_acceptance:
+        - "Focused tests, diagnostics assertions, and Playwright local QA prove the selected PTY bridge stale-session behavior is hardened end-to-end."
+        - "TTYD default remains unchanged; PTY behavior is still exercised behind ISSUECTL_PTY_BRIDGE=1."
+      final_status: "complete"
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the PTY bridge rollout hardening tranche satisfies the oracle."
+    inputs:
+      - "All task receipts"
+      - "Current diff"
+      - "Verification results"
+      - "Diagnostics evidence"
+      - "QA notes"
+    constraints:
+      - "Read-only."
+      - "Reject completion if any required Worker task remains queued without a receipt explaining why it is unnecessary."
+      - "Reject completion if the chosen hardening behavior lacks focused tests or diagnostics evidence."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      decision: "complete"
+      full_outcome_complete: true
+      audit:
+        - requirement: "PTY bridge remains feature-flagged behind ISSUECTL_PTY_BRIDGE=1."
+          evidence: "Implementation only changes PTY deployment handling after an existing deployment has terminalBackend pty_bridge; Playwright proof explicitly ran with ISSUECTL_PTY_BRIDGE=1."
+          result: "proved"
+        - requirement: "Real launch and manual QA stay restricted to approved issuectl test repositories."
+          evidence: "No real launch was performed in this tranche; Playwright used isolated local fixtures for issuectl repos and controlled fake tmux behavior."
+          result: "proved"
+        - requirement: "Diagnostics make stale cleanup and close outcomes explainable."
+          evidence: "ensure-terminal unit coverage asserts pty.tmux_missing diagnostics; deployment end route unit coverage asserts pty.tmux_killed diagnostics."
+          result: "proved"
+        - requirement: "Workbench recovers clearly from failed PTY reconnect without misleading active sessions."
+          evidence: "Playwright stale PTY reconnect test proves the real ensure endpoint returns alive:false/backend pty_bridge/error Terminal session has ended and removes the active session row."
+          result: "proved"
+        - requirement: "Stale or missing PTY/tmux processes reconcile with visible session state."
+          evidence: "PTY ensure checks isTmuxSessionAlive before issuing websocket metadata, ends stale deployments, and the Playwright stale test removes the running issue from the filtered issue queue."
+          result: "proved"
+        - requirement: "Focused automated tests cover the selected hardening behavior including a stale/failure path."
+          evidence: "Focused Vitest and Playwright commands passed for stale PTY reconnect, PTY end cleanup, and PTY happy path."
+          result: "proved"
+        - requirement: "Playwright or CLI local evidence proves UI and diagnostics behavior."
+          evidence: "ISSUECTL_PTY_BRIDGE=1 Playwright run passed three local-server tests covering stale reconnect UI, end cleanup UI, and PTY terminal diagnostics UI."
+          result: "proved"
+        - requirement: "Final audit maps changed behavior to diagnostics evidence and user-visible state."
+          evidence: "T003, T004, T998, and this T999 receipt map behavior changes to pty.tmux_missing, pty.tmux_killed, session-row removal, issue-filter removal, and tmux kill command evidence."
+          result: "proved"
+      verification:
+        - "PASS pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'"
+        - "PASS pnpm --dir packages/core build"
+        - "PASS ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+        - "PASS pnpm --dir packages/core typecheck"
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/web lint"
+        - "PASS git diff --check"
+      missing_evidence: []
+      next_task: null
+
+checks:
+  dirty_fingerprint: "PTY tmux liveness and cleanup slice"
+  last_verification:
+    result: "pass"
+    task: T999
+    commands:
+      - "pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'"
+      - "pnpm --dir packages/core build"
+      - "ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session\""
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "git diff --check"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,6 +243,7 @@ export {
   tmuxSessionName,
   type SpawnTtydOptions,
 } from "./launch/ttyd.js";
+export { killTmuxSession } from "./launch/tmux-session.js";
 export { updateTtydInfo } from "./db/deployments.js";
 export {
   validateClaudeArgs,

--- a/packages/web/app/api/v1/deployments/[id]/end/route.test.ts
+++ b/packages/web/app/api/v1/deployments/[id]/end/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const getDeploymentById = vi.hoisted(() => vi.fn());
+const endDeployment = vi.hoisted(() => vi.fn());
+const killTmuxSession = vi.hoisted(() => vi.fn());
+const killTtyd = vi.hoisted(() => vi.fn());
+const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
+const removeLabel = vi.hoisted(() => vi.fn());
+const clearCacheKey = vi.hoisted(() => vi.fn());
+const withAuthRetry = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
+  endDeployment: (...args: unknown[]) => endDeployment(...args),
+  killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
+  killTtyd: (...args: unknown[]) => killTtyd(...args),
+  tmuxSessionName: (repo: string, issueNumber: number) => `issuectl-${repo}-${issueNumber}`,
+  cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+  removeLabel: (...args: unknown[]) => removeLabel(...args),
+  LIFECYCLE_LABEL: { inProgress: "issuectl:in-progress" },
+  clearCacheKey: (...args: unknown[]) => clearCacheKey(...args),
+  withAuthRetry: (...args: unknown[]) => withAuthRetry(...args),
+}));
+
+import { POST } from "./route";
+
+const db = { prepare: vi.fn() };
+const params = Promise.resolve({ id: "17" });
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/deployments/17/end", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function deployment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 17,
+    repoId: 3,
+    issueNumber: 137,
+    ttydPid: 444,
+    endedAt: null,
+    terminalBackend: "ttyd",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  getDb.mockReset();
+  getRepo.mockReset();
+  getDeploymentById.mockReset();
+  endDeployment.mockReset();
+  killTmuxSession.mockReset();
+  killTtyd.mockReset();
+  cleanupStaleContextFiles.mockReset();
+  recordDiagnosticEventSafely.mockReset();
+  removeLabel.mockReset();
+  clearCacheKey.mockReset();
+  withAuthRetry.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue(db);
+  getRepo.mockReturnValue({ id: 3, owner: "mean-weasel", name: "issuectl-test-repo" });
+  getDeploymentById.mockReturnValue(deployment());
+  cleanupStaleContextFiles.mockResolvedValue(undefined);
+  withAuthRetry.mockImplementation((fn: (octokit: unknown) => unknown) => fn({}));
+});
+
+describe("POST /api/v1/deployments/[id]/end", () => {
+  it("kills ttyd for TTYD deployments before ending the row", async () => {
+    const response = await POST(makeRequest({
+      owner: "mean-weasel",
+      repo: "issuectl-test-repo",
+      issueNumber: 137,
+    }), { params });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(killTtyd).toHaveBeenCalledWith(444, "issuectl-issuectl-test-repo-137");
+    expect(killTmuxSession).not.toHaveBeenCalled();
+    expect(endDeployment).toHaveBeenCalledWith(db, 17);
+  });
+
+  it("kills tmux directly for PTY bridge deployments with no ttyd PID", async () => {
+    getDeploymentById.mockReturnValue(deployment({
+      ttydPid: null,
+      terminalBackend: "pty_bridge",
+    }));
+
+    const response = await POST(makeRequest({
+      owner: "mean-weasel",
+      repo: "issuectl-test-repo",
+      issueNumber: 137,
+    }), { params });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(killTtyd).not.toHaveBeenCalled();
+    expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-test-repo-137");
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        level: "info",
+        event: "pty.tmux_killed",
+        source: "web.end-session",
+        owner: "mean-weasel",
+        repo: "issuectl-test-repo",
+        issueNumber: 137,
+        deploymentId: 17,
+        sessionName: "issuectl-issuectl-test-repo-137",
+      }),
+    );
+    expect(endDeployment).toHaveBeenCalledWith(db, 17);
+  });
+
+  it("returns auth denials before touching the database", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await POST(makeRequest({
+      owner: "mean-weasel",
+      repo: "issuectl-test-repo",
+      issueNumber: 137,
+    }), { params });
+
+    expect(response.status).toBe(401);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/deployments/[id]/end/route.ts
+++ b/packages/web/app/api/v1/deployments/[id]/end/route.ts
@@ -6,9 +6,11 @@ import {
   getRepo,
   getDeploymentById,
   endDeployment,
+  killTmuxSession,
   killTtyd,
   tmuxSessionName,
   cleanupStaleContextFiles,
+  recordDiagnosticEventSafely,
   removeLabel,
   LIFECYCLE_LABEL,
   clearCacheKey,
@@ -70,12 +72,25 @@ export async function POST(
       return NextResponse.json({ success: true });
     }
 
+    const sessionName = tmuxSessionName(body.repo, body.issueNumber);
     if (deployment.ttydPid) {
       try {
-        killTtyd(deployment.ttydPid, tmuxSessionName(body.repo, body.issueNumber));
+        killTtyd(deployment.ttydPid, sessionName);
       } catch (killErr) {
         log.warn({ err: killErr, msg: "kill_ttyd_failed", deploymentId, pid: deployment.ttydPid });
       }
+    } else if ((deployment as { terminalBackend?: string }).terminalBackend === "pty_bridge") {
+      killTmuxSession(sessionName);
+      recordDiagnosticEventSafely(db, {
+        level: "info",
+        event: "pty.tmux_killed",
+        source: "web.end-session",
+        owner: body.owner,
+        repo: body.repo,
+        issueNumber: body.issueNumber,
+        deploymentId,
+        sessionName,
+      });
     }
     endDeployment(db, deploymentId);
 

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -45,6 +45,8 @@ let dbPath = "";
 let apiToken = "";
 let isolatedWebRoot = "";
 let serverOutput = "";
+let tmuxCommandLog = "";
+let tmuxMissingSessionsFile = "";
 
 type FixtureIssue = {
   number: number;
@@ -190,10 +192,20 @@ test.beforeAll(async () => {
   );
   chmodSync(fakeGh, 0o755);
   const fakeTmux = join(tmpDir, "tmux");
+  tmuxCommandLog = join(tmpDir, "tmux-commands.log");
+  tmuxMissingSessionsFile = join(tmpDir, "tmux-missing-sessions");
   writeFileSync(
     fakeTmux,
     [
       "#!/bin/sh",
+      `echo "$*" >> ${JSON.stringify(tmuxCommandLog)}`,
+      `missing_file=${JSON.stringify(tmuxMissingSessionsFile)}`,
+      "if [ -f \"$missing_file\" ]; then",
+      "  while IFS= read -r missing; do",
+      "    [ -n \"$missing\" ] || continue",
+      "    case \"$*\" in *\"$missing\"*) exit 1 ;; esac",
+      "  done < \"$missing_file\"",
+      "fi",
       "case \"$*\" in",
       "  *issuectl-issuectl-447*) echo 'running tests'; exit 0 ;;",
       "  *issuectl-issuectl-486*) echo 'Error: preview failed'; exit 0 ;;",
@@ -228,6 +240,7 @@ test.beforeAll(async () => {
 
 test.beforeEach(async ({ page }) => {
   seedWorkbenchRepos(dbPath);
+  if (tmuxMissingSessionsFile) writeFileSync(tmuxMissingSessionsFile, "");
   await page.addInitScript((token) => {
     window.localStorage.setItem("issuectl.apiToken", token);
   }, apiToken);
@@ -264,8 +277,8 @@ function seedWorkbenchRepos(path: string, repos: FixtureRepo[] = workbenchPayloa
       for (const deployment of item.deployments) {
         db.prepare(
           `INSERT INTO deployments
-           (id, repo_id, issue_number, agent, branch_name, workspace_mode, workspace_path, state, launched_at, ended_at, ttyd_port, ttyd_pid, idle_since)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+           (id, repo_id, issue_number, agent, branch_name, workspace_mode, workspace_path, state, launched_at, ended_at, ttyd_port, ttyd_pid, idle_since, terminal_backend)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         ).run(
           deployment.id,
           item.id,
@@ -280,6 +293,7 @@ function seedWorkbenchRepos(path: string, repos: FixtureRepo[] = workbenchPayloa
           deployment.ttydPort,
           deployment.ttydPid,
           deployment.idleSince,
+          deployment.terminalBackend ?? "ttyd",
         );
       }
       for (const issue of item.issues) {
@@ -3013,6 +3027,38 @@ test("removes a stale session when reconnect reports the deployment already ende
   await expect(page.getByLabel("Issue #486")).toHaveCount(0);
 });
 
+test("removes a stale PTY bridge session when reconnect finds tmux missing", async ({ page }) => {
+  const staleRepo = repo(1, "issuectl", 1);
+  staleRepo.deployments[0] = {
+    ...staleRepo.deployments[0],
+    id: 104,
+    issueNumber: 447,
+    branchName: "issue-447-stale-pty",
+    ttydPort: null,
+    ttydPid: null,
+    terminalBackend: "pty_bridge",
+  };
+  seedWorkbenchRepos(dbPath, [staleRepo]);
+
+  await gotoWorkbenchWithRetry(page);
+  const activeSessions = page.getByRole("complementary", { name: "Active sessions" });
+  await expect(activeSessions.getByLabel("Session #447")).toBeVisible();
+  writeFileSync(tmuxMissingSessionsFile, "issuectl-issuectl-447\n");
+  const ensureResponse = page.waitForResponse("**/api/v1/deployments/104/ensure-ttyd");
+  await activeSessions.getByLabel("Session #447").getByRole("button", { name: "Reconnect" }).click();
+  const staleResponse = await ensureResponse;
+  expect(staleResponse.status()).toBe(200);
+  await expect(staleResponse.json()).resolves.toMatchObject({
+    alive: false,
+    backend: "pty_bridge",
+    error: "Terminal session has ended",
+  });
+
+  await expect(activeSessions.getByLabel("Session #447")).toHaveCount(0);
+  await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: /Running/ }).click();
+  await expect(page.getByLabel("Repo issue queue").getByLabel("Issue #447")).toHaveCount(0);
+});
+
 test("removes a stale selected session when terminal focus reports the session ended", async ({ page }) => {
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
@@ -3059,6 +3105,33 @@ test("ends a session through the deployment endpoint and removes its row", async
   await expect(page.getByLabel("Issue-backed sessions").getByRole("article")).toHaveCount(2);
   await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Running 2" }).click();
   await expect(page.getByLabel("Issue #498")).toHaveCount(0);
+});
+
+test("ends a PTY bridge session and removes its tmux session", async ({ page }) => {
+  writeFileSync(tmuxCommandLog, "");
+  const ptyRepo = repo(1, "issuectl", 1);
+  ptyRepo.deployments[0] = {
+    ...ptyRepo.deployments[0],
+    id: 105,
+    issueNumber: 498,
+    branchName: "issue-498-pty-end",
+    ttydPort: null,
+    ttydPid: null,
+    terminalBackend: "pty_bridge",
+  };
+  seedWorkbenchRepos(dbPath, [ptyRepo]);
+
+  await gotoWorkbenchWithRetry(page);
+  const session = page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #498");
+  await expect(session).toContainText("PTY bridge connected");
+  await session.getByText("End", { exact: true }).click();
+  const endResponse = page.waitForResponse("**/api/v1/deployments/105/end");
+  await session.getByRole("button", { name: "End session" }).click();
+  expect((await endResponse).status()).toBe(200);
+
+  await expect(page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #498"))
+    .toHaveCount(0);
+  expect(readFileSync(tmuxCommandLog, "utf8")).toContain("kill-session -t issuectl-issuectl-498");
 });
 
 test("canceling end session is local-only and does not navigate or call the end endpoint", async ({ page }) => {
@@ -4308,6 +4381,7 @@ function repo(id: number, name: string, deploymentCount: number): {
     idleSince: null;
     owner: string;
     repoName: string;
+    terminalBackend?: "ttyd" | "pty_bridge";
   }>;
   previews: {};
   issues: FixtureIssue[];

--- a/packages/web/lib/actions/launch.test.ts
+++ b/packages/web/lib/actions/launch.test.ts
@@ -16,6 +16,7 @@ const getDeploymentById = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
 const getSetting = vi.hoisted(() => vi.fn());
+const killTmuxSession = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const coreEndDeployment = vi.hoisted(() => vi.fn());
 const cleanupStaleContextFiles = vi.hoisted(() => vi.fn());
@@ -30,6 +31,7 @@ vi.mock("@issuectl/core", () => ({
   getRepo: (...args: unknown[]) => getRepo(...args),
   getRepoById: (...args: unknown[]) => getRepoById(...args),
   getSetting: (...args: unknown[]) => getSetting(...args),
+  killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   endDeployment: (...args: unknown[]) => coreEndDeployment(...args),
   cleanupStaleContextFiles: (...args: unknown[]) => cleanupStaleContextFiles(...args),
@@ -89,6 +91,7 @@ beforeEach(() => {
   getRepo.mockReset();
   getRepoById.mockReset();
   getSetting.mockReset();
+  killTmuxSession.mockReset();
   killTtyd.mockReset();
   coreEndDeployment.mockReset();
   cleanupStaleContextFiles.mockReset();
@@ -204,6 +207,21 @@ describe("endSession", () => {
     const result = await endSession(...ARGS);
 
     expect(killTtyd).not.toHaveBeenCalled();
+    expect(killTmuxSession).not.toHaveBeenCalled();
+    expect(coreEndDeployment).toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it("kills tmux directly when ending a PTY bridge deployment", async () => {
+    getDeploymentById.mockReturnValue({
+      ...makeDeployment(null),
+      terminalBackend: "pty_bridge",
+    });
+
+    const result = await endSession(...ARGS);
+
+    expect(killTtyd).not.toHaveBeenCalled();
+    expect(killTmuxSession).toHaveBeenCalledWith("issuectl-repo-7");
     expect(coreEndDeployment).toHaveBeenCalled();
     expect(result).toMatchObject({ success: true });
   });

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -7,6 +7,7 @@ import {
   getDeploymentById,
   executeLaunch,
   endDeployment as coreEndDeployment,
+  killTmuxSession,
   killTtyd,
   isTmuxSessionAlive,
   tmuxSessionName,
@@ -190,9 +191,10 @@ export async function endSession(
       return { success: false, error: "Deployment does not match the specified issue" };
     }
 
+    const sessionName = tmuxSessionName(repo, issueNumber);
     if (deployment.ttydPid) {
       try {
-        killTtyd(deployment.ttydPid, tmuxSessionName(repo, issueNumber));
+        killTtyd(deployment.ttydPid, sessionName);
       } catch (killErr) {
         console.warn(
           "[issuectl] Failed to kill ttyd process, proceeding with session end:",
@@ -200,6 +202,8 @@ export async function endSession(
           killErr,
         );
       }
+    } else if ((deployment as { terminalBackend?: string }).terminalBackend === "pty_bridge") {
+      killTmuxSession(sessionName);
     }
     coreEndDeployment(db, deploymentId);
 

--- a/packages/web/lib/ensure-terminal.test.ts
+++ b/packages/web/lib/ensure-terminal.test.ts
@@ -2,12 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDb = vi.hoisted(() => vi.fn());
 const getDeploymentById = vi.hoisted(() => vi.fn());
+const getRepoById = vi.hoisted(() => vi.fn());
+const endDeployment = vi.hoisted(() => vi.fn());
+const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const ensureTtydForDeployment = vi.hoisted(() => vi.fn());
 const createPtyTerminalToken = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
   getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
+  getRepoById: (...args: unknown[]) => getRepoById(...args),
+  endDeployment: (...args: unknown[]) => endDeployment(...args),
+  isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+  tmuxSessionName: (repo: string, issueNumber: number) => `issuectl-${repo}-${issueNumber}`,
 }));
 
 vi.mock("./ensure-ttyd", () => ({
@@ -25,10 +34,17 @@ const db = { prepare: vi.fn() };
 beforeEach(() => {
   getDb.mockReset();
   getDeploymentById.mockReset();
+  getRepoById.mockReset();
+  endDeployment.mockReset();
+  isTmuxSessionAlive.mockReset();
+  recordDiagnosticEventSafely.mockReset();
   ensureTtydForDeployment.mockReset();
+  createPtyTerminalToken.mockReset();
 
   getDb.mockReturnValue(db);
   getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "ttyd" });
+  getRepoById.mockReturnValue({ id: 1, owner: "acme", name: "api" });
+  isTmuxSessionAlive.mockReturnValue(true);
   createPtyTerminalToken.mockReturnValue("pty-token");
   delete process.env.ISSUECTL_PTY_BRIDGE;
 });
@@ -71,11 +87,12 @@ describe("ensureTerminalForDeployment", () => {
       error: "PTY bridge terminal backend is not implemented yet",
     });
     expect(ensureTtydForDeployment).not.toHaveBeenCalled();
+    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
   });
 
   it("returns PTY bridge attach metadata when the experiment flag is enabled", async () => {
     process.env.ISSUECTL_PTY_BRIDGE = "1";
-    getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "pty_bridge" });
+    getDeploymentById.mockReturnValue({ id: 1, repoId: 1, issueNumber: 7, terminalBackend: "pty_bridge" });
 
     await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
       backend: "pty_bridge",
@@ -84,5 +101,34 @@ describe("ensureTerminalForDeployment", () => {
       wsUrl: "/api/terminal/pty/1/ws?terminalToken=pty-token",
     });
     expect(ensureTtydForDeployment).not.toHaveBeenCalled();
+    expect(isTmuxSessionAlive).toHaveBeenCalledWith("issuectl-api-7");
+  });
+
+  it("ends stale PTY bridge deployments before returning attach metadata", async () => {
+    process.env.ISSUECTL_PTY_BRIDGE = "1";
+    getDeploymentById.mockReturnValue({ id: 1, repoId: 1, issueNumber: 7, terminalBackend: "pty_bridge" });
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
+      alive: false,
+      backend: "pty_bridge",
+      error: "Terminal session has ended",
+    });
+    expect(endDeployment).toHaveBeenCalledWith(db, 1);
+    expect(createPtyTerminalToken).not.toHaveBeenCalled();
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        level: "warn",
+        event: "pty.tmux_missing",
+        source: "web.ensure-terminal",
+        owner: "acme",
+        repo: "api",
+        issueNumber: 7,
+        deploymentId: 1,
+        sessionName: "issuectl-api-7",
+        message: "Terminal session has ended",
+      }),
+    );
   });
 });

--- a/packages/web/lib/ensure-terminal.ts
+++ b/packages/web/lib/ensure-terminal.ts
@@ -1,4 +1,12 @@
-import { getDb, getDeploymentById } from "@issuectl/core";
+import {
+  endDeployment,
+  getDb,
+  getDeploymentById,
+  getRepoById,
+  isTmuxSessionAlive,
+  recordDiagnosticEventSafely,
+  tmuxSessionName,
+} from "@issuectl/core";
 import { ensureTtydForDeployment, type EnsureTtydResult } from "./ensure-ttyd";
 import { createPtyTerminalToken } from "./terminal-auth";
 
@@ -19,27 +27,17 @@ export async function ensureTerminalForDeployment(
     return { alive: false, error: "Invalid deployment ID" };
   }
 
+  let db: ReturnType<typeof getDb> | null = null;
+  let deployment: DeploymentWithTerminalBackend | null = null;
   try {
-    const db = getDb();
-    const deployment = getDeploymentById(db, deploymentId) as DeploymentWithTerminalBackend;
-    if (deployment?.terminalBackend === "pty_bridge") {
-      const terminalToken = createPtyTerminalToken(deploymentId);
-      if (terminalToken && process.env.ISSUECTL_PTY_BRIDGE === "1") {
-        return {
-          backend: "pty_bridge",
-          deploymentId,
-          terminalToken,
-          wsUrl: `/api/terminal/pty/${deploymentId}/ws?terminalToken=${encodeURIComponent(terminalToken)}`,
-        };
-      }
-      return {
-        alive: false,
-        backend: "pty_bridge",
-        error: "PTY bridge terminal backend is not implemented yet",
-      };
-    }
+    db = getDb();
+    deployment = getDeploymentById(db, deploymentId) as DeploymentWithTerminalBackend;
   } catch {
     // Let the existing ttyd ensure path keep its current error handling.
+  }
+
+  if (db && deployment?.terminalBackend === "pty_bridge") {
+    return ensurePtyBridgeTerminal(db, deploymentId, deployment);
   }
 
   const result = await ensureTtydForDeployment(deploymentId);
@@ -47,4 +45,76 @@ export async function ensureTerminalForDeployment(
     return { backend: "ttyd", ...result };
   }
   return result;
+}
+
+function ensurePtyBridgeTerminal(
+  db: ReturnType<typeof getDb>,
+  deploymentId: number,
+  deployment: NonNullable<DeploymentWithTerminalBackend>,
+): EnsureTerminalResult {
+  if (process.env.ISSUECTL_PTY_BRIDGE !== "1") {
+    return {
+      alive: false,
+      backend: "pty_bridge",
+      error: "PTY bridge terminal backend is not implemented yet",
+    };
+  }
+
+  try {
+    const repo = getRepoById(db, deployment.repoId);
+    if (!repo) {
+      recordDiagnosticEventSafely(db, {
+        level: "error",
+        event: "pty.ensure_failed",
+        source: "web.ensure-terminal",
+        issueNumber: deployment.issueNumber,
+        deploymentId,
+        message: "Repository not found",
+      });
+      return { alive: false, backend: "pty_bridge", error: "Repository not found" };
+    }
+
+    const sessionName = tmuxSessionName(repo.name, deployment.issueNumber);
+    if (!isTmuxSessionAlive(sessionName)) {
+      try {
+        endDeployment(db, deploymentId);
+      } catch {
+        // The UI still needs a stale-session response if another request already ended the row.
+      }
+      recordDiagnosticEventSafely(db, {
+        level: "warn",
+        event: "pty.tmux_missing",
+        source: "web.ensure-terminal",
+        owner: repo.owner,
+        repo: repo.name,
+        issueNumber: deployment.issueNumber,
+        deploymentId,
+        sessionName,
+        message: "Terminal session has ended",
+      });
+      return { alive: false, backend: "pty_bridge", error: "Terminal session has ended" };
+    }
+
+    const terminalToken = createPtyTerminalToken(deploymentId);
+    if (terminalToken) {
+      return {
+        backend: "pty_bridge",
+        deploymentId,
+        terminalToken,
+        wsUrl: `/api/terminal/pty/${deploymentId}/ws?terminalToken=${encodeURIComponent(terminalToken)}`,
+      };
+    }
+
+    return {
+      alive: false,
+      backend: "pty_bridge",
+      error: "PTY terminal auth token could not be created",
+    };
+  } catch {
+    return {
+      alive: false,
+      backend: "pty_bridge",
+      error: "PTY terminal could not be prepared",
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- check PTY bridge tmux liveness before issuing websocket attach metadata
- mark stale PTY deployments ended with diagnostics and stale-session UI responses
- kill PTY tmux sessions on end even when ttydPid is null
- add focused unit and Playwright coverage plus the GoalBuddy hardening board

## Validation

- pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/actions/launch.test.ts 'app/api/v1/deployments/[id]/end/route.test.ts'\n- pnpm --dir packages/core build\n- ISSUECTL_PTY_BRIDGE=1 pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "launches an issue with the PTY bridge backend|removes a stale PTY bridge session when reconnect finds tmux missing|ends a PTY bridge session and removes its tmux session"\n- pnpm --dir packages/core typecheck\n- pnpm --dir packages/web typecheck\n- pnpm --dir packages/web lint\n- git diff --check\n\n## Notes\n\nPTY bridge remains feature-flagged behind ISSUECTL_PTY_BRIDGE=1. No real launch was performed outside the approved issuectl test repo scope; the Playwright proof uses isolated local fixtures and controlled fake tmux behavior.