### PR TITLE
fix: allow recorded PTY deployments to attach without launch flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         run: pnpm turbo build --filter=@issuectl/core
       - name: Verify gh CLI auth
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         # GH_TOKEN env var satisfies both `gh auth status` here and the
         # canRun() probe inside both specs (which call `gh auth token`).
         # Specs hard-fail in CI if canRun() returns false, so a
@@ -163,7 +163,7 @@ jobs:
         run: pnpm --filter @issuectl/web exec playwright install --with-deps chromium webkit
       - name: Run mobile UX regression spec
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         # Specs run in separate invocations because two `next dev`
         # processes against the same packages/web/.next/cache/webpack/
         # collide on pack file rename, even sequentially. Each
@@ -171,55 +171,55 @@ jobs:
         run: pnpm --filter @issuectl/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-chromium
       - name: Run launch UI spec
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test launch-ui.spec.ts --project=mobile-chromium
       - name: Run viewport health spec
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test viewport-health.spec.ts --project=mobile-chromium
       - name: Run compact workbench WebKit dynamic journey
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact issue and terminal context across keyboard navigation history and reload"
       - name: Run compact workbench WebKit issue mutation and terminal navigation
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutations and session navigation coherent end to end"
       - name: Run compact workbench WebKit issue mutation failure recovery
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact issue mutation failures visible and recoverable in WebKit"
       - name: Run compact workbench WebKit dense issue detail content
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact dense issue detail content readable in WebKit"
       - name: Run compact workbench WebKit invalid deep-link recovery
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "recovers compact invalid deep links to a usable overview"
       - name: Run compact workbench WebKit cross-mode quick create persistence
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "preserves compact quick create drafts across cross-mode navigation in WebKit"
       - name: Run compact workbench WebKit terminal recovery
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "recovers compact unavailable terminal sessions without showing the sessions pane"
       - name: Run compact workbench WebKit failure states
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact empty and service failure states stable in WebKit"
       - name: Run compact workbench WebKit degraded refresh states
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "keeps compact degraded refresh states usable in WebKit"
       - name: Run compact workbench WebKit stale refresh reconciliation
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "reconciles compact stale overview data after refresh in WebKit"
       - name: Run command sheet WebKit scroll lock
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: pnpm --filter @issuectl/web exec playwright test mobile-ux-patterns.spec.ts --project=mobile-webkit --grep "body is scroll-locked when command sheet is open"
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/macos-e2e-local.yml
+++ b/.github/workflows/macos-e2e-local.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Verify gh CLI auth
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: gh auth status
 
       - name: Install Playwright browsers
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run mobile Chromium E2E
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pnpm --filter @issuectl/web exec playwright test \
             mobile-ux-patterns.spec.ts \
@@ -119,7 +119,7 @@ jobs:
 
       - name: Run mobile WebKit E2E
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pnpm --filter @issuectl/web exec playwright test \
             mobile-ux-patterns.spec.ts \

--- a/packages/web/lib/ensure-terminal.test.ts
+++ b/packages/web/lib/ensure-terminal.test.ts
@@ -78,16 +78,17 @@ describe("ensureTerminalForDeployment", () => {
     });
   });
 
-  it("does not route pty_bridge deployments through ttyd when the experiment flag is disabled", async () => {
-    getDeploymentById.mockReturnValue({ id: 1, terminalBackend: "pty_bridge" });
+  it("returns PTY bridge attach metadata for recorded PTY deployments without the global flag", async () => {
+    getDeploymentById.mockReturnValue({ id: 1, repoId: 1, issueNumber: 7, terminalBackend: "pty_bridge" });
 
     await expect(ensureTerminalForDeployment(1)).resolves.toEqual({
-      alive: false,
       backend: "pty_bridge",
-      error: "PTY bridge terminal backend is not implemented yet",
+      deploymentId: 1,
+      terminalToken: "pty-token",
+      wsUrl: "/api/terminal/pty/1/ws?terminalToken=pty-token",
     });
     expect(ensureTtydForDeployment).not.toHaveBeenCalled();
-    expect(isTmuxSessionAlive).not.toHaveBeenCalled();
+    expect(isTmuxSessionAlive).toHaveBeenCalledWith("issuectl-api-7");
   });
 
   it("returns PTY bridge attach metadata when the experiment flag is enabled", async () => {

--- a/packages/web/lib/ensure-terminal.ts
+++ b/packages/web/lib/ensure-terminal.ts
@@ -52,14 +52,6 @@ function ensurePtyBridgeTerminal(
   deploymentId: number,
   deployment: NonNullable<DeploymentWithTerminalBackend>,
 ): EnsureTerminalResult {
-  if (process.env.ISSUECTL_PTY_BRIDGE !== "1") {
-    return {
-      alive: false,
-      backend: "pty_bridge",
-      error: "PTY bridge terminal backend is not implemented yet",
-    };
-  }
-
   try {
     const repo = getRepoById(db, deployment.repoId);
     if (!repo) {

--- a/packages/web/lib/pty-terminal-websocket.test.ts
+++ b/packages/web/lib/pty-terminal-websocket.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureNodePtySpawnHelperExecutable } from "./node-pty-spawn-helper.js";
-import { isPtyBridgeEnabled, parsePtyClientMessage } from "./pty-terminal-websocket.js";
+import { handlePtyUpgrade, isPtyBridgeEnabled, parsePtyClientMessage } from "./pty-terminal-websocket.js";
 
 describe("isPtyBridgeEnabled", () => {
   beforeEach(() => {
@@ -33,6 +35,29 @@ describe("parsePtyClientMessage", () => {
   it("rejects malformed or oversized input", () => {
     expect(parsePtyClientMessage(Buffer.from("{"))).toBeNull();
     expect(parsePtyClientMessage(Buffer.from(JSON.stringify({ type: "input", data: "x".repeat(70_000) })))).toBeNull();
+  });
+});
+
+describe("handlePtyUpgrade", () => {
+  beforeEach(() => {
+    delete process.env.ISSUECTL_PTY_BRIDGE;
+  });
+
+  it("does not reject recorded PTY websocket upgrades only because the global launch flag is disabled", async () => {
+    const writes: string[] = [];
+    const socket = {
+      destroyed: false,
+      write: vi.fn((chunk: string) => {
+        writes.push(chunk);
+      }),
+      destroy: vi.fn(),
+    } as unknown as Duplex;
+    const req = { url: "/api/terminal/pty/1/ws" } as IncomingMessage;
+
+    await handlePtyUpgrade(req, socket, Buffer.alloc(0), 1);
+
+    expect(writes.join("")).toContain("401 Unauthorized");
+    expect(writes.join("")).not.toContain("404 Not Found");
   });
 });
 

--- a/packages/web/lib/pty-terminal-websocket.ts
+++ b/packages/web/lib/pty-terminal-websocket.ts
@@ -72,12 +72,6 @@ export async function handlePtyUpgrade(
   head: Buffer,
   deploymentId: number,
 ): Promise<void> {
-  if (!isPtyBridgeEnabled()) {
-    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
-    socket.destroy();
-    return;
-  }
-
   const url = new URL(req.url ?? "/", "http://localhost");
   if (!validatePtyTerminalToken(url.searchParams.get("terminalToken"), deploymentId)) {
     recordPtyEvent(deploymentId, "warn", "pty.auth_failed", { status: "unauthorized" });


### PR DESCRIPTION
## Summary

Fixes the PTY bridge attach path for deployments that were explicitly recorded as `pty_bridge` while the global `ISSUECTL_PTY_BRIDGE` launch-default flag is off.

Root cause: launch selection and terminal attach used different gates. A per-launch override could record a deployment as `pty_bridge`, but `ensureTerminalForDeployment` and the PTY websocket upgrade handler still rejected the attach path unless the global experiment flag was enabled.

## Changes

- Allow recorded PTY bridge deployments to return PTY attach metadata without requiring `ISSUECTL_PTY_BRIDGE=1`.
- Allow PTY websocket upgrades to proceed to normal deployment/token validation for recorded PTY deployments without requiring the global flag.
- Add regression coverage for both the ensure-terminal path and websocket upgrade path.

## Validation

- `pnpm --dir packages/web test -- lib/ensure-terminal.test.ts lib/pty-terminal-websocket.test.ts`
- `pnpm --dir packages/web test`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- Commit hook typecheck/lint across `@issuectl/cli`, `@issuectl/core`, and `@issuectl/web`

Live readiness on clean unflagged server `http://localhost:3848`, with no persisted `terminal_backend` default:

- Focused PTY attach and reattach probe: `mean-weasel/issuectl-test-repo#177`, deployment `127`, screenshot evidence in `/tmp/issuectl-pty-probe-fixed.png` and `/tmp/issuectl-pty-probe-reattach.png`.
- Four-cell matrix, all temporary issues closed and deployments ended:
  - TTYD: `mean-weasel/issuectl-test-repo#178`, deployment `128`
  - PTY bridge: `mean-weasel/issuectl-test-repo#179`, deployment `129`
  - PTY bridge: `mean-weasel/issuectl-test-repo-2#19`, deployment `130`
  - TTYD: `mean-weasel/issuectl-test-repo-2#20`, deployment `131`

Matrix covered desktop render, reload, navigate away/back, browser reopen, and mobile viewport. Diagnostics showed activation, websocket connection, first output, and no stop-condition events for the checked deployments.
