### PR TITLE
[codex] Add PTY bridge rollout controls

### DIFF
--- a/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/app.js
+++ b/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/index.html
+++ b/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/styles.css
+++ b/docs/goals/pty-bridge-rollout-controls/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/pty-bridge-rollout-controls/goal.md
+++ b/docs/goals/pty-bridge-rollout-controls/goal.md
@@ -1,0 +1,95 @@
+# PTY Bridge Rollout Controls
+
+## Objective
+
+Plan the next PTY bridge stabilization tranche: make backend selection visible and safer for new launches, preserve ttyd as the default, and add enough comparison telemetry to dogfood PTY bridge without confusing active deployment behavior.
+
+## Original Request
+
+Plan the backend selection visibility and safer opt-in controls work with `$goalbuddy:goal-prep`.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl maintainers dogfooding and debugging issue launch terminal sessions
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: focused tests, Playwright/manual QA evidence, and diagnostics/telemetry output prove new launches clearly expose their selected terminal backend, active deployments keep their recorded backend, and maintainers can compare ttyd versus PTY bridge outcomes.
+- Goal oracle: a maintainer can launch approved test-repo sessions under ttyd and PTY bridge, see which backend will be used before and after launch, verify changing the default affects only new deployments, and inspect diagnostics/reporting that compares attach/first-output/reconnect/cleanup signals by backend.
+- Likely misfire: adding another hidden env flag or static label while users still cannot tell what backend a launch will use or whether changing the setting could affect active sessions.
+- Blind spots considered: backend choice may belong in env, repo settings, launch UI, or all three; active deployments must be immutable by recorded backend; telemetry must avoid terminal I/O and secrets; Apple clients and CLI launches may need compatibility; live manual QA must stay within approved issuectl test repositories.
+- Existing plan facts: ttyd remains the default; PTY bridge remains feature-flagged; existing PTY diagnostics, status strip, visual polish, stale cleanup, and tmux durability must be preserved; this is Phase 3 rollout control work from `docs/specs/2026-05-21-pty-bridge-terminal-design.md`.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A verified ttyd/PT bridge launch comparison flow shows backend selection before launch, records backend per deployment, leaves active deployments on their original backend after setting changes, and exposes backend-grouped diagnostics/reporting without logging terminal input, output, tokens, command strings, context, or environment.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Complete the next reversible Phase 3 rollout-controls tranche for the feature-flagged PTY bridge. The expected shape is: discover current backend selection and launch surfaces, choose the largest safe useful implementation slice, implement backend visibility/opt-in controls and comparison telemetry needed for dogfooding, verify with focused tests and Playwright/manual QA against approved test repos, then audit against the oracle.
+
+## Non-Negotiable Constraints
+
+- Keep ttyd as the default backend unless a later explicit rollout decision changes it.
+- PTY bridge must remain opt-in and feature-flagged for this tranche.
+- Changing a backend default or preference must affect only new launches, not active deployments.
+- Active deployments must continue using the backend recorded at launch.
+- Do not log raw terminal input, raw terminal output, terminal tokens, command strings, context file contents, or environment variables.
+- Use diagnostics-first debugging for terminal/session failures.
+- Do not launch real sessions outside the approved issuectl test repositories.
+- Preserve existing ttyd behavior while the dual path exists.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+A Worker should finish the whole assigned slice. A Judge should judge the whole assigned slice. A PM should reorient the board when tasks are safe but not moving the outcome.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/pty-bridge-rollout-controls/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/pty-bridge-rollout-controls/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the intake, constraints, existing plan facts, and likely misfire.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/pty-bridge-rollout-controls/state.yaml
+++ b/docs/goals/pty-bridge-rollout-controls/state.yaml
@@ -1,0 +1,417 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "PTY Bridge Rollout Controls"
+  slug: "pty-bridge-rollout-controls"
+  kind: specific
+  tranche: "Make PTY bridge backend selection visible, safely opt-in, and measurable before broader dogfooding."
+  status: done
+  oracle:
+    signal: "A verified ttyd/PT bridge launch comparison flow shows backend selection before launch, records backend per deployment, leaves active deployments on their original backend after setting changes, and exposes backend-grouped diagnostics/reporting without logging sensitive terminal data."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Focused tests, Playwright/manual QA evidence, and diagnostics/reporting output map backend visibility, immutable active deployment backend behavior, and comparison telemetry back to the oracle."
+  intake:
+    original_request: "Plan the backend selection visibility and safer opt-in controls work with $goalbuddy:goal-prep."
+    interpreted_outcome: "Prepare a GoalBuddy board for the next PTY bridge Phase 3 rollout-controls tranche."
+    input_shape: specific
+    audience: "issuectl maintainers dogfooding and debugging issue launch terminal sessions"
+    authority: requested
+    proof_type: test
+    completion_proof: "Focused tests, Playwright/manual QA evidence, and diagnostics/telemetry output prove backend selection visibility, safe opt-in behavior, and ttyd versus PTY bridge comparison signals."
+    likely_misfire: "Adding another hidden env flag or static label while users still cannot tell what backend a launch will use or whether changing the setting could affect active sessions."
+    blind_spots_considered:
+      - "Backend choice may belong in env, repo settings, launch UI, or all three."
+      - "Active deployments must be immutable by recorded backend even after rollout setting changes."
+      - "Telemetry must avoid terminal input/output, tokens, command strings, context, and environment."
+      - "Apple clients and CLI launches may need compatibility with any API or settings changes."
+      - "Live manual QA must stay within approved issuectl test repositories."
+    existing_plan_facts:
+      - "ttyd remains the default backend."
+      - "PTY bridge remains opt-in and feature-flagged for this tranche."
+      - "Existing PTY diagnostics, status strip, visual polish, stale cleanup, and tmux durability must be preserved."
+      - "This is Phase 3 rollout control work from docs/specs/2026-05-21-pty-bridge-terminal-design.md."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/pty-bridge-rollout-controls/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/docs/goals/pty-bridge-rollout-controls"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: medium
+    objective: "Map current backend selection, launch UI/API surfaces, diagnostics/reporting data, tests, and compatibility risks for safer PTY bridge rollout controls."
+    inputs:
+      - "docs/goals/pty-bridge-rollout-controls/goal.md"
+      - "docs/specs/2026-05-21-pty-bridge-terminal-design.md"
+      - "Current launch, deployment, workbench, diagnostics, CLI, and Apple-client surfaces"
+      - "Recent PTY bridge diagnostics/status/polish/cleanup receipts"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not launch real sessions outside approved issuectl test repositories."
+      - "Use diagnostics-first evidence for terminal/session behavior."
+      - "Preserve ttyd as default and PTY bridge as opt-in."
+      - "Do not propose logging terminal input/output, tokens, command strings, context, or environment."
+    expected_output:
+      - "File/path map for backend selection, launch request handling, deployment persistence, workbench launch UI, diagnostics CLI/reporting, tests, and Apple/CLI compatibility."
+      - "Assessment of env-only versus settings/UI-backed rollout controls for this tranche."
+      - "Recommended largest safe first Worker slice with allowed_files, verify commands, Playwright/manual QA acceptance criteria, and stop_if conditions."
+      - "Risks or unknowns that require Judge review before implementation."
+    receipt:
+      result: done
+      summary: "Mapped the current rollout-control surface. Backend selection is currently env-only in core launch, persisted per deployment, returned through launch APIs, and visible only after launch through deployment/session UI. Workbench settings and launch options do not show or control the backend before launch, and the diagnostics CLI can filter timelines but cannot summarize backend comparison metrics."
+      evidence:
+        - "packages/core/src/launch/launch.ts"
+        - "packages/core/src/db/deployments.ts"
+        - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts"
+        - "packages/web/components/workbench/IssueFocus.tsx"
+        - "packages/web/components/workbench/SettingsFocus.tsx"
+        - "packages/web/components/workbench/TerminalFocus.tsx"
+        - "packages/web/lib/workbench-data.ts"
+        - "packages/cli/src/commands/diag.ts"
+        - "apple/IssueCTLShared/Models/Deployment.swift"
+      file_map:
+        - "packages/core/src/launch/launch.ts selects terminalBackend from ISSUECTL_PTY_BRIDGE, verifies tmux for pty_bridge or ttyd for ttyd, records the selected backend in deployments, and returns terminalBackend/ttydPort."
+        - "packages/core/src/db/deployments.ts persists terminal_backend and defaults missing values to ttyd."
+        - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts validates launch input, delegates to executeLaunch, and returns terminalBackend/ttydPort."
+        - "packages/web/components/workbench/IssueFocus.tsx renders launch options and receives terminalBackend only after launch; it does not show the prospective backend before launch."
+        - "packages/web/components/workbench/SettingsFocus.tsx exposes launch agent/settings but no terminal backend default."
+        - "packages/web/components/workbench/TerminalFocus.tsx and InstancePane.tsx show active deployment backend/status after launch."
+        - "packages/web/lib/workbench-data.ts includes editable settings and active deployments but no computed terminal backend default."
+        - "packages/cli/src/commands/diag.ts supports list/tail/show filters but no backend-grouped rollup."
+        - "apple/IssueCTLShared/Models/Deployment.swift and Mac launch/session UI are ttyd-port shaped and do not decode terminalBackend yet."
+      assessment:
+        - "Env-only rollout control is safe for core behavior but too hidden for dogfooding because users cannot see the backend before launching."
+        - "A persistent settings-backed default would improve UI clarity but needs compatibility work because settings keys are typed in core, web settings routes, workbench payloads, and Apple settings models."
+        - "The largest safe first slice should add a typed terminal backend default setting while preserving env override semantics and ttyd as default."
+        - "Active deployment immutability is already mostly preserved by persisted terminal_backend; the next slice should add tests proving changing settings affects only new launch calls."
+        - "Backend comparison telemetry can be delivered first as a diagnostics CLI report over existing safe events and deployment backend metadata, without schema changes or logging terminal data."
+      recommended_worker:
+        objective: "Add a default terminal backend setting and Workbench launch visibility/control for new launches, keep ISSUECTL_PTY_BRIDGE as an override, preserve active deployment backend immutability, and add a diagnostics backend-summary CLI over existing events."
+        allowed_files:
+          - "packages/core/src/types.ts"
+          - "packages/core/src/db/settings.ts"
+          - "packages/core/src/db/settings.test.ts"
+          - "packages/core/src/launch/launch.ts"
+          - "packages/core/src/launch/launch-execute-agents.test.ts"
+          - "packages/core/src/launch/launch-terminal-backend.test.ts"
+          - "packages/web/lib/workbench-data.ts"
+          - "packages/web/app/api/v1/settings/route.ts"
+          - "packages/web/app/api/v1/settings/route.test.ts"
+          - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts"
+          - "packages/web/components/workbench/workbench-types.ts"
+          - "packages/web/components/workbench/workbench-api.ts"
+          - "packages/web/components/workbench/SettingsFocus.tsx"
+          - "packages/web/components/workbench/IssueFocus.tsx"
+          - "packages/web/components/workbench/WorkbenchShell.module.css"
+          - "packages/web/e2e/workbench.spec.ts"
+          - "packages/cli/src/commands/diag.ts"
+          - "packages/cli/src/commands/diag.test.ts"
+          - "packages/cli/src/commands/diag-summary.ts"
+          - "packages/cli/src/commands/diag-summary.test.ts"
+      verify:
+        - "pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts"
+        - "pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'"
+        - "pnpm --dir packages/cli test -- src/commands/diag.test.ts"
+        - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+        - "pnpm --dir packages/core typecheck"
+        - "pnpm --dir packages/web typecheck"
+        - "pnpm --dir packages/cli typecheck"
+        - "pnpm --dir packages/web lint"
+      acceptance:
+        - "Workbench settings shows terminal backend default with ttyd default and PTY bridge experimental option."
+        - "Issue launch options show the backend that will be used before launch."
+        - "Launch API/core tests prove ttyd remains default, settings can select pty_bridge for new launches, and ISSUECTL_PTY_BRIDGE=1 still forces pty_bridge."
+        - "A test proves an existing active deployment keeps its recorded backend when the default setting changes."
+        - "Diagnostics CLI can summarize safe backend comparison counts such as launch/activation/first-output/failure events by backend using existing sanitized data."
+      risks:
+        - "Apple clients currently treat nil ttydPort as not ready and do not decode terminalBackend, so this tranche should avoid making PTY bridge the default for Apple paths."
+        - "If settings-backed selection requires a database migration beyond seeded key defaults, Judge should split the slice."
+        - "A diagnostics summary that cannot infer backend from existing events/deployments may need a narrower event-safety task first."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate Scout findings and choose the largest safe useful implementation slice for backend selection visibility, opt-in controls, and comparison telemetry."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle and non-negotiable constraints"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Reject any slice that changes ttyd as the default."
+      - "Reject any slice that can alter active deployment backends after launch."
+      - "Reject telemetry that logs terminal input/output, tokens, command strings, context, or environment."
+      - "Prefer a vertical dogfood-enabling slice over helper-only work."
+    expected_output:
+      - "Decision: approved, revise, or blocked."
+      - "Exact Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "Playwright/manual QA acceptance criteria."
+      - "Diagnostics/reporting acceptance criteria."
+      - "stop_if conditions."
+      - "Whether a follow-up Judge is required before broader rollout or default changes."
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Approve one vertical rollout-controls Worker slice. The slice is broad enough to make PTY dogfooding safer: typed backend default, Workbench settings and launch-option visibility, preserved env override, immutable persisted deployment backend behavior, and a backend summary diagnostics command. It does not change ttyd as default or broaden PTY rollout."
+      rationale:
+        - "Env-only selection is too hidden for manual QA and dogfooding because launch options do not show the prospective backend."
+        - "A settings-backed default is reversible and affects only new launches when executeLaunch snapshots the selected backend into the deployment row."
+        - "The diagnostics CLI already reads the local database, so a backend summary can be implemented without schema changes or logging terminal I/O."
+        - "Apple clients should remain compatible because ttyd remains default and JSON decoding tolerates additional launch response/settings fields; making PTY default for Apple is explicitly out of scope."
+      worker:
+        objective: "Add a safe terminal backend rollout control: typed default setting, Workbench settings selector, pre-launch backend visibility in issue launch options, core/API tests proving default/override/new-launch behavior, and a diagnostics backend-summary CLI over existing safe events."
+        allowed_files:
+          - "packages/core/src/types.ts"
+          - "packages/core/src/db/settings.ts"
+          - "packages/core/src/db/settings.test.ts"
+          - "packages/core/src/launch/launch.ts"
+          - "packages/core/src/launch/launch-execute-agents.test.ts"
+          - "packages/web/lib/workbench-data.ts"
+          - "packages/web/app/api/v1/settings/route.ts"
+          - "packages/web/app/api/v1/settings/route.test.ts"
+          - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts"
+          - "packages/web/components/workbench/workbench-types.ts"
+          - "packages/web/components/workbench/workbench-api.ts"
+          - "packages/web/components/workbench/SettingsFocus.tsx"
+          - "packages/web/components/workbench/IssueFocus.tsx"
+          - "packages/web/components/workbench/WorkbenchShell.module.css"
+          - "packages/web/e2e/workbench.spec.ts"
+          - "packages/cli/src/commands/diag.ts"
+          - "packages/cli/src/commands/diag.test.ts"
+        verify:
+          - "pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts src/launch/launch-terminal-backend.test.ts"
+          - "pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'"
+          - "pnpm --dir packages/cli test -- src/commands/diag.test.ts src/commands/diag-summary.test.ts"
+          - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+          - "pnpm --dir packages/core typecheck"
+          - "pnpm --dir packages/web typecheck"
+          - "pnpm --dir packages/cli typecheck"
+          - "pnpm --dir packages/web lint"
+        acceptance:
+          - "ttyd remains the seeded/default terminal backend."
+          - "ISSUECTL_PTY_BRIDGE=1 continues to force PTY bridge for new launches."
+          - "When no env override is set, a validated terminal_backend setting selects the backend for new launches."
+          - "Workbench settings exposes Terminal backend with ttyd and PTY bridge labels, with PTY clearly experimental."
+          - "Issue launch options show the backend that will be used before clicking Launch issue."
+          - "Tests prove active deployment rows retain their recorded terminalBackend and the UI displays that recorded backend after launch."
+          - "Diagnostics CLI exposes a backend-grouped summary using only event names, statuses, deployment IDs, timestamps, and safe aggregate data."
+      stop_if:
+        - "Implementation requires changing ttyd as the default backend."
+        - "Implementation requires migrating or mutating active deployment backends after launch."
+        - "Implementation requires logging terminal input/output, tokens, command strings, context, or environment."
+        - "Diagnostics summary cannot infer backend from safe existing data and deployment metadata."
+        - "Apple or CLI launch compatibility requires a separate API contract decision."
+      follow_up_gate: "A later Judge decision is required before any default switch, Apple PTY enablement, or repo/user-specific rollout policy beyond the default setting."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Execute the Judge-approved terminal backend rollout-control implementation slice."
+    allowed_files:
+      - "packages/core/src/types.ts"
+      - "packages/core/src/db/settings.ts"
+      - "packages/core/src/db/settings.test.ts"
+      - "packages/core/src/launch/launch.ts"
+      - "packages/core/src/launch/launch-execute-agents.test.ts"
+      - "packages/core/src/launch/launch-terminal-backend.test.ts"
+      - "packages/web/lib/workbench-data.ts"
+      - "packages/web/app/api/v1/settings/route.ts"
+      - "packages/web/app/api/v1/settings/route.test.ts"
+      - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts"
+      - "packages/web/components/workbench/workbench-types.ts"
+      - "packages/web/components/workbench/workbench-api.ts"
+      - "packages/web/components/workbench/SettingsFocus.tsx"
+      - "packages/web/components/workbench/IssueFocus.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/e2e/workbench.spec.ts"
+      - "packages/cli/src/commands/diag.ts"
+      - "packages/cli/src/commands/diag.test.ts"
+      - "packages/cli/src/commands/diag-summary.ts"
+      - "packages/cli/src/commands/diag-summary.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts src/launch/launch-terminal-backend.test.ts"
+      - "pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'"
+      - "pnpm --dir packages/cli test -- src/commands/diag.test.ts src/commands/diag-summary.test.ts"
+      - "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/cli typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Need to change ttyd as the default backend."
+      - "Need to mutate active deployment backend behavior after launch."
+      - "Need to log terminal input/output, tokens, command strings, context, or environment."
+      - "Behavior is ambiguous between env, settings, launch UI, CLI, or Apple clients."
+      - "Focused verification fails twice for the same cause."
+    receipt:
+      result: done
+      summary: "Implemented the approved rollout-control slice. New launches now use a validated terminal_backend setting unless ISSUECTL_PTY_BRIDGE=1 forces PTY bridge, Workbench settings exposes the default, issue launch options show the prospective backend, and diag summary reports backend-grouped lifecycle counts from safe existing diagnostics/deployment data."
+      changed_files:
+        - "packages/core/src/types.ts"
+        - "packages/core/src/db/settings.ts"
+        - "packages/core/src/db/settings.test.ts"
+        - "packages/core/src/launch/launch.ts"
+        - "packages/core/src/launch/launch-execute-agents.test.ts"
+        - "packages/core/src/launch/launch-terminal-backend.test.ts"
+        - "packages/web/lib/workbench-data.ts"
+        - "packages/web/app/api/v1/settings/route.ts"
+        - "packages/web/app/api/v1/settings/route.test.ts"
+        - "packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts"
+        - "packages/web/components/workbench/workbench-types.ts"
+        - "packages/web/components/workbench/SettingsFocus.tsx"
+        - "packages/web/components/workbench/IssueFocus.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+        - "packages/cli/src/commands/diag.ts"
+        - "packages/cli/src/commands/diag.test.ts"
+        - "packages/cli/src/commands/diag-summary.ts"
+        - "packages/cli/src/commands/diag-summary.test.ts"
+      implementation:
+        - "Added terminal_backend to SettingKey and default settings with ttyd as the seeded default."
+        - "executeLaunch now snapshots a selected backend from ISSUECTL_PTY_BRIDGE=1 or terminal_backend, then persists it on the deployment row."
+        - "Workbench settings now shows a Terminal backend selector with TTYD and PTY bridge (experimental)."
+        - "Workbench issue launch options now show the backend that will be used before launching."
+        - "Workbench payload carries the effective terminal backend default, including the PTY env override."
+        - "Added diag summary to group safe lifecycle counts by ttyd, pty_bridge, or unknown backend."
+        - "Split new tests into focused files so max-lines lint remains clean."
+      commands:
+        - cmd: "pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts src/launch/launch-terminal-backend.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'"
+          status: pass
+        - cmd: "pnpm --dir packages/cli test -- src/commands/diag.test.ts src/commands/diag-summary.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/cli typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core build"
+          status: pass
+        - cmd: "pnpm --dir packages/cli build"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+        - cmd: "pnpm --dir packages/cli lint"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm --dir packages/cli exec issuectl diag summary --since 7d --json"
+          status: pass
+      notes:
+        - "No real issue launch/manual QA was run during this Worker; the Playwright harness covered both backend UI paths without touching non-test repos."
+        - "Diagnostics summary against the local journal produced backend groups for pty_bridge, ttyd, and unknown."
+        - "A later Judge decision is still required before any default switch, Apple PTY enablement, or repo/user-specific rollout policy."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the rollout-controls tranche is complete against the original user outcome and goal oracle."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "Playwright/manual QA evidence"
+      - "Diagnostics/reporting evidence"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if required Worker work is still queued or active."
+      - "Reject completion if backend selection remains invisible before launch."
+      - "Reject completion if changing defaults could affect active deployments."
+      - "Reject completion if comparison telemetry cannot distinguish ttyd from PTY bridge outcomes."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "oracle mapping"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "The rollout-controls tranche is complete. The implementation makes backend selection visible before launch, keeps ttyd as the default, preserves env-forced PTY opt-in, snapshots backend per deployment, proves active deployment backend immutability, and adds backend-grouped diagnostics reporting without logging terminal content or secrets."
+      oracle_mapping:
+        - requirement: "Backend selection visible before launch."
+          evidence: "IssueFocus renders Terminal backend for new launch; focused Playwright asserts TTYD in the ttyd flow and PTY bridge experimental in the PTY flow."
+        - requirement: "ttyd remains default."
+          evidence: "seedDefaults sets terminal_backend=ttyd; Workbench E2E seed uses ttyd; core tests pass default ttyd behavior."
+        - requirement: "PTY bridge remains opt-in/feature-flagged."
+          evidence: "executeLaunch uses terminal_backend only for new launches and ISSUECTL_PTY_BRIDGE=1 remains a PTY override; no default switch was introduced."
+        - requirement: "Active deployments keep their recorded backend."
+          evidence: "launch-terminal-backend.test.ts proves an existing ttyd deployment remains ttyd after the default changes to pty_bridge while a new launch uses pty_bridge."
+        - requirement: "Diagnostics/reporting compares ttyd and PTY bridge outcomes."
+          evidence: "diag summary groups safe lifecycle counts by backend; CLI tests cover formatting and local journal command returned pty_bridge, ttyd, and unknown groups."
+        - requirement: "No terminal content or secrets logged."
+          evidence: "The diagnostics summary reads existing DiagnosticEvent fields and deployment terminal_backend metadata; it adds no terminal I/O, token, command, context, or environment logging."
+        - requirement: "Verification covers both backend launch flows."
+          evidence: "Focused Playwright passed for checks worktree status and launches an issue with selected context, and launches an issue with the PTY bridge backend."
+      verification:
+        - "PASS pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts src/launch/launch-terminal-backend.test.ts"
+        - "PASS pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'"
+        - "PASS pnpm --dir packages/cli test -- src/commands/diag.test.ts src/commands/diag-summary.test.ts"
+        - "PASS pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g \"checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend\""
+        - "PASS pnpm --dir packages/core typecheck"
+        - "PASS pnpm --dir packages/web typecheck"
+        - "PASS pnpm --dir packages/cli typecheck"
+        - "PASS pnpm --dir packages/web lint"
+        - "PASS pnpm --dir packages/core lint"
+        - "PASS pnpm --dir packages/cli lint"
+        - "PASS git diff --check"
+      follow_up:
+        - "Before any default switch, run a separate Judge-approved live dogfood pass against the two approved issuectl test repos."
+        - "Apple PTY enablement remains a separate compatibility tranche."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/packages/cli/src/commands/diag-summary.test.ts
+++ b/packages/cli/src/commands/diag-summary.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticEvent } from "@issuectl/core";
+import { summarizeBackends } from "./diag-summary.js";
+
+function makeEvent(overrides: Partial<DiagnosticEvent> = {}): DiagnosticEvent {
+  return {
+    id: 1,
+    timestamp: Date.UTC(2026, 4, 20, 12, 0, 0),
+    level: "info",
+    event: "test.event",
+    source: "test",
+    correlationId: null,
+    owner: null,
+    repo: null,
+    issueNumber: null,
+    deploymentId: null,
+    sessionName: null,
+    ttydPort: null,
+    ttydPid: null,
+    status: null,
+    message: null,
+    data: null,
+    ...overrides,
+  };
+}
+
+describe("summarizeBackends", () => {
+  it("summarizes diagnostics by inferred backend", () => {
+    const db = {
+      prepare: vi.fn(() => ({
+        get: vi.fn(() => ({ terminal_backend: "pty_bridge" })),
+      })),
+    };
+
+    expect(summarizeBackends([
+      makeEvent({ event: "deployment.activated", deploymentId: 7 }),
+      makeEvent({ event: "pty.first_output_seen", deploymentId: 7 }),
+      makeEvent({ event: "terminal.first_output_seen", deploymentId: 8 }),
+      makeEvent({ event: "ensure_ttyd.failed", level: "error", deploymentId: 8 }),
+    ], db)).toEqual([
+      {
+        backend: "pty_bridge",
+        events: 2,
+        launches: 0,
+        activations: 1,
+        firstOutput: 1,
+        reconnects: 0,
+        failures: 0,
+        cleanups: 0,
+      },
+      {
+        backend: "ttyd",
+        events: 2,
+        launches: 0,
+        activations: 0,
+        firstOutput: 1,
+        reconnects: 0,
+        failures: 1,
+        cleanups: 0,
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/diag-summary.ts
+++ b/packages/cli/src/commands/diag-summary.ts
@@ -1,0 +1,91 @@
+import type { DiagnosticEvent } from "@issuectl/core";
+
+export type TerminalBackend = "ttyd" | "pty_bridge" | "unknown";
+
+export type BackendSummary = {
+  backend: TerminalBackend;
+  events: number;
+  launches: number;
+  activations: number;
+  firstOutput: number;
+  reconnects: number;
+  failures: number;
+  cleanups: number;
+};
+
+export function summarizeBackends(events: DiagnosticEvent[], db?: unknown): BackendSummary[] {
+  const summaries = new Map<TerminalBackend, BackendSummary>();
+  for (const event of events) {
+    const backend = inferBackend(event, db);
+    const summary = summaries.get(backend) ?? emptySummary(backend);
+    summary.events += 1;
+    if (isLaunchEvent(event.event)) summary.launches += 1;
+    if (event.event === "deployment.activated") summary.activations += 1;
+    if (event.event === "terminal.first_output_seen" || event.event === "pty.first_output_seen") {
+      summary.firstOutput += 1;
+    }
+    if (event.event === "ensure_ttyd.respawned" || event.event === "terminal.respawned") {
+      summary.reconnects += 1;
+    }
+    if (event.level === "error" || event.event.endsWith("_failed") || event.event.endsWith(".failed")) {
+      summary.failures += 1;
+    }
+    if (isCleanupEvent(event.event)) summary.cleanups += 1;
+    summaries.set(backend, summary);
+  }
+  return [...summaries.values()].sort((left, right) => left.backend.localeCompare(right.backend));
+}
+
+function inferBackend(event: DiagnosticEvent, db?: unknown): TerminalBackend {
+  const dataBackend = event.data?.backend;
+  if (dataBackend === "ttyd" || dataBackend === "pty_bridge") return dataBackend;
+  if (event.event.startsWith("pty.")) return "pty_bridge";
+  if (event.event.startsWith("ttyd.") || event.event.startsWith("terminal.") || event.event.startsWith("ensure_ttyd.")) {
+    return "ttyd";
+  }
+  if (event.deploymentId !== null) {
+    const backend = lookupDeploymentBackend(db, event.deploymentId);
+    if (backend) return backend;
+  }
+  return "unknown";
+}
+
+function lookupDeploymentBackend(db: unknown, deploymentId: number): TerminalBackend | null {
+  if (!db || typeof db !== "object" || !("prepare" in db) || typeof db.prepare !== "function") {
+    return null;
+  }
+  try {
+    const row = db
+      .prepare("SELECT terminal_backend FROM deployments WHERE id = ?")
+      .get(deploymentId) as { terminal_backend?: unknown } | undefined;
+    return row?.terminal_backend === "ttyd" || row?.terminal_backend === "pty_bridge"
+      ? row.terminal_backend
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isLaunchEvent(event: string): boolean {
+  return event === "ttyd.spawned" || event === "pty.bridge_spawned";
+}
+
+function isCleanupEvent(event: string): boolean {
+  return event === "pty.tmux_killed" ||
+    event === "pty.process_exit" ||
+    event === "terminal.ws_closed" ||
+    event === "pty.ws_closed";
+}
+
+function emptySummary(backend: TerminalBackend): BackendSummary {
+  return {
+    backend,
+    events: 0,
+    launches: 0,
+    activations: 0,
+    firstOutput: 0,
+    reconnects: 0,
+    failures: 0,
+    cleanups: 0,
+  };
+}

--- a/packages/cli/src/commands/diag.test.ts
+++ b/packages/cli/src/commands/diag.test.ts
@@ -157,6 +157,7 @@ describe("diag command helpers", () => {
     expect(line).toContain("mean-weasel/issuectl-test-repo#152");
     expect(line).toContain("Deployment not found or already ended");
   });
+
 });
 
 describe("diag commands", () => {
@@ -220,6 +221,24 @@ describe("diag commands", () => {
       },
     });
     expect(JSON.parse(result.stdout)).toEqual(events);
+  });
+
+  it("summary prints backend-grouped counts", async () => {
+    vi.mocked(queryDiagnosticEvents).mockReturnValue([
+      makeEvent({ event: "ttyd.spawned", deploymentId: 1 }),
+      makeEvent({ event: "deployment.activated", deploymentId: 1, data: { backend: "ttyd" } }),
+      makeEvent({ event: "pty.bridge_spawned", deploymentId: 2 }),
+      makeEvent({ event: "pty.first_output_seen", deploymentId: 2 }),
+    ]);
+
+    const result = await parseCommand(["diag", "summary", "--since", "1h"]);
+
+    expect(queryDiagnosticEvents).toHaveBeenCalledWith(mockDb, {
+      since: Date.UTC(2026, 4, 20, 11, 0, 0),
+      limit: 1000,
+    });
+    expect(result.stdout).toContain("backend=pty_bridge events=2 launches=1");
+    expect(result.stdout).toContain("backend=ttyd events=2 launches=1 activations=1");
   });
 
   it("invalid since exits through Commander without stack trace output", async () => {

--- a/packages/cli/src/commands/diag.ts
+++ b/packages/cli/src/commands/diag.ts
@@ -7,6 +7,7 @@ import {
   type DiagnosticLevel,
   type DiagnosticQuery,
 } from "@issuectl/core";
+import { summarizeBackends, type BackendSummary } from "./diag-summary.js";
 import { requireDb } from "../utils/db.js";
 
 type CommonOptions = {
@@ -32,6 +33,13 @@ type ShowOptions = {
   deployment?: string;
   issue?: string;
   correlation?: string;
+  limit?: string;
+  json?: boolean;
+};
+
+type SummaryOptions = {
+  since?: string;
+  issue?: string;
   limit?: string;
   json?: boolean;
 };
@@ -98,6 +106,23 @@ export function registerDiagCommands(program: Command): void {
     .action((options: ShowOptions, command: Command) => {
       const query = parseCommandInput(command, () => buildQuery(options));
       printEvents(getDiagnosticTimeline(requireDb(), query), Boolean(options.json));
+    });
+
+  diag
+    .command("summary")
+    .description("Summarize diagnostics by terminal backend")
+    .option("--since <duration>", "Relative duration to query, e.g. 15m, 2h, 1d", "1d")
+    .option("--issue <owner/repo#number>", "Filter by issue")
+    .option("--limit <count>", "Maximum rows to summarize", "1000")
+    .option("--json", "Print JSON")
+    .action((options: SummaryOptions, command: Command) => {
+      const db = requireDb();
+      const query = parseCommandInput(command, () =>
+        buildQuery(options, {
+          since: options.since ? Date.now() - parseDurationMs(options.since) : undefined,
+        }),
+      );
+      printBackendSummary(summarizeBackends(queryDiagnosticEvents(db, query), db), Boolean(options.json));
     });
 }
 
@@ -258,5 +283,27 @@ function printEvents(events: DiagnosticEvent[], json: boolean): void {
 
   for (const event of events) {
     process.stdout.write(`${formatDiagnosticEvent(event)}\n`);
+  }
+}
+
+function printBackendSummary(summaries: BackendSummary[], json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(summaries, null, 2)}\n`);
+    return;
+  }
+
+  for (const summary of summaries) {
+    process.stdout.write(
+      [
+        `backend=${summary.backend}`,
+        `events=${summary.events}`,
+        `launches=${summary.launches}`,
+        `activations=${summary.activations}`,
+        `first_output=${summary.firstOutput}`,
+        `reconnects=${summary.reconnects}`,
+        `failures=${summary.failures}`,
+        `cleanups=${summary.cleanups}`,
+      ].join(" ") + "\n",
+    );
   }
 }

--- a/packages/core/src/db/settings.test.ts
+++ b/packages/core/src/db/settings.test.ts
@@ -63,13 +63,14 @@ describe("seedDefaults", () => {
   it("inserts all default settings", () => {
     seedDefaults(db);
     const settings = getSettings(db);
-    expect(settings).toHaveLength(8);
+    expect(settings).toHaveLength(9);
 
     const keys = settings.map((s) => s.key);
     expect(keys).toContain("branch_pattern");
     expect(keys).toContain("cache_ttl");
     expect(keys).toContain("worktree_dir");
     expect(keys).toContain("launch_agent");
+    expect(keys).toContain("terminal_backend");
     expect(keys).toContain("claude_extra_args");
     expect(keys).toContain("codex_extra_args");
     expect(keys).toContain("idle_grace_period");
@@ -85,6 +86,11 @@ describe("seedDefaults", () => {
     seedDefaults(db);
     expect(getSetting(db, "launch_agent")).toBe("claude");
     expect(getSetting(db, "codex_extra_args")).toBe("");
+  });
+
+  it("seedDefaults keeps ttyd as the terminal backend default", () => {
+    seedDefaults(db);
+    expect(getSetting(db, "terminal_backend")).toBe("ttyd");
   });
 
   it("uses INSERT OR IGNORE — does not overwrite existing values", () => {

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS: Setting[] = [
   { key: "cache_ttl", value: "300" },
   { key: "worktree_dir", value: DEFAULT_WORKTREE_DIR },
   { key: "launch_agent", value: "claude" },
+  { key: "terminal_backend", value: "ttyd" },
   { key: "claude_extra_args", value: "--dangerously-skip-permissions" },
   { key: "codex_extra_args", value: "" },
   { key: "idle_grace_period", value: "300" },

--- a/packages/core/src/launch/launch-execute-agents.test.ts
+++ b/packages/core/src/launch/launch-execute-agents.test.ts
@@ -327,4 +327,5 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       }),
     );
   });
+
 });

--- a/packages/core/src/launch/launch-terminal-backend.test.ts
+++ b/packages/core/src/launch/launch-terminal-backend.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type Database from "better-sqlite3";
+import type { Octokit } from "@octokit/rest";
+import { executeLaunch } from "./launch.js";
+import { createTestDb } from "../db/test-helpers.js";
+import { addRepo } from "../db/repos.js";
+import { recordDeployment } from "../db/deployments.js";
+
+const { prepareWorkspaceSpy } = vi.hoisted(() => ({
+  prepareWorkspaceSpy: vi.fn(async () => ({
+    path: "/tmp/fake-workspace",
+    branchName: "fake-branch",
+  })),
+}));
+
+vi.mock("./workspace.js", () => ({
+  prepareWorkspace: prepareWorkspaceSpy,
+}));
+
+const { verifyTtydSpy, verifyTmuxSpy, spawnTtydSpy, spawnPtyBridgeSessionSpy, allocatePortSpy } = vi.hoisted(() => ({
+  verifyTtydSpy: vi.fn(),
+  verifyTmuxSpy: vi.fn(),
+  spawnTtydSpy: vi.fn(async () => ({ pid: 12345, port: 7700 })),
+  spawnPtyBridgeSessionSpy: vi.fn(),
+  allocatePortSpy: vi.fn(async () => 7700),
+}));
+
+vi.mock("./ttyd.js", () => ({
+  verifyTtyd: verifyTtydSpy,
+  verifyTmux: verifyTmuxSpy,
+  spawnTtyd: spawnTtydSpy,
+  spawnPtyBridgeSession: spawnPtyBridgeSessionSpy,
+  allocatePort: allocatePortSpy,
+  tmuxSessionName: (repo: string, issueNumber: number) =>
+    `issuectl-${repo}-${issueNumber}`,
+}));
+
+const { reserveTtydPortSpy, updateTtydInfoSpy } = vi.hoisted(() => ({
+  reserveTtydPortSpy: vi.fn(),
+  updateTtydInfoSpy: vi.fn(),
+}));
+
+vi.mock("../db/deployments.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../db/deployments.js")>(
+      "../db/deployments.js",
+    );
+  return {
+    ...actual,
+    reserveTtydPort: reserveTtydPortSpy,
+    updateTtydInfo: updateTtydInfoSpy,
+  };
+});
+
+vi.mock("../db/diagnostics.js", () => ({
+  recordDiagnosticEventSafely: vi.fn(),
+}));
+
+vi.mock("../data/issues.js", () => ({
+  getIssueDetail: async () => ({
+    issue: {
+      number: 42,
+      title: "test issue",
+      body: "",
+      state: "open",
+      labels: [],
+      user: null,
+      commentCount: 0,
+      createdAt: "2026-04-12T00:00:00Z",
+      updatedAt: "2026-04-12T00:00:00Z",
+      closedAt: null,
+      htmlUrl: "https://example.invalid",
+    },
+    comments: [],
+    referencedFiles: [],
+  }),
+}));
+
+vi.mock("./context.js", () => ({
+  assembleContext: () => "fake context",
+  writeContextFile: async () => "/tmp/fake-context.md",
+}));
+
+vi.mock("../github/labels.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../github/labels.js")>(
+      "../github/labels.js",
+    );
+  return {
+    ...actual,
+    ensureLifecycleLabels: async () => {},
+    addLabels: async () => {},
+  };
+});
+
+describe("executeLaunch terminal backend selection", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    delete process.env.ISSUECTL_PTY_BRIDGE;
+    prepareWorkspaceSpy.mockClear();
+    verifyTtydSpy.mockClear();
+    verifyTmuxSpy.mockClear();
+    spawnTtydSpy.mockClear();
+    spawnPtyBridgeSessionSpy.mockClear();
+    allocatePortSpy.mockClear();
+    reserveTtydPortSpy.mockClear();
+    updateTtydInfoSpy.mockClear();
+    db = createTestDb();
+  });
+
+  async function withConsoleWarnSilenced<T>(fn: () => Promise<T>): Promise<T> {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      return await fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it("uses the terminal_backend setting for new launches when no env override is set", async () => {
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(
+      "terminal_backend",
+      "pty_bridge",
+    );
+
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 46,
+      agent: "codex",
+      branchName: "setting-pty-bridge",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+    }));
+
+    expect(result.terminalBackend).toBe("pty_bridge");
+    expect(verifyTmuxSpy).toHaveBeenCalledTimes(1);
+    expect(verifyTtydSpy).not.toHaveBeenCalled();
+    expect(spawnPtyBridgeSessionSpy).toHaveBeenCalledTimes(1);
+    expect(spawnTtydSpy).not.toHaveBeenCalled();
+
+    const row = db
+      .prepare("SELECT terminal_backend FROM deployments WHERE repo_id = ? AND issue_number = ?")
+      .get(repo.id, 46) as { terminal_backend: string };
+    expect(row.terminal_backend).toBe("pty_bridge");
+  });
+
+  it("keeps the recorded backend on existing deployments when the default changes", async () => {
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    const existing = recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 46,
+      branchName: "existing-ttyd",
+      workspaceMode: "existing",
+      workspacePath: "/tmp/existing",
+      terminalBackend: "ttyd",
+    });
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(
+      "terminal_backend",
+      "pty_bridge",
+    );
+
+    await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 47,
+      agent: "codex",
+      branchName: "new-pty-bridge",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+    }));
+
+    const rows = db
+      .prepare("SELECT id, terminal_backend FROM deployments WHERE repo_id = ? ORDER BY id")
+      .all(repo.id) as Array<{ id: number; terminal_backend: string }>;
+    expect(rows).toContainEqual({ id: existing.id, terminal_backend: "ttyd" });
+    expect(rows.at(-1)?.terminal_backend).toBe("pty_bridge");
+  });
+});

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -93,7 +93,7 @@ export async function executeLaunch(
     workspaceMode: options.workspaceMode,
   });
 
-  const terminalBackend: TerminalBackend = process.env.ISSUECTL_PTY_BRIDGE === "1" ? "pty_bridge" : "ttyd";
+  const terminalBackend = selectTerminalBackend(db);
 
   // 0. Verify terminal backend prerequisites.
   if (terminalBackend === "pty_bridge") {
@@ -321,3 +321,8 @@ export { type WorkspaceMode, type WorkspaceResult } from "./workspace.js";
 export { type LaunchContext } from "./context.js";
 export { buildClaudeCommand, buildLaunchAgentCommand } from "./launch-agent-command.js";
 export { expandHome } from "./launch-workspace-setup.js";
+
+function selectTerminalBackend(db: Database.Database): TerminalBackend {
+  if (process.env.ISSUECTL_PTY_BRIDGE === "1") return "pty_bridge";
+  return getSetting(db, "terminal_backend") === "pty_bridge" ? "pty_bridge" : "ttyd";
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,7 @@ export type SettingKey =
   | "cache_ttl"
   | "worktree_dir"
   | "launch_agent"
+  | "terminal_backend"
   | "claude_extra_args"
   | "codex_extra_args"
   | "default_repo_id"

--- a/packages/web/app/api/v1/settings/route.test.ts
+++ b/packages/web/app/api/v1/settings/route.test.ts
@@ -57,6 +57,7 @@ describe("/api/v1/settings", () => {
   it("GET includes launch agent and codex args settings", async () => {
     getSettings.mockReturnValue([
       { key: "launch_agent", value: "codex" },
+      { key: "terminal_backend", value: "pty_bridge" },
       { key: "codex_extra_args", value: "--sandbox danger-full-access" },
       { key: "api_token", value: "secret" },
     ]);
@@ -67,6 +68,7 @@ describe("/api/v1/settings", () => {
     expect(response.status).toBe(200);
     expect(json.settings).toMatchObject({
       launch_agent: "codex",
+      terminal_backend: "pty_bridge",
       codex_extra_args: "--sandbox danger-full-access",
     });
     expect(json.settings.api_token).toBeUndefined();
@@ -76,6 +78,7 @@ describe("/api/v1/settings", () => {
     const response = await PATCH(
       makePatchRequest({
         launch_agent: "codex",
+        terminal_backend: "pty_bridge",
         codex_extra_args: " --ask-for-approval never ",
       }),
     );
@@ -84,6 +87,7 @@ describe("/api/v1/settings", () => {
     expect(response.status).toBe(200);
     expect(json).toEqual({ success: true });
     expect(setSetting).toHaveBeenCalledWith(expect.anything(), "launch_agent", "codex");
+    expect(setSetting).toHaveBeenCalledWith(expect.anything(), "terminal_backend", "pty_bridge");
     expect(setSetting).toHaveBeenCalledWith(
       expect.anything(),
       "codex_extra_args",
@@ -97,6 +101,15 @@ describe("/api/v1/settings", () => {
 
     expect(response.status).toBe(400);
     expect(json.error).toMatch(/launch_agent/i);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("PATCH rejects an invalid terminal_backend", async () => {
+    const response = await PATCH(makePatchRequest({ terminal_backend: "shell" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toMatch(/terminal_backend/i);
     expect(setSetting).not.toHaveBeenCalled();
   });
 

--- a/packages/web/app/api/v1/settings/route.ts
+++ b/packages/web/app/api/v1/settings/route.ts
@@ -18,6 +18,7 @@ const EDITABLE_KEYS: readonly SettingKey[] = [
   "cache_ttl",
   "worktree_dir",
   "launch_agent",
+  "terminal_backend",
   "claude_extra_args",
   "codex_extra_args",
   "default_repo_id",
@@ -32,6 +33,9 @@ function validateSettingValue(
   const trimmed = value.trim();
   if (key === "launch_agent" && trimmed !== "claude" && trimmed !== "codex") {
     return "Launch agent must be claude or codex";
+  }
+  if (key === "terminal_backend" && trimmed !== "ttyd" && trimmed !== "pty_bridge") {
+    return "Terminal backend must be ttyd or pty_bridge";
   }
   if (key === "claude_extra_args") {
     const result = validateClaudeArgs(trimmed);

--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -156,6 +156,7 @@ export function IssueFocus({
   }, [ref, workspaceMode]);
 
   const loadedIssue = detail?.issue;
+  const selectedBackend = repo.terminalBackendDefault ?? "ttyd";
   const title = loadedIssue?.title ?? issue.title;
   const titleChanged = titleDraft.trim().length > 0 && titleDraft.trim() !== title;
   const priority = issue.priority;
@@ -515,6 +516,11 @@ export function IssueFocus({
                 repo={repo.name}
                 issueNumber={issue.number}
               />
+              <div className={styles.backendPreview} aria-label="Terminal backend for new launch">
+                <span>Terminal backend</span>
+                <strong>{terminalBackendLabel(selectedBackend)}</strong>
+                {selectedBackend === "pty_bridge" && <em>experimental</em>}
+              </div>
             </div>
             <div>
               <h2>Worktree</h2>
@@ -593,6 +599,10 @@ export function IssueFocus({
       </div>
     </div>
   );
+}
+
+function terminalBackendLabel(backend: TerminalBackend): string {
+  return backend === "pty_bridge" ? "PTY bridge" : "TTYD";
 }
 
 function DeploymentRow({

--- a/packages/web/components/workbench/SettingsFocus.tsx
+++ b/packages/web/components/workbench/SettingsFocus.tsx
@@ -60,6 +60,7 @@ export function SettingsFocus({ payload, collapsedSections, onToggleSection, onS
         cache_ttl: settings.cache_ttl ?? "",
         worktree_dir: settings.worktree_dir ?? "",
         launch_agent: settings.launch_agent ?? "codex",
+        terminal_backend: settings.terminal_backend ?? "ttyd",
         claude_extra_args: settings.claude_extra_args ?? "",
         codex_extra_args: settings.codex_extra_args ?? "",
         idle_grace_period: settings.idle_grace_period ?? "",
@@ -139,6 +140,18 @@ export function SettingsFocus({ payload, collapsedSections, onToggleSection, onS
             >
               <option value="codex">Codex</option>
               <option value="claude">Claude Code</option>
+            </select>
+          </label>
+          <label className={styles.workbenchField}>
+            <span>Terminal backend</span>
+            <select
+              aria-label="Terminal backend"
+              value={settings.terminal_backend ?? "ttyd"}
+              onChange={(event) => updateSetting("terminal_backend", event.target.value)}
+              className={styles.workbenchInput}
+            >
+              <option value="ttyd">TTYD</option>
+              <option value="pty_bridge">PTY bridge (experimental)</option>
             </select>
           </label>
           <SettingInput label="Claude extra args" value={settings.claude_extra_args} onChange={(value) => updateSetting("claude_extra_args", value)} />

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1233,6 +1233,35 @@
   overflow-wrap: anywhere;
 }
 
+.backendPreview {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: rgba(255, 255, 255, 0.24);
+  color: var(--paper-ink-muted);
+  font-size: 13px;
+}
+
+.backendPreview span {
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.backendPreview strong {
+  color: var(--paper-ink);
+  font-weight: 700;
+}
+
+.backendPreview em {
+  color: var(--paper-accent);
+  font-size: 12px;
+}
+
 .issueFocusGrid button {
   justify-self: start;
   min-height: 36px;

--- a/packages/web/components/workbench/workbench-types.ts
+++ b/packages/web/components/workbench/workbench-types.ts
@@ -53,6 +53,7 @@ export type WorkbenchRepo = {
   badgeCount: number;
   deployedCount: number;
   launchAgent: LaunchAgent | null;
+  terminalBackendDefault?: TerminalBackend;
   issueError: string | null;
   issuesFromCache: boolean;
   issuesCachedAt: string | null;

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -267,6 +267,7 @@ function seedWorkbenchRepos(path: string, repos: FixtureRepo[] = workbenchPayloa
     db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run("cache_ttl", "99999");
     db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run("branch_pattern", "issue-{number}-{slug}");
     db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run("launch_agent", "codex");
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run("terminal_backend", "ttyd");
 
     for (const item of repos) {
       db.prepare(
@@ -302,6 +303,15 @@ function seedWorkbenchRepos(path: string, repos: FixtureRepo[] = workbenchPayloa
         ).run(item.id, issue.number, issue.priority, Date.now());
       }
     }
+  } finally {
+    db.close();
+  }
+}
+
+function setWorkbenchSetting(path: string, key: string, value: string): void {
+  const db = new Database(path);
+  try {
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run(key, value);
   } finally {
     db.close();
   }
@@ -421,6 +431,7 @@ test("direct-load workbench settings bootstraps the API token before client acti
             cache_ttl: "99999",
             worktree_dir: "/tmp/worktrees",
             launch_agent: "codex",
+            terminal_backend: "ttyd",
             claude_extra_args: "--verbose",
             codex_extra_args: "",
             idle_grace_period: "300",
@@ -438,6 +449,7 @@ test("direct-load workbench settings bootstraps the API token before client acti
       cache_ttl: "120",
       worktree_dir: "/tmp/worktrees",
       launch_agent: "codex",
+      terminal_backend: "ttyd",
       claude_extra_args: "--verbose",
       codex_extra_args: "",
       idle_grace_period: "300",
@@ -810,6 +822,7 @@ test("keeps compact state-changing workbench workflows inside the viewport", asy
             cache_ttl: "99999",
             worktree_dir: "/tmp/worktrees",
             launch_agent: "codex",
+            terminal_backend: "ttyd",
             claude_extra_args: "--verbose",
             codex_extra_args: "",
             idle_grace_period: "300",
@@ -826,6 +839,7 @@ test("keeps compact state-changing workbench workflows inside the viewport", asy
       cache_ttl: "120",
       worktree_dir: "",
       launch_agent: "codex",
+      terminal_backend: "ttyd",
       claude_extra_args: "",
       codex_extra_args: "",
       idle_grace_period: "",
@@ -2824,6 +2838,7 @@ test("renders settings mode with health and saves settings through APIs", async 
             cache_ttl: "99999",
             worktree_dir: "/tmp/worktrees",
             launch_agent: "codex",
+            terminal_backend: "ttyd",
             claude_extra_args: "--verbose",
             codex_extra_args: "",
             idle_grace_period: "300",
@@ -2839,6 +2854,7 @@ test("renders settings mode with health and saves settings through APIs", async 
       cache_ttl: "120",
       worktree_dir: "/tmp/worktrees",
       launch_agent: "codex",
+      terminal_backend: "ttyd",
       claude_extra_args: "--verbose",
       codex_extra_args: "",
       idle_grace_period: "300",
@@ -3484,6 +3500,7 @@ test("checks worktree status and launches an issue with selected context", async
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Codex", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Claude Code", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Terminal backend for new launch")).toContainText("TTYD");
   await expect(page.getByLabel("Launch options").getByText("Existing repo")).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Git worktree")).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Fresh clone")).toBeVisible();
@@ -3528,6 +3545,7 @@ test("checks worktree status and launches an issue with selected context", async
 });
 
 test("launches an issue with the PTY bridge backend and keeps the terminal session navigable", async ({ page }) => {
+  setWorkbenchSetting(dbPath, "terminal_backend", "pty_bridge");
   await installClipboardCapture(page);
   await installFakePtyWebSocket(page);
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -3594,6 +3612,8 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
   await gotoWorkbenchWithRetry(page);
   await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expect(page.getByLabel("Terminal backend for new launch")).toContainText("PTY bridge");
+  await expect(page.getByLabel("Terminal backend for new launch")).toContainText("experimental");
   await page.getByRole("button", { name: "Launch issue" }).click();
 
   await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-instances-pane", "visible");

--- a/packages/web/lib/workbench-data.ts
+++ b/packages/web/lib/workbench-data.ts
@@ -33,6 +33,7 @@ const WORKBENCH_SETTING_KEYS: readonly Exclude<SettingKey, "api_token">[] = [
   "cache_ttl",
   "worktree_dir",
   "launch_agent",
+  "terminal_backend",
   "claude_extra_args",
   "codex_extra_args",
   "default_repo_id",
@@ -59,7 +60,7 @@ export async function getWorkbenchPayload({
   const settings = readWorkbenchSettings(db);
   const [user, workbenchRepos] = await Promise.all([
     includeUser ? readCurrentUser() : Promise.resolve({ login: null, error: null }),
-    readWorkbenchRepos(db, repos, activeDeployments, previews),
+    readWorkbenchRepos(db, repos, activeDeployments, previews, settings),
   ]);
 
   return {
@@ -75,11 +76,17 @@ export async function getWorkbenchPayload({
 
 function readWorkbenchSettings(db: unknown): WorkbenchSettings {
   const allowed = new Set<string>(WORKBENCH_SETTING_KEYS);
-  return Object.fromEntries(
+  const settings = Object.fromEntries(
     getSettings(db as Parameters<typeof getSettings>[0])
       .filter((setting) => allowed.has(setting.key))
       .map((setting) => [setting.key, setting.value]),
   ) as WorkbenchSettings;
+  return {
+    ...settings,
+    terminal_backend: process.env.ISSUECTL_PTY_BRIDGE === "1"
+      ? "pty_bridge"
+      : settings.terminal_backend ?? "ttyd",
+  };
 }
 
 async function readCurrentUser(): Promise<WorkbenchUser> {
@@ -109,6 +116,7 @@ async function readWorkbenchRepos(
   repos: Repo[],
   deployments: ActiveDeploymentWithRepo[],
   previews: Record<string, WorkbenchPreview>,
+  settings: WorkbenchSettings,
 ): Promise<WorkbenchRepo[]> {
   return mapLimit(repos, DEFAULT_REPO_FANOUT, async (repo) => {
     const repoDeployments = sortDeploymentsByRunningState(
@@ -124,6 +132,7 @@ async function readWorkbenchRepos(
       );
       return buildWorkbenchRepo({
         repo,
+        terminalBackendDefault: terminalBackendDefault(settings),
         repoDeployments,
         priorities,
         repoPreviews,
@@ -141,6 +150,7 @@ async function readWorkbenchRepos(
       });
       return buildWorkbenchRepo({
         repo,
+        terminalBackendDefault: terminalBackendDefault(settings),
         repoDeployments,
         priorities,
         repoPreviews,
@@ -175,6 +185,7 @@ function previewRank(
 
 function buildWorkbenchRepo(input: {
   repo: Repo;
+  terminalBackendDefault: WorkbenchRepo["terminalBackendDefault"];
   repoDeployments: ActiveDeploymentWithRepo[];
   priorities: IssuePriority[];
   repoPreviews: Record<string, WorkbenchPreview>;
@@ -196,6 +207,7 @@ function buildWorkbenchRepo(input: {
     badgeCount: input.repoDeployments.length,
     deployedCount: input.repoDeployments.length,
     launchAgent: input.repoDeployments[0]?.agent ?? null,
+    terminalBackendDefault: input.terminalBackendDefault,
     issueError: input.issueError,
     issuesFromCache: input.issuesFromCache,
     issuesCachedAt: input.issuesCachedAt,
@@ -206,6 +218,10 @@ function buildWorkbenchRepo(input: {
       summarizeIssue(issue, priorityByIssue.get(issue.number) ?? "normal", activeIssueNumbers),
     ),
   };
+}
+
+function terminalBackendDefault(settings: WorkbenchSettings): WorkbenchRepo["terminalBackendDefault"] {
+  return settings.terminal_backend === "pty_bridge" ? "pty_bridge" : "ttyd";
 }
 
 function summarizeIssue(


### PR DESCRIPTION
## Summary
- add typed terminal_backend launch default with ttyd default and ISSUECTL_PTY_BRIDGE override
- show backend selector in Workbench settings and pre-launch backend visibility in issue launch options
- add diag summary backend rollup plus focused tests for backend immutability and UI flows

## Verification
- pnpm --dir packages/core test -- src/db/settings.test.ts src/launch/launch-execute-agents.test.ts src/launch/launch-terminal-backend.test.ts
- pnpm --dir packages/web test -- app/api/v1/settings/route.test.ts 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'\n- pnpm --dir packages/cli test -- src/commands/diag.test.ts src/commands/diag-summary.test.ts\n- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend"\n- pnpm --dir packages/core typecheck\n- pnpm --dir packages/web typecheck\n- pnpm --dir packages/cli typecheck\n- pnpm --dir packages/core lint\n- pnpm --dir packages/web lint\n- pnpm --dir packages/cli lint\n- pnpm --dir packages/core build\n- pnpm --dir packages/cli build\n- git diff --check\n- pnpm --dir packages/cli exec issuectl diag summary --since 7d --json