### PR TITLE
[codex] Add per-launch terminal backend override

### DIFF
--- a/packages/core/src/launch/launch-terminal-backend.test.ts
+++ b/packages/core/src/launch/launch-terminal-backend.test.ts
@@ -152,6 +152,74 @@ describe("executeLaunch terminal backend selection", () => {
     expect(row.terminal_backend).toBe("pty_bridge");
   });
 
+  it("uses a per-launch backend override without changing the saved default", async () => {
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(
+      "terminal_backend",
+      "ttyd",
+    );
+
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 48,
+      agent: "codex",
+      branchName: "override-pty-bridge",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+      terminalBackend: "pty_bridge",
+    }));
+
+    expect(result.terminalBackend).toBe("pty_bridge");
+    expect(verifyTmuxSpy).toHaveBeenCalledTimes(1);
+    expect(verifyTtydSpy).not.toHaveBeenCalled();
+    expect(spawnPtyBridgeSessionSpy).toHaveBeenCalledTimes(1);
+    expect(spawnTtydSpy).not.toHaveBeenCalled();
+
+    const row = db
+      .prepare("SELECT terminal_backend FROM deployments WHERE repo_id = ? AND issue_number = ?")
+      .get(repo.id, 48) as { terminal_backend: string };
+    expect(row.terminal_backend).toBe("pty_bridge");
+    expect(db.prepare("SELECT value FROM settings WHERE key = ?").get("terminal_backend")).toEqual({ value: "ttyd" });
+  });
+
+  it("lets an explicit ttyd launch override the PTY bridge environment flag", async () => {
+    process.env.ISSUECTL_PTY_BRIDGE = "1";
+    const repo = addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+
+    const result = await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 49,
+      agent: "codex",
+      branchName: "override-ttyd",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+      terminalBackend: "ttyd",
+    }));
+
+    expect(result.terminalBackend).toBe("ttyd");
+    expect(verifyTtydSpy).toHaveBeenCalledTimes(1);
+    expect(verifyTmuxSpy).not.toHaveBeenCalled();
+    expect(spawnTtydSpy).toHaveBeenCalledTimes(1);
+    expect(spawnPtyBridgeSessionSpy).not.toHaveBeenCalled();
+
+    const row = db
+      .prepare("SELECT terminal_backend FROM deployments WHERE repo_id = ? AND issue_number = ?")
+      .get(repo.id, 49) as { terminal_backend: string };
+    expect(row.terminal_backend).toBe("ttyd");
+  });
+
   it("keeps the recorded backend on existing deployments when the default changes", async () => {
     const repo = addRepo(db, {
       owner: "acme",

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -53,6 +53,7 @@ export interface LaunchOptions {
   selectedFiles: string[];
   preamble?: string;
   forceResume?: boolean;
+  terminalBackend?: TerminalBackend;
   correlationId?: string;
 }
 
@@ -93,7 +94,7 @@ export async function executeLaunch(
     workspaceMode: options.workspaceMode,
   });
 
-  const terminalBackend = selectTerminalBackend(db);
+  const terminalBackend = selectTerminalBackend(db, options.terminalBackend);
 
   // 0. Verify terminal backend prerequisites.
   if (terminalBackend === "pty_bridge") {
@@ -322,7 +323,11 @@ export { type LaunchContext } from "./context.js";
 export { buildClaudeCommand, buildLaunchAgentCommand } from "./launch-agent-command.js";
 export { expandHome } from "./launch-workspace-setup.js";
 
-function selectTerminalBackend(db: Database.Database): TerminalBackend {
+function selectTerminalBackend(
+  db: Database.Database,
+  override?: TerminalBackend,
+): TerminalBackend {
+  if (override) return override;
   if (process.env.ISSUECTL_PTY_BRIDGE === "1") return "pty_bridge";
   return getSetting(db, "terminal_backend") === "pty_bridge" ? "pty_bridge" : "ttyd";
 }

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts
@@ -35,6 +35,11 @@ vi.mock("@issuectl/core", () => ({
 import { POST } from "./route";
 
 const params = Promise.resolve({ owner: "owner", repo: "repo", number: "7" });
+const approvedParams = Promise.resolve({
+  owner: "mean-weasel",
+  repo: "issuectl-test-repo",
+  number: "7",
+});
 const baseBody = {
   branchName: "issue-7",
   workspaceMode: "worktree",
@@ -42,8 +47,8 @@ const baseBody = {
   selectedFilePaths: ["src/main.ts"],
 };
 
-function makeRequest(body: unknown): NextRequest {
-  return new NextRequest("http://localhost/api/v1/launch/owner/repo/7", {
+function makeRequest(body: unknown, path = "/api/v1/launch/owner/repo/7"): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -140,6 +145,58 @@ describe("POST /api/v1/launch/[owner]/[repo]/[number]", () => {
       terminalBackend: "pty_bridge",
       ttydPort: null,
     });
+  });
+
+  it("passes a terminal backend override for approved test repositories", async () => {
+    getRepo.mockReturnValue({ id: 1, owner: "mean-weasel", name: "issuectl-test-repo" });
+
+    const response = await POST(
+      makeRequest(
+        { ...baseBody, terminalBackend: "pty_bridge" },
+        "/api/v1/launch/mean-weasel/issuectl-test-repo/7",
+      ),
+      { params: approvedParams },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(executeLaunch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        terminalBackend: "pty_bridge",
+        correlationId: json.correlationId,
+      }),
+    );
+  });
+
+  it("rejects a terminal backend override for non-test repositories", async () => {
+    const response = await POST(
+      makeRequest({ ...baseBody, terminalBackend: "pty_bridge" }),
+      { params },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({
+      error: "Terminal backend override is only available for approved issuectl test repositories",
+    });
+    expect(executeLaunch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid terminal backend override", async () => {
+    const response = await POST(
+      makeRequest(
+        { ...baseBody, terminalBackend: "screen" },
+        "/api/v1/launch/mean-weasel/issuectl-test-repo/7",
+      ),
+      { params: approvedParams },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Invalid terminal backend" });
+    expect(executeLaunch).not.toHaveBeenCalled();
   });
 
   it("rejects an invalid launch agent", async () => {

--- a/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
+++ b/packages/web/app/api/v1/launch/[owner]/[repo]/[number]/route.ts
@@ -12,6 +12,7 @@ import {
   DuplicateInFlightError,
   formatErrorForUser,
   type LaunchAgent,
+  type TerminalBackend,
   type WorkspaceMode,
 } from "@issuectl/core";
 import { VALID_BRANCH_RE, MAX_PREAMBLE } from "@/lib/constants";
@@ -26,6 +27,7 @@ type LaunchRequestBody = {
   selectedFilePaths: string[];
   preamble?: string;
   forceResume?: boolean;
+  terminalBackend?: TerminalBackend;
   idempotencyKey?: string;
 };
 
@@ -35,6 +37,11 @@ const VALID_WORKSPACE_MODES: WorkspaceMode[] = [
   "clone",
 ];
 const VALID_LAUNCH_AGENTS: LaunchAgent[] = ["claude", "codex"];
+const VALID_TERMINAL_BACKENDS: TerminalBackend[] = ["ttyd", "pty_bridge"];
+const TERMINAL_BACKEND_OVERRIDE_REPOS = new Set([
+  "mean-weasel/issuectl-test-repo",
+  "mean-weasel/issuectl-test-repo-2",
+]);
 
 export async function POST(
   request: NextRequest,
@@ -69,6 +76,15 @@ export async function POST(
   }
   if (body.agent && !VALID_LAUNCH_AGENTS.includes(body.agent)) {
     return NextResponse.json({ error: "Invalid launch agent" }, { status: 400 });
+  }
+  if (body.terminalBackend && !VALID_TERMINAL_BACKENDS.includes(body.terminalBackend)) {
+    return NextResponse.json({ error: "Invalid terminal backend" }, { status: 400 });
+  }
+  if (body.terminalBackend && !TERMINAL_BACKEND_OVERRIDE_REPOS.has(`${owner}/${repo}`)) {
+    return NextResponse.json(
+      { error: "Terminal backend override is only available for approved issuectl test repositories" },
+      { status: 400 },
+    );
   }
   if (!Array.isArray(body.selectedCommentIndices) ||
       body.selectedCommentIndices.some((i) => !Number.isInteger(i) || i < 0)) {
@@ -113,6 +129,7 @@ export async function POST(
         selectedFiles: body.selectedFilePaths,
         preamble: body.preamble || undefined,
         forceResume: body.forceResume,
+        terminalBackend: body.terminalBackend,
         correlationId,
       } as Parameters<typeof executeLaunch>[2] & { correlationId: string };
       const r = await withAuthRetry((octokit) =>

--- a/packages/web/components/workbench/IssueFocus.tsx
+++ b/packages/web/components/workbench/IssueFocus.tsx
@@ -82,6 +82,7 @@ export function IssueFocus({
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [preamble, setPreamble] = useState("Investigate workbench implementation");
   const [forceResume, setForceResume] = useState(false);
+  const [terminalBackendOverride, setTerminalBackendOverride] = useState<TerminalBackend | "default">("default");
   const [worktreeStatus, setWorktreeStatus] = useState<WorktreeStatusResult | null>(null);
   const [launchMessage, setLaunchMessage] = useState<string | null>(null);
   const [reassignTargetKey, setReassignTargetKey] = useState("");
@@ -118,6 +119,7 @@ export function IssueFocus({
     setSelectedFiles([]);
     setPreamble("Investigate workbench implementation");
     setForceResume(false);
+    setTerminalBackendOverride("default");
     setWorktreeStatus(null);
     setLaunchMessage(null);
     setActionMessage(null);
@@ -156,7 +158,9 @@ export function IssueFocus({
   }, [ref, workspaceMode]);
 
   const loadedIssue = detail?.issue;
-  const selectedBackend = repo.terminalBackendDefault ?? "ttyd";
+  const selectedBackend = terminalBackendOverride === "default"
+    ? repo.terminalBackendDefault ?? "ttyd"
+    : terminalBackendOverride;
   const title = loadedIssue?.title ?? issue.title;
   const titleChanged = titleDraft.trim().length > 0 && titleDraft.trim() !== title;
   const priority = issue.priority;
@@ -520,6 +524,16 @@ export function IssueFocus({
                 <span>Terminal backend</span>
                 <strong>{terminalBackendLabel(selectedBackend)}</strong>
                 {selectedBackend === "pty_bridge" && <em>experimental</em>}
+                <select
+                  aria-label="Terminal backend for this launch"
+                  value={terminalBackendOverride}
+                  disabled={pendingAction !== null}
+                  onChange={(event) => setTerminalBackendOverride(event.target.value as TerminalBackend | "default")}
+                >
+                  <option value="default">Default</option>
+                  <option value="ttyd">TTYD for this launch</option>
+                  <option value="pty_bridge">PTY bridge for this launch</option>
+                </select>
               </div>
             </div>
             <div>
@@ -568,6 +582,7 @@ export function IssueFocus({
                     selectedFilePaths: selectedFiles,
                     preamble,
                     forceResume,
+                    terminalBackend: terminalBackendOverride === "default" ? undefined : terminalBackendOverride,
                     idempotencyKey: newIdempotencyKey(),
                   });
                   const terminalBackend = result.terminalBackend ?? "ttyd";

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1262,6 +1262,16 @@
   font-size: 12px;
 }
 
+.backendPreview select {
+  min-height: 32px;
+  max-width: 100%;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.32);
+  color: var(--paper-ink);
+  font: 12px var(--paper-mono);
+}
+
 .issueFocusGrid button {
   justify-self: start;
   min-height: 36px;

--- a/packages/web/components/workbench/workbench-api.ts
+++ b/packages/web/components/workbench/workbench-api.ts
@@ -268,6 +268,7 @@ export type LaunchIssueRequest = {
   selectedFilePaths: string[];
   preamble?: string;
   forceResume: boolean;
+  terminalBackend?: TerminalBackend;
   idempotencyKey: string;
 };
 

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -3501,6 +3501,7 @@ test("checks worktree status and launches an issue with selected context", async
   await expect(page.getByLabel("Launch options").getByText("Codex", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Claude Code", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Terminal backend for new launch")).toContainText("TTYD");
+  await expect(page.getByLabel("Terminal backend for this launch")).toHaveValue("default");
   await expect(page.getByLabel("Launch options").getByText("Existing repo")).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Git worktree")).toBeVisible();
   await expect(page.getByLabel("Launch options").getByText("Fresh clone")).toBeVisible();
@@ -3545,7 +3546,6 @@ test("checks worktree status and launches an issue with selected context", async
 });
 
 test("launches an issue with the PTY bridge backend and keeps the terminal session navigable", async ({ page }) => {
-  setWorkbenchSetting(dbPath, "terminal_backend", "pty_bridge");
   await installClipboardCapture(page);
   await installFakePtyWebSocket(page);
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -3576,6 +3576,7 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
       selectedFilePaths: ["packages/web/app/workbench/page.tsx"],
       preamble: "Investigate workbench implementation",
       forceResume: false,
+      terminalBackend: "pty_bridge",
     });
     expect(typeof idempotencyKey).toBe("string");
     await route.fulfill({
@@ -3612,6 +3613,8 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
   await gotoWorkbenchWithRetry(page);
   await page.getByRole("complementary", { name: "Repo issues" }).getByLabel("Issue #512").click();
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+  await expect(page.getByLabel("Terminal backend for new launch")).toContainText("TTYD");
+  await page.getByLabel("Terminal backend for this launch").selectOption("pty_bridge");
   await expect(page.getByLabel("Terminal backend for new launch")).toContainText("PTY bridge");
   await expect(page.getByLabel("Terminal backend for new launch")).toContainText("experimental");
   await page.getByRole("button", { name: "Launch issue" }).click();


### PR DESCRIPTION
## Summary
- add an optional per-launch `terminalBackend` override to core launch options
- validate launch API backend overrides and restrict them to the two issuectl test repos
- expose a Workbench launch selector that sends an override only for the current launch
- cover core selection, API validation, and Workbench E2E behavior

## Why
The PTY bridge default-readiness dogfood matrix needed a non-persistent way to run one PTY launch without changing global env or saved defaults. This keeps TTYD as the default and leaves existing deployments governed by their recorded backend.

## Validation
- `pnpm turbo typecheck`
- `pnpm --dir packages/core test -- src/launch/launch-terminal-backend.test.ts`
- `pnpm --dir packages/web test -- 'app/api/v1/launch/[owner]/[repo]/[number]/route.test.ts'`\n- `pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts --project=desktop-chromium -g "checks worktree status and launches an issue with selected context|launches an issue with the PTY bridge backend"`\n- `pnpm --dir packages/web lint`\n- `git diff --check`\n\n## Dogfood\nOn an unflagged local server, deployment `118` launched with explicit `pty_bridge`, deployment `119` launched later without an override and recorded `ttyd`, and both were ended successfully. `settings.terminal_backend` remained unset.