### PR TITLE
Fix TTYD reconnect respawn race

### DIFF
--- a/packages/web/lib/actions/launch-ensure-ttyd.test.ts
+++ b/packages/web/lib/actions/launch-ensure-ttyd.test.ts
@@ -151,6 +151,33 @@ describe("ensureTtyd", () => {
     );
   });
 
+  it("deduplicates concurrent respawn attempts for the same deployment", async () => {
+    getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
+    isTtydAlive.mockReturnValue(false);
+    isTmuxSessionAlive.mockReturnValue(true);
+    let resolveRespawn: (value: { pid: number }) => void = () => {};
+    respawnTtyd.mockReturnValue(new Promise((resolve) => {
+      resolveRespawn = resolve;
+    }));
+
+    const first = ensureTtyd(1);
+    const second = ensureTtyd(1);
+    await vi.waitFor(() => expect(respawnTtyd).toHaveBeenCalledTimes(1));
+    resolveRespawn({ pid: 99 });
+
+    await expect(first).resolves.toEqual({
+      port: 7700,
+      terminalToken: expect.any(String),
+      respawned: true,
+    });
+    await expect(second).resolves.toEqual({
+      port: 7700,
+      terminalToken: expect.any(String),
+      respawned: true,
+    });
+    expect(updateTtydInfo).toHaveBeenCalledTimes(1);
+  });
+
   it("returns alive false when both ttyd and tmux are dead", async () => {
     getDeploymentById.mockReturnValue({ ...makeDeployment(42), ttydPort: 7700 });
     isTtydAlive.mockReturnValue(false);

--- a/packages/web/lib/ensure-ttyd.ts
+++ b/packages/web/lib/ensure-ttyd.ts
@@ -18,12 +18,32 @@ export type EnsureTtydResult =
   | { port: number; terminalToken: string; respawned?: true; alive?: never; error?: never }
   | { alive: false; error?: string; port?: never };
 
+const ensureTtydInFlight = new Map<number, Promise<EnsureTtydResult>>();
+
 export async function ensureTtydForDeployment(
   deploymentId: number,
 ): Promise<EnsureTtydResult> {
   if (!Number.isInteger(deploymentId) || deploymentId <= 0) {
     return { alive: false, error: "Invalid deployment ID" };
   }
+
+  const pending = ensureTtydInFlight.get(deploymentId);
+  if (pending) {
+    return pending;
+  }
+
+  const promise = runEnsureTtydForDeployment(deploymentId);
+  ensureTtydInFlight.set(deploymentId, promise);
+  try {
+    return await promise;
+  } finally {
+    ensureTtydInFlight.delete(deploymentId);
+  }
+}
+
+async function runEnsureTtydForDeployment(
+  deploymentId: number,
+): Promise<EnsureTtydResult> {
   let db: ReturnType<typeof getDb> | undefined;
   try {
     db = getDb();

--- a/packages/web/lib/terminal-proxy.test.ts
+++ b/packages/web/lib/terminal-proxy.test.ts
@@ -91,6 +91,22 @@ describe("rewriteHtml", () => {
     expect(result).toContain("window.WebSocket=AuthWebSocket");
     expect(result).toContain("window.fetch=function");
     expect(result).toContain("XMLHttpRequest.prototype.open=function");
+    expect(result).toContain("u.host===window.location.host");
     expect(result).toContain("abc123");
+  });
+
+  it("strips terminalToken from the visible iframe URL before ttyd scripts run", () => {
+    const result = rewriteHtml(
+      '<html><head><script src="/auth_token.js"></script></head><body></body></html>',
+      7701,
+      "abc123",
+    );
+
+    expect(result).toContain("window.history.replaceState");
+    expect(result).toContain("hadTerminalToken=current.searchParams.has('terminalToken')");
+    expect(result).toContain("current.searchParams.delete('terminalToken')");
+    expect(result.indexOf("window.history.replaceState")).toBeLessThan(
+      result.indexOf('<script src="/api/terminal/7701/auth_token.js?terminalToken=abc123"></script>'),
+    );
   });
 });

--- a/packages/web/lib/terminal-proxy.ts
+++ b/packages/web/lib/terminal-proxy.ts
@@ -44,9 +44,15 @@ export function rewriteHtml(html: string, port: number, terminalToken?: string):
         "(()=>{",
         `const token=${JSON.stringify(token)};`,
         `const port=${JSON.stringify(port)};`,
+        "try{",
+        "const current=new URL(window.location.href);",
+        "const hadTerminalToken=current.searchParams.has('terminalToken');",
+        "current.searchParams.delete('terminalToken');",
+        "if(hadTerminalToken)window.history.replaceState(window.history.state,'',current.toString());",
+        "}catch{}",
         "function authUrl(url){",
         "const u=new URL(url,window.location.href);",
-        "if(u.origin===window.location.origin&&u.pathname.startsWith('/api/terminal/'+port+'/')&&!u.searchParams.has('terminalToken'))u.searchParams.set('terminalToken',token);",
+        "if(u.host===window.location.host&&u.pathname.startsWith('/api/terminal/'+port+'/')&&!u.searchParams.has('terminalToken'))u.searchParams.set('terminalToken',token);",
         "return u;",
         "}",
         "const NativeWebSocket=window.WebSocket;",
@@ -87,7 +93,9 @@ export function rewriteHtml(html: string, port: number, terminalToken?: string):
       )
     : rewritten;
   if (!browserApiPatch) return withToken;
-  return withToken.includes("</head>")
-    ? withToken.replace("</head>", `${browserApiPatch}</head>`)
+  return withToken.includes("<head>")
+    ? withToken.replace("<head>", `<head>${browserApiPatch}`)
+    : withToken.includes("</head>")
+      ? withToken.replace("</head>", `${browserApiPatch}</head>`)
     : `${browserApiPatch}${withToken}`;
 }


### PR DESCRIPTION
## Summary
- Deduplicate concurrent TTYD ensure/reconnect calls per deployment so only one respawn can claim a terminal port.
- Keep the terminal auth token available to proxied asset/WebSocket requests while stripping it from the visible ttyd iframe URL before ttyd scripts parse options.
- Add regression coverage for the respawn race and proxy token bootstrap behavior.

## Root Cause
Concurrent reconnect requests could both observe the old ttyd PID as dead, both confirm tmux was alive, and both call `respawnTtyd` for the same deployment port. One respawn would win; the other could die immediately because the port was already reclaimed, producing `ensure_ttyd.failed`.

## Verification
- `pnpm --dir packages/web test` — 32 files, 298 tests passed
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- Commit hooks also ran monorepo typecheck/lint successfully
- Live approved-repo check: created `mean-weasel/issuectl-test-repo#172`, launched TTYD deployment `121`, killed ttyd, hit ensure concurrently, confirmed successful respawn and no `ensure_ttyd.failed` for the race
- Playwright CLI check against deployment `121`: terminal iframe visible, no Terminal unavailable state, no token-related ttyd warning, no console errors

## Cleanup
- Deployment `121` ended
- Temporary issue `mean-weasel/issuectl-test-repo#172` closed
- Scratch server on `:3849` stopped