### PR TITLE
fix: close webhook follow-up gaps

### DIFF
--- a/docs/goals/issue-506-507-followup-fixes/goal.md
+++ b/docs/goals/issue-506-507-followup-fixes/goal.md
@@ -1,0 +1,107 @@
+# Issue 506/507 Follow-Up Fixes
+
+## Objective
+
+Fix the remaining implementation gaps found in the post-release audit of issues 506 and 507, then verify the backend, CLI, and dashboard behavior with focused tests and a final completion audit.
+
+## Original Request
+
+"make a detailed plan to fix all using [$goalbuddy:goal-prep]"
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: issuectl maintainers and operators using webhook automation.
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: all four audited gaps are either implemented or explicitly rejected by a final Judge receipt, with focused core/web/cli tests passing and the final audit recording `full_outcome_complete: true`.
+- Goal oracle: focused tests plus source inspection prove the four named gaps are closed:
+  - `issuectl webhook replay <delivery_id>` exists, re-enqueues a retained delivery safely, records diagnostics, and is covered by CLI/core tests.
+  - CLI `repo add` onboarding defaults and prompts match the accepted product decision for #507, with tests updated.
+  - webhook event retention pruning exists for old `webhook_events` rows while preserving replay tombstones as intended, with tests.
+  - REST repo add/update API supports `reviewPreamble` when API parity is in scope, with tests.
+- Likely misfire: closing only the easiest CLI/test gaps while leaving product semantics undecided for retention or prompt defaults.
+- Blind spots considered:
+  - Replay can be unsafe if it bypasses repo/target gating incorrectly or destroys replay tombstones.
+  - Retention must not break dedup/replay protection by deleting `webhook_deliveries`.
+  - CLI prompt changes may intentionally differ from the original issue text if later product decisions changed defaults.
+  - REST API parity may be optional if Apple/API clients are not expected to manage review preambles yet.
+- Existing plan facts:
+  - Gap 1: missing `issuectl webhook replay <delivery_id>` command.
+  - Gap 2: CLI `repo add` prompts currently default automation and agents differently from #507 text.
+  - Gap 3: raw payload pruning exists, but 30-day webhook event row pruning was not found.
+  - Gap 4: web Server Actions support `reviewPreamble`, but REST repo add/update endpoints do not.
+  - Focused tests already passed before this board: core 39, web 59, cli 30.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A final Judge/PM audit maps each of the four audited gaps to a code path and passing verification command, with no required Worker task still queued or active.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Complete the follow-up fixes for the four gaps from the audit. The intended execution flow is: validate the gap list and product decisions, implement the largest safe coherent slices, run focused tests after each slice, then perform an integration audit against the original issue 506/507 requirements.
+
+## Non-Negotiable Constraints
+
+- Follow `AGENTS.md` and `CLAUDE.md`.
+- Do not modify unrelated issuectl behavior or broad-refactor the webhook subsystem.
+- Preserve SQLite replay tombstones unless a Judge explicitly approves a different retention model.
+- Use repo-local patterns: ESM, strict TypeScript, functional style, explicit DB and Octokit parameters, Server Actions for web mutations, Server Components for reads.
+- Keep Worker edits inside each task's `allowed_files`.
+- Update tests with each behavior change.
+- Do not create commits, push, or open a PR unless the user explicitly asks later.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+The preferred Worker slices are:
+
+1. CLI replay as a complete vertical slice: DB helper, CLI command, diagnostics, tests.
+2. CLI onboarding semantics as a complete CLI slice: prompt/default decision, implementation, tests.
+3. Webhook retention as a complete persistence/worker slice: schema/settings decision if needed, prune helper, worker wiring, tests.
+4. REST review preamble parity as a complete API slice: request validation, DB update wiring, response tests.
+
+If Judge decides any slice is no longer needed, it must record why and how the goal oracle remains satisfied.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/issue-506-507-followup-fixes/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/issue-506-507-followup-fixes/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Work only on the active board task.
+5. Write compact receipts into `state.yaml`.
+6. Activate the next largest safe useful task until the oracle is satisfied.
+7. Finish only with a Judge/PM audit receipt that maps all four gaps to code and verification, and records `full_outcome_complete: true`.

--- a/docs/goals/issue-506-507-followup-fixes/state.yaml
+++ b/docs/goals/issue-506-507-followup-fixes/state.yaml
@@ -1,0 +1,598 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "Issue 506/507 Follow-Up Fixes"
+  slug: "issue-506-507-followup-fixes"
+  kind: existing_plan
+  tranche: "Close the four audited follow-up gaps for issuectl webhook automation, with focused tests and final audit proof."
+  status: done
+  oracle:
+    signal: "Source inspection plus focused core/web/cli tests prove the four named gaps are implemented or explicitly rejected with rationale."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Final Judge/PM receipt maps each gap to code paths, tests, and verification results, with full_outcome_complete: true."
+  intake:
+    original_request: "make a detailed plan to fix all using goalbuddy:goal-prep"
+    interpreted_outcome: "Prepare a GoalBuddy board that can execute fixes for all remaining issue 506/507 audit gaps."
+    input_shape: existing_plan
+    audience: "issuectl maintainers and webhook automation operators"
+    authority: requested
+    proof_type: test
+    completion_proof: "Focused core/web/cli tests pass and final audit confirms all four gaps are closed or intentionally deferred."
+    likely_misfire: "Passing existing tests or making superficial command additions without proving the four audit gaps are actually closed."
+    blind_spots_considered:
+      - "Replay must preserve security/gating semantics and not undermine delivery tombstones."
+      - "Retention must prune old event rows without deleting replay-protection tombstones unless explicitly decided."
+      - "CLI prompt/default behavior may need product-decision validation because the code may intentionally differ from the original issue text."
+      - "REST reviewPreamble parity may be optional if no API client needs it; Judge must decide before Worker edits."
+    existing_plan_facts:
+      - "Gap 1: missing issuectl webhook replay <delivery_id> operator command."
+      - "Gap 2: CLI repo add prompts/defaults differ from issue 507 onboarding text."
+      - "Gap 3: raw payload pruning exists, but webhook_events row retention pruning was not found."
+      - "Gap 4: Server Actions support reviewPreamble, but REST repo add/update endpoints do not."
+      - "Focused pre-board verification passed: core 39 tests, web 59 tests, cli 30 tests."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/issue-506-507-followup-fixes/"
+    command: "npx goalbuddy board docs/goals/issue-506-507-followup-fixes"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the four-gap plan, decide exact product semantics, and approve the first safe Worker slice."
+    inputs:
+      - "docs/goals/issue-506-507-followup-fixes/goal.md"
+      - "Current repo state"
+      - "Audit findings summarized in goal.intake.existing_plan_facts"
+      - "Issue 506/507 product requirements as already summarized in the charter"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Treat source files and tests as evidence; do not rely only on prior chat."
+      - "If a gap is intentionally out of scope, record why and adjust or block the corresponding Worker task."
+    expected_output:
+      - "Decision for each gap: implement | already covered | intentionally defer | needs owner input."
+      - "Exact first Worker objective."
+      - "allowed_files for the first Worker."
+      - "verify commands for the first Worker."
+      - "stop_if conditions for the first Worker."
+      - "Any board task edits needed before implementation."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      decision: "approved"
+      decision_by_gap:
+        gap_1_webhook_replay: "implement: no issuectl webhook replay command exists, and core has enough retained webhook metadata to safely re-enqueue eligible issue/pr events without deleting delivery tombstones."
+        gap_2_cli_onboarding: "implement after T010: current CLI defaults/prompts still need explicit alignment with the accepted #507 operator onboarding decision."
+        gap_3_event_retention: "implement after onboarding: raw payload pruning exists, but webhook_events row retention pruning is not present; preserve webhook_deliveries tombstones."
+        gap_4_rest_review_preamble: "implement after retention: Server Actions already support reviewPreamble, so REST add/update parity is in scope unless later tests expose a compatibility blocker."
+      first_worker:
+        task: T010
+        objective: "Implement issuectl webhook replay <delivery_id> as a vertical CLI/core slice."
+        allowed_files:
+          - "packages/cli/src/commands/webhook.ts"
+          - "packages/cli/src/commands/webhook.test.ts"
+          - "packages/core/src/db/webhooks.ts"
+          - "packages/core/src/db/webhooks.test.ts"
+          - "packages/core/src/index.ts"
+          - "packages/core/src/types.ts"
+          - "packages/core/src/db/diagnostics.ts"
+        verify:
+          - "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts"
+          - "pnpm --dir packages/cli test -- --run src/commands/webhook.test.ts"
+          - "pnpm --dir packages/cli typecheck"
+        stop_if:
+          - "Replay needs network refetch/signature semantics beyond retained local metadata."
+          - "A schema change or file outside allowed_files is needed."
+          - "Focused verification fails twice for unrelated reasons."
+      board_edits: "Activated T010 with no scope changes."
+
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement the CLI webhook replay vertical slice."
+    inputs:
+      - "T001 receipt"
+      - "packages/cli/src/commands/webhook.ts"
+      - "packages/cli/src/commands/webhook.test.ts"
+      - "packages/core/src/db/webhooks.ts"
+      - "packages/core/src/db/webhooks.test.ts"
+      - "packages/core/src/db/diagnostics.ts"
+    constraints:
+      - "Preserve webhook_deliveries replay tombstones."
+      - "Replay must not bypass target/repo semantics silently."
+      - "Record diagnostics for operator replay attempts and outcomes."
+      - "Prefer structured DB helper(s) over ad hoc SQL in CLI command code."
+    allowed_files:
+      - "packages/cli/src/commands/webhook.ts"
+      - "packages/cli/src/commands/webhook.test.ts"
+      - "packages/core/src/db/webhooks.ts"
+      - "packages/core/src/db/webhooks.test.ts"
+      - "packages/core/src/index.ts"
+      - "packages/core/src/types.ts"
+      - "packages/core/src/db/diagnostics.ts"
+    verify:
+      - "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts"
+      - "pnpm --dir packages/cli test -- --run src/commands/webhook.test.ts"
+      - "pnpm --dir packages/cli typecheck"
+    stop_if:
+      - "Replay semantics require network refetch or webhook signature decisions not covered by existing requirements."
+      - "Need schema changes outside allowed_files."
+      - "Verification fails twice for unrelated reasons."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      summary:
+        - "Added core replayWebhookDelivery helper that looks up retained webhook event metadata by delivery_id, validates target/action replayability, preserves webhook_deliveries tombstones, and re-enqueues an immediate webhook_intent."
+        - "Added issuectl webhook replay <delivery-id> --yes CLI command with operator diagnostics for success and failure."
+        - "Covered successful replay, ineligible missing-target replay, CLI success output, and CLI failure diagnostics."
+      changed_files:
+        - "packages/core/src/db/webhooks.ts"
+        - "packages/core/src/db/webhooks.test.ts"
+        - "packages/core/src/index.ts"
+        - "packages/cli/src/commands/webhook.ts"
+        - "packages/cli/src/commands/webhook.test.ts"
+      commands:
+        - command: "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/cli test -- --run src/commands/webhook.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/core build"
+          status: pass
+        - command: "pnpm --dir packages/cli typecheck"
+          status: pass
+      verification:
+        - command: "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts"
+          result: pass
+          evidence: "1 file passed, 13 tests passed."
+        - command: "pnpm --dir packages/cli test -- --run src/commands/webhook.test.ts"
+          result: pass
+          evidence: "1 file passed, 12 tests passed."
+        - command: "pnpm --dir packages/core build"
+          result: pass
+          evidence: "Refreshed local core dist declarations required by CLI package-boundary typecheck."
+        - command: "pnpm --dir packages/cli typecheck"
+          result: pass
+          evidence: "tsc --noEmit exited 0 after core declarations were rebuilt."
+      notes:
+        - "Replay intentionally excludes pull_request:unlabeled and issues:unlabeled from metadata-only replay because retained metadata does not prove which label changed."
+
+  - id: T020
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Align CLI repo onboarding prompts/defaults with the validated #507 product decision."
+    inputs:
+      - "T001 receipt"
+      - "packages/cli/src/commands/repo.ts"
+      - "packages/cli/src/commands/repo.test.ts"
+      - "Issue 507 onboarding text summarized in goal.md"
+    constraints:
+      - "If Judge decides current defaults are intentional, block this task with rationale instead of editing."
+      - "Keep preflight warnings non-fatal unless Judge explicitly chooses fail-fast."
+      - "Update tests to lock whichever prompt/default behavior Judge approves."
+    allowed_files:
+      - "packages/cli/src/commands/repo.ts"
+      - "packages/cli/src/commands/repo.test.ts"
+      - "packages/cli/src/index.ts"
+    verify:
+      - "pnpm --dir packages/cli test -- --run src/commands/repo.test.ts"
+      - "pnpm --dir packages/cli typecheck"
+    stop_if:
+      - "Product default is ambiguous after T001."
+      - "Implementing fail-fast preflight would require broader UX/CLI policy changes."
+      - "Verification fails twice for unrelated reasons."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      summary:
+        - "Aligned interactive repo add automation prompts with #507 by using opt-in defaults for issue auto-launch and PR auto-review."
+        - "Changed prompted issue and PR automation agent defaults from codex to claude while preserving explicit flag behavior."
+        - "Added regression coverage for declined automation and default Claude agent prompts."
+      changed_files:
+        - "packages/cli/src/commands/repo.ts"
+        - "packages/cli/src/commands/repo.test.ts"
+      commands:
+        - command: "pnpm --dir packages/cli test -- --run src/commands/repo.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/cli typecheck"
+          status: pass
+      verification:
+        - command: "pnpm --dir packages/cli test -- --run src/commands/repo.test.ts"
+          result: pass
+          evidence: "1 file passed, 13 tests passed."
+        - command: "pnpm --dir packages/cli typecheck"
+          result: pass
+          evidence: "tsc --noEmit exited 0."
+
+  - id: T030
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement webhook event row retention pruning while preserving replay-protection delivery tombstones."
+    inputs:
+      - "T001 receipt"
+      - "packages/core/src/db/webhooks.ts"
+      - "packages/core/src/db/webhooks.test.ts"
+      - "packages/core/src/db/settings.ts"
+      - "packages/web/lib/webhook-payload-retention.ts"
+      - "packages/web/lib/webhook-intent-worker.ts"
+      - "packages/web/lib/webhook-intent-worker.test.ts"
+    constraints:
+      - "Do not delete webhook_deliveries tombstones unless Judge explicitly approves."
+      - "Default retention should match #507 if still accepted: 30 days for webhook_events."
+      - "Keep metadata needed by logs/diagnostics coherent after pruning."
+      - "Avoid deleting rows referenced by active intents unless a safe policy is implemented and tested."
+    allowed_files:
+      - "packages/core/src/db/webhooks.ts"
+      - "packages/core/src/db/webhooks.test.ts"
+      - "packages/core/src/db/settings.ts"
+      - "packages/core/src/db/schema.ts"
+      - "packages/core/src/db/migrations.ts"
+      - "packages/core/src/types.ts"
+      - "packages/core/src/index.ts"
+      - "packages/web/lib/webhook-payload-retention.ts"
+      - "packages/web/lib/webhook-intent-worker.ts"
+      - "packages/web/lib/webhook-intent-worker.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts src/db/schema-invariants.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/webhook-intent-worker.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Retention needs a config-file system outside DB settings."
+      - "Pruning would break webhook log UI expectations without broader UI changes."
+      - "Need files outside allowed_files."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      summary:
+        - "Added core pruneOldWebhookEvents helper for age-based webhook_events row pruning while preserving webhook_deliveries replay tombstones."
+        - "Kept event rows attached to active intents so live debounce/processing lineage remains available."
+        - "Wired the web worker retention pass to prune webhook_events older than 30 days and broadcast live-tail updates when event rows are removed."
+      changed_files:
+        - "packages/core/src/db/webhooks.ts"
+        - "packages/core/src/db/webhooks.test.ts"
+        - "packages/core/src/index.ts"
+        - "packages/web/lib/webhook-payload-retention.ts"
+        - "packages/web/lib/webhook-intent-worker.ts"
+        - "packages/web/lib/webhook-intent-worker.test.ts"
+      commands:
+        - command: "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts src/db/schema-invariants.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/core build"
+          status: pass
+        - command: "pnpm --dir packages/web test -- --run lib/webhook-intent-worker.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/core typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+      verification:
+        - command: "pnpm --dir packages/core test -- --run src/db/webhooks.test.ts src/db/schema-invariants.test.ts"
+          result: pass
+          evidence: "2 files passed, 22 tests passed."
+        - command: "pnpm --dir packages/core build"
+          result: pass
+          evidence: "Refreshed local core dist export for web package-boundary tests/typecheck."
+        - command: "pnpm --dir packages/web test -- --run lib/webhook-intent-worker.test.ts"
+          result: pass
+          evidence: "1 file passed, 10 tests passed."
+        - command: "pnpm --dir packages/core typecheck"
+          result: pass
+          evidence: "tsc --noEmit exited 0."
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+          evidence: "tsc --noEmit exited 0."
+
+  - id: T040
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add REST API parity for repo reviewPreamble when Judge confirms it is in scope."
+    inputs:
+      - "T001 receipt"
+      - "packages/web/app/api/v1/repos/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+      - "packages/web/app/api/v1/repos/route.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "packages/core/src/db/repos.ts"
+    constraints:
+      - "If Judge decides API parity is optional/out of scope, block this task with rationale."
+      - "Validate reviewPreamble as string or null."
+      - "Preserve existing REST auth and error style."
+      - "Do not change Server Action behavior unless tests reveal a shared helper is necessary."
+    allowed_files:
+      - "packages/web/app/api/v1/repos/route.ts"
+      - "packages/web/app/api/v1/repos/route.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- --run app/api/v1/repos/route.test.ts app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "API schema/Apple-client compatibility requires a larger contract decision."
+      - "Need files outside allowed_files."
+      - "Verification fails twice for unrelated reasons."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      summary:
+        - "Added REST add/update support for reviewPreamble with string/null validation."
+        - "Passed reviewPreamble through updateRepoWebhookSettings for both POST /api/v1/repos and PATCH /api/v1/repos/[owner]/[repo]."
+        - "Added route tests for string pass-through, null reset, and invalid type rejection."
+      changed_files:
+        - "packages/web/app/api/v1/repos/route.ts"
+        - "packages/web/app/api/v1/repos/route.test.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      commands:
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web test -- --run app/api/v1/repos/route.test.ts 'app/api/v1/repos/[owner]/[repo]/route.test.ts'"
+          status: pass
+      verification:
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+          evidence: "tsc --noEmit exited 0."
+        - command: "pnpm --dir packages/web test -- --run app/api/v1/repos/route.test.ts 'app/api/v1/repos/[owner]/[repo]/route.test.ts'"
+          result: pass
+          evidence: "2 files passed, 9 tests passed."
+
+  - id: T050
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the implemented packages for integration risks before broad verification."
+    inputs:
+      - "Receipts from T010, T020, T030, and T040 or their blocked/deferred rationales."
+      - "Current dirty diff"
+      - "Focused test outputs"
+    constraints:
+      - "Read-only."
+      - "Do not require perfection beyond the four-gap goal."
+      - "Call out missing tests, stale docs/help output, or behavior conflicts."
+    expected_output:
+      - "approved | needs_fix"
+      - "Findings with file paths"
+      - "Whether a follow-up Worker task is required before final audit"
+      - "Recommended broad verification commands"
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      decision: approved
+      findings: []
+      summary: "Integration review approved the four implemented slices. Diff is scoped to the planned CLI/core/web files, focused tests cover each behavior, git diff --check is clean, and no follow-up Worker fix is required before broad verification."
+      recommended_broad_verification:
+        - "pnpm --dir packages/core test"
+        - "pnpm --dir packages/cli test"
+        - "pnpm --dir packages/web test"
+        - "pnpm --dir packages/core typecheck"
+        - "pnpm --dir packages/cli typecheck"
+        - "pnpm --dir packages/web typecheck"
+
+  - id: T060
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Address any concrete integration findings from T050."
+    inputs:
+      - "T050 receipt"
+      - "Current dirty diff"
+    constraints:
+      - "Only execute if T050 records needs_fix."
+      - "PM must populate allowed_files and verify from T050 before activation."
+    allowed_files: []
+    verify: []
+    stop_if:
+      - "T050 did not approve a bounded fix."
+      - "Need files outside allowed_files."
+      - "Verification fails twice for unrelated reasons."
+    receipt:
+      result: not_needed
+      summary: "Not activated because T050 approved the integration review with no concrete findings requiring a fix Worker."
+      next_task: T090
+
+  - id: T090
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: medium
+    objective: "Run final verification commands and prepare the audit evidence."
+    inputs:
+      - "All Worker receipts"
+      - "T050/T060 receipts"
+    constraints:
+      - "Do not implement new behavior in this task."
+      - "If verification fails, record the failure and activate an appropriate recovery task."
+    expected_output:
+      - "Verification command list with pass/fail."
+      - "Dirty diff summary."
+      - "Gap-to-evidence matrix for final Judge."
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      summary: "Broad PM verification passed after the four implementation slices and integration review."
+      commands:
+        - command: "pnpm --dir packages/core test"
+          status: pass
+          evidence: "60 files passed, 552 tests passed."
+        - command: "pnpm --dir packages/cli test"
+          status: pass
+          evidence: "7 files passed, 55 tests passed."
+        - command: "pnpm --dir packages/web test"
+          status: pass
+          evidence: "58 files passed, 425 tests passed; expected test logger output exercised a handled failure path."
+        - command: "pnpm --dir packages/core typecheck"
+          status: pass
+          evidence: "tsc --noEmit exited 0."
+        - command: "pnpm --dir packages/cli typecheck"
+          status: pass
+          evidence: "tsc --noEmit exited 0."
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+          evidence: "tsc --noEmit exited 0."
+        - command: "pnpm --dir packages/core lint"
+          status: pass
+          evidence: "eslint src/ exited 0."
+        - command: "pnpm --dir packages/cli lint"
+          status: pass
+          evidence: "eslint src/ exited 0 after adding existing-pattern max-lines annotations to expanded webhook command/test files."
+        - command: "pnpm --dir packages/web lint"
+          status: pass
+          evidence: "eslint app/ components/ lib/ exited 0."
+        - command: "git diff --check"
+          status: pass
+          evidence: "No whitespace errors."
+      dirty_diff_summary:
+        - "14 tracked files modified across CLI, core, and web."
+        - "GoalBuddy files remain untracked under docs/goals/issue-506-507-followup-fixes/."
+      gap_to_evidence:
+        webhook_replay: "packages/core/src/db/webhooks.ts, packages/cli/src/commands/webhook.ts, tests in core/cli."
+        cli_onboarding: "packages/cli/src/commands/repo.ts and repo.test.ts."
+        event_retention: "packages/core/src/db/webhooks.ts, packages/web/lib/webhook-payload-retention.ts, packages/web/lib/webhook-intent-worker.ts, tests in core/web."
+        rest_review_preamble: "packages/web/app/api/v1/repos routes and route tests."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether all issue 506/507 follow-up gaps are closed."
+    inputs:
+      - "All done task receipts"
+      - "T090 verification evidence"
+      - "Current dirty diff"
+      - "Goal oracle"
+    constraints:
+      - "Read-only."
+      - "Reject completion if any required Worker task is queued, active, or missing a receipt."
+      - "Reject completion if any of the four gaps lacks code evidence or an explicit defer/block rationale."
+      - "Reject completion if focused verification is stale or failing."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Gap-to-evidence mapping"
+      - "Missing evidence"
+      - "Next task if not complete"
+    receipt:
+      completed_at: "2026-05-25T00:00:00-07:00"
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "Final audit approved completion. All four issue 506/507 follow-up gaps are mapped to code evidence and passing verification. T060 was not needed because T050 found no integration defects."
+      gap_mapping:
+        - gap: "Missing issuectl webhook replay <delivery_id> operator command."
+          outcome: "Fixed by T010."
+          code:
+            - "packages/core/src/db/webhooks.ts"
+            - "packages/cli/src/commands/webhook.ts"
+          tests:
+            - "packages/core/src/db/webhooks.test.ts"
+            - "packages/cli/src/commands/webhook.test.ts"
+        - gap: "CLI repo add onboarding prompts/defaults differed from #507 text."
+          outcome: "Fixed by T020."
+          code:
+            - "packages/cli/src/commands/repo.ts"
+          tests:
+            - "packages/cli/src/commands/repo.test.ts"
+        - gap: "Webhook_events row retention pruning was missing."
+          outcome: "Fixed by T030."
+          code:
+            - "packages/core/src/db/webhooks.ts"
+            - "packages/web/lib/webhook-payload-retention.ts"
+            - "packages/web/lib/webhook-intent-worker.ts"
+          tests:
+            - "packages/core/src/db/webhooks.test.ts"
+            - "packages/web/lib/webhook-intent-worker.test.ts"
+        - gap: "REST repo add/update API did not accept reviewPreamble."
+          outcome: "Fixed by T040."
+          code:
+            - "packages/web/app/api/v1/repos/route.ts"
+            - "packages/web/app/api/v1/repos/[owner]/[repo]/route.ts"
+          tests:
+            - "packages/web/app/api/v1/repos/route.test.ts"
+            - "packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts"
+      verification:
+        - command: "pnpm --dir packages/core test"
+          result: pass
+        - command: "pnpm --dir packages/cli test"
+          result: pass
+        - command: "pnpm --dir packages/web test"
+          result: pass
+        - command: "pnpm --dir packages/core typecheck"
+          result: pass
+        - command: "pnpm --dir packages/cli typecheck"
+          result: pass
+        - command: "pnpm --dir packages/web typecheck"
+          result: pass
+        - command: "pnpm --dir packages/core lint"
+          result: pass
+        - command: "pnpm --dir packages/cli lint"
+          result: pass
+        - command: "pnpm --dir packages/web lint"
+          result: pass
+        - command: "git diff --check"
+          result: pass
+      residual_risk:
+        - "Core dist was rebuilt locally so CLI/web package-boundary checks saw new core exports; generated dist files are not tracked in git status."
+        - "No commit, push, or PR was created because the user did not request one."
+
+checks:
+  dirty_fingerprint: "14 tracked source/test files modified plus GoalBuddy receipts"
+  last_verification:
+    result: pass
+    task: T090
+    commands:
+      - "pnpm --dir packages/core test"
+      - "pnpm --dir packages/cli test"
+      - "pnpm --dir packages/web test"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/cli typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core lint"
+      - "pnpm --dir packages/cli lint"
+      - "pnpm --dir packages/web lint"
+      - "git diff --check"

--- a/packages/cli/src/commands/repo.test.ts
+++ b/packages/cli/src/commands/repo.test.ts
@@ -185,11 +185,11 @@ describe("repo commands", () => {
 
     expect(confirm).toHaveBeenCalledWith({
       message: "Auto-launch issue sessions from webhooks?",
-      default: true,
+      default: false,
     });
     expect(confirm).toHaveBeenCalledWith({
       message: "Reserve PRs for automatic review from webhooks?",
-      default: true,
+      default: false,
     });
     expect(execFileSync).toHaveBeenCalledWith("gh", ["auth", "status", "--show-token-scopes"], {
       encoding: "utf8",
@@ -217,6 +217,65 @@ describe("repo commands", () => {
     expect(updateRepoWebhookSettings).toHaveBeenCalledWith(mockDb, 1, {
       webhookId: 123,
       webhookSecret: expect.any(String),
+    });
+  });
+
+  it("defaults interactive webhook automation to opt-in and skips automation prompts when declined", async () => {
+    vi.mocked(getRepo).mockReturnValue(undefined);
+    vi.mocked(addRepo).mockReturnValue(makeRepo());
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    vi.mocked(input).mockResolvedValueOnce("");
+
+    await repoAddCommand("mean-weasel/issuectl", {});
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Auto-launch issue sessions from webhooks?",
+      default: false,
+    });
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Reserve PRs for automatic review from webhooks?",
+      default: false,
+    });
+    expect(input).toHaveBeenCalledTimes(1);
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(mockDb, 1, {
+      autoLaunchIssues: false,
+      autoReviewPrs: false,
+    });
+    expect(createIssuectlWebhook).not.toHaveBeenCalled();
+  });
+
+  it("defaults prompted automation agents to claude", async () => {
+    vi.mocked(getRepo).mockReturnValue(undefined);
+    vi.mocked(addRepo).mockReturnValue(makeRepo());
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    vi.mocked(input)
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("metadata")
+      .mockResolvedValueOnce("");
+
+    await repoAddCommand("mean-weasel/issuectl", {});
+
+    expect(input).toHaveBeenCalledWith(expect.objectContaining({
+      message: "Issue session agent",
+      default: "claude",
+    }));
+    expect(input).toHaveBeenCalledWith(expect.objectContaining({
+      message: "PR review agent",
+      default: "claude",
+    }));
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(mockDb, 1, {
+      autoLaunchIssues: true,
+      autoReviewPrs: true,
+      issueAgent: "claude",
+      reviewAgent: "claude",
+      webhookPayloadMode: "metadata",
     });
   });
 

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -224,25 +224,25 @@ async function collectRepoAddWebhookOptions(
   const autoLaunchIssues = options.autoLaunchIssues === undefined
     ? await confirm({
         message: "Auto-launch issue sessions from webhooks?",
-        default: true,
+        default: false,
       })
     : normalizeOptionalBoolean(options.autoLaunchIssues, "--auto-launch-issues");
   const autoReviewPrs = options.autoReviewPrs === undefined
     ? await confirm({
         message: "Reserve PRs for automatic review from webhooks?",
-        default: true,
+        default: false,
       })
     : normalizeOptionalBoolean(options.autoReviewPrs, "--auto-review-prs");
   const automationEnabled = autoLaunchIssues || autoReviewPrs;
 
   let issueAgent = normalizeOptionalAgent(options.issueAgent, "--issue-agent");
   if (autoLaunchIssues && issueAgent === undefined) {
-    issueAgent = await promptLaunchAgent("Issue session agent", "codex");
+    issueAgent = await promptLaunchAgent("Issue session agent", "claude");
   }
 
   let reviewAgent = normalizeOptionalAgent(options.reviewAgent, "--review-agent");
   if (autoReviewPrs && reviewAgent === undefined) {
-    reviewAgent = await promptLaunchAgent("PR review agent", "codex");
+    reviewAgent = await promptLaunchAgent("PR review agent", "claude");
   }
 
   let webhookPayloadMode = normalizeOptionalPayloadMode(options.webhookPayloadMode);

--- a/packages/cli/src/commands/webhook.test.ts
+++ b/packages/cli/src/commands/webhook.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -5,9 +6,12 @@ import {
   getSetting,
   listRepos,
   listWebhookEvents,
+  recordDiagnosticEventSafely,
+  replayWebhookDelivery,
   type Repo,
   type RepoWebhookConfig,
   type WebhookEvent,
+  type WebhookIntent,
 } from "@issuectl/core";
 import { requireDb } from "../utils/db.js";
 import { registerWebhookCommands } from "./webhook.js";
@@ -20,6 +24,8 @@ vi.mock("@issuectl/core", async (importOriginal) => {
     getSetting: vi.fn(),
     listRepos: vi.fn(),
     listWebhookEvents: vi.fn(),
+    recordDiagnosticEventSafely: vi.fn(),
+    replayWebhookDelivery: vi.fn(),
   };
 });
 
@@ -61,6 +67,30 @@ function makeWebhookEvent(overrides: Partial<WebhookEvent> = {}): WebhookEvent {
     payloadJson: null,
     receivedAt: 1_000,
     intentId: null,
+    ...overrides,
+  };
+}
+
+function makeWebhookIntent(overrides: Partial<WebhookIntent> = {}): WebhookIntent {
+  return {
+    id: 9,
+    repoId: 1,
+    targetType: "issue",
+    targetNumber: 42,
+    firstSignalAt: 2_000,
+    lastSignalAt: 2_000,
+    scheduledAt: 2_000,
+    processingStartedAt: null,
+    leaseExpiresAt: null,
+    generation: 1,
+    desiredHeadSha: null,
+    requestedAgent: null,
+    reviewMode: null,
+    signalCount: 1,
+    status: "pending",
+    resolvedAt: null,
+    deploymentId: null,
+    failureReason: null,
     ...overrides,
   };
 }
@@ -109,6 +139,8 @@ beforeEach(() => {
   vi.mocked(getSetting).mockReset();
   vi.mocked(listRepos).mockReset();
   vi.mocked(listWebhookEvents).mockReset();
+  vi.mocked(recordDiagnosticEventSafely).mockReset();
+  vi.mocked(replayWebhookDelivery).mockReset();
 });
 
 afterEach(() => {
@@ -251,5 +283,61 @@ describe("webhook commands", () => {
     expect(result.stderr).toContain("--target must use issue#number or pr#number.");
     expect(requireDb).not.toHaveBeenCalled();
     expect(listWebhookEvents).not.toHaveBeenCalled();
+  });
+
+  it("replays a retained webhook delivery", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    vi.mocked(listRepos).mockReturnValue([
+      makeRepo({ id: 1, owner: "mean-weasel", name: "issuectl" }),
+    ]);
+    vi.mocked(replayWebhookDelivery).mockReturnValue({
+      replayed: true,
+      event: makeWebhookEvent({ deliveryId: "delivery-1" }),
+      intent: makeWebhookIntent({ id: 9, scheduledAt: 2_000 }),
+    });
+
+    const result = await parseCommand(["webhook", "replay", "delivery-1", "--yes"]);
+
+    expect(replayWebhookDelivery).toHaveBeenCalledWith(mockDb, {
+      deliveryId: "delivery-1",
+      now: 2_000,
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(mockDb, expect.objectContaining({
+      event: "webhook.replayed",
+      source: "cli",
+      correlationId: "delivery-1",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      targetType: "issue",
+      targetNumber: 42,
+    }));
+    expect(result.stdout).toContain("9\tmean-weasel/issuectl\tissue#42\tpending\tscheduled=2000");
+  });
+
+  it("reports why a webhook delivery cannot be replayed", async () => {
+    vi.mocked(replayWebhookDelivery).mockReturnValue({
+      replayed: false,
+      reason: "missing_target",
+      event: makeWebhookEvent({
+        deliveryId: "delivery-1",
+        targetType: null,
+        targetNumber: null,
+      }),
+    });
+    vi.mocked(listRepos).mockReturnValue([
+      makeRepo({ id: 1, owner: "mean-weasel", name: "issuectl" }),
+    ]);
+
+    const result = await parseCommand(["webhook", "replay", "delivery-1", "--yes"]);
+
+    expect(result.error).toBeInstanceOf(CommanderError);
+    expect(result.stderr).toContain("delivery has no issue or PR target metadata");
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(mockDb, expect.objectContaining({
+      event: "webhook.replay_failed",
+      source: "cli",
+      correlationId: "delivery-1",
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
   });
 });

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { randomBytes } from "node:crypto";
 import type { Command } from "commander";
 import { confirm } from "@inquirer/prompts";
@@ -6,6 +7,8 @@ import {
   getSetting,
   listRepos,
   listWebhookEvents,
+  recordDiagnosticEventSafely,
+  replayWebhookDelivery,
   updateRepoWebhookSettings,
   withAuthRetry,
   type RepoWebhookConfig,
@@ -288,6 +291,64 @@ export function registerWebhookCommands(program: Command): void {
   registerWebhookIntentCommands(webhook);
 
   webhook
+    .command("replay <delivery-id>")
+    .description("Re-enqueue a retained webhook delivery")
+    .option("--yes", "Skip confirmation prompt")
+    .action(async (deliveryId: string, opts: { yes?: boolean }, command: Command) => {
+      await parseCommandInput(command, () =>
+        requireConfirmation(opts.yes, `Replay webhook delivery ${deliveryId}?`),
+      );
+      const db = requireDb();
+      const result = replayWebhookDelivery(db, {
+        deliveryId,
+        now: Date.now(),
+      });
+      if (!result.replayed) {
+        const repo = result.event
+          ? listRepos(db).find((candidate) => candidate.id === result.event?.repoId)
+          : undefined;
+        recordDiagnosticEventSafely(db, {
+          level: "warn",
+          event: "webhook.replay_failed",
+          source: "cli",
+          correlationId: deliveryId,
+          owner: repo?.owner,
+          repo: repo?.name,
+          targetType: result.event?.targetType ?? undefined,
+          targetNumber: result.event?.targetNumber ?? undefined,
+          message: `Webhook delivery replay failed: ${result.reason}`,
+          data: {
+            deliveryId,
+            reason: result.reason,
+            eventId: result.event?.id,
+          },
+        });
+        command.error(`Cannot replay webhook delivery ${deliveryId}: ${formatReplayFailure(result.reason)}.`);
+      }
+
+      const repo = listRepos(db).find((candidate) => candidate.id === result.event.repoId);
+      recordDiagnosticEventSafely(db, {
+        level: "info",
+        event: "webhook.replayed",
+        source: "cli",
+        correlationId: deliveryId,
+        owner: repo?.owner,
+        repo: repo?.name,
+        targetType: result.intent.targetType,
+        targetNumber: result.intent.targetNumber,
+        message: "Webhook delivery replayed by operator",
+        data: {
+          deliveryId,
+          eventId: result.event.id,
+          intentId: result.intent.id,
+        },
+      });
+      process.stdout.write(
+        `${result.intent.id}\t${repo ? `${repo.owner}/${repo.name}` : result.intent.repoId}\t${result.intent.targetType}#${result.intent.targetNumber}\t${result.intent.status}\tscheduled=${result.intent.scheduledAt}\n`,
+      );
+    });
+
+  webhook
     .command("create <repo>")
     .description("Create the GitHub webhook for a tracked repo")
     .option("--yes", "Skip confirmation prompt")
@@ -302,4 +363,11 @@ export function registerWebhookCommands(program: Command): void {
     .action((repoRef: string, opts: { yes?: boolean }, command: Command) =>
       configureWebhook(command, repoRef, { yes: opts.yes, rotate: true }),
     );
+}
+
+function formatReplayFailure(reason: "not_found" | "missing_target" | "missing_action" | "not_replayable"): string {
+  if (reason === "not_found") return "delivery not found";
+  if (reason === "missing_target") return "delivery has no issue or PR target metadata";
+  if (reason === "missing_action") return "delivery has no GitHub action metadata";
+  return "delivery event/action is not replayable";
 }

--- a/packages/core/src/db/webhooks.test.ts
+++ b/packages/core/src/db/webhooks.test.ts
@@ -16,9 +16,11 @@ import {
   listWebhookLogEntries,
   listWebhookEvents,
   mergeWebhookIntent,
+  pruneOldWebhookEvents,
   pruneExpiredWebhookPayloads,
   recordWebhookEvent,
   recoverExpiredWebhookIntentLeases,
+  replayWebhookDelivery,
 } from "./webhooks.js";
 
 describe("webhook DB helpers", () => {
@@ -310,6 +312,64 @@ describe("webhook DB helpers", () => {
     ).toEqual({ count: 2 });
   });
 
+  it("prunes old event rows without deleting delivery tombstones", () => {
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-old",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: "issue",
+      targetNumber: 506,
+      receivedAt: 1_000,
+    });
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-new",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: "issue",
+      targetNumber: 507,
+      receivedAt: 5_000,
+    });
+
+    expect(pruneOldWebhookEvents(db, 5_000, 3_000)).toBe(1);
+
+    expect(listWebhookEvents(db)).toEqual([
+      expect.objectContaining({ deliveryId: "delivery-new" }),
+    ]);
+    expect(
+      db.prepare("SELECT delivery_id FROM webhook_deliveries ORDER BY delivery_id").all(),
+    ).toEqual([
+      { delivery_id: "delivery-new" },
+      { delivery_id: "delivery-old" },
+    ]);
+  });
+
+  it("does not prune old event rows attached to active intents", () => {
+    const oldEvent = recordWebhookEvent(db, {
+      deliveryId: "delivery-active",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: "issue",
+      targetNumber: 506,
+      receivedAt: 1_000,
+    });
+    mergeWebhookIntent(db, {
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      signalAt: 1_000,
+      scheduledAt: 10_000,
+      eventId: oldEvent.eventId,
+    });
+
+    expect(pruneOldWebhookEvents(db, 5_000, 3_000)).toBe(0);
+    expect(listWebhookEvents(db)).toEqual([
+      expect.objectContaining({ deliveryId: "delivery-active" }),
+    ]);
+  });
+
   it("finds an existing event by delivery id and repo", () => {
     recordWebhookEvent(db, {
       deliveryId: "delivery-1",
@@ -344,6 +404,73 @@ describe("webhook DB helpers", () => {
         repoId: repoId + 1,
       }),
     ).toBeUndefined();
+  });
+
+  it("replays a retained delivery into an immediate webhook intent", () => {
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-replay",
+      repoId,
+      eventType: "pull_request",
+      action: "synchronize",
+      senderLogin: "octocat",
+      targetType: "pr",
+      targetNumber: 42,
+      payloadJson: JSON.stringify({
+        pull_request: { head: { sha: "abc123" } },
+      }),
+      receivedAt: 1_000,
+      retainedUntil: 5_000,
+    });
+
+    const result = replayWebhookDelivery(db, {
+      deliveryId: "delivery-replay",
+      now: 2_000,
+    });
+
+    expect(result).toEqual({
+      replayed: true,
+      event: expect.objectContaining({
+        deliveryId: "delivery-replay",
+        targetType: "pr",
+        targetNumber: 42,
+      }),
+      intent: expect.objectContaining({
+        repoId,
+        targetType: "pr",
+        targetNumber: 42,
+        status: "pending",
+        scheduledAt: 2_000,
+        desiredHeadSha: "abc123",
+      }),
+    });
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM webhook_deliveries").get(),
+    ).toEqual({ count: 1 });
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM webhook_events").get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("rejects replay when retained metadata cannot identify a target", () => {
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-no-target",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: null,
+      targetNumber: null,
+      receivedAt: 1_000,
+    });
+
+    expect(replayWebhookDelivery(db, {
+      deliveryId: "delivery-no-target",
+      now: 2_000,
+    })).toEqual({
+      replayed: false,
+      reason: "missing_target",
+      event: expect.objectContaining({ deliveryId: "delivery-no-target" }),
+    });
+    expect(listWebhookIntents(db)).toEqual([]);
   });
 
   it("claims and recovers stale processing intents", () => {

--- a/packages/core/src/db/webhooks.ts
+++ b/packages/core/src/db/webhooks.ts
@@ -31,6 +31,24 @@ export type {
 } from "./webhook-records.js";
 
 const MERGE_TRANSACTION_ATTEMPTS = 3;
+const REPLAYABLE_WEBHOOK_SIGNALS = new Set([
+  "issues:opened",
+  "issues:labeled",
+  "issues:closed",
+  "issues:reopened",
+  "pull_request:opened",
+  "pull_request:labeled",
+  "pull_request:synchronize",
+  "pull_request:closed",
+]);
+
+export type ReplayWebhookDeliveryResult =
+  | { replayed: true; event: WebhookEvent; intent: WebhookIntent }
+  | {
+      replayed: false;
+      reason: "not_found" | "missing_target" | "missing_action" | "not_replayable";
+      event?: WebhookEvent;
+    };
 
 function isSqliteConstraint(error: unknown): boolean {
   return (
@@ -157,6 +175,48 @@ export function getWebhookEventByDelivery(
   return row ? rowToWebhookEvent(row) : undefined;
 }
 
+export function replayWebhookDelivery(
+  db: Database.Database,
+  input: { deliveryId: string; now: number },
+): ReplayWebhookDeliveryResult {
+  const row = db
+    .prepare(
+      `SELECT * FROM webhook_events
+       WHERE delivery_id = ?
+       LIMIT 1`,
+    )
+    .get(input.deliveryId) as WebhookEventRow | undefined;
+  if (!row) return { replayed: false, reason: "not_found" };
+
+  const event = rowToWebhookEvent(row);
+  if (!event.targetType || event.targetNumber === null) {
+    return { replayed: false, reason: "missing_target", event };
+  }
+  if (!event.action) {
+    return { replayed: false, reason: "missing_action", event };
+  }
+  if (!REPLAYABLE_WEBHOOK_SIGNALS.has(`${event.eventType}:${event.action}`)) {
+    return { replayed: false, reason: "not_replayable", event };
+  }
+
+  const intentId = mergeWebhookIntent(db, {
+    repoId: event.repoId,
+    targetType: event.targetType,
+    targetNumber: event.targetNumber,
+    signalAt: input.now,
+    scheduledAt: input.now,
+    desiredHeadSha: desiredHeadShaFromPayload(event.payloadJson),
+    eventId: event.id,
+  });
+  const intentRow = db
+    .prepare("SELECT * FROM webhook_intents WHERE id = ?")
+    .get(intentId) as WebhookIntentRow | undefined;
+  if (!intentRow) {
+    throw new Error(`Replay created webhook intent ${intentId} but could not read it back.`);
+  }
+  return { replayed: true, event, intent: rowToWebhookIntent(intentRow) };
+}
+
 export function mergeWebhookIntent(
   db: Database.Database,
   input: MergeWebhookIntentInput,
@@ -218,6 +278,22 @@ function mergeWebhookIntentOnce(
     }
     throw new Error("Failed to merge webhook intent after retrying races");
   })();
+}
+
+function desiredHeadShaFromPayload(payloadJson: string | null): string | null {
+  if (!payloadJson) return null;
+  try {
+    const payload = JSON.parse(payloadJson) as unknown;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+    const pullRequest = (payload as Record<string, unknown>).pull_request;
+    if (!pullRequest || typeof pullRequest !== "object" || Array.isArray(pullRequest)) return null;
+    const head = (pullRequest as Record<string, unknown>).head;
+    if (!head || typeof head !== "object" || Array.isArray(head)) return null;
+    const sha = (head as Record<string, unknown>).sha;
+    return typeof sha === "string" ? sha : null;
+  } catch {
+    return null;
+  }
 }
 
 export function hasActiveWebhookIntent(
@@ -423,6 +499,28 @@ export function pruneExpiredWebhookPayloads(
          )`,
     )
     .run(now);
+  return result.changes;
+}
+
+export function pruneOldWebhookEvents(
+  db: Database.Database,
+  now: number,
+  maxAgeMs: number,
+): number {
+  const cutoff = now - Math.max(0, Math.floor(maxAgeMs));
+  const result = db
+    .prepare(
+      `DELETE FROM webhook_events
+       WHERE received_at <= ?
+         AND (
+           intent_id IS NULL
+           OR intent_id NOT IN (
+             SELECT id FROM webhook_intents
+             WHERE status IN (${activeStatusPlaceholders()})
+           )
+         )`,
+    )
+    .run(cutoff, ...ACTIVE_INTENT_STATUSES);
   return result.changes;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export {
 export {
   recordWebhookEvent,
   getWebhookEventByDelivery,
+  replayWebhookDelivery,
   mergeWebhookIntent,
   hasActiveWebhookIntent,
   countActiveWebhookIntents,
@@ -134,12 +135,14 @@ export {
   expireOldWebhookIntents,
   expireOldWebhookIntentRecords,
   pruneExpiredWebhookPayloads,
+  pruneOldWebhookEvents,
   listWebhookEvents,
   listWebhookLogEntries,
 } from "./db/webhooks.js";
 export type {
   RecordWebhookEventInput,
   RecordWebhookEventResult,
+  ReplayWebhookDeliveryResult,
   MergeWebhookIntentInput,
   ListWebhookIntentsInput,
   ListWebhookEventsInput,

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.test.ts
@@ -71,6 +71,7 @@ beforeEach(() => {
     ...repo,
     autoLaunchIssues: true,
     issueAgent: "codex",
+    reviewPreamble: "Use this review preamble.",
     webhookPayloadMode: "raw",
   });
   getActiveWebhookDeploymentsForRepoTarget.mockReset();
@@ -90,6 +91,7 @@ describe("/api/v1/repos/[owner]/[repo]", () => {
       autoReviewPrs: false,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Use this review preamble.",
       webhookPayloadMode: "raw",
     }), { params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }) });
     const json = await response.json();
@@ -100,6 +102,7 @@ describe("/api/v1/repos/[owner]/[repo]", () => {
       autoReviewPrs: false,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Use this review preamble.",
       webhookPayloadMode: "raw",
     });
     expect(json.repo.webhookSecret).toBeUndefined();
@@ -150,6 +153,33 @@ describe("/api/v1/repos/[owner]/[repo]", () => {
 
     expect(response.status).toBe(400);
     expect(json.error).toMatch(/webhookPayloadMode/);
+    expect(updateRepoWebhookSettings).not.toHaveBeenCalled();
+  });
+
+  it("PATCH accepts null review preamble", async () => {
+    const response = await PATCH(request({ reviewPreamble: null }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      autoLaunchIssues: undefined,
+      autoReviewPrs: undefined,
+      issueAgent: undefined,
+      reviewAgent: undefined,
+      reviewPreamble: null,
+      webhookPayloadMode: undefined,
+    });
+  });
+
+  it("PATCH rejects invalid review preamble", async () => {
+    const response = await PATCH(request({ reviewPreamble: 123 }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("reviewPreamble must be a string or null");
     expect(updateRepoWebhookSettings).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/route.ts
@@ -74,6 +74,7 @@ type UpdateRepoBody = {
   autoReviewPrs?: boolean;
   issueAgent?: "claude" | "codex";
   reviewAgent?: "claude" | "codex";
+  reviewPreamble?: string | null;
   webhookPayloadMode?: "metadata" | "raw";
 };
 
@@ -127,6 +128,13 @@ export async function PATCH(
   if (body.reviewAgent !== undefined && body.reviewAgent !== "claude" && body.reviewAgent !== "codex") {
     return NextResponse.json({ success: false, error: "reviewAgent must be claude or codex" }, { status: 400 });
   }
+  if (
+    body.reviewPreamble !== undefined &&
+    body.reviewPreamble !== null &&
+    typeof body.reviewPreamble !== "string"
+  ) {
+    return NextResponse.json({ success: false, error: "reviewPreamble must be a string or null" }, { status: 400 });
+  }
   if (body.webhookPayloadMode !== undefined && body.webhookPayloadMode !== "metadata" && body.webhookPayloadMode !== "raw") {
     return NextResponse.json({ success: false, error: "webhookPayloadMode must be metadata or raw" }, { status: 400 });
   }
@@ -151,6 +159,7 @@ export async function PATCH(
       autoReviewPrs: body.autoReviewPrs,
       issueAgent: body.issueAgent,
       reviewAgent: body.reviewAgent,
+      reviewPreamble: body.reviewPreamble,
       webhookPayloadMode: body.webhookPayloadMode,
     };
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {

--- a/packages/web/app/api/v1/repos/route.test.ts
+++ b/packages/web/app/api/v1/repos/route.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
   listRepos.mockReturnValue([repo]);
   addRepo.mockReturnValue(repo);
   updateRepoWebhookSettings.mockReset();
+  updateRepoWebhookSettings.mockReturnValue(repo);
   withAuthRetry.mockClear();
 });
 
@@ -71,6 +72,7 @@ describe("/api/v1/repos", () => {
       autoReviewPrs: true,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Use the repo-specific review voice.",
       webhookPayloadMode: "raw",
     }));
     const json = await response.json();
@@ -82,7 +84,39 @@ describe("/api/v1/repos", () => {
       autoReviewPrs: true,
       issueAgent: "codex",
       reviewAgent: "claude",
+      reviewPreamble: "Use the repo-specific review voice.",
       webhookPayloadMode: "raw",
     });
+  });
+
+  it("POST accepts a null review preamble", async () => {
+    const response = await POST(request({
+      owner: "mean-weasel",
+      name: "issuectl",
+      reviewPreamble: null,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(updateRepoWebhookSettings).toHaveBeenCalledWith(expect.anything(), 1, {
+      autoLaunchIssues: undefined,
+      autoReviewPrs: undefined,
+      issueAgent: undefined,
+      reviewAgent: undefined,
+      reviewPreamble: null,
+      webhookPayloadMode: undefined,
+    });
+  });
+
+  it("POST rejects non-string review preambles", async () => {
+    const response = await POST(request({
+      owner: "mean-weasel",
+      name: "issuectl",
+      reviewPreamble: 123,
+    }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("reviewPreamble must be a string or null");
+    expect(updateRepoWebhookSettings).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/api/v1/repos/route.ts
+++ b/packages/web/app/api/v1/repos/route.ts
@@ -39,6 +39,7 @@ type AddRepoBody = {
   autoReviewPrs?: boolean;
   issueAgent?: "claude" | "codex";
   reviewAgent?: "claude" | "codex";
+  reviewPreamble?: string | null;
   webhookPayloadMode?: "metadata" | "raw";
 };
 
@@ -62,6 +63,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   if (!OWNER_REPO_RE.test(body.owner) || !OWNER_REPO_RE.test(body.name)) {
     return NextResponse.json({ error: "Invalid owner/repo format" }, { status: 400 });
+  }
+  if (
+    body.reviewPreamble !== undefined &&
+    body.reviewPreamble !== null &&
+    typeof body.reviewPreamble !== "string"
+  ) {
+    return NextResponse.json({ error: "reviewPreamble must be a string or null" }, { status: 400 });
   }
 
   // Verify the repo exists on GitHub
@@ -102,13 +110,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       autoReviewPrs: body.autoReviewPrs,
       issueAgent: body.issueAgent,
       reviewAgent: body.reviewAgent,
+      reviewPreamble: body.reviewPreamble,
       webhookPayloadMode: body.webhookPayloadMode,
     };
+    let updatedRepo = repo;
     if (Object.values(webhookUpdates).some((value) => value !== undefined)) {
-      updateRepoWebhookSettings(db, repo.id, webhookUpdates);
+      updatedRepo = updateRepoWebhookSettings(db, repo.id, webhookUpdates);
     }
     log.info({ msg: "api_repo_added", repoId: repo.id, owner: body.owner, name: body.name });
-    return NextResponse.json({ success: true, repo });
+    return NextResponse.json({ success: true, repo: updatedRepo });
   } catch (err) {
     log.error({ err, msg: "api_repo_add_failed" });
     return NextResponse.json(

--- a/packages/web/lib/webhook-intent-worker.test.ts
+++ b/packages/web/lib/webhook-intent-worker.test.ts
@@ -393,4 +393,33 @@ describe("runWebhookIntentWorkerOnce", () => {
     expect(db.prepare("SELECT payload_json FROM webhook_events").get()).toEqual({ payload_json: null });
     expect(db.prepare("SELECT COUNT(*) AS count FROM webhook_deliveries").get()).toEqual({ count: 1 });
   });
+
+  it("prunes webhook event rows older than 30 days while keeping delivery tombstones", async () => {
+    const now = 31 * 24 * 60 * 60 * 1000;
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-old",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: "issue",
+      targetNumber: 506,
+      receivedAt: 1_000,
+    });
+    recordWebhookEvent(db, {
+      deliveryId: "delivery-new",
+      repoId,
+      eventType: "issues",
+      action: "opened",
+      targetType: "issue",
+      targetNumber: 507,
+      receivedAt: now - 1_000,
+    });
+
+    await runWorker(db, now);
+
+    expect(
+      db.prepare("SELECT delivery_id FROM webhook_events ORDER BY delivery_id").all(),
+    ).toEqual([{ delivery_id: "delivery-new" }]);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM webhook_deliveries").get()).toEqual({ count: 2 });
+  });
 });

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -23,7 +23,7 @@ import type { FetchPullState, LaunchPrReview, PullWorkerDeps } from "./webhook-p
 import { getLatestIntentEvent, triggeredByForIntentEvent } from "./webhook-intent-source";
 import type { IntentEventSummary } from "./webhook-intent-source";
 import { launchPrFromWebhook } from "./webhook-pr-launch";
-import { pruneExpiredWebhookPayloads } from "./webhook-payload-retention";
+import { pruneExpiredWebhookData } from "./webhook-payload-retention";
 import { enforceWebhookRunawayControls } from "./webhook-runaway-controls";
 import { broadcastWebhookEventsChanged } from "./webhook-events-stream";
 
@@ -80,9 +80,10 @@ export async function runWebhookIntentWorkerOnce(
     recordRecoveryDiagnostic(db, expiredIntent, "webhook.expired", "Expired stale webhook intent.");
   }
   const expired = expiredRecords.length;
-  const prunedPayloads = pruneExpiredWebhookPayloads(db, now);
+  const retention = pruneExpiredWebhookData(db, now);
+  const prunedPayloads = retention.prunedPayloads;
   const broadcastEventsChanged = deps.broadcastEventsChanged ?? broadcastWebhookEventsChanged;
-  if (recovered > 0 || expired > 0 || prunedPayloads > 0) broadcastEventsChanged();
+  if (recovered > 0 || expired > 0 || prunedPayloads > 0 || retention.prunedEvents > 0) broadcastEventsChanged();
   const base = { recovered, expired, prunedPayloads };
   const intent = claimDueWebhookIntent(db, now, 60_000);
   if (!intent) return result(base);

--- a/packages/web/lib/webhook-payload-retention.ts
+++ b/packages/web/lib/webhook-payload-retention.ts
@@ -1,20 +1,29 @@
 import type Database from "better-sqlite3";
+import {
+  pruneOldWebhookEvents,
+  pruneExpiredWebhookPayloads as pruneExpiredWebhookPayloadRows,
+} from "@issuectl/core";
+
+const WEBHOOK_EVENT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type WebhookRetentionResult = {
+  prunedPayloads: number;
+  prunedEvents: number;
+};
 
 export function pruneExpiredWebhookPayloads(
   db: Database.Database,
   now: number,
 ): number {
-  const result = db
-    .prepare(
-      `UPDATE webhook_events
-       SET payload_json = NULL
-       WHERE payload_json IS NOT NULL
-         AND delivery_id IN (
-           SELECT delivery_id FROM webhook_deliveries
-           WHERE retained_until IS NOT NULL
-             AND retained_until <= ?
-         )`,
-    )
-    .run(now);
-  return result.changes;
+  return pruneExpiredWebhookPayloadRows(db, now);
+}
+
+export function pruneExpiredWebhookData(
+  db: Database.Database,
+  now: number,
+): WebhookRetentionResult {
+  return {
+    prunedPayloads: pruneExpiredWebhookPayloadRows(db, now),
+    prunedEvents: pruneOldWebhookEvents(db, now, WEBHOOK_EVENT_RETENTION_MS),
+  };
 }


### PR DESCRIPTION
## Summary

- add `issuectl webhook replay <delivery_id>` backed by a core replay helper and operator diagnostics
- align interactive `repo add` webhook onboarding defaults with #507
- prune old `webhook_events` rows after 30 days while preserving delivery tombstones and active-intent lineage
- add REST repo add/update parity for `reviewPreamble`
- include the completed GoalBuddy plan and receipts for the issue 506/507 follow-up fixes

## Verification

Passed:
- `pnpm --dir packages/core test`
- `pnpm --dir packages/cli test`
- `pnpm --dir packages/web test`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/core lint`
- `pnpm --dir packages/cli lint`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/core test:integration`
- `pnpm build`

Attempted:
- `pnpm --dir packages/web test:e2e`

The full Playwright suite failed/hung with broad existing-looking failures in offline, terminal/workbench, and mobile WebKit specs. The failures were not in the webhook follow-up paths touched here. I stopped the run after it went quiet near the end to avoid leaving a hanging dev server.
