### PR TITLE
Complete issue 507 UX

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,9 @@
 import { confirm, input } from "@inquirer/prompts";
-import { dbExists, getDb, closeDb, seedDefaults, addRepo, generateApiToken } from "@issuectl/core";
+import { dbExists, getDb, closeDb, seedDefaults, generateApiToken } from "@issuectl/core";
 import * as log from "../utils/logger.js";
 import { requireAuth } from "../utils/auth.js";
 import { validateOwnerRepo, parseOwnerRepo } from "../utils/validation.js";
+import { repoAddCommand } from "./repo.js";
 
 export async function initCommand(): Promise<void> {
   log.banner();
@@ -60,22 +61,16 @@ export async function initCommand(): Promise<void> {
       validate: validateOwnerRepo,
     });
 
-    const { owner, name } = parseOwnerRepo(ownerRepo);
+    const { name } = parseOwnerRepo(ownerRepo);
 
     const localPath = await input({
       message: "Local path (optional, press Enter to skip):",
       default: `~/Desktop/${name}`,
     });
 
-    const repo = addRepo(db, {
-      owner,
-      name,
-      localPath: localPath || undefined,
-    });
-
-    log.success(`Added ${repo.owner}/${repo.name}`);
-    if (repo.localPath) {
-      log.info(`Local path: ${repo.localPath}`);
+    await repoAddCommand(ownerRepo, { path: localPath || undefined });
+    if (localPath) {
+      log.info(`Local path: ${localPath}`);
     }
   }
 

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { confirm, input } from "@inquirer/prompts";
 import {
   addRepo,
   endDeployment,
@@ -12,12 +14,18 @@ import {
   updateRepoWebhookSettings,
   type Repo,
 } from "@issuectl/core";
+import { execFileSync } from "node:child_process";
 import { requireDb } from "../utils/db.js";
 import { repoAddCommand, repoSetCommand, repoShowCommand, repoUpdateCommand } from "./repo.js";
 
 vi.mock("@inquirer/prompts", () => ({
   confirm: vi.fn(),
   input: vi.fn(async () => ""),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock("@issuectl/core", async (importOriginal) => {
@@ -64,6 +72,11 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
 
 beforeEach(() => {
   vi.mocked(requireDb).mockReturnValue(mockDb as never);
+  vi.mocked(confirm).mockReset();
+  vi.mocked(input).mockReset();
+  vi.mocked(input).mockResolvedValue("");
+  vi.mocked(execFileSync).mockReset();
+  vi.mocked(execFileSync).mockReturnValue("Token scopes: repo, admin:repo_hook");
   vi.mocked(addRepo).mockReset();
   vi.mocked(getRepo).mockReset();
   vi.mocked(getActiveWebhookDeploymentsForRepoTarget).mockReset();
@@ -107,6 +120,47 @@ describe("repo commands", () => {
       autoReviewPrs: true,
       issueAgent: "codex",
       reviewAgent: "claude",
+      webhookPayloadMode: "raw",
+    });
+  });
+
+  it("prompts for repo automation during add and runs local preflight", async () => {
+    vi.mocked(getRepo).mockReturnValue(undefined);
+    vi.mocked(addRepo).mockReturnValue(makeRepo());
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    vi.mocked(input)
+      .mockResolvedValueOnce("~/Desktop/issuectl")
+      .mockResolvedValueOnce("claude")
+      .mockResolvedValueOnce("raw")
+      .mockResolvedValueOnce("https://hooks.example.test/");
+
+    await repoAddCommand("mean-weasel/issuectl", {});
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Auto-launch issue sessions from webhooks?",
+      default: true,
+    });
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Reserve PRs for automatic review from webhooks?",
+      default: true,
+    });
+    expect(execFileSync).toHaveBeenCalledWith("gh", ["auth", "status", "--show-token-scopes"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(execFileSync).toHaveBeenCalledWith("cloudflared", ["--version"], { stdio: "ignore" });
+    expect(addRepo).toHaveBeenCalledWith(mockDb, {
+      owner: "mean-weasel",
+      name: "issuectl",
+      localPath: "~/Desktop/issuectl",
+    });
+    expect(setSetting).toHaveBeenCalledWith(mockDb, "public_webhook_base_url", "https://hooks.example.test");
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(mockDb, 1, {
+      autoLaunchIssues: true,
+      autoReviewPrs: false,
+      issueAgent: "claude",
       webhookPayloadMode: "raw",
     });
   });

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -1,4 +1,6 @@
+/* eslint-disable max-lines */
 import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { confirm, input } from "@inquirer/prompts";
 import {
   addRepo,
@@ -52,13 +54,15 @@ export async function repoAddCommand(
     log.warn(`Path "${localPath}" does not exist. Saving anyway.`);
   }
 
+  const webhookOptions = await collectRepoAddWebhookOptions(options);
   const repo = addRepo(db, {
     owner,
     name,
     localPath: localPath || undefined,
   });
-  applyWebhookOptions(db, repo, options);
+  applyWebhookOptions(db, repo, webhookOptions);
   log.success(`Added ${repo.owner}/${repo.name}`);
+  printRepoAddNextSteps(repo.owner, repo.name, webhookOptions);
 }
 
 export async function repoRemoveCommand(ownerRepo: string): Promise<void> {
@@ -181,6 +185,152 @@ type RepoSetCommandOptions = {
   webhookPayloadMode?: string;
   webhookBaseUrl?: string;
 };
+
+async function collectRepoAddWebhookOptions(
+  options: RepoCommandOptions,
+): Promise<RepoCommandOptions> {
+  const autoLaunchIssues = options.autoLaunchIssues === undefined
+    ? await confirm({
+        message: "Auto-launch issue sessions from webhooks?",
+        default: true,
+      })
+    : normalizeOptionalBoolean(options.autoLaunchIssues, "--auto-launch-issues");
+  const autoReviewPrs = options.autoReviewPrs === undefined
+    ? await confirm({
+        message: "Reserve PRs for automatic review from webhooks?",
+        default: true,
+      })
+    : normalizeOptionalBoolean(options.autoReviewPrs, "--auto-review-prs");
+  const automationEnabled = autoLaunchIssues || autoReviewPrs;
+
+  let issueAgent = normalizeOptionalAgent(options.issueAgent, "--issue-agent");
+  if (autoLaunchIssues && issueAgent === undefined) {
+    issueAgent = await promptLaunchAgent("Issue session agent", "codex");
+  }
+
+  let reviewAgent = normalizeOptionalAgent(options.reviewAgent, "--review-agent");
+  if (autoReviewPrs && reviewAgent === undefined) {
+    reviewAgent = await promptLaunchAgent("PR review agent", "codex");
+  }
+
+  let webhookPayloadMode = normalizeOptionalPayloadMode(options.webhookPayloadMode);
+  if (automationEnabled && webhookPayloadMode === undefined) {
+    webhookPayloadMode = await promptWebhookPayloadMode();
+  }
+
+  let webhookBaseUrl = options.webhookBaseUrl;
+  if (automationEnabled && webhookBaseUrl === undefined) {
+    const value = await input({
+      message: "Public webhook base URL (optional, e.g. https://hooks.example.com):",
+      default: "",
+      validate: (candidate) => {
+        if (!candidate.trim()) return true;
+        try {
+          normalizeWebhookBaseUrl(candidate);
+          return true;
+        } catch (err) {
+          return err instanceof Error ? err.message : "Invalid URL";
+        }
+      },
+    });
+    webhookBaseUrl = value.trim() || undefined;
+  }
+
+  if (automationEnabled) {
+    runRepoAddPreflight(webhookBaseUrl);
+  }
+
+  return {
+    ...options,
+    autoLaunchIssues,
+    autoReviewPrs,
+    issueAgent,
+    reviewAgent,
+    webhookPayloadMode,
+    webhookBaseUrl,
+  };
+}
+
+async function promptLaunchAgent(
+  message: string,
+  defaultValue: LaunchAgent,
+): Promise<LaunchAgent> {
+  const value = await input({
+    message,
+    default: defaultValue,
+    validate: (candidate) =>
+      candidate === "claude" || candidate === "codex"
+        ? true
+        : "Use claude or codex.",
+  });
+  return normalizeOptionalAgent(value || defaultValue, "--agent") ?? defaultValue;
+}
+
+async function promptWebhookPayloadMode(): Promise<WebhookPayloadMode> {
+  const value = await input({
+    message: "Webhook payload storage mode",
+    default: "metadata",
+    validate: (candidate) =>
+      candidate === "metadata" || candidate === "raw"
+        ? true
+        : "Use metadata or raw.",
+  });
+  return normalizeOptionalPayloadMode(value || "metadata") ?? "metadata";
+}
+
+function runRepoAddPreflight(webhookBaseUrl?: string): void {
+  const ghScopes = getGhAuthScopes();
+  if (ghScopes === "missing") {
+    log.warn("GitHub CLI auth check unavailable. Run `gh auth status --show-token-scopes` and confirm repo hook access before installing the webhook.");
+  } else if (!hasRepoHookScope(ghScopes)) {
+    log.warn("GitHub CLI token may be missing repo hook scope. Re-auth with `gh auth refresh -s admin:repo_hook` before webhook install.");
+  }
+
+  if (!commandWorks("cloudflared", ["--version"])) {
+    log.warn("cloudflared was not found. Install it or provide a public --webhook-base-url before installing GitHub webhooks.");
+  }
+
+  if (!webhookBaseUrl) {
+    log.info("After you have a public webhook URL, run `issuectl webhook create owner/repo` or finish setup from repo settings.");
+  }
+}
+
+function getGhAuthScopes(): string | "missing" {
+  try {
+    return String(execFileSync("gh", ["auth", "status", "--show-token-scopes"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }));
+  } catch {
+    return "missing";
+  }
+}
+
+function hasRepoHookScope(output: string): boolean {
+  return /\badmin:repo_hook\b/.test(output) || /\brepo\b/.test(output);
+}
+
+function commandWorks(command: string, args: string[]): boolean {
+  try {
+    execFileSync(command, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function printRepoAddNextSteps(
+  owner: string,
+  name: string,
+  options: RepoCommandOptions,
+): void {
+  const issueAutomation = normalizeOptionalBoolean(options.autoLaunchIssues, "--auto-launch-issues");
+  const reviewAutomation = normalizeOptionalBoolean(options.autoReviewPrs, "--auto-review-prs");
+  if (!issueAutomation && !reviewAutomation) return;
+
+  log.info(`Webhook settings saved for ${owner}/${name}.`);
+  log.info(`Open repo settings or run \`issuectl webhook create ${owner}/${name}\` to finish GitHub installation.`);
+}
 
 function applyWebhookOptions(
   db: ReturnType<typeof requireDb>,

--- a/packages/core/src/db/pr-reviews.test.ts
+++ b/packages/core/src/db/pr-reviews.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { beforeEach, describe, expect, it } from "vitest";
 import type Database from "better-sqlite3";
 import { createRawTestDb, createTestDb } from "./test-helpers.js";

--- a/packages/core/src/db/pr-reviews.test.ts
+++ b/packages/core/src/db/pr-reviews.test.ts
@@ -10,6 +10,7 @@ import {
   getActivePrReview,
   getLatestCompletedPrReview,
   getPrReviewById,
+  listPrReviewsForPull,
   listPrReviewsForRepo,
   markActivePrReviewForDeploymentTerminal,
   reservePrReview,
@@ -135,6 +136,46 @@ describe("pr_reviews", () => {
     });
 
     expect(listPrReviewsForRepo(db, repoId, 1)).toEqual([latest]);
+  });
+
+  it("lists PR review lineage for one pull request", () => {
+    const first = reservePrReview(db, {
+      repoId,
+      prNumber: 506,
+      startedHeadSha: "head-b",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-b",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/webhooks",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    const latest = reservePrReview(db, {
+      repoId,
+      prNumber: 506,
+      startedHeadSha: "head-c",
+      reviewBaseSha: "base-a",
+      reviewedFromSha: "head-b",
+      reviewedToSha: "head-c",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/webhooks",
+      triggeredBy: "comment_command",
+      startedAt: 2_000,
+    });
+    reservePrReview(db, {
+      repoId,
+      prNumber: 507,
+      startedHeadSha: "other-head",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "other-head",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/other",
+      triggeredBy: "webhook",
+      startedAt: 3_000,
+    });
+
+    expect(listPrReviewsForPull(db, repoId, 506)).toEqual([latest, first]);
+    expect(listPrReviewsForPull(db, repoId, 506, 1)).toEqual([latest]);
   });
 
   it("stores at most one coalesced desired head for a running review", () => {

--- a/packages/core/src/db/pr-reviews.ts
+++ b/packages/core/src/db/pr-reviews.ts
@@ -90,6 +90,22 @@ export function listPrReviewsForRepo(
   return rows.map(rowToPrReview);
 }
 
+export function listPrReviewsForPull(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+  limit = 24,
+): PrReview[] {
+  const boundedLimit = Math.max(1, Math.floor(limit));
+  const rows = db.prepare(
+    `SELECT * FROM pr_reviews
+     WHERE repo_id = ? AND pr_number = ?
+     ORDER BY started_at DESC, id DESC
+     LIMIT ?`,
+  ).all(repoId, prNumber, boundedLimit) as PrReviewRow[];
+  return rows.map(rowToPrReview);
+}
+
 export function completePrReview(
   db: Database.Database,
   reviewId: number,

--- a/packages/core/src/db/webhook-records.ts
+++ b/packages/core/src/db/webhook-records.ts
@@ -71,6 +71,22 @@ export type WebhookIntent = {
   failureReason: string | null;
 };
 
+export type WebhookLogResult =
+  | "fired"
+  | "debouncing"
+  | "processing"
+  | "gated"
+  | "dropped"
+  | "failed"
+  | "received";
+
+export type WebhookLogEntry = WebhookEvent & {
+  intent: WebhookIntent | null;
+  result: WebhookLogResult;
+  resultDetail: string | null;
+  actionId: string | null;
+};
+
 export type WebhookEventRow = {
   id: number;
   delivery_id: string;
@@ -113,6 +129,27 @@ export type WebhookIntentRow = {
   failure_reason: string | null;
 };
 
+export type WebhookLogEntryRow = WebhookEventRow & {
+  intent_id_joined: number | null;
+  intent_repo_id: number | null;
+  intent_target_type: WebhookTargetType | null;
+  intent_target_number: number | null;
+  first_signal_at: number | null;
+  last_signal_at: number | null;
+  scheduled_at: number | null;
+  processing_started_at: number | null;
+  lease_expires_at: number | null;
+  generation: number | null;
+  desired_head_sha: string | null;
+  requested_agent: "claude" | "codex" | null;
+  review_mode: "auto" | "full" | null;
+  signal_count: number | null;
+  intent_status: WebhookIntentStatus | null;
+  resolved_at: number | null;
+  deployment_id: number | null;
+  failure_reason: string | null;
+};
+
 export function rowToWebhookEvent(row: WebhookEventRow): WebhookEvent {
   return {
     id: row.id,
@@ -150,4 +187,60 @@ export function rowToWebhookIntent(row: WebhookIntentRow): WebhookIntent {
     deploymentId: row.deployment_id,
     failureReason: row.failure_reason,
   };
+}
+
+export function rowToWebhookLogEntry(row: WebhookLogEntryRow): WebhookLogEntry {
+  const event = rowToWebhookEvent(row);
+  const intent = row.intent_id_joined === null
+    ? null
+    : rowToWebhookIntent({
+      id: row.intent_id_joined,
+      repo_id: row.intent_repo_id ?? row.repo_id,
+      target_type: row.intent_target_type ?? (row.target_type ?? "issue"),
+      target_number: row.intent_target_number ?? (row.target_number ?? 0),
+      first_signal_at: row.first_signal_at ?? row.received_at,
+      last_signal_at: row.last_signal_at ?? row.received_at,
+      scheduled_at: row.scheduled_at ?? row.received_at,
+      processing_started_at: row.processing_started_at,
+      lease_expires_at: row.lease_expires_at,
+      generation: row.generation ?? 1,
+      desired_head_sha: row.desired_head_sha,
+      requested_agent: row.requested_agent,
+      review_mode: row.review_mode,
+      signal_count: row.signal_count ?? 1,
+      status: row.intent_status ?? "pending",
+      resolved_at: row.resolved_at,
+      deployment_id: row.deployment_id,
+      failure_reason: row.failure_reason,
+    });
+  const result = resultForIntent(intent);
+  return {
+    ...event,
+    intent,
+    result,
+    resultDetail: resultDetailForIntent(intent, result),
+    actionId: intent?.deploymentId ? `dep_${intent.deploymentId}` : null,
+  };
+}
+
+function resultForIntent(intent: WebhookIntent | null): WebhookLogResult {
+  if (!intent) return "received";
+  if (intent.status === "launched") return "fired";
+  if (intent.status === "pending" || intent.status === "deferred") return "debouncing";
+  if (intent.status === "processing") return "processing";
+  if (intent.status === "failed") return "failed";
+  if (intent.status === "skipped_locked" || intent.status === "skipped_optout") return "gated";
+  if (intent.status === "expired") return "dropped";
+  return "received";
+}
+
+function resultDetailForIntent(
+  intent: WebhookIntent | null,
+  result: WebhookLogResult,
+): string | null {
+  if (!intent) return null;
+  if (intent.failureReason) return intent.failureReason;
+  if (intent.deploymentId) return `deployment ${intent.deploymentId}`;
+  if (result === "debouncing") return `scheduled ${intent.scheduledAt}`;
+  return intent.status;
 }

--- a/packages/core/src/db/webhooks.test.ts
+++ b/packages/core/src/db/webhooks.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import { createRawTestDb } from "./test-helpers.js";
@@ -5,9 +6,11 @@ import { initSchema } from "./schema.js";
 import { runMigrations } from "./migrations.js";
 import { seedDefaults } from "./settings.js";
 import { addRepo } from "./repos.js";
+import { recordDeployment } from "./deployments.js";
 import {
   claimDueWebhookIntent,
   getWebhookEventByDelivery,
+  listWebhookLogEntries,
   listWebhookEvents,
   mergeWebhookIntent,
   pruneExpiredWebhookPayloads,
@@ -134,6 +137,96 @@ describe("webhook DB helpers", () => {
         repoId,
         targetType: "issue",
         targetNumber: 506,
+      }),
+    ]);
+  });
+
+  it("lists webhook log entries with intent chain and result state", () => {
+    const firedEvent = recordWebhookEvent(db, {
+      deliveryId: "delivery-fired",
+      repoId,
+      eventType: "issues",
+      action: "labeled",
+      senderLogin: "octocat",
+      targetType: "issue",
+      targetNumber: 507,
+      receivedAt: 1_000,
+    });
+    const firedIntentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "issue",
+      targetNumber: 507,
+      signalAt: 1_000,
+      scheduledAt: 1_060,
+      eventId: firedEvent.eventId,
+      requestedAgent: "codex",
+    });
+    const deployment = recordDeployment(db, {
+      repoId,
+      issueNumber: 507,
+      branchName: "issue-507",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/issue-507",
+      agent: "codex",
+      triggeredBy: "webhook",
+    });
+    db.prepare(
+      `UPDATE webhook_intents
+       SET status = 'launched',
+           resolved_at = ?,
+           deployment_id = ?
+       WHERE id = ?`,
+    ).run(1_070, deployment.id, firedIntentId);
+
+    const droppedEvent = recordWebhookEvent(db, {
+      deliveryId: "delivery-dropped",
+      repoId,
+      eventType: "pull_request",
+      action: "synchronize",
+      senderLogin: "hubot",
+      targetType: "pr",
+      targetNumber: 42,
+      receivedAt: 2_000,
+    });
+    const droppedIntentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 42,
+      signalAt: 2_000,
+      scheduledAt: 2_060,
+      eventId: droppedEvent.eventId,
+      reviewMode: "auto",
+    });
+    db.prepare(
+      `UPDATE webhook_intents
+       SET status = 'skipped_optout',
+           resolved_at = ?,
+           failure_reason = ?
+       WHERE id = ?`,
+    ).run(2_010, "gated: label missing", droppedIntentId);
+
+    expect(listWebhookLogEntries(db, { repoId })).toEqual([
+      expect.objectContaining({
+        deliveryId: "delivery-dropped",
+        result: "gated",
+        resultDetail: "gated: label missing",
+        intent: expect.objectContaining({
+          id: droppedIntentId,
+          status: "skipped_optout",
+          reviewMode: "auto",
+        }),
+        actionId: null,
+      }),
+      expect.objectContaining({
+        deliveryId: "delivery-fired",
+        result: "fired",
+        resultDetail: `deployment ${deployment.id}`,
+        intent: expect.objectContaining({
+          id: firedIntentId,
+          status: "launched",
+          requestedAgent: "codex",
+        }),
+        actionId: `dep_${deployment.id}`,
       }),
     ]);
   });

--- a/packages/core/src/db/webhooks.ts
+++ b/packages/core/src/db/webhooks.ts
@@ -3,6 +3,7 @@ import type Database from "better-sqlite3";
 import {
   ACTIVE_INTENT_STATUSES,
   rowToWebhookEvent,
+  rowToWebhookLogEntry,
   rowToWebhookIntent,
   type MergeWebhookIntentInput,
   type ListWebhookEventsInput,
@@ -11,6 +12,8 @@ import {
   type WebhookEvent,
   type WebhookEventRow,
   type WebhookIntent,
+  type WebhookLogEntry,
+  type WebhookLogEntryRow,
   type WebhookIntentRow,
 } from "./webhook-records.js";
 
@@ -21,6 +24,8 @@ export type {
   RecordWebhookEventResult,
   WebhookEvent,
   WebhookIntent,
+  WebhookLogEntry,
+  WebhookLogResult,
 } from "./webhook-records.js";
 
 const MERGE_TRANSACTION_ATTEMPTS = 3;
@@ -364,4 +369,62 @@ export function listWebhookEvents(
     )
     .all(...params) as WebhookEventRow[];
   return rows.map(rowToWebhookEvent);
+}
+
+export function listWebhookLogEntries(
+  db: Database.Database,
+  input: number | ListWebhookEventsInput = 50,
+): WebhookLogEntry[] {
+  const options = typeof input === "number" ? { limit: input } : input;
+  const normalizedLimit = Number.isFinite(options.limit)
+    ? Math.floor(options.limit ?? 50)
+    : 50;
+  const boundedLimit = Math.max(1, normalizedLimit);
+  const where: string[] = [];
+  const params: unknown[] = [];
+
+  if (options.repoId !== undefined) {
+    where.push("e.repo_id = ?");
+    params.push(options.repoId);
+  }
+  if (options.targetType !== undefined) {
+    where.push("e.target_type = ?");
+    params.push(options.targetType);
+  }
+  if (options.targetNumber !== undefined) {
+    where.push("e.target_number = ?");
+    params.push(options.targetNumber);
+  }
+
+  params.push(boundedLimit);
+  const rows = db
+    .prepare(
+      `SELECT
+         e.*,
+         i.id AS intent_id_joined,
+         i.repo_id AS intent_repo_id,
+         i.target_type AS intent_target_type,
+         i.target_number AS intent_target_number,
+         i.first_signal_at,
+         i.last_signal_at,
+         i.scheduled_at,
+         i.processing_started_at,
+         i.lease_expires_at,
+         i.generation,
+         i.desired_head_sha,
+         i.requested_agent,
+         i.review_mode,
+         i.signal_count,
+         i.status AS intent_status,
+         i.resolved_at,
+         i.deployment_id,
+         i.failure_reason
+       FROM webhook_events e
+       LEFT JOIN webhook_intents i ON i.id = e.intent_id
+       ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+       ORDER BY e.received_at DESC, e.id DESC
+       LIMIT ?`,
+    )
+    .all(...params) as WebhookLogEntryRow[];
+  return rows.map(rowToWebhookLogEntry);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,6 +132,7 @@ export {
   expireOldWebhookIntentRecords,
   pruneExpiredWebhookPayloads,
   listWebhookEvents,
+  listWebhookLogEntries,
 } from "./db/webhooks.js";
 export type {
   RecordWebhookEventInput,
@@ -140,6 +141,8 @@ export type {
   ListWebhookEventsInput,
   WebhookEvent,
   WebhookIntent,
+  WebhookLogEntry,
+  WebhookLogResult,
 } from "./db/webhooks.js";
 // GitHub client
 export type {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const ensureLifecycleLabels = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const listLabels = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
+const getLabel = vi.hoisted(() => vi.fn());
+const createLabel = vi.hoisted(() => vi.fn());
+const withAuthRetry = vi.hoisted(() => vi.fn((fn: (octokit: unknown) => unknown) => fn({
+  rest: {
+    issues: {
+      getLabel,
+      createLabel,
+    },
+  },
+})));
+
+vi.mock("@issuectl/core", () => ({
+  ensureLifecycleLabels: (...args: unknown[]) => ensureLifecycleLabels(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+  getDb: () => getDb(),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  listLabels: (...args: unknown[]) => listLabels(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+  withAuthRetry: (fn: (octokit: unknown) => unknown) => withAuthRetry(fn),
+}));
+
+import { GET, POST } from "./route";
+
+function request(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/repos/mean-weasel/issuectl/labels", {
+    method: body === undefined ? "GET" : "POST",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue({});
+  getRepo.mockReturnValue({ id: 1, owner: "mean-weasel", name: "issuectl" });
+  listLabels.mockReset();
+  listLabels.mockResolvedValue([{ name: "issuectl:auto-launch" }]);
+  ensureLifecycleLabels.mockReset();
+  ensureLifecycleLabels.mockResolvedValue(undefined);
+  getLabel.mockReset();
+  getLabel.mockRejectedValue({ status: 404 });
+  createLabel.mockReset();
+  createLabel.mockResolvedValue({});
+  recordDiagnosticEventSafely.mockReset();
+  withAuthRetry.mockClear();
+});
+
+describe("/api/v1/repos/[owner]/[repo]/labels", () => {
+  it("lists labels for a tracked repo", async () => {
+    const response = await GET(request(), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.labels).toEqual([{ name: "issuectl:auto-launch" }]);
+  });
+
+  it("recreates lifecycle labels and records diagnostics", async () => {
+    const response = await POST(request({ action: "recreate" }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ success: true });
+    expect(ensureLifecycleLabels).toHaveBeenCalledWith(expect.anything(), "mean-weasel", "issuectl");
+    expect(createLabel).toHaveBeenCalledWith(expect.objectContaining({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      name: "issuectl:auto-launch",
+    }));
+    expect(createLabel).toHaveBeenCalledWith(expect.objectContaining({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      name: "issuectl:auto-review",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.label_recreated",
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
+  });
+
+  it("rejects unknown label actions", async () => {
+    const response = await POST(request({ action: "bad" }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(ensureLifecycleLabels).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/labels/route.ts
@@ -1,9 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
-import { getDb, getRepo, withAuthRetry, listLabels, formatErrorForUser } from "@issuectl/core";
+import {
+  ensureLifecycleLabels,
+  formatErrorForUser,
+  getDb,
+  getRepo,
+  listLabels,
+  recordDiagnosticEventSafely,
+  withAuthRetry,
+} from "@issuectl/core";
 
 export const dynamic = "force-dynamic";
+
+const AUTOMATION_LABELS = [
+  {
+    name: "issuectl:auto-launch",
+    color: "2f81f7",
+    description: "Opt issue into issuectl auto-launch",
+  },
+  {
+    name: "issuectl:auto-review",
+    color: "a371f7",
+    description: "Opt PR into issuectl auto-review",
+  },
+];
 
 export async function GET(
   request: NextRequest,
@@ -31,5 +52,77 @@ export async function GET(
       { error: formatErrorForUser(err) },
       { status: 500 },
     );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo } = await params;
+  const body = await readBody(request);
+  if (body instanceof NextResponse) return body;
+  if (body.action !== "recreate") {
+    return NextResponse.json({ error: "action must be recreate" }, { status: 400 });
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+    await withAuthRetry(async (octokit) => {
+      await ensureLifecycleLabels(octokit, owner, repo);
+      await ensureAutomationLabels(octokit, owner, repo);
+    });
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "repo.label_recreated",
+      source: "web",
+      owner,
+      repo,
+      message: "Repository automation labels recreated",
+    });
+    log.info({ msg: "api_labels_recreated", owner, repo });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err, msg: "api_labels_recreate_failed", owner, repo });
+    return NextResponse.json(
+      { error: formatErrorForUser(err) },
+      { status: 500 },
+    );
+  }
+}
+
+async function ensureAutomationLabels(
+  octokit: Parameters<typeof ensureLifecycleLabels>[0],
+  owner: string,
+  repo: string,
+): Promise<void> {
+  await Promise.all(AUTOMATION_LABELS.map(async (label) => {
+    try {
+      await octokit.rest.issues.getLabel({ owner, repo, name: label.name });
+    } catch (err) {
+      if ((err as { status?: number }).status !== 404) throw err;
+      await octokit.rest.issues.createLabel({
+        owner,
+        repo,
+        name: label.name,
+        color: label.color,
+        description: label.description,
+      });
+    }
+  }));
+}
+
+async function readBody(request: NextRequest): Promise<{ action?: string } | NextResponse> {
+  try {
+    return await request.json() as { action?: string };
+  } catch (err) {
+    log.warn({ err, msg: "api_request_body_parse_failed", url: request.nextUrl.pathname });
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 }

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
@@ -16,6 +16,7 @@ const getActiveWebhookDeploymentsForRepoTarget = vi.hoisted(() => vi.fn());
 const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const killTmuxSession = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const tmuxSessionName = vi.hoisted(() => vi.fn((repo: string, targetNumber: number, targetType = "issue") => `issuectl-${repo}-${targetType}-${targetNumber}`));
 const updateRepo = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
@@ -27,6 +28,7 @@ vi.mock("@issuectl/core", () => ({
   endDeployment: (...args: unknown[]) => endDeployment(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
   tmuxSessionName: (repo: string, targetNumber: number, targetType?: "issue" | "pr") => tmuxSessionName(repo, targetNumber, targetType),
   updateRepo: (...args: unknown[]) => updateRepo(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
@@ -74,6 +76,7 @@ beforeEach(() => {
   endDeployment.mockReset();
   killTtyd.mockReset();
   killTmuxSession.mockReset();
+  recordDiagnosticEventSafely.mockReset();
   tmuxSessionName.mockClear();
 });
 
@@ -97,6 +100,11 @@ describe("/api/v1/repos/[owner]/[repo]", () => {
       webhookPayloadMode: "raw",
     });
     expect(json.repo.webhookSecret).toBeUndefined();
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.automation_enabled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
   });
 
   it("PATCH ends active webhook sessions when automation is disabled", async () => {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -9,6 +9,7 @@ import {
   endDeployment,
   killTtyd,
   killTmuxSession,
+  recordDiagnosticEventSafely,
   tmuxSessionName,
   updateRepo,
   updateRepoWebhookSettings,
@@ -43,6 +44,15 @@ export async function DELETE(
     }
 
     removeRepo(db, repo.id);
+    recordDiagnosticEventSafely(db, {
+      level: "warn",
+      event: "repo.removed",
+      source: "web",
+      owner,
+      repo: repoName,
+      message: "Repository removed from local tracking",
+      data: { repoId: repo.id },
+    });
     log.info({ msg: "api_repo_removed", repoId: repo.id, owner, name: repoName });
     return NextResponse.json({ success: true });
   } catch (err) {
@@ -143,6 +153,7 @@ export async function PATCH(
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
       updated = updateRepoWebhookSettings(db, repo.id, webhookUpdates);
       endDisabledAutomationSessions(db, repo, webhookUpdates);
+      recordAutomationDiagnostics(db, repo, webhookUpdates);
     }
     log.info({ msg: "api_repo_updated", repoId: repo.id, owner, name: repoName, updates, webhookUpdates });
     return NextResponse.json({ success: true, repo: updated });
@@ -152,6 +163,35 @@ export async function PATCH(
       { success: false, error: formatErrorForUser(err) },
       { status: 500 },
     );
+  }
+}
+
+function recordAutomationDiagnostics(
+  db: ReturnType<typeof getDb>,
+  repo: { id: number; owner: string; name: string },
+  updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
+): void {
+  if (updates.autoLaunchIssues === true || updates.autoReviewPrs === true) {
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "repo.automation_enabled",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: "Repository webhook automation enabled",
+      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs },
+    });
+  }
+  if (updates.autoLaunchIssues === false || updates.autoReviewPrs === false) {
+    recordDiagnosticEventSafely(db, {
+      level: "warn",
+      event: "repo.automation_disabled",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: "Repository webhook automation disabled",
+      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs },
+    });
   }
 }
 

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
@@ -93,6 +93,15 @@ describe("/api/v1/repos/[owner]/[repo]/webhook", () => {
       owner: "mean-weasel",
       repo: "issuectl",
     }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "webhook.url_reconciled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({
+        hookId: 123,
+        url: "https://hooks.example.test/api/webhook/github/1",
+      }),
+    }));
     expect(JSON.stringify(json)).not.toContain("webhookSecret");
   });
 
@@ -116,6 +125,10 @@ describe("/api/v1/repos/[owner]/[repo]/webhook", () => {
     });
     expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       event: "repo.webhook_secret_rotated",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "webhook.url_reconciled",
+      data: expect.objectContaining({ hookId: 456 }),
     }));
   });
 

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
@@ -15,6 +15,7 @@ const getDb = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
 const getRepoWebhookConfigById = vi.hoisted(() => vi.fn());
 const getSetting = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const rotateIssuectlWebhook = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
 const withAuthRetry = vi.hoisted(() => vi.fn((fn: (octokit: unknown) => unknown) => fn({})));
@@ -26,6 +27,7 @@ vi.mock("@issuectl/core", () => ({
   getRepo: (...args: unknown[]) => getRepo(...args),
   getRepoWebhookConfigById: (...args: unknown[]) => getRepoWebhookConfigById(...args),
   getSetting: (...args: unknown[]) => getSetting(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
   rotateIssuectlWebhook: (...args: unknown[]) => rotateIssuectlWebhook(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
   withAuthRetry: (fn: (octokit: unknown) => unknown) => withAuthRetry(fn),
@@ -57,6 +59,7 @@ beforeEach(() => {
   createIssuectlWebhook.mockResolvedValue({ id: 123, createdBy: "jeremy" });
   rotateIssuectlWebhook.mockReset();
   rotateIssuectlWebhook.mockResolvedValue({ id: 456, createdBy: "jeremy" });
+  recordDiagnosticEventSafely.mockReset();
   updateRepoWebhookSettings.mockReset();
   updateRepoWebhookSettings.mockReturnValue({ ...repo, webhookId: 123 });
   withAuthRetry.mockClear();
@@ -85,6 +88,11 @@ describe("/api/v1/repos/[owner]/[repo]/webhook", () => {
       url: "https://hooks.example.test/api/webhook/github/1",
       createdBy: "jeremy",
     });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_reinstalled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
     expect(JSON.stringify(json)).not.toContain("webhookSecret");
   });
 
@@ -106,6 +114,9 @@ describe("/api/v1/repos/[owner]/[repo]/webhook", () => {
       webhookId: 456,
       webhookSecret: expect.any(String),
     });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_secret_rotated",
+    }));
   });
 
   it("rejects rotate when no webhook id is stored", async () => {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
@@ -71,6 +71,15 @@ export async function POST(
       message: action === "create" ? "Repository webhook installed" : "Repository webhook secret rotated",
       data: { repoId: repo.id, hookId: result.id, url },
     });
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "webhook.url_reconciled",
+      source: "web",
+      owner,
+      repo: repoName,
+      message: "Repository webhook URL reconciled",
+      data: { repoId: repo.id, hookId: result.id, url },
+    });
 
     log.info({
       msg: "api_repo_webhook_configured",

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
@@ -9,6 +9,7 @@ import {
   getRepo,
   getRepoWebhookConfigById,
   getSetting,
+  recordDiagnosticEventSafely,
   rotateIssuectlWebhook,
   updateRepoWebhookSettings,
   withAuthRetry,
@@ -60,6 +61,15 @@ export async function POST(
     const updated = updateRepoWebhookSettings(db, repo.id, {
       webhookId: result.id,
       webhookSecret: secret,
+    });
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: action === "create" ? "repo.webhook_reinstalled" : "repo.webhook_secret_rotated",
+      source: "web",
+      owner,
+      repo: repoName,
+      message: action === "create" ? "Repository webhook installed" : "Repository webhook secret rotated",
+      data: { repoId: repo.id, hookId: result.id, url },
     });
 
     log.info({

--- a/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
+++ b/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
@@ -32,9 +32,16 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
 
     function connect() {
       if (cancelled) return;
+      const apiToken = readApiToken();
+      if (!apiToken) {
+        setState("offline");
+        return;
+      }
       setState((current) => current === "offline" ? "reconnecting" : "connecting");
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      socket = new WebSocket(`${protocol}//${window.location.host}${endpoint}`);
+      const url = new URL(`${protocol}//${window.location.host}${endpoint}`);
+      url.searchParams.set("apiToken", apiToken);
+      socket = new WebSocket(url);
 
       socket.addEventListener("open", () => {
         if (!cancelled) setState("live");
@@ -92,4 +99,9 @@ function parseStreamMessage(value: unknown): StreamMessage | null {
   } catch {
     return null;
   }
+}
+
+function readApiToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem("issuectl.apiToken");
 }

--- a/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
+++ b/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import styles from "./page.module.css";
+
+type StreamState = "connecting" | "live" | "paused" | "reconnecting" | "offline";
+
+type StreamMessage = {
+  type?: string;
+  payload?: {
+    generatedAt?: string;
+    entries?: unknown[];
+    error?: string;
+  };
+};
+
+export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
+  const [paused, setPaused] = useState(false);
+  const [state, setState] = useState<StreamState>("connecting");
+  const [lastUpdate, setLastUpdate] = useState<string | null>(null);
+  const [visibleEvents, setVisibleEvents] = useState(0);
+  const reconnectRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (paused) {
+      setState("paused");
+      return;
+    }
+
+    let socket: WebSocket | null = null;
+    let cancelled = false;
+
+    function connect() {
+      if (cancelled) return;
+      setState((current) => current === "offline" ? "reconnecting" : "connecting");
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      socket = new WebSocket(`${protocol}//${window.location.host}${endpoint}`);
+
+      socket.addEventListener("open", () => {
+        if (!cancelled) setState("live");
+      });
+      socket.addEventListener("message", (event) => {
+        if (cancelled) return;
+        const message = parseStreamMessage(event.data);
+        const generatedAt = message?.payload?.generatedAt;
+        if (generatedAt) setLastUpdate(generatedAt);
+        if (Array.isArray(message?.payload?.entries)) {
+          setVisibleEvents(message.payload.entries.length);
+        }
+      });
+      socket.addEventListener("close", () => {
+        if (cancelled) return;
+        setState("offline");
+        reconnectRef.current = window.setTimeout(connect, 2500);
+      });
+      socket.addEventListener("error", () => {
+        if (!cancelled) setState("offline");
+      });
+    }
+
+    connect();
+    return () => {
+      cancelled = true;
+      if (reconnectRef.current !== null) {
+        window.clearTimeout(reconnectRef.current);
+        reconnectRef.current = null;
+      }
+      socket?.close();
+    };
+  }, [endpoint, paused]);
+
+  const label = paused ? "Resume" : "Pause";
+  return (
+    <div className={styles.liveTail} aria-label="Webhook live tail">
+      <div>
+        <span className={styles.liveLabel} data-state={state}>{state}</span>
+        <span className={styles.liveMeta}>
+          {lastUpdate ? `Updated ${new Date(lastUpdate).toLocaleTimeString()}` : `${visibleEvents} visible events`}
+        </span>
+      </div>
+      <button className={styles.secondaryButton} type="button" onClick={() => setPaused((value) => !value)}>
+        {label}
+      </button>
+    </div>
+  );
+}
+
+function parseStreamMessage(value: unknown): StreamMessage | null {
+  if (typeof value !== "string") return null;
+  try {
+    return JSON.parse(value) as StreamMessage;
+  } catch {
+    return null;
+  }
+}

--- a/packages/web/app/logs/webhooks/loading.tsx
+++ b/packages/web/app/logs/webhooks/loading.tsx
@@ -1,0 +1,11 @@
+import styles from "./page.module.css";
+
+export default function WebhookLogLoading() {
+  return (
+    <main className={styles.shell}>
+      <div className={styles.skeletonHeader} />
+      <div className={styles.skeletonToolbar} />
+      <div className={styles.skeletonTable} />
+    </main>
+  );
+}

--- a/packages/web/app/logs/webhooks/page.module.css
+++ b/packages/web/app/logs/webhooks/page.module.css
@@ -1,0 +1,369 @@
+.shell {
+  padding: 20px 32px 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--text-secondary);
+  font: 700 11px var(--paper-mono);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 30px;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  max-width: 720px;
+}
+
+.healthStrip,
+.toolbar,
+.tableWrap,
+.emptyState {
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-surface);
+}
+
+.healthStrip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1px;
+  overflow: hidden;
+}
+
+.metric {
+  padding: 14px 16px;
+  display: grid;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.metric dt {
+  color: var(--text-secondary);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.metric dd {
+  margin: 0;
+  font: 600 17px var(--paper-serif);
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  padding: 0 9px;
+  border-radius: 999px;
+  color: #14351f;
+  background: #dff3df;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.statusPill[data-tone="amber"] {
+  color: #5d4100;
+  background: #ffe8aa;
+}
+
+.statusPill[data-tone="red"] {
+  color: #6e2119;
+  background: #ffd6ce;
+}
+
+.toolbar {
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.liveTail {
+  min-height: 42px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-surface);
+}
+
+.liveTail > div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.liveLabel {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  color: #14351f;
+  background: #dff3df;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.liveLabel[data-state="connecting"],
+.liveLabel[data-state="reconnecting"],
+.liveLabel[data-state="paused"] {
+  color: #5d4100;
+  background: #ffe8aa;
+}
+
+.liveLabel[data-state="offline"] {
+  color: #6e2119;
+  background: #ffd6ce;
+}
+
+.liveMeta {
+  color: var(--text-secondary);
+  font: 12px var(--paper-mono);
+}
+
+.secondaryButton {
+  min-height: 32px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 0 12px;
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--text-primary);
+  font: 700 12px var(--paper-mono);
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  min-height: 30px;
+  padding: 0 11px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  color: var(--text-primary);
+  text-decoration: none;
+  font: 700 11px var(--paper-mono);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.chip[data-active="true"] {
+  border-color: var(--paper-accent);
+  color: var(--paper-accent);
+  background: rgba(87, 99, 66, 0.12);
+}
+
+.searchRow {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(150px, 220px) auto;
+  gap: 10px;
+}
+
+.input,
+.select {
+  min-height: 38px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  padding: 0 10px;
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--text-primary);
+  font: 13px var(--paper-serif);
+}
+
+.button {
+  min-height: 38px;
+  border: 1px solid var(--paper-accent);
+  border-radius: var(--paper-radius-sm);
+  padding: 0 14px;
+  background: var(--paper-accent);
+  color: white;
+  font: 700 12px var(--paper-mono);
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 960px;
+}
+
+.table th,
+.table td {
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--paper-line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  color: var(--text-secondary);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.rowSummary {
+  display: grid;
+  gap: 4px;
+}
+
+.delivery {
+  font: 700 12px var(--paper-mono);
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+.result {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+  background: #ece8de;
+}
+
+.result[data-result="fired"] {
+  color: #15391f;
+  background: #dff3df;
+}
+
+.result[data-result="failed"],
+.result[data-result="dropped"] {
+  color: #6e2119;
+  background: #ffd6ce;
+}
+
+.result[data-result="debouncing"],
+.result[data-result="processing"],
+.result[data-result="gated"] {
+  color: #5d4100;
+  background: #ffe8aa;
+}
+
+.detailsCell {
+  padding: 0 12px 14px;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.details {
+  margin-top: 8px;
+}
+
+.details summary {
+  cursor: pointer;
+  color: var(--paper-accent);
+  font: 700 12px var(--paper-mono);
+}
+
+.detailGrid {
+  margin-top: 12px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.detailBlock {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.detailBlock h3 {
+  margin: 0;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.code {
+  overflow-wrap: anywhere;
+  font: 12px var(--paper-mono);
+}
+
+.payload {
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px;
+  border-radius: var(--paper-radius-sm);
+  background: rgba(0, 0, 0, 0.06);
+  font: 12px var(--paper-mono);
+  white-space: pre-wrap;
+}
+
+.emptyState {
+  padding: 24px;
+}
+
+.skeletonHeader,
+.skeletonToolbar,
+.skeletonTable {
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-bg);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.skeletonHeader {
+  height: 86px;
+}
+
+.skeletonToolbar {
+  height: 92px;
+}
+
+.skeletonTable {
+  height: 340px;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+@media (max-width: 720px) {
+  .shell {
+    padding: 16px;
+  }
+
+  .hero,
+  .searchRow,
+  .liveTail {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+}

--- a/packages/web/app/logs/webhooks/page.tsx
+++ b/packages/web/app/logs/webhooks/page.tsx
@@ -1,0 +1,352 @@
+/* eslint-disable max-lines */
+import Link from "next/link";
+import {
+  dbExists,
+  getDb,
+  listRepos,
+  listWebhookLogEntries,
+  type Repo,
+  type WebhookLogEntry,
+  type WebhookLogResult,
+} from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { WebhookLiveTail } from "./WebhookLiveTail";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Webhook logs - issuectl" };
+
+type SearchParams = {
+  repo?: string;
+  result?: string;
+  event?: string;
+  q?: string;
+};
+
+const RESULT_FILTERS: Array<{ label: string; value: WebhookLogResult | "all" }> = [
+  { label: "All", value: "all" },
+  { label: "Fired", value: "fired" },
+  { label: "Debouncing", value: "debouncing" },
+  { label: "Gated", value: "gated" },
+  { label: "Dropped", value: "dropped" },
+  { label: "Failed", value: "failed" },
+];
+
+export default async function WebhookLogsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Webhook logs" breadcrumb={<Link href="/settings">settings</Link>} />
+        <main className={styles.shell}>
+          <section className={styles.emptyState}>
+            <p>Run <code>issuectl init</code> to create the local database.</p>
+          </section>
+        </main>
+      </>
+    );
+  }
+
+  const db = getDb();
+  const repos = listRepos(db);
+  const selectedRepoId = parsePositiveInt(params.repo);
+  const selectedRepo = repos.find((repo) => repo.id === selectedRepoId);
+  const entries = filterEntries(
+    listWebhookLogEntries(db, {
+      limit: 200,
+      ...(selectedRepo ? { repoId: selectedRepo.id } : {}),
+    }),
+    params,
+    repos,
+  );
+  const metrics = summarize(entries);
+  const health = webhookHealth(entries);
+
+  return (
+    <>
+      <PageHeader title="Webhook logs" breadcrumb={<Link href="/">dashboard</Link>} />
+      <main className={styles.shell}>
+        <section className={styles.hero}>
+          <div>
+            <p className={styles.eyebrow}>Operator log</p>
+            <h1 className={styles.title}>GitHub webhook events</h1>
+            <p className={styles.subtitle}>
+              Read-only delivery, debounce, action, and diagnostic trail for webhook automation.
+            </p>
+          </div>
+          <span className={styles.statusPill} data-tone={health.tone}>
+            {health.label}
+          </span>
+        </section>
+
+        <dl className={styles.healthStrip} aria-label="Webhook receiver summary">
+          <Metric label="Today" value={`${metrics.today} deliveries`} />
+          <Metric label="Actions" value={`${metrics.fired} fired`} />
+          <Metric label="Dropped" value={`${metrics.dropped + metrics.gated} gated/drop`} />
+          <Metric label="Raw payloads" value={`${metrics.retained} retained`} />
+          <Metric label="Stream" value="/api/webhooks/events/stream" />
+        </dl>
+        <WebhookLiveTail endpoint="/api/webhooks/events/stream" />
+
+        <form className={styles.toolbar} action="/logs/webhooks">
+          <div className={styles.filters} aria-label="Webhook result filters">
+            {RESULT_FILTERS.map((filter) => (
+              <Link
+                key={filter.value}
+                className={styles.chip}
+                data-active={activeResult(params.result) === filter.value}
+                href={hrefFor(params, {
+                  result: filter.value === "all" ? undefined : filter.value,
+                })}
+              >
+                {filter.label}
+              </Link>
+            ))}
+          </div>
+          <div className={styles.searchRow}>
+            <input
+              className={styles.input}
+              type="search"
+              name="q"
+              defaultValue={params.q ?? ""}
+              placeholder="delivery, correlation, owner/repo#507"
+              aria-label="Search webhook logs"
+            />
+            <select className={styles.select} name="repo" defaultValue={selectedRepo?.id ?? ""} aria-label="Filter by repo">
+              <option value="">All repos</option>
+              {repos.map((repo) => (
+                <option key={repo.id} value={repo.id}>{repo.owner}/{repo.name}</option>
+              ))}
+            </select>
+            <button className={styles.button} type="submit">Apply</button>
+          </div>
+          {params.result && <input type="hidden" name="result" value={params.result} />}
+        </form>
+
+        {entries.length === 0 ? (
+          <section className={styles.emptyState}>
+            <h2>No webhook events match these filters.</h2>
+            <p className={styles.muted}>Use `issuectl webhook tail` to mirror this timeline in the terminal.</p>
+          </section>
+        ) : (
+          <WebhookTable entries={entries} repos={repos} />
+        )}
+      </main>
+    </>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.metric}>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function WebhookTable({ entries, repos }: { entries: WebhookLogEntry[]; repos: Repo[] }) {
+  return (
+    <section className={styles.tableWrap} aria-label="Webhook event timeline">
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Delivery</th>
+            <th>Repo</th>
+            <th>Event</th>
+            <th>Intent</th>
+            <th>Action</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <WebhookRow key={entry.id} entry={entry} repo={repos.find((item) => item.id === entry.repoId)} />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function WebhookRow({ entry, repo }: { entry: WebhookLogEntry; repo: Repo | undefined }) {
+  const target = targetLabel(entry);
+  const command = diagnosticsCommand(entry, repo);
+  return (
+    <>
+      <tr>
+        <td>{formatAge(entry.receivedAt)}</td>
+        <td>
+          <div className={styles.rowSummary}>
+            <span className={styles.delivery}>{shortId(entry.deliveryId)}</span>
+            <span className={styles.muted}>{entry.senderLogin ?? "GitHub"}</span>
+          </div>
+        </td>
+        <td>{repo ? `${repo.owner}/${repo.name}` : `repo ${entry.repoId}`}</td>
+        <td>{entry.eventType}{entry.action ? `.${entry.action}` : ""}</td>
+        <td>{entry.intent ? `int_${entry.intent.id}` : "-"}</td>
+        <td>{entry.actionId ?? "-"}</td>
+        <td>
+          <span className={styles.result} data-result={entry.result}>{entry.result}</span>
+        </td>
+      </tr>
+      <tr>
+        <td className={styles.detailsCell} colSpan={7}>
+          <details className={styles.details}>
+            <summary>Details for {target}</summary>
+            <div className={styles.detailGrid}>
+              <DetailBlock title="Headers">
+                <span className={styles.code}>X-GitHub-Delivery: {entry.deliveryId}</span>
+                <span className={styles.code}>Event: {entry.eventType}</span>
+                <span className={styles.code}>Sender: {entry.senderLogin ?? "unknown"}</span>
+                <span className={styles.code}>Received: {new Date(entry.receivedAt).toLocaleString()}</span>
+              </DetailBlock>
+              <DetailBlock title="Chain">
+                <span className={styles.code}>Target: {target}</span>
+                <span className={styles.code}>Intent: {entry.intent ? `int_${entry.intent.id}` : "none"}</span>
+                <span className={styles.code}>Result: {entry.resultDetail ?? entry.result}</span>
+                <span className={styles.code}>CLI hint: {cliHint(entry)}</span>
+              </DetailBlock>
+              <DetailBlock title="Diagnostics">
+                <span className={styles.code}>{command}</span>
+              </DetailBlock>
+              <DetailBlock title="Raw payload">
+                {entry.payloadJson ? (
+                  entry.payloadJson.length > 100_000 ? (
+                    <span className={styles.code}>payload: {entry.payloadJson.length} bytes; use CLI export for full payload</span>
+                  ) : (
+                    <pre className={styles.payload}>{formatPayload(entry.payloadJson)}</pre>
+                  )
+                ) : (
+                  <span className={styles.muted}>No raw payload retained.</span>
+                )}
+              </DetailBlock>
+            </div>
+          </details>
+        </td>
+      </tr>
+    </>
+  );
+}
+
+function DetailBlock({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className={styles.detailBlock}>
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function filterEntries(
+  entries: WebhookLogEntry[],
+  params: SearchParams,
+  repos: Repo[],
+): WebhookLogEntry[] {
+  const result = activeResult(params.result);
+  const query = params.q?.trim().toLowerCase();
+  return entries.filter((entry) => {
+    if (result !== "all" && entry.result !== result) return false;
+    if (!query) return true;
+    const repo = repos.find((item) => item.id === entry.repoId);
+    const haystack = [
+      entry.deliveryId,
+      entry.eventType,
+      entry.action,
+      entry.senderLogin,
+      entry.targetNumber ? `${repo?.owner}/${repo?.name}#${entry.targetNumber}` : null,
+      entry.intent ? `int_${entry.intent.id}` : null,
+      entry.actionId,
+      entry.resultDetail,
+    ].filter(Boolean).join(" ").toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function summarize(entries: WebhookLogEntry[]) {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  return {
+    today: entries.filter((entry) => entry.receivedAt >= todayStart.getTime()).length,
+    fired: entries.filter((entry) => entry.result === "fired").length,
+    dropped: entries.filter((entry) => entry.result === "dropped" || entry.result === "failed").length,
+    gated: entries.filter((entry) => entry.result === "gated").length,
+    retained: entries.filter((entry) => entry.payloadJson).length,
+  };
+}
+
+function webhookHealth(entries: WebhookLogEntry[]): { label: string; tone: "green" | "amber" | "red" } {
+  const last = entries[0]?.receivedAt;
+  if (!last) return { label: "No deliveries", tone: "red" };
+  const ageMs = Date.now() - last;
+  if (ageMs < 5 * 60 * 1000) return { label: "Healthy", tone: "green" };
+  if (ageMs < 60 * 60 * 1000) return { label: "Quiet", tone: "amber" };
+  return { label: "Stale", tone: "red" };
+}
+
+function activeResult(value: string | undefined): WebhookLogResult | "all" {
+  return RESULT_FILTERS.some((filter) => filter.value === value) ? value as WebhookLogResult : "all";
+}
+
+function hrefFor(params: SearchParams, next: Partial<SearchParams>): string {
+  const search = new URLSearchParams();
+  const merged = { ...params, ...next };
+  for (const [key, value] of Object.entries(merged)) {
+    if (value) search.set(key, value);
+  }
+  return `/logs/webhooks${search.size > 0 ? `?${search.toString()}` : ""}`;
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function targetLabel(entry: WebhookLogEntry): string {
+  if (!entry.targetType || !entry.targetNumber) return "repo event";
+  return `${entry.targetType === "pr" ? "PR" : "issue"} #${entry.targetNumber}`;
+}
+
+function shortId(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 10)}...` : value;
+}
+
+function formatAge(value: number): string {
+  const deltaSeconds = Math.max(0, Math.floor((Date.now() - value) / 1000));
+  if (deltaSeconds < 60) return `${deltaSeconds}s ago`;
+  const deltaMinutes = Math.floor(deltaSeconds / 60);
+  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  const deltaHours = Math.floor(deltaMinutes / 60);
+  if (deltaHours < 48) return `${deltaHours}h ago`;
+  return new Date(value).toLocaleDateString();
+}
+
+function diagnosticsCommand(entry: WebhookLogEntry, repo: Repo | undefined): string {
+  if (entry.targetType && entry.targetNumber && repo) {
+    return `pnpm --dir packages/cli exec issuectl diag show --issue ${repo.owner}/${repo.name}#${entry.targetNumber}`;
+  }
+  return "pnpm --dir packages/cli exec issuectl webhook tail --limit 20";
+}
+
+function cliHint(entry: WebhookLogEntry): string {
+  if (entry.result === "debouncing" && entry.intent) {
+    return `issuectl webhook intent fire int_${entry.intent.id}`;
+  }
+  if (entry.result === "dropped" || entry.result === "failed") {
+    return `issuectl webhook replay ${entry.deliveryId}`;
+  }
+  return "issuectl webhook tail";
+}
+
+function formatPayload(payload: string): string {
+  try {
+    return JSON.stringify(JSON.parse(payload), null, 2);
+  } catch {
+    return payload;
+  }
+}

--- a/packages/web/app/logs/webhooks/page.tsx
+++ b/packages/web/app/logs/webhooks/page.tsx
@@ -116,6 +116,14 @@ export default async function WebhookLogsPage({
               placeholder="delivery, correlation, owner/repo#507"
               aria-label="Search webhook logs"
             />
+            <input
+              className={styles.input}
+              type="search"
+              name="event"
+              defaultValue={params.event ?? ""}
+              placeholder="issues, pull_request, labeled"
+              aria-label="Filter by event"
+            />
             <select className={styles.select} name="repo" defaultValue={selectedRepo?.id ?? ""} aria-label="Filter by repo">
               <option value="">All repos</option>
               {repos.map((repo) => (
@@ -250,8 +258,11 @@ function filterEntries(
 ): WebhookLogEntry[] {
   const result = activeResult(params.result);
   const query = params.q?.trim().toLowerCase();
+  const eventQuery = params.event?.trim().toLowerCase();
   return entries.filter((entry) => {
     if (result !== "all" && entry.result !== result) return false;
+    const eventText = `${entry.eventType} ${entry.action ?? ""}`.toLowerCase();
+    if (eventQuery && !eventText.includes(eventQuery)) return false;
     if (!query) return true;
     const repo = repos.find((item) => item.id === entry.repoId);
     const haystack = [
@@ -328,17 +339,18 @@ function formatAge(value: number): string {
 
 function diagnosticsCommand(entry: WebhookLogEntry, repo: Repo | undefined): string {
   if (entry.targetType && entry.targetNumber && repo) {
-    return `pnpm --dir packages/cli exec issuectl diag show --issue ${repo.owner}/${repo.name}#${entry.targetNumber}`;
+    const targetFlag = entry.targetType === "pr" ? "--pr" : "--issue";
+    return `pnpm --dir packages/cli exec issuectl diag show ${targetFlag} ${repo.owner}/${repo.name}#${entry.targetNumber}`;
   }
   return "pnpm --dir packages/cli exec issuectl webhook tail --limit 20";
 }
 
 function cliHint(entry: WebhookLogEntry): string {
-  if (entry.result === "debouncing" && entry.intent) {
-    return `issuectl webhook intent fire int_${entry.intent.id}`;
+  if (entry.targetType && entry.targetNumber) {
+    return `issuectl webhook tail --target ${entry.targetType}/${entry.targetNumber} --limit 20`;
   }
   if (entry.result === "dropped" || entry.result === "failed") {
-    return `issuectl webhook replay ${entry.deliveryId}`;
+    return "issuectl diag list --event webhook.runaway_limited webhook.launch_failed --limit 50";
   }
   return "issuectl webhook tail";
 }

--- a/packages/web/app/repos/[owner]/[repo]/settings/loading.tsx
+++ b/packages/web/app/repos/[owner]/[repo]/settings/loading.tsx
@@ -1,0 +1,9 @@
+import styles from "./page.module.css";
+
+export default function Loading() {
+  return (
+    <main className={styles.shell}>
+      <p className={styles.empty}>Loading repo settings...</p>
+    </main>
+  );
+}

--- a/packages/web/app/repos/[owner]/[repo]/settings/page.module.css
+++ b/packages/web/app/repos/[owner]/[repo]/settings/page.module.css
@@ -1,0 +1,15 @@
+.shell {
+  padding: 20px 32px 36px;
+  max-width: 1040px;
+}
+
+.empty {
+  padding: 24px;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 720px) {
+  .shell {
+    padding: 16px;
+  }
+}

--- a/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
+++ b/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  dbExists,
+  getActiveDeployments,
+  getDb,
+  getRepo,
+  getSetting,
+  listPrReviewsForRepo,
+  listRecentTerminalDeploymentsByRepo,
+  listWebhookEvents,
+} from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { RepoSettingsPanel } from "@/components/repos/RepoSettingsPanel";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Repo settings - issuectl" };
+
+export default async function RepoSettingsPage({
+  params,
+}: {
+  params: Promise<{ owner: string; repo: string }>;
+}) {
+  const { owner, repo: repoName } = await params;
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Repo settings" breadcrumb={<Link href="/settings/repos">repos</Link>} />
+        <main className={styles.empty}>
+          Run <code>issuectl init</code> to create the local database.
+        </main>
+      </>
+    );
+  }
+
+  const db = getDb();
+  const repo = getRepo(db, owner, repoName);
+  if (!repo) notFound();
+
+  const publicWebhookBaseUrl = getSetting(db, "public_webhook_base_url");
+  const webhookUrl = publicWebhookBaseUrl
+    ? `${publicWebhookBaseUrl.replace(/\/$/, "")}/api/webhook/github/${repo.id}`
+    : null;
+  const activeSessions = getActiveDeployments(db).filter((deployment) => deployment.repoId === repo.id).length;
+  const activity = {
+    activeSessions,
+    recentCompletions: listRecentTerminalDeploymentsByRepo(db, repo.id, 25).length,
+    webhookEvents: listWebhookEvents(db, { repoId: repo.id, limit: 25 }).length,
+    prReviews: listPrReviewsForRepo(db, repo.id, 25).length,
+  };
+
+  return (
+    <>
+      <PageHeader title={`${repo.owner}/${repo.name}`} breadcrumb={<Link href="/settings/repos">repos</Link>} />
+      <main className={styles.shell}>
+        <RepoSettingsPanel
+          repo={repo}
+          webhookUrl={webhookUrl}
+          activity={activity}
+          settingsHref="/settings/repos"
+        />
+      </main>
+    </>
+  );
+}

--- a/packages/web/app/reviews/[reviewId]/actions.ts
+++ b/packages/web/app/reviews/[reviewId]/actions.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getDb,
+  getPrReviewById,
+  getRepoById,
+  mergeWebhookIntent,
+  recordDiagnosticEventSafely,
+} from "@issuectl/core";
+import { buildReviewActionRequest } from "@/lib/review-detail-data";
+
+export async function retryPrReviewAction(formData: FormData): Promise<void> {
+  return requestReviewRun(formData, "retry");
+}
+
+export async function manualFullRerunPrReviewAction(formData: FormData): Promise<void> {
+  return requestReviewRun(formData, "full");
+}
+
+async function requestReviewRun(
+  formData: FormData,
+  mode: "retry" | "full",
+): Promise<void> {
+  const reviewId = Number(formData.get("reviewId"));
+  if (!Number.isInteger(reviewId) || reviewId <= 0) {
+    return;
+  }
+
+  const db = getDb();
+  const review = getPrReviewById(db, reviewId);
+  if (!review) return;
+  const repo = getRepoById(db, review.repoId);
+  if (!repo) return;
+
+  const request = buildReviewActionRequest({ review, repo, mode, now: Date.now() });
+  const intentId = mergeWebhookIntent(db, request.intent);
+  recordDiagnosticEventSafely(db, {
+    level: "info",
+    event: request.diagnosticEvent,
+    source: "review-detail",
+    owner: repo.owner,
+    repo: repo.name,
+    targetType: "pr",
+    targetNumber: review.prNumber,
+    deploymentId: review.deploymentId ?? undefined,
+    message: request.diagnosticMessage,
+    data: {
+      reviewId: review.id,
+      intentId,
+      reviewMode: request.intent.reviewMode,
+      desiredHeadSha: request.intent.desiredHeadSha,
+    },
+  });
+
+  revalidatePath(`/reviews/${review.id}`);
+  revalidatePath("/sessions");
+}

--- a/packages/web/app/reviews/[reviewId]/loading.tsx
+++ b/packages/web/app/reviews/[reviewId]/loading.tsx
@@ -1,0 +1,16 @@
+import { PageHeader } from "@/components/ui/PageHeader";
+import styles from "./page.module.css";
+
+export default function ReviewDetailLoading() {
+  return (
+    <>
+      <PageHeader title="PR review" />
+      <main className={styles.shell}>
+        <div className={styles.loadingLayout}>
+          <div />
+          <div />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/packages/web/app/reviews/[reviewId]/page.module.css
+++ b/packages/web/app/reviews/[reviewId]/page.module.css
@@ -1,0 +1,46 @@
+.shell {
+  padding: 20px 32px 36px;
+}
+
+.headerLink {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+  white-space: nowrap;
+}
+
+.loadingLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 18px;
+}
+
+.loadingLayout div {
+  min-height: 420px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-bg-warm);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@media (max-width: 960px) {
+  .shell {
+    padding: 16px;
+  }
+
+  .loadingLayout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/web/app/reviews/[reviewId]/page.tsx
+++ b/packages/web/app/reviews/[reviewId]/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { ReviewDetailPanel } from "@/components/reviews/ReviewDetailPanel";
+import { getReviewDetailData } from "@/lib/review-detail-data";
+import { manualFullRerunPrReviewAction, retryPrReviewAction } from "./actions";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "PR review - issuectl" };
+
+export default async function ReviewDetailPage({
+  params,
+}: {
+  params: Promise<{ reviewId: string }>;
+}) {
+  const { reviewId } = await params;
+  const id = Number(reviewId);
+  if (!Number.isInteger(id) || id <= 0) notFound();
+  const data = getReviewDetailData(id);
+  if (!data) notFound();
+
+  return (
+    <>
+      <PageHeader
+        title="PR review"
+        breadcrumb={<Link href="/sessions?tab=reviews">reviews</Link>}
+        actions={<Link className={styles.headerLink} href={data.links.githubPr}>GitHub PR</Link>}
+      />
+      <main className={styles.shell}>
+        <ReviewDetailPanel
+          data={data}
+          retryAction={retryPrReviewAction}
+          fullRerunAction={manualFullRerunPrReviewAction}
+        />
+      </main>
+    </>
+  );
+}

--- a/packages/web/app/sessions/loading.tsx
+++ b/packages/web/app/sessions/loading.tsx
@@ -1,0 +1,24 @@
+import { PageHeader } from "@/components/ui/PageHeader";
+import styles from "./page.module.css";
+
+export default function SessionsLoading() {
+  return (
+    <>
+      <PageHeader title="Sessions" />
+      <main className={styles.shell}>
+        <section className={styles.intro}>
+          <div>
+            <h1>Sessions and reviews</h1>
+            <p>Loading session and review activity.</p>
+          </div>
+        </section>
+        <div className={styles.loadingGrid}>
+          <div />
+          <div />
+          <div />
+          <div />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/packages/web/app/sessions/page.module.css
+++ b/packages/web/app/sessions/page.module.css
@@ -1,0 +1,79 @@
+.shell {
+  padding: 20px 32px 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.intro {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.intro h1 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 30px;
+  font-weight: 600;
+}
+
+.intro p {
+  margin: 8px 0 0;
+  max-width: 720px;
+  color: var(--paper-ink-muted);
+}
+
+.headerLink,
+.secondaryLink {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+  white-space: nowrap;
+}
+
+.loadingGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.loadingGrid div {
+  min-height: 76px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-bg-warm);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@media (max-width: 820px) {
+  .shell {
+    padding: 16px;
+  }
+
+  .intro {
+    display: grid;
+  }
+
+  .loadingGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .loadingGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/web/app/sessions/page.tsx
+++ b/packages/web/app/sessions/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { SessionsReviewList } from "@/components/sessions/SessionsReviewList";
+import { getSessionsOverviewData, normalizeSessionsFilters } from "@/lib/sessions-data";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Sessions - issuectl" };
+
+export default async function SessionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const filters = normalizeSessionsFilters(await searchParams);
+  const data = await getSessionsOverviewData(filters);
+
+  return (
+    <>
+      <PageHeader
+        title="Sessions"
+        breadcrumb={<Link href="/">dashboard</Link>}
+        actions={<Link className={styles.headerLink} href="/workbench">Workbench</Link>}
+      />
+      <main className={styles.shell}>
+        <section className={styles.intro}>
+          <div>
+            <h1>Sessions and reviews</h1>
+            <p>Scan active terminals, recently ended agent sessions, and PR review runs across tracked repositories.</p>
+          </div>
+          <Link className={styles.secondaryLink} href="/settings/repos">Repo settings</Link>
+        </section>
+        <SessionsReviewList data={data} />
+      </main>
+    </>
+  );
+}

--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -17,6 +17,18 @@
   justify-content: space-between;
 }
 
+.sectionLink {
+  min-height: 28px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  color: var(--text-primary);
+  font: 700 11px var(--paper-mono);
+  text-decoration: none;
+}
+
 .sectionSkeleton {
   height: 40px;
   background: var(--paper-bg);

--- a/packages/web/app/settings/page.module.css
+++ b/packages/web/app/settings/page.module.css
@@ -17,15 +17,23 @@
   justify-content: space-between;
 }
 
-.sectionLink {
-  min-height: 28px;
-  padding: 0 10px;
+.quickLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: -6px 0 16px;
+}
+
+.quickLinks a {
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
+  padding: 0 10px;
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-sm);
-  color: var(--text-primary);
-  font: 700 11px var(--paper-mono);
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
   text-decoration: none;
 }
 

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -64,7 +64,10 @@ export default async function SettingsPage({
       <PageHeader title="Settings" breadcrumb={<Link href={returnHref}>← dashboard</Link>} />
       <div className={styles.content}>
         <section className={styles.section}>
-          <div className={styles.sectionTitle}>Tracked Repositories</div>
+          <div className={styles.sectionTitle}>
+            Tracked Repositories
+            <Link className={styles.sectionLink} href="/settings/repos">Repo settings</Link>
+          </div>
           <TrackedRepos repos={repos} />
         </section>
 

--- a/packages/web/app/settings/page.tsx
+++ b/packages/web/app/settings/page.tsx
@@ -64,9 +64,11 @@ export default async function SettingsPage({
       <PageHeader title="Settings" breadcrumb={<Link href={returnHref}>← dashboard</Link>} />
       <div className={styles.content}>
         <section className={styles.section}>
-          <div className={styles.sectionTitle}>
-            Tracked Repositories
-            <Link className={styles.sectionLink} href="/settings/repos">Repo settings</Link>
+          <div className={styles.sectionTitle}>Tracked Repositories</div>
+          <div className={styles.quickLinks}>
+            <Link href="/settings/repos">Repo settings</Link>
+            <Link href="/sessions">Sessions and reviews</Link>
+            <Link href="/workbench">Workbench</Link>
           </div>
           <TrackedRepos repos={repos} />
         </section>

--- a/packages/web/app/settings/repos/loading.tsx
+++ b/packages/web/app/settings/repos/loading.tsx
@@ -1,0 +1,14 @@
+import styles from "./page.module.css";
+
+export default function Loading() {
+  return (
+    <main className={styles.shell}>
+      <section className={styles.summary}>
+        <div>
+          <h1>Tracked repositories</h1>
+          <p className={styles.muted}>Loading repo settings...</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/packages/web/app/settings/repos/page.module.css
+++ b/packages/web/app/settings/repos/page.module.css
@@ -1,0 +1,92 @@
+.shell {
+  padding: 20px 32px 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.summary h1 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 30px;
+  font-weight: 600;
+}
+
+.summary p {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  max-width: 680px;
+}
+
+.repoGrid {
+  display: grid;
+  gap: 12px;
+}
+
+.repoCard {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-surface);
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.repoCard header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.repoCard h2 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 20px;
+}
+
+.repoMeta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: #ece8de;
+  color: var(--text-primary);
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.pill[data-on="true"] {
+  color: #14351f;
+  background: #dff3df;
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+@media (max-width: 720px) {
+  .shell {
+    padding: 16px;
+  }
+
+  .summary,
+  .repoCard header {
+    display: grid;
+  }
+}

--- a/packages/web/app/settings/repos/page.tsx
+++ b/packages/web/app/settings/repos/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { dbExists, getDb, listRepos } from "@issuectl/core";
+import { PageHeader } from "@/components/ui/PageHeader";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Repo settings - issuectl" };
+
+export default async function RepoSettingsIndexPage() {
+  if (!dbExists()) {
+    return (
+      <>
+        <PageHeader title="Repo settings" breadcrumb={<Link href="/settings">settings</Link>} />
+        <main className={styles.shell}>
+          <p className={styles.muted}>Run <code>issuectl init</code> to create the local database.</p>
+        </main>
+      </>
+    );
+  }
+
+  const repos = listRepos(getDb());
+  return (
+    <>
+      <PageHeader title="Repo settings" breadcrumb={<Link href="/settings">settings</Link>} />
+      <main className={styles.shell}>
+        <section className={styles.summary}>
+          <div>
+            <h1>Tracked repositories</h1>
+            <p>Open a repository to configure local defaults, automation, webhook health, labels, and removal controls.</p>
+          </div>
+          <span className={styles.pill}>{repos.length} tracked</span>
+        </section>
+
+        <section className={styles.repoGrid} aria-label="Tracked repositories">
+          {repos.map((repo) => (
+            <Link
+              key={repo.id}
+              className={styles.repoCard}
+              href={`/repos/${repo.owner}/${repo.name}/settings`}
+            >
+              <header>
+                <div>
+                  <h2>{repo.owner}/{repo.name}</h2>
+                  <p className={styles.muted}>{repo.localPath ?? "No local path configured"}</p>
+                </div>
+                <div className={styles.repoMeta}>
+                  <span className={styles.pill} data-on={repo.autoLaunchIssues}>issues</span>
+                  <span className={styles.pill} data-on={repo.autoReviewPrs}>PRs</span>
+                  <span className={styles.pill}>{repo.webhookId ? `hook ${repo.webhookId}` : "no hook"}</span>
+                </div>
+              </header>
+              <span className={styles.muted}>Branch pattern: {repo.branchPattern ?? "default"}</span>
+            </Link>
+          ))}
+          {repos.length === 0 && (
+            <p className={styles.muted}>No repositories are tracked yet.</p>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}

--- a/packages/web/components/repos/RepoSettingsPanel.module.css
+++ b/packages/web/components/repos/RepoSettingsPanel.module.css
@@ -1,0 +1,209 @@
+.shell {
+  display: grid;
+  gap: 18px;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.hero h1,
+.section h2,
+.dangerSection h2 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-weight: 600;
+}
+
+.hero p,
+.section p,
+.dangerSection p {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--text-secondary);
+  font: 700 11px var(--paper-mono);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.activityGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-line);
+}
+
+.metric {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  background: var(--paper-surface);
+}
+
+.metric span {
+  color: var(--text-secondary);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.metric strong {
+  font-family: var(--paper-serif);
+  font-size: 22px;
+}
+
+.section,
+.dangerSection {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-surface);
+}
+
+.dangerSection {
+  border-color: #d9aaa2;
+}
+
+.formGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.toggleGrid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.toggleGrid label {
+  min-height: 42px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.section label {
+  display: grid;
+  gap: 6px;
+}
+
+.section label > span {
+  color: var(--text-secondary);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.section input:not([type="checkbox"]),
+.section select {
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--text-primary);
+  font: 13px var(--paper-serif);
+}
+
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton {
+  min-height: 36px;
+  padding: 0 13px;
+  border-radius: var(--paper-radius-sm);
+  font: 700 12px var(--paper-mono);
+}
+
+.primaryButton {
+  border: 1px solid var(--paper-accent);
+  background: var(--paper-accent);
+  color: white;
+}
+
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border: 1px solid var(--paper-line);
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.dangerButton {
+  width: fit-content;
+  border: 1px solid #b44a3d;
+  background: #b44a3d;
+  color: white;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 26px;
+  padding: 0 9px;
+  border-radius: 999px;
+  color: #5d4100;
+  background: #ffe8aa;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.statusPill[data-state="healthy"] {
+  color: #14351f;
+  background: #dff3df;
+}
+
+.statusPill[data-state="error"] {
+  color: #6e2119;
+  background: #ffd6ce;
+}
+
+.stickyActions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 0;
+  background: var(--paper-bg);
+}
+
+.stickyActions p {
+  margin: 0;
+  color: var(--paper-accent);
+}
+
+.error {
+  color: #9f1d12 !important;
+}
+
+@media (max-width: 720px) {
+  .hero,
+  .stickyActions {
+    display: grid;
+  }
+}

--- a/packages/web/components/repos/RepoSettingsPanel.module.css
+++ b/packages/web/components/repos/RepoSettingsPanel.module.css
@@ -171,6 +171,20 @@
   text-transform: uppercase;
 }
 
+.warningPill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid #d6a33f;
+  border-radius: var(--paper-radius-sm);
+  color: #5d4100;
+  background: #fff2c9;
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
 .statusPill[data-state="healthy"] {
   color: #14351f;
   background: #dff3df;

--- a/packages/web/components/repos/RepoSettingsPanel.tsx
+++ b/packages/web/components/repos/RepoSettingsPanel.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { LaunchAgent, Repo, WebhookPayloadMode } from "@issuectl/core";
+import { removeRepo, updateRepo } from "@/lib/actions/repos";
+import styles from "./RepoSettingsPanel.module.css";
+
+export type RepoSettingsActivity = {
+  activeSessions: number;
+  recentCompletions: number;
+  webhookEvents: number;
+  prReviews: number;
+};
+
+export type RepoSettingsPanelProps = {
+  repo: Repo;
+  webhookUrl: string | null;
+  activity: RepoSettingsActivity;
+  settingsHref?: string;
+};
+
+type LabelHealth = {
+  status: "idle" | "checking" | "healthy" | "missing" | "error";
+  message: string;
+};
+
+type WebhookResult = {
+  success: true;
+  repo: Repo;
+  webhook: { id: number; url: string; createdBy: string };
+} | { success: false; error: string };
+
+const REQUIRED_LABELS = ["issuectl:auto-launch", "issuectl:auto-review"];
+
+export function RepoSettingsPanel({
+  repo,
+  webhookUrl,
+  activity,
+  settingsHref,
+}: RepoSettingsPanelProps) {
+  const [localPath, setLocalPath] = useState(repo.localPath ?? "");
+  const [branchPattern, setBranchPattern] = useState(repo.branchPattern ?? "");
+  const [autoLaunchIssues, setAutoLaunchIssues] = useState(repo.autoLaunchIssues);
+  const [autoReviewPrs, setAutoReviewPrs] = useState(repo.autoReviewPrs);
+  const [issueAgent, setIssueAgent] = useState<LaunchAgent>(repo.issueAgent);
+  const [reviewAgent, setReviewAgent] = useState<LaunchAgent>(repo.reviewAgent);
+  const [webhookPayloadMode, setWebhookPayloadMode] = useState<WebhookPayloadMode>(repo.webhookPayloadMode);
+  const [webhookId, setWebhookId] = useState(repo.webhookId);
+  const [labelHealth, setLabelHealth] = useState<LabelHealth>({
+    status: "idle",
+    message: "Not checked",
+  });
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const repoPath = `${repo.owner}/${repo.name}`;
+  const webhookConfigured = webhookId !== null && webhookId !== undefined;
+
+  function saveSettings() {
+    setMessage(null);
+    setError(null);
+    startTransition(async () => {
+      const result = await updateRepo(repo.id, {
+        localPath: localPath.trim() || undefined,
+        branchPattern: branchPattern.trim() || undefined,
+        autoLaunchIssues,
+        autoReviewPrs,
+        issueAgent,
+        reviewAgent,
+        webhookPayloadMode,
+      });
+      if (!result.success) {
+        setError(result.error ?? "Failed to save repo settings");
+        return;
+      }
+      setMessage("Repo settings saved");
+    });
+  }
+
+  function removeTrackedRepo() {
+    const confirmed = window.confirm(`Remove ${repoPath}? Active webhook sessions may be ended.`);
+    if (!confirmed) return;
+    setMessage(null);
+    setError(null);
+    startTransition(async () => {
+      const result = await removeRepo(repo.id);
+      if (!result.success) {
+        setError(result.error ?? "Failed to remove repository");
+        return;
+      }
+      setMessage(`${repoPath} removed`);
+    });
+  }
+
+  async function configureWebhook(action: "create" | "rotate") {
+    setMessage(null);
+    setError(null);
+    try {
+      const response = await fetch(`/api/v1/repos/${repo.owner}/${repo.name}/webhook`, {
+        method: "POST",
+        headers: requestHeaders(),
+        body: JSON.stringify({ action }),
+      });
+      const body = await response.json().catch(() => undefined) as WebhookResult | undefined;
+      if (!response.ok || !body || body.success !== true) {
+        const failure = body as { error?: string } | undefined;
+        throw new Error(failure?.error ?? `Webhook request failed with ${response.status}`);
+      }
+      setWebhookId(body.webhook.id);
+      setMessage(`${action === "create" ? "Webhook installed" : "Webhook secret rotated"} by ${body.webhook.createdBy}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Webhook request failed");
+    }
+  }
+
+  async function checkLabels() {
+    setLabelHealth({ status: "checking", message: "Checking labels" });
+    setError(null);
+    try {
+      const response = await fetch(`/api/v1/repos/${repo.owner}/${repo.name}/labels`, {
+        method: "GET",
+        headers: requestHeaders(),
+      });
+      const body = await response.json().catch(() => undefined) as {
+        labels?: Array<{ name: string }>;
+        error?: string;
+      } | undefined;
+      if (!response.ok) throw new Error(body?.error ?? "Label check failed");
+      const names = new Set((body?.labels ?? []).map((label) => label.name));
+      const missing = REQUIRED_LABELS.filter((label) => !names.has(label));
+      setLabelHealth(missing.length === 0
+        ? { status: "healthy", message: "Required labels are present" }
+        : { status: "missing", message: `Missing ${missing.join(", ")}` });
+    } catch (err) {
+      setLabelHealth({
+        status: "error",
+        message: err instanceof Error ? err.message : "Label check failed",
+      });
+    }
+  }
+
+  async function recreateLabels() {
+    setLabelHealth({ status: "checking", message: "Recreating labels" });
+    setError(null);
+    try {
+      const response = await fetch(`/api/v1/repos/${repo.owner}/${repo.name}/labels`, {
+        method: "POST",
+        headers: requestHeaders(),
+        body: JSON.stringify({ action: "recreate" }),
+      });
+      const body = await response.json().catch(() => undefined) as { success?: boolean; error?: string } | undefined;
+      if (!response.ok || !body?.success) throw new Error(body?.error ?? "Label recreate failed");
+      setLabelHealth({ status: "healthy", message: "Required labels recreated" });
+      setMessage("Label health restored");
+    } catch (err) {
+      setLabelHealth({
+        status: "error",
+        message: err instanceof Error ? err.message : "Label recreate failed",
+      });
+    }
+  }
+
+  return (
+    <div className={styles.shell}>
+      <section className={styles.hero}>
+        <div>
+          <p className={styles.eyebrow}>Repository settings</p>
+          <h1>{repoPath}</h1>
+          <p>Automation, webhook, labels, activity, and removal controls for this tracked repository.</p>
+        </div>
+        {settingsHref && <a className={styles.secondaryButton} href={settingsHref}>All repos</a>}
+      </section>
+
+      <section className={styles.activityGrid} aria-label="Repository activity">
+        <Metric label="Active" value={activity.activeSessions} />
+        <Metric label="Completed" value={activity.recentCompletions} />
+        <Metric label="Webhooks" value={activity.webhookEvents} />
+        <Metric label="Reviews" value={activity.prReviews} />
+      </section>
+
+      <section className={styles.section} aria-label="Local defaults">
+        <div>
+          <h2>Local defaults</h2>
+          <p>These defaults drive worktree setup and branch naming when automation starts work.</p>
+        </div>
+        <div className={styles.formGrid}>
+          <label>
+            <span>Local path</span>
+            <input value={localPath} onChange={(event) => setLocalPath(event.target.value)} placeholder="~/Desktop/issuectl" />
+          </label>
+          <label>
+            <span>Branch pattern</span>
+            <input value={branchPattern} onChange={(event) => setBranchPattern(event.target.value)} placeholder="issue-{number}-{slug}" />
+          </label>
+        </div>
+      </section>
+
+      <section className={styles.section} aria-label="Automation">
+        <div>
+          <h2>Automation</h2>
+          <p>Choose which GitHub events can create local sessions and which agent handles them.</p>
+        </div>
+        <div className={styles.toggleGrid}>
+          <label>
+            <input type="checkbox" checked={autoLaunchIssues} onChange={(event) => setAutoLaunchIssues(event.target.checked)} />
+            <span>Auto-launch labeled issues</span>
+          </label>
+          <label>
+            <input type="checkbox" checked={autoReviewPrs} onChange={(event) => setAutoReviewPrs(event.target.checked)} />
+            <span>Auto-review labeled PRs</span>
+          </label>
+        </div>
+        <div className={styles.formGrid}>
+          <label>
+            <span>Issue agent</span>
+            <select value={issueAgent} onChange={(event) => setIssueAgent(event.target.value as LaunchAgent)}>
+              <option value="claude">Claude</option>
+              <option value="codex">Codex</option>
+            </select>
+          </label>
+          <label>
+            <span>Review agent</span>
+            <select value={reviewAgent} onChange={(event) => setReviewAgent(event.target.value as LaunchAgent)}>
+              <option value="claude">Claude</option>
+              <option value="codex">Codex</option>
+            </select>
+          </label>
+          <label>
+            <span>Payload mode</span>
+            <select value={webhookPayloadMode} onChange={(event) => setWebhookPayloadMode(event.target.value as WebhookPayloadMode)}>
+              <option value="metadata">Metadata</option>
+              <option value="raw">Raw payloads</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section className={styles.section} aria-label="Webhook">
+        <div>
+          <h2>Webhook</h2>
+          <p>{webhookConfigured ? `GitHub hook ${webhookId} is stored locally.` : "No GitHub webhook id is stored locally."}</p>
+        </div>
+        <label>
+          <span>Receiver URL</span>
+          <input value={webhookUrl ?? "Set Public Webhook Base URL first"} readOnly />
+        </label>
+        <div className={styles.actionRow}>
+          <button type="button" className={styles.secondaryButton} disabled={!webhookUrl} onClick={() => void copyWebhookUrl(webhookUrl)}>
+            Copy URL
+          </button>
+          <button type="button" className={styles.secondaryButton} disabled={!webhookUrl} onClick={() => void configureWebhook(webhookConfigured ? "rotate" : "create")}>
+            {webhookConfigured ? "Rotate secret" : "Install webhook"}
+          </button>
+        </div>
+      </section>
+
+      <section className={styles.section} aria-label="Label health">
+        <div>
+          <h2>Label health</h2>
+          <p>Automation listens for `issuectl:auto-launch` and `issuectl:auto-review` labels.</p>
+        </div>
+        <span className={styles.statusPill} data-state={labelHealth.status}>{labelHealth.message}</span>
+        <div className={styles.actionRow}>
+          <button type="button" className={styles.secondaryButton} onClick={() => void checkLabels()}>
+            Check labels
+          </button>
+          <button type="button" className={styles.secondaryButton} onClick={() => void recreateLabels()}>
+            Recreate labels
+          </button>
+        </div>
+      </section>
+
+      <section className={styles.dangerSection} aria-label="Danger zone">
+        <div>
+          <h2>Danger zone</h2>
+          <p>Removing a repo deletes local tracking and can end active webhook-launched sessions.</p>
+        </div>
+        <button type="button" className={styles.dangerButton} onClick={removeTrackedRepo} disabled={isPending}>
+          Remove repository
+        </button>
+      </section>
+
+      <div className={styles.stickyActions}>
+        <button type="button" className={styles.primaryButton} onClick={saveSettings} disabled={isPending}>
+          {isPending ? "Saving" : "Save settings"}
+        </button>
+        {message && <p role="status">{message}</p>}
+        {error && <p role="alert" className={styles.error}>{error}</p>}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className={styles.metric}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+async function copyWebhookUrl(value: string | null): Promise<void> {
+  if (!value) return;
+  await navigator.clipboard.writeText(value);
+}
+
+function requestHeaders(): Headers {
+  const headers = new Headers({ Accept: "application/json", "Content-Type": "application/json" });
+  const token = window.localStorage.getItem("issuectl.apiToken")
+    ?? window.localStorage.getItem("issuectlApiToken");
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  return headers;
+}

--- a/packages/web/components/repos/RepoSettingsPanel.tsx
+++ b/packages/web/components/repos/RepoSettingsPanel.tsx
@@ -56,6 +56,7 @@ export function RepoSettingsPanel({
 
   const repoPath = `${repo.owner}/${repo.name}`;
   const webhookConfigured = webhookId !== null && webhookId !== undefined;
+  const waitingForFirstPing = webhookConfigured && activity.webhookEvents === 0;
 
   function saveSettings() {
     setMessage(null);
@@ -108,7 +109,8 @@ export function RepoSettingsPanel({
         throw new Error(failure?.error ?? `Webhook request failed with ${response.status}`);
       }
       setWebhookId(body.webhook.id);
-      setMessage(`${action === "create" ? "Webhook installed" : "Webhook secret rotated"} by ${body.webhook.createdBy}`);
+      const successMessage = `${action === "create" ? "Webhook installed" : "Webhook secret rotated"} by ${body.webhook.createdBy}`;
+      setMessage(activity.webhookEvents === 0 ? `${successMessage}. Waiting for first delivery.` : successMessage);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Webhook request failed");
     }
@@ -241,6 +243,11 @@ export function RepoSettingsPanel({
           <h2>Webhook</h2>
           <p>{webhookConfigured ? `GitHub hook ${webhookId} is stored locally.` : "No GitHub webhook id is stored locally."}</p>
         </div>
+        {waitingForFirstPing && (
+          <div className={styles.warningPill} role="status">
+            Waiting for first GitHub delivery
+          </div>
+        )}
         <label>
           <span>Receiver URL</span>
           <input value={webhookUrl ?? "Set Public Webhook Base URL first"} readOnly />

--- a/packages/web/components/reviews/ReviewDetailPanel.module.css
+++ b/packages/web/components/reviews/ReviewDetailPanel.module.css
@@ -1,0 +1,303 @@
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 18px;
+  align-items: start;
+}
+
+.main,
+.railPanel {
+  display: grid;
+  gap: 14px;
+}
+
+.summary,
+.section,
+.card {
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-bg) 78%, white);
+}
+
+.summary {
+  padding: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.summary p {
+  margin: 0;
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.summary h1 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 30px;
+  font-weight: 600;
+}
+
+.chips,
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.chip {
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 8px;
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  background: #ece8de;
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.chip[data-tone="good"] {
+  border-color: #b8d8b8;
+  background: #dff3df;
+  color: #14351f;
+}
+
+.chip[data-tone="accent"] {
+  border-color: #bfd2c4;
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+}
+
+.chip[data-tone="warn"] {
+  border-color: #e2c57d;
+  background: #f1e0ae;
+  color: #5d4210;
+}
+
+.chip[data-tone="bad"] {
+  border-color: #e0b4a7;
+  background: #f0d4cc;
+  color: #6b2417;
+}
+
+.banners,
+.timeline,
+.diagnostics {
+  display: grid;
+  gap: 10px;
+}
+
+.banner {
+  padding: 12px 14px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+}
+
+.banner[data-tone="bad"] {
+  border-color: #d99a89;
+  background: #f0d4cc;
+}
+
+.banner[data-tone="warn"] {
+  border-color: #d7b867;
+  background: #f1e0ae;
+}
+
+.banner[data-tone="info"] {
+  border-color: #bfd2c4;
+  background: var(--paper-accent-soft);
+}
+
+.banner p,
+.diagnostic p {
+  margin: 4px 0 0;
+  color: var(--paper-ink-muted);
+}
+
+.section {
+  padding: 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.sectionHeader h2,
+.card h2 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.sectionHeader span {
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.run {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--paper-line-soft);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, white 32%, transparent);
+}
+
+.run[data-active="true"] {
+  border-color: color-mix(in srgb, var(--paper-accent) 42%, var(--paper-line));
+}
+
+.rail {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px;
+  border-radius: 999px;
+  background: var(--paper-accent);
+  box-shadow: 0 0 0 4px var(--paper-accent-soft);
+}
+
+.runBody {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.runTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.runBody p {
+  margin: 0;
+  color: var(--paper-ink-muted);
+  font-family: var(--paper-mono);
+}
+
+.facts,
+.sideFacts {
+  display: grid;
+  gap: 8px;
+}
+
+.facts {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.facts div,
+.sideFacts div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.facts dt,
+.sideFacts dt {
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.facts dd,
+.sideFacts dd {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diagnostic {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--paper-line-soft);
+}
+
+.diagnostic:last-child {
+  border-bottom: 0;
+}
+
+.diagnostic span {
+  display: block;
+  margin-top: 3px;
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.card {
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.card form {
+  display: grid;
+}
+
+.card button,
+.links a {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+  white-space: nowrap;
+}
+
+.card button {
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+}
+
+.card code {
+  display: block;
+  padding: 10px;
+  overflow-x: auto;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg-warm);
+  color: var(--paper-ink-muted);
+  font-size: var(--paper-fs-xs);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .summary h1 {
+    font-size: 24px;
+  }
+
+  .facts {
+    grid-template-columns: 1fr;
+  }
+
+  .runTop,
+  .sectionHeader {
+    display: grid;
+    justify-content: stretch;
+  }
+}

--- a/packages/web/components/reviews/ReviewDetailPanel.tsx
+++ b/packages/web/components/reviews/ReviewDetailPanel.tsx
@@ -1,0 +1,179 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type { ReviewDetailData } from "@/lib/review-detail-data";
+import styles from "./ReviewDetailPanel.module.css";
+
+type Action = (formData: FormData) => void | Promise<void>;
+
+type Props = {
+  data: ReviewDetailData;
+  retryAction: Action;
+  fullRerunAction: Action;
+};
+
+export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props) {
+  return (
+    <div className={styles.layout}>
+      <section className={styles.main}>
+        <header className={styles.summary}>
+          <p>{data.repo.owner}/{data.repo.name}</p>
+          <h1>PR #{data.review.prNumber} review run #{data.review.id}</h1>
+          <div className={styles.chips}>
+            <Chip tone={statusTone(data.review.status)}>{labelize(data.review.status)}</Chip>
+            <Chip tone="accent">{triggerLabel(data.review.triggeredBy)}</Chip>
+            <Chip tone="neutral">{data.review.headRef}</Chip>
+          </div>
+        </header>
+
+        {data.banners.length > 0 && (
+          <div className={styles.banners} aria-label="Review status banners">
+            {data.banners.map((banner) => (
+              <article key={banner.title} className={styles.banner} data-tone={banner.tone}>
+                <strong>{banner.title}</strong>
+                <p>{banner.body}</p>
+              </article>
+            ))}
+          </div>
+        )}
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2>Lineage</h2>
+            <span>{data.lineage.length} runs</span>
+          </div>
+          <div className={styles.timeline}>
+            {data.lineage.map((run) => (
+              <article key={run.id} className={styles.run} data-active={run.active ? "true" : undefined}>
+                <div className={styles.rail} aria-hidden="true" />
+                <div className={styles.runBody}>
+                  <div className={styles.runTop}>
+                    <strong>Run #{run.id}</strong>
+                    <Chip tone={statusTone(run.status)}>{labelize(run.status)}</Chip>
+                  </div>
+                  <p>{run.label}</p>
+                  <dl className={styles.facts}>
+                    <div>
+                      <dt>Started</dt>
+                      <dd>{formatUnix(run.startedAt)}</dd>
+                    </div>
+                    <div>
+                      <dt>Completed</dt>
+                      <dd>{run.completedAt ? formatUnix(run.completedAt) : "not complete"}</dd>
+                    </div>
+                    <div>
+                      <dt>Head</dt>
+                      <dd>{shortSha(run.reviewedToSha)}</dd>
+                    </div>
+                    <div>
+                      <dt>Trigger</dt>
+                      <dd>{triggerLabel(run.triggeredBy)}</dd>
+                    </div>
+                  </dl>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2>Diagnostics</h2>
+            <span>{data.diagnostics.length} events</span>
+          </div>
+          <div className={styles.diagnostics}>
+            {data.diagnostics.length === 0 && <p>No diagnostic events recorded for this PR target yet.</p>}
+            {data.diagnostics.map((event) => (
+              <article key={event.id} className={styles.diagnostic}>
+                <strong>{event.event}</strong>
+                <span>{formatUnix(Math.floor(event.timestamp / 1000))} - {event.level}</span>
+                {event.message && <p>{event.message}</p>}
+              </article>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <aside className={styles.railPanel}>
+        <section className={styles.card}>
+          <h2>Actions</h2>
+          <form action={retryAction}>
+            <input type="hidden" name="reviewId" value={data.review.id} />
+            <button type="submit">Retry review</button>
+          </form>
+          <form action={fullRerunAction}>
+            <input type="hidden" name="reviewId" value={data.review.id} />
+            <button type="submit">Full rerun</button>
+          </form>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Run details</h2>
+          <dl className={styles.sideFacts}>
+            <div>
+              <dt>Base</dt>
+              <dd>{shortSha(data.review.reviewBaseSha)}</dd>
+            </div>
+            <div>
+              <dt>Range</dt>
+              <dd>{data.review.reviewedFromSha ? `${shortSha(data.review.reviewedFromSha)}..${shortSha(data.review.reviewedToSha)}` : `full ${shortSha(data.review.reviewedToSha)}`}</dd>
+            </div>
+            <div>
+              <dt>Head repo</dt>
+              <dd>{data.review.headRepoFullName}</dd>
+            </div>
+            <div>
+              <dt>Session</dt>
+              <dd>{data.deployment ? `#${data.deployment.id}` : "none linked"}</dd>
+            </div>
+            <div>
+              <dt>Terminal</dt>
+              <dd>{data.deployment?.terminalReason ? labelize(data.deployment.terminalReason) : "not recorded"}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Links</h2>
+          <div className={styles.links}>
+            <a href={data.links.githubPr}>GitHub PR</a>
+            <Link href={data.links.workbench}>Workbench</Link>
+            <Link href={data.links.sessions}>Sessions list</Link>
+            <Link href={data.links.repoSettings}>Repo settings</Link>
+          </div>
+        </section>
+
+        <section className={styles.card}>
+          <h2>CLI hint</h2>
+          <code>{data.links.diagnosticsCli}</code>
+        </section>
+      </aside>
+    </div>
+  );
+}
+
+function Chip({ children, tone }: { children: ReactNode; tone: string }) {
+  return <span className={styles.chip} data-tone={tone}>{children}</span>;
+}
+
+function statusTone(status: string): string {
+  if (status === "completed") return "good";
+  if (status === "failed") return "bad";
+  if (status === "superseded") return "warn";
+  return "accent";
+}
+
+function triggerLabel(trigger: string): string {
+  return trigger === "comment_command" ? "comment" : trigger;
+}
+
+function labelize(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 7);
+}
+
+function formatUnix(value: number): string {
+  return new Date(value * 1000).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}

--- a/packages/web/components/sessions/SessionsReviewList.module.css
+++ b/packages/web/components/sessions/SessionsReviewList.module.css
@@ -1,0 +1,312 @@
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.metric {
+  min-height: 76px;
+  padding: 14px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-bg-warm) 62%, white);
+}
+
+.metric strong {
+  font-family: var(--paper-serif);
+  font-size: 28px;
+  line-height: 1;
+}
+
+.metric span {
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.tabs {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-bg-warm) 72%, white);
+  overflow-x: auto;
+}
+
+.tab {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  border-radius: var(--paper-radius-sm);
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tab[data-active="true"] {
+  background: var(--paper-accent);
+  color: white;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(160px, 220px) minmax(130px, 160px) minmax(130px, 160px) auto auto;
+  gap: 10px;
+  align-items: end;
+  padding: 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-bg-warm);
+}
+
+.filters label {
+  display: grid;
+  gap: 5px;
+}
+
+.filters label span {
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.filters input,
+.filters select {
+  min-height: 36px;
+  width: 100%;
+  padding: 0 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 48%, var(--paper-bg));
+}
+
+.filters button,
+.resetLink,
+.linkButton {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+  white-space: nowrap;
+}
+
+.resetLink,
+.linkButton {
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+}
+
+.groups {
+  display: grid;
+  gap: 12px;
+}
+
+.group,
+.empty {
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-bg) 78%, white);
+}
+
+.groupHeader {
+  min-height: 74px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.groupHeader p,
+.rowMeta,
+.preview {
+  color: var(--paper-ink-muted);
+}
+
+.groupHeader p {
+  margin: 0 0 4px;
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.groupHeader h2 {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.rows,
+.timeline {
+  display: grid;
+}
+
+.row,
+.reviewRun {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--paper-line-soft);
+}
+
+.row:last-child,
+.reviewRun:last-child {
+  border-bottom: 0;
+}
+
+.reviewRun {
+  grid-template-columns: 18px minmax(220px, 1fr) auto;
+}
+
+.runRail {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--paper-accent);
+  box-shadow: 0 0 0 4px var(--paper-accent-soft);
+}
+
+.rowMain {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.rowTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.rowMeta,
+.preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--paper-fs-sm);
+}
+
+.chips,
+.rowLinks {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.rowLinks a {
+  color: var(--paper-accent);
+  font: 600 var(--paper-fs-sm) var(--paper-mono);
+}
+
+.chip {
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 8px;
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  background: #ece8de;
+  color: var(--paper-ink);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.chip[data-tone="good"] {
+  border-color: #b8d8b8;
+  background: #dff3df;
+  color: #14351f;
+}
+
+.chip[data-tone="accent"] {
+  border-color: #bfd2c4;
+  background: var(--paper-accent-soft);
+  color: var(--paper-accent);
+}
+
+.chip[data-tone="warn"] {
+  border-color: #e2c57d;
+  background: #f1e0ae;
+  color: #5d4210;
+}
+
+.chip[data-tone="bad"] {
+  border-color: #e0b4a7;
+  background: #f0d4cc;
+  color: #6b2417;
+}
+
+.empty {
+  padding: 22px;
+}
+
+.empty h2 {
+  margin: 0 0 6px;
+  font-family: var(--paper-serif);
+  font-size: 22px;
+}
+
+.empty p {
+  margin: 0;
+  color: var(--paper-ink-muted);
+}
+
+@media (max-width: 980px) {
+  .summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .searchBox {
+    grid-column: 1 / -1;
+  }
+
+  .row,
+  .reviewRun {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .chips,
+  .rowLinks {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .summary,
+  .filters {
+    grid-template-columns: 1fr;
+  }
+
+  .groupHeader {
+    display: grid;
+    align-items: start;
+  }
+}

--- a/packages/web/components/sessions/SessionsReviewList.tsx
+++ b/packages/web/components/sessions/SessionsReviewList.tsx
@@ -1,0 +1,291 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type {
+  ReviewPrGroup,
+  SessionTargetGroup,
+  SessionsFilters,
+  SessionsOverviewData,
+  SessionsTab,
+} from "@/lib/sessions-data";
+import styles from "./SessionsReviewList.module.css";
+
+type Props = {
+  data: SessionsOverviewData;
+};
+
+const TABS: Array<{ id: SessionsTab; label: string }> = [
+  { id: "sessions", label: "Sessions" },
+  { id: "reviews", label: "Reviews" },
+];
+
+export function SessionsReviewList({ data }: Props) {
+  const { filters } = data;
+  return (
+    <div className={styles.stack}>
+      <section className={styles.summary} aria-label="Sessions and reviews summary">
+        <Metric label="Active sessions" value={data.summary.activeSessions} />
+        <Metric label="Recently ended" value={data.summary.endedSessions} />
+        <Metric label="Review runs" value={data.summary.reviewRuns} />
+        <Metric label="Active reviews" value={data.summary.activeReviewRuns} />
+      </section>
+
+      <nav className={styles.tabs} aria-label="Sessions view">
+        {TABS.map((tab) => (
+          <Link
+            key={tab.id}
+            className={styles.tab}
+            data-active={filters.tab === tab.id ? "true" : undefined}
+            href={filterHref(filters, { tab: tab.id })}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+
+      <Filters data={data} />
+
+      {!data.initialized && (
+        <section className={styles.empty}>
+          <h2>No local database</h2>
+          <p>Run <code>issuectl init</code> before reviewing session and PR review history.</p>
+        </section>
+      )}
+
+      {data.initialized && filters.tab === "sessions" && (
+        <SessionGroups groups={data.sessionGroups} />
+      )}
+      {data.initialized && filters.tab === "reviews" && (
+        <ReviewGroups groups={data.reviewGroups} />
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className={styles.metric}>
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function Filters({ data }: Props) {
+  const { filters } = data;
+  return (
+    <form className={styles.filters} action="/sessions">
+      <input type="hidden" name="tab" value={filters.tab} />
+      <label className={styles.searchBox}>
+        <span>Search</span>
+        <input name="q" defaultValue={filters.q} placeholder="repo, branch, target, SHA" />
+      </label>
+
+      <label>
+        <span>Repo</span>
+        <select name="repo" defaultValue={filters.repo}>
+          <option value="">All repos</option>
+          {data.repos.map((repo) => (
+            <option key={repo.id} value={repo.fullName}>{repo.fullName}</option>
+          ))}
+        </select>
+      </label>
+
+      <label>
+        <span>Trigger</span>
+        <select name="trigger" defaultValue={filters.trigger}>
+          <option value="all">All triggers</option>
+          <option value="manual">Manual</option>
+          <option value="webhook">Webhook</option>
+          <option value="comment_command">Comment</option>
+        </select>
+      </label>
+
+      {filters.tab === "sessions" ? (
+        <label>
+          <span>State</span>
+          <select name="state" defaultValue={filters.state}>
+            <option value="all">All states</option>
+            <option value="active">Active</option>
+            <option value="ended">Ended</option>
+          </select>
+        </label>
+      ) : (
+        <label>
+          <span>Status</span>
+          <select name="status" defaultValue={filters.status}>
+            <option value="all">All statuses</option>
+            <option value="reserved">Reserved</option>
+            <option value="launching">Launching</option>
+            <option value="in_progress">In progress</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+            <option value="superseded">Superseded</option>
+          </select>
+        </label>
+      )}
+
+      <button type="submit">Apply</button>
+      <Link className={styles.resetLink} href="/sessions">Reset</Link>
+    </form>
+  );
+}
+
+function SessionGroups({ groups }: { groups: SessionTargetGroup[] }) {
+  if (groups.length === 0) {
+    return (
+      <section className={styles.empty}>
+        <h2>No sessions match</h2>
+        <p>Try a wider repo, trigger, state, or search filter.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.groups} aria-label="Session groups">
+      {groups.map((group) => (
+        <article key={group.key} className={styles.group}>
+          <header className={styles.groupHeader}>
+            <div>
+              <p>{group.repoFullName}</p>
+              <h2>{group.targetLabel}</h2>
+            </div>
+            <Link className={styles.linkButton} href={`/workbench?repo=${encodeURIComponent(group.repoFullName)}`}>
+              Workbench
+            </Link>
+          </header>
+          <div className={styles.rows}>
+            {group.sessions.map((session) => (
+              <div key={session.id} className={styles.row}>
+                <div className={styles.rowMain}>
+                  <span className={styles.rowTitle}>{session.branchName}</span>
+                  <span className={styles.rowMeta}>
+                    {session.agent} - {session.workspaceMode} - launched {formatDateTime(session.launchedAt)}
+                  </span>
+                  <span className={styles.preview}>{session.preview?.lines.join(" ") || session.workspacePath}</span>
+                </div>
+                <div className={styles.chips}>
+                  <Chip tone={session.endedAt ? "neutral" : "good"}>{session.endedAt ? "ended" : "active"}</Chip>
+                  <Chip tone="accent" title={triggerTitle(session.triggeredBy)}>{triggerLabel(session.triggeredBy)}</Chip>
+                  {session.terminalReason && <Chip tone="warn">{labelize(session.terminalReason)}</Chip>}
+                  {session.linkedPrNumber && <Chip tone="neutral">PR #{session.linkedPrNumber}</Chip>}
+                  {session.webhookDepth > 0 && <Chip tone="neutral">depth {session.webhookDepth}</Chip>}
+                </div>
+                <div className={styles.rowLinks}>
+                  <a href={githubTargetHref(session.owner, session.repoName, session.targetType, session.targetNumber)}>
+                    GitHub
+                  </a>
+                  <Link href={`/repos/${session.owner}/${session.repoName}/settings`}>Repo settings</Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function ReviewGroups({ groups }: { groups: ReviewPrGroup[] }) {
+  if (groups.length === 0) {
+    return (
+      <section className={styles.empty}>
+        <h2>No review runs match</h2>
+        <p>Try a wider repo, trigger, status, or search filter.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.groups} aria-label="PR review groups">
+      {groups.map((group) => (
+        <article key={group.key} className={styles.group}>
+          <header className={styles.groupHeader}>
+            <div>
+              <p>{group.repoFullName}</p>
+              <h2>PR #{group.prNumber}</h2>
+            </div>
+            <a className={styles.linkButton} href={githubTargetHref(group.owner, group.repoName, "pr", group.prNumber)}>
+              GitHub PR
+            </a>
+          </header>
+          <div className={styles.timeline}>
+            {group.runs.map((run) => (
+              <div key={run.id} className={styles.reviewRun}>
+                <div className={styles.runRail} aria-hidden="true" />
+                <div className={styles.rowMain}>
+                  <span className={styles.rowTitle}>Run #{run.id}</span>
+                  <span className={styles.rowMeta}>
+                    {formatUnix(run.startedAt)} - {run.headRepoFullName}:{run.headRef}
+                  </span>
+                  <span className={styles.preview}>
+                    {shortSha(run.reviewedFromSha) ?? "base"} to {shortSha(run.reviewedToSha)}
+                    {run.deployment ? ` - session ${run.deployment.id}` : ""}
+                  </span>
+                </div>
+                <div className={styles.chips}>
+                  <Chip tone={reviewTone(run.status)}>{labelize(run.status)}</Chip>
+                  <Chip tone="accent" title={triggerTitle(run.triggeredBy)}>{triggerLabel(run.triggeredBy)}</Chip>
+                  {run.completedAt && <Chip tone="neutral">done {formatUnix(run.completedAt)}</Chip>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function Chip({ children, tone, title }: { children: ReactNode; tone: string; title?: string }) {
+  return <span className={styles.chip} data-tone={tone} title={title}>{children}</span>;
+}
+
+function filterHref(filters: SessionsFilters, next: Partial<SessionsFilters>): string {
+  const merged = { ...filters, ...next };
+  const params = new URLSearchParams();
+  params.set("tab", merged.tab);
+  if (merged.q) params.set("q", merged.q);
+  if (merged.repo) params.set("repo", merged.repo);
+  if (merged.trigger !== "all") params.set("trigger", merged.trigger);
+  if (merged.tab === "sessions" && merged.state !== "all") params.set("state", merged.state);
+  if (merged.tab === "reviews" && merged.status !== "all") params.set("status", merged.status);
+  return `/sessions?${params.toString()}`;
+}
+
+function githubTargetHref(owner: string, repo: string, targetType: "issue" | "pr", targetNumber: number): string {
+  const segment = targetType === "pr" ? "pull" : "issues";
+  return `https://github.com/${owner}/${repo}/${segment}/${targetNumber}`;
+}
+
+function triggerLabel(trigger: string): string {
+  return trigger === "comment_command" ? "comment" : trigger;
+}
+
+function triggerTitle(trigger: string): string {
+  if (trigger === "comment_command") return "Triggered by an issuectl comment command";
+  if (trigger === "webhook") return "Triggered by GitHub webhook automation";
+  return "Triggered manually";
+}
+
+function reviewTone(status: string): string {
+  if (status === "completed") return "good";
+  if (status === "failed") return "bad";
+  if (status === "superseded") return "warn";
+  return "accent";
+}
+
+function labelize(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function shortSha(value: string | null): string | null {
+  return value ? value.slice(0, 7) : null;
+}
+
+function formatUnix(value: number): string {
+  return new Date(value * 1000).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}

--- a/packages/web/components/settings/AddRepoForm.module.css
+++ b/packages/web/components/settings/AddRepoForm.module.css
@@ -9,6 +9,72 @@
   margin-bottom: 8px;
 }
 
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  color: var(--paper-ink-muted);
+  font-family: var(--paper-serif);
+  cursor: pointer;
+}
+
+.step:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.stepActive {
+  color: var(--paper-ink);
+  border-color: var(--paper-accent);
+  background: var(--paper-bg);
+}
+
+.stepIndex {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--paper-line);
+  color: var(--paper-ink);
+  font-size: 12px;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.stepActive .stepIndex {
+  background: var(--paper-accent);
+  color: var(--paper-bg);
+}
+
+.stepLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .row {
   display: flex;
   flex-direction: column;
@@ -137,6 +203,91 @@
   margin-top: 4px;
 }
 
+.automationGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.toggleRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  cursor: pointer;
+}
+
+.toggleRow input {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: var(--paper-accent);
+}
+
+.toggleRow span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.toggleRow strong {
+  color: var(--paper-ink);
+  font-size: 14px;
+}
+
+.toggleRow small {
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.summary {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+}
+
+.summary strong,
+.summary span {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.installList {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 22px;
+  color: var(--paper-ink);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.doneItem {
+  color: var(--paper-accent);
+  font-weight: 600;
+}
+
+.postAddActions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.postAddActions > * {
+  width: 100%;
+  min-height: 44px;
+}
+
 /* Darker warm yellow (#d9a54d on cream fails WCAG AA at 1.89:1). */
 .warning {
   font-size: 13px;
@@ -150,12 +301,29 @@
     align-items: flex-start;
   }
 
+  .automationGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .actions {
     flex-direction: row;
     justify-content: flex-end;
   }
 
   .actions > * {
+    width: auto;
+  }
+
+  .postAddActions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+
+  .postAddActions > * {
     width: auto;
   }
 }

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable max-lines */
 "use client";
 
-import { useState, useTransition, useRef, useEffect } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import type { LaunchAgent, WebhookPayloadMode } from "@issuectl/core";
 import { addRepo } from "@/lib/actions/repos";
 import { Button } from "@/components/paper";
 import { useToast } from "@/components/ui/ToastProvider";
@@ -15,13 +17,28 @@ type Props = {
 
 type RepoIdentity = { owner: string; name: string };
 
-// Discriminated state instead of `mode` + `selected` nullable pair.
-// `mode: "selected" && selected === null` was representable before; now it
-// isn't — the "selected" variant carries its repo inline.
+type WizardStep = "identify" | "automation" | "install";
+
+type AutomationState = {
+  autoLaunchIssues: boolean;
+  autoReviewPrs: boolean;
+  issueAgent: LaunchAgent;
+  reviewAgent: LaunchAgent;
+  webhookPayloadMode: WebhookPayloadMode;
+};
+
 type FormMode =
   | { kind: "picker" }
   | { kind: "selected"; repo: RepoIdentity }
   | { kind: "manual"; input: string };
+
+const DEFAULT_AUTOMATION: AutomationState = {
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookPayloadMode: "metadata",
+};
 
 function parseManual(input: string): RepoIdentity | null {
   const parts = input.trim().split("/");
@@ -29,34 +46,64 @@ function parseManual(input: string): RepoIdentity | null {
   return { owner: parts[0], name: parts[1] };
 }
 
+function repoKey(repo: RepoIdentity): string {
+  return `${repo.owner}/${repo.name}`;
+}
+
 export function AddRepoForm({ onClose, trackedSet }: Props) {
   const router = useRouter();
   const { showToast } = useToast();
+  const [step, setStep] = useState<WizardStep>("identify");
   const [formMode, setFormMode] = useState<FormMode>({ kind: "picker" });
   const [localPath, setLocalPath] = useState("");
+  const [automation, setAutomation] = useState<AutomationState>(DEFAULT_AUTOMATION);
+  const [addedRepo, setAddedRepo] = useState<RepoIdentity | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
+  const target = useMemo(() => {
+    if (formMode.kind === "manual") return parseManual(formMode.input);
+    if (formMode.kind === "selected") return formMode.repo;
+    return null;
+  }, [formMode]);
+
+  const settingsHref = target
+    ? `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.name)}/settings`
+    : "/settings/repos";
+  const dashboardHref = target
+    ? `/?repo=${encodeURIComponent(repoKey(target))}`
+    : "/";
+
+  function updateAutomation(updates: Partial<AutomationState>) {
+    setAutomation((current) => ({ ...current, ...updates }));
+  }
+
+  function handleNext() {
+    setError(null);
+    if (step === "identify") {
+      if (!target) {
+        setError("Format: owner/repo (e.g., mean-weasel/seatify)");
+        return;
+      }
+      if (trackedSet.has(repoKey(target))) {
+        setError(`${repoKey(target)} is already tracked`);
+        return;
+      }
+      setStep("automation");
+      return;
+    }
+    if (step === "automation") {
+      setStep("install");
+    }
+  }
 
   function handleSubmit() {
     setError(null);
     setWarning(null);
-
-    const target =
-      formMode.kind === "manual"
-        ? parseManual(formMode.input)
-        : formMode.kind === "selected"
-          ? formMode.repo
-          : null;
     if (!target) {
       setError("Format: owner/repo (e.g., mean-weasel/seatify)");
+      setStep("identify");
       return;
     }
 
@@ -65,112 +112,253 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
         target.owner,
         target.name,
         localPath.trim() || undefined,
+        automation,
       );
       if (!result.success) {
         setError(result.error);
         return;
       }
-      const { addedRepo } = result;
-      const repoHref = `/?repo=${encodeURIComponent(`${addedRepo.owner}/${addedRepo.name}`)}`;
-      if (result.warning) {
-        setWarning(result.warning);
-        timerRef.current = setTimeout(() => {
-          onClose();
-          router.push(repoHref);
-        }, 2000);
-      } else {
-        showToast("Repository added", "success");
-        onClose();
-        router.push(repoHref);
-      }
+      setAddedRepo(result.addedRepo);
+      setWarning(result.warning ?? null);
+      showToast("Repository added", "success");
     });
   }
 
-  const canSubmit =
+  const canAdvanceIdentify =
     !isPending &&
     (formMode.kind === "manual"
       ? formMode.input.trim().length > 0
       : formMode.kind === "selected");
+  const canSubmit = !isPending && step === "install" && Boolean(target) && !addedRepo;
 
   return (
     <div className={styles.form}>
-      <div className={styles.row}>
-        <div className={styles.field}>
-          <div className={styles.label}>Repository</div>
+      <div className={styles.steps} aria-label="Add repository progress">
+        {(["identify", "automation", "install"] as const).map((item, index) => (
+          <button
+            key={item}
+            type="button"
+            className={`${styles.step} ${step === item ? styles.stepActive : ""}`}
+            onClick={() => setStep(item)}
+            disabled={isPending || (item !== "identify" && !target)}
+            aria-current={step === item ? "step" : undefined}
+          >
+            <span className={styles.stepIndex}>{index + 1}</span>
+            <span className={styles.stepLabel}>
+              {item === "identify" ? "Identify" : item === "automation" ? "Automation" : "Install"}
+            </span>
+          </button>
+        ))}
+      </div>
 
-          {formMode.kind === "picker" && (
-            <RepoPicker
-              trackedSet={trackedSet}
-              disabled={isPending}
-              onSelect={(owner, name) =>
-                setFormMode({ kind: "selected", repo: { owner, name } })
-              }
-              onManualEntry={() => setFormMode({ kind: "manual", input: "" })}
-            />
-          )}
+      {step === "identify" && (
+        <div className={styles.panel}>
+          <div className={styles.row}>
+            <div className={styles.field}>
+              <div className={styles.label}>Repository</div>
 
-          {formMode.kind === "selected" && (
-            <div className={styles.selected}>
-              <span className={styles.selectedDot} />
-              <span className={styles.selectedName}>
-                {formMode.repo.owner}/{formMode.repo.name}
-              </span>
-              <button
-                type="button"
-                className={styles.selectedChange}
-                onClick={() => setFormMode({ kind: "picker" })}
-                disabled={isPending}
-              >
-                change
-              </button>
+              {formMode.kind === "picker" && (
+                <RepoPicker
+                  trackedSet={trackedSet}
+                  disabled={isPending}
+                  onSelect={(owner, name) =>
+                    setFormMode({ kind: "selected", repo: { owner, name } })
+                  }
+                  onManualEntry={() => setFormMode({ kind: "manual", input: "" })}
+                />
+              )}
+
+              {formMode.kind === "selected" && (
+                <div className={styles.selected}>
+                  <span className={styles.selectedDot} />
+                  <span className={styles.selectedName}>
+                    {formMode.repo.owner}/{formMode.repo.name}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.selectedChange}
+                    onClick={() => setFormMode({ kind: "picker" })}
+                    disabled={isPending}
+                  >
+                    change
+                  </button>
+                </div>
+              )}
+
+              {formMode.kind === "manual" && (
+                <div className={styles.manual}>
+                  <input
+                    className={styles.input}
+                    value={formMode.input}
+                    onChange={(event) =>
+                      setFormMode({ kind: "manual", input: event.target.value })
+                    }
+                    placeholder="owner/repo (e.g., mean-weasel/seatify)"
+                    disabled={isPending}
+                    autoFocus
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    enterKeyHint="done"
+                  />
+                  <button
+                    type="button"
+                    className={styles.backLink}
+                    onClick={() => setFormMode({ kind: "picker" })}
+                    disabled={isPending}
+                  >
+                    back to picker
+                  </button>
+                </div>
+              )}
             </div>
-          )}
 
-          {formMode.kind === "manual" && (
-            <div className={styles.manual}>
+            <div className={styles.field}>
+              <div className={styles.label}>Local Path</div>
               <input
                 className={styles.input}
-                value={formMode.input}
-                onChange={(e) =>
-                  setFormMode({ kind: "manual", input: e.target.value })
-                }
-                placeholder="owner/repo (e.g., mean-weasel/seatify)"
+                value={localPath}
+                onChange={(event) => setLocalPath(event.target.value)}
+                placeholder="~/Desktop/my-repo"
                 disabled={isPending}
-                autoFocus
                 autoComplete="off"
                 autoCapitalize="off"
                 autoCorrect="off"
                 spellCheck={false}
-                enterKeyHint="done"
               />
-              <button
-                type="button"
-                className={styles.backLink}
-                onClick={() => setFormMode({ kind: "picker" })}
+              <div className={styles.pathHint}>Optional. Leave blank to prompt on launch.</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {step === "automation" && (
+        <div className={styles.panel}>
+          <div className={styles.automationGrid}>
+            <label className={styles.toggleRow}>
+              <input
+                type="checkbox"
+                checked={automation.autoLaunchIssues}
+                onChange={(event) =>
+                  updateAutomation({ autoLaunchIssues: event.target.checked })
+                }
+                disabled={isPending}
+              />
+              <span>
+                <strong>Issue sessions</strong>
+                <small>Launch a session when labeled issues arrive.</small>
+              </span>
+            </label>
+            <label className={styles.toggleRow}>
+              <input
+                type="checkbox"
+                checked={automation.autoReviewPrs}
+                onChange={(event) =>
+                  updateAutomation({ autoReviewPrs: event.target.checked })
+                }
+                disabled={isPending}
+              />
+              <span>
+                <strong>PR reviews</strong>
+                <small>Reserve opened PRs for review sessions.</small>
+              </span>
+            </label>
+          </div>
+
+          <div className={styles.row}>
+            <label className={styles.field}>
+              <div className={styles.label}>Issue Agent</div>
+              <select
+                className={styles.input}
+                value={automation.issueAgent}
+                onChange={(event) =>
+                  updateAutomation({ issueAgent: event.target.value as LaunchAgent })
+                }
+                disabled={isPending || !automation.autoLaunchIssues}
+              >
+                <option value="codex">Codex</option>
+                <option value="claude">Claude</option>
+              </select>
+            </label>
+            <label className={styles.field}>
+              <div className={styles.label}>Review Agent</div>
+              <select
+                className={styles.input}
+                value={automation.reviewAgent}
+                onChange={(event) =>
+                  updateAutomation({ reviewAgent: event.target.value as LaunchAgent })
+                }
+                disabled={isPending || !automation.autoReviewPrs}
+              >
+                <option value="codex">Codex</option>
+                <option value="claude">Claude</option>
+              </select>
+            </label>
+            <label className={styles.field}>
+              <div className={styles.label}>Payload</div>
+              <select
+                className={styles.input}
+                value={automation.webhookPayloadMode}
+                onChange={(event) =>
+                  updateAutomation({ webhookPayloadMode: event.target.value as WebhookPayloadMode })
+                }
                 disabled={isPending}
               >
-                &larr; back to picker
-              </button>
+                <option value="metadata">Metadata</option>
+                <option value="raw">Raw</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {step === "install" && (
+        <div className={styles.panel}>
+          <div className={styles.summary}>
+            <div>
+              <div className={styles.label}>Repository</div>
+              <strong>{target ? repoKey(target) : "Select a repository"}</strong>
+            </div>
+            <div>
+              <div className={styles.label}>Automation</div>
+              <span>
+                {automation.autoLaunchIssues ? "Issues on" : "Issues off"} ·{" "}
+                {automation.autoReviewPrs ? "PRs on" : "PRs off"} ·{" "}
+                {automation.webhookPayloadMode}
+              </span>
+            </div>
+          </div>
+
+          <ol className={styles.installList}>
+            <li className={addedRepo ? styles.doneItem : ""}>
+              Save repository and automation defaults.
+            </li>
+            <li>Install the GitHub webhook from repo settings.</li>
+            <li>Create or confirm automation labels before enabling live traffic.</li>
+          </ol>
+
+          {addedRepo && (
+            <div className={styles.postAddActions}>
+              <Button
+                variant="primary"
+                onClick={() => router.push(settingsHref)}
+              >
+                Open repo settings
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  onClose();
+                  router.push(dashboardHref);
+                }}
+              >
+                Open dashboard
+              </Button>
             </div>
           )}
         </div>
-
-        <div className={styles.field}>
-          <div className={styles.label}>Local Path (optional)</div>
-          <input
-            className={styles.input}
-            value={localPath}
-            onChange={(e) => setLocalPath(e.target.value)}
-            placeholder="~/Desktop/my-repo"
-            disabled={isPending}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
-          <div className={styles.pathHint}>Leave blank to prompt on launch</div>
-        </div>
-      </div>
+      )}
 
       {error && (
         <span className={styles.error} role="alert">
@@ -183,18 +371,39 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
         </span>
       )}
 
-      <div className={styles.actions}>
-        <Button variant="ghost" onClick={onClose} disabled={isPending}>
-          Cancel
-        </Button>
-        <Button
-          variant="primary"
-          onClick={handleSubmit}
-          disabled={!canSubmit}
-        >
-          {isPending ? "Adding..." : "Add Repo"}
-        </Button>
-      </div>
+      {!addedRepo && (
+        <div className={styles.actions}>
+          <Button variant="ghost" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          {step !== "identify" && (
+            <Button
+              variant="ghost"
+              onClick={() => setStep(step === "install" ? "automation" : "identify")}
+              disabled={isPending}
+            >
+              Back
+            </Button>
+          )}
+          {step === "install" ? (
+            <Button
+              variant="primary"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+            >
+              {isPending ? "Adding..." : "Add repo"}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              onClick={handleNext}
+              disabled={step === "identify" ? !canAdvanceIdentify : isPending}
+            >
+              Next
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/components/workbench/RepoOverviewFocus.tsx
+++ b/packages/web/components/workbench/RepoOverviewFocus.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { previewForDeployment } from "./workbench-selectors";
 import type { WorkbenchDeployment, WorkbenchHealth, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
@@ -71,6 +72,12 @@ export function RepoOverviewFocus({
       )}
 
       <div className={styles.overviewActions}>
+        <Link
+          className={styles.secondaryButton}
+          href={`/repos/${repo.owner}/${repo.name}/settings`}
+        >
+          Repo settings
+        </Link>
         <button
           type="button"
           className={styles.primaryButton}

--- a/packages/web/components/workbench/RepoSetupFocus.tsx
+++ b/packages/web/components/workbench/RepoSetupFocus.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import type { CSSProperties } from "react";
 import type { WorkbenchRepo, WorkbenchSettings } from "./workbench-types";
@@ -212,6 +213,13 @@ export function RepoSetupFocus({
       <p className={styles.muted}>
         Configure local checkout defaults and add accessible GitHub repositories to the workbench.
       </p>
+      {editableRepo && (
+        <p className={styles.muted}>
+          <Link href={`/repos/${editableRepo.owner}/${editableRepo.name}/settings`}>
+            Open full repo settings
+          </Link>
+        </p>
+      )}
 
       {editableRepo && (
         <section aria-label="Repository settings" style={sectionStyle}>

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1586,9 +1586,12 @@
 }
 
 .secondaryButton {
+  display: inline-flex;
+  align-items: center;
   border: 1px solid var(--paper-line);
   background: rgba(255, 255, 255, 0.22);
   color: var(--paper-ink);
+  text-decoration: none;
 }
 
 .primaryButton:disabled {

--- a/packages/web/lib/actions/repos.test.ts
+++ b/packages/web/lib/actions/repos.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDb = vi.hoisted(() => vi.fn());
+const coreAddRepo = vi.hoisted(() => vi.fn());
 const coreUpdateRepo = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
@@ -9,6 +10,10 @@ const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const killTmuxSession = vi.hoisted(() => vi.fn());
 const tmuxSessionName = vi.hoisted(() => vi.fn((repo: string, targetNumber: number, targetType = "issue") => `issuectl-${repo}-${targetType}-${targetNumber}`));
+const withAuthRetry = vi.hoisted(() => vi.fn());
+const getIssues = vi.hoisted(() => vi.fn());
+const getPulls = vi.hoisted(() => vi.fn());
+const listLabels = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
@@ -18,16 +23,16 @@ vi.mock("@issuectl/core", () => ({
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
   tmuxSessionName: (repo: string, targetNumber: number, targetType?: "issue" | "pr") => tmuxSessionName(repo, targetNumber, targetType),
-  addRepo: vi.fn(),
+  addRepo: (...args: unknown[]) => coreAddRepo(...args),
   removeRepo: vi.fn(),
   updateRepo: (...args: unknown[]) => coreUpdateRepo(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
   readCachedAccessibleRepos: vi.fn(),
   refreshAccessibleRepos: vi.fn(),
-  getIssues: vi.fn(),
-  getPulls: vi.fn(),
-  listLabels: vi.fn(),
-  withAuthRetry: vi.fn(),
+  getIssues: (...args: unknown[]) => getIssues(...args),
+  getPulls: (...args: unknown[]) => getPulls(...args),
+  listLabels: (...args: unknown[]) => listLabels(...args),
+  withAuthRetry: (...args: unknown[]) => withAuthRetry(...args),
   formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
 }));
 
@@ -35,10 +40,22 @@ vi.mock("@/lib/revalidate", () => ({
   revalidateSafely: () => ({ stale: false }),
 }));
 
-import { updateRepo } from "./repos.js";
+import { addRepo, updateRepo } from "./repos.js";
 
 beforeEach(() => {
   getDb.mockReturnValue({});
+  withAuthRetry.mockReset();
+  withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
+    fn({ rest: { repos: { get: vi.fn() } } }),
+  );
+  getIssues.mockReset();
+  getIssues.mockResolvedValue([]);
+  getPulls.mockReset();
+  getPulls.mockResolvedValue([]);
+  listLabels.mockReset();
+  listLabels.mockResolvedValue([]);
+  coreAddRepo.mockReset();
+  coreAddRepo.mockReturnValue({ id: 1, owner: "mean-weasel", name: "issuectl" });
   coreUpdateRepo.mockReset();
   updateRepoWebhookSettings.mockReset();
   getRepoById.mockReset();
@@ -52,6 +69,33 @@ beforeEach(() => {
 });
 
 describe("updateRepo action", () => {
+  it("adds a repo and persists onboarding automation choices", async () => {
+    const result = await addRepo("mean-weasel", "issuectl", undefined, {
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      issueAgent: "codex",
+      reviewAgent: "claude",
+      webhookPayloadMode: "raw",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      addedRepo: { id: 1, owner: "mean-weasel", name: "issuectl" },
+    });
+    expect(coreAddRepo).toHaveBeenCalledWith(expect.anything(), {
+      owner: "mean-weasel",
+      name: "issuectl",
+      localPath: undefined,
+    });
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      issueAgent: "codex",
+      reviewAgent: "claude",
+      webhookPayloadMode: "raw",
+    });
+  });
+
   it("updates webhook settings without requiring path changes", async () => {
     const result = await updateRepo(1, {
       autoLaunchIssues: true,

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -39,16 +39,25 @@ function errMessage(err: unknown): unknown {
 export type AddRepoResult =
   | {
       success: true;
-      addedRepo: { owner: string; name: string };
+      addedRepo: { id: number; owner: string; name: string };
       warning?: string;
       cacheStale?: true;
     }
   | { success: false; error: string };
 
+export type AddRepoOptions = {
+  autoLaunchIssues?: boolean;
+  autoReviewPrs?: boolean;
+  issueAgent?: LaunchAgent;
+  reviewAgent?: LaunchAgent;
+  webhookPayloadMode?: WebhookPayloadMode;
+};
+
 export async function addRepo(
   owner: string,
   name: string,
   localPath?: string,
+  options: AddRepoOptions = {},
 ): Promise<AddRepoResult> {
   if (!owner || !name) {
     return { success: false, error: "Owner and repo name are required" };
@@ -69,9 +78,21 @@ export async function addRepo(
     };
   }
 
+  let addedRepo: { id: number; owner: string; name: string };
   try {
     const db = getDb();
-    coreAddRepo(db, { owner, name, localPath });
+    const repo = coreAddRepo(db, { owner, name, localPath });
+    addedRepo = { id: repo.id, owner: repo.owner, name: repo.name };
+    const webhookUpdates = {
+      autoLaunchIssues: options.autoLaunchIssues,
+      autoReviewPrs: options.autoReviewPrs,
+      issueAgent: options.issueAgent,
+      reviewAgent: options.reviewAgent,
+      webhookPayloadMode: options.webhookPayloadMode,
+    };
+    if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
+      updateRepoWebhookSettings(db, repo.id, webhookUpdates);
+    }
   } catch (err) {
     console.error("[issuectl] Failed to add repo:", errMessage(err));
     const msg =
@@ -115,8 +136,12 @@ export async function addRepo(
     );
   });
 
-  const { stale } = revalidateSafely("/settings", "/");
-  const addedRepo = { owner, name };
+  const { stale } = revalidateSafely(
+    "/settings",
+    "/settings/repos",
+    `/repos/${owner}/${name}/settings`,
+    "/",
+  );
 
   if (localPath) {
     const exists = await stat(expandHome(localPath)).catch(() => null);

--- a/packages/web/lib/github-webhook-handler.ts
+++ b/packages/web/lib/github-webhook-handler.ts
@@ -30,6 +30,7 @@ import {
   verifySignature,
   writeJson,
 } from "./github-webhook-utils";
+import { broadcastWebhookEventsChanged } from "./webhook-events-stream";
 
 export const GITHUB_WEBHOOK_PATH_RE = /^\/api\/webhook\/github\/(\d+)$/;
 export const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
@@ -176,6 +177,7 @@ export async function handleGithubWebhookRequest(
       payload,
     });
     if (intentId !== null) {
+      broadcastWebhookEventsChanged();
       writeJson(res, 200, { ok: true, deduped: true, intentId });
       return true;
     }
@@ -194,6 +196,7 @@ export async function handleGithubWebhookRequest(
     targetNumber,
     eventId: recorded.eventId,
   });
+  broadcastWebhookEventsChanged();
 
   if (await handleIssuectlCommentCommand(db, repo, payload, res, {
     deliveryId,

--- a/packages/web/lib/review-detail-data.test.ts
+++ b/packages/web/lib/review-detail-data.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { Deployment, DiagnosticEvent, PrReview, Repo } from "@issuectl/core";
+import { buildReviewActionRequest, buildReviewDetailData } from "./review-detail-data";
+
+const repo: Repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: "/tmp/issuectl",
+  branchPattern: null,
+  autoLaunchIssues: false,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 1,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-24T00:00:00.000Z",
+};
+
+describe("review-detail-data", () => {
+  it("derives lineage labels, links, and follow-up banners", () => {
+    const current = review({
+      id: 2,
+      reviewedFromSha: "bbbbbbb2222222",
+      reviewedToSha: "ccccccc3333333",
+      resultJson: JSON.stringify({ desiredHeadSha: "ddddddd4444444", followUpGeneration: 1 }),
+    });
+    const data = buildReviewDetailData({
+      repo,
+      review: current,
+      lineage: [current, review({ id: 1, reviewedFromSha: null, reviewedToSha: "bbbbbbb2222222" })],
+      diagnostics: [diagnostic()],
+    });
+
+    expect(data.lineage.map((item) => item.label)).toEqual(["bbbbbbb..ccccccc", "full bbbbbbb"]);
+    expect(data.lineage[0].active).toBe(true);
+    expect(data.banners).toEqual([
+      expect.objectContaining({ tone: "info", title: "Follow-up requested" }),
+    ]);
+    expect(data.links.githubPr).toBe("https://github.com/mean-weasel/issuectl/pull/44");
+    expect(data.links.sessions).toContain("tab=reviews");
+    expect(data.diagnostics).toHaveLength(1);
+  });
+
+  it("shows failed and superseded banners from status and result json", () => {
+    const data = buildReviewDetailData({
+      repo,
+      review: review({ status: "failed", resultJson: JSON.stringify({ reason: "liveness_missing" }) }),
+      deployment: deployment({ completionResultJson: JSON.stringify({ status: "failed" }) }),
+    });
+    const superseded = buildReviewDetailData({
+      repo,
+      review: review({ status: "superseded", resultJson: JSON.stringify({ reason: "force_push" }) }),
+    });
+
+    expect(data.banners).toEqual([
+      expect.objectContaining({ tone: "bad", body: "liveness_missing" }),
+    ]);
+    expect(superseded.banners).toEqual([
+      expect.objectContaining({ tone: "warn", title: "Reviewed range superseded" }),
+    ]);
+  });
+
+  it("builds local webhook intent requests for retry and full rerun", () => {
+    const retry = buildReviewActionRequest({ repo, review: review(), mode: "retry", now: 10 });
+    const full = buildReviewActionRequest({ repo, review: review(), mode: "full", now: 11 });
+
+    expect(retry).toEqual({
+      intent: expect.objectContaining({
+        repoId: repo.id,
+        targetType: "pr",
+        targetNumber: 44,
+        desiredHeadSha: "ccccccc3333333",
+        requestedAgent: "codex",
+        reviewMode: "auto",
+      }),
+      diagnosticEvent: "pr_review.retry",
+      diagnosticMessage: "PR review retry requested.",
+    });
+    expect(full.intent.reviewMode).toBe("full");
+    expect(full.diagnosticEvent).toBe("pr_review.manual_rerun");
+  });
+});
+
+function review(overrides: Partial<PrReview> = {}): PrReview {
+  return {
+    id: 1,
+    repoId: repo.id,
+    prNumber: 44,
+    deploymentId: 12,
+    startedHeadSha: "ccccccc3333333",
+    completedHeadSha: null,
+    reviewBaseSha: "aaaaaaa1111111",
+    reviewedFromSha: "bbbbbbb2222222",
+    reviewedToSha: "ccccccc3333333",
+    headRepoFullName: "mean-weasel/issuectl",
+    headRef: "feature/review",
+    status: "completed",
+    triggeredBy: "webhook",
+    resultJson: null,
+    startedAt: 1_000,
+    completedAt: 2_000,
+    ...overrides,
+  };
+}
+
+function deployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: 12,
+    repoId: repo.id,
+    issueNumber: null,
+    targetType: "pr",
+    targetNumber: 44,
+    agent: "codex",
+    branchName: "review-44",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/review",
+    linkedPrNumber: null,
+    state: "active",
+    terminalBackend: "ttyd",
+    triggeredBy: "webhook",
+    parentDeploymentId: null,
+    webhookDepth: 0,
+    launchedAt: "2026-05-24T00:00:00.000Z",
+    endedAt: "2026-05-24T00:10:00.000Z",
+    terminalReason: "completed",
+    completionToken: null,
+    completionResultJson: null,
+    notificationSentAt: null,
+    ttydPort: null,
+    ttydPid: null,
+    idleSince: null,
+    ...overrides,
+  };
+}
+
+function diagnostic(): DiagnosticEvent {
+  return {
+    id: 5,
+    timestamp: 10,
+    level: "info",
+    event: "webhook.pr_launched",
+    source: "webhook-worker",
+    correlationId: null,
+    owner: repo.owner,
+    repo: repo.name,
+    issueNumber: null,
+    targetType: "pr",
+    targetNumber: 44,
+    deploymentId: 12,
+    sessionName: null,
+    ttydPort: null,
+    ttydPid: null,
+    status: null,
+    message: "launched",
+    data: null,
+  };
+}

--- a/packages/web/lib/review-detail-data.ts
+++ b/packages/web/lib/review-detail-data.ts
@@ -1,0 +1,194 @@
+import {
+  dbExists,
+  getDb,
+  getDeploymentById,
+  getPrReviewById,
+  getRepoById,
+  listPrReviewsForPull,
+  queryDiagnosticEvents,
+  type Deployment,
+  type DiagnosticEvent,
+  type PrReview,
+  type Repo,
+} from "@issuectl/core";
+
+export type ReviewBanner = {
+  tone: "bad" | "warn" | "info";
+  title: string;
+  body: string;
+};
+
+export type ReviewLineageItem = PrReview & {
+  active: boolean;
+  result: Record<string, unknown>;
+  label: string;
+};
+
+export type ReviewDetailData = {
+  initialized: boolean;
+  review: PrReview;
+  repo: Repo;
+  deployment: Deployment | null;
+  lineage: ReviewLineageItem[];
+  diagnostics: DiagnosticEvent[];
+  result: Record<string, unknown>;
+  deploymentResult: Record<string, unknown>;
+  banners: ReviewBanner[];
+  links: {
+    githubPr: string;
+    workbench: string;
+    repoSettings: string;
+    sessions: string;
+    diagnosticsCli: string;
+  };
+};
+
+export type ReviewActionRequest = {
+  review: PrReview;
+  repo: Repo;
+  mode: "retry" | "full";
+  now: number;
+};
+
+export function getReviewDetailData(reviewId: number): ReviewDetailData | null {
+  if (!dbExists()) return null;
+  const db = getDb();
+  const review = getPrReviewById(db, reviewId);
+  if (!review) return null;
+  const repo = getRepoById(db, review.repoId);
+  if (!repo) return null;
+  const deployment = review.deploymentId ? getDeploymentById(db, review.deploymentId) ?? null : null;
+  const lineage = listPrReviewsForPull(db, review.repoId, review.prNumber, 24);
+  const diagnostics = queryDiagnosticEvents(db, {
+    target: { owner: repo.owner, repo: repo.name, targetType: "pr", targetNumber: review.prNumber },
+    limit: 12,
+  });
+  return buildReviewDetailData({ review, repo, deployment, lineage, diagnostics });
+}
+
+export function buildReviewDetailData(input: {
+  review: PrReview;
+  repo: Repo;
+  deployment?: Deployment | null;
+  lineage?: PrReview[];
+  diagnostics?: DiagnosticEvent[];
+}): ReviewDetailData {
+  const result = parseJsonObject(input.review.resultJson);
+  const deploymentResult = parseJsonObject(input.deployment?.completionResultJson ?? null);
+  const lineage = (input.lineage ?? [input.review]).map((item) => ({
+    ...item,
+    active: item.id === input.review.id,
+    result: parseJsonObject(item.resultJson),
+    label: lineageLabel(item),
+  }));
+  return {
+    initialized: true,
+    review: input.review,
+    repo: input.repo,
+    deployment: input.deployment ?? null,
+    lineage,
+    diagnostics: input.diagnostics ?? [],
+    result,
+    deploymentResult,
+    banners: deriveBanners(input.review, result, deploymentResult),
+    links: reviewLinks(input.repo, input.review),
+  };
+}
+
+export function buildReviewActionRequest(input: ReviewActionRequest): {
+  intent: {
+    repoId: number;
+    targetType: "pr";
+    targetNumber: number;
+    signalAt: number;
+    scheduledAt: number;
+    desiredHeadSha: string;
+    requestedAgent: "claude" | "codex";
+    reviewMode: "auto" | "full";
+  };
+  diagnosticEvent: "pr_review.retry" | "pr_review.manual_rerun";
+  diagnosticMessage: string;
+} {
+  const full = input.mode === "full";
+  return {
+    intent: {
+      repoId: input.repo.id,
+      targetType: "pr",
+      targetNumber: input.review.prNumber,
+      signalAt: input.now,
+      scheduledAt: input.now,
+      desiredHeadSha: input.review.reviewedToSha,
+      requestedAgent: input.repo.reviewAgent,
+      reviewMode: full ? "full" : "auto",
+    },
+    diagnosticEvent: full ? "pr_review.manual_rerun" : "pr_review.retry",
+    diagnosticMessage: full ? "Manual full PR review rerun requested." : "PR review retry requested.",
+  };
+}
+
+function deriveBanners(
+  review: PrReview,
+  result: Record<string, unknown>,
+  deploymentResult: Record<string, unknown>,
+): ReviewBanner[] {
+  const banners: ReviewBanner[] = [];
+  const reason = stringValue(result.reason) ?? stringValue(result.error) ?? stringValue(deploymentResult.reason);
+  if (review.status === "failed" || typeof result.error === "string") {
+    banners.push({
+      tone: "bad",
+      title: "Review failed",
+      body: reason ?? "The review worker recorded a failed terminal state.",
+    });
+  }
+  if (review.status === "superseded" || reason === "force_push") {
+    banners.push({
+      tone: "warn",
+      title: "Reviewed range superseded",
+      body: "A later force push or review run replaced this reviewed range.",
+    });
+  }
+  if (typeof result.desiredHeadSha === "string" || result.followUpGeneration === 1) {
+    banners.push({
+      tone: "info",
+      title: "Follow-up requested",
+      body: "A newer PR head was coalesced while this review was active.",
+    });
+  }
+  return banners;
+}
+
+function reviewLinks(repo: Repo, review: PrReview): ReviewDetailData["links"] {
+  const fullName = `${repo.owner}/${repo.name}`;
+  return {
+    githubPr: `https://github.com/${fullName}/pull/${review.prNumber}`,
+    workbench: `/workbench?repo=${encodeURIComponent(fullName)}`,
+    repoSettings: `/repos/${repo.owner}/${repo.name}/settings`,
+    sessions: `/sessions?tab=reviews&repo=${encodeURIComponent(fullName)}&q=${encodeURIComponent(`PR #${review.prNumber}`)}`,
+    diagnosticsCli: `pnpm --dir packages/cli exec issuectl diag show --issue ${fullName}#${review.prNumber}`,
+  };
+}
+
+function lineageLabel(review: PrReview): string {
+  if (review.reviewedFromSha) return `${shortSha(review.reviewedFromSha)}..${shortSha(review.reviewedToSha)}`;
+  return `full ${shortSha(review.reviewedToSha)}`;
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 7);
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/web/lib/sessions-data.test.ts
+++ b/packages/web/lib/sessions-data.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { ActiveDeploymentWithRepo, Deployment, PrReview, Repo } from "@issuectl/core";
+import { buildSessionsOverview, normalizeSessionsFilters } from "./sessions-data";
+
+const repo: Repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: "/tmp/issuectl",
+  branchPattern: null,
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-24T00:00:00.000Z",
+};
+
+describe("sessions-data", () => {
+  it("normalizes unknown filters to safe defaults", () => {
+    expect(normalizeSessionsFilters({
+      tab: "wat",
+      trigger: "bot",
+      state: "stuck",
+      status: "???",
+      q: "  PR #44  ",
+    })).toEqual({
+      tab: "sessions",
+      q: "PR #44",
+      repo: "",
+      trigger: "all",
+      state: "all",
+      status: "all",
+    });
+  });
+
+  it("groups active and ended sessions by repo target with trigger filtering", () => {
+    const data = buildSessionsOverview({
+      repos: [repo],
+      activeDeployments: [activeDeployment({ id: 10, targetType: "issue", targetNumber: 507, triggeredBy: "webhook" })],
+      recentDeploymentsByRepo: new Map([
+        [repo.id, [endedDeployment({ id: 9, targetType: "issue", targetNumber: 507, triggeredBy: "manual" })]],
+      ]),
+      reviewsByRepo: new Map(),
+      previews: { "7710": { status: "active", lines: ["running tests"], lastUpdatedMs: 1, lastChangedMs: 1 } },
+      filters: normalizeSessionsFilters({ trigger: "webhook" }),
+    });
+
+    expect(data.summary.activeSessions).toBe(1);
+    expect(data.summary.endedSessions).toBe(1);
+    expect(data.sessionGroups).toHaveLength(1);
+    expect(data.sessionGroups[0].targetLabel).toBe("Issue #507");
+    expect(data.sessionGroups[0].sessions).toHaveLength(1);
+    expect(data.sessionGroups[0].sessions[0].preview?.lines).toEqual(["running tests"]);
+  });
+
+  it("groups review runs by PR and supports status search", () => {
+    const data = buildSessionsOverview({
+      repos: [repo],
+      activeDeployments: [activeDeployment({ id: 20, targetType: "pr", targetNumber: 44, triggeredBy: "comment_command" })],
+      recentDeploymentsByRepo: new Map(),
+      reviewsByRepo: new Map([
+        [repo.id, [
+          review({ id: 3, prNumber: 44, deploymentId: 20, status: "in_progress", startedAt: 30 }),
+          review({ id: 2, prNumber: 44, deploymentId: null, status: "completed", startedAt: 20 }),
+        ]],
+      ]),
+      previews: {},
+      filters: normalizeSessionsFilters({ tab: "reviews", status: "in_progress", q: "feature" }),
+    });
+
+    expect(data.summary.reviewRuns).toBe(2);
+    expect(data.summary.activeReviewRuns).toBe(1);
+    expect(data.reviewGroups).toHaveLength(1);
+    expect(data.reviewGroups[0].prNumber).toBe(44);
+    expect(data.reviewGroups[0].runs).toHaveLength(1);
+    expect(data.reviewGroups[0].runs[0].deployment?.id).toBe(20);
+  });
+});
+
+function activeDeployment(input: {
+  id: number;
+  targetType: "issue" | "pr";
+  targetNumber: number;
+  triggeredBy: "manual" | "webhook" | "comment_command";
+}): ActiveDeploymentWithRepo {
+  return {
+    ...baseDeployment(input),
+    state: "active",
+    endedAt: null,
+    owner: repo.owner,
+    repoName: repo.name,
+  };
+}
+
+function endedDeployment(input: {
+  id: number;
+  targetType: "issue" | "pr";
+  targetNumber: number;
+  triggeredBy: "manual" | "webhook" | "comment_command";
+}): Deployment {
+  return {
+    ...baseDeployment(input),
+    state: "active",
+    endedAt: "2026-05-24T01:00:00.000Z",
+    terminalReason: "completed",
+  };
+}
+
+function baseDeployment(input: {
+  id: number;
+  targetType: "issue" | "pr";
+  targetNumber: number;
+  triggeredBy: "manual" | "webhook" | "comment_command";
+}): Deployment {
+  return {
+    id: input.id,
+    repoId: repo.id,
+    issueNumber: input.targetType === "issue" ? input.targetNumber : null,
+    targetType: input.targetType,
+    targetNumber: input.targetNumber,
+    agent: "codex",
+    branchName: input.targetType === "pr" ? "review/feature-branch" : "issue-507-ux",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/worktree",
+    linkedPrNumber: input.targetType === "issue" ? 44 : null,
+    state: "active",
+    terminalBackend: "ttyd",
+    triggeredBy: input.triggeredBy,
+    parentDeploymentId: null,
+    webhookDepth: input.triggeredBy === "webhook" ? 1 : 0,
+    launchedAt: "2026-05-24T00:00:00.000Z",
+    endedAt: null,
+    terminalReason: null,
+    completionToken: null,
+    completionResultJson: null,
+    notificationSentAt: null,
+    ttydPort: input.id === 10 ? 7710 : null,
+    ttydPid: null,
+    idleSince: null,
+  };
+}
+
+function review(input: {
+  id: number;
+  prNumber: number;
+  deploymentId: number | null;
+  status: "in_progress" | "completed";
+  startedAt: number;
+}): PrReview {
+  return {
+    id: input.id,
+    repoId: repo.id,
+    prNumber: input.prNumber,
+    deploymentId: input.deploymentId,
+    startedHeadSha: "abcdef123456",
+    completedHeadSha: input.status === "completed" ? "fedcba654321" : null,
+    reviewBaseSha: "111111111111",
+    reviewedFromSha: "222222222222",
+    reviewedToSha: "333333333333",
+    headRepoFullName: repo.owner + "/" + repo.name,
+    headRef: "feature-branch",
+    status: input.status,
+    triggeredBy: "comment_command",
+    resultJson: null,
+    startedAt: input.startedAt,
+    completedAt: input.status === "completed" ? input.startedAt + 5 : null,
+  };
+}

--- a/packages/web/lib/sessions-data.ts
+++ b/packages/web/lib/sessions-data.ts
@@ -1,0 +1,349 @@
+/* eslint-disable max-lines */
+import {
+  dbExists,
+  getActiveDeployments,
+  getDb,
+  listPrReviewsForRepo,
+  listRecentTerminalDeploymentsByRepo,
+  listRepos,
+  type ActiveDeploymentWithRepo,
+  type Deployment,
+  type DeploymentTargetType,
+  type DeploymentTriggeredBy,
+  type PrReview,
+  type PrReviewStatus,
+  type Repo,
+} from "@issuectl/core";
+import { getSessionPreviews, type SessionPreview } from "@/lib/session-previews";
+
+export type SessionsTab = "sessions" | "reviews";
+export type SessionsStateFilter = "active" | "ended" | "all";
+export type TriggerFilter = DeploymentTriggeredBy | "all";
+export type ReviewStatusFilter = PrReviewStatus | "all";
+
+export type SessionsFilters = {
+  tab: SessionsTab;
+  q: string;
+  repo: string;
+  trigger: TriggerFilter;
+  state: SessionsStateFilter;
+  status: ReviewStatusFilter;
+};
+
+export type SessionListItem = {
+  id: number;
+  repoId: number;
+  repoFullName: string;
+  owner: string;
+  repoName: string;
+  targetType: DeploymentTargetType;
+  targetNumber: number;
+  targetLabel: string;
+  issueNumber: number | null;
+  branchName: string;
+  agent: string;
+  workspaceMode: string;
+  workspacePath: string;
+  linkedPrNumber: number | null;
+  triggeredBy: DeploymentTriggeredBy;
+  parentDeploymentId: number | null;
+  webhookDepth: number;
+  terminalReason: string | null;
+  launchedAt: string;
+  endedAt: string | null;
+  ttydPort: number | null;
+  idleSince: string | null;
+  preview: SessionPreview | null;
+};
+
+export type SessionTargetGroup = {
+  key: string;
+  repoFullName: string;
+  targetType: DeploymentTargetType;
+  targetNumber: number;
+  targetLabel: string;
+  sessions: SessionListItem[];
+};
+
+export type ReviewRunItem = PrReview & {
+  repoFullName: string;
+  owner: string;
+  repoName: string;
+  deployment: SessionListItem | null;
+};
+
+export type ReviewPrGroup = {
+  key: string;
+  repoFullName: string;
+  owner: string;
+  repoName: string;
+  prNumber: number;
+  runs: ReviewRunItem[];
+};
+
+export type SessionsOverviewData = {
+  initialized: boolean;
+  filters: SessionsFilters;
+  repos: Array<{ id: number; fullName: string }>;
+  sessionGroups: SessionTargetGroup[];
+  reviewGroups: ReviewPrGroup[];
+  summary: {
+    activeSessions: number;
+    endedSessions: number;
+    reviewRuns: number;
+    activeReviewRuns: number;
+  };
+};
+
+type BuildInput = {
+  repos: Repo[];
+  activeDeployments: ActiveDeploymentWithRepo[];
+  recentDeploymentsByRepo: Map<number, Deployment[]>;
+  reviewsByRepo: Map<number, PrReview[]>;
+  previews: Record<string, SessionPreview>;
+  filters: SessionsFilters;
+};
+
+const SESSION_STATES: SessionsStateFilter[] = ["active", "ended", "all"];
+const TRIGGERS: TriggerFilter[] = ["manual", "webhook", "comment_command", "all"];
+const REVIEW_STATUSES: ReviewStatusFilter[] = [
+  "reserved",
+  "launching",
+  "in_progress",
+  "completed",
+  "failed",
+  "superseded",
+  "all",
+];
+const ACTIVE_REVIEW_STATUSES = new Set<PrReviewStatus>(["reserved", "launching", "in_progress"]);
+
+export async function getSessionsOverviewData(filters: SessionsFilters): Promise<SessionsOverviewData> {
+  if (!dbExists()) {
+    return emptySessionsOverview(filters);
+  }
+
+  const db = getDb();
+  const repos = listRepos(db);
+  const activeDeployments = getActiveDeployments(db);
+  const previews = await getSessionPreviews(activeDeployments);
+  const recentDeploymentsByRepo = new Map<number, Deployment[]>();
+  const reviewsByRepo = new Map<number, PrReview[]>();
+
+  for (const repo of repos) {
+    recentDeploymentsByRepo.set(repo.id, listRecentTerminalDeploymentsByRepo(db, repo.id, 12));
+    reviewsByRepo.set(repo.id, listPrReviewsForRepo(db, repo.id, 24));
+  }
+
+  return buildSessionsOverview({
+    repos,
+    activeDeployments,
+    recentDeploymentsByRepo,
+    reviewsByRepo,
+    previews,
+    filters,
+  });
+}
+
+export function normalizeSessionsFilters(input: Record<string, string | string[] | undefined>): SessionsFilters {
+  const first = (value: string | string[] | undefined): string => Array.isArray(value) ? value[0] ?? "" : value ?? "";
+  const tab = first(input.tab);
+  const state = first(input.state);
+  const trigger = first(input.trigger);
+  const status = first(input.status);
+  return {
+    tab: tab === "reviews" ? "reviews" : "sessions",
+    q: first(input.q).trim(),
+    repo: first(input.repo).trim(),
+    trigger: isOneOf(trigger, TRIGGERS) ? trigger : "all",
+    state: isOneOf(state, SESSION_STATES) ? state : "all",
+    status: isOneOf(status, REVIEW_STATUSES) ? status : "all",
+  };
+}
+
+export function buildSessionsOverview(input: BuildInput): SessionsOverviewData {
+  const sessions = input.repos.flatMap((repo) => [
+    ...input.activeDeployments.filter((deployment) => deployment.repoId === repo.id),
+    ...(input.recentDeploymentsByRepo.get(repo.id) ?? []),
+  ].map((deployment) => sessionFromDeployment(repo, deployment, input.previews)));
+  const filteredSessions = sessions.filter((session) => sessionMatchesFilters(session, input.filters));
+  const reviews = input.repos.flatMap((repo) =>
+    (input.reviewsByRepo.get(repo.id) ?? []).map((review) =>
+      reviewFromRun(repo, review, sessions.find((session) => session.id === review.deploymentId) ?? null),
+    ),
+  );
+  const filteredReviews = reviews.filter((review) => reviewMatchesFilters(review, input.filters));
+
+  return {
+    initialized: true,
+    filters: input.filters,
+    repos: input.repos.map((repo) => ({ id: repo.id, fullName: repoFullName(repo) })),
+    sessionGroups: groupSessions(filteredSessions),
+    reviewGroups: groupReviews(filteredReviews),
+    summary: {
+      activeSessions: sessions.filter((session) => !session.endedAt).length,
+      endedSessions: sessions.filter((session) => session.endedAt).length,
+      reviewRuns: reviews.length,
+      activeReviewRuns: reviews.filter((review) => ACTIVE_REVIEW_STATUSES.has(review.status)).length,
+    },
+  };
+}
+
+function emptySessionsOverview(filters: SessionsFilters): SessionsOverviewData {
+  return {
+    initialized: false,
+    filters,
+    repos: [],
+    sessionGroups: [],
+    reviewGroups: [],
+    summary: { activeSessions: 0, endedSessions: 0, reviewRuns: 0, activeReviewRuns: 0 },
+  };
+}
+
+function sessionFromDeployment(
+  repo: Repo,
+  deployment: Deployment | ActiveDeploymentWithRepo,
+  previews: Record<string, SessionPreview>,
+): SessionListItem {
+  const preview = deployment.ttydPort === null ? null : previews[String(deployment.ttydPort)] ?? null;
+  return {
+    id: deployment.id,
+    repoId: deployment.repoId,
+    repoFullName: repoFullName(repo),
+    owner: repo.owner,
+    repoName: repo.name,
+    targetType: deployment.targetType,
+    targetNumber: deployment.targetNumber,
+    targetLabel: targetLabel(deployment.targetType, deployment.targetNumber),
+    issueNumber: deployment.issueNumber,
+    branchName: deployment.branchName,
+    agent: deployment.agent,
+    workspaceMode: deployment.workspaceMode,
+    workspacePath: deployment.workspacePath,
+    linkedPrNumber: deployment.linkedPrNumber,
+    triggeredBy: deployment.triggeredBy,
+    parentDeploymentId: deployment.parentDeploymentId,
+    webhookDepth: deployment.webhookDepth,
+    terminalReason: deployment.terminalReason,
+    launchedAt: deployment.launchedAt,
+    endedAt: deployment.endedAt,
+    ttydPort: deployment.ttydPort,
+    idleSince: deployment.idleSince,
+    preview,
+  };
+}
+
+function reviewFromRun(repo: Repo, review: PrReview, deployment: SessionListItem | null): ReviewRunItem {
+  return {
+    ...review,
+    repoFullName: repoFullName(repo),
+    owner: repo.owner,
+    repoName: repo.name,
+    deployment,
+  };
+}
+
+function groupSessions(sessions: SessionListItem[]): SessionTargetGroup[] {
+  const groups = new Map<string, SessionTargetGroup>();
+  for (const session of sessions) {
+    const key = `${session.repoId}:${session.targetType}:${session.targetNumber}`;
+    const group = groups.get(key) ?? {
+      key,
+      repoFullName: session.repoFullName,
+      targetType: session.targetType,
+      targetNumber: session.targetNumber,
+      targetLabel: session.targetLabel,
+      sessions: [],
+    };
+    group.sessions.push(session);
+    groups.set(key, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      sessions: [...group.sessions].sort(compareSessions),
+    }))
+    .sort((left, right) => compareSessions(left.sessions[0], right.sessions[0]));
+}
+
+function groupReviews(reviews: ReviewRunItem[]): ReviewPrGroup[] {
+  const groups = new Map<string, ReviewPrGroup>();
+  for (const review of reviews) {
+    const key = `${review.repoId}:${review.prNumber}`;
+    const group = groups.get(key) ?? {
+      key,
+      repoFullName: review.repoFullName,
+      owner: review.owner,
+      repoName: review.repoName,
+      prNumber: review.prNumber,
+      runs: [],
+    };
+    group.runs.push(review);
+    groups.set(key, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      runs: [...group.runs].sort((left, right) => right.startedAt - left.startedAt || right.id - left.id),
+    }))
+    .sort((left, right) => right.runs[0].startedAt - left.runs[0].startedAt || right.runs[0].id - left.runs[0].id);
+}
+
+function sessionMatchesFilters(session: SessionListItem, filters: SessionsFilters): boolean {
+  if (filters.repo && session.repoFullName !== filters.repo) return false;
+  if (filters.trigger !== "all" && session.triggeredBy !== filters.trigger) return false;
+  if (filters.state === "active" && session.endedAt) return false;
+  if (filters.state === "ended" && !session.endedAt) return false;
+  if (!filters.q) return true;
+  return searchable([
+    session.repoFullName,
+    session.targetLabel,
+    session.branchName,
+    session.agent,
+    session.triggeredBy,
+    session.terminalReason ?? "",
+    session.preview?.lines.join(" ") ?? "",
+  ]).includes(filters.q.toLowerCase());
+}
+
+function reviewMatchesFilters(review: ReviewRunItem, filters: SessionsFilters): boolean {
+  if (filters.repo && review.repoFullName !== filters.repo) return false;
+  if (filters.trigger !== "all" && review.triggeredBy !== filters.trigger) return false;
+  if (filters.status !== "all" && review.status !== filters.status) return false;
+  if (!filters.q) return true;
+  return searchable([
+    review.repoFullName,
+    `PR #${review.prNumber}`,
+    review.status,
+    review.triggeredBy,
+    review.headRepoFullName,
+    review.headRef,
+    review.reviewedFromSha ?? "",
+    review.reviewedToSha,
+    review.deployment?.branchName ?? "",
+  ]).includes(filters.q.toLowerCase());
+}
+
+function compareSessions(left: SessionListItem | undefined, right: SessionListItem | undefined): number {
+  if (!left || !right) return 0;
+  const leftActive = left.endedAt ? 1 : 0;
+  const rightActive = right.endedAt ? 1 : 0;
+  return leftActive - rightActive
+    || Date.parse(right.launchedAt) - Date.parse(left.launchedAt)
+    || right.id - left.id;
+}
+
+function targetLabel(targetType: DeploymentTargetType, targetNumber: number): string {
+  return targetType === "pr" ? `PR #${targetNumber}` : `Issue #${targetNumber}`;
+}
+
+function repoFullName(repo: Repo): string {
+  return `${repo.owner}/${repo.name}`;
+}
+
+function searchable(parts: string[]): string {
+  return parts.join(" ").toLowerCase();
+}
+
+function isOneOf<T extends string>(value: string, options: readonly T[]): value is T {
+  return options.includes(value as T);
+}

--- a/packages/web/lib/webhook-events-stream.test.ts
+++ b/packages/web/lib/webhook-events-stream.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { IncomingMessage } from "node:http";
 import {
   formatWebhookStreamEvent,
+  isWebhookEventsStreamAuthorized,
   isWebhookEventsStreamRequest,
 } from "./webhook-events-stream";
+
+vi.mock("./api-auth", () => ({
+  validateApiToken: (headers: Headers) => headers.get("Authorization") === "Bearer valid-token",
+}));
 
 describe("webhook events stream helpers", () => {
   it("matches only the webhook events stream upgrade path", () => {
@@ -25,4 +31,18 @@ describe("webhook events stream helpers", () => {
       }),
     );
   });
+
+  it("requires the dashboard API token for stream upgrades", () => {
+    expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream?apiToken=valid-token"))).toBe(true);
+    expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream", "Bearer valid-token"))).toBe(true);
+    expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream"))).toBe(false);
+    expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream?apiToken=wrong-token"))).toBe(false);
+  });
 });
+
+function makeRequest(url: string, authorization?: string): IncomingMessage {
+  return {
+    url,
+    headers: authorization ? { authorization } : {},
+  } as IncomingMessage;
+}

--- a/packages/web/lib/webhook-events-stream.test.ts
+++ b/packages/web/lib/webhook-events-stream.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatWebhookStreamEvent,
+  isWebhookEventsStreamRequest,
+} from "./webhook-events-stream";
+
+describe("webhook events stream helpers", () => {
+  it("matches only the webhook events stream upgrade path", () => {
+    expect(isWebhookEventsStreamRequest("/api/webhooks/events/stream")).toBe(true);
+    expect(isWebhookEventsStreamRequest("/api/webhooks/events/stream?repo=2")).toBe(true);
+    expect(isWebhookEventsStreamRequest("/api/webhooks/events")).toBe(false);
+    expect(isWebhookEventsStreamRequest("/api/terminal/3847/ws")).toBe(false);
+  });
+
+  it("formats stream payloads as JSON messages", () => {
+    expect(
+      formatWebhookStreamEvent("webhook_event_created", {
+        id: 1,
+        deliveryId: "delivery-1",
+      }),
+    ).toBe(
+      JSON.stringify({
+        type: "webhook_event_created",
+        payload: { id: 1, deliveryId: "delivery-1" },
+      }),
+    );
+  });
+});

--- a/packages/web/lib/webhook-events-stream.ts
+++ b/packages/web/lib/webhook-events-stream.ts
@@ -1,0 +1,87 @@
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocket, WebSocketServer } from "ws";
+import { getDb, listWebhookLogEntries } from "@issuectl/core";
+import log from "./logger";
+
+const WEBHOOK_EVENTS_STREAM_PATH = "/api/webhooks/events/stream";
+const MAX_BUFFERED_BYTES = 1_000_000;
+
+const wss = new WebSocketServer({ noServer: true });
+const clients = new Set<WebSocket>();
+
+export function isWebhookEventsStreamRequest(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    return new URL(url, "http://localhost").pathname === WEBHOOK_EVENTS_STREAM_PATH;
+  } catch {
+    return false;
+  }
+}
+
+export function formatWebhookStreamEvent(type: string, payload: unknown): string {
+  return JSON.stringify({ type, payload });
+}
+
+export function activeWebhookEventsStreamCount(): number {
+  return clients.size;
+}
+
+export async function handleWebhookEventsStreamUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      clients.add(ws);
+      ws.on("close", () => clients.delete(ws));
+      ws.on("error", (err) => {
+        log.warn({ err, msg: "webhook_events_stream_client_error" });
+        clients.delete(ws);
+      });
+      sendSnapshot(ws);
+      resolve();
+    });
+  });
+}
+
+export function broadcastWebhookEventsChanged(): void {
+  const payload = readSnapshotPayload();
+  for (const ws of clients) {
+    safeSend(ws, "webhook_events_changed", payload);
+  }
+}
+
+function sendSnapshot(ws: WebSocket): void {
+  safeSend(ws, "webhook_events_snapshot", readSnapshotPayload());
+}
+
+function readSnapshotPayload(): unknown {
+  try {
+    return {
+      generatedAt: new Date().toISOString(),
+      entries: listWebhookLogEntries(getDb(), { limit: 50 }),
+    };
+  } catch (err) {
+    log.warn({ err, msg: "webhook_events_stream_snapshot_failed" });
+    return {
+      generatedAt: new Date().toISOString(),
+      entries: [],
+      error: "Webhook event stream snapshot failed",
+    };
+  }
+}
+
+function safeSend(ws: WebSocket, type: string, payload: unknown): boolean {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  if (ws.bufferedAmount > MAX_BUFFERED_BYTES) {
+    log.warn({
+      msg: "webhook_events_stream_backpressure_drop",
+      bufferedAmount: ws.bufferedAmount,
+    });
+    return false;
+  }
+  ws.send(formatWebhookStreamEvent(type, payload));
+  return true;
+}

--- a/packages/web/lib/webhook-events-stream.ts
+++ b/packages/web/lib/webhook-events-stream.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer } from "ws";
 import { getDb, listWebhookLogEntries } from "@issuectl/core";
+import { validateApiToken } from "./api-auth";
 import log from "./logger";
 
 const WEBHOOK_EVENTS_STREAM_PATH = "/api/webhooks/events/stream";
@@ -23,6 +24,12 @@ export function formatWebhookStreamEvent(type: string, payload: unknown): string
   return JSON.stringify({ type, payload });
 }
 
+export function isWebhookEventsStreamAuthorized(req: IncomingMessage): boolean {
+  const token = tokenFromRequest(req);
+  if (!token) return false;
+  return validateApiToken(new Headers({ Authorization: `Bearer ${token}` }));
+}
+
 export function activeWebhookEventsStreamCount(): number {
   return clients.size;
 }
@@ -32,6 +39,13 @@ export async function handleWebhookEventsStreamUpgrade(
   socket: Duplex,
   head: Buffer,
 ): Promise<void> {
+  if (!isWebhookEventsStreamAuthorized(req)) {
+    log.warn({ msg: "webhook_events_stream_auth_failed" });
+    socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
   await new Promise<void>((resolve) => {
     wss.handleUpgrade(req, socket, head, (ws) => {
       clients.add(ws);
@@ -44,6 +58,19 @@ export async function handleWebhookEventsStreamUpgrade(
       resolve();
     });
   });
+}
+
+function tokenFromRequest(req: IncomingMessage): string | null {
+  const auth = req.headers.authorization;
+  if (typeof auth === "string" && auth.startsWith("Bearer ")) {
+    return auth.slice(7);
+  }
+  try {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    return url.searchParams.get("apiToken");
+  } catch {
+    return null;
+  }
 }
 
 export function broadcastWebhookEventsChanged(): void {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -17,7 +17,7 @@ import { startWebhookIntentWorker, stopWebhookIntentWorker } from "./lib/webhook
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
 const PTY_TERMINAL_WS_RE = /^\/api\/terminal\/pty\/(\d+)\/ws/;
-const SENSITIVE_QUERY_PARAMS = new Set(["terminalToken"]);
+const SENSITIVE_QUERY_PARAMS = new Set(["terminalToken", "apiToken"]);
 
 const dev = process.argv.includes("--dev");
 const port = Number(process.env.PORT ?? 3847);
@@ -79,7 +79,7 @@ function redactSensitiveUrl(rawUrl: string | undefined, host: string | undefined
     }
     return redacted ? `${parsed.pathname}${parsed.search}` : rawUrl;
   } catch {
-    return rawUrl.replace(/([?&]terminalToken=)[^&]*/g, "$1[redacted]");
+    return rawUrl.replace(/([?&](?:terminalToken|apiToken)=)[^&]*/g, "$1[redacted]");
   }
 }
 

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -6,6 +6,11 @@ import log, { logPath } from "./lib/logger";
 import { handleGithubWebhookRequest, isGithubWebhookRequest } from "./lib/github-webhook-handler";
 import { handleUpgrade, activeWsCount } from "./lib/terminal-proxy";
 import { handlePtyUpgrade, activePtyWsCount } from "./lib/pty-terminal-websocket";
+import {
+  activeWebhookEventsStreamCount,
+  handleWebhookEventsStreamUpgrade,
+  isWebhookEventsStreamRequest,
+} from "./lib/webhook-events-stream";
 import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./lib/network-info.js";
 import { startIdleChecker, stopIdleChecker } from "./lib/idle-checker";
 import { startWebhookIntentWorker, stopWebhookIntentWorker } from "./lib/webhook-intent-worker";
@@ -189,6 +194,18 @@ interceptUpgradeRegistrations("addListener");
 // Our terminal handler runs first (prepend). It marks the socket so
 // any later upgrade listeners (Next.js HMR, etc.) are no-ops.
 server.prependListener("upgrade", (req: IncomingMessage, socket: Duplex & { [HANDLED]?: boolean }, head: Buffer) => {
+  if (isWebhookEventsStreamRequest(req.url)) {
+    socket[HANDLED] = true;
+    handleWebhookEventsStreamUpgrade(req, socket, head).catch((err) => {
+      log.error({ err, msg: "webhook_events_stream_upgrade_failed" });
+      if (!socket.destroyed) {
+        socket.write("HTTP/1.1 500 Internal Server Error\r\n\r\n");
+        socket.destroy();
+      }
+    });
+    return;
+  }
+
   const ptyMatch = req.url?.match(PTY_TERMINAL_WS_RE);
   if (ptyMatch) {
     const deploymentId = Number(ptyMatch[1]);
@@ -232,6 +249,7 @@ function heartbeat(): void {
     rssMB: Math.round(mem.rss / 1024 / 1024),
     activeWs: activeWsCount(),
     activePtyWs: activePtyWsCount(),
+    activeWebhookEventsWs: activeWebhookEventsStreamCount(),
   });
 }
 


### PR DESCRIPTION
## Summary
- integrates the issue #507 UX checkpoint branches on top of current main after issue #506 merged
- adds webhook log UX, repo onboarding/settings UX, sessions/reviews overview, PR review detail UX, and webhook first-ping diagnostics
- includes regression coverage for the new core/web/CLI surfaces

## Verification
- pnpm --dir packages/core test
- pnpm --dir packages/web test
- pnpm --dir packages/cli test
- pnpm --dir packages/core typecheck
- pnpm --dir packages/web typecheck
- pnpm --dir packages/cli typecheck
- pnpm --dir packages/core lint
- pnpm --dir packages/web lint
- pnpm --dir packages/cli lint
- pnpm turbo typecheck

## UX route proof
- local dev server rendered /logs/webhooks, /settings, /settings/repos, /repos/mean-weasel/issuectl/settings, /sessions, and /reviews/<temp-review-id> with 200 responses
- WebSocket probe opened /api/webhooks/events/stream and received webhook_events_snapshot
- screenshots captured locally at /tmp/issue507-webhooks.png, /tmp/issue507-settings-repos.png, /tmp/issue507-repo-settings.png, /tmp/issue507-sessions.png, /tmp/issue507-review-detail.png, and /tmp/issue507-add-repo-wizard.png

## Notes
- /pr-review-toolkit:review-pr all is still unavailable in this Codex environment; tool discovery returned no matching callable tool.
