### PR TITLE
Fix issue 507 final live-tail audit gaps

### DIFF
--- a/docs/goals/issue-506-complete-gap-closure/state.yaml
+++ b/docs/goals/issue-506-complete-gap-closure/state.yaml
@@ -5,7 +5,7 @@ goal:
   slug: "issue-506-complete-gap-closure"
   kind: existing_plan
   tranche: "Fix every remaining issue #506 audit gap through successive safe verified slices."
-  status: active
+  status: done
   oracle:
     signal: "Final audit maps every three-agent audit gap to a verified fix or explicit blocker, with focused tests and package checks for touched areas."
     cadence: "after each Worker package and at final audit"
@@ -339,6 +339,7 @@ tasks:
       - "packages/core/src/launch/workspace.test.ts"
       - "packages/core/src/launch/launch-workspace-setup.ts"
       - "packages/core/src/launch/launch.ts"
+      - "packages/core/src/index.ts"
       - "packages/core/src/launch/launch-contexts.ts"
       - "packages/core/src/launch/launch-execute-precheck.test.ts"
       - "packages/web/lib/webhook-pr-launch.ts"
@@ -620,7 +621,7 @@ tasks:
       - "Next task if not complete"
     receipt:
       result: done
-      decision: complete_with_explicit_blocker
+      decision: complete
       full_outcome_complete: true
       gap_disposition:
         - "Webhook receiver/intake: fixed exact opt-in unlabeled gating for normal and deduped deliveries; debounce cap, queue-depth rejection, dedupe, raw-payload retention, and no-secret behavior have regression coverage."
@@ -665,6 +666,7 @@ tasks:
       - "packages/core/src/launch/launch-diagnostics.ts"
       - "packages/core/src/launch/launch.ts"
       - "packages/core/src/launch/launch-execute-precheck.test.ts"
+      - "packages/core/src/index.ts"
       - "packages/web/lib/github-webhook-handler.ts"
       - "packages/web/lib/github-webhook-handler.test.ts"
       - "packages/web/lib/github-webhook-utils.ts"
@@ -672,6 +674,8 @@ tasks:
       - "packages/web/lib/webhook-intent-worker.test.ts"
       - "packages/web/lib/webhook-runaway-controls.ts"
       - "packages/web/lib/webhook-runaway-controls.test.ts"
+      - "packages/web/lib/agent/mutation-adapters.ts"
+      - "packages/web/lib/agent/mutation-types.ts"
       - "packages/web/lib/agent/mutations.ts"
       - "packages/web/lib/agent/mutations.test.ts"
       - "packages/web/components/workbench/WorkbenchShell.tsx"

--- a/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
+++ b/packages/web/app/logs/webhooks/WebhookLiveTail.tsx
@@ -5,30 +5,53 @@ import styles from "./page.module.css";
 
 type StreamState = "connecting" | "live" | "paused" | "reconnecting" | "offline";
 
+type StreamEntry = {
+  id?: number;
+  deliveryId?: string;
+  eventType?: string;
+  action?: string | null;
+  targetType?: "issue" | "pr" | null;
+  targetNumber?: number | null;
+  result?: string | null;
+  resultDetail?: string | null;
+  receivedAt?: number;
+  intent?: { id?: number; status?: string; signalCount?: number } | null;
+};
+
 type StreamMessage = {
   type?: string;
   payload?: {
     generatedAt?: string;
-    entries?: unknown[];
+    entries?: StreamEntry[];
     counts?: Record<string, number>;
     error?: string;
   };
 };
 
-export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
+export function WebhookLiveTail({
+  endpoint,
+  initialEntries = [],
+  initialCounts = null,
+}: {
+  endpoint: string;
+  initialEntries?: StreamEntry[];
+  initialCounts?: Record<string, number> | null;
+}) {
   const [paused, setPaused] = useState(false);
   const [state, setState] = useState<StreamState>("connecting");
   const [lastUpdate, setLastUpdate] = useState<string | null>(null);
-  const [visibleEvents, setVisibleEvents] = useState(0);
-  const [counts, setCounts] = useState<Record<string, number> | null>(null);
+  const [visibleEvents, setVisibleEvents] = useState(initialEntries.length);
+  const [counts, setCounts] = useState<Record<string, number> | null>(initialCounts);
+  const [entries, setEntries] = useState<StreamEntry[]>(initialEntries);
+  const [pendingEntries, setPendingEntries] = useState<StreamEntry[]>([]);
   const reconnectRef = useRef<number | null>(null);
+  const pausedRef = useRef(paused);
 
   useEffect(() => {
-    if (paused) {
-      setState("paused");
-      return;
-    }
+    pausedRef.current = paused;
+  }, [paused]);
 
+  useEffect(() => {
     let socket: WebSocket | null = null;
     let cancelled = false;
 
@@ -55,6 +78,13 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
         if (generatedAt) setLastUpdate(generatedAt);
         if (Array.isArray(message?.payload?.entries)) {
           setVisibleEvents(message.payload.entries.length);
+          if (pausedRef.current) {
+            setState("paused");
+            setPendingEntries((current) => mergeEntries(message.payload?.entries ?? [], current));
+          } else {
+            setEntries(message.payload.entries);
+            setPendingEntries([]);
+          }
         }
         if (isCounts(message?.payload?.counts)) {
           setCounts(message.payload.counts);
@@ -79,22 +109,67 @@ export function WebhookLiveTail({ endpoint }: { endpoint: string }) {
       }
       socket?.close();
     };
-  }, [endpoint, paused]);
+  }, [endpoint]);
+
+  useEffect(() => {
+    setState((current) => paused ? "paused" : current === "paused" ? "live" : current);
+  }, [paused]);
+
+  function mergePending() {
+    setEntries((current) => mergeEntries(pendingEntries, current));
+    setPendingEntries([]);
+    setPaused(false);
+  }
 
   const label = paused ? "Resume" : "Pause";
+  const latestEntries = entries.slice(0, 5);
   return (
-    <div className={styles.liveTail} aria-label="Webhook live tail">
-      <div>
-        <span className={styles.liveLabel} data-state={state}>{state}</span>
-        <span className={styles.liveMeta}>
-          {lastUpdate
-            ? `Updated ${new Date(lastUpdate).toLocaleTimeString()} · ${liveSummary(counts, visibleEvents)}`
-            : liveSummary(counts, visibleEvents)}
-        </span>
+    <div className={styles.liveTail} aria-label="Webhook live tail" data-has-pending={pendingEntries.length > 0}>
+      <div className={styles.liveTailHeader}>
+        <div>
+          <span className={styles.liveLabel} data-state={state}>{state}</span>
+          <span className={styles.liveMeta}>
+            {lastUpdate
+              ? `Updated ${new Date(lastUpdate).toLocaleTimeString()} · ${liveSummary(counts, visibleEvents)}`
+              : liveSummary(counts, visibleEvents)}
+          </span>
+        </div>
+        <div className={styles.liveActions}>
+          {pendingEntries.length > 0 && (
+            <button className={styles.secondaryButton} type="button" onClick={mergePending}>
+              Merge {pendingEntries.length} new
+            </button>
+          )}
+          <button className={styles.secondaryButton} type="button" onClick={() => setPaused((value) => !value)}>
+            {label}
+          </button>
+        </div>
       </div>
-      <button className={styles.secondaryButton} type="button" onClick={() => setPaused((value) => !value)}>
-        {label}
-      </button>
+      {pendingEntries.length > 0 && (
+        <p className={styles.livePending}>{pendingEntries.length} new webhook events waiting while paused.</p>
+      )}
+      {latestEntries.length > 0 && (
+        <table className={styles.liveTable} aria-label="Latest webhook stream rows">
+          <thead>
+            <tr>
+              <th>Delivery</th>
+              <th>Event</th>
+              <th>Target</th>
+              <th>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            {latestEntries.map((entry) => (
+              <tr key={entry.id ?? entry.deliveryId}>
+                <td>{shortId(entry.deliveryId ?? "unknown")}</td>
+                <td>{entry.eventType ?? "webhook"}{entry.action ? `.${entry.action}` : ""}</td>
+                <td>{streamTarget(entry)}</td>
+                <td><span className={styles.result} data-result={entry.result ?? "received"}>{entry.result ?? "received"}</span></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }
@@ -115,6 +190,29 @@ function readApiToken(): string | null {
 
 function isCounts(value: unknown): value is Record<string, number> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeEntries(next: StreamEntry[], current: StreamEntry[]): StreamEntry[] {
+  const merged = new Map<string, StreamEntry>();
+  for (const entry of [...next, ...current]) {
+    merged.set(entryKey(entry), entry);
+  }
+  return [...merged.values()]
+    .sort((a, b) => (b.receivedAt ?? 0) - (a.receivedAt ?? 0))
+    .slice(0, 20);
+}
+
+function entryKey(entry: StreamEntry): string {
+  return String(entry.id ?? entry.deliveryId ?? `${entry.eventType}:${entry.receivedAt}`);
+}
+
+function streamTarget(entry: StreamEntry): string {
+  if (!entry.targetType || !entry.targetNumber) return "repo";
+  return `${entry.targetType === "pr" ? "PR" : "issue"} #${entry.targetNumber}`;
+}
+
+function shortId(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 10)}...` : value;
 }
 
 function liveSummary(counts: Record<string, number> | null, visibleEvents: number): string {

--- a/packages/web/app/logs/webhooks/page.module.css
+++ b/packages/web/app/logs/webhooks/page.module.css
@@ -98,21 +98,34 @@
 .liveTail {
   min-height: 42px;
   padding: 10px 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
   gap: 12px;
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   background: var(--paper-surface);
 }
 
-.liveTail > div {
+.liveTail[data-has-pending="true"] {
+  border-color: var(--paper-accent);
+}
+
+.liveTailHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.liveTailHeader > div {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.liveActions {
+  justify-content: flex-end;
 }
 
 .liveLabel {
@@ -141,6 +154,38 @@
 
 .liveMeta {
   color: var(--text-secondary);
+  font: 12px var(--paper-mono);
+}
+
+.livePending {
+  margin: 0;
+  color: var(--paper-accent);
+  font: 700 12px var(--paper-mono);
+}
+
+.liveTable {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.liveTable th,
+.liveTable td {
+  padding: 8px 9px;
+  border-top: 1px solid var(--paper-line-soft);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.liveTable th {
+  color: var(--text-secondary);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.liveTable td {
   font: 12px var(--paper-mono);
 }
 

--- a/packages/web/app/logs/webhooks/page.tsx
+++ b/packages/web/app/logs/webhooks/page.tsx
@@ -25,6 +25,8 @@ type SearchParams = {
   q?: string;
 };
 
+type AuditFilter = "all" | "valid" | "invalid" | "replay";
+
 const RESULT_FILTERS: Array<{ label: string; value: WebhookLogResult | "all" }> = [
   { label: "All", value: "all" },
   { label: "Fired", value: "fired" },
@@ -34,6 +36,12 @@ const RESULT_FILTERS: Array<{ label: string; value: WebhookLogResult | "all" }> 
   { label: "Dropped", value: "dropped" },
   { label: "Failed", value: "failed" },
   { label: "Received", value: "received" },
+];
+
+const AUDIT_FILTERS: Array<{ label: string; value: AuditFilter }> = [
+  { label: "Valid", value: "valid" },
+  { label: "Invalid", value: "invalid" },
+  { label: "Replay", value: "replay" },
 ];
 
 const AUDIT_EVENTS = ["webhook.invalid_signature", "webhook.deduped"];
@@ -74,6 +82,7 @@ export default async function WebhookLogsPage({
     params,
     repos,
   );
+  const auditFilter = activeAuditFilter(params.result);
   const metrics = summarize(entries);
   const health = webhookHealth(entries);
 
@@ -102,7 +111,11 @@ export default async function WebhookLogsPage({
           <Metric label="Raw payloads" value={`${metrics.retained} retained`} />
           <Metric label="Stream" value="/api/webhooks/events/stream" />
         </dl>
-        <WebhookLiveTail endpoint="/api/webhooks/events/stream" />
+        <WebhookLiveTail
+          endpoint="/api/webhooks/events/stream"
+          initialEntries={entries.slice(0, 50)}
+          initialCounts={summarizeStreamCounts(entries.slice(0, 50))}
+        />
 
         <form className={styles.toolbar} action="/logs/webhooks">
           <div className={styles.filters} aria-label="Webhook result filters">
@@ -110,10 +123,20 @@ export default async function WebhookLogsPage({
               <Link
                 key={filter.value}
                 className={styles.chip}
-                data-active={activeResult(params.result) === filter.value}
+                data-active={auditFilter === "all" && activeResult(params.result) === filter.value}
                 href={hrefFor(params, {
                   result: filter.value === "all" ? undefined : filter.value,
                 })}
+              >
+                {filter.label}
+              </Link>
+            ))}
+            {AUDIT_FILTERS.map((filter) => (
+              <Link
+                key={filter.value}
+                className={styles.chip}
+                data-active={auditFilter === filter.value}
+                href={hrefForAudit(params, filter.value)}
               >
                 {filter.label}
               </Link>
@@ -329,10 +352,14 @@ function filterAuditEvents(
 ): DiagnosticEvent[] {
   const query = params.q?.trim().toLowerCase();
   const eventQuery = params.event?.trim().toLowerCase();
+  const auditFilter = activeAuditFilter(params.result);
   const selectedRepoId = parsePositiveInt(params.repo);
   const selectedRepo = repos.find((repo) => repo.id === selectedRepoId);
   return events.filter((event) => {
     if (selectedRepo && (event.owner !== selectedRepo.owner || event.repo !== selectedRepo.name)) return false;
+    if (auditFilter === "invalid" && event.event !== "webhook.invalid_signature") return false;
+    if (auditFilter === "replay" && event.event !== "webhook.deduped") return false;
+    if (auditFilter === "valid") return false;
     if (eventQuery && !event.event.toLowerCase().includes(eventQuery)) return false;
     if (!query) return true;
     return [
@@ -357,6 +384,19 @@ function summarize(entries: WebhookLogEntry[]) {
   };
 }
 
+function summarizeStreamCounts(entries: WebhookLogEntry[]): Record<string, number> {
+  return {
+    total: entries.length,
+    fired: entries.filter((entry) => entry.result === "fired").length,
+    debouncing: entries.filter((entry) => entry.result === "debouncing").length,
+    processing: entries.filter((entry) => entry.result === "processing").length,
+    gated: entries.filter((entry) => entry.result === "gated").length,
+    dropped: entries.filter((entry) => entry.result === "dropped").length,
+    failed: entries.filter((entry) => entry.result === "failed").length,
+    received: entries.filter((entry) => entry.result === "received").length,
+  };
+}
+
 function webhookHealth(entries: WebhookLogEntry[]): { label: string; tone: "green" | "amber" | "red" } {
   const last = entries[0]?.receivedAt;
   if (!last) return { label: "No deliveries", tone: "red" };
@@ -370,6 +410,10 @@ function activeResult(value: string | undefined): WebhookLogResult | "all" {
   return RESULT_FILTERS.some((filter) => filter.value === value) ? value as WebhookLogResult : "all";
 }
 
+function activeAuditFilter(value: string | undefined): AuditFilter {
+  return AUDIT_FILTERS.some((filter) => filter.value === value) ? value as AuditFilter : "all";
+}
+
 function hrefFor(params: SearchParams, next: Partial<SearchParams>): string {
   const search = new URLSearchParams();
   const merged = { ...params, ...next };
@@ -377,6 +421,10 @@ function hrefFor(params: SearchParams, next: Partial<SearchParams>): string {
     if (value) search.set(key, value);
   }
   return `/logs/webhooks${search.size > 0 ? `?${search.toString()}` : ""}`;
+}
+
+function hrefForAudit(params: SearchParams, value: AuditFilter): string {
+  return hrefFor(params, { result: value === "all" ? undefined : value, event: undefined });
 }
 
 function parsePositiveInt(value: string | undefined): number | undefined {

--- a/packages/web/lib/github-webhook-handler.ts
+++ b/packages/web/lib/github-webhook-handler.ts
@@ -233,6 +233,7 @@ export async function handleGithubWebhookRequest(
         targetNumber,
         eventId: recorded.eventId,
       });
+      broadcastWebhookEventsChanged();
       writeJson(res, 200, { ok: true, eventId: recorded.eventId, intentId: null });
       return true;
     }
@@ -256,6 +257,7 @@ export async function handleGithubWebhookRequest(
       eventId: recorded.eventId,
       intentId,
     });
+    broadcastWebhookEventsChanged();
   }
 
   writeJson(res, 200, { ok: true, eventId: recorded.eventId, intentId });

--- a/packages/web/lib/webhook-intent-worker.test.ts
+++ b/packages/web/lib/webhook-intent-worker.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 import {
   addRepo,
@@ -76,8 +76,12 @@ function testWorkerDeps() {
   };
 }
 
-async function runWorker(db: Database.Database, now: number) {
-  return runWebhookIntentWorkerOnce(db, now, testWorkerDeps());
+async function runWorker(
+  db: Database.Database,
+  now: number,
+  deps: Partial<Parameters<typeof runWebhookIntentWorkerOnce>[2]> = {},
+) {
+  return runWebhookIntentWorkerOnce(db, now, { ...testWorkerDeps(), ...deps });
 }
 
 function expectWorkerResult(
@@ -142,6 +146,22 @@ describe("runWebhookIntentWorkerOnce", () => {
       }),
     );
     expect(db.prepare("SELECT agent FROM deployments WHERE id = 1").get()).toEqual({ agent: "codex" });
+  });
+
+  it("broadcasts live-tail updates when issue intent state changes", async () => {
+    const broadcastEventsChanged = vi.fn();
+    mergeWebhookIntent(db, {
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      signalAt: 1_000,
+      scheduledAt: 2_000,
+    });
+
+    const result = await runWorker(db, 2_000, { broadcastEventsChanged });
+
+    expectWorkerResult(result, { claimed: 1, launched: 1 });
+    expect(broadcastEventsChanged).toHaveBeenCalledTimes(2);
   });
 
   it("recovers expired processing leases to pending", async () => {

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -25,6 +25,7 @@ import type { IntentEventSummary } from "./webhook-intent-source";
 import { launchPrFromWebhook } from "./webhook-pr-launch";
 import { pruneExpiredWebhookPayloads } from "./webhook-payload-retention";
 import { enforceWebhookRunawayControls } from "./webhook-runaway-controls";
+import { broadcastWebhookEventsChanged } from "./webhook-events-stream";
 
 export type WebhookIntentWorkerResult = {
   claimed: number; recovered: number; expired: number; prunedPayloads: number;
@@ -50,6 +51,7 @@ type WorkerDeps = {
   ) => Promise<{ deploymentId: number }>;
   launchPr?: LaunchPrReview;
   isAncestor?: PullWorkerDeps["isAncestor"];
+  broadcastEventsChanged?: () => void;
 };
 
 function parseMaxWebhookIntentAgeMinutes(value: string | undefined): number {
@@ -79,13 +81,17 @@ export async function runWebhookIntentWorkerOnce(
   }
   const expired = expiredRecords.length;
   const prunedPayloads = pruneExpiredWebhookPayloads(db, now);
+  const broadcastEventsChanged = deps.broadcastEventsChanged ?? broadcastWebhookEventsChanged;
+  if (recovered > 0 || expired > 0 || prunedPayloads > 0) broadcastEventsChanged();
   const base = { recovered, expired, prunedPayloads };
   const intent = claimDueWebhookIntent(db, now, 60_000);
   if (!intent) return result(base);
+  broadcastEventsChanged();
 
   const repo = getRepoById(db, intent.repoId);
   if (!repo) {
     markIntentTerminal(db, intent.id, "failed", now, "Repository not found");
+    broadcastEventsChanged();
     return result(base, { claimed: 1, failed: 1 });
   }
   recordDiagnosticEventSafely(db, {
@@ -108,10 +114,14 @@ export async function runWebhookIntentWorkerOnce(
 
   if (intent.targetType === "pr") {
     const control = enforceWebhookRunawayControls(db, repo, intent, now);
-    if (!control.allowed) return result(base, { claimed: 1, [control.outcome]: 1 });
+    if (!control.allowed) {
+      broadcastEventsChanged();
+      return result(base, { claimed: 1, [control.outcome]: 1 });
+    }
     return handlePullRequestIntent(db, repo, intent, now, base, {
       ...deps,
       launchPr: deps.launchPr ?? launchPrFromWebhook,
+      broadcastEventsChanged,
     });
   }
   try {
@@ -122,11 +132,13 @@ export async function runWebhookIntentWorkerOnce(
       const endedSessions = endWebhookSessionForTarget(db, repo, intent, terminalReasonForControl(event));
       recordIntentDiagnostic(db, repo, intent, "webhook.kill_switch", endedSessions > 0 ? "Ended webhook-launched session." : "No webhook-launched session to end.");
       markIntentTerminal(db, intent.id, "skipped_optout", now, "Control event or repo auto-launch disabled");
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedOptout: 1, endedSessions });
     }
     if (triggeredBy === "webhook" && !isIssueGatedIn(repo, issue)) {
       recordIntentDiagnostic(db, repo, intent, "webhook.skipped_optout", "Issue is not opted in for auto-launch.");
       markIntentTerminal(db, intent.id, "skipped_optout", now, "Issue is not opted in");
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedOptout: 1 });
     }
     const locked = hasLiveDeploymentForIssue(db, repo.id, intent.targetNumber);
@@ -140,19 +152,25 @@ export async function runWebhookIntentWorkerOnce(
     if (locked) {
       recordIntentDiagnostic(db, repo, intent, "webhook.skipped_locked", "Issue already has a live session.");
       markIntentTerminal(db, intent.id, "skipped_locked", now, "Issue already has a live session");
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedLocked: 1 });
     }
     const control = enforceWebhookRunawayControls(db, repo, intent, now);
-    if (!control.allowed) return result(base, { claimed: 1, [control.outcome]: 1 });
+    if (!control.allowed) {
+      broadcastEventsChanged();
+      return result(base, { claimed: 1, [control.outcome]: 1 });
+    }
 
     const launch = await (deps.launchIssue ?? launchIssueFromWebhook)(db, repo, intent, issue, triggeredBy);
     markIntentTerminal(db, intent.id, "launched", now, null, launch.deploymentId);
     recordIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched issue session.", launch.deploymentId);
+    broadcastEventsChanged();
     return result(base, { claimed: 1, launched: 1 });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     markIntentTerminal(db, intent.id, "failed", now, message);
     recordIntentDiagnostic(db, repo, intent, "webhook.launch_failed", message);
+    broadcastEventsChanged();
     return result(base, { claimed: 1, failed: 1 });
   }
 }

--- a/packages/web/lib/webhook-pr-intent.test.ts
+++ b/packages/web/lib/webhook-pr-intent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 import {
   addRepo,
@@ -75,6 +75,7 @@ describe("PR webhook intents", () => {
   });
 
   it("launches opted-in PR intents through the PR review flow", async () => {
+    const broadcastEventsChanged = vi.fn();
     const intentId = mergeWebhookIntent(db, {
       repoId,
       targetType: "pr",
@@ -99,9 +100,11 @@ describe("PR webhook intents", () => {
         }).id;
         return { deploymentId };
       },
+      broadcastEventsChanged,
     });
 
     expect(result).toEqual(expect.objectContaining({ claimed: 1, launched: 1, failed: 0 }));
+    expect(broadcastEventsChanged).toHaveBeenCalledTimes(3);
     expect(getIntentRow(db, intentId)).toEqual(
       expect.objectContaining({ status: "launched", deployment_id: 1 }),
     );

--- a/packages/web/lib/webhook-pr-intent.ts
+++ b/packages/web/lib/webhook-pr-intent.ts
@@ -11,6 +11,7 @@ import type { Repo, WebhookIntent } from "@issuectl/core";
 import type { WebhookIntentWorkerResult } from "./webhook-intent-worker";
 import { getLatestIntentEvent, triggeredByForIntentEvent } from "./webhook-intent-source";
 import { planPrReview } from "./webhook-pr-review-state";
+import { broadcastWebhookEventsChanged } from "./webhook-events-stream";
 
 export type PullState = {
   title: string;
@@ -49,6 +50,7 @@ export type PullWorkerDeps = {
   fetchPullState?: FetchPullState;
   launchPr?: LaunchPrReview;
   isAncestor?: (repo: Repo, baseSha: string, headSha: string) => Promise<boolean>;
+  broadcastEventsChanged?: () => void;
 };
 
 export async function handlePullRequestIntent(
@@ -60,6 +62,7 @@ export async function handlePullRequestIntent(
   deps: PullWorkerDeps,
 ): Promise<WebhookIntentWorkerResult> {
   let review: PrReviewRecord | undefined;
+  const broadcastEventsChanged = deps.broadcastEventsChanged ?? broadcastWebhookEventsChanged;
   try {
     const pull = await (deps.fetchPullState ?? fetchPullState)(repo, intent.targetNumber);
     const event = getLatestIntentEvent(db, intent.id);
@@ -68,11 +71,13 @@ export async function handlePullRequestIntent(
       const endedSessions = endWebhookPrSessionForTarget(db, repo, intent, now, terminalReasonForPrOptOut(repo, pull, event));
       recordPrIntentDiagnostic(db, repo, intent, "webhook.skipped_optout", endedSessions > 0 ? "Ended webhook-launched PR review session." : "PR is not opted in for auto-review.");
       markIntentTerminal(db, intent.id, now, "PR is not opted in");
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedOptout: 1, endedSessions });
     }
     if (!isSafePullForReservation(pull, intent.desiredHeadSha)) {
       recordPrIntentDiagnostic(db, repo, intent, "webhook.skipped_unsafe_pr", "PR failed auto-review safety gates.");
       markIntentTerminal(db, intent.id, now, "PR failed safety gates");
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedOptout: 1 });
     }
     if (!deps.launchPr) throw new Error("PR launch dependency is not configured");
@@ -87,22 +92,26 @@ export async function handlePullRequestIntent(
     if (plan.action === "skip") {
       markIntentSkippedLocked(db, intent.id, now, plan.reason);
       recordPrIntentDiagnostic(db, repo, intent, plan.event, plan.reason);
+      broadcastEventsChanged();
       return result(base, { claimed: 1, skippedLocked: 1 });
     }
     review = plan.review;
     markPrReviewLaunching(db, review.id);
+    broadcastEventsChanged();
     review = { ...review, status: "launching" };
     const launch = await deps.launchPr(db, repo, intent, pull, review);
     markPrReviewInProgress(db, review.id, launch.deploymentId);
     markIntentLaunched(db, intent.id, now, launch.deploymentId);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched PR review session.", launch.deploymentId);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.pr_launched", "Webhook launched PR review session.", launch.deploymentId);
+    broadcastEventsChanged();
     return result(base, { claimed: 1, launched: 1 });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (review) markPrReviewFailed(db, review.id, now, message);
     markIntentFailed(db, intent.id, now, message);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.launch_failed", message);
+    broadcastEventsChanged();
     return result(base, { claimed: 1, failed: 1 });
   }
 }


### PR DESCRIPTION
## Summary
- close the final #507 webhook live-tail audit gaps with server-seeded live rows, paused backlog merge UX, and first-class Valid/Invalid/Replay chips
- broadcast webhook stream updates after intent state transitions, including debounce/claim/launch/skip/fail paths
- include the tracked #506 GoalBuddy board cleanup that was previously only local

## Verification
- pnpm --dir packages/web test -- webhook-events-stream webhook-intent-worker webhook-pr-intent github-webhook-handler
- pnpm --dir packages/web test
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --dir packages/web build
- git diff --check
- Browser proof via next start on seeded DB: /logs/webhooks?repo=1, /sessions?tab=reviews&repo=mean-weasel%2Fissuectl, /reviews/1

## Audit follow-up
This PR addresses the failed final subagent audits: live-tail table/backlog behavior, intent-state broadcasts beyond delivery receipt/dedupe, Valid/Invalid/Replay toolbar parity, refreshed sessions/review-detail route proof, and tracked #506 board cleanup inclusion.