### PR TITLE
Close webhook diagnostics and onboarding gaps

### DIFF
--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -25,6 +25,15 @@ type WebhookOctokit = {
   };
 };
 
+const ISSUECTL_WEBHOOK_EVENTS = [
+  "issues",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "issue_comment",
+  "push",
+];
+
 function parseLimit(value: string): number {
   const trimmed = value.trim();
   if (!/^[1-9]\d*$/.test(trimmed)) {
@@ -173,7 +182,7 @@ async function createWebhook(
     repo: input.repo,
     name: "web",
     active: true,
-    events: ["issues", "issue_comment", "pull_request", "pull_request_review_comment"],
+    events: ISSUECTL_WEBHOOK_EVENTS,
     config: webhookConfig(input),
   });
   return { id: data.id };
@@ -188,7 +197,7 @@ async function rotateWebhook(
     repo: input.repo,
     hook_id: input.hookId,
     active: true,
-    events: ["issues", "issue_comment", "pull_request", "pull_request_review_comment"],
+    events: ISSUECTL_WEBHOOK_EVENTS,
     config: webhookConfig(input),
   });
   return { id: data.id };

--- a/packages/core/src/github/webhooks.test.ts
+++ b/packages/core/src/github/webhooks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Octokit } from "@octokit/rest";
 import {
+  ISSUECTL_WEBHOOK_EVENTS,
   createIssuectlWebhook,
   rotateIssuectlWebhook,
 } from "./webhooks.js";
@@ -38,7 +39,7 @@ describe("GitHub webhook management", () => {
       owner: "mean-weasel",
       repo: "issuectl",
       active: true,
-      events: ["issues", "issue_comment", "pull_request", "pull_request_review_comment"],
+      events: ISSUECTL_WEBHOOK_EVENTS,
       config: {
         url: "https://hooks.example.test/api/webhook/github/1",
         content_type: "json",
@@ -61,6 +62,7 @@ describe("GitHub webhook management", () => {
 
     expect(updateWebhook).toHaveBeenCalledWith(expect.objectContaining({
       hook_id: 456,
+      events: ISSUECTL_WEBHOOK_EVENTS,
       config: expect.objectContaining({ secret: "new-secret" }),
     }));
   });

--- a/packages/core/src/github/webhooks.ts
+++ b/packages/core/src/github/webhooks.ts
@@ -1,10 +1,12 @@
 import type { Octokit } from "@octokit/rest";
 
-const WEBHOOK_EVENTS = [
+export const ISSUECTL_WEBHOOK_EVENTS = [
   "issues",
   "issue_comment",
   "pull_request",
+  "pull_request_review",
   "pull_request_review_comment",
+  "push",
 ];
 
 export type GitHubWebhookSetupInput = {
@@ -29,7 +31,7 @@ export async function createIssuectlWebhook(
     repo: input.repo,
     name: "web",
     active: true,
-    events: WEBHOOK_EVENTS,
+    events: ISSUECTL_WEBHOOK_EVENTS,
     config: webhookConfig(input),
   });
   return { id: data.id, createdBy };
@@ -45,7 +47,7 @@ export async function rotateIssuectlWebhook(
     repo: input.repo,
     hook_id: input.hookId,
     active: true,
-    events: WEBHOOK_EVENTS,
+    events: ISSUECTL_WEBHOOK_EVENTS,
     config: webhookConfig(input),
   });
   return { id: data.id, createdBy };

--- a/packages/web/app/api/v1/repos/route.test.ts
+++ b/packages/web/app/api/v1/repos/route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const addRepo = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const listRepos = vi.hoisted(() => vi.fn());
+const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
+const withAuthRetry = vi.hoisted(() => vi.fn((fn: (octokit: unknown) => unknown) =>
+  fn({ rest: { repos: { get: vi.fn() } } }),
+));
+
+vi.mock("@issuectl/core", () => ({
+  addRepo: (...args: unknown[]) => addRepo(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+  getDb: () => getDb(),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  listRepos: (...args: unknown[]) => listRepos(...args),
+  updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
+  withAuthRetry: (fn: (octokit: unknown) => unknown) => withAuthRetry(fn),
+}));
+
+import { GET, POST } from "./route";
+
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+};
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/repos", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue({});
+  getRepo.mockReturnValue(undefined);
+  listRepos.mockReturnValue([repo]);
+  addRepo.mockReturnValue(repo);
+  updateRepoWebhookSettings.mockReset();
+  withAuthRetry.mockClear();
+});
+
+describe("/api/v1/repos", () => {
+  it("GET returns tracked repos", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/v1/repos"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.repos).toEqual([repo]);
+  });
+
+  it("POST persists onboarding automation choices", async () => {
+    const response = await POST(request({
+      owner: "mean-weasel",
+      name: "issuectl",
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      issueAgent: "codex",
+      reviewAgent: "claude",
+      webhookPayloadMode: "raw",
+    }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ success: true, repo });
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      issueAgent: "codex",
+      reviewAgent: "claude",
+      webhookPayloadMode: "raw",
+    });
+  });
+});

--- a/packages/web/app/api/v1/repos/route.ts
+++ b/packages/web/app/api/v1/repos/route.ts
@@ -7,6 +7,7 @@ import {
   addRepo,
   getRepo,
   formatErrorForUser,
+  updateRepoWebhookSettings,
   withAuthRetry,
 } from "@issuectl/core";
 
@@ -34,6 +35,11 @@ const OWNER_REPO_RE = /^[a-zA-Z0-9._-]+$/;
 type AddRepoBody = {
   owner: string;
   name: string;
+  autoLaunchIssues?: boolean;
+  autoReviewPrs?: boolean;
+  issueAgent?: "claude" | "codex";
+  reviewAgent?: "claude" | "codex";
+  webhookPayloadMode?: "metadata" | "raw";
 };
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -91,6 +97,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     const repo = addRepo(db, { owner: body.owner, name: body.name });
+    const webhookUpdates = {
+      autoLaunchIssues: body.autoLaunchIssues,
+      autoReviewPrs: body.autoReviewPrs,
+      issueAgent: body.issueAgent,
+      reviewAgent: body.reviewAgent,
+      webhookPayloadMode: body.webhookPayloadMode,
+    };
+    if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
+      updateRepoWebhookSettings(db, repo.id, webhookUpdates);
+    }
     log.info({ msg: "api_repo_added", repoId: repo.id, owner: body.owner, name: body.name });
     return NextResponse.json({ success: true, repo });
   } catch (err) {

--- a/packages/web/components/settings/AddRepoForm.module.css
+++ b/packages/web/components/settings/AddRepoForm.module.css
@@ -262,19 +262,54 @@
   overflow-wrap: anywhere;
 }
 
-.installList {
+.installPane {
   display: grid;
   gap: 8px;
-  margin: 0;
-  padding-left: 22px;
-  color: var(--paper-ink);
-  font-size: 14px;
-  line-height: 1.4;
 }
 
-.doneItem {
-  color: var(--paper-accent);
-  font-weight: 600;
+.installRow {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  padding: 8px 10px;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  color: var(--paper-ink);
+  font-size: 13px;
+}
+
+.installRow strong {
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.installDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--paper-line);
+}
+
+.installDot_running {
+  background: var(--paper-accent);
+}
+
+.installDot_done {
+  background: #2f7d4f;
+}
+
+.installDot_warning,
+.installDot_failed {
+  background: var(--paper-brick);
+}
+
+.installDot_skipped {
+  background: var(--paper-ink-muted);
 }
 
 .postAddActions {

--- a/packages/web/components/settings/AddRepoForm.tsx
+++ b/packages/web/components/settings/AddRepoForm.tsx
@@ -27,6 +27,8 @@ type AutomationState = {
   webhookPayloadMode: WebhookPayloadMode;
 };
 
+type InstallState = "idle" | "running" | "done" | "warning" | "skipped" | "failed";
+
 type FormMode =
   | { kind: "picker" }
   | { kind: "selected"; repo: RepoIdentity }
@@ -60,6 +62,12 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
   const [addedRepo, setAddedRepo] = useState<RepoIdentity | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
+  const [installState, setInstallState] = useState<Record<string, InstallState>>({
+    secret: "idle",
+    webhook: "idle",
+    labels: "idle",
+    ping: "idle",
+  });
   const [isPending, startTransition] = useTransition();
 
   const target = useMemo(() => {
@@ -107,19 +115,32 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
       return;
     }
 
+    setInstallState({
+      secret: "running",
+      webhook: "running",
+      labels: "running",
+      ping: "running",
+    });
     startTransition(async () => {
       const result = await addRepo(
         target.owner,
         target.name,
         localPath.trim() || undefined,
-        automation,
+        { ...automation, installWebhook: true },
       );
       if (!result.success) {
+        setInstallState({ secret: "idle", webhook: "idle", labels: "idle", ping: "idle" });
         setError(result.error);
         return;
       }
       setAddedRepo(result.addedRepo);
       setWarning(result.warning ?? null);
+      setInstallState({
+        secret: result.install.webhook === "skipped" ? "skipped" : "done",
+        webhook: result.install.webhook === "installed" ? "done" : result.install.webhook,
+        labels: result.install.labels.length > 0 ? "done" : "skipped",
+        ping: result.install.firstPing === "received" ? "done" : result.install.firstPing === "timeout" ? "warning" : "skipped",
+      });
       showToast("Repository added", "success");
     });
   }
@@ -330,13 +351,12 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
             </div>
           </div>
 
-          <ol className={styles.installList}>
-            <li className={addedRepo ? styles.doneItem : ""}>
-              Save repository and automation defaults.
-            </li>
-            <li>Install the GitHub webhook from repo settings.</li>
-            <li>Create or confirm automation labels before enabling live traffic.</li>
-          </ol>
+          <div className={styles.installPane} aria-live="polite">
+            <InstallRow label="Generating secret" state={installState.secret} />
+            <InstallRow label="Installing webhook" state={installState.webhook} />
+            <InstallRow label="Creating automation labels" state={installState.labels} />
+            <InstallRow label="Waiting for first delivery" state={installState.ping} />
+          </div>
 
           {addedRepo && (
             <div className={styles.postAddActions}>
@@ -404,6 +424,16 @@ export function AddRepoForm({ onClose, trackedSet }: Props) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function InstallRow({ label, state }: { label: string; state: InstallState }) {
+  return (
+    <div className={styles.installRow}>
+      <span className={`${styles.installDot} ${styles[`installDot_${state}`]}`} />
+      <span>{label}</span>
+      <strong>{state === "idle" ? "pending" : state}</strong>
     </div>
   );
 }

--- a/packages/web/lib/actions/repos.test.ts
+++ b/packages/web/lib/actions/repos.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDb = vi.hoisted(() => vi.fn());
 const coreAddRepo = vi.hoisted(() => vi.fn());
+const createIssuectlWebhook = vi.hoisted(() => vi.fn());
 const coreUpdateRepo = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
+const getSetting = vi.hoisted(() => vi.fn());
 const getActiveWebhookDeploymentsForRepoTarget = vi.hoisted(() => vi.fn());
 const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
@@ -13,6 +15,7 @@ const tmuxSessionName = vi.hoisted(() => vi.fn((repo: string, targetNumber: numb
 const withAuthRetry = vi.hoisted(() => vi.fn());
 const getIssues = vi.hoisted(() => vi.fn());
 const getPulls = vi.hoisted(() => vi.fn());
+const listWebhookEvents = vi.hoisted(() => vi.fn());
 const listLabels = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
@@ -24,13 +27,16 @@ vi.mock("@issuectl/core", () => ({
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
   tmuxSessionName: (repo: string, targetNumber: number, targetType?: "issue" | "pr") => tmuxSessionName(repo, targetNumber, targetType),
   addRepo: (...args: unknown[]) => coreAddRepo(...args),
+  createIssuectlWebhook: (...args: unknown[]) => createIssuectlWebhook(...args),
   removeRepo: vi.fn(),
   updateRepo: (...args: unknown[]) => coreUpdateRepo(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
+  getSetting: (...args: unknown[]) => getSetting(...args),
   readCachedAccessibleRepos: vi.fn(),
   refreshAccessibleRepos: vi.fn(),
   getIssues: (...args: unknown[]) => getIssues(...args),
   getPulls: (...args: unknown[]) => getPulls(...args),
+  listWebhookEvents: (...args: unknown[]) => listWebhookEvents(...args),
   listLabels: (...args: unknown[]) => listLabels(...args),
   withAuthRetry: (...args: unknown[]) => withAuthRetry(...args),
   formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
@@ -46,12 +52,26 @@ beforeEach(() => {
   getDb.mockReturnValue({});
   withAuthRetry.mockReset();
   withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
-    fn({ rest: { repos: { get: vi.fn() } } }),
+    fn({
+      rest: {
+        repos: { get: vi.fn() },
+        issues: {
+          getLabel: vi.fn(async () => ({ data: {} })),
+          createLabel: vi.fn(async () => ({ data: {} })),
+        },
+      },
+    }),
   );
+  createIssuectlWebhook.mockReset();
+  createIssuectlWebhook.mockResolvedValue({ id: 123, createdBy: "octocat" });
+  getSetting.mockReset();
+  getSetting.mockReturnValue("https://hooks.example.test");
   getIssues.mockReset();
   getIssues.mockResolvedValue([]);
   getPulls.mockReset();
   getPulls.mockResolvedValue([]);
+  listWebhookEvents.mockReset();
+  listWebhookEvents.mockReturnValue([]);
   listLabels.mockReset();
   listLabels.mockResolvedValue([]);
   coreAddRepo.mockReset();
@@ -81,6 +101,7 @@ describe("updateRepo action", () => {
     expect(result).toEqual({
       success: true,
       addedRepo: { id: 1, owner: "mean-weasel", name: "issuectl" },
+      install: { webhook: "skipped", labels: [], firstPing: "skipped" },
     });
     expect(coreAddRepo).toHaveBeenCalledWith(expect.anything(), {
       owner: "mean-weasel",
@@ -94,6 +115,64 @@ describe("updateRepo action", () => {
       reviewAgent: "claude",
       webhookPayloadMode: "raw",
     });
+  });
+
+  it("installs the webhook, creates enabled automation labels, and reports first ping timeout", async () => {
+    const labelNames: string[] = [];
+    withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
+      fn({
+        rest: {
+          repos: { get: vi.fn() },
+          issues: {
+            getLabel: vi.fn(async ({ name }: { name: string }) => {
+              labelNames.push(name);
+              throw Object.assign(new Error("missing"), { status: 404 });
+            }),
+            createLabel: vi.fn(async ({ name }: { name: string }) => {
+              labelNames.push(`created:${name}`);
+              return { data: {} };
+            }),
+          },
+        },
+      }),
+    );
+
+    const result = await addRepo("mean-weasel", "issuectl", undefined, {
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      installWebhook: true,
+      firstPingTimeoutMs: 0,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      addedRepo: { id: 1, owner: "mean-weasel", name: "issuectl" },
+      install: expect.objectContaining({
+        webhook: "installed",
+        labels: ["issuectl:auto-launch", "issuectl:auto-review"],
+        firstPing: "timeout",
+        webhookId: 123,
+        url: "https://hooks.example.test/api/webhook/github/1",
+        createdBy: "octocat",
+      }),
+      warning: "Webhook installed, but no first delivery arrived before the timeout.",
+    });
+    expect(createIssuectlWebhook).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      url: "https://hooks.example.test/api/webhook/github/1",
+      secret: expect.any(String),
+    }));
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      webhookId: 123,
+      webhookSecret: expect.any(String),
+    });
+    expect(labelNames).toEqual([
+      "issuectl:auto-launch",
+      "issuectl:auto-review",
+      "created:issuectl:auto-launch",
+      "created:issuectl:auto-review",
+    ]);
   });
 
   it("updates webhook settings without requiring path changes", async () => {

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -1,15 +1,19 @@
 "use server";
 
+/* eslint-disable max-lines */
+import { randomBytes } from "node:crypto";
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import {
   getDb,
   addRepo as coreAddRepo,
+  createIssuectlWebhook,
   removeRepo as coreRemoveRepo,
   updateRepo as coreUpdateRepo,
   updateRepoWebhookSettings,
   getRepoById,
+  getSetting,
   getActiveWebhookDeploymentsForRepoTarget,
   endDeployment,
   killTtyd,
@@ -19,6 +23,7 @@ import {
   refreshAccessibleRepos,
   getIssues,
   getPulls,
+  listWebhookEvents,
   listLabels,
   withAuthRetry,
   formatErrorForUser,
@@ -40,10 +45,20 @@ export type AddRepoResult =
   | {
       success: true;
       addedRepo: { id: number; owner: string; name: string };
+      install: AddRepoInstallResult;
       warning?: string;
       cacheStale?: true;
     }
   | { success: false; error: string };
+
+export type AddRepoInstallResult = {
+  webhook: "installed" | "skipped" | "failed";
+  labels: Array<"issuectl:auto-launch" | "issuectl:auto-review">;
+  firstPing: "received" | "timeout" | "skipped";
+  webhookId?: number;
+  url?: string;
+  createdBy?: string;
+};
 
 export type AddRepoOptions = {
   autoLaunchIssues?: boolean;
@@ -51,6 +66,8 @@ export type AddRepoOptions = {
   issueAgent?: LaunchAgent;
   reviewAgent?: LaunchAgent;
   webhookPayloadMode?: WebhookPayloadMode;
+  installWebhook?: boolean;
+  firstPingTimeoutMs?: number;
 };
 
 export async function addRepo(
@@ -79,6 +96,12 @@ export async function addRepo(
   }
 
   let addedRepo: { id: number; owner: string; name: string };
+  let install: AddRepoInstallResult = {
+    webhook: "skipped",
+    labels: [],
+    firstPing: "skipped",
+  };
+  let installWarning: string | undefined;
   try {
     const db = getDb();
     const repo = coreAddRepo(db, { owner, name, localPath });
@@ -92,6 +115,11 @@ export async function addRepo(
     };
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
       updateRepoWebhookSettings(db, repo.id, webhookUpdates);
+    }
+    if (options.installWebhook) {
+      const result = await installRepoAutomation(db, repo.id, owner, name, options);
+      install = result.install;
+      installWarning = result.warning;
     }
   } catch (err) {
     console.error("[issuectl] Failed to add repo:", errMessage(err));
@@ -149,6 +177,7 @@ export async function addRepo(
       return {
         success: true,
         addedRepo,
+        install,
         warning: "Local path does not exist — will prompt to clone on launch",
         ...(stale ? { cacheStale: true as const } : {}),
       };
@@ -158,8 +187,113 @@ export async function addRepo(
   return {
     success: true,
     addedRepo,
+    install,
+    ...(installWarning ? { warning: installWarning } : {}),
     ...(stale ? { cacheStale: true as const } : {}),
   };
+}
+
+async function installRepoAutomation(
+  db: ReturnType<typeof getDb>,
+  repoId: number,
+  owner: string,
+  name: string,
+  options: AddRepoOptions,
+): Promise<{ install: AddRepoInstallResult; warning?: string }> {
+  const labels = automationLabels(options);
+  const baseUrl = getSetting(db, "public_webhook_base_url");
+  if (!baseUrl) {
+    return {
+      install: { webhook: "skipped", labels: [], firstPing: "skipped" },
+      warning: "Webhook install skipped: public webhook base URL is not configured.",
+    };
+  }
+
+  const url = `${baseUrl.replace(/\/$/, "")}/api/webhook/github/${repoId}`;
+  const secret = randomBytes(32).toString("hex");
+  try {
+    const webhook = await withAuthRetry(async (octokit) => {
+      const created = await createIssuectlWebhook(octokit, {
+        owner,
+        repo: name,
+        url,
+        secret,
+      });
+      await Promise.all(labels.map((label) => ensureRepoLabel(octokit, owner, name, label)));
+      return created;
+    });
+    updateRepoWebhookSettings(db, repoId, {
+      webhookId: webhook.id,
+      webhookSecret: secret,
+    });
+    const firstPing = await waitForFirstPing(db, repoId, options.firstPingTimeoutMs ?? 5_000);
+    return {
+      install: {
+        webhook: "installed",
+        labels,
+        firstPing,
+        webhookId: webhook.id,
+        url,
+        createdBy: webhook.createdBy,
+      },
+      ...(firstPing === "timeout" ? { warning: "Webhook installed, but no first delivery arrived before the timeout." } : {}),
+    };
+  } catch (err) {
+    console.error("[issuectl] Webhook install failed:", errMessage(err));
+    return {
+      install: { webhook: "failed", labels: [], firstPing: "skipped", url },
+      warning: `Webhook install failed: ${formatErrorForUser(err)}`,
+    };
+  }
+}
+
+function automationLabels(options: AddRepoOptions): Array<"issuectl:auto-launch" | "issuectl:auto-review"> {
+  return [
+    ...(options.autoLaunchIssues ? ["issuectl:auto-launch" as const] : []),
+    ...(options.autoReviewPrs ? ["issuectl:auto-review" as const] : []),
+  ];
+}
+
+async function ensureRepoLabel(
+  octokit: Parameters<Parameters<typeof withAuthRetry>[0]>[0],
+  owner: string,
+  repo: string,
+  name: "issuectl:auto-launch" | "issuectl:auto-review",
+): Promise<void> {
+  const meta = name === "issuectl:auto-launch"
+    ? { color: "2f81f7", description: "Opt issue into issuectl auto-launch" }
+    : { color: "a371f7", description: "Opt PR into issuectl auto-review" };
+  try {
+    await octokit.rest.issues.getLabel({ owner, repo, name });
+  } catch (err) {
+    if ((err as { status?: number }).status !== 404) throw err;
+    try {
+      await octokit.rest.issues.createLabel({ owner, repo, name, ...meta });
+    } catch (createErr) {
+      if ((createErr as { status?: number }).status !== 422) throw createErr;
+    }
+  }
+}
+
+async function waitForFirstPing(
+  db: ReturnType<typeof getDb>,
+  repoId: number,
+  timeoutMs: number,
+): Promise<"received" | "timeout"> {
+  if (hasPingDelivery(db, repoId)) return "received";
+  if (timeoutMs <= 0) return "timeout";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
+    if (hasPingDelivery(db, repoId)) return "received";
+  }
+  return "timeout";
+}
+
+function hasPingDelivery(db: ReturnType<typeof getDb>, repoId: number): boolean {
+  return listWebhookEvents(db, 50).some((event) =>
+    event.repoId === repoId && event.eventType === "ping",
+  );
 }
 
 export async function removeRepo(

--- a/packages/web/lib/agent/completion.test.ts
+++ b/packages/web/lib/agent/completion.test.ts
@@ -174,5 +174,17 @@ describe("web agent completion check-ins", () => {
       desired_head_sha: "head-c",
       status: "pending",
     });
+    expect(queryDiagnosticEvents(db, {
+      target: { owner: "mean-weasel", repo: "issuectl", targetType: "pr", targetNumber: 44 },
+      events: ["webhook.completed"],
+    })).toEqual([
+      expect.objectContaining({
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        deploymentId: deployment.id,
+        status: "no_changes",
+      }),
+    ]);
   });
 });

--- a/packages/web/lib/agent/completion.ts
+++ b/packages/web/lib/agent/completion.ts
@@ -123,17 +123,21 @@ function recordCompletionDiagnostic(
 ): void {
   const session = getCompletionSession(db, input.deploymentId);
   const repo = session ? getRepoById(db, session.repoId) : undefined;
+  const targetType = session?.targetType;
+  const targetNumber = session?.targetNumber ?? undefined;
   recordDiagnosticEventSafely(db, {
     level,
     event,
     source: "agent.completion",
     owner: repo?.owner,
     repo: repo?.name,
-    issueNumber: session?.issueNumber ?? undefined,
+    issueNumber: targetType === "issue" ? targetNumber : undefined,
+    targetType,
+    targetNumber,
     deploymentId: input.deploymentId,
     status: reason ?? input.status,
     message: reason ? `Agent completion denied: ${reason}` : "Agent completion recorded",
-    data: { status: input.status, reason },
+    data: { status: input.status, reason, targetType, targetNumber },
   });
 }
 

--- a/packages/web/lib/webhook-intent-worker.test.ts
+++ b/packages/web/lib/webhook-intent-worker.test.ts
@@ -122,6 +122,17 @@ describe("runWebhookIntentWorkerOnce", () => {
     const result = await runWorker(db, 2_000);
 
     expectWorkerResult(result, { claimed: 1, launched: 1 });
+    expect(queryDiagnosticEvents(db, {
+      target: { owner: "mean-weasel", repo: "issuectl", targetType: "issue", targetNumber: 506 },
+      events: ["webhook.lock_check"],
+    })).toEqual([
+      expect.objectContaining({
+        issueNumber: 506,
+        targetType: "issue",
+        targetNumber: 506,
+        message: "Issue has no live session.",
+      }),
+    ]);
     expect(getIntentRow(db, intentId)).toEqual(
       expect.objectContaining({
         status: "launched",
@@ -199,6 +210,17 @@ describe("runWebhookIntentWorkerOnce", () => {
     const result = await runWorker(db, 2_000);
 
     expectWorkerResult(result, { claimed: 1, skippedLocked: 1 });
+    expect(queryDiagnosticEvents(db, {
+      target: { owner: "mean-weasel", repo: "issuectl", targetType: "issue", targetNumber: 506 },
+      events: ["webhook.lock_check"],
+    })).toEqual([
+      expect.objectContaining({
+        issueNumber: 506,
+        targetType: "issue",
+        targetNumber: 506,
+        message: "Issue already has a live session.",
+      }),
+    ]);
     expect(getIntentRow(db, intentId)).toEqual(
       expect.objectContaining({
         status: "skipped_locked",

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -129,7 +129,15 @@ export async function runWebhookIntentWorkerOnce(
       markIntentTerminal(db, intent.id, "skipped_optout", now, "Issue is not opted in");
       return result(base, { claimed: 1, skippedOptout: 1 });
     }
-    if (hasLiveDeploymentForIssue(db, repo.id, intent.targetNumber)) {
+    const locked = hasLiveDeploymentForIssue(db, repo.id, intent.targetNumber);
+    recordIntentDiagnostic(
+      db,
+      repo,
+      intent,
+      "webhook.lock_check",
+      locked ? "Issue already has a live session." : "Issue has no live session.",
+    );
+    if (locked) {
       recordIntentDiagnostic(db, repo, intent, "webhook.skipped_locked", "Issue already has a live session.");
       markIntentTerminal(db, intent.id, "skipped_locked", now, "Issue already has a live session");
       return result(base, { claimed: 1, skippedLocked: 1 });

--- a/packages/web/lib/webhook-pr-intent.test.ts
+++ b/packages/web/lib/webhook-pr-intent.test.ts
@@ -108,6 +108,19 @@ describe("PR webhook intents", () => {
     expect(
       db.prepare("SELECT pr_number, status, deployment_id, reviewed_to_sha FROM pr_reviews").get(),
     ).toEqual({ pr_number: 44, status: "in_progress", deployment_id: 1, reviewed_to_sha: "head-b" });
+    const prTarget = { owner: "mean-weasel", repo: "issuectl", targetType: "pr" as const, targetNumber: 44 };
+    expect(queryDiagnosticEvents(db, {
+      target: prTarget,
+      events: ["webhook.lock_check"],
+    })).toEqual([
+      expect.objectContaining({ issueNumber: null, targetType: "pr", targetNumber: 44, message: "PR has no active review blocking launch." }),
+    ]);
+    expect(queryDiagnosticEvents(db, {
+      target: prTarget,
+      events: ["webhook.launched"],
+    })).toEqual([
+      expect.objectContaining({ issueNumber: null, targetType: "pr", targetNumber: 44, deploymentId: 1 }),
+    ]);
     expect(queryDiagnosticEvents(db, { events: ["webhook.pr_launched"] })).toHaveLength(1);
   });
 

--- a/packages/web/lib/webhook-pr-intent.ts
+++ b/packages/web/lib/webhook-pr-intent.ts
@@ -77,6 +77,13 @@ export async function handlePullRequestIntent(
     }
     if (!deps.launchPr) throw new Error("PR launch dependency is not configured");
     const plan = await planPrReview(db, repo, intent, pull, now, deps, triggeredBy);
+    recordPrIntentDiagnostic(
+      db,
+      repo,
+      intent,
+      "webhook.lock_check",
+      plan.action === "skip" ? plan.reason : "PR has no active review blocking launch.",
+    );
     if (plan.action === "skip") {
       markIntentSkippedLocked(db, intent.id, now, plan.reason);
       recordPrIntentDiagnostic(db, repo, intent, plan.event, plan.reason);
@@ -88,6 +95,7 @@ export async function handlePullRequestIntent(
     const launch = await deps.launchPr(db, repo, intent, pull, review);
     markPrReviewInProgress(db, review.id, launch.deploymentId);
     markIntentLaunched(db, intent.id, now, launch.deploymentId);
+    recordPrIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched PR review session.", launch.deploymentId);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.pr_launched", "Webhook launched PR review session.", launch.deploymentId);
     return result(base, { claimed: 1, launched: 1 });
   } catch (err) {


### PR DESCRIPTION
## Summary
- make PR completion and webhook launch diagnostics target-aware/queryable for PR targets
- add webhook lock-check diagnostics for issue and PR launch decisions
- expand GitHub webhook install event subscriptions for #507 and wire Add Repo to install webhook, create automation labels, and report first-ping status

## Verification
- pnpm --dir packages/web test -- completion webhook-intent-worker webhook-pr-intent
- pnpm --dir packages/core test -- diagnostics
- pnpm --dir packages/cli test -- diag
- pnpm --dir packages/core test -- webhooks
- pnpm --dir packages/cli test -- webhook
- pnpm --dir packages/web test -- repos
- pnpm --dir packages/core typecheck
- pnpm --dir packages/cli typecheck
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- git diff --check
- commit hook: turbo typecheck, core build, lint
- push hook: turbo build

## GoalBuddy
Checkpoint for T004/T005 on docs/goals/issue-506-507-gap-closure. T003 direct PR fix-push remains queued for product/security decision.