### PR TITLE
[codex] Close webhook autosession gaps

### DIFF
--- a/docs/goals/close-webhook-autosession-gaps/goal.md
+++ b/docs/goals/close-webhook-autosession-gaps/goal.md
@@ -1,0 +1,45 @@
+# Close Webhook Auto-Session Gaps
+
+## Original Request
+
+Use GoalBuddy to make a detailed plan to close the verified implementation gaps for GitHub issues #506 and #507, while treating the CLI `repo add` end-to-end installer as product polish/follow-up rather than a blocking correctness gap.
+
+## Interpreted Outcome
+
+The issuectl repo should be brought to a state where the remaining webhook auto-session and operator UX gaps are fixed, verified, and audited against the original issue requirements. The next `/goal` run should execute the plan, not merely re-plan it.
+
+## Input Shape
+
+specific / existing-plan hybrid
+
+The user supplied a prior three-agent audit and accepted one scope decision: CLI `repo add` not performing full webhook installation is not blocking issue #507 completion, but should be tracked as a follow-up/polish item.
+
+## Goal Oracle
+
+The goal is complete when a final Judge or PM audit verifies all required gaps are either fixed with passing tests or explicitly recorded as non-blocking follow-up:
+
+- PR review fix-push behavior is implemented end to end through the daemon-mediated mutation gateway, or the product/spec is updated with an explicit non-goal accepted by the operator.
+- Disabling/removing repo automation ends active webhook PR sessions and also marks linked `pr_reviews` terminal so future reviews are not locked.
+- Webhook log links from repo settings correctly filter by repo and delivery.
+- `repo.automation_disabled` diagnostics include affected session IDs.
+- Review detail exposes the required metadata/link-outs that are supported by persisted data, or the unsupported fields are recorded as follow-up with evidence.
+- Relevant core/web/cli tests, typecheck/lint as appropriate, and a final local dirty-diff audit pass.
+
+## Constraints
+
+- Follow `CLAUDE.md` and `AGENTS.md`.
+- Do not revert unrelated user changes.
+- Keep edits narrowly scoped to the affected webhook, repo settings, review detail, diagnostics, and tests.
+- Use diagnostics-first reasoning for launch/session/workbench failures.
+- Keep the CLI `repo add` full installer as follow-up/polish unless the operator changes scope.
+- Prefer existing project patterns: ESM, strict TypeScript, no classes, Server Actions for mutations, Server Components for reads, CSS Modules.
+- Worker tasks must be bounded by explicit allowed files and verification commands.
+
+## Likely Misfire
+
+The run could declare success after adding tests or UI affordances while leaving the daemon-mediated push path or stale PR-review lock behavior incomplete. The board must keep pressure on actual behavioral proof, not just surface-level coverage.
+
+## Current Tranche
+
+Close the verified blockers from the audit, preserve the accepted non-blocking CLI follow-up decision, and finish with a final audit that maps code, tests, and issue requirements.
+

--- a/docs/goals/close-webhook-autosession-gaps/state.yaml
+++ b/docs/goals/close-webhook-autosession-gaps/state.yaml
@@ -1,0 +1,394 @@
+version: 2
+
+goal:
+  title: "Close Webhook Auto-Session Gaps"
+  slug: "close-webhook-autosession-gaps"
+  kind: existing_plan
+  tranche: "Close the verified #506/#507 correctness gaps through successive safe, verified local slices; keep CLI repo add full install as non-blocking polish."
+  status: done
+  oracle:
+    signal: "Targeted tests and final audit prove every blocking gap is fixed or explicitly classified as accepted follow-up."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "A final Judge/PM receipt maps G1-G5/F1 to code changes, verification commands, and any accepted follow-up decisions with full_outcome_complete: true."
+  intake:
+    original_request: "make a detailed plan with GoalBuddy to close these gaps"
+    interpreted_outcome: "Close the remaining verified #506/#507 implementation gaps with bounded fixes, verification, and final audit."
+    input_shape: existing_plan
+    audience: "issuectl maintainer/operator"
+    authority: approved
+    proof_type: test
+    completion_proof: "Final audit receipt maps every required gap to fixed code and passing verification, with accepted CLI installer polish recorded as non-blocking follow-up."
+    likely_misfire: "Fixing only UI/tests while PR fix-push or PR review lock cleanup remains behaviorally incomplete."
+    blind_spots_considered:
+      - "Direct PR fix-push may require a product/security decision instead of straightforward implementation."
+      - "Review detail may not currently persist every requested link-out, so unsupported metadata may need follow-up classification."
+      - "Shared automation-disable helpers span web actions, REST API, and CLI paths."
+    existing_plan_facts:
+      - "G1: daemon-mediated PR push path validates safety but returns unsupported_local_push."
+      - "G2: automation disable/remove paths can leave linked pr_reviews active."
+      - "G3: repo settings webhook log links pass owner/name and delivery params the log page does not honor."
+      - "G4: repo.automation_disabled diagnostics omit affected session IDs."
+      - "G5: review detail lacks some specified metadata/link-outs."
+      - "F1: CLI repo add full webhook install is accepted as non-blocking polish/follow-up."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/close-webhook-autosession-gaps/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/docs/goals/close-webhook-autosession-gaps"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: default
+    objective: "Validate the audited gap list against current repo state and convert it into executable Worker slices."
+    inputs:
+      - "docs/goals/close-webhook-autosession-gaps/goal.md"
+      - "Known audit findings from the three sub-agents in conversation"
+      - "Current repo checkout"
+    constraints:
+      - "Read implementation only as needed to confirm current file locations and write scopes."
+      - "Do not perform product edits during this PM task."
+      - "Keep CLI repo add full installer as follow-up unless new evidence shows it blocks a required oracle."
+    expected_output:
+      - "Receipt confirming the gap list and any corrected file scopes."
+      - "Updated Worker tasks with allowed_files, verify, and stop_if if file scopes need adjustment."
+      - "Next active task selected."
+    receipt:
+      result: done
+      summary: "Confirmed the audited gaps against current repo state. T010 and T030 overlap on the same automation-disable helper, so the first Worker slice should fix stale PR review locks and affected-session diagnostics together across web, REST, and CLI. CLI repo add full installer remains non-blocking polish."
+      evidence:
+        - "packages/web/lib/actions/repos.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+        - "packages/cli/src/commands/repo.ts"
+        - "packages/core/src/db/pr-reviews.ts"
+        - "packages/web/lib/agent/mutations.ts"
+      next_active_task: T010
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Fix stale PR review locks and record affected session IDs when repo automation is disabled or a repo is removed."
+    allowed_files:
+      - "packages/core/src/db/pr-reviews.ts"
+      - "packages/core/src/db/pr-reviews.test.ts"
+      - "packages/core/src/db/deployments.ts"
+      - "packages/core/src/db/deployments.test.ts"
+      - "packages/web/lib/actions/repos.ts"
+      - "packages/web/lib/actions/repos.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "packages/cli/src/commands/repo.ts"
+      - "packages/cli/src/commands/repo.test.ts"
+    verify:
+      - "pnpm --dir packages/core test src/db/pr-reviews.test.ts"
+      - "pnpm --dir packages/web test lib/actions/repos.test.ts app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "pnpm --dir packages/cli test src/commands/repo.test.ts"
+    stop_if:
+      - "Needs a schema change not listed in allowed_files."
+      - "Finds that remove-repo behavior spans additional unlisted packages."
+      - "Verification fails twice for different root causes."
+      - "Fix conflicts with T030; include affected-session diagnostics here and leave T030 for audit/cleanup."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/actions/repos.ts"
+        - "packages/web/lib/actions/repos.test.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+        - "packages/cli/src/commands/repo.ts"
+        - "packages/cli/src/commands/repo.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test src/db/pr-reviews.test.ts src/db/deployments.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web test lib/actions/repos.test.ts 'app/api/v1/repos/[owner]/[repo]/route.test.ts'"
+          status: pass
+        - cmd: "pnpm --dir packages/cli test src/commands/repo.test.ts"
+          status: pass
+      summary: "Automation disable/remove paths now collect affected webhook deployment IDs, terminalize linked PR reviews as superseded for PR sessions, and include affectedSessionIds in diagnostics across web actions, REST, and CLI."
+  - id: T020
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Fix webhook log repo and delivery prefilter links from repo settings."
+    allowed_files:
+      - "packages/web/components/repos/RepoSettingsPanel.tsx"
+      - "packages/web/app/logs/webhooks/page.tsx"
+      - "packages/web/app/logs/webhooks/page.module.css"
+      - "packages/web/lib/webhook-events-stream.ts"
+      - "packages/web/lib/webhook-events-stream.test.ts"
+      - "packages/web/lib/actions/repos.test.ts"
+    verify:
+      - "pnpm --dir packages/web test lib/review-detail-data.test.ts"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Filtering requires a new persistent query API outside allowed files."
+      - "Delivery highlighting requires browser verification before code can be trusted."
+      - "Verification fails twice for different root causes."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/components/repos/RepoSettingsPanel.tsx"
+        - "packages/web/app/logs/webhooks/page.tsx"
+      commands:
+        - cmd: "pnpm --dir packages/web test lib/webhook-events-stream.test.ts lib/actions/repos.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+      summary: "Repo settings webhook links now pass the numeric repo id expected by /logs/webhooks, and the log page honors a delivery query param for event rows and audit diagnostics."
+  - id: T030
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Record affected session IDs in repo.automation_disabled diagnostics."
+    allowed_files:
+      - "packages/web/lib/actions/repos.ts"
+      - "packages/web/lib/actions/repos.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "packages/cli/src/commands/repo.ts"
+      - "packages/cli/src/commands/repo.test.ts"
+    verify:
+      - "pnpm --dir packages/web test lib/actions/repos.test.ts app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "pnpm --dir packages/cli test src/commands/repo.test.ts"
+    stop_if:
+      - "Diagnostic payload shape is shared with external API consumers and needs a product decision."
+      - "The fix conflicts with T010's shared helper; merge into T010 instead of duplicating logic."
+      - "Verification fails twice for different root causes."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/actions/repos.ts"
+        - "packages/web/lib/actions/repos.test.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+        - "packages/cli/src/commands/repo.ts"
+        - "packages/cli/src/commands/repo.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test lib/actions/repos.test.ts 'app/api/v1/repos/[owner]/[repo]/route.test.ts'"
+          status: pass
+        - cmd: "pnpm --dir packages/cli test src/commands/repo.test.ts"
+          status: pass
+      summary: "Merged into T010 because affected-session diagnostics used the same automation-disable helper and verification surface."
+      covered_by: T010
+  - id: T040
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide the minimal correct scope for review-detail metadata/link-outs."
+    inputs:
+      - "Issue #507 review-detail requirements"
+      - "Current persisted review/deployment/webhook data"
+      - "Existing ReviewDetailPanel and data loader"
+    constraints:
+      - "Read-only."
+      - "Do not require rendering GitHub review comments inside issuectl."
+      - "Prefer implementing fields that are already persisted; record unsupported fields as follow-up only with evidence."
+    expected_output:
+      - "Decision: implement now | split follow-up | no-op with rationale."
+      - "If implement now: exact Worker objective, allowed_files, verify, and stop_if."
+      - "If follow-up: concise issue text or board receipt content."
+    receipt:
+      result: done
+      decision: "implement supported fields now; record missing persistence as follow-up evidence"
+      full_outcome_complete: false
+      rationale: "Current data supports current repo review preamble, trigger diagnostics, webhook-log link, and optional posted review URL when present in result/completion JSON. It does not persist an immutable preamble-used snapshot or guaranteed GitHub review URL for every run."
+      worker_task: T041
+  - id: T041
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Expose supported review-detail metadata and optional posted GitHub review link."
+    allowed_files:
+      - "packages/web/lib/review-detail-data.ts"
+      - "packages/web/lib/review-detail-data.test.ts"
+      - "packages/web/components/reviews/ReviewDetailPanel.tsx"
+      - "packages/web/components/reviews/ReviewDetailPanel.module.css"
+    verify:
+      - "pnpm --dir packages/web test lib/review-detail-data.test.ts"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Requires schema changes to persist immutable preamble-used or posted review URL."
+      - "Requires rendering GitHub review comments inside issuectl."
+      - "Verification fails twice for different root causes."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/review-detail-data.ts"
+        - "packages/web/lib/review-detail-data.test.ts"
+        - "packages/web/components/reviews/ReviewDetailPanel.tsx"
+      commands:
+        - cmd: "pnpm --dir packages/web test lib/review-detail-data.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+      summary: "Review detail now exposes current repo review preamble, the relevant trigger diagnostic, and an optional GitHub review link when review/completion result JSON carries one. Immutable preamble-used and guaranteed posted-review URL still require persisted fields and are not fabricated."
+  - id: T050
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide whether daemon-mediated PR fix-push is safe and bounded enough for this tranche."
+    inputs:
+      - "Issue #506 direct-push requirements"
+      - "Current agent mutation gateway"
+      - "Current PR safety checks and tests"
+    constraints:
+      - "Read-only."
+      - "Do not approve broad ambient git/GitHub credentials."
+      - "If implementation requires product/security choices, mark the Worker blocked and produce an explicit follow-up decision request."
+    expected_output:
+      - "Decision: implement bounded push path now | block for product/security decision | narrow spec with operator approval."
+      - "If implement now: exact Worker objective, allowed_files, verify, and stop_if."
+      - "If blocked: exact missing decision and safest local work that can still proceed."
+    receipt:
+      result: done
+      decision: "approved"
+      full_outcome_complete: false
+      rationale: "The gateway already authenticates by deployment token, rejects manual sessions, checks same-repo/non-default/unprotected PR heads, validates current PR head SHA, verifies local checkout branch/remote/head, and enforces action budgets. The safe missing slice is to verify the workspace head equals payload.newSha and call the existing push adapter with refs/heads/<expectedHeadRef>."
+      worker_task: T060
+  - id: T060
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Implement daemon-mediated PR fix-push only if T050 approves a bounded write scope."
+    allowed_files:
+      - "packages/web/lib/agent/mutations.ts"
+      - "packages/web/lib/agent/mutations.test.ts"
+      - "packages/web/lib/agent/mutation-types.ts"
+      - "packages/web/lib/agent/mutation-adapters.ts"
+    verify:
+      - "pnpm --dir packages/web test lib/agent/mutations.test.ts"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "T050 has not approved exact allowed_files and verification."
+      - "Implementation needs credentials, network mutation, or destructive git operations during tests."
+      - "Safety gates cannot be enforced without changing the product decision."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/agent/mutations.ts"
+        - "packages/web/lib/agent/mutations.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test lib/agent/mutations.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+      summary: "Bounded PR fix-push now verifies the PR still points at the expected old head, confirms the local workspace branch/remotes are safe and already at the requested new head, then performs a non-force refs/heads/<expectedHeadRef> update through the existing push adapter. Missing push adapter still fails closed before budget is consumed."
+  - id: T900
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: default
+    objective: "Record the accepted CLI repo add installer follow-up without treating it as a blocking gap."
+    inputs:
+      - "User decision to follow Codex recommendation on #5"
+    constraints:
+      - "Do not implement the CLI full installer in this tranche."
+      - "If creating an external GitHub issue is desired, ask the operator first unless already explicitly approved."
+    expected_output:
+      - "Board receipt noting the follow-up/polish classification."
+      - "Optional queued follow-up issue/PR task only if operator approves."
+    receipt:
+      result: done
+      classification: "accepted_follow_up"
+      full_outcome_complete: false
+      summary: "CLI `repo add` full webhook installation remains useful polish, but is not a blocking correctness gap for #506/#507 because existing CLI automation disable/remove paths are fixed and verified. No external GitHub issue was created in this tranche."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the #506/#507 gap-closure tranche is complete."
+    inputs:
+      - "All completed task receipts"
+      - "Final git diff/status"
+      - "Final verification command outputs"
+      - "docs/goals/close-webhook-autosession-gaps/goal.md"
+    constraints:
+      - "Read-only."
+      - "Do not mark complete if any blocking gap remains unimplemented, unverified, or undecided."
+      - "CLI repo add installer follow-up must be explicitly classified as non-blocking."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Gap-by-gap mapping to receipts and verification."
+      - "Missing evidence and next task if not complete."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      gap_mapping:
+        G1: "T050 approved a bounded daemon-mediated PR fix-push; T060 implemented and verified non-force ref updates after final PR-head and local workspace-head safety checks."
+        G2: "T010 terminalizes linked active PR reviews as superseded when automation disable/remove ends PR sessions."
+        G3: "T020 fixes repo settings webhook-log links to use numeric repo id and delivery filtering honored by /logs/webhooks."
+        G4: "T010/T030 include affectedSessionIds in repo.automation_disabled diagnostics across web action, REST API, and CLI paths."
+        G5: "T040/T041 expose currently persisted review-detail metadata/link-outs and explicitly classify unsupported immutable preamble snapshot / guaranteed posted-review URL as persistence follow-up."
+        F1: "T900 records CLI repo add full webhook installer as accepted non-blocking polish/follow-up."
+      commands:
+        - cmd: "pnpm --dir packages/core test"
+          status: pass
+        - cmd: "pnpm --dir packages/web test"
+          status: pass
+        - cmd: "pnpm --dir packages/cli test"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/cli typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+        - cmd: "pnpm --dir packages/cli lint"
+          status: pass
+        - cmd: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.7/skills/goalbuddy/scripts/check-goal-state.mjs docs/goals/close-webhook-autosession-gaps/state.yaml"
+          status: pass
+      summary: "All blocking #506/#507 correctness gaps are implemented or explicitly accepted as follow-up, and the final package tests, typechecks, lints, and GoalBuddy state validation pass."
+
+checks:
+  dirty_fingerprint: "T010 changes present; not final"
+  last_verification:
+    result: pass
+    task: T060
+    commands:
+      - "pnpm --dir packages/web test lib/agent/mutations.test.ts"
+      - "pnpm --dir packages/web typecheck"

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -6,8 +6,10 @@ import {
   endDeployment,
   getRepo,
   getActiveWebhookDeploymentsForRepoTarget,
+  markActivePrReviewForDeploymentTerminal,
   killTmuxSession,
   killTtyd,
+  recordDiagnosticEventSafely,
   setSetting,
   tmuxSessionName,
   updateRepo,
@@ -35,9 +37,11 @@ vi.mock("@issuectl/core", async (importOriginal) => {
     addRepo: vi.fn(),
     getRepo: vi.fn(),
     getActiveWebhookDeploymentsForRepoTarget: vi.fn(),
+    markActivePrReviewForDeploymentTerminal: vi.fn(),
     endDeployment: vi.fn(),
     killTmuxSession: vi.fn(),
     killTtyd: vi.fn(),
+    recordDiagnosticEventSafely: vi.fn(),
     setSetting: vi.fn(),
     tmuxSessionName: vi.fn((repo: string, targetNumber: number, targetType = "issue") => `issuectl-${repo}-${targetType}-${targetNumber}`),
     updateRepo: vi.fn(),
@@ -81,9 +85,11 @@ beforeEach(() => {
   vi.mocked(getRepo).mockReset();
   vi.mocked(getActiveWebhookDeploymentsForRepoTarget).mockReset();
   vi.mocked(getActiveWebhookDeploymentsForRepoTarget).mockReturnValue([]);
+  vi.mocked(markActivePrReviewForDeploymentTerminal).mockReset();
   vi.mocked(endDeployment).mockReset();
   vi.mocked(killTmuxSession).mockReset();
   vi.mocked(killTtyd).mockReset();
+  vi.mocked(recordDiagnosticEventSafely).mockReset();
   vi.mocked(setSetting).mockReset();
   vi.mocked(tmuxSessionName).mockClear();
   vi.mocked(updateRepo).mockReset();
@@ -304,6 +310,21 @@ describe("repo commands", () => {
     expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-pr-44");
     expect(endDeployment).toHaveBeenCalledWith(mockDb, 10, "killed_by_label");
     expect(endDeployment).toHaveBeenCalledWith(mockDb, 11, "killed_by_label");
+    expect(markActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(mockDb, 11, {
+      completedAt: expect.any(Number),
+      status: "superseded",
+      reason: "killed_by_label",
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(mockDb, expect.objectContaining({
+      event: "repo.automation_disabled",
+      source: "cli",
+      data: expect.objectContaining({ targetType: "issue", affectedSessionIds: [10] }),
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(mockDb, expect.objectContaining({
+      event: "repo.automation_disabled",
+      source: "cli",
+      data: expect.objectContaining({ targetType: "pr", affectedSessionIds: [11] }),
+    }));
   });
 
   it("shows webhook configuration without secrets", () => {

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -8,9 +8,11 @@ import {
   listRepos,
   getRepo,
   getActiveWebhookDeploymentsForRepoTarget,
+  markActivePrReviewForDeploymentTerminal,
   endDeployment,
   killTtyd,
   killTmuxSession,
+  recordDiagnosticEventSafely,
   setSetting,
   tmuxSessionName,
   updateRepo,
@@ -85,7 +87,18 @@ export async function repoRemoveCommand(ownerRepo: string): Promise<void> {
     return;
   }
 
+  const endedIssueSessionIds = endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
+  const endedPrSessionIds = endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
   removeRepo(db, repo.id);
+  recordDiagnosticEventSafely(db, {
+    level: "info",
+    event: "repo.removed",
+    source: "cli",
+    owner,
+    repo: name,
+    message: "Repository removed from issuectl",
+    data: { repoId: repo.id, affectedSessionIds: [...endedIssueSessionIds, ...endedPrSessionIds] },
+  });
   log.success(`Removed ${owner}/${name}`);
 }
 
@@ -355,7 +368,8 @@ function applyWebhookOptions(
   }
   if (Object.keys(compact).length === 0) return options.webhookBaseUrl !== undefined;
   updateRepoWebhookSettings(db, repo.id, compact);
-  endDisabledAutomationSessions(db, repo, updates);
+  const endedSessionIds = endDisabledAutomationSessions(db, repo, updates);
+  recordAutomationDiagnostics(db, repo, updates, endedSessionIds);
   return true;
 }
 
@@ -405,15 +419,17 @@ function normalizeWebhookBaseUrl(value: string): string {
 
 function endDisabledAutomationSessions(
   db: ReturnType<typeof requireDb>,
-  repo: { id: number; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean },
+  repo: { id: number; owner?: string; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean },
   updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
-): void {
+): { issue: number[]; pr: number[] } {
+  const ended = { issue: [] as number[], pr: [] as number[] };
   if (repo.autoLaunchIssues && updates.autoLaunchIssues === false) {
-    endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
+    ended.issue = endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
   }
   if (repo.autoReviewPrs && updates.autoReviewPrs === false) {
-    endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
+    ended.pr = endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
   }
+  return ended;
 }
 
 function endActiveWebhookDeployments(
@@ -421,11 +437,51 @@ function endActiveWebhookDeployments(
   repoId: number,
   repoName: string,
   targetType: "issue" | "pr",
-): void {
+): number[] {
+  const endedSessionIds: number[] = [];
   for (const deployment of getActiveWebhookDeploymentsForRepoTarget(db, repoId, targetType)) {
     const sessionName = tmuxSessionName(repoName, deployment.targetNumber, targetType);
     if (deployment.ttydPid) killTtyd(deployment.ttydPid, sessionName);
     else if (deployment.terminalBackend === "pty_bridge") killTmuxSession(sessionName);
     endDeployment(db, deployment.id, "killed_by_label");
+    if (targetType === "pr") {
+      markActivePrReviewForDeploymentTerminal(db, deployment.id, {
+        completedAt: Date.now(),
+        status: "superseded",
+        reason: "killed_by_label",
+      });
+    }
+    endedSessionIds.push(deployment.id);
+  }
+  return endedSessionIds;
+}
+
+function recordAutomationDiagnostics(
+  db: ReturnType<typeof requireDb>,
+  repo: { id: number; owner?: string; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean },
+  updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
+  affectedSessionIds: { issue: number[]; pr: number[] },
+): void {
+  if (updates.autoLaunchIssues !== undefined && updates.autoLaunchIssues !== repo.autoLaunchIssues) {
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: updates.autoLaunchIssues ? "repo.automation_enabled" : "repo.automation_disabled",
+      source: "cli",
+      owner: repo.owner,
+      repo: repo.name,
+      message: updates.autoLaunchIssues ? "Issue auto-launch enabled" : "Issue auto-launch disabled",
+      data: { repoId: repo.id, targetType: "issue", affectedSessionIds: affectedSessionIds.issue },
+    });
+  }
+  if (updates.autoReviewPrs !== undefined && updates.autoReviewPrs !== repo.autoReviewPrs) {
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: updates.autoReviewPrs ? "repo.automation_enabled" : "repo.automation_disabled",
+      source: "cli",
+      owner: repo.owner,
+      repo: repo.name,
+      message: updates.autoReviewPrs ? "PR auto-review enabled" : "PR auto-review disabled",
+      data: { repoId: repo.id, targetType: "pr", affectedSessionIds: affectedSessionIds.pr },
+    });
   }
 }

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/logger", () => ({
 const getDb = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
 const getActiveWebhookDeploymentsForRepoTarget = vi.hoisted(() => vi.fn());
+const markActivePrReviewForDeploymentTerminal = vi.hoisted(() => vi.fn());
 const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const killTmuxSession = vi.hoisted(() => vi.fn());
@@ -25,6 +26,7 @@ vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
   getRepo: (...args: unknown[]) => getRepo(...args),
   getActiveWebhookDeploymentsForRepoTarget: (...args: unknown[]) => getActiveWebhookDeploymentsForRepoTarget(...args),
+  markActivePrReviewForDeploymentTerminal: (...args: unknown[]) => markActivePrReviewForDeploymentTerminal(...args),
   endDeployment: (...args: unknown[]) => endDeployment(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
@@ -73,6 +75,7 @@ beforeEach(() => {
   });
   getActiveWebhookDeploymentsForRepoTarget.mockReset();
   getActiveWebhookDeploymentsForRepoTarget.mockReturnValue([]);
+  markActivePrReviewForDeploymentTerminal.mockReset();
   endDeployment.mockReset();
   killTtyd.mockReset();
   killTmuxSession.mockReset();
@@ -126,6 +129,17 @@ describe("/api/v1/repos/[owner]/[repo]", () => {
     expect(response.status).toBe(200);
     expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-pr-44");
     expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 22, "killed_by_label");
+    expect(markActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(expect.anything(), 22, {
+      completedAt: expect.any(Number),
+      status: "superseded",
+      reason: "killed_by_label",
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.automation_disabled",
+      data: expect.objectContaining({
+        affectedSessionIds: expect.objectContaining({ pr: [22] }),
+      }),
+    }));
   });
 
   it("PATCH rejects invalid webhook payload mode", async () => {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -6,6 +6,7 @@ import {
   removeRepo,
   getRepo,
   getActiveWebhookDeploymentsForRepoTarget,
+  markActivePrReviewForDeploymentTerminal,
   endDeployment,
   killTtyd,
   killTmuxSession,
@@ -43,6 +44,8 @@ export async function DELETE(
       );
     }
 
+    const endedIssueSessionIds = endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
+    const endedPrSessionIds = endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
     removeRepo(db, repo.id);
     recordDiagnosticEventSafely(db, {
       level: "warn",
@@ -51,7 +54,7 @@ export async function DELETE(
       owner,
       repo: repoName,
       message: "Repository removed from local tracking",
-      data: { repoId: repo.id },
+      data: { repoId: repo.id, affectedSessionIds: [...endedIssueSessionIds, ...endedPrSessionIds] },
     });
     log.info({ msg: "api_repo_removed", repoId: repo.id, owner, name: repoName });
     return NextResponse.json({ success: true });
@@ -152,8 +155,8 @@ export async function PATCH(
     };
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
       updated = updateRepoWebhookSettings(db, repo.id, webhookUpdates);
-      endDisabledAutomationSessions(db, repo, webhookUpdates);
-      recordAutomationDiagnostics(db, repo, webhookUpdates);
+      const endedSessionIds = endDisabledAutomationSessions(db, repo, webhookUpdates);
+      recordAutomationDiagnostics(db, repo, webhookUpdates, endedSessionIds);
     }
     log.info({ msg: "api_repo_updated", repoId: repo.id, owner, name: repoName, updates, webhookUpdates });
     return NextResponse.json({ success: true, repo: updated });
@@ -170,6 +173,7 @@ function recordAutomationDiagnostics(
   db: ReturnType<typeof getDb>,
   repo: { id: number; owner: string; name: string },
   updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
+  affectedSessionIds: { issue: number[]; pr: number[] } = { issue: [], pr: [] },
 ): void {
   if (updates.autoLaunchIssues === true || updates.autoReviewPrs === true) {
     recordDiagnosticEventSafely(db, {
@@ -179,7 +183,7 @@ function recordAutomationDiagnostics(
       owner: repo.owner,
       repo: repo.name,
       message: "Repository webhook automation enabled",
-      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs },
+      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs, affectedSessionIds },
     });
   }
   if (updates.autoLaunchIssues === false || updates.autoReviewPrs === false) {
@@ -190,7 +194,7 @@ function recordAutomationDiagnostics(
       owner: repo.owner,
       repo: repo.name,
       message: "Repository webhook automation disabled",
-      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs },
+      data: { repoId: repo.id, autoLaunchIssues: updates.autoLaunchIssues, autoReviewPrs: updates.autoReviewPrs, affectedSessionIds },
     });
   }
 }
@@ -199,13 +203,15 @@ function endDisabledAutomationSessions(
   db: ReturnType<typeof getDb>,
   repo: { id: number; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean },
   updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
-): void {
+): { issue: number[]; pr: number[] } {
+  const ended = { issue: [] as number[], pr: [] as number[] };
   if (repo.autoLaunchIssues && updates.autoLaunchIssues === false) {
-    endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
+    ended.issue = endActiveWebhookDeployments(db, repo.id, repo.name, "issue");
   }
   if (repo.autoReviewPrs && updates.autoReviewPrs === false) {
-    endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
+    ended.pr = endActiveWebhookDeployments(db, repo.id, repo.name, "pr");
   }
+  return ended;
 }
 
 function endActiveWebhookDeployments(
@@ -213,11 +219,21 @@ function endActiveWebhookDeployments(
   repoId: number,
   repoName: string,
   targetType: "issue" | "pr",
-): void {
+): number[] {
+  const endedSessionIds: number[] = [];
   for (const deployment of getActiveWebhookDeploymentsForRepoTarget(db, repoId, targetType)) {
     const sessionName = tmuxSessionName(repoName, deployment.targetNumber, targetType);
     if (deployment.ttydPid) killTtyd(deployment.ttydPid, sessionName);
     else if (deployment.terminalBackend === "pty_bridge") killTmuxSession(sessionName);
     endDeployment(db, deployment.id, "killed_by_label");
+    if (targetType === "pr") {
+      markActivePrReviewForDeploymentTerminal(db, deployment.id, {
+        completedAt: Date.now(),
+        status: "superseded",
+        reason: "killed_by_label",
+      });
+    }
+    endedSessionIds.push(deployment.id);
   }
+  return endedSessionIds;
 }

--- a/packages/web/app/logs/webhooks/page.tsx
+++ b/packages/web/app/logs/webhooks/page.tsx
@@ -20,6 +20,7 @@ export const metadata = { title: "Webhook logs - issuectl" };
 
 type SearchParams = {
   repo?: string;
+  delivery?: string;
   result?: string;
   event?: string;
   q?: string;
@@ -168,6 +169,7 @@ export default async function WebhookLogsPage({
             <button className={styles.button} type="submit">Apply</button>
           </div>
           {params.result && <input type="hidden" name="result" value={params.result} />}
+          {params.delivery && <input type="hidden" name="delivery" value={params.delivery} />}
         </form>
 
         {entries.length === 0 ? (
@@ -325,7 +327,9 @@ function filterEntries(
   const result = activeResult(params.result);
   const query = params.q?.trim().toLowerCase();
   const eventQuery = params.event?.trim().toLowerCase();
+  const deliveryQuery = params.delivery?.trim();
   return entries.filter((entry) => {
+    if (deliveryQuery && entry.deliveryId !== deliveryQuery) return false;
     if (result !== "all" && entry.result !== result) return false;
     const eventText = `${entry.eventType} ${entry.action ?? ""}`.toLowerCase();
     if (eventQuery && !eventText.includes(eventQuery)) return false;
@@ -352,6 +356,7 @@ function filterAuditEvents(
 ): DiagnosticEvent[] {
   const query = params.q?.trim().toLowerCase();
   const eventQuery = params.event?.trim().toLowerCase();
+  const deliveryQuery = params.delivery?.trim().toLowerCase();
   const auditFilter = activeAuditFilter(params.result);
   const selectedRepoId = parsePositiveInt(params.repo);
   const selectedRepo = repos.find((repo) => repo.id === selectedRepoId);
@@ -361,6 +366,7 @@ function filterAuditEvents(
     if (auditFilter === "replay" && event.event !== "webhook.deduped") return false;
     if (auditFilter === "valid") return false;
     if (eventQuery && !event.event.toLowerCase().includes(eventQuery)) return false;
+    if (deliveryQuery && event.correlationId?.toLowerCase() !== deliveryQuery) return false;
     if (!query) return true;
     return [
       event.event,

--- a/packages/web/components/repos/RepoSettingsPanel.tsx
+++ b/packages/web/components/repos/RepoSettingsPanel.tsx
@@ -331,7 +331,7 @@ export function RepoSettingsPanel({
           <a className={styles.secondaryButton} href={`/sessions?repo=${encodeURIComponent(repoPath)}`}>
             View repo sessions
           </a>
-          <a className={styles.secondaryButton} href={`/logs/webhooks?repo=${encodeURIComponent(repoPath)}`}>
+          <a className={styles.secondaryButton} href={`/logs/webhooks?repo=${repo.id}`}>
             View webhook events
           </a>
         </div>
@@ -375,7 +375,7 @@ function RecentDeliveries({ repo, deliveries }: { repo: Repo; deliveries: Webhoo
         {deliveries.slice(0, 10).map((event) => (
           <a
             key={event.id}
-            href={`/logs/webhooks?repo=${encodeURIComponent(`${repo.owner}/${repo.name}`)}&delivery=${encodeURIComponent(event.deliveryId)}`}
+            href={`/logs/webhooks?repo=${repo.id}&delivery=${encodeURIComponent(event.deliveryId)}`}
           >
             <span>{event.eventType}{event.action ? `.${event.action}` : ""}</span>
             <code>{event.deliveryId}</code>

--- a/packages/web/components/reviews/ReviewDetailPanel.tsx
+++ b/packages/web/components/reviews/ReviewDetailPanel.tsx
@@ -145,6 +145,14 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
               <dt>Terminal</dt>
               <dd>{data.deployment?.terminalReason ? labelize(data.deployment.terminalReason) : "not recorded"}</dd>
             </div>
+            <div>
+              <dt>Trigger event</dt>
+              <dd>{data.metadata.triggerEvent?.event ?? "not recorded"}</dd>
+            </div>
+            <div>
+              <dt>Review preamble</dt>
+              <dd>{data.metadata.currentReviewPreamble ?? "default"}</dd>
+            </div>
           </dl>
         </section>
 
@@ -152,6 +160,7 @@ export function ReviewDetailPanel({ data, retryAction, fullRerunAction }: Props)
           <h2>Links</h2>
           <div className={styles.links}>
             <a href={data.links.githubPr}>GitHub PR</a>
+            {data.links.githubReview && <a href={data.links.githubReview}>GitHub review</a>}
             <a href={data.links.githubReviewFiles}>Review files</a>
             <Link href={data.links.workbench}>Workbench</Link>
             <Link href={data.links.webhookLogs}>Webhook logs</Link>

--- a/packages/web/lib/actions/repos.test.ts
+++ b/packages/web/lib/actions/repos.test.ts
@@ -10,6 +10,7 @@ const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
 const getRepoById = vi.hoisted(() => vi.fn());
 const getSetting = vi.hoisted(() => vi.fn());
 const getActiveWebhookDeploymentsForRepoTarget = vi.hoisted(() => vi.fn());
+const markActivePrReviewForDeploymentTerminal = vi.hoisted(() => vi.fn());
 const endDeployment = vi.hoisted(() => vi.fn());
 const killTtyd = vi.hoisted(() => vi.fn());
 const killTmuxSession = vi.hoisted(() => vi.fn());
@@ -25,6 +26,7 @@ vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
   getRepoById: (...args: unknown[]) => getRepoById(...args),
   getActiveWebhookDeploymentsForRepoTarget: (...args: unknown[]) => getActiveWebhookDeploymentsForRepoTarget(...args),
+  markActivePrReviewForDeploymentTerminal: (...args: unknown[]) => markActivePrReviewForDeploymentTerminal(...args),
   endDeployment: (...args: unknown[]) => endDeployment(...args),
   killTtyd: (...args: unknown[]) => killTtyd(...args),
   killTmuxSession: (...args: unknown[]) => killTmuxSession(...args),
@@ -93,6 +95,7 @@ beforeEach(() => {
   getRepoById.mockReturnValue({ id: 1, owner: "mean-weasel", name: "issuectl", webhookId: null, autoLaunchIssues: false, autoReviewPrs: false });
   getActiveWebhookDeploymentsForRepoTarget.mockReset();
   getActiveWebhookDeploymentsForRepoTarget.mockReturnValue([]);
+  markActivePrReviewForDeploymentTerminal.mockReset();
   endDeployment.mockReset();
   killTtyd.mockReset();
   killTmuxSession.mockReset();
@@ -215,31 +218,51 @@ describe("updateRepo action", () => {
     }));
   });
 
-  it("ends webhook sessions when repo automation is disabled", async () => {
+  it("ends webhook sessions and records affected ids when repo automation is disabled", async () => {
     getRepoById.mockReturnValue({
       id: 1,
       owner: "mean-weasel",
       name: "issuectl",
       autoLaunchIssues: true,
-      autoReviewPrs: false,
+      autoReviewPrs: true,
     });
-    getActiveWebhookDeploymentsForRepoTarget.mockReturnValue([{
-      id: 12,
-      targetNumber: 506,
-      terminalBackend: "ttyd",
-      ttydPid: 123,
-    }]);
+    getActiveWebhookDeploymentsForRepoTarget
+      .mockReturnValueOnce([{
+        id: 12,
+        targetNumber: 506,
+        terminalBackend: "ttyd",
+        ttydPid: 123,
+      }])
+      .mockReturnValueOnce([{
+        id: 44,
+        targetNumber: 44,
+        terminalBackend: "pty_bridge",
+        ttydPid: null,
+      }]);
 
-    const result = await updateRepo(1, { autoLaunchIssues: false });
+    const result = await updateRepo(1, { autoLaunchIssues: false, autoReviewPrs: false });
 
     expect(result).toEqual({ success: true });
     expect(killTtyd).toHaveBeenCalledWith(123, "issuectl-issuectl-issue-506");
+    expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-pr-44");
     expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 12, "killed_by_label");
+    expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 44, "killed_by_label");
+    expect(markActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(expect.anything(), 44, {
+      completedAt: expect.any(Number),
+      status: "superseded",
+      reason: "killed_by_label",
+    });
     expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       event: "repo.automation_disabled",
       owner: "mean-weasel",
       repo: "issuectl",
-      data: expect.objectContaining({ targetType: "issue" }),
+      data: expect.objectContaining({ targetType: "issue", affectedSessionIds: [12] }),
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.automation_disabled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({ targetType: "pr", affectedSessionIds: [44] }),
     }));
   });
 
@@ -340,10 +363,16 @@ describe("updateRepo action", () => {
     });
     expect(killTmuxSession).toHaveBeenCalledWith("issuectl-issuectl-pr-44");
     expect(endDeployment).toHaveBeenCalledWith(expect.anything(), 44, "killed_by_label");
+    expect(markActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(expect.anything(), 44, {
+      completedAt: expect.any(Number),
+      status: "superseded",
+      reason: "killed_by_label",
+    });
     expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       event: "repo.removed",
       owner: "mean-weasel",
       repo: "issuectl",
+      data: expect.objectContaining({ affectedSessionIds: [44] }),
     }));
   });
 });

--- a/packages/web/lib/actions/repos.ts
+++ b/packages/web/lib/actions/repos.ts
@@ -15,6 +15,7 @@ import {
   getRepoById,
   getSetting,
   getActiveWebhookDeploymentsForRepoTarget,
+  markActivePrReviewForDeploymentTerminal,
   endDeployment,
   killTtyd,
   killTmuxSession,
@@ -309,8 +310,8 @@ export async function removeRepo(
     const db = getDb();
     const repo = getRepoById(db, id);
     if (!repo) return { success: false, error: "Repository not found" };
-    endActiveWebhookDeployments(db, id, repo.name, "issue", "killed_by_label");
-    endActiveWebhookDeployments(db, id, repo.name, "pr", "killed_by_label");
+    const endedIssueSessionIds = endActiveWebhookDeployments(db, id, repo.name, "issue", "killed_by_label");
+    const endedPrSessionIds = endActiveWebhookDeployments(db, id, repo.name, "pr", "killed_by_label");
     await deleteRepoWebhook(repo).catch((err) => {
       console.warn("[issuectl] Failed to delete repo webhook:", errMessage(err));
       recordDiagnosticEventSafely(db, {
@@ -331,7 +332,7 @@ export async function removeRepo(
       owner: repo.owner,
       repo: repo.name,
       message: "Repository removed from issuectl",
-      data: { repoId: id, hookId: repo.webhookId },
+      data: { repoId: id, hookId: repo.webhookId, affectedSessionIds: [...endedIssueSessionIds, ...endedPrSessionIds] },
     });
   } catch (err) {
     console.error("[issuectl] Failed to remove repo:", errMessage(err));
@@ -440,8 +441,8 @@ export async function updateRepo(
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
       const previous = getRepoById(db, id);
       updateRepoWebhookSettings(db, id, webhookUpdates);
-      endDisabledAutomationSessions(db, id, previous, webhookUpdates);
-      recordRepoSettingsDiagnostics(db, id, previous, webhookUpdates);
+      const endedSessionIds = endDisabledAutomationSessions(db, id, previous, webhookUpdates);
+      recordRepoSettingsDiagnostics(db, id, previous, webhookUpdates, endedSessionIds);
     }
   } catch (err) {
     console.error("[issuectl] Failed to update repo:", errMessage(err));
@@ -584,6 +585,7 @@ function recordRepoSettingsDiagnostics(
   repoId: number,
   previous: { owner: string; name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean } | undefined,
   updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
+  affectedSessionIds: { issue: number[]; pr: number[] } = { issue: [], pr: [] },
 ): void {
   if (!previous) return;
   if (updates.autoLaunchIssues !== undefined && updates.autoLaunchIssues !== previous.autoLaunchIssues) {
@@ -594,7 +596,7 @@ function recordRepoSettingsDiagnostics(
       owner: previous.owner,
       repo: previous.name,
       message: updates.autoLaunchIssues ? "Issue auto-launch enabled" : "Issue auto-launch disabled",
-      data: { repoId, targetType: "issue" },
+      data: { repoId, targetType: "issue", affectedSessionIds: affectedSessionIds.issue },
     });
   }
   if (updates.autoReviewPrs !== undefined && updates.autoReviewPrs !== previous.autoReviewPrs) {
@@ -605,7 +607,7 @@ function recordRepoSettingsDiagnostics(
       owner: previous.owner,
       repo: previous.name,
       message: updates.autoReviewPrs ? "PR auto-review enabled" : "PR auto-review disabled",
-      data: { repoId, targetType: "pr" },
+      data: { repoId, targetType: "pr", affectedSessionIds: affectedSessionIds.pr },
     });
   }
 }
@@ -615,14 +617,16 @@ function endDisabledAutomationSessions(
   repoId: number,
   previous: { name: string; autoLaunchIssues: boolean; autoReviewPrs: boolean } | undefined,
   updates: { autoLaunchIssues?: boolean; autoReviewPrs?: boolean },
-): void {
-  if (!previous) return;
+): { issue: number[]; pr: number[] } {
+  const ended = { issue: [] as number[], pr: [] as number[] };
+  if (!previous) return ended;
   if (previous.autoLaunchIssues && updates.autoLaunchIssues === false) {
-    endActiveWebhookDeployments(db, repoId, previous.name, "issue", "killed_by_label");
+    ended.issue = endActiveWebhookDeployments(db, repoId, previous.name, "issue", "killed_by_label");
   }
   if (previous.autoReviewPrs && updates.autoReviewPrs === false) {
-    endActiveWebhookDeployments(db, repoId, previous.name, "pr", "killed_by_label");
+    ended.pr = endActiveWebhookDeployments(db, repoId, previous.name, "pr", "killed_by_label");
   }
+  return ended;
 }
 
 function endActiveWebhookDeployments(
@@ -631,11 +635,21 @@ function endActiveWebhookDeployments(
   repoName: string,
   targetType: "issue" | "pr",
   terminalReason: "killed_by_label",
-): void {
+): number[] {
+  const endedSessionIds: number[] = [];
   for (const deployment of getActiveWebhookDeploymentsForRepoTarget(db, repoId, targetType)) {
     const sessionName = tmuxSessionName(repoName, deployment.targetNumber, targetType);
     if (deployment.ttydPid) killTtyd(deployment.ttydPid, sessionName);
     else if (deployment.terminalBackend === "pty_bridge") killTmuxSession(sessionName);
     endDeployment(db, deployment.id, terminalReason);
+    if (targetType === "pr") {
+      markActivePrReviewForDeploymentTerminal(db, deployment.id, {
+        completedAt: Date.now(),
+        status: "superseded",
+        reason: terminalReason,
+      });
+    }
+    endedSessionIds.push(deployment.id);
   }
+  return endedSessionIds;
 }

--- a/packages/web/lib/agent/mutations.test.ts
+++ b/packages/web/lib/agent/mutations.test.ts
@@ -280,7 +280,7 @@ describe("executeAgentMutationRequest", () => {
     expect(budgetRow(db, deploymentId, "push")).toEqual({ limit_count: 1, used_count: 0 });
   });
 
-  it("denies push after same-repo, non-default, unprotected, final-head and checkout verification until local upload exists", async () => {
+  it("pushes the new local head after same-repo, non-default, unprotected, final-head and checkout verification", async () => {
     const push = vi.fn().mockResolvedValue(undefined);
     const verifyWorkspaceHead = vi.fn().mockResolvedValue({ ok: true });
     setBudget(db, deploymentId, "push", 1);
@@ -304,15 +304,46 @@ describe("executeAgentMutationRequest", () => {
       push,
     });
 
-    expect(result).toEqual({ allowed: false, reason: "unsupported_local_push" });
+    expect(result).toEqual({ allowed: true });
     expect(verifyWorkspaceHead).toHaveBeenCalledWith({
       workspacePath: "/tmp/issuectl-pr-44",
       expectedHeadRef: "feature/review",
-      expectedHeadSha: "head-a",
+      expectedHeadSha: "head-b",
       owner: "acme",
       repo: "api",
     });
-    expect(push).not.toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "api",
+      ref: "heads/feature/review",
+      sha: "head-b",
+      expectedHeadSha: "head-a",
+    });
+    expect(budgetRow(db, deploymentId, "push")).toEqual({ limit_count: 1, used_count: 1 });
+  });
+
+  it("denies push when the push adapter is not configured", async () => {
+    setBudget(db, deploymentId, "push", 1);
+
+    const result = await executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-44",
+      repoId,
+      targetType: "pr",
+      targetNumber: 44,
+      actionType: "push",
+      payload: {
+        expectedHeadRef: "feature/review",
+        expectedHeadSha: "head-a",
+        newSha: "head-b",
+      },
+    }, {
+      fetchPull: async () => pull(),
+      isBranchProtected: async () => false,
+      verifyWorkspaceHead: async () => ({ ok: true }),
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "action_unimplemented" });
     expect(budgetRow(db, deploymentId, "push")).toEqual({ limit_count: 1, used_count: 0 });
   });
 

--- a/packages/web/lib/agent/mutations.ts
+++ b/packages/web/lib/agent/mutations.ts
@@ -266,7 +266,7 @@ async function preparePushExecution(
   if (request.targetType !== "pr") return denyAgentMutation(db, request, "target_mismatch");
   const payload = parsePushPayload(request.payload);
   if (!payload) return denyAgentMutation(db, request, "invalid_payload");
-  if (!adapters.fetchPull || !adapters.isBranchProtected) {
+  if (!adapters.fetchPull || !adapters.isBranchProtected || !adapters.push) {
     return denyAgentMutation(db, request, "action_unimplemented");
   }
 
@@ -295,13 +295,22 @@ async function preparePushExecution(
   const checkout = await adapters.verifyWorkspaceHead({
     workspacePath: session.workspacePath,
     expectedHeadRef: payload.expectedHeadRef,
-    expectedHeadSha: payload.expectedHeadSha,
+    expectedHeadSha: payload.newSha,
     owner: repo.owner,
     repo: repo.name,
   });
   if (!checkout.ok) return denyAgentMutation(db, request, checkout.reason);
 
-  return denyAgentMutation(db, request, "unsupported_local_push");
+  return {
+    allowed: true,
+    run: () => adapters.push?.({
+      owner: repo.owner,
+      repo: repo.name,
+      ref: `heads/${payload.expectedHeadRef}`,
+      sha: payload.newSha,
+      expectedHeadSha: payload.expectedHeadSha,
+    }) ?? Promise.resolve(),
+  };
 }
 
 function isSameRepoPull(pull: PullForSafety, baseRepoFullName: string): boolean {

--- a/packages/web/lib/review-detail-data.test.ts
+++ b/packages/web/lib/review-detail-data.test.ts
@@ -24,7 +24,11 @@ describe("review-detail-data", () => {
       id: 2,
       reviewedFromSha: "bbbbbbb2222222",
       reviewedToSha: "ccccccc3333333",
-      resultJson: JSON.stringify({ desiredHeadSha: "ddddddd4444444", followUpGeneration: 1 }),
+      resultJson: JSON.stringify({
+        desiredHeadSha: "ddddddd4444444",
+        followUpGeneration: 1,
+        githubReviewUrl: "https://github.com/mean-weasel/issuectl/pull/44#pullrequestreview-1",
+      }),
     });
     const data = buildReviewDetailData({
       repo,
@@ -39,12 +43,17 @@ describe("review-detail-data", () => {
       expect.objectContaining({ tone: "info", title: "Follow-up requested" }),
     ]);
     expect(data.links.githubPr).toBe("https://github.com/mean-weasel/issuectl/pull/44");
+    expect(data.links.githubReview).toBe("https://github.com/mean-weasel/issuectl/pull/44#pullrequestreview-1");
     expect(data.links.githubReviewFiles).toBe("https://github.com/mean-weasel/issuectl/pull/44/files");
     expect(data.links.sessions).toContain("tab=reviews");
     expect(data.links.webhookLogs).toContain("q=mean-weasel%2Fissuectl%2344");
     expect(data.links.diagnosticsCli).toBe("pnpm --dir packages/cli exec issuectl diag show --pr mean-weasel/issuectl#44");
     expect(data.actions.canRetry).toBe(true);
     expect(data.diagnostics).toHaveLength(1);
+    expect(data.metadata).toEqual({
+      currentReviewPreamble: null,
+      triggerEvent: expect.objectContaining({ event: "webhook.pr_launched" }),
+    });
   });
 
   it("shows failed and superseded banners from status and result json", () => {

--- a/packages/web/lib/review-detail-data.ts
+++ b/packages/web/lib/review-detail-data.ts
@@ -33,6 +33,10 @@ export type ReviewDetailData = {
   diagnostics: DiagnosticEvent[];
   result: Record<string, unknown>;
   deploymentResult: Record<string, unknown>;
+  metadata: {
+    currentReviewPreamble: string | null;
+    triggerEvent: DiagnosticEvent | null;
+  };
   banners: ReviewBanner[];
   actions: {
     canRetry: boolean;
@@ -41,6 +45,7 @@ export type ReviewDetailData = {
   };
   links: {
     githubPr: string;
+    githubReview: string | null;
     githubReviewFiles: string;
     workbench: string;
     repoSettings: string;
@@ -89,6 +94,7 @@ export function buildReviewDetailData(input: {
     label: lineageLabel(item),
   }));
   const activeReview = lineage.find((item) => ACTIVE_REVIEW_STATUSES.has(item.status));
+  const triggerEvent = triggerDiagnostic(input.diagnostics ?? []);
   return {
     initialized: true,
     review: input.review,
@@ -98,13 +104,17 @@ export function buildReviewDetailData(input: {
     diagnostics: input.diagnostics ?? [],
     result,
     deploymentResult,
+    metadata: {
+      currentReviewPreamble: input.repo.reviewPreamble,
+      triggerEvent,
+    },
     banners: deriveBanners(input.review, result, deploymentResult),
     actions: {
       canRetry: !activeReview,
       canFullRerun: !activeReview,
       disabledReason: activeReview ? `Run #${activeReview.id} is still ${labelize(activeReview.status)}.` : null,
     },
-    links: reviewLinks(input.repo, input.review),
+    links: reviewLinks(input.repo, input.review, result, deploymentResult),
   };
 }
 
@@ -170,10 +180,16 @@ function deriveBanners(
   return banners;
 }
 
-function reviewLinks(repo: Repo, review: PrReview): ReviewDetailData["links"] {
+function reviewLinks(
+  repo: Repo,
+  review: PrReview,
+  result: Record<string, unknown>,
+  deploymentResult: Record<string, unknown>,
+): ReviewDetailData["links"] {
   const fullName = `${repo.owner}/${repo.name}`;
   return {
     githubPr: `https://github.com/${fullName}/pull/${review.prNumber}`,
+    githubReview: reviewUrl(result) ?? reviewUrl(deploymentResult),
     githubReviewFiles: `https://github.com/${fullName}/pull/${review.prNumber}/files`,
     workbench: `/workbench?repo=${encodeURIComponent(fullName)}`,
     repoSettings: `/repos/${repo.owner}/${repo.name}/settings`,
@@ -181,6 +197,23 @@ function reviewLinks(repo: Repo, review: PrReview): ReviewDetailData["links"] {
     webhookLogs: `/logs/webhooks?q=${encodeURIComponent(`${fullName}#${review.prNumber}`)}`,
     diagnosticsCli: `pnpm --dir packages/cli exec issuectl diag show --pr ${fullName}#${review.prNumber}`,
   };
+}
+
+function triggerDiagnostic(events: DiagnosticEvent[]): DiagnosticEvent | null {
+  return events.find((event) =>
+    event.event === "webhook.pr_launched" ||
+    event.event === "webhook.launched" ||
+    event.event === "pr_review.retry" ||
+    event.event === "pr_review.manual_rerun"
+  ) ?? events[0] ?? null;
+}
+
+function reviewUrl(value: Record<string, unknown>): string | null {
+  return stringValue(value.githubReviewUrl)
+    ?? stringValue(value.reviewUrl)
+    ?? stringValue(value.reviewHtmlUrl)
+    ?? stringValue(value.postedReviewUrl)
+    ?? null;
 }
 
 function lineageLabel(review: PrReview): string {


### PR DESCRIPTION
## Summary
- close the remaining #506/#507 webhook auto-session correctness gaps
- terminalize PR review locks when automation disable/remove ends PR sessions and include affected session IDs in diagnostics
- fix webhook log repo/delivery filters and expose supported review-detail metadata/link-outs
- implement bounded daemon-mediated PR fix-push with final PR-head and local checkout safety checks

## Validation
- pnpm --dir packages/core test
- pnpm --dir packages/web test
- pnpm --dir packages/cli test
- pnpm --dir packages/core typecheck
- pnpm --dir packages/web typecheck
- pnpm --dir packages/cli typecheck
- pnpm --dir packages/core lint
- pnpm --dir packages/web lint
- pnpm --dir packages/cli lint
- pnpm build (pre-push hook)
- node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.7/skills/goalbuddy/scripts/check-goal-state.mjs docs/goals/close-webhook-autosession-gaps/state.yaml

## Notes
- CLI repo add full webhook installation remains accepted non-blocking polish/follow-up.
- Review detail only exposes metadata that is currently persisted; immutable preamble-used snapshots and guaranteed posted-review URLs need future persistence work.