### PR TITLE
Finish issue 507 operator UX

### DIFF
--- a/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
+++ b/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
@@ -10,6 +10,7 @@ type StreamMessage = {
   payload?: {
     generatedAt?: string;
     entries?: unknown[];
+    counts?: Record<string, number>;
     error?: string;
   };
 };
@@ -19,6 +20,7 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
   const [state, setState] = useState<StreamState>("connecting");
   const [lastUpdate, setLastUpdate] = useState<string | null>(null);
   const [visibleEvents, setVisibleEvents] = useState(0);
+  const [counts, setCounts] = useState<Record<string, number> | null>(null);
   const reconnectRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -54,6 +56,9 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
         if (Array.isArray(message?.payload?.entries)) {
           setVisibleEvents(message.payload.entries.length);
         }
+        if (isCounts(message?.payload?.counts)) {
+          setCounts(message.payload.counts);
+        }
       });
       socket.addEventListener("close", () => {
         if (cancelled) return;
@@ -82,7 +87,9 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
       <div>
         <span className={styles.liveLabel} data-state={state}>{state}</span>
         <span className={styles.liveMeta}>
-          {lastUpdate ? `Updated ${new Date(lastUpdate).toLocaleTimeString()}` : `${visibleEvents} visible events`}
+          {lastUpdate
+            ? `Updated ${new Date(lastUpdate).toLocaleTimeString()} · ${liveSummary(counts, visibleEvents)}`
+            : liveSummary(counts, visibleEvents)}
         </span>
       </div>
       <button className={styles.secondaryButton} type="button" onClick={() => setPaused((value) => !value)}>
@@ -104,4 +111,13 @@ function parseStreamMessage(value: unknown): StreamMessage | null {
 function readApiToken(): string | null {
   if (typeof window === "undefined") return null;
   return window.localStorage.getItem("issuectl.apiToken");
+}
+
+function isCounts(value: unknown): value is Record<string, number> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function liveSummary(counts: Record<string, number> | null, visibleEvents: number): string {
+  if (!counts) return `${visibleEvents} visible events`;
+  return `${counts.total ?? visibleEvents} visible · ${counts.fired ?? 0} fired · ${counts.debouncing ?? 0} debouncing · ${counts.failed ?? 0} failed`;
 }

--- a/packages/web/app/logs/webhooks/page.module.css
+++ b/packages/web/app/logs/webhooks/page.module.css
@@ -279,6 +279,57 @@
   border-bottom: 1px solid var(--paper-line);
 }
 
+.auditPanel {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.auditHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.auditHeader h2 {
+  margin: 0 0 4px;
+  font-family: var(--paper-serif);
+  font-size: 20px;
+}
+
+.auditList {
+  display: grid;
+  gap: 8px;
+}
+
+.auditItem {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--paper-line-soft);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.auditItem strong {
+  text-transform: uppercase;
+  font: 700 11px var(--paper-mono);
+}
+
+.auditItem span,
+.auditItem code {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.auditItem code {
+  overflow-x: auto;
+}
+
 .details {
   margin-top: 8px;
 }

--- a/packages/web/app/logs/webhooks/page.tsx
+++ b/packages/web/app/logs/webhooks/page.tsx
@@ -5,6 +5,8 @@ import {
   getDb,
   listRepos,
   listWebhookLogEntries,
+  queryDiagnosticEvents,
+  type DiagnosticEvent,
   type Repo,
   type WebhookLogEntry,
   type WebhookLogResult,
@@ -27,10 +29,14 @@ const RESULT_FILTERS: Array<{ label: string; value: WebhookLogResult | "all" }> 
   { label: "All", value: "all" },
   { label: "Fired", value: "fired" },
   { label: "Debouncing", value: "debouncing" },
+  { label: "Processing", value: "processing" },
   { label: "Gated", value: "gated" },
   { label: "Dropped", value: "dropped" },
   { label: "Failed", value: "failed" },
+  { label: "Received", value: "received" },
 ];
+
+const AUDIT_EVENTS = ["webhook.invalid_signature", "webhook.deduped"];
 
 export default async function WebhookLogsPage({
   searchParams,
@@ -63,6 +69,11 @@ export default async function WebhookLogsPage({
     params,
     repos,
   );
+  const auditEvents = filterAuditEvents(
+    queryDiagnosticEvents(db, { events: AUDIT_EVENTS, limit: 30 }),
+    params,
+    repos,
+  );
   const metrics = summarize(entries);
   const health = webhookHealth(entries);
 
@@ -87,6 +98,7 @@ export default async function WebhookLogsPage({
           <Metric label="Today" value={`${metrics.today} deliveries`} />
           <Metric label="Actions" value={`${metrics.fired} fired`} />
           <Metric label="Dropped" value={`${metrics.dropped + metrics.gated} gated/drop`} />
+          <Metric label="Audit" value={`${auditEvents.length} invalid/replay`} />
           <Metric label="Raw payloads" value={`${metrics.retained} retained`} />
           <Metric label="Stream" value="/api/webhooks/events/stream" />
         </dl>
@@ -143,6 +155,7 @@ export default async function WebhookLogsPage({
         ) : (
           <WebhookTable entries={entries} repos={repos} />
         )}
+        <WebhookAuditPanel events={auditEvents} />
       </main>
     </>
   );
@@ -178,6 +191,36 @@ function WebhookTable({ entries, repos }: { entries: WebhookLogEntry[]; repos: R
           ))}
         </tbody>
       </table>
+    </section>
+  );
+}
+
+function WebhookAuditPanel({ events }: { events: DiagnosticEvent[] }) {
+  return (
+    <section className={styles.auditPanel} aria-label="Webhook invalid and replay audit">
+      <div className={styles.auditHeader}>
+        <div>
+          <h2>Invalid and replay audit</h2>
+          <p className={styles.muted}>Metadata-only diagnostics for rejected signatures and duplicate deliveries.</p>
+        </div>
+        <div className={styles.filters}>
+          <Link className={styles.chip} href="/logs/webhooks?event=webhook.invalid_signature">Invalid</Link>
+          <Link className={styles.chip} href="/logs/webhooks?event=webhook.deduped">Replay</Link>
+        </div>
+      </div>
+      {events.length === 0 ? (
+        <p className={styles.muted}>No invalid signature or replay diagnostics match these filters.</p>
+      ) : (
+        <div className={styles.auditList}>
+          {events.map((event) => (
+            <article key={event.id} className={styles.auditItem}>
+              <strong>{event.event === "webhook.deduped" ? "replayed delivery" : "invalid signature"}</strong>
+              <span>{event.owner}/{event.repo} · {event.correlationId ?? "unknown delivery"} · {formatAge(event.timestamp)}</span>
+              <code>{auditCliHint(event)}</code>
+            </article>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -279,6 +322,29 @@ function filterEntries(
   });
 }
 
+function filterAuditEvents(
+  events: DiagnosticEvent[],
+  params: SearchParams,
+  repos: Repo[],
+): DiagnosticEvent[] {
+  const query = params.q?.trim().toLowerCase();
+  const eventQuery = params.event?.trim().toLowerCase();
+  const selectedRepoId = parsePositiveInt(params.repo);
+  const selectedRepo = repos.find((repo) => repo.id === selectedRepoId);
+  return events.filter((event) => {
+    if (selectedRepo && (event.owner !== selectedRepo.owner || event.repo !== selectedRepo.name)) return false;
+    if (eventQuery && !event.event.toLowerCase().includes(eventQuery)) return false;
+    if (!query) return true;
+    return [
+      event.event,
+      event.correlationId,
+      event.owner && event.repo ? `${event.owner}/${event.repo}` : null,
+      event.targetNumber ? `${event.owner}/${event.repo}#${event.targetNumber}` : null,
+      event.message,
+    ].filter(Boolean).join(" ").toLowerCase().includes(query);
+  });
+}
+
 function summarize(entries: WebhookLogEntry[]) {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
@@ -347,12 +413,23 @@ function diagnosticsCommand(entry: WebhookLogEntry, repo: Repo | undefined): str
 
 function cliHint(entry: WebhookLogEntry): string {
   if (entry.targetType && entry.targetNumber) {
-    return `issuectl webhook tail --target ${entry.targetType}/${entry.targetNumber} --limit 20`;
+    return `issuectl webhook tail --target ${entry.targetType}#${entry.targetNumber} --limit 20`;
   }
   if (entry.result === "dropped" || entry.result === "failed") {
     return "issuectl diag list --event webhook.runaway_limited webhook.launch_failed --limit 50";
   }
   return "issuectl webhook tail";
+}
+
+function auditCliHint(event: DiagnosticEvent): string {
+  if (event.targetType && event.targetNumber && event.owner && event.repo) {
+    const targetFlag = event.targetType === "pr" ? "--pr" : "--issue";
+    return `pnpm --dir packages/cli exec issuectl diag show ${targetFlag} ${event.owner}/${event.repo}#${event.targetNumber}`;
+  }
+  if (event.correlationId) {
+    return `pnpm --dir packages/cli exec issuectl diag list --correlation ${event.correlationId}`;
+  }
+  return `pnpm --dir packages/cli exec issuectl diag list --event ${event.event}`;
 }
 
 function formatPayload(payload: string): string {

--- a/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
+++ b/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   dbExists,
+  getActiveWebhookDeploymentsForRepoTarget,
   getActiveDeployments,
   getDb,
   getRepo,
@@ -43,10 +44,15 @@ export default async function RepoSettingsPage({
     ? `${publicWebhookBaseUrl.replace(/\/$/, "")}/api/webhook/github/${repo.id}`
     : null;
   const activeSessions = getActiveDeployments(db).filter((deployment) => deployment.repoId === repo.id).length;
+  const activeIssueSessions = getActiveWebhookDeploymentsForRepoTarget(db, repo.id, "issue").length;
+  const activePrSessions = getActiveWebhookDeploymentsForRepoTarget(db, repo.id, "pr").length;
+  const recentDeliveries = listWebhookEvents(db, { repoId: repo.id, limit: 10 });
   const activity = {
     activeSessions,
+    activeIssueSessions,
+    activePrSessions,
     recentCompletions: listRecentTerminalDeploymentsByRepo(db, repo.id, 25).length,
-    webhookEvents: listWebhookEvents(db, { repoId: repo.id, limit: 25 }).length,
+    webhookEvents: recentDeliveries.length,
     prReviews: listPrReviewsForRepo(db, repo.id, 25).length,
   };
 
@@ -58,6 +64,7 @@ export default async function RepoSettingsPage({
           repo={repo}
           webhookUrl={webhookUrl}
           activity={activity}
+          recentDeliveries={recentDeliveries}
           settingsHref="/settings/repos"
         />
       </main>

--- a/packages/web/components/repos/RepoSettingsPanel.module.css
+++ b/packages/web/components/repos/RepoSettingsPanel.module.css
@@ -110,7 +110,8 @@
 }
 
 .section input:not([type="checkbox"]),
-.section select {
+.section select,
+.section textarea {
   min-height: 38px;
   padding: 0 10px;
   border: 1px solid var(--paper-line);
@@ -118,6 +119,12 @@
   background: rgba(255, 255, 255, 0.28);
   color: var(--text-primary);
   font: 13px var(--paper-serif);
+}
+
+.section textarea {
+  min-height: 96px;
+  padding: 10px;
+  resize: vertical;
 }
 
 .actionRow {
@@ -183,6 +190,50 @@
   background: #fff2c9;
   font: 700 11px var(--paper-mono);
   text-transform: uppercase;
+}
+
+.deliveryDetails {
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.deliveryDetails summary {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  cursor: pointer;
+  font: 700 12px var(--paper-mono);
+}
+
+.deliveryTable {
+  display: grid;
+  border-top: 1px solid var(--paper-line);
+}
+
+.deliveryTable a,
+.deliveryEmpty {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(96px, 160px) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 10px;
+  color: var(--text-primary);
+  text-decoration: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+}
+
+.deliveryTable a:first-child {
+  border-top: 0;
+}
+
+.deliveryTable code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .statusPill[data-state="healthy"] {

--- a/packages/web/components/repos/RepoSettingsPanel.tsx
+++ b/packages/web/components/repos/RepoSettingsPanel.tsx
@@ -1,12 +1,21 @@
+/* eslint-disable max-lines */
 "use client";
 
 import { useState, useTransition } from "react";
-import type { LaunchAgent, Repo, WebhookPayloadMode } from "@issuectl/core";
-import { removeRepo, updateRepo } from "@/lib/actions/repos";
+import type { LaunchAgent, Repo, WebhookEvent, WebhookPayloadMode } from "@issuectl/core";
+import {
+  configureRepoWebhook,
+  recreateRepoLabels,
+  removeRepo,
+  resendLastPing,
+  updateRepo,
+} from "@/lib/actions/repos";
 import styles from "./RepoSettingsPanel.module.css";
 
 export type RepoSettingsActivity = {
   activeSessions: number;
+  activeIssueSessions: number;
+  activePrSessions: number;
   recentCompletions: number;
   webhookEvents: number;
   prReviews: number;
@@ -16,6 +25,7 @@ export type RepoSettingsPanelProps = {
   repo: Repo;
   webhookUrl: string | null;
   activity: RepoSettingsActivity;
+  recentDeliveries: WebhookEvent[];
   settingsHref?: string;
 };
 
@@ -24,18 +34,13 @@ type LabelHealth = {
   message: string;
 };
 
-type WebhookResult = {
-  success: true;
-  repo: Repo;
-  webhook: { id: number; url: string; createdBy: string };
-} | { success: false; error: string };
-
 const REQUIRED_LABELS = ["issuectl:auto-launch", "issuectl:auto-review"];
 
 export function RepoSettingsPanel({
   repo,
   webhookUrl,
   activity,
+  recentDeliveries,
   settingsHref,
 }: RepoSettingsPanelProps) {
   const [localPath, setLocalPath] = useState(repo.localPath ?? "");
@@ -44,6 +49,7 @@ export function RepoSettingsPanel({
   const [autoReviewPrs, setAutoReviewPrs] = useState(repo.autoReviewPrs);
   const [issueAgent, setIssueAgent] = useState<LaunchAgent>(repo.issueAgent);
   const [reviewAgent, setReviewAgent] = useState<LaunchAgent>(repo.reviewAgent);
+  const [reviewPreamble, setReviewPreamble] = useState(repo.reviewPreamble ?? "");
   const [webhookPayloadMode, setWebhookPayloadMode] = useState<WebhookPayloadMode>(repo.webhookPayloadMode);
   const [webhookId, setWebhookId] = useState(repo.webhookId);
   const [labelHealth, setLabelHealth] = useState<LabelHealth>({
@@ -69,6 +75,7 @@ export function RepoSettingsPanel({
         autoReviewPrs,
         issueAgent,
         reviewAgent,
+        reviewPreamble: reviewPreamble.trim() || null,
         webhookPayloadMode,
       });
       if (!result.success) {
@@ -80,7 +87,7 @@ export function RepoSettingsPanel({
   }
 
   function removeTrackedRepo() {
-    const confirmed = window.confirm(`Remove ${repoPath}? Active webhook sessions may be ended.`);
+    const confirmed = window.confirm(`Remove ${repoPath}? ${activity.activeSessions} active sessions may be ended and the GitHub webhook will be deleted best-effort.`);
     if (!confirmed) return;
     setMessage(null);
     setError(null);
@@ -94,26 +101,35 @@ export function RepoSettingsPanel({
     });
   }
 
-  async function configureWebhook(action: "create" | "rotate") {
+  function setIssueAutomation(enabled: boolean) {
+    if (!enabled && autoLaunchIssues && activity.activeIssueSessions > 0) {
+      const ok = window.confirm(`This will end ${activity.activeIssueSessions} active auto-sessions for issues. Continue?`);
+      if (!ok) return;
+    }
+    setAutoLaunchIssues(enabled);
+  }
+
+  function setPrAutomation(enabled: boolean) {
+    if (!enabled && autoReviewPrs && activity.activePrSessions > 0) {
+      const ok = window.confirm(`This will end ${activity.activePrSessions} active auto-sessions for PR reviews. Continue?`);
+      if (!ok) return;
+    }
+    setAutoReviewPrs(enabled);
+  }
+
+  function runWebhookAction(action: "rotate" | "reinstall") {
     setMessage(null);
     setError(null);
-    try {
-      const response = await fetch(`/api/v1/repos/${repo.owner}/${repo.name}/webhook`, {
-        method: "POST",
-        headers: requestHeaders(),
-        body: JSON.stringify({ action }),
-      });
-      const body = await response.json().catch(() => undefined) as WebhookResult | undefined;
-      if (!response.ok || !body || body.success !== true) {
-        const failure = body as { error?: string } | undefined;
-        throw new Error(failure?.error ?? `Webhook request failed with ${response.status}`);
+    startTransition(async () => {
+      const result = await configureRepoWebhook(repo.id, action);
+      if (!result.success) {
+        setError(result.error);
+        return;
       }
-      setWebhookId(body.webhook.id);
-      const successMessage = `${action === "create" ? "Webhook installed" : "Webhook secret rotated"} by ${body.webhook.createdBy}`;
+      setWebhookId(result.webhook.id);
+      const successMessage = `${action === "reinstall" ? "Webhook reinstalled" : "Webhook secret rotated"} by ${result.webhook.createdBy}`;
       setMessage(activity.webhookEvents === 0 ? `${successMessage}. Waiting for first delivery.` : successMessage);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Webhook request failed");
-    }
+    });
   }
 
   async function checkLabels() {
@@ -142,25 +158,31 @@ export function RepoSettingsPanel({
     }
   }
 
-  async function recreateLabels() {
+  function recreateLabelsWithAction() {
     setLabelHealth({ status: "checking", message: "Recreating labels" });
     setError(null);
-    try {
-      const response = await fetch(`/api/v1/repos/${repo.owner}/${repo.name}/labels`, {
-        method: "POST",
-        headers: requestHeaders(),
-        body: JSON.stringify({ action: "recreate" }),
-      });
-      const body = await response.json().catch(() => undefined) as { success?: boolean; error?: string } | undefined;
-      if (!response.ok || !body?.success) throw new Error(body?.error ?? "Label recreate failed");
+    startTransition(async () => {
+      const result = await recreateRepoLabels(repo.id);
+      if (!result.success) {
+        setLabelHealth({ status: "error", message: result.error });
+        return;
+      }
       setLabelHealth({ status: "healthy", message: "Required labels recreated" });
       setMessage("Label health restored");
-    } catch (err) {
-      setLabelHealth({
-        status: "error",
-        message: err instanceof Error ? err.message : "Label recreate failed",
-      });
-    }
+    });
+  }
+
+  function resendPing() {
+    setMessage(null);
+    setError(null);
+    startTransition(async () => {
+      const result = await resendLastPing(repo.id);
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      setMessage("Webhook ping sent");
+    });
   }
 
   return (
@@ -205,11 +227,11 @@ export function RepoSettingsPanel({
         </div>
         <div className={styles.toggleGrid}>
           <label>
-            <input type="checkbox" checked={autoLaunchIssues} onChange={(event) => setAutoLaunchIssues(event.target.checked)} />
+            <input type="checkbox" checked={autoLaunchIssues} onChange={(event) => setIssueAutomation(event.target.checked)} />
             <span>Auto-launch labeled issues</span>
           </label>
           <label>
-            <input type="checkbox" checked={autoReviewPrs} onChange={(event) => setAutoReviewPrs(event.target.checked)} />
+            <input type="checkbox" checked={autoReviewPrs} onChange={(event) => setPrAutomation(event.target.checked)} />
             <span>Auto-review labeled PRs</span>
           </label>
         </div>
@@ -236,12 +258,27 @@ export function RepoSettingsPanel({
             </select>
           </label>
         </div>
+        <label>
+          <span>Review preamble</span>
+          <textarea
+            value={reviewPreamble}
+            onChange={(event) => setReviewPreamble(event.target.value)}
+            placeholder="Optional instructions added to PR review sessions for this repo."
+            rows={4}
+          />
+        </label>
+        {reviewPreamble !== (repo.reviewPreamble ?? "") && (
+          <button type="button" className={styles.secondaryButton} onClick={() => setReviewPreamble(repo.reviewPreamble ?? "")}>
+            Reset preamble
+          </button>
+        )}
       </section>
 
       <section className={styles.section} aria-label="Webhook">
         <div>
           <h2>Webhook</h2>
           <p>{webhookConfigured ? `GitHub hook ${webhookId} is stored locally.` : "No GitHub webhook id is stored locally."}</p>
+          <p>Last delivery: {recentDeliveries[0] ? formatWebhookAge(recentDeliveries[0].receivedAt) : "none yet"} · 7-day success: tracked in the webhook log</p>
         </div>
         {waitingForFirstPing && (
           <div className={styles.warningPill} role="status">
@@ -256,10 +293,17 @@ export function RepoSettingsPanel({
           <button type="button" className={styles.secondaryButton} disabled={!webhookUrl} onClick={() => void copyWebhookUrl(webhookUrl)}>
             Copy URL
           </button>
-          <button type="button" className={styles.secondaryButton} disabled={!webhookUrl} onClick={() => void configureWebhook(webhookConfigured ? "rotate" : "create")}>
-            {webhookConfigured ? "Rotate secret" : "Install webhook"}
+          <button type="button" className={styles.secondaryButton} disabled={!webhookUrl || isPending} onClick={() => runWebhookAction("reinstall")}>
+            Reinstall webhook
+          </button>
+          <button type="button" className={styles.secondaryButton} disabled={!webhookConfigured || isPending} onClick={() => runWebhookAction("rotate")}>
+            Rotate secret
+          </button>
+          <button type="button" className={styles.secondaryButton} disabled={!webhookConfigured || isPending} onClick={resendPing}>
+            Re-send last ping
           </button>
         </div>
+        <RecentDeliveries repo={repo} deliveries={recentDeliveries} />
       </section>
 
       <section className={styles.section} aria-label="Label health">
@@ -272,9 +316,24 @@ export function RepoSettingsPanel({
           <button type="button" className={styles.secondaryButton} onClick={() => void checkLabels()}>
             Check labels
           </button>
-          <button type="button" className={styles.secondaryButton} onClick={() => void recreateLabels()}>
+          <button type="button" className={styles.secondaryButton} onClick={recreateLabelsWithAction}>
             Recreate labels
           </button>
+        </div>
+      </section>
+
+      <section className={styles.section} aria-label="Activity links">
+        <div>
+          <h2>Activity</h2>
+          <p>Jump to the operational views for this repository.</p>
+        </div>
+        <div className={styles.actionRow}>
+          <a className={styles.secondaryButton} href={`/sessions?repo=${encodeURIComponent(repoPath)}`}>
+            View repo sessions
+          </a>
+          <a className={styles.secondaryButton} href={`/logs/webhooks?repo=${encodeURIComponent(repoPath)}`}>
+            View webhook events
+          </a>
         </div>
       </section>
 
@@ -306,6 +365,35 @@ function Metric({ label, value }: { label: string; value: number }) {
       <strong>{value}</strong>
     </div>
   );
+}
+
+function RecentDeliveries({ repo, deliveries }: { repo: Repo; deliveries: WebhookEvent[] }) {
+  return (
+    <details className={styles.deliveryDetails}>
+      <summary>Show recent deliveries</summary>
+      <div className={styles.deliveryTable}>
+        {deliveries.slice(0, 10).map((event) => (
+          <a
+            key={event.id}
+            href={`/logs/webhooks?repo=${encodeURIComponent(`${repo.owner}/${repo.name}`)}&delivery=${encodeURIComponent(event.deliveryId)}`}
+          >
+            <span>{event.eventType}{event.action ? `.${event.action}` : ""}</span>
+            <code>{event.deliveryId}</code>
+            <span>{formatWebhookAge(event.receivedAt)}</span>
+          </a>
+        ))}
+        {deliveries.length === 0 && <span className={styles.deliveryEmpty}>No deliveries recorded yet.</span>}
+      </div>
+    </details>
+  );
+}
+
+function formatWebhookAge(receivedAt: number): string {
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - receivedAt) / 1000));
+  if (diffSeconds < 60) return `${diffSeconds}s ago`;
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`;
+  if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)}h ago`;
+  return `${Math.floor(diffSeconds / 86400)}d ago`;
 }
 
 async function copyWebhookUrl(value: string | null): Promise<void> {

--- a/packages/web/components/reviews/ReviewDetailPanel.module.css
+++ b/packages/web/components/reviews/ReviewDetailPanel.module.css
@@ -46,6 +46,36 @@
   gap: 7px;
 }
 
+.summaryFacts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.summaryFacts div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  border: 1px solid var(--paper-line-soft);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 32%, transparent);
+}
+
+.summaryFacts dt {
+  color: var(--paper-ink-muted);
+  font: 600 var(--paper-fs-xs) var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.summaryFacts dd {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chip {
   min-height: 24px;
   display: inline-flex;
@@ -113,7 +143,8 @@
 }
 
 .banner p,
-.diagnostic p {
+.diagnostic p,
+.muted {
   margin: 4px 0 0;
   color: var(--paper-ink-muted);
 }
@@ -260,6 +291,11 @@
   white-space: nowrap;
 }
 
+.card button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .card button {
   background: var(--paper-ink);
   color: var(--paper-bg);
@@ -283,6 +319,10 @@
 
   .facts {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summaryFacts {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/packages/web/components/reviews/ReviewDetailPanel.tsx
+++ b/packages/web/components/reviews/ReviewDetailPanel.tsx
@@ -23,6 +23,20 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
             <Chip tone="accent">{triggerLabel(data.review.triggeredBy)}</Chip>
             <Chip tone="neutral">{data.review.headRef}</Chip>
           </div>
+          <dl className={styles.summaryFacts}>
+            <div>
+              <dt>Trigger</dt>
+              <dd>{triggerDescription(data.review.triggeredBy)}</dd>
+            </div>
+            <div>
+              <dt>Range</dt>
+              <dd>{data.review.reviewedFromSha ? `${shortSha(data.review.reviewedFromSha)}..${shortSha(data.review.reviewedToSha)}` : `full ${shortSha(data.review.reviewedToSha)}`}</dd>
+            </div>
+            <div>
+              <dt>Result</dt>
+              <dd>{resultSummary(data.result)}</dd>
+            </div>
+          </dl>
         </header>
 
         {data.banners.length > 0 && (
@@ -51,6 +65,7 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
                     <Chip tone={statusTone(run.status)}>{labelize(run.status)}</Chip>
                   </div>
                   <p>{run.label}</p>
+                  {stringValue(run.result.reason) && <p>Reason: {stringValue(run.result.reason)}</p>}
                   <dl className={styles.facts}>
                     <div>
                       <dt>Started</dt>
@@ -96,13 +111,14 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
       <aside className={styles.railPanel}>
         <section className={styles.card}>
           <h2>Actions</h2>
+          {data.actions.disabledReason && <p className={styles.muted}>{data.actions.disabledReason}</p>}
           <form action={retryAction}>
             <input type="hidden" name="reviewId" value={data.review.id} />
-            <button type="submit">Retry review</button>
+            <button type="submit" disabled={!data.actions.canRetry}>Retry review</button>
           </form>
           <form action={fullRerunAction}>
             <input type="hidden" name="reviewId" value={data.review.id} />
-            <button type="submit">Full rerun</button>
+            <button type="submit" disabled={!data.actions.canFullRerun}>Full rerun</button>
           </form>
         </section>
 
@@ -136,7 +152,9 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
           <h2>Links</h2>
           <div className={styles.links}>
             <a href={data.links.githubPr}>GitHub PR</a>
+            <a href={data.links.githubReviewFiles}>Review files</a>
             <Link href={data.links.workbench}>Workbench</Link>
+            <Link href={data.links.webhookLogs}>Webhook logs</Link>
             <Link href={data.links.sessions}>Sessions list</Link>
             <Link href={data.links.repoSettings}>Repo settings</Link>
           </div>
@@ -166,8 +184,23 @@ function triggerLabel(trigger: string): string {
   return trigger === "comment_command" ? "comment" : trigger;
 }
 
+function triggerDescription(trigger: string): string {
+  if (trigger === "comment_command") return "Requested from an issuectl comment command";
+  if (trigger === "webhook") return "Started by GitHub webhook automation";
+  return "Started manually";
+}
+
 function labelize(value: string): string {
   return value.replaceAll("_", " ");
+}
+
+function resultSummary(result: Record<string, unknown>): string {
+  const summary = result.summary ?? result.reason ?? result.error ?? result.status;
+  return typeof summary === "string" && summary.length > 0 ? summary : "not recorded";
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function shortSha(value: string): string {

--- a/packages/web/components/sessions/SessionsReviewList.module.css
+++ b/packages/web/components/sessions/SessionsReviewList.module.css
@@ -178,6 +178,20 @@
 
 .reviewRun {
   grid-template-columns: 18px minmax(220px, 1fr) auto;
+  color: inherit;
+  text-decoration: none;
+}
+
+.reviewRun:hover {
+  background: color-mix(in srgb, var(--paper-accent-soft) 38%, transparent);
+}
+
+.reviewRun[data-status="superseded"] {
+  background: color-mix(in srgb, #f1e0ae 28%, transparent);
+}
+
+.reviewRun[data-status="failed"] {
+  background: color-mix(in srgb, #f0d4cc 26%, transparent);
 }
 
 .runRail {

--- a/packages/web/components/sessions/SessionsReviewList.tsx
+++ b/packages/web/components/sessions/SessionsReviewList.tsx
@@ -168,6 +168,8 @@ function SessionGroups({ groups }: { groups: SessionTargetGroup[] }) {
                   <Chip tone="accent" title={triggerTitle(session.triggeredBy)}>{triggerLabel(session.triggeredBy)}</Chip>
                   {session.terminalReason && <Chip tone="warn">{labelize(session.terminalReason)}</Chip>}
                   {session.linkedPrNumber && <Chip tone="neutral">PR #{session.linkedPrNumber}</Chip>}
+                  {session.parentDeploymentId && <Chip tone="neutral">parent #{session.parentDeploymentId}</Chip>}
+                  {session.childDeploymentCount > 0 && <Chip tone="accent">{session.childDeploymentCount} child</Chip>}
                   {session.webhookDepth > 0 && <Chip tone="neutral">depth {session.webhookDepth}</Chip>}
                 </div>
                 <div className={styles.rowLinks}>
@@ -210,7 +212,13 @@ function ReviewGroups({ groups }: { groups: ReviewPrGroup[] }) {
           </header>
           <div className={styles.timeline}>
             {group.runs.map((run) => (
-              <div key={run.id} className={styles.reviewRun}>
+              <Link
+                key={run.id}
+                className={styles.reviewRun}
+                data-status={run.status}
+                href={run.detailHref}
+                aria-label={`Open PR #${run.prNumber} review run #${run.id}`}
+              >
                 <div className={styles.runRail} aria-hidden="true" />
                 <div className={styles.rowMain}>
                   <span className={styles.rowTitle}>Run #{run.id}</span>
@@ -218,16 +226,18 @@ function ReviewGroups({ groups }: { groups: ReviewPrGroup[] }) {
                     {formatUnix(run.startedAt)} - {run.headRepoFullName}:{run.headRef}
                   </span>
                   <span className={styles.preview}>
-                    {shortSha(run.reviewedFromSha) ?? "base"} to {shortSha(run.reviewedToSha)}
+                    {run.rangeLabel}
+                    {run.summary ? ` - ${run.summary}` : ""}
                     {run.deployment ? ` - session ${run.deployment.id}` : ""}
                   </span>
                 </div>
                 <div className={styles.chips}>
                   <Chip tone={reviewTone(run.status)}>{labelize(run.status)}</Chip>
                   <Chip tone="accent" title={triggerTitle(run.triggeredBy)}>{triggerLabel(run.triggeredBy)}</Chip>
+                  {run.findingCount !== null && <Chip tone={run.findingCount > 0 ? "warn" : "good"}>{run.findingCount} findings</Chip>}
                   {run.completedAt && <Chip tone="neutral">done {formatUnix(run.completedAt)}</Chip>}
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </article>
@@ -276,10 +286,6 @@ function reviewTone(status: string): string {
 
 function labelize(value: string): string {
   return value.replaceAll("_", " ");
-}
-
-function shortSha(value: string | null): string | null {
-  return value ? value.slice(0, 7) : null;
 }
 
 function formatUnix(value: number): string {

--- a/packages/web/lib/actions/repos.test.ts
+++ b/packages/web/lib/actions/repos.test.ts
@@ -1,8 +1,10 @@
+/* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDb = vi.hoisted(() => vi.fn());
 const coreAddRepo = vi.hoisted(() => vi.fn());
 const createIssuectlWebhook = vi.hoisted(() => vi.fn());
+const rotateIssuectlWebhook = vi.hoisted(() => vi.fn());
 const coreUpdateRepo = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
@@ -11,6 +13,7 @@ const getActiveWebhookDeploymentsForRepoTarget = vi.hoisted(() => vi.fn());
 const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const killTmuxSession = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const tmuxSessionName = vi.hoisted(() => vi.fn((repo: string, targetNumber: number, targetType = "issue") => `issuectl-${repo}-${targetType}-${targetNumber}`));
 const withAuthRetry = vi.hoisted(() => vi.fn());
 const getIssues = vi.hoisted(() => vi.fn());
@@ -25,9 +28,11 @@ vi.mock("@issuectl/core", () => ({
   endDeployment: (...args: unknown[]) => endDeployment(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
   tmuxSessionName: (repo: string, targetNumber: number, targetType?: "issue" | "pr") => tmuxSessionName(repo, targetNumber, targetType),
   addRepo: (...args: unknown[]) => coreAddRepo(...args),
   createIssuectlWebhook: (...args: unknown[]) => createIssuectlWebhook(...args),
+  rotateIssuectlWebhook: (...args: unknown[]) => rotateIssuectlWebhook(...args),
   removeRepo: vi.fn(),
   updateRepo: (...args: unknown[]) => coreUpdateRepo(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),
@@ -46,7 +51,7 @@ vi.mock("@/lib/revalidate", () => ({
   revalidateSafely: () => ({ stale: false }),
 }));
 
-import { addRepo, updateRepo } from "./repos.js";
+import { addRepo, configureRepoWebhook, recreateRepoLabels, removeRepo, resendLastPing, updateRepo } from "./repos.js";
 
 beforeEach(() => {
   getDb.mockReturnValue({});
@@ -54,7 +59,11 @@ beforeEach(() => {
   withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
     fn({
       rest: {
-        repos: { get: vi.fn() },
+        repos: {
+          get: vi.fn(),
+          deleteWebhook: vi.fn(),
+          pingWebhook: vi.fn(),
+        },
         issues: {
           getLabel: vi.fn(async () => ({ data: {} })),
           createLabel: vi.fn(async () => ({ data: {} })),
@@ -64,6 +73,8 @@ beforeEach(() => {
   );
   createIssuectlWebhook.mockReset();
   createIssuectlWebhook.mockResolvedValue({ id: 123, createdBy: "octocat" });
+  rotateIssuectlWebhook.mockReset();
+  rotateIssuectlWebhook.mockResolvedValue({ id: 123, createdBy: "octocat" });
   getSetting.mockReset();
   getSetting.mockReturnValue("https://hooks.example.test");
   getIssues.mockReset();
@@ -79,13 +90,14 @@ beforeEach(() => {
   coreUpdateRepo.mockReset();
   updateRepoWebhookSettings.mockReset();
   getRepoById.mockReset();
-  getRepoById.mockReturnValue({ id: 1, name: "issuectl", autoLaunchIssues: false, autoReviewPrs: false });
+  getRepoById.mockReturnValue({ id: 1, owner: "mean-weasel", name: "issuectl", webhookId: null, autoLaunchIssues: false, autoReviewPrs: false });
   getActiveWebhookDeploymentsForRepoTarget.mockReset();
   getActiveWebhookDeploymentsForRepoTarget.mockReturnValue([]);
   endDeployment.mockReset();
   killTtyd.mockReset();
   killTmuxSession.mockReset();
   tmuxSessionName.mockClear();
+  recordDiagnosticEventSafely.mockReset();
 });
 
 describe("updateRepo action", () => {
@@ -181,6 +193,7 @@ describe("updateRepo action", () => {
       autoReviewPrs: false,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Review security boundaries first.",
       webhookPayloadMode: "raw",
     });
 
@@ -191,13 +204,21 @@ describe("updateRepo action", () => {
       autoReviewPrs: false,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Review security boundaries first.",
       webhookPayloadMode: "raw",
     });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.automation_enabled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({ targetType: "issue" }),
+    }));
   });
 
   it("ends webhook sessions when repo automation is disabled", async () => {
     getRepoById.mockReturnValue({
       id: 1,
+      owner: "mean-weasel",
       name: "issuectl",
       autoLaunchIssues: true,
       autoReviewPrs: false,
@@ -214,5 +235,115 @@ describe("updateRepo action", () => {
     expect(result).toEqual({ success: true });
     expect(killTtyd).toHaveBeenCalledWith(123, "issuectl-issuectl-issue-506");
     expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 12, "killed_by_label");
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.automation_disabled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({ targetType: "issue" }),
+    }));
+  });
+
+  it("rotates, reinstalls, recreates labels, and resends pings with diagnostics", async () => {
+    const pingWebhook = vi.fn();
+    withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
+      fn({
+        rest: {
+          repos: {
+            get: vi.fn(),
+            deleteWebhook: vi.fn(),
+            pingWebhook,
+          },
+          issues: {
+            getLabel: vi.fn(async () => ({ data: {} })),
+            createLabel: vi.fn(async () => ({ data: {} })),
+          },
+        },
+      }),
+    );
+    getRepoById.mockReturnValue({
+      id: 1,
+      owner: "mean-weasel",
+      name: "issuectl",
+      webhookId: 456,
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+    });
+
+    await expect(configureRepoWebhook(1, "reinstall")).resolves.toEqual({
+      success: true,
+      webhook: {
+        id: 123,
+        url: "https://hooks.example.test/api/webhook/github/1",
+        createdBy: "octocat",
+      },
+    });
+    await expect(recreateRepoLabels(1)).resolves.toEqual({ success: true });
+    await expect(resendLastPing(1)).resolves.toEqual({ success: true });
+
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      webhookId: 123,
+      webhookSecret: expect.any(String),
+    });
+    expect(pingWebhook).toHaveBeenCalledWith({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      hook_id: 456,
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_reinstalled",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.label_recreated",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_ping_sent",
+    }));
+  });
+
+  it("removes repos after ending webhook sessions and best-effort deleting the hook", async () => {
+    const deleteWebhook = vi.fn();
+    withAuthRetry.mockImplementation(async (fn: (octokit: unknown) => unknown) =>
+      fn({
+        rest: {
+          repos: {
+            get: vi.fn(),
+            deleteWebhook,
+            pingWebhook: vi.fn(),
+          },
+          issues: {
+            getLabel: vi.fn(async () => ({ data: {} })),
+            createLabel: vi.fn(async () => ({ data: {} })),
+          },
+        },
+      }),
+    );
+    getRepoById.mockReturnValue({
+      id: 1,
+      owner: "mean-weasel",
+      name: "issuectl",
+      webhookId: 789,
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+    });
+    getActiveWebhookDeploymentsForRepoTarget.mockImplementation((_, __, targetType) =>
+      targetType === "pr"
+        ? [{ id: 44, targetNumber: 44, terminalBackend: "pty_bridge", ttydPid: null }]
+        : [],
+    );
+
+    await expect(removeRepo(1)).resolves.toEqual({ success: true });
+
+    expect(deleteWebhook).toHaveBeenCalledWith({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      hook_id: 789,
+    });
+    expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-pr-44");
+    expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 44, "killed_by_label");
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.removed",
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
   });
 });

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -19,12 +19,14 @@ import {
   killTtyd,
   killTmuxSession,
   tmuxSessionName,
+  recordDiagnosticEventSafely,
   readCachedAccessibleRepos,
   refreshAccessibleRepos,
   getIssues,
   getPulls,
   listWebhookEvents,
   listLabels,
+  rotateIssuectlWebhook,
   withAuthRetry,
   formatErrorForUser,
   type AccessibleReposSnapshot,
@@ -305,7 +307,32 @@ export async function removeRepo(
 
   try {
     const db = getDb();
+    const repo = getRepoById(db, id);
+    if (!repo) return { success: false, error: "Repository not found" };
+    endActiveWebhookDeployments(db, id, repo.name, "issue", "killed_by_label");
+    endActiveWebhookDeployments(db, id, repo.name, "pr", "killed_by_label");
+    await deleteRepoWebhook(repo).catch((err) => {
+      console.warn("[issuectl] Failed to delete repo webhook:", errMessage(err));
+      recordDiagnosticEventSafely(db, {
+        level: "warn",
+        event: "repo.webhook_delete_failed",
+        source: "web",
+        owner: repo.owner,
+        repo: repo.name,
+        message: formatErrorForUser(err),
+        data: { repoId: id, hookId: repo.webhookId },
+      });
+    });
     coreRemoveRepo(db, id);
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "repo.removed",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: "Repository removed from issuectl",
+      data: { repoId: id, hookId: repo.webhookId },
+    });
   } catch (err) {
     console.error("[issuectl] Failed to remove repo:", errMessage(err));
     return { success: false, error: "Failed to remove repository" };
@@ -355,6 +382,7 @@ export async function updateRepo(
     autoReviewPrs?: boolean;
     issueAgent?: LaunchAgent;
     reviewAgent?: LaunchAgent;
+    reviewPreamble?: string | null;
     webhookPayloadMode?: WebhookPayloadMode;
   },
 ): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
@@ -406,12 +434,14 @@ export async function updateRepo(
       autoReviewPrs: updates.autoReviewPrs,
       issueAgent: updates.issueAgent,
       reviewAgent: updates.reviewAgent,
+      reviewPreamble: updates.reviewPreamble,
       webhookPayloadMode: updates.webhookPayloadMode,
     };
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
       const previous = getRepoById(db, id);
       updateRepoWebhookSettings(db, id, webhookUpdates);
       endDisabledAutomationSessions(db, id, previous, webhookUpdates);
+      recordRepoSettingsDiagnostics(db, id, previous, webhookUpdates);
     }
   } catch (err) {
     console.error("[issuectl] Failed to update repo:", errMessage(err));
@@ -419,6 +449,165 @@ export async function updateRepo(
   }
   const { stale } = revalidateSafely("/settings");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}
+
+export async function configureRepoWebhook(
+  id: number,
+  action: "rotate" | "reinstall",
+): Promise<{
+  success: true;
+  webhook: { id: number; url: string; createdBy: string };
+} | { success: false; error: string }> {
+  try {
+    const db = getDb();
+    const repo = getRepoById(db, id);
+    if (!repo) return { success: false, error: "Repository not found" };
+    const url = repoWebhookUrl(db, id);
+    const secret = randomBytes(32).toString("hex");
+    const webhook = await withAuthRetry(async (octokit) => {
+      if (repo.webhookId) {
+        try {
+          return await rotateIssuectlWebhook(octokit, {
+            owner: repo.owner,
+            repo: repo.name,
+            hookId: repo.webhookId,
+            url,
+            secret,
+          });
+        } catch (err) {
+          if (action !== "reinstall" || (err as { status?: number }).status !== 404) throw err;
+        }
+      }
+      return createIssuectlWebhook(octokit, {
+        owner: repo.owner,
+        repo: repo.name,
+        url,
+        secret,
+      });
+    });
+    updateRepoWebhookSettings(db, id, {
+      webhookId: webhook.id,
+      webhookSecret: secret,
+    });
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: action === "rotate" ? "repo.webhook_secret_rotated" : "repo.webhook_reinstalled",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: action === "rotate" ? "Repository webhook secret rotated" : "Repository webhook reinstalled",
+      data: { repoId: id, hookId: webhook.id, url },
+    });
+    return { success: true, webhook: { id: webhook.id, url, createdBy: webhook.createdBy } };
+  } catch (err) {
+    return { success: false, error: formatErrorForUser(err) };
+  }
+}
+
+export async function recreateRepoLabels(
+  id: number,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const db = getDb();
+    const repo = getRepoById(db, id);
+    if (!repo) return { success: false, error: "Repository not found" };
+    await withAuthRetry(async (octokit) => {
+      await Promise.all([
+        ensureRepoLabel(octokit, repo.owner, repo.name, "issuectl:auto-launch"),
+        ensureRepoLabel(octokit, repo.owner, repo.name, "issuectl:auto-review"),
+      ]);
+    });
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "repo.label_recreated",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: "Repository automation labels recreated",
+      data: { repoId: id },
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: formatErrorForUser(err) };
+  }
+}
+
+export async function resendLastPing(
+  id: number,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const db = getDb();
+    const repo = getRepoById(db, id);
+    if (!repo) return { success: false, error: "Repository not found" };
+    if (!repo.webhookId) return { success: false, error: "No webhook id is stored for this repo" };
+    await withAuthRetry((octokit) =>
+      octokit.rest.repos.pingWebhook({
+        owner: repo.owner,
+        repo: repo.name,
+        hook_id: repo.webhookId ?? 0,
+      }),
+    );
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "repo.webhook_ping_sent",
+      source: "web",
+      owner: repo.owner,
+      repo: repo.name,
+      message: "Repository webhook ping resent",
+      data: { repoId: id, hookId: repo.webhookId },
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: formatErrorForUser(err) };
+  }
+}
+
+function repoWebhookUrl(db: ReturnType<typeof getDb>, repoId: number): string {
+  const baseUrl = getSetting(db, "public_webhook_base_url");
+  if (!baseUrl) throw new Error("public_webhook_base_url is not configured.");
+  return `${baseUrl.replace(/\/$/, "")}/api/webhook/github/${repoId}`;
+}
+
+async function deleteRepoWebhook(repo: { owner: string; name: string; webhookId: number | null }): Promise<void> {
+  if (!repo.webhookId) return;
+  await withAuthRetry((octokit) =>
+    octokit.rest.repos.deleteWebhook({
+      owner: repo.owner,
+      repo: repo.name,
+      hook_id: repo.webhookId ?? 0,
+    }),
+  );
+}
+
+function recordRepoSettingsDiagnostics(
+  db: ReturnType<typeof getDb>,
+  repoId: number,
+  previous: { owner: string; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean } | undefined,
+  updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
+): void {
+  if (!previous) return;
+  if (updates.autoLaunchIssues !== undefined && updates.autoLaunchIssues !== previous.autoLaunchIssues) {
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: updates.autoLaunchIssues ? "repo.automation_enabled" : "repo.automation_disabled",
+      source: "web",
+      owner: previous.owner,
+      repo: previous.name,
+      message: updates.autoLaunchIssues ? "Issue auto-launch enabled" : "Issue auto-launch disabled",
+      data: { repoId, targetType: "issue" },
+    });
+  }
+  if (updates.autoReviewPrs !== undefined && updates.autoReviewPrs !== previous.autoReviewPrs) {
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: updates.autoReviewPrs ? "repo.automation_enabled" : "repo.automation_disabled",
+      source: "web",
+      owner: previous.owner,
+      repo: previous.name,
+      message: updates.autoReviewPrs ? "PR auto-review enabled" : "PR auto-review disabled",
+      data: { repoId, targetType: "pr" },
+    });
+  }
 }
 
 function endDisabledAutomationSessions(

--- a/packages/web/lib/github-webhook-handler.test.ts
+++ b/packages/web/lib/github-webhook-handler.test.ts
@@ -142,6 +142,13 @@ describe("handleGithubWebhookRequest", () => {
     });
     expect(res.statusCode).toBe(401);
     expect(jsonBody(res)).toEqual({ ok: false, error: "Unauthorized" });
+    expect(queryDiagnosticEvents(db, { events: ["webhook.invalid_signature"] })).toEqual([
+      expect.objectContaining({
+        owner: "mean-weasel",
+        repo: "issuectl",
+        correlationId: "delivery-1",
+      }),
+    ]);
   });
 
   it("rejects oversized bodies with 413", async () => {

--- a/packages/web/lib/github-webhook-handler.ts
+++ b/packages/web/lib/github-webhook-handler.ts
@@ -97,6 +97,14 @@ export async function handleGithubWebhookRequest(
     !signature ||
     !verifySignature(body.buffer, repo.webhookSecret, signature)
   ) {
+    recordWebhookDiagnostic(db, repo, {
+      event: "webhook.invalid_signature",
+      deliveryId: getBoundedHeader(req, "x-github-delivery", MAX_DELIVERY_ID_LENGTH) ?? "unknown",
+      eventType: getBoundedHeader(req, "x-github-event", MAX_EVENT_TYPE_LENGTH) ?? "unknown",
+      action: null,
+      targetType: null,
+      targetNumber: null,
+    });
     writeJson(res, 401, { ok: false, error: "Unauthorized" });
     return true;
   }

--- a/packages/web/lib/review-detail-data.test.ts
+++ b/packages/web/lib/review-detail-data.test.ts
@@ -39,7 +39,11 @@ describe("review-detail-data", () => {
       expect.objectContaining({ tone: "info", title: "Follow-up requested" }),
     ]);
     expect(data.links.githubPr).toBe("https://github.com/mean-weasel/issuectl/pull/44");
+    expect(data.links.githubReviewFiles).toBe("https://github.com/mean-weasel/issuectl/pull/44/files");
     expect(data.links.sessions).toContain("tab=reviews");
+    expect(data.links.webhookLogs).toContain("q=mean-weasel%2Fissuectl%2344");
+    expect(data.links.diagnosticsCli).toBe("pnpm --dir packages/cli exec issuectl diag show --pr mean-weasel/issuectl#44");
+    expect(data.actions.canRetry).toBe(true);
     expect(data.diagnostics).toHaveLength(1);
   });
 
@@ -80,6 +84,23 @@ describe("review-detail-data", () => {
     });
     expect(full.intent.reviewMode).toBe("full");
     expect(full.diagnosticEvent).toBe("pr_review.manual_rerun");
+  });
+
+  it("disables retry actions while any run for the PR is in flight", () => {
+    const data = buildReviewDetailData({
+      repo,
+      review: review({ id: 2, status: "failed" }),
+      lineage: [
+        review({ id: 3, status: "in_progress", completedAt: null }),
+        review({ id: 2, status: "failed" }),
+      ],
+    });
+
+    expect(data.actions).toEqual({
+      canRetry: false,
+      canFullRerun: false,
+      disabledReason: "Run #3 is still in progress.",
+    });
   });
 });
 

--- a/packages/web/lib/review-detail-data.ts
+++ b/packages/web/lib/review-detail-data.ts
@@ -34,11 +34,18 @@ export type ReviewDetailData = {
   result: Record<string, unknown>;
   deploymentResult: Record<string, unknown>;
   banners: ReviewBanner[];
+  actions: {
+    canRetry: boolean;
+    canFullRerun: boolean;
+    disabledReason: string | null;
+  };
   links: {
     githubPr: string;
+    githubReviewFiles: string;
     workbench: string;
     repoSettings: string;
     sessions: string;
+    webhookLogs: string;
     diagnosticsCli: string;
   };
 };
@@ -81,6 +88,7 @@ export function buildReviewDetailData(input: {
     result: parseJsonObject(item.resultJson),
     label: lineageLabel(item),
   }));
+  const activeReview = lineage.find((item) => ACTIVE_REVIEW_STATUSES.has(item.status));
   return {
     initialized: true,
     review: input.review,
@@ -91,6 +99,11 @@ export function buildReviewDetailData(input: {
     result,
     deploymentResult,
     banners: deriveBanners(input.review, result, deploymentResult),
+    actions: {
+      canRetry: !activeReview,
+      canFullRerun: !activeReview,
+      disabledReason: activeReview ? `Run #${activeReview.id} is still ${labelize(activeReview.status)}.` : null,
+    },
     links: reviewLinks(input.repo, input.review),
   };
 }
@@ -161,10 +174,12 @@ function reviewLinks(repo: Repo, review: PrReview): ReviewDetailData["links"] {
   const fullName = `${repo.owner}/${repo.name}`;
   return {
     githubPr: `https://github.com/${fullName}/pull/${review.prNumber}`,
+    githubReviewFiles: `https://github.com/${fullName}/pull/${review.prNumber}/files`,
     workbench: `/workbench?repo=${encodeURIComponent(fullName)}`,
     repoSettings: `/repos/${repo.owner}/${repo.name}/settings`,
     sessions: `/sessions?tab=reviews&repo=${encodeURIComponent(fullName)}&q=${encodeURIComponent(`PR #${review.prNumber}`)}`,
-    diagnosticsCli: `pnpm --dir packages/cli exec issuectl diag show --issue ${fullName}#${review.prNumber}`,
+    webhookLogs: `/logs/webhooks?q=${encodeURIComponent(`${fullName}#${review.prNumber}`)}`,
+    diagnosticsCli: `pnpm --dir packages/cli exec issuectl diag show --pr ${fullName}#${review.prNumber}`,
   };
 }
 
@@ -192,3 +207,9 @@ function parseJsonObject(value: string | null): Record<string, unknown> {
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
+
+function labelize(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+const ACTIVE_REVIEW_STATUSES = new Set(["reserved", "launching", "in_progress"]);

--- a/packages/web/lib/sessions-data.test.ts
+++ b/packages/web/lib/sessions-data.test.ts
@@ -39,7 +39,10 @@ describe("sessions-data", () => {
   it("groups active and ended sessions by repo target with trigger filtering", () => {
     const data = buildSessionsOverview({
       repos: [repo],
-      activeDeployments: [activeDeployment({ id: 10, targetType: "issue", targetNumber: 507, triggeredBy: "webhook" })],
+      activeDeployments: [
+        activeDeployment({ id: 10, targetType: "issue", targetNumber: 507, triggeredBy: "webhook" }),
+        activeDeployment({ id: 11, targetType: "issue", targetNumber: 507, triggeredBy: "webhook", parentDeploymentId: 10 }),
+      ],
       recentDeploymentsByRepo: new Map([
         [repo.id, [endedDeployment({ id: 9, targetType: "issue", targetNumber: 507, triggeredBy: "manual" })]],
       ]),
@@ -48,12 +51,14 @@ describe("sessions-data", () => {
       filters: normalizeSessionsFilters({ trigger: "webhook" }),
     });
 
-    expect(data.summary.activeSessions).toBe(1);
+    expect(data.summary.activeSessions).toBe(2);
     expect(data.summary.endedSessions).toBe(1);
     expect(data.sessionGroups).toHaveLength(1);
     expect(data.sessionGroups[0].targetLabel).toBe("Issue #507");
-    expect(data.sessionGroups[0].sessions).toHaveLength(1);
-    expect(data.sessionGroups[0].sessions[0].preview?.lines).toEqual(["running tests"]);
+    expect(data.sessionGroups[0].sessions).toHaveLength(2);
+    expect(data.sessionGroups[0].sessions.find((session) => session.id === 10)?.childDeploymentCount).toBe(1);
+    expect(data.sessionGroups[0].sessions.find((session) => session.id === 11)?.parentDeploymentId).toBe(10);
+    expect(data.sessionGroups[0].sessions.find((session) => session.id === 10)?.preview?.lines).toEqual(["running tests"]);
   });
 
   it("groups review runs by PR and supports status search", () => {
@@ -64,7 +69,14 @@ describe("sessions-data", () => {
       reviewsByRepo: new Map([
         [repo.id, [
           review({ id: 3, prNumber: 44, deploymentId: 20, status: "in_progress", startedAt: 30 }),
-          review({ id: 2, prNumber: 44, deploymentId: null, status: "completed", startedAt: 20 }),
+          review({
+            id: 2,
+            prNumber: 44,
+            deploymentId: null,
+            status: "completed",
+            startedAt: 20,
+            resultJson: JSON.stringify({ summary: "two comments", findings: [{ path: "a.ts" }, { path: "b.ts" }] }),
+          }),
         ]],
       ]),
       previews: {},
@@ -77,6 +89,38 @@ describe("sessions-data", () => {
     expect(data.reviewGroups[0].prNumber).toBe(44);
     expect(data.reviewGroups[0].runs).toHaveLength(1);
     expect(data.reviewGroups[0].runs[0].deployment?.id).toBe(20);
+    expect(data.reviewGroups[0].runs[0].detailHref).toBe("/reviews/3");
+    expect(data.reviewGroups[0].runs[0].rangeLabel).toBe("2222222..3333333");
+  });
+
+  it("derives review summaries and finding counts for navigable rows", () => {
+    const data = buildSessionsOverview({
+      repos: [repo],
+      activeDeployments: [],
+      recentDeploymentsByRepo: new Map(),
+      reviewsByRepo: new Map([
+        [repo.id, [
+          review({
+            id: 7,
+            prNumber: 44,
+            deploymentId: null,
+            status: "completed",
+            startedAt: 40,
+            reviewedFromSha: null,
+            resultJson: JSON.stringify({ summary: "clean pass", findingCount: 0 }),
+          }),
+        ]],
+      ]),
+      previews: {},
+      filters: normalizeSessionsFilters({ tab: "reviews" }),
+    });
+
+    expect(data.reviewGroups[0].runs[0]).toEqual(expect.objectContaining({
+      detailHref: "/reviews/7",
+      rangeLabel: "full 3333333",
+      summary: "clean pass",
+      findingCount: 0,
+    }));
   });
 });
 
@@ -85,6 +129,7 @@ function activeDeployment(input: {
   targetType: "issue" | "pr";
   targetNumber: number;
   triggeredBy: "manual" | "webhook" | "comment_command";
+  parentDeploymentId?: number | null;
 }): ActiveDeploymentWithRepo {
   return {
     ...baseDeployment(input),
@@ -114,6 +159,7 @@ function baseDeployment(input: {
   targetType: "issue" | "pr";
   targetNumber: number;
   triggeredBy: "manual" | "webhook" | "comment_command";
+  parentDeploymentId?: number | null;
 }): Deployment {
   return {
     id: input.id,
@@ -129,7 +175,7 @@ function baseDeployment(input: {
     state: "active",
     terminalBackend: "ttyd",
     triggeredBy: input.triggeredBy,
-    parentDeploymentId: null,
+    parentDeploymentId: input.parentDeploymentId ?? null,
     webhookDepth: input.triggeredBy === "webhook" ? 1 : 0,
     launchedAt: "2026-05-24T00:00:00.000Z",
     endedAt: null,
@@ -149,6 +195,8 @@ function review(input: {
   deploymentId: number | null;
   status: "in_progress" | "completed";
   startedAt: number;
+  reviewedFromSha?: string | null;
+  resultJson?: string | null;
 }): PrReview {
   return {
     id: input.id,
@@ -158,13 +206,13 @@ function review(input: {
     startedHeadSha: "abcdef123456",
     completedHeadSha: input.status === "completed" ? "fedcba654321" : null,
     reviewBaseSha: "111111111111",
-    reviewedFromSha: "222222222222",
+    reviewedFromSha: input.reviewedFromSha === undefined ? "222222222222" : input.reviewedFromSha,
     reviewedToSha: "333333333333",
     headRepoFullName: repo.owner + "/" + repo.name,
     headRef: "feature-branch",
     status: input.status,
     triggeredBy: "comment_command",
-    resultJson: null,
+    resultJson: input.resultJson ?? null,
     startedAt: input.startedAt,
     completedAt: input.status === "completed" ? input.startedAt + 5 : null,
   };

--- a/packages/web/lib/sessions-data.ts
+++ b/packages/web/lib/sessions-data.ts
@@ -47,6 +47,7 @@ export type SessionListItem = {
   linkedPrNumber: number | null;
   triggeredBy: DeploymentTriggeredBy;
   parentDeploymentId: number | null;
+  childDeploymentCount: number;
   webhookDepth: number;
   terminalReason: string | null;
   launchedAt: string;
@@ -70,6 +71,11 @@ export type ReviewRunItem = PrReview & {
   owner: string;
   repoName: string;
   deployment: SessionListItem | null;
+  result: Record<string, unknown>;
+  summary: string | null;
+  findingCount: number | null;
+  rangeLabel: string;
+  detailHref: string;
 };
 
 export type ReviewPrGroup = {
@@ -161,10 +167,14 @@ export function normalizeSessionsFilters(input: Record<string, string | string[]
 }
 
 export function buildSessionsOverview(input: BuildInput): SessionsOverviewData {
-  const sessions = input.repos.flatMap((repo) => [
+  const rawSessions = input.repos.flatMap((repo) => [
     ...input.activeDeployments.filter((deployment) => deployment.repoId === repo.id),
     ...(input.recentDeploymentsByRepo.get(repo.id) ?? []),
-  ].map((deployment) => sessionFromDeployment(repo, deployment, input.previews)));
+  ].map((deployment) => ({ repo, deployment })));
+  const childCounts = deploymentChildCounts(rawSessions.map((item) => item.deployment));
+  const sessions = rawSessions.map(({ repo, deployment }) =>
+    sessionFromDeployment(repo, deployment, input.previews, childCounts),
+  );
   const filteredSessions = sessions.filter((session) => sessionMatchesFilters(session, input.filters));
   const reviews = input.repos.flatMap((repo) =>
     (input.reviewsByRepo.get(repo.id) ?? []).map((review) =>
@@ -203,6 +213,7 @@ function sessionFromDeployment(
   repo: Repo,
   deployment: Deployment | ActiveDeploymentWithRepo,
   previews: Record<string, SessionPreview>,
+  childCounts: Map<number, number>,
 ): SessionListItem {
   const preview = deployment.ttydPort === null ? null : previews[String(deployment.ttydPort)] ?? null;
   return {
@@ -222,6 +233,7 @@ function sessionFromDeployment(
     linkedPrNumber: deployment.linkedPrNumber,
     triggeredBy: deployment.triggeredBy,
     parentDeploymentId: deployment.parentDeploymentId,
+    childDeploymentCount: childCounts.get(deployment.id) ?? 0,
     webhookDepth: deployment.webhookDepth,
     terminalReason: deployment.terminalReason,
     launchedAt: deployment.launchedAt,
@@ -233,12 +245,18 @@ function sessionFromDeployment(
 }
 
 function reviewFromRun(repo: Repo, review: PrReview, deployment: SessionListItem | null): ReviewRunItem {
+  const result = parseJsonObject(review.resultJson);
   return {
     ...review,
     repoFullName: repoFullName(repo),
     owner: repo.owner,
     repoName: repo.name,
     deployment,
+    result,
+    summary: stringValue(result.summary) ?? stringValue(result.reason) ?? stringValue(result.error) ?? null,
+    findingCount: numberValue(result.findingCount) ?? arrayLength(result.findings) ?? arrayLength(result.comments),
+    rangeLabel: reviewRangeLabel(review),
+    detailHref: `/reviews/${review.id}`,
   };
 }
 
@@ -338,6 +356,48 @@ function targetLabel(targetType: DeploymentTargetType, targetNumber: number): st
 
 function repoFullName(repo: Repo): string {
   return `${repo.owner}/${repo.name}`;
+}
+
+function deploymentChildCounts(deployments: Array<Deployment | ActiveDeploymentWithRepo>): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const deployment of deployments) {
+    if (deployment.parentDeploymentId === null) continue;
+    counts.set(deployment.parentDeploymentId, (counts.get(deployment.parentDeploymentId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function reviewRangeLabel(review: PrReview): string {
+  if (review.reviewedFromSha) return `${shortSha(review.reviewedFromSha)}..${shortSha(review.reviewedToSha)}`;
+  return `full ${shortSha(review.reviewedToSha)}`;
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 7);
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function arrayLength(value: unknown): number | null {
+  return Array.isArray(value) ? value.length : null;
 }
 
 function searchable(parts: string[]): string {

--- a/packages/web/lib/webhook-events-stream.test.ts
+++ b/packages/web/lib/webhook-events-stream.test.ts
@@ -4,6 +4,7 @@ import {
   formatWebhookStreamEvent,
   isWebhookEventsStreamAuthorized,
   isWebhookEventsStreamRequest,
+  summarizeWebhookStreamEntries,
 } from "./webhook-events-stream";
 
 vi.mock("./api-auth", () => ({
@@ -37,6 +38,26 @@ describe("webhook events stream helpers", () => {
     expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream", "Bearer valid-token"))).toBe(true);
     expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream"))).toBe(false);
     expect(isWebhookEventsStreamAuthorized(makeRequest("/api/webhooks/events/stream?apiToken=wrong-token"))).toBe(false);
+  });
+
+  it("summarizes stream snapshots by webhook result", () => {
+    expect(summarizeWebhookStreamEntries([
+      { result: "fired" },
+      { result: "debouncing" },
+      { result: "debouncing" },
+      { result: "failed" },
+      { result: "unknown" },
+      {},
+    ])).toEqual({
+      total: 6,
+      fired: 1,
+      debouncing: 2,
+      processing: 0,
+      gated: 0,
+      dropped: 0,
+      failed: 1,
+      received: 0,
+    });
   });
 });
 

--- a/packages/web/lib/webhook-events-stream.ts
+++ b/packages/web/lib/webhook-events-stream.ts
@@ -86,18 +86,40 @@ function sendSnapshot(ws: WebSocket): void {
 
 function readSnapshotPayload(): unknown {
   try {
+    const entries = listWebhookLogEntries(getDb(), { limit: 50 });
     return {
       generatedAt: new Date().toISOString(),
-      entries: listWebhookLogEntries(getDb(), { limit: 50 }),
+      entries,
+      counts: summarizeWebhookStreamEntries(entries),
     };
   } catch (err) {
     log.warn({ err, msg: "webhook_events_stream_snapshot_failed" });
     return {
       generatedAt: new Date().toISOString(),
       entries: [],
+      counts: summarizeWebhookStreamEntries([]),
       error: "Webhook event stream snapshot failed",
     };
   }
+}
+
+export function summarizeWebhookStreamEntries(
+  entries: Array<{ result?: string | null }>,
+): Record<string, number> {
+  const counts: Record<string, number> = {
+    total: entries.length,
+    fired: 0,
+    debouncing: 0,
+    processing: 0,
+    gated: 0,
+    dropped: 0,
+    failed: 0,
+    received: 0,
+  };
+  for (const entry of entries) {
+    if (entry.result && entry.result in counts) counts[entry.result] += 1;
+  }
+  return counts;
 }
 
 function safeSend(ws: WebSocket, type: string, payload: unknown): boolean {


### PR DESCRIPTION
## Summary\n- finish repo settings operations for automation toggles, review preamble, webhook reinstall/rotate/ping, label recreation, recent deliveries, activity links, and safer removal\n- make sessions/reviews and review detail navigable with lineage, result, finding, diagnostics, and in-flight action state\n- improve webhook logs/live-tail with invalid/replay audit visibility, valid CLI hints, metadata-only invalid signature diagnostics, and stream result counts\n\n## Verification\n- pnpm --dir packages/core test -- repos webhooks\n- pnpm --dir packages/web test -- repos sessions review-detail github-webhook-handler webhook-events-stream\n- pnpm --dir packages/cli test -- webhook\n- pnpm --dir packages/web typecheck\n- pnpm --dir packages/web lint\n- pnpm --dir packages/web build\n- git diff --check\n- Playwright route proofs for repo settings, sessions/reviews, review detail, webhook logs, and WebSocket snapshot using isolated local DBs