### PR TITLE
Fix issue 506 and 507 gap closures

### DIFF
--- a/docs/goals/fix-506-507-gaps/.goalbuddy-board/app.js
+++ b/docs/goals/fix-506-507-gaps/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/fix-506-507-gaps/.goalbuddy-board/index.html
+++ b/docs/goals/fix-506-507-gaps/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/fix-506-507-gaps/.goalbuddy-board/styles.css
+++ b/docs/goals/fix-506-507-gaps/.goalbuddy-board/styles.css
@@ -1,0 +1,991 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/fix-506-507-gaps/goal.md
+++ b/docs/goals/fix-506-507-gaps/goal.md
@@ -1,0 +1,100 @@
+# Fix Issue 506/507 Implementation Gaps
+
+## Objective
+
+Close the remaining implementation gaps from the independent #506/#507 audit in successive safe, verified slices until the repo behavior matches the intended webhook, auto-session, PR review, and operator UX outcomes.
+
+## Original Request
+
+Use GoalBuddy goal-prep to make a plan to fix all gaps found in issues 506 and 507.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: issuectl maintainer/operator and future users of webhook auto-sessions.
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: focused core/web/cli tests, typechecks, lint/build checks for touched packages, and a final audit mapping every known gap to a fixed, blocked-by-policy, or explicitly-deferred outcome.
+- Goal oracle: a final Judge/PM audit over the #506/#507 gap list, current diff, and verification output that records `full_outcome_complete: true`.
+- Likely misfire: only polishing UI or only adding tests while leaving high-risk backend/session safety gaps unresolved.
+- Blind spots considered: direct PR push semantics, credential isolation limits, PR review recovery, incremental range correctness, boot-time webhook reconciliation, replay lineage, and UX scope that may be product-polish rather than blocker.
+- Existing plan facts: preserve and validate the ten-gap audit from the prior analysis; prioritize backend/security/session correctness before UX polish; do not treat planning as completion.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A final audit proves each known #506/#507 gap is either fixed with tests and package verification, intentionally deferred with a recorded product decision, or blocked with a precise external requirement; no required Worker tasks remain queued or active.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Execute the first full gap-closure tranche. Validate the audit, choose the largest safe useful implementation slice, fix it, verify it, then continue through the remaining high-priority slices until the complete known gap list is resolved or explicitly deferred by product decision.
+
+## Non-Negotiable Constraints
+
+- Work from the repo’s current branch/worktree unless the operator asks for a different branch.
+- Do not revert unrelated user changes.
+- Preserve project conventions from `CLAUDE.md` and `AGENTS.md`.
+- Use diagnostics-first reasoning for launch, terminal, ttyd, tmux, session, and workbench failures.
+- Prefer focused package checks for touched code and broader checks before completion.
+- Keep Worker scopes bounded with explicit `allowed_files`, verification commands, and stop conditions.
+- Do not claim completion while any known #506/#507 gap remains unaddressed or undecided.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if safe Worker work can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+Do not create one Worker/Judge pair per repeated file, table, route, or helper. Put repeated same-shape work into one Worker package and review the package as a whole.
+
+Do not stop because a slice needs owner input, credentials, production access, destructive operations, or policy decisions. Mark that exact slice blocked with a receipt, create the smallest safe follow-up or workaround task, and continue all local, non-destructive work that can still move the goal toward the full outcome.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+A Worker should finish the whole assigned slice. A Judge should judge the whole assigned slice. A PM should reorient the board when tasks are safe but not moving the outcome.
+
+Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice. Tiny tasks are bad when they keep happening, do not change behavior, only add wrappers/contracts/proof files, or avoid the real milestone.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/fix-506-507-gaps/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/fix-506-507-gaps/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Re-check the intake: original request, input shape, authority, proof, blind spots, existing plan facts, and likely misfire.
+4. Work only on the active board task.
+5. Assign Scout, Judge, Worker, or PM according to the task.
+6. Write a compact task receipt.
+7. Update the board.
+8. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+9. Review at phase, risk, rejected-verification, ambiguity, or final-completion boundaries.
+10. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/fix-506-507-gaps/state.yaml
+++ b/docs/goals/fix-506-507-gaps/state.yaml
@@ -1,0 +1,467 @@
+# GoalBuddy v2 state.yaml
+version: 2
+
+goal:
+  title: "Fix Issue 506/507 Implementation Gaps"
+  slug: "fix-506-507-gaps"
+  kind: existing_plan
+  tranche: "Validate and close the known #506/#507 implementation gaps in safe verified slices until the final audit proves the full gap list is resolved."
+  status: done
+  oracle:
+    signal: "Final audit maps every known #506/#507 gap to fixed verification, explicit deferral decision, or precise blocker."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Passing focused checks for touched packages plus a final Judge/PM receipt with full_outcome_complete: true and no required Worker tasks left queued or active."
+  intake:
+    original_request: "Use GoalBuddy goal-prep to make a plan to fix all gaps."
+    interpreted_outcome: "Create a durable execution board that will drive implementation of all remaining #506/#507 gaps."
+    input_shape: existing_plan
+    audience: "issuectl maintainer/operator"
+    authority: requested
+    proof_type: test
+    completion_proof: "Focused tests/typechecks/lint/build for touched packages and final audit against the known gap list."
+    likely_misfire: "Spending the run on planning or UI polish while leaving backend safety/session gaps unresolved."
+    blind_spots_considered:
+      - "Direct PR push may update refs without uploading local objects."
+      - "Webhook issue sessions may lack completion tokens."
+      - "PR review recovery may strand active locks."
+      - "Incremental review may track ranges without using range-limited diffs."
+      - "Credential isolation may be best-effort rather than enforced."
+      - "Some #507 UX gaps may need product deferral rather than immediate implementation."
+    existing_plan_facts:
+      - "Known backend gaps include issue completion tokens, PR review recovery, direct fix-push semantics, incremental range behavior, pre-launch PR safety gates, action budget defaults, and credential isolation."
+      - "Known UX/operator gaps include boot-time webhook URL reconciliation, replay lineage inconsistency, thinner repo settings/sessions/reviews/log UX, and REST/web semantic drift."
+      - "Prioritize correctness and security before cosmetic UX parity."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/fix-506-507-gaps/"
+    command: "npx goalbuddy board docs/goals/fix-506-507-gaps"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the known #506/#507 gap list and choose the first largest safe implementation slice."
+    inputs:
+      - "Prior independent audit summary in the current thread"
+      - "GitHub issues #506 and #507"
+      - "Current repo state"
+      - "AGENTS.md and CLAUDE.md project guidance"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Preserve the prior audit as plan facts, but verify current file evidence before assigning Worker scope."
+      - "Prioritize backend/security/session correctness over UX polish unless evidence shows a UX slice is safer and higher leverage."
+    expected_output:
+      - "Validated gap list with keep/drop/merge decisions"
+      - "Risk-ranked implementation order"
+      - "Exact first Worker objective"
+      - "allowed_files for first Worker"
+      - "verify commands for first Worker"
+      - "stop_if conditions for first Worker"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Validated current branch evidence after one goal_judge timeout. Several prior audit gaps are already addressed on this branch: issue webhook launches generate completion tokens, issue sessions seed zero push/create budgets, PR pre-launch safety includes protected-head data, and web startup calls the webhook URL reconciler. Remaining high-priority gaps include startup PR-review recovery, direct PR fix-push semantics, incremental range-limited diff context, hard credential isolation limits, replay lineage, and thinner UX/operator parity."
+      evidence:
+        - "packages/web/lib/webhook-intent-worker.ts: issue launches call randomUUID() and pass completionToken into executeLaunch."
+        - "packages/core/src/launch/launch-contexts.ts: issue-triggered sessions get zero push/create budgets; PR sessions still allow one push/create budget."
+        - "packages/web/server.ts and packages/web/lib/webhook-url-reconciler.ts: web boot starts URL reconciliation."
+        - "packages/core/src/launch/ttyd.ts: reconcileOrphanedDeployments only sets deployments.ended_at and does not update linked pr_reviews or terminal_reason."
+        - "packages/web/lib/agent/mutation-adapters.ts: push uses GitHub git.updateRef for an existing SHA, not object upload/local git push."
+      risk_ranked_order:
+        - "1. Startup PR-review recovery for orphaned/missing tmux sessions."
+        - "2. Direct PR fix-push semantics and final ref/object verification."
+        - "3. Incremental PR review range-limited diff context and superseding all invalidated ranges."
+        - "4. Credential isolation hardening or explicit product deferral."
+        - "5. Replay lineage/schema/docs consistency."
+        - "6. Remaining #507 UX/operator parity."
+      required_board_updates:
+        - "Activate T002 for startup PR-review recovery."
+        - "Late goal_judge receipt agreed with this slice and refined risk order: PR review recovery, direct PR push semantics, incremental PR range context, replay lineage, credential isolation decision/enforcement, UX/operator polish disposition."
+      spawned_tasks:
+        - T002
+
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Fix startup reconciliation so missing tmux sessions mark linked active PR reviews terminal and record the deployment terminal reason."
+    allowed_files:
+      - "packages/core/src/launch/ttyd.ts"
+      - "packages/core/src/launch/ttyd-respawn.test.ts"
+      - "packages/core/src/db/pr-reviews.ts"
+      - "packages/core/src/db/pr-reviews.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- ttyd-respawn pr-reviews"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/core lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The selected behavior conflicts with the #506/#507 specs or project guidance."
+      - "A product/security decision is required before implementation."
+      - "Verification fails twice for reasons outside the selected slice."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/core/src/launch/ttyd.ts"
+        - "packages/core/src/launch/ttyd-respawn.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- ttyd-respawn pr-reviews"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+      summary: "Startup reconciliation now records terminal_reason='liveness_missing', emits target_type/target_number diagnostics, and marks linked active PR reviews failed when the tmux session is missing. Added a regression test for missing PR tmux-session reconciliation."
+
+  - id: T003
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the first Worker slice and select the next largest safe slice."
+    inputs:
+      - "T001 receipt"
+      - "T002 receipt"
+      - "Current diff"
+      - "Verification output"
+    constraints:
+      - "Do not implement."
+      - "Approve the slice only if it resolves or intentionally narrows at least one known high-priority gap."
+      - "If safe work remains, produce the next Worker objective with allowed_files, verify, and stop_if."
+    expected_output:
+      - "approved | rejected | needs_followup"
+      - "resolved gaps"
+      - "remaining gaps"
+      - "next Worker task details if not complete"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Approved T002: startup reconciliation now releases PR-review locks for missing tmux sessions and passed core focused tests, typecheck, and lint. Next largest safe slice is direct PR fix-push correctness."
+      resolved_gaps:
+        - "Startup PR-review recovery for orphaned/missing tmux sessions."
+      remaining_gaps:
+        - "Direct PR fix-push semantics and final ref/object verification."
+        - "Incremental PR review range-limited diff context and superseding invalidated ranges."
+        - "Credential isolation hardening or explicit product deferral."
+        - "Replay lineage/schema/docs consistency."
+        - "Remaining #507 UX/operator parity."
+      required_board_updates:
+        - "Activate T004 for direct PR fix-push semantics."
+
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Fix direct PR fix-push semantics so successful fix pushes use local git push from the verified workspace, with final remote ref/object verification and focused regression coverage."
+    allowed_files:
+      - "packages/web/lib/agent/mutation-adapters.ts"
+      - "packages/web/lib/agent/mutation-types.ts"
+      - "packages/web/lib/agent/mutations.ts"
+      - "packages/web/lib/agent/mutations.test.ts"
+      - "packages/web/lib/agent/mutation-actions.test.ts"
+      - "packages/web/lib/agent/mutation-adapters.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- agent/mutations mutation-adapters"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The correct push strategy requires a product/security decision about credentials or fork permissions."
+      - "GitHub API behavior cannot be safely represented by existing tests without adding local adapter test coverage."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/agent/mutation-adapters.ts"
+        - "packages/web/lib/agent/mutation-types.ts"
+        - "packages/web/lib/agent/mutations.ts"
+        - "packages/web/lib/agent/mutations.test.ts"
+        - "packages/web/lib/agent/mutation-adapters.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test -- agent/mutations mutation-adapters"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+      summary: "Direct PR fix pushes now run local git commands from the verified workspace: validate the target commit object, require expected head ancestry, push the commit to origin, and verify the remote ref resolves to the pushed SHA. The mutation coordinator now passes session.workspacePath into the push adapter, with regression coverage for command sequencing and remote verification failure."
+
+  - id: T005
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Triage UX/operator gaps into implement-now, defer-with-decision, or blocked categories after backend safety slices are stable."
+    inputs:
+      - "Current known #507 UX gap list"
+      - "Receipts from prior Worker/Judge tasks"
+    constraints:
+      - "Update only GoalBuddy control files unless explicitly activating a Worker task."
+      - "Do not hide product deferrals; record them clearly."
+    expected_output:
+      - "UX/operator gap disposition"
+      - "Spawned or updated Worker tasks for implement-now items"
+      - "Deferral rationale for product-polish items"
+    receipt:
+      result: done
+      full_outcome_complete: false
+      ux_operator_disposition:
+        implement_now:
+          - "No additional high-risk UX/operator implementation required for this local gap-closure run after backend/session safety fixes."
+        explicit_deferrals:
+          - "Richer replay-count lineage beyond retained-delivery replay diagnostics remains a later schema/UX extension."
+          - "Additional visual polish for repo settings, sessions, reviews, and logs remains product-polish unless the owner asks for parity beyond current tested surfaces."
+          - "Optional manual-session scrubbed credential controls remain an owner product decision; manual sessions continue to use ambient credentials by design."
+      summary: "Triaged remaining #507 operator gaps after backend safety work. Current repo already has boot-time webhook URL reconciliation, repo webhook controls, sessions/review provenance surfaces, diagnostics, replay command support for retained deliveries, and PR review lineage display. Remaining UX/operator items are explicit product deferrals, not required backend correctness gaps."
+
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Make incremental PR review context use range-limited diffs/files for reviewed_from_sha..reviewed_to_sha and supersede all invalidated completed ranges on force-push."
+    allowed_files:
+      - "packages/core/src/data/pulls.ts"
+      - "packages/core/src/github/pulls.ts"
+      - "packages/core/src/github/types.ts"
+      - "packages/core/src/launch/launch-contexts.ts"
+      - "packages/core/src/launch/launch-execute-precheck.test.ts"
+      - "packages/core/src/launch/context.test.ts"
+      - "packages/web/lib/webhook-pr-review-state.ts"
+      - "packages/web/lib/webhook-pr-incremental.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- launch-execute-precheck context"
+      - "pnpm --dir packages/web test -- webhook-pr-incremental"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "GitHub compare API behavior requires live-network verification beyond local unit coverage."
+      - "Force-push invalidation needs a product decision beyond superseding completed ranges for the same PR."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/core/src/data/pulls.ts"
+        - "packages/core/src/github/pulls.ts"
+        - "packages/core/src/launch/launch-contexts.ts"
+        - "packages/core/src/launch/launch-execute-precheck.test.ts"
+        - "packages/web/lib/webhook-pr-review-state.ts"
+        - "packages/web/lib/webhook-pr-incremental.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- launch-execute-precheck context"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- webhook-pr-incremental"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+      summary: "Incremental PR launches now request files from the reviewed_from_sha..reviewed_to_sha compare range and bypass the full PR-detail cache for that ranged context. Force-push planning now supersedes all completed reviews for the PR before launching a full replacement review, with focused core and web regression coverage."
+
+  - id: T007
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the direct push and incremental PR slices, then select the next largest safe gap to close."
+    inputs:
+      - "T004 receipt"
+      - "T006 receipt"
+      - "Current dirty diff"
+      - "Validated remaining gap list from T001/T003"
+    constraints:
+      - "Do not implement."
+      - "Approve only if the direct push and incremental changes map to the known gaps and verification is sufficient."
+      - "Pick the next safe Worker slice from credential isolation, replay lineage, or #507 UX/operator parity."
+    expected_output:
+      - "approved | rejected | needs_followup"
+      - "resolved gaps"
+      - "remaining gaps"
+      - "next Worker task details if not complete"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Approved T004 and T006. Direct PR fix-push now performs local workspace push with remote ref verification, and incremental PR reviews now use compare-range files while force-push invalidation supersedes all completed ranges for the PR. Next largest safe backend slice is hardening scrubbed launch credentials so webhook/comment-command agent shells cannot reuse global Git credential helpers or prompt for credentials."
+      resolved_gaps:
+        - "Direct PR fix-push semantics and final ref/object verification."
+        - "Incremental PR review range-limited diff context and superseding invalidated ranges."
+      remaining_gaps:
+        - "Credential isolation hardening or explicit product deferral."
+        - "Replay lineage/schema/docs consistency."
+        - "Remaining #507 UX/operator parity."
+      required_board_updates:
+        - "Activate T008 for credential isolation hardening."
+
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Harden scrubbed webhook/comment-command agent sessions so ambient GitHub token env vars, SSH agents, global Git config, and interactive credential prompts are unavailable inside the agent tmux shell."
+    allowed_files:
+      - "packages/core/src/launch/tmux-session.ts"
+      - "packages/core/src/launch/ttyd-spawn.test.ts"
+      - "packages/core/src/launch/launch-terminal-backend.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- ttyd-spawn launch-terminal-backend"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/core lint"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The desired isolation requires sandboxing filesystem access beyond shell environment controls."
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/core/src/launch/tmux-session.ts"
+        - "packages/core/src/launch/ttyd-spawn.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- ttyd-spawn launch-terminal-backend"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+      summary: "Scrubbed webhook/comment-command tmux sessions now remove ambient GitHub token env vars, SSH/Git askpass hooks, and SSH agent access, use an empty GitHub CLI config dir, disable global/system Git config, and prevent interactive Git credential prompts. Manual launches keep ambient credentials."
+
+  - id: T009
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Bring the #506/#507 spec and follow-up notes in line with the implemented daemon-mediated local push and credential-isolation behavior, and record any remaining replay-lineage/product UX decisions explicitly."
+    allowed_files:
+      - "docs/specs/2026-05-23-webhooks-design.md"
+      - "docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md"
+      - "docs/goals/fix-506-507-gaps/goal.md"
+      - "docs/goals/fix-506-507-gaps/state.yaml"
+    verify:
+      - "rg -n \"unsupported_local_push|True local commit upload for PR review fixes is not implemented yet\" docs/specs/2026-05-23-webhooks-design.md docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md"
+      - "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.7/skills/goalbuddy/scripts/check-goal-state.mjs docs/goals/fix-506-507-gaps/state.yaml"
+    stop_if:
+      - "Docs reveal an implementation gap needing code outside allowed_files."
+      - "A product decision is required that cannot be recorded as an explicit deferral."
+    receipt:
+      result: done
+      changed_files:
+        - "docs/specs/2026-05-23-webhooks-design.md"
+        - "docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md"
+      commands:
+        - cmd: "rg -n \"unsupported_local_push|True local commit upload for PR review fixes is not implemented yet\" docs/specs/2026-05-23-webhooks-design.md docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md"
+          status: pass
+        - cmd: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.7/skills/goalbuddy/scripts/check-goal-state.mjs docs/goals/fix-506-507-gaps/state.yaml"
+          status: pass
+      summary: "Updated stale #506/#507 docs: retained-delivery webhook replay is implemented with diagnostics while replay-count lineage is a deferred schema/UX extension, and PR review fix pushes are now daemon-mediated local git pushes with final remote-ref verification rather than unsupported_local_push."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether all #506/#507 implementation gaps are fixed, blocked, or explicitly deferred."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "Validated gap list from T001"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if any required Worker task is still queued or active."
+      - "Reject completion if a known high-risk backend/security/session gap lacks a fix, blocker, or explicit deferral decision."
+      - "Reject completion on planning-only evidence."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "gap-by-gap disposition"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      gap_by_gap_disposition:
+        - gap: "Issue webhook completion tokens and issue-scoped budgets."
+          disposition: "fixed_before_this_run"
+          evidence: "T001 verified issue webhook launches generate completion tokens and issue sessions seed zero push/create budgets."
+        - gap: "Startup PR-review recovery for orphaned/missing tmux sessions."
+          disposition: "fixed"
+          evidence: "T002 marks linked active PR reviews failed and records terminal_reason='liveness_missing'; core test/typecheck/lint passed."
+        - gap: "Direct PR fix-push semantics and final ref/object verification."
+          disposition: "fixed"
+          evidence: "T004 switched push to local workspace git validation/push/ls-remote verification; web test/typecheck/lint passed."
+        - gap: "Incremental PR review range-limited context and force-push invalidation."
+          disposition: "fixed"
+          evidence: "T006 uses reviewed_from_sha..reviewed_to_sha compare files and supersedes all completed ranges on force push; core/web tests/typechecks/lints passed."
+        - gap: "Credential isolation for webhook/comment-command sessions."
+          disposition: "fixed"
+          evidence: "T008 scrubbed token env vars, SSH agent/askpass, GitHub CLI config, global/system Git config, and interactive Git prompts; core test/typecheck/lint passed."
+        - gap: "Pre-launch PR safety gates and webhook URL reconciliation."
+          disposition: "fixed_before_this_run"
+          evidence: "T001 verified protected-head PR gating evidence and web startup webhook URL reconciliation."
+        - gap: "Replay lineage/schema/docs consistency."
+          disposition: "fixed_with_deferral"
+          evidence: "T009 docs now match retained-delivery replay behavior and explicitly defer richer replay-count lineage to later schema/UX work."
+        - gap: "Remaining #507 UX/operator parity."
+          disposition: "explicitly_deferred"
+          evidence: "T005 records current implemented surfaces and defers remaining polish/product choices rather than treating them as backend correctness blockers."
+      missing_evidence: []
+      summary: "All known #506/#507 gaps from the validated audit are now fixed, verified as already fixed on this branch, or explicitly deferred as product/UX decisions. No required Worker tasks remain queued or active."
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T999
+    commands:
+      - "pnpm --dir packages/core test -- ttyd-respawn pr-reviews"
+      - "pnpm --dir packages/web test -- agent/mutations mutation-adapters"
+      - "pnpm --dir packages/core test -- launch-execute-precheck context"
+      - "pnpm --dir packages/web test -- webhook-pr-incremental"
+      - "pnpm --dir packages/core test -- ttyd-spawn launch-terminal-backend"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core lint"
+      - "pnpm --dir packages/web lint"

--- a/docs/goals/issue-506-507-gap-fixes/goal.md
+++ b/docs/goals/issue-506-507-gap-fixes/goal.md
@@ -1,0 +1,68 @@
+# Issue 506/507 Gap Fixes
+
+## Original Request
+
+Use GoalBuddy goal-prep to comprehensively plan fixes for the remaining gaps between the current repository state and the plans in GitHub issues #506 and #507.
+
+## Interpreted Outcome
+
+Close the verified residual gaps from the independent #506/#507 audit while preserving the large implemented surface already present: webhook receiver/session lifecycle, PR review automation, daemon-mediated mutations, repo onboarding/settings, sessions/reviews navigation, webhook logs, diagnostics, and tests.
+
+## Input Shape
+
+`existing_plan`
+
+The plan source is the already completed three-agent read-only audit. Do not restart broad discovery from scratch. Use Scout and Judge only to sharpen evidence, prioritize safely, and prevent the PM from fixing the wrong thing.
+
+## Goal Oracle
+
+The goal is complete only when a final Judge audit maps every audited gap to one of:
+
+- fixed with passing focused verification;
+- intentionally deferred with updated repo-native documentation and a clear reason;
+- invalidated by source evidence.
+
+Required proof:
+
+- targeted core/web/cli tests for the files changed;
+- `pnpm --dir packages/core typecheck`, `pnpm --dir packages/web typecheck`, and `pnpm --dir packages/cli typecheck` when touched surfaces require them;
+- route or unit coverage for web-server boot reconciliation if implemented;
+- final docs consistency check for `docs/specs/2026-05-23-webhooks-design.md`;
+- `git diff --check`;
+- final Judge receipt with `full_outcome_complete: true`.
+
+## Known Gap Backlog
+
+The previous audit identified these candidate gaps:
+
+1. PR auto-review launch does not reject protected PR head branches before launching. Push mutation denies protected branches later, but #506 asked for launch-time safety gates.
+2. `review_hard_timeout_minutes` and hard-timeout enforcement/recovery for PR reviews are missing or unproven.
+3. `issuectl web` boot does not appear to reconcile stored webhook URLs for tunnel drift; reconciliation exists only through explicit repo webhook API/configuration paths.
+4. Webhook issue sessions do not appear to receive completion tokens, so issue-session completion/check-in is not wired like PR review completion.
+5. Agent action budgets are seeded only for PR sessions, not webhook issue sessions; decide whether that is a product gap or an intentional scope boundary, then fix or document it.
+6. CLI onboarding preflight warns instead of fail-fast behavior for hook scope/cloudflared/start-tunnel described in #507; decide whether this is a required fix or a deliberately softened UX.
+7. `docs/specs/2026-05-23-webhooks-design.md` contradicts implementation for webhook replay and PR push support.
+8. Some #507 UI details are lighter than the plan, including sessions row actions, trigger icon/chip fidelity, and webhook log expansion detail. Decide which are acceptance gaps versus acceptable design simplifications.
+
+## Constraints
+
+- Follow `AGENTS.md` and `CLAUDE.md`.
+- Do not revert unrelated user changes.
+- Keep implementation slices bounded and reversible.
+- Prefer existing core/web/cli patterns and tests.
+- Use diagnostics-first reasoning for launch/session/webhook behavior.
+- Do not treat planning or discovery as completion.
+- Do not make broad UI redesigns unless Judge decides a specific #507 acceptance gap requires it.
+- Avoid destructive GitHub or local state operations unless a task explicitly allows them and verification can be local/mocked.
+
+## Likely Misfire
+
+The PM could overfit to cosmetic #507 fidelity work while leaving high-risk lifecycle gaps unresolved, or could mark the issue complete after updating docs without proving webhook/PR session behavior. The board should prioritize safety/lifecycle correctness first, then docs and UX fidelity.
+
+## Current Tranche Definition
+
+Complete all safe local fixes and documentation corrections for the audited #506/#507 gaps, with tests proving behavior. If a gap needs a product decision or live credential/tunnel access, block that exact task with a receipt and continue with all safe local work.
+
+## Starter Command
+
+`/goal Follow docs/goals/issue-506-507-gap-fixes/goal.md.`

--- a/docs/goals/issue-506-507-gap-fixes/state.yaml
+++ b/docs/goals/issue-506-507-gap-fixes/state.yaml
@@ -1,0 +1,707 @@
+version: 2
+
+goal:
+  title: "Issue 506/507 Gap Fixes"
+  slug: issue-506-507-gap-fixes
+  kind: existing_plan
+  tranche: "Complete all safe local fixes and documentation corrections for the audited #506/#507 gaps, with tests proving behavior."
+  status: done
+  oracle:
+    signal: "Targeted verification plus final Judge mapping of every audited gap to fixed, deferred, invalid, or still open."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "All required gap tasks are fixed, blocked with owner-worthy rationale, or invalidated, and final Judge audit reports full_outcome_complete: true."
+  intake:
+    original_request: "use goalbuddy:goal-prep to comprehensively plan fixes to these gaps"
+    interpreted_outcome: "Fix or explicitly resolve every remaining gap from the three-agent #506/#507 audit with focused verification and a final audit."
+    input_shape: existing_plan
+    audience: "issuectl maintainer/operator"
+    authority: requested
+    proof_type: test
+    completion_proof: "All audited gaps are fixed, explicitly deferred with repo-native documentation, or invalidated by source evidence; focused tests/typechecks pass; final Judge approves full completion."
+    likely_misfire: "Updating docs or polishing UI while leaving lifecycle and safety gaps unresolved."
+    blind_spots_considered:
+      - "Some audited gaps may be intentional product decisions rather than bugs; Judge must separate fix work from explicit deferral."
+      - "Boot-time webhook URL reconciliation may need live GitHub credentials; keep implementation locally testable with adapters/mocks."
+      - "Issue-session mutation budgets may have product/security implications if issue agents are expected to create PRs/issues."
+    existing_plan_facts:
+      - "Three independent read-only agents audited issues #506 and #507 before this board."
+      - "Core receiver/session/mutation/review/log surfaces are mostly implemented."
+      - "Remaining high-confidence gaps include protected-branch launch gating, review timeout/recovery, boot URL reconciliation, and stale docs."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/issue-506-507-gap-fixes/"
+    command: "npx goalbuddy board docs/goals/issue-506-507-gap-fixes"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the audited gap list and choose the safest first implementation slice."
+    inputs:
+      - "docs/goals/issue-506-507-gap-fixes/goal.md"
+      - "Prior three-agent audit summary from the conversation"
+      - "GitHub issues #506 and #507"
+    constraints:
+      - "Read-only."
+      - "Do not rediscover the entire implemented feature set."
+      - "Focus on whether each candidate gap is required, optional, invalid, or needs a product decision."
+    expected_output:
+      - "Gap matrix: required_fix | explicit_deferral | invalid | needs_scout"
+      - "Decision on first Worker slice"
+      - "allowed_files for first Worker"
+      - "verify commands for first Worker"
+      - "stop_if conditions"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Validated the audited #506/#507 gap list and selected protected-branch PR launch gating as the first safe Worker slice."
+      evidence:
+        - "Issue #506 requires PR auto-review safety gates before launch, including non-protected heads unless explicitly enabled."
+        - "Docs/goals charter lists the candidate gaps and requires focused verification plus final Judge audit."
+        - "Review timeout/recovery, issue completion token/budgets, boot URL reconciliation, CLI preflight, stale docs, and UX fidelity remain for later tasks."
+      required_board_updates:
+        - "protected-branch PR launch gating=required_fix"
+        - "review hard timeout/recovery=needs_scout"
+        - "boot-time webhook URL reconciliation=required_fix or explicit_deferral after feasibility"
+        - "issue completion token=required_fix"
+        - "issue mutation budgets=needs_scout/product_decision"
+        - "CLI preflight warn-vs-fail-fast=needs_scout/product_decision"
+        - "stale docs=required_fix after behavior tasks"
+        - "lighter #507 UX details=needs_scout via T009"
+
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Implement the first safety/lifecycle fix selected by Judge."
+    allowed_files: []
+    verify: []
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Judge has not provided a concrete first slice."
+      - "The behavior requires a live GitHub credential or tunnel and cannot be mocked locally."
+      - "Focused verification fails twice with different root causes."
+    receipt:
+      result: blocked
+      summary: "Superseded by Judge selection of concrete Worker T007; keep this placeholder inactive rather than duplicating the same write scope."
+      replacement_task: T007
+
+  - id: T003
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map review hard-timeout and stale PR review recovery requirements to existing worker/liveness code and tests."
+    inputs:
+      - "Issue #506 recovery and settings requirements"
+      - "packages/web/lib/webhook-intent-worker.ts"
+      - "packages/core/src/db/pr-reviews.ts"
+      - "packages/core/src/db/settings.ts"
+      - "packages/core/src/types.ts"
+    constraints:
+      - "Read-only."
+      - "Return only evidence and recommended bounded fix shape."
+    expected_output:
+      - "Whether hard timeout is truly missing"
+      - "Exact files/functions likely needing edits"
+      - "Focused tests to add or update"
+      - "Risks and stop conditions"
+    receipt:
+      result: done
+      summary: "Hard timeout for active PR reviews is missing. Existing code expires pre-launch webhook intents and handles liveness/completion/control terminal paths, but does not age out a live deployment/pr_review that exceeds a review runtime cap."
+      evidence:
+        - "packages/web/lib/webhook-intent-worker.ts expires max_webhook_intent_age_minutes only before launch."
+        - "packages/core/src/db/settings.ts and packages/core/src/types.ts have no review timeout setting key/default."
+        - "packages/web/lib/idle-checker.ts handles liveness_missing but has no max-age timeout branch."
+        - "packages/core/src/db/pr-reviews.ts has markActivePrReviewForDeploymentTerminal, a likely reuse point for timeout terminalization."
+      facts:
+        - "Likely edit files include settings/types, idle-checker, idle-checker tests, settings tests, and possibly pr-reviews tests."
+        - "Focused tests should prove old active PR deployments are ended with terminal_reason=timeout and linked PR reviews are failed, while below-threshold and issue deployments are untouched."
+      ambiguity_requiring_judge:
+        - "Timeout duration/default and whether 0 disables timeout."
+        - "Scope: webhook PR reviews only, all PR reviews, or all deployments."
+        - "PR review terminal status on timeout."
+        - "Precedence when both timeout and tmux_missing apply."
+        - "Whether timeout only unblocks future intents or also enqueues recovery."
+
+  - id: T014
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Resolve PR review hard-timeout semantics and update the T004 Worker contract."
+    inputs:
+      - "T003 receipt"
+      - "Issue #506 timeout/recovery requirements"
+      - "packages/web/lib/idle-checker.ts"
+      - "packages/core/src/db/pr-reviews.ts"
+      - "packages/core/src/db/settings.ts"
+      - "packages/core/src/types.ts"
+    constraints:
+      - "Read-only."
+      - "Choose the smallest semantics that satisfy #506 without broad launch/session redesign."
+      - "Prefer local, mockable verification."
+    expected_output:
+      - "Decision on timeout default, disabled semantics, scope, terminal status, liveness precedence, and recovery action."
+      - "Updated T004 allowed_files"
+      - "Updated T004 verify commands"
+      - "Updated T004 stop_if conditions"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Approved a bounded PR review hard-timeout slice: active PR review deployments older than review_hard_timeout_minutes should be ended as timeout, with linked active PR reviews marked failed."
+      semantics:
+        timeout_setting_key: "review_hard_timeout_minutes"
+        default_minutes: 30
+        disabled_when: "0"
+        invalid_values: "missing, negative, or non-numeric values use default 30"
+        scope: "Only active deployments whose target_type is pr and whose linked pr_review is reserved, launching, or in_progress."
+        terminal_reason: "timeout"
+        pr_review_status: "failed"
+        pr_review_result_reason: "timeout"
+        liveness_precedence: "tmux_missing wins over timeout in the same liveness pass"
+        recovery_action: "Terminal recovery only: release locks via terminalizing the active review and send normal deployment terminal notification; do not enqueue or auto-launch a follow-up in this slice."
+      updated_worker: T004
+
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add bounded PR review hard-timeout behavior: default 30 minutes, 0 disables, invalid values fall back to default, tmux_missing wins, timed-out PR deployments end with terminal_reason=timeout and linked active PR reviews fail with reason=timeout."
+    allowed_files:
+      - "packages/core/src/db/settings.ts"
+      - "packages/core/src/db/settings.test.ts"
+      - "packages/core/src/types.ts"
+      - "packages/core/src/db/pr-reviews.ts"
+      - "packages/core/src/db/pr-reviews.test.ts"
+      - "packages/web/lib/idle-checker.ts"
+      - "packages/web/lib/idle-checker.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- --run src/db/settings.test.ts src/db/pr-reviews.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/idle-checker.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Implementing timeout requires launch/session redesign, new startup recovery architecture, or webhook intent requeue semantics."
+      - "Cannot implement with local mocks for Date.now, getActiveDeployments, getSetting, isTmuxSessionAlive, endDeployment, markActivePrReviewForDeploymentTerminal."
+      - "Product decision needed to auto-relaunch/enqueue follow-up after timeout."
+      - "Timeout implementation would change issue deployment idle/liveness behavior."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/core/src/db/settings.ts"
+        - "packages/core/src/db/settings.test.ts"
+        - "packages/core/src/types.ts"
+        - "packages/core/src/db/pr-reviews.ts"
+        - "packages/core/src/db/pr-reviews.test.ts"
+        - "packages/web/lib/idle-checker.ts"
+        - "packages/web/lib/idle-checker.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- --run src/db/settings.test.ts src/db/pr-reviews.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- --run lib/idle-checker.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Added review_hard_timeout_minutes default/type support and PR-only liveness hard timeout. Old PR deployments are timed out only when a linked active PR review exists; timeout 0 disables, invalid values use the 30-minute default, tmux_missing keeps precedence, linked reviews fail with reason=timeout, and issue deployments are untouched."
+      remaining_blockers: []
+
+  - id: T005
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map issue-session completion-token and mutation-budget behavior against #506 security and completion requirements."
+    constraints:
+      - "Read-only."
+      - "Determine whether issue webhook sessions need completion tokens, budgets, both, or an explicit documented deferral."
+    expected_output:
+      - "Evidence for current issue launch token/env behavior"
+      - "Evidence for current issue mutation budget behavior"
+      - "Recommended fix or deferral"
+      - "Minimal tests required"
+    receipt:
+      result: done
+      summary: "Issue webhook sessions launch without completion tokens, so they cannot use agent completion or daemon mutation endpoints. PR webhook sessions get tokens and budgets. Completion tokens should be fixed for issue webhook sessions; issue mutation budgets require a Judge decision because docs describe daemon-mediated mutations broadly while code currently budgets PR sessions only."
+      evidence:
+        - "packages/web/lib/webhook-intent-worker.ts builds issue webhook launch options without completionToken."
+        - "packages/web/lib/webhook-pr-launch.ts builds PR webhook launch options with completionToken: randomUUID()."
+        - "packages/core/src/launch/launch.ts persists options.completionToken and passes it to buildAgentEnvironment."
+        - "packages/core/src/launch/launch-contexts.ts returns no ISSUECTL_AGENT_TOKEN env when completionToken is absent."
+        - "packages/core/src/launch/launch-contexts.ts seeds budgets only when targetType is pr and triggeredBy is webhook/comment_command."
+        - "packages/web/lib/agent/completion.ts denies completion check-ins when deployment has no completionToken or token mismatches."
+        - "packages/web/lib/agent/mutations.ts denies mutations for missing/invalid token, target mismatch, ended deployment, or manual sessions."
+        - "docs/specs/2026-05-23-webhooks-design.md says webhook/comment-command agents must route GitHub mutations through daemon-mediated issuectl agent mutate."
+      facts:
+        - "Current issue webhook sessions do not receive ISSUECTL_AGENT_TOKEN or related daemon-control env."
+        - "Manual issue launches having no completion token appears intentional."
+        - "Recommended fixed part: generate a completionToken for issue webhook/comment-command launches and pass it to executeLaunch."
+        - "Recommended decision point: choose whether issue webhook sessions get only completion check-ins or bounded non-push daemon mutations."
+      contradictions:
+        - "Docs describe webhook/comment-command daemon-mediated mutations generally, but code only enables PR webhook sessions for token-backed completion/mutations."
+        - "Completion notification requirements include webhook issue sessions, but those sessions cannot self-report completion today."
+      ambiguity_requiring_judge:
+        - "Should webhook issue sessions be allowed daemon-mediated mutations at all, or only completion check-ins?"
+        - "If issue-session mutations are allowed, what exact limits apply for comment, label, create_issue, create_pr, and push?"
+
+  - id: T015
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Resolve issue webhook completion-token and mutation-budget semantics and update the T006 Worker contract."
+    inputs:
+      - "T005 receipt"
+      - "Issue #506 security/completion requirements"
+      - "packages/core/src/launch/launch-contexts.ts"
+      - "packages/web/lib/webhook-intent-worker.ts"
+      - "packages/web/lib/agent/completion.ts"
+      - "packages/web/lib/agent/mutations.ts"
+      - "docs/specs/2026-05-23-webhooks-design.md"
+    constraints:
+      - "Read-only."
+      - "Prefer the smallest secure semantics satisfying #506."
+      - "Do not weaken PR review mutation budgets or manual-session denial."
+      - "Keep verification local and mockable."
+    expected_output:
+      - "Decision on whether issue webhook/comment-command sessions get completion tokens."
+      - "Decision on whether issue sessions get mutation budgets, and exact per-action limits if yes."
+      - "Updated T006 allowed_files"
+      - "Updated T006 verify commands"
+      - "Updated T006 stop_if conditions"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Approved bounded issue-session controls: webhook/comment-command issue sessions need completion tokens, and get daemon mutation budgets for comment=1 and label=2 only. create_issue/create_pr/push stay disallowed for issue sessions; PR budgets and manual-session denial stay unchanged."
+      evidence:
+        - "T005 showed issue webhook sessions currently lack completionToken, ISSUECTL_AGENT_TOKEN env, and mutation budgets."
+        - "Issue #506 requires per-deployment random completion tokens and daemon-enforced mutation budgets/check-in gates for webhook-triggered agents."
+        - "packages/core/src/launch/launch-contexts.ts currently budgets PR webhook/comment_command sessions only."
+        - "packages/web/lib/agent/mutations.ts already denies missing/invalid tokens, target mismatch, ended deployments, and manual sessions."
+      semantics:
+        issue_completion_tokens: "Required for target_type=issue when triggered_by is webhook or comment_command; manual issue launches stay without completion tokens."
+        issue_mutation_budgets:
+          scope: "target_type=issue and triggered_by in webhook/comment_command"
+          comment: 1
+          label: 2
+          create_issue: 0
+          create_pr: 0
+          push: 0
+        pr_mutation_budgets: "Leave existing PR review budgets unchanged: comment=1, label=2, create_issue=1, create_pr=1, push=1."
+        manual_sessions: "Keep manual-session mutation denial unchanged."
+
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Wire completion tokens and bounded daemon mutation budgets for webhook/comment-command issue sessions: comment=1, label=2, create_issue=0, create_pr=0, push=0; preserve PR budgets and manual-session denial."
+    allowed_files:
+      - "packages/web/lib/webhook-intent-worker.ts"
+      - "packages/web/lib/webhook-intent-worker.test.ts"
+      - "packages/web/lib/webhook-intent-worker-comment-command.test.ts"
+      - "packages/core/src/launch/launch-contexts.ts"
+      - "packages/core/src/launch/launch-execute-precheck.test.ts"
+      - "packages/web/lib/agent/completion.test.ts"
+      - "packages/web/lib/agent/mutations.test.ts"
+    verify:
+      - "pnpm --dir packages/core test -- --run src/launch/launch-execute-precheck.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/webhook-intent-worker.test.ts lib/webhook-intent-worker-comment-command.test.ts lib/agent/completion.test.ts lib/agent/mutations.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Completion token propagation requires broad launch API redesign instead of passing a randomUUID completionToken through existing executeLaunch options."
+      - "Implementation would change PR review mutation budgets, weaken manual-session denial, or grant ambient GitHub credentials to webhook/comment_command sessions."
+      - "Issue mutation semantics require product approval beyond comment=1, label=2, create_issue=0, create_pr=0, push=0."
+      - "Implementation requires live GitHub credentials, a tunnel, APNs, or other non-local verification."
+      - "Focused tests prove issue webhook/comment-command sessions are already tokenized and explicitly budgeted under the approved limits."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/webhook-intent-worker.ts"
+        - "packages/web/lib/webhook-intent-worker.test.ts"
+        - "packages/web/lib/webhook-intent-worker-comment-command.test.ts"
+        - "packages/core/src/launch/launch-contexts.ts"
+        - "packages/core/src/launch/launch-execute-precheck.test.ts"
+        - "packages/web/lib/agent/mutations.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- --run src/launch/launch-execute-precheck.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- --run lib/webhook-intent-worker.test.ts lib/webhook-intent-worker-comment-command.test.ts lib/agent/completion.test.ts lib/agent/mutations.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Wired random completion tokens into webhook/comment-command issue launches through existing executeLaunch options. Seeded issue webhook/comment-command daemon budgets as comment=1, label=2, create_issue=0, create_pr=0, push=0, preserving PR budgets and manual-session denial."
+      remaining_blockers: []
+
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add launch-time protected-branch gating for automatic PR review if confirmed required."
+    allowed_files:
+      - "packages/web/lib/webhook-pr-intent.ts"
+      - "packages/web/lib/webhook-pr-intent.test.ts"
+      - "packages/web/lib/webhook-pr-launch.ts"
+      - "packages/web/lib/webhook-pr-launch.test.ts"
+      - "packages/core/src/github/pr-safety.ts"
+      - "packages/core/src/github/pr-safety.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- --run lib/webhook-pr-intent.test.ts lib/webhook-pr-launch.test.ts"
+      - "pnpm --dir packages/core test -- --run src/github/pr-safety.test.ts"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Protected-branch lookup requires a live GitHub API call in a place without injectable/mocked dependencies."
+      - "Manual comment-command review semantics differ from automatic webhook semantics and need Judge decision."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/webhook-pr-intent.ts"
+        - "packages/web/lib/webhook-pr-intent.test.ts"
+        - "packages/web/lib/webhook-pr-launch.test.ts"
+        - "packages/core/src/github/pr-safety.ts"
+        - "packages/core/src/github/pr-safety.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test -- --run lib/webhook-pr-intent.test.ts lib/webhook-pr-launch.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/core test -- --run src/github/pr-safety.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Added launch-time protected-branch gating for automatic webhook PR review before reservation/launch, with injectable pull-state branch protection data and tests proving protected webhook PRs are skipped while comment-command behavior remains allowed."
+      remaining_blockers: []
+
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement or explicitly defer boot-time webhook URL drift reconciliation."
+    allowed_files:
+      - "packages/web/server.ts"
+      - "packages/web/lib/webhook-url-reconciler.ts"
+      - "packages/web/lib/webhook-url-reconciler.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts"
+      - "packages/core/src/github/webhooks.ts"
+      - "packages/core/src/github/webhooks.test.ts"
+      - "docs/specs/2026-05-23-webhooks-design.md"
+    verify:
+      - "pnpm --dir packages/web test -- --run lib/webhook-url-reconciler.test.ts app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts"
+      - "pnpm --dir packages/core test -- --run src/github/webhooks.test.ts"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/core typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Reconciliation requires live tunnel or GitHub access without an injectable adapter."
+      - "Server startup side effects risk blocking dashboard boot."
+      - "The product decision is to keep reconciliation manual/API-only."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/server.ts"
+        - "packages/web/lib/webhook-url-reconciler.ts"
+        - "packages/web/lib/webhook-url-reconciler.test.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts"
+        - "docs/specs/2026-05-23-webhooks-design.md"
+      commands:
+        - cmd: "pnpm --dir packages/web test -- --run lib/webhook-url-reconciler.test.ts 'app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts'"
+          status: pass
+        - cmd: "pnpm --dir packages/core test -- --run src/github/webhooks.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Implemented non-blocking boot-time webhook URL reconciliation after dashboard listen. The reconciler derives URLs from public_webhook_base_url, updates only repos with stored hook ids through an injectable adapter, records diagnostics for drift/failures, reuses the URL builder in the manual webhook route, and documents the behavior."
+      remaining_blockers: []
+
+  - id: T009
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide which #507 UX fidelity gaps are required for this tranche."
+    constraints:
+      - "Read-only."
+      - "Prefer implementation only for UX gaps that materially affect operator debugging or acceptance."
+      - "Cosmetic icon fidelity alone should not displace lifecycle correctness."
+    expected_output:
+      - "required UX fixes, if any"
+      - "explicit deferrals, if any"
+      - "allowed_files and verification for a single UX Worker if needed"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      summary: "Require one targeted #507 UX fix: sessions rows need a direct action to open the exact active terminal session because that materially affects operator debugging. Defer cosmetic trigger icon fidelity; no webhook-log expansion work is required because rows already expose expandable operational detail."
+      evidence:
+        - "packages/web/components/sessions/SessionsReviewList.tsx has only group Workbench plus GitHub/repo settings links, lacking a per-session exact terminal action."
+        - "packages/web/components/workbench/WorkbenchShell.tsx already supports /workbench?deployment=<id>."
+        - "packages/web/components/sessions/SessionsReviewList.tsx already shows status, trigger, terminal reason, PR/parent/child/depth chips."
+        - "packages/web/app/logs/webhooks/page.tsx already renders expandable webhook details with headers, chain, diagnostics command, and raw payload handling."
+      deferrals:
+        - "Defer trigger icon/chip visual fidelity beyond clear text chips and title labels."
+        - "Defer webhook log expansion changes because the current log already has expandable operational detail."
+
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add a per-session direct action on active session rows that opens the exact terminal via /workbench?deployment=<deployment_id>; do not redesign the sessions page or change lifecycle behavior."
+    allowed_files:
+      - "packages/web/components/sessions/SessionsReviewList.tsx"
+      - "packages/web/components/sessions/SessionsReviewList.module.css"
+      - "packages/web/components/sessions/SessionsReviewList.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- --run components/sessions/SessionsReviewList.test.tsx lib/sessions-data.test.ts"
+      - "pnpm --dir packages/web typecheck"
+      - "git diff --check"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "The fix expands into broad sessions/workbench redesign instead of a direct row action."
+      - "The link cannot use existing /workbench?deployment=<id> selection without changing Workbench routing."
+      - "A local component/static-render test cannot cover the link and browser verification would require unrelated harness work."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/components/sessions/SessionsReviewList.tsx"
+        - "packages/web/components/sessions/SessionsReviewList.module.css"
+        - "packages/web/components/sessions/SessionsReviewList.test.ts"
+      commands:
+        - cmd: "pnpm --dir packages/web test -- --run components/sessions/SessionsReviewList.test.ts lib/sessions-data.test.ts"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Added a direct Terminal link for active session rows that opens /workbench?deployment=<deployment_id>, styled as the primary row action. Added a static render test proving active rows get the exact deployment link and ended rows do not."
+      remaining_blockers: []
+
+  - id: T011
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide whether CLI onboarding preflight warning-vs-fail-fast behavior is a required #507 fix or accepted divergence."
+    constraints:
+      - "Read-only."
+      - "Consider existing CLI tests, local-only tool availability, and user experience."
+    expected_output:
+      - "required_fix | accepted_divergence | needs_owner_decision"
+      - "If required_fix: Worker allowed_files, verify, stop_if"
+      - "If accepted_divergence: exact docs update needed"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      classification: accepted_divergence
+      summary: "Accepted CLI onboarding preflight warning-vs-fail-fast as intentional. Repo automation settings can be saved while local gh/cloudflared checks or GitHub webhook install remain incomplete; tunnel tooling is provider-flexible, so fail-fast would harm onboarding."
+      evidence:
+        - "packages/cli/src/commands/repo.ts runs preflight only when automation is enabled, warns on missing gh/scope/cloudflared, and still returns options."
+        - "packages/cli/src/commands/repo.ts installs webhooks only when labels and webhookBaseUrl exist, then catches install failures as warnings."
+        - "packages/cli/src/commands/repo.test.ts covers preflight proceeding when tools are mocked and skipping when automation is declined."
+        - "docs/specs/2026-05-23-webhooks-design.md documents cloudflared, ngrok, and tailscale as tunnel options."
+      required_docs_update: "Document that repo add preflight is advisory and preserves saved automation settings when local tooling or first ping is unavailable."
+
+  - id: T012
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Document accepted CLI onboarding preflight behavior: repo add performs advisory local checks and preserves saved automation settings rather than failing when gh/cloudflared/scope/first-ping checks are unavailable."
+    allowed_files:
+      - "docs/specs/2026-05-23-webhooks-design.md"
+    verify:
+      - "rg -n \"advisory local preflight|Missing `gh`|first-ping timeout\" docs/specs/2026-05-23-webhooks-design.md"
+      - "git diff --check"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Docs would imply fail-fast behavior or require cloudflared as the only tunnel provider."
+    receipt:
+      result: done
+      changed_files:
+        - "docs/specs/2026-05-23-webhooks-design.md"
+      commands:
+        - cmd: "rg -n 'advisory local preflight|Missing `gh`|first-ping timeout' docs/specs/2026-05-23-webhooks-design.md"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Documented accepted CLI onboarding preflight behavior: repo add warns for unavailable local tooling, scope, cloudflared, or first-ping checks and preserves saved automation settings so operators can finish setup with any tunnel provider."
+      remaining_blockers: []
+
+  - id: T013
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Update stale #506/#507 webhook docs after behavioral fixes and decisions are complete."
+    allowed_files:
+      - "docs/specs/2026-05-23-webhooks-design.md"
+      - "docs/goals/issue-506-507-gap-fixes/notes"
+    verify:
+      - "rg -n \"webhook replay remains deferred|True local commit upload|unsupported_local_push|fails closed\" docs/specs/2026-05-23-webhooks-design.md"
+      - "git diff --check"
+    stop_if:
+      - "Docs would need to describe behavior not yet implemented or explicitly deferred."
+      - "A previous Worker changed behavior and tests are still failing."
+    receipt:
+      result: done
+      changed_files:
+        - "docs/specs/2026-05-23-webhooks-design.md"
+      commands:
+        - cmd: "rg -n \"webhook replay remains deferred|True local commit upload|unsupported_local_push|fails closed|comment actions are limited to one|label actions are limited to two\" docs/specs/2026-05-23-webhooks-design.md"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Updated webhook docs for completed #506/#507 decisions: issue/comment-command mutation budgets, protected-branch PR launch fail-closed gating, PR review hard timeout semantics, startup URL reconciliation, advisory CLI preflight, and explicit replay/local-push deferrals."
+      remaining_blockers: []
+
+  - id: T998
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Run the focused verification bundle for all changed packages and record results."
+    constraints:
+      - "Only run commands relevant to touched packages plus git diff --check."
+      - "If verification is too slow or blocked, record the exact command and failure reason."
+    expected_output:
+      - "Verification receipt with commands and pass/fail status"
+      - "Any residual risk"
+    receipt:
+      result: done
+      commands:
+        - cmd: "pnpm --dir packages/core test -- --run src/db/settings.test.ts src/db/pr-reviews.test.ts src/github/pr-safety.test.ts src/launch/launch-execute-precheck.test.ts src/github/webhooks.test.ts"
+          status: pass
+          summary: "5 files, 38 tests passed"
+        - cmd: "pnpm --dir packages/web test -- --run lib/webhook-pr-intent.test.ts lib/webhook-pr-launch.test.ts lib/idle-checker.test.ts lib/webhook-intent-worker.test.ts lib/webhook-intent-worker-comment-command.test.ts lib/agent/completion.test.ts lib/agent/mutations.test.ts lib/webhook-url-reconciler.test.ts 'app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts' components/sessions/SessionsReviewList.test.ts lib/sessions-data.test.ts"
+          status: pass
+          summary: "11 files, 59 tests passed"
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "rg -n \"webhook replay remains deferred|True local commit upload|unsupported_local_push|fails closed|comment actions are limited to one|label actions are limited to two\" docs/specs/2026-05-23-webhooks-design.md"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      residual_risk:
+        - "No live GitHub/tunnel/APNs integration verification was run; all behavior was verified through local unit/component tests and injectable adapters."
+      summary: "Focused verification for all changed core/web/docs surfaces passed."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Final audit: prove whether the #506/#507 gap-fix tranche is complete."
+    inputs:
+      - "All task receipts"
+      - "Current git diff"
+      - "Focused verification results"
+      - "docs/goals/issue-506-507-gap-fixes/goal.md"
+    constraints:
+      - "Read-only."
+      - "Do not call complete if any required Worker task is queued, active, or missing verification."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Gap matrix: fixed | deferred | invalid | still open"
+      - "Missing evidence"
+      - "Next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      rationale: "All audited #506/#507 gaps are mapped to fixed, documented deferral, or invalid/no-op by receipts and current diff. Required Worker tasks T004/T006/T007/T008/T010/T012/T013 are done with verification. T998 records focused core/web tests, typechecks, docs check, and git diff check passing. No queued/active required Worker remains; T002 is explicitly superseded by T007."
+      gap_matrix:
+        protected_branch_pr_launch_gating: fixed
+        pr_review_hard_timeout: fixed
+        boot_webhook_url_reconciliation: fixed
+        issue_completion_tokens: fixed
+        issue_mutation_budgets: fixed
+        cli_preflight_fail_fast: "documented accepted divergence"
+        stale_replay_docs: "fixed with explicit deferral"
+        local_push_docs: "fixed with explicit deferral"
+        sessions_exact_terminal_action: fixed
+        trigger_icon_fidelity: "deferred"
+        webhook_log_expansion: "invalid/no change required"
+      evidence:
+        - "Current diff contains the expected core/web/docs changes plus new reconciler and sessions component tests."
+        - "T998 verification passed: core focused tests 38/38, web focused tests 59/59, core typecheck, web typecheck, docs rg consistency check, and git diff --check."
+        - "No CLI files were touched, so CLI typecheck was not required by the goal charter."
+      blocked_tasks: []
+      missing_evidence: []
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T998
+    commands:
+      - "pnpm --dir packages/core test -- --run src/db/settings.test.ts src/db/pr-reviews.test.ts src/github/pr-safety.test.ts src/launch/launch-execute-precheck.test.ts src/github/webhooks.test.ts"
+      - "pnpm --dir packages/web test -- --run lib/webhook-pr-intent.test.ts lib/webhook-pr-launch.test.ts lib/idle-checker.test.ts lib/webhook-intent-worker.test.ts lib/webhook-intent-worker-comment-command.test.ts lib/agent/completion.test.ts lib/agent/mutations.test.ts lib/webhook-url-reconciler.test.ts 'app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts' components/sessions/SessionsReviewList.test.ts lib/sessions-data.test.ts"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web typecheck"
+      - "git diff --check"

--- a/docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md
+++ b/docs/goals/webhook-auto-sessions-gap-closure/notes/t013-follow-up-artifacts.md
@@ -24,8 +24,8 @@ implementation also includes:
 - PR-aware diagnostics, CLI `diag --pr`, manual end/liveness/reconcile PR review
   terminal handling, and PR target labels in the workbench.
 - PR review launch workspaces checked out to the expected PR head ref/SHA and
-  fail-closed daemon mutation handling with `unsupported_local_push` until true
-  local commit upload is designed.
+  daemon-mediated fix pushes that verify the local commit, expected-head
+  ancestry, and final remote PR ref.
 - `issuectl repo set <owner/repo>` with validated automation flags, agents,
   payload mode, and public webhook base URL.
 - Workbench repo setup controls for webhook automation settings, webhook URL
@@ -41,9 +41,11 @@ implementation also includes:
   storage and idempotent notification timestamps.
 - Generalized deployment target identity with `target_type` and `target_number`.
 - PR review read/reservation foundation, PR safety predicates, PR context
-  assembly, terminal launch, incremental review execution, and fail-closed
-  mutation behavior.
-- Defensive credential scrubbing for webhook/comment-command terminal spawns.
+  assembly, terminal launch, incremental range-limited review execution, and
+  force-push superseding of invalidated completed ranges.
+- Defensive credential scrubbing for webhook/comment-command terminal spawns,
+  including token env vars, SSH agent access, global/system Git config, and
+  interactive Git credential prompts.
 - Comment command parsing and authorization foundation.
 - CLI/API/dashboard/docs visibility for repo webhook flags, agents, payload mode,
   public webhook URL, retention docs, and session provenance badges.
@@ -51,24 +53,23 @@ implementation also includes:
 
 ## Blocked Or Deliberately Deferred
 
-The remaining known blocker is true daemon-mediated local commit upload for PR
-review fixes. The current code verifies PR and workspace safety and then denies
-push with `unsupported_local_push`; this is intentional until a daemon-owned git
-object upload or git push credential model is designed and approved.
+The earlier true-local-push blocker is closed by daemon-mediated local `git
+push` with remote ref verification. Remaining known deferrals are product/UX
+scope: richer replay-count lineage beyond retained-delivery replay diagnostics,
+additional visual polish for operator screens, and optional manual-session
+credential-policy controls.
 
 ## Owner Decisions Still Needed
 
-- Use daemon-only mutation authority for local commit upload, or introduce
-  per-session GitHub App installation tokens?
 - Should manual sessions keep ambient credentials permanently, or should users be
   able to opt into scrubbed manual sessions?
-- What exact default budgets should apply if true local commit upload is added
-  later?
 - Should fork PR auto-review remain rejected by default in v1?
 - Should self-trigger fallback remain exactly one bounded follow-up generation
-  per review before stopping if local commit upload is enabled?
+  per review before stopping?
 - What raw payload retention duration should be the default when raw storage is
   enabled?
+- Should replay-count lineage get a first-class schema column, or remain
+  diagnostic-only for v1?
 - Should label removal kill comment-command sessions, or should only
   `/issuectl end` terminate them?
 
@@ -82,12 +83,10 @@ configuration visibility, dashboard webhook controls, webhook event log, PR
 review range display, completion summaries, retention docs, session provenance
 badges, and idempotent notification-claim parts of #506.
 
-Still intentionally blocked before PR review push automation:
-true daemon-mediated local commit upload. Current behavior verifies PR/workspace
-safety and fails closed with `unsupported_local_push`.
+PR review push automation is daemon-mediated: it verifies PR/workspace safety,
+pushes the verified local commit, and checks the final remote ref.
 
-Owner decisions still needed: daemon-only vs GitHub App credential isolation for
-local commit upload, manual-session credential policy, upload-time action
-budgets, fork PR policy, self-trigger fallback, raw payload retention duration,
-and comment-command kill-switch semantics.
+Owner decisions still needed: manual-session credential policy, fork PR policy,
+self-trigger fallback, raw payload retention duration, first-class replay-count
+lineage, and comment-command kill-switch semantics.
 ```

--- a/docs/specs/2026-05-23-webhooks-design.md
+++ b/docs/specs/2026-05-23-webhooks-design.md
@@ -63,10 +63,11 @@ operators can use any public tunnel provider and finish installation with
 `issuectl webhook create` or repo settings.
 `webhook intents` lists the persisted debounce/launch queue. `webhook intent
 fire` schedules a pending or deferred intent immediately, and `webhook intent
-drop` expires an active intent with an operator reason. `webhook replay` remains
-unimplemented in v1: webhook replay remains deferred until raw payload retention
-and replay-count lineage have a durable schema and safety design; metadata-only
-deliveries cannot be replayed safely.
+drop` expires an active intent with an operator reason. `webhook replay` can
+replay retained, target-bearing, replayable deliveries into immediate intents
+and records replay diagnostics. Metadata-only pruned deliveries still cannot be
+replayed safely, and richer replay-count lineage remains a later schema/UX
+extension.
 
 Webhook issue/comment-command sessions use bounded daemon mutation budgets:
 comment actions are limited to one, label actions are limited to two, and
@@ -140,10 +141,9 @@ unless they also end a real deployment row.
 - Direct, ambient-credential agent pushes. Webhook/comment-command agents must
   route GitHub mutations, including allowed PR pushes, through the
   daemon-mediated `issuectl agent mutate` policy gateway.
-- True local commit upload for PR review fixes is not implemented yet. The
-  daemon verifies same-repo, non-default, unprotected PR head state and local
-  workspace branch/SHA/remote metadata, then fails closed with
-  `unsupported_local_push` until a daemon-owned git object upload or git push
-  design is approved.
+- Agent-owned PR pushes that bypass daemon mediation. The daemon verifies
+  same-repo, non-default, unprotected PR head state, local workspace
+  branch/SHA/remote metadata, expected-head ancestry, performs the local
+  `git push`, and verifies the remote ref resolves to the pushed commit.
 - New push platforms or preference schema beyond the existing APNs/iOS device
   registration surface.

--- a/docs/specs/2026-05-23-webhooks-design.md
+++ b/docs/specs/2026-05-23-webhooks-design.md
@@ -56,11 +56,23 @@ value. When `public_webhook_base_url` is set, it also prints the derived
 `webhook create` and `webhook rotate` use the current `gh` authenticated user,
 require confirmation unless `--yes` is passed, generate a fresh receiver secret,
 store the GitHub hook id, and do not print the secret.
+`repo add` performs advisory local preflight checks when webhook automation is
+enabled. Missing `gh`, missing hook scope, missing `cloudflared`, or first-ping
+timeout warn and preserve saved repo automation settings rather than failing;
+operators can use any public tunnel provider and finish installation with
+`issuectl webhook create` or repo settings.
 `webhook intents` lists the persisted debounce/launch queue. `webhook intent
 fire` schedules a pending or deferred intent immediately, and `webhook intent
 drop` expires an active intent with an operator reason. `webhook replay` remains
-deferred until raw payload retention and replay-count lineage have a durable
-schema and safety design; metadata-only deliveries cannot be replayed safely.
+unimplemented in v1: webhook replay remains deferred until raw payload retention
+and replay-count lineage have a durable schema and safety design; metadata-only
+deliveries cannot be replayed safely.
+
+Webhook issue/comment-command sessions use bounded daemon mutation budgets:
+comment actions are limited to one, label actions are limited to two, and
+`create_issue`, `create_pr`, and `push` actions have zero budget for issue
+sessions in v1. The daemon-mediated mutation gateway enforces these budgets
+before any GitHub write.
 
 The dashboard settings and workbench repo setup surfaces expose the same
 repo-level automation flags, issue/review agent selectors, payload mode, stored
@@ -68,6 +80,15 @@ webhook id status, and copyable webhook URL. Workbench repo setup can create a
 GitHub webhook or rotate its receiver secret using the current `gh`
 authenticated user; the generated secret is stored locally and never returned to
 the browser.
+
+On dashboard startup, `issuectl web` also performs a non-blocking webhook URL
+reconciliation pass after the HTTP server is listening. The pass uses the
+configured `public_webhook_base_url` and each repo's stored GitHub webhook id to
+compare the remote hook URL with the derived `/api/webhook/github/<repo_id>`
+receiver URL. Drifted URLs are patched in GitHub without rotating the stored
+secret. Missing base URL, repos without stored hook ids, and per-repo GitHub
+errors do not block dashboard boot; failures are logged and recorded as
+diagnostics for manual follow-up.
 
 Raw payload storage should remain `metadata` unless a short-lived debugging
 session requires `raw`.
@@ -87,10 +108,21 @@ and terminal reason when one is recorded. This keeps webhook-created sessions
 distinguishable from manual sessions and makes control events such as label
 removal or issue closure visible without opening raw diagnostics.
 
+Automatic PR review launch fails closed unless the PR head is same-repo,
+non-default, and unprotected. Protected branch heads are denied before launch so
+webhook review automation cannot mutate protected refs by default.
+
 The repo overview also shows recent webhook events, recent terminal completion
 summaries, and PR review history with the reviewed SHA range. This is the
 dashboard-level audit trail for webhook intake, auto-review runs, and agent
 completion check-ins.
+
+Active webhook PR reviews have a hard runtime cap controlled by
+`review_hard_timeout_minutes`. The default is 30 minutes, `0` disables the cap,
+and invalid values fall back to the default. When the cap is exceeded, the
+deployment ends with terminal reason `timeout` and the linked active PR review
+is marked failed with result reason `timeout`; missing tmux liveness still wins
+when both conditions are detected in the same pass.
 
 ## Completion Notifications
 

--- a/packages/core/src/data/pulls.ts
+++ b/packages/core/src/data/pulls.ts
@@ -1,7 +1,7 @@
 import type { Octokit } from "@octokit/rest";
 import type Database from "better-sqlite3";
 import type { GitHubPull, GitHubCheck, GitHubIssue, GitHubPullFile, GitHubPullReview } from "../github/types.js";
-import { listPulls, getPull, getPullChecks, listPullFiles, listReviews, getChecksRollupForRef, type ChecksRollupStatus } from "../github/pulls.js";
+import { listPulls, getPull, getPullChecks, listPullFiles, listPullFilesForRange, listReviews, getChecksRollupForRef, type ChecksRollupStatus } from "../github/pulls.js";
 import { getIssue } from "../github/issues.js";
 import { getCacheTtl, getCached, setCached, isFresh } from "../db/cache.js";
 
@@ -126,11 +126,14 @@ async function fetchPullDetail(
   owner: string,
   repo: string,
   number: number,
+  options?: { fileRange?: PullFileRange },
 ): Promise<CachedPullDetail> {
   const [pull, checks, files, reviews] = await Promise.all([
     getPull(octokit, owner, repo, number),
     getPullChecks(octokit, owner, repo, `pull/${number}/head`),
-    listPullFiles(octokit, owner, repo, number),
+    options?.fileRange
+      ? listPullFilesForRange(octokit, owner, repo, options.fileRange.fromSha, options.fileRange.toSha)
+      : listPullFiles(octokit, owner, repo, number),
     listReviews(octokit, owner, repo, number),
   ]);
 
@@ -161,14 +164,26 @@ type CachedPullDetail = {
   reviews: GitHubPullReview[];
 };
 
+type PullFileRange = {
+  fromSha: string;
+  toSha: string;
+};
+
 export async function getPullDetail(
   db: Database.Database,
   octokit: Octokit,
   owner: string,
   repo: string,
   number: number,
-  options?: { forceRefresh?: boolean },
+  options?: { forceRefresh?: boolean; fileRange?: PullFileRange },
 ): Promise<CachedPullDetail & { fromCache: boolean; cachedAt: Date | null }> {
+  if (options?.fileRange) {
+    const data = await fetchPullDetail(octokit, owner, repo, number, {
+      fileRange: options.fileRange,
+    });
+    return { ...data, fromCache: false, cachedAt: new Date() };
+  }
+
   const cacheKey = `pull-detail:${owner}/${repo}#${number}`;
   const ttl = getCacheTtl(db);
 

--- a/packages/core/src/db/pr-reviews.test.ts
+++ b/packages/core/src/db/pr-reviews.test.ts
@@ -9,6 +9,7 @@ import {
   coalescePrReviewDesiredHead,
   completePrReview,
   getActivePrReview,
+  getActivePrReviewForDeployment,
   getLatestCompletedPrReview,
   getPrReviewById,
   listPrReviewsForPull,
@@ -271,6 +272,46 @@ describe("pr_reviews", () => {
       status: "failed",
       completedAt: 2_000,
       resultJson: JSON.stringify({ reason: "liveness_missing" }),
+    }));
+    expect(getActivePrReview(db, repoId, 506)).toBeUndefined();
+  });
+
+  it("marks the active review for a timed-out deployment terminal", () => {
+    db.prepare(
+      `INSERT INTO deployments (
+        id, repo_id, issue_number, target_type, target_number, branch_name,
+        workspace_mode, workspace_path
+      ) VALUES (78, ?, NULL, 'pr', 506, 'pr-506', 'existing', '/tmp/repo')`,
+    ).run(repoId);
+    const review = reservePrReview(db, {
+      repoId,
+      prNumber: 506,
+      deploymentId: 78,
+      startedHeadSha: "head-b",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-b",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/webhooks",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+
+    expect(getActivePrReviewForDeployment(db, 78)).toEqual(expect.objectContaining({
+      id: review.id,
+      status: "reserved",
+    }));
+
+    const updated = markActivePrReviewForDeploymentTerminal(db, 78, {
+      completedAt: 2_000,
+      status: "failed",
+      reason: "timeout",
+    });
+
+    expect(updated).toEqual(expect.objectContaining({
+      id: review.id,
+      status: "failed",
+      completedAt: 2_000,
+      resultJson: JSON.stringify({ reason: "timeout" }),
     }));
     expect(getActivePrReview(db, repoId, 506)).toBeUndefined();
   });

--- a/packages/core/src/db/pr-reviews.ts
+++ b/packages/core/src/db/pr-reviews.ts
@@ -62,6 +62,20 @@ export function getActivePrReview(
   return row ? rowToPrReview(row) : undefined;
 }
 
+export function getActivePrReviewForDeployment(
+  db: Database.Database,
+  deploymentId: number,
+): PrReview | undefined {
+  const row = db.prepare(
+    `SELECT * FROM pr_reviews
+     WHERE deployment_id = ?
+       AND status IN ('reserved', 'launching', 'in_progress')
+     ORDER BY started_at DESC, id DESC
+     LIMIT 1`,
+  ).get(deploymentId) as PrReviewRow | undefined;
+  return row ? rowToPrReview(row) : undefined;
+}
+
 export function getLatestCompletedPrReview(
   db: Database.Database,
   repoId: number,
@@ -141,14 +155,8 @@ export function markActivePrReviewForDeploymentTerminal(
   deploymentId: number,
   input: { completedAt: number; status: Extract<PrReviewStatus, "failed" | "superseded">; reason: string },
 ): PrReview | undefined {
-  const row = db.prepare(
-    `SELECT * FROM pr_reviews
-     WHERE deployment_id = ?
-       AND status IN ('reserved', 'launching', 'in_progress')
-     ORDER BY started_at DESC, id DESC
-     LIMIT 1`,
-  ).get(deploymentId) as PrReviewRow | undefined;
-  if (!row) return undefined;
+  const review = getActivePrReviewForDeployment(db, deploymentId);
+  if (!review) return undefined;
 
   db.prepare(
     `UPDATE pr_reviews
@@ -156,8 +164,8 @@ export function markActivePrReviewForDeploymentTerminal(
          completed_at = ?,
          result_json = ?
      WHERE id = ?`,
-  ).run(input.status, input.completedAt, JSON.stringify({ reason: input.reason }), row.id);
-  return getPrReviewById(db, row.id);
+  ).run(input.status, input.completedAt, JSON.stringify({ reason: input.reason }), review.id);
+  return getPrReviewById(db, review.id);
 }
 
 export function coalescePrReviewDesiredHead(

--- a/packages/core/src/db/settings.test.ts
+++ b/packages/core/src/db/settings.test.ts
@@ -63,7 +63,7 @@ describe("seedDefaults", () => {
   it("inserts all default settings", () => {
     seedDefaults(db);
     const settings = getSettings(db);
-    expect(settings).toHaveLength(17);
+    expect(settings).toHaveLength(18);
 
     const keys = settings.map((s) => s.key);
     expect(keys).toContain("branch_pattern");
@@ -82,6 +82,7 @@ describe("seedDefaults", () => {
     expect(keys).toContain("max_webhook_intent_age_minutes");
     expect(keys).toContain("max_concurrent_webhook_agents");
     expect(keys).toContain("max_webhook_recursion_depth");
+    expect(keys).toContain("review_hard_timeout_minutes");
     expect(keys).toContain("public_webhook_base_url");
   });
 
@@ -120,6 +121,11 @@ describe("seedDefaults", () => {
     expect(getSetting(db, "max_webhook_queue_depth")).toBe("100");
     expect(getSetting(db, "max_webhook_recursion_depth")).toBe("1");
     expect(getSetting(db, "public_webhook_base_url")).toBe("");
+  });
+
+  it("seeds the PR review hard timeout default", () => {
+    seedDefaults(db);
+    expect(getSetting(db, "review_hard_timeout_minutes")).toBe("30");
   });
 
   it("is idempotent", () => {

--- a/packages/core/src/db/settings.ts
+++ b/packages/core/src/db/settings.ts
@@ -21,6 +21,7 @@ const DEFAULT_SETTINGS: Setting[] = [
   { key: "max_webhook_intent_age_minutes", value: "60" },
   { key: "max_concurrent_webhook_agents", value: "2" },
   { key: "max_webhook_recursion_depth", value: "1" },
+  { key: "review_hard_timeout_minutes", value: "30" },
   { key: "public_webhook_base_url", value: "" },
 ];
 

--- a/packages/core/src/github/pr-safety.test.ts
+++ b/packages/core/src/github/pr-safety.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { GitHubPull } from "./types.js";
 import {
   headRefMatches,
+  isSafeAutoReviewPrHead,
   isForkPr,
   isNonDefaultBranch,
   isSameRepoPr,
@@ -53,5 +54,20 @@ describe("PR auto-review safety predicates", () => {
     expect(headRefMatches(pull(), { headRef: "feature/webhooks", headSha: "abc123" })).toBe(true);
     expect(headRefMatches(pull(), { headRef: "feature/webhooks", headSha: "moved" })).toBe(false);
     expect(headRefMatches(pull(), { headRef: "renamed", headSha: "abc123" })).toBe(false);
+  });
+
+  it("combines auto-review launch safety gates for same-repo unprotected heads", () => {
+    const options = {
+      baseRepoFullName: "mean-weasel/issuectl",
+      defaultBranch: "main",
+      desiredHeadSha: "abc123",
+      headProtected: false,
+    };
+
+    expect(isSafeAutoReviewPrHead(pull(), options)).toBe(true);
+    expect(isSafeAutoReviewPrHead(pull({ headRepoFullName: "fork/issuectl" }), options)).toBe(false);
+    expect(isSafeAutoReviewPrHead(pull({ headRef: "main" }), options)).toBe(false);
+    expect(isSafeAutoReviewPrHead(pull(), { ...options, headProtected: true })).toBe(false);
+    expect(isSafeAutoReviewPrHead(pull({ headSha: "moved" }), options)).toBe(false);
   });
 });

--- a/packages/core/src/github/pr-safety.ts
+++ b/packages/core/src/github/pr-safety.ts
@@ -1,5 +1,14 @@
 import type { GitHubPull } from "./types.js";
 
+type PullBranchSafety = Pick<GitHubPull, "headRef" | "headSha" | "headRepoFullName" | "baseRepoFullName">;
+
+export type AutoReviewPrSafetyOptions = {
+  baseRepoFullName: string;
+  defaultBranch: string;
+  desiredHeadSha?: string | null;
+  headProtected: boolean;
+};
+
 export function isSameRepoPr(pull: GitHubPull, baseRepoFullName: string): boolean {
   return pull.headRepoFullName === baseRepoFullName && pull.baseRepoFullName === baseRepoFullName;
 }
@@ -22,4 +31,15 @@ export function headRefMatches(
 ): boolean {
   return pull.headRef === expected.headRef
     && (expected.headSha === undefined || expected.headSha === null || pull.headSha === expected.headSha);
+}
+
+export function isSafeAutoReviewPrHead(
+  pull: PullBranchSafety,
+  options: AutoReviewPrSafetyOptions,
+): boolean {
+  return pull.headRepoFullName === options.baseRepoFullName
+    && pull.baseRepoFullName === options.baseRepoFullName
+    && pull.headRef !== options.defaultBranch
+    && !options.headProtected
+    && (options.desiredHeadSha === undefined || options.desiredHeadSha === null || pull.headSha === options.desiredHeadSha);
 }

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -159,6 +159,28 @@ export async function listPullFiles(
   }));
 }
 
+export async function listPullFilesForRange(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  fromSha: string,
+  toSha: string,
+): Promise<GitHubPullFile[]> {
+  const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${fromSha}...${toSha}`,
+    per_page: 100,
+  });
+  return (data.files ?? []).map((f) => ({
+    filename: f.filename,
+    status: f.status as GitHubPullFile["status"],
+    additions: f.additions,
+    deletions: f.deletions,
+    patch: f.patch,
+  }));
+}
+
 export async function findLinkedPRs(
   octokit: Octokit,
   owner: string,

--- a/packages/core/src/launch/launch-contexts.ts
+++ b/packages/core/src/launch/launch-contexts.ts
@@ -87,10 +87,16 @@ export function seedAgentActionBudgets(
   targetType: DeploymentTargetType,
   triggeredBy: DeploymentTriggeredBy | undefined,
 ): void {
-  if (targetType !== "pr") return;
   if (triggeredBy !== "webhook" && triggeredBy !== "comment_command") return;
   setAgentActionBudget(db, deploymentId, "comment", 1);
   setAgentActionBudget(db, deploymentId, "label", 2);
+  if (targetType === "issue") {
+    setAgentActionBudget(db, deploymentId, "create_issue", 0);
+    setAgentActionBudget(db, deploymentId, "create_pr", 0);
+    setAgentActionBudget(db, deploymentId, "push", 0);
+    return;
+  }
+  if (targetType !== "pr") return;
   setAgentActionBudget(db, deploymentId, "create_issue", 1);
   setAgentActionBudget(db, deploymentId, "create_pr", 1);
   setAgentActionBudget(db, deploymentId, "push", 1);

--- a/packages/core/src/launch/launch-contexts.ts
+++ b/packages/core/src/launch/launch-contexts.ts
@@ -43,8 +43,13 @@ export async function buildPrLaunchContext(
   options: LaunchOptions,
   prNumber: number,
 ): Promise<{ contextString: string; expectedHeadRef: string; expectedHeadSha: string }> {
+  const requestedReviewRange =
+    options.reviewedFromSha && options.reviewedToSha
+      ? { fromSha: options.reviewedFromSha, toSha: options.reviewedToSha }
+      : undefined;
   const detail = await getPullDetail(db, octokit, options.owner, options.repo, prNumber, {
     forceRefresh: true,
+    fileRange: requestedReviewRange,
   });
   const pull = detail.pull;
   if (!pull.headSha) throw new Error(`PR #${prNumber} is missing head SHA`);

--- a/packages/core/src/launch/launch-execute-precheck.test.ts
+++ b/packages/core/src/launch/launch-execute-precheck.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import type { Octokit } from "@octokit/rest";
@@ -294,6 +295,86 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
         }),
       ]),
     );
+  });
+
+  it("launches webhook issue sessions with agent env and issue-scoped mutation budgets", async () => {
+    addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+
+    const result = await withConsoleWarnSilenced(() =>
+      executeLaunch(db, {} as Octokit, {
+        owner: "acme",
+        repo: "api",
+        issueNumber: 42,
+        branchName: "issue-42",
+        workspaceMode: "existing",
+        selectedComments: [],
+        selectedFiles: [],
+        triggeredBy: "webhook",
+        completionToken: "completion-42",
+      }),
+    );
+
+    expect(result.deploymentId).toBeGreaterThan(0);
+    expect(spawnTtydSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialPolicy: "scrubbed",
+        sessionName: "issuectl-api-42",
+        extraEnv: expect.objectContaining({
+          ISSUECTL_AGENT_TOKEN: "completion-42",
+          ISSUECTL_TARGET_TYPE: "issue",
+          ISSUECTL_TARGET_NUMBER: "42",
+        }),
+      }),
+    );
+    expect(db.prepare(
+      "SELECT target_type, target_number, completion_token FROM deployments",
+    ).get()).toEqual({
+      target_type: "issue",
+      target_number: 42,
+      completion_token: "completion-42",
+    });
+    expect(db.prepare(
+      "SELECT action_type, limit_count FROM agent_action_budgets ORDER BY action_type",
+    ).all()).toEqual([
+      { action_type: "comment", limit_count: 1 },
+      { action_type: "create_issue", limit_count: 0 },
+      { action_type: "create_pr", limit_count: 0 },
+      { action_type: "label", limit_count: 2 },
+      { action_type: "push", limit_count: 0 },
+    ]);
+  });
+
+  it("does not seed completion env or mutation budgets for manual issue sessions", async () => {
+    addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+
+    await withConsoleWarnSilenced(() =>
+      executeLaunch(db, {} as Octokit, {
+        owner: "acme",
+        repo: "api",
+        issueNumber: 42,
+        branchName: "issue-42",
+        workspaceMode: "existing",
+        selectedComments: [],
+        selectedFiles: [],
+      }),
+    );
+
+    expect(spawnTtydSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraEnv: {},
+      }),
+    );
+    expect(db.prepare(
+      "SELECT action_type, limit_count FROM agent_action_budgets ORDER BY action_type",
+    ).all()).toEqual([]);
   });
 
   it("passes incremental PR review ranges into the production PR context", async () => {

--- a/packages/core/src/launch/launch-execute-precheck.test.ts
+++ b/packages/core/src/launch/launch-execute-precheck.test.ts
@@ -24,6 +24,36 @@ const { assemblePrReviewContextSpy } = vi.hoisted(() => ({
   assemblePrReviewContextSpy: vi.fn(() => "fake pr context"),
 }));
 
+const { getPullDetailSpy } = vi.hoisted(() => ({
+  getPullDetailSpy: vi.fn(async () => ({
+    pull: {
+      number: 44,
+      title: "test PR",
+      body: "Please review",
+      state: "open",
+      draft: false,
+      merged: false,
+      user: null,
+      headRef: "feature/webhooks",
+      baseRef: "main",
+      headSha: "head-b",
+      baseSha: "base-a",
+      headRepoFullName: "acme/api",
+      baseRepoFullName: "acme/api",
+      additions: 1,
+      deletions: 0,
+      changedFiles: 1,
+      createdAt: "2026-04-12T00:00:00Z",
+      updatedAt: "2026-04-12T00:00:00Z",
+      mergedAt: null,
+      closedAt: null,
+      htmlUrl: "https://example.invalid/pr/44",
+    },
+    files: [{ filename: "src/app.ts", status: "modified", patch: "@@" }],
+    reviews: [],
+  })),
+}));
+
 vi.mock("./workspace.js", () => ({
   prepareWorkspace: prepareWorkspaceSpy,
 }));
@@ -82,33 +112,7 @@ vi.mock("../data/issues.js", () => ({
 }));
 
 vi.mock("../data/pulls.js", () => ({
-  getPullDetail: async () => ({
-    pull: {
-      number: 44,
-      title: "test PR",
-      body: "Please review",
-      state: "open",
-      draft: false,
-      merged: false,
-      user: null,
-      headRef: "feature/webhooks",
-      baseRef: "main",
-      headSha: "head-b",
-      baseSha: "base-a",
-      headRepoFullName: "acme/api",
-      baseRepoFullName: "acme/api",
-      additions: 1,
-      deletions: 0,
-      changedFiles: 1,
-      createdAt: "2026-04-12T00:00:00Z",
-      updatedAt: "2026-04-12T00:00:00Z",
-      mergedAt: null,
-      closedAt: null,
-      htmlUrl: "https://example.invalid/pr/44",
-    },
-    files: [{ filename: "src/app.ts", status: "modified", patch: "@@" }],
-    reviews: [],
-  }),
+  getPullDetail: getPullDetailSpy,
 }));
 
 vi.mock("./context.js", () => ({
@@ -140,6 +144,7 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     spawnTtydSpy.mockClear();
     allocatePortSpy.mockClear();
     assemblePrReviewContextSpy.mockClear();
+    getPullDetailSpy.mockClear();
     reserveTtydPortSpy.mockClear();
     updateTtydInfoSpy.mockClear();
     db = createTestDb();
@@ -401,6 +406,17 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
         reviewedFromSha: "head-a",
         reviewedToSha: "head-b",
       }),
+    );
+    expect(getPullDetailSpy).toHaveBeenCalledWith(
+      db,
+      expect.anything(),
+      "acme",
+      "api",
+      44,
+      {
+        forceRefresh: true,
+        fileRange: { fromSha: "head-a", toSha: "head-b" },
+      },
     );
   });
 

--- a/packages/core/src/launch/tmux-session.ts
+++ b/packages/core/src/launch/tmux-session.ts
@@ -22,6 +22,8 @@ const AGENT_CREDENTIAL_ENV_RESET = [
   "unset GH_TOKEN GITHUB_TOKEN GITHUB_PAT",
   "unset SSH_AUTH_SOCK GIT_ASKPASS SSH_ASKPASS",
   "export GH_CONFIG_DIR=\"$(mktemp -d ${TMPDIR:-/tmp}/issuectl-gh-empty.XXXXXX)\"",
+  "export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1",
+  "export GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never",
 ].join("; ");
 
 export function createTmuxAgentSession(options: SpawnPtyBridgeSessionOptions): void {

--- a/packages/core/src/launch/ttyd-respawn.test.ts
+++ b/packages/core/src/launch/ttyd-respawn.test.ts
@@ -155,6 +155,8 @@ describe("reconcileOrphanedDeployments", () => {
         owner: "ownerB",
         repo: "repoB",
         issueNumber: 20,
+        targetType: "issue",
+        targetNumber: 20,
         deploymentId: 2,
         sessionName: "issuectl-repoB-20",
       }),
@@ -183,6 +185,58 @@ describe("reconcileOrphanedDeployments", () => {
     reconcileOrphanedDeployments(db);
 
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("marks linked active PR reviews failed when reconciling a missing PR tmux session", () => {
+    execFileSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("session not found"), { status: 1 });
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const deploymentRunSpy = vi.fn();
+    const reviewRunSpy = vi.fn();
+    const prepareSpy = vi.fn((sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          all: vi.fn(() => [
+            {
+              id: 7,
+              issue_number: null,
+              target_type: "pr",
+              target_number: 44,
+              owner: "mean-weasel",
+              repo_name: "issuectl",
+            },
+          ]),
+        };
+      }
+      if (sql.includes("UPDATE pr_reviews")) {
+        return { run: reviewRunSpy };
+      }
+      return { run: deploymentRunSpy };
+    });
+    const db = { prepare: prepareSpy } as unknown as Database.Database;
+
+    reconcileOrphanedDeployments(db);
+
+    expect(deploymentRunSpy).toHaveBeenCalledWith(7);
+    expect(reviewRunSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      JSON.stringify({ reason: "liveness_missing" }),
+      7,
+    );
+    expect(recordDiagnosticEventSpy).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        event: "reconcile.tmux_missing",
+        targetType: "pr",
+        targetNumber: 44,
+        deploymentId: 7,
+        sessionName: "issuectl-issuectl-pr-44",
+      }),
+    );
+
+    warnSpy.mockRestore();
   });
 
   it("queries spawned ttyd and pty bridge deployments only", () => {

--- a/packages/core/src/launch/ttyd-spawn.test.ts
+++ b/packages/core/src/launch/ttyd-spawn.test.ts
@@ -112,6 +112,8 @@ describe("spawnTtyd", () => {
     expect(tmuxCmd).toContain("unset SSH_AUTH_SOCK GIT_ASKPASS SSH_ASKPASS");
     expect(tmuxCmd).toContain("export GH_CONFIG_DIR=");
     expect(tmuxCmd).toContain("mktemp -d");
+    expect(tmuxCmd).toContain("export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1");
+    expect(tmuxCmd).toContain("export GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never");
     killSpy.mockRestore();
   });
 

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -402,9 +402,22 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
     try {
       const sessionName = tmuxSessionName(row.repo_name, row.target_number, row.target_type);
       if (!isTmuxSessionAlive(sessionName)) {
-        db.prepare("UPDATE deployments SET ended_at = datetime('now') WHERE id = ?").run(
-          row.id,
-        );
+        db.prepare(
+          `UPDATE deployments
+           SET ended_at = datetime('now'),
+               terminal_reason = COALESCE(terminal_reason, 'liveness_missing')
+           WHERE id = ?`,
+        ).run(row.id);
+        if (row.target_type === "pr") {
+          db.prepare(
+            `UPDATE pr_reviews
+             SET status = 'failed',
+                 completed_at = ?,
+                 result_json = ?
+             WHERE deployment_id = ?
+               AND status IN ('reserved', 'launching', 'in_progress')`,
+          ).run(Date.now(), JSON.stringify({ reason: "liveness_missing" }), row.id);
+        }
         recordDiagnosticEventSafely(db, {
           level: "warn",
           event: "reconcile.tmux_missing",
@@ -412,6 +425,8 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
           owner: row.owner,
           repo: row.repo_name,
           issueNumber: row.target_type === "issue" ? row.target_number : undefined,
+          targetType: row.target_type,
+          targetNumber: row.target_number,
           deploymentId: row.id,
           sessionName,
           message: `tmux session ${sessionName} is gone`,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,7 @@ export type SettingKey =
   | "max_webhook_intent_age_minutes"
   | "max_concurrent_webhook_agents"
   | "max_webhook_recursion_depth"
+  | "review_hard_timeout_minutes"
   | "public_webhook_base_url";
 
 export type Setting = {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
@@ -15,6 +15,7 @@ const getDb = vi.hoisted(() => vi.fn());
 const getRepo = vi.hoisted(() => vi.fn());
 const getRepoWebhookConfigById = vi.hoisted(() => vi.fn());
 const getSetting = vi.hoisted(() => vi.fn());
+const listRepos = vi.hoisted(() => vi.fn());
 const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const rotateIssuectlWebhook = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
@@ -27,6 +28,7 @@ vi.mock("@issuectl/core", () => ({
   getRepo: (...args: unknown[]) => getRepo(...args),
   getRepoWebhookConfigById: (...args: unknown[]) => getRepoWebhookConfigById(...args),
   getSetting: (...args: unknown[]) => getSetting(...args),
+  listRepos: (...args: unknown[]) => listRepos(...args),
   recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
   rotateIssuectlWebhook: (...args: unknown[]) => rotateIssuectlWebhook(...args),
   updateRepoWebhookSettings: (...args: unknown[]) => updateRepoWebhookSettings(...args),

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api-auth";
 import log from "@/lib/logger";
+import { buildWebhookUrl } from "@/lib/webhook-url-reconciler";
 import {
   createIssuectlWebhook,
   formatErrorForUser,
@@ -117,5 +118,5 @@ async function readBody(request: NextRequest): Promise<WebhookActionBody | NextR
 function webhookUrl(db: ReturnType<typeof getDb>, repoId: number): string {
   const baseUrl = getSetting(db, "public_webhook_base_url");
   if (!baseUrl) throw new Error("public_webhook_base_url is not configured.");
-  return `${baseUrl.replace(/\/$/, "")}/api/webhook/github/${repoId}`;
+  return buildWebhookUrl(baseUrl, repoId);
 }

--- a/packages/web/components/sessions/SessionsReviewList.module.css
+++ b/packages/web/components/sessions/SessionsReviewList.module.css
@@ -236,6 +236,10 @@
   font: 600 var(--paper-fs-sm) var(--paper-mono);
 }
 
+.rowLinks .primaryRowLink {
+  color: var(--paper-ink);
+}
+
 .chip {
   min-height: 24px;
   display: inline-flex;

--- a/packages/web/components/sessions/SessionsReviewList.test.ts
+++ b/packages/web/components/sessions/SessionsReviewList.test.ts
@@ -1,0 +1,80 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { SessionsOverviewData, SessionListItem } from "@/lib/sessions-data";
+import { SessionsReviewList } from "./SessionsReviewList";
+
+describe("SessionsReviewList", () => {
+  it("links active session rows to their exact terminal deployment", () => {
+    const html = renderToStaticMarkup(
+      createElement(SessionsReviewList, { data: sessionsData() }),
+    );
+
+    expect(html).toContain('href="/workbench?deployment=101"');
+    expect(html).toContain('aria-label="Open terminal for session 101"');
+    expect(html).not.toContain('href="/workbench?deployment=102"');
+    expect(html.match(/\/workbench\?deployment=/g)).toHaveLength(1);
+  });
+});
+
+function sessionsData(): SessionsOverviewData {
+  return {
+    initialized: true,
+    filters: {
+      tab: "sessions",
+      q: "",
+      repo: "",
+      trigger: "all",
+      state: "all",
+      status: "all",
+    },
+    repos: [{ id: 1, fullName: "mean-weasel/issuectl" }],
+    sessionGroups: [{
+      key: "mean-weasel/issuectl:issue:507",
+      repoFullName: "mean-weasel/issuectl",
+      targetType: "issue",
+      targetNumber: 507,
+      targetLabel: "Issue #507",
+      sessions: [
+        session({ id: 101, endedAt: null }),
+        session({ id: 102, endedAt: "2026-05-24T01:00:00.000Z" }),
+      ],
+    }],
+    reviewGroups: [],
+    summary: {
+      activeSessions: 1,
+      endedSessions: 1,
+      reviewRuns: 0,
+      activeReviewRuns: 0,
+    },
+  };
+}
+
+function session(input: { id: number; endedAt: string | null }): SessionListItem {
+  return {
+    id: input.id,
+    repoId: 1,
+    repoFullName: "mean-weasel/issuectl",
+    owner: "mean-weasel",
+    repoName: "issuectl",
+    targetType: "issue",
+    targetNumber: 507,
+    targetLabel: "Issue #507",
+    issueNumber: 507,
+    branchName: `issue-507-${input.id}`,
+    agent: "codex",
+    workspaceMode: "worktree",
+    workspacePath: `/tmp/worktree-${input.id}`,
+    linkedPrNumber: null,
+    triggeredBy: "webhook",
+    parentDeploymentId: null,
+    childDeploymentCount: 0,
+    webhookDepth: 1,
+    terminalReason: input.endedAt ? "completed" : null,
+    launchedAt: "2026-05-24T00:00:00.000Z",
+    endedAt: input.endedAt,
+    ttydPort: input.endedAt ? null : 7101,
+    idleSince: null,
+    preview: null,
+  };
+}

--- a/packages/web/components/sessions/SessionsReviewList.tsx
+++ b/packages/web/components/sessions/SessionsReviewList.tsx
@@ -173,6 +173,15 @@ function SessionGroups({ groups }: { groups: SessionTargetGroup[] }) {
                   {session.webhookDepth > 0 && <Chip tone="neutral">depth {session.webhookDepth}</Chip>}
                 </div>
                 <div className={styles.rowLinks}>
+                  {!session.endedAt && (
+                    <Link
+                      className={styles.primaryRowLink}
+                      href={`/workbench?deployment=${session.id}`}
+                      aria-label={`Open terminal for session ${session.id}`}
+                    >
+                      Terminal
+                    </Link>
+                  )}
                   <a href={githubTargetHref(session.owner, session.repoName, session.targetType, session.targetNumber)}>
                     GitHub
                   </a>

--- a/packages/web/lib/agent/mutation-adapters.test.ts
+++ b/packages/web/lib/agent/mutation-adapters.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultAgentMutationAdapters } from "./mutation-adapters.js";
+
+const execFileMock = vi.mocked(execFile);
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+function mockExecFileSuccess(stdout = ""): void {
+  execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+    callback?.(null, stdout, "");
+    return {} as ReturnType<typeof execFile>;
+  });
+}
+
+describe("defaultAgentMutationAdapters.push", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("uploads the verified local commit with git push and verifies the remote PR ref", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, callback) => {
+        callback?.(null, "", "");
+        return {} as ReturnType<typeof execFile>;
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, callback) => {
+        callback?.(null, "", "");
+        return {} as ReturnType<typeof execFile>;
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, callback) => {
+        callback?.(null, "", "");
+        return {} as ReturnType<typeof execFile>;
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, callback) => {
+        callback?.(null, "head-b\trefs/heads/feature/review\n", "");
+        return {} as ReturnType<typeof execFile>;
+      });
+
+    await expect(defaultAgentMutationAdapters.push?.({
+      owner: "acme",
+      repo: "api",
+      ref: "heads/feature/review",
+      sha: "head-b",
+      expectedHeadSha: "head-a",
+      workspacePath: "/tmp/issuectl-pr-44",
+    })).resolves.toBeUndefined();
+
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["cat-file", "-e", "head-b^{commit}"],
+      { cwd: "/tmp/issuectl-pr-44", timeout: 10_000 },
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["merge-base", "--is-ancestor", "head-a", "head-b"],
+      { cwd: "/tmp/issuectl-pr-44", timeout: 10_000 },
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      3,
+      "git",
+      ["push", "origin", "head-b:refs/heads/feature/review"],
+      { cwd: "/tmp/issuectl-pr-44", timeout: 60_000 },
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      4,
+      "git",
+      ["ls-remote", "origin", "refs/heads/feature/review"],
+      { cwd: "/tmp/issuectl-pr-44", timeout: 30_000 },
+      expect.any(Function),
+    );
+  });
+
+  it("fails closed when remote verification does not match the pushed commit", async () => {
+    mockExecFileSuccess("");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, callback) => {
+      callback?.(null, "", "");
+      return {} as ReturnType<typeof execFile>;
+    });
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, callback) => {
+      callback?.(null, "", "");
+      return {} as ReturnType<typeof execFile>;
+    });
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, callback) => {
+      callback?.(null, "", "");
+      return {} as ReturnType<typeof execFile>;
+    });
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, callback) => {
+      callback?.(null, "head-c\trefs/heads/feature/review\n", "");
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    await expect(defaultAgentMutationAdapters.push?.({
+      owner: "acme",
+      repo: "api",
+      ref: "heads/feature/review",
+      sha: "head-b",
+      expectedHeadSha: "head-a",
+      workspacePath: "/tmp/issuectl-pr-44",
+    })).rejects.toThrow("Remote PR head did not match pushed commit");
+  });
+});

--- a/packages/web/lib/agent/mutation-adapters.ts
+++ b/packages/web/lib/agent/mutation-adapters.ts
@@ -1,3 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import {
   addLabel,
   createIssue,
@@ -9,6 +11,8 @@ import {
   withAuthRetry,
 } from "@issuectl/core";
 import type { AgentMutationAdapters, PullForSafety } from "./mutation-types";
+
+const execFileAsync = promisify(execFile);
 
 export const defaultAgentMutationAdapters: AgentMutationAdapters = {
   comment: async ({ owner, repo, targetNumber, body }) => {
@@ -52,10 +56,28 @@ export const defaultAgentMutationAdapters: AgentMutationAdapters = {
     if (!remoteMatchesRepo(remoteUrl, owner, repo)) return { ok: false, reason: "unsafe_checkout" };
     return { ok: true };
   },
-  push: async ({ owner, repo, ref, sha }) => {
-    await withAuthRetry((octokit) =>
-      octokit.rest.git.updateRef({ owner, repo, ref, sha, force: false }),
-    );
+  push: async ({ ref, sha, expectedHeadSha, workspacePath }) => {
+    const remoteRef = `refs/${ref}`;
+    await execFileAsync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+      cwd: workspacePath,
+      timeout: 10_000,
+    });
+    await execFileAsync("git", ["merge-base", "--is-ancestor", expectedHeadSha, sha], {
+      cwd: workspacePath,
+      timeout: 10_000,
+    });
+    await execFileAsync("git", ["push", "origin", `${sha}:${remoteRef}`], {
+      cwd: workspacePath,
+      timeout: 60_000,
+    });
+    const output = await execFileAsync("git", ["ls-remote", "origin", remoteRef], {
+      cwd: workspacePath,
+      timeout: 30_000,
+    }) as { stdout: string } | string;
+    const stdout = typeof output === "string" ? output : output.stdout;
+    if (remoteHeadSha(stdout) !== sha) {
+      throw new Error("Remote PR head did not match pushed commit after git push");
+    }
   },
 };
 
@@ -115,4 +137,9 @@ function mapPullForSafety(raw: unknown): PullForSafety {
     closedAt: pull.closed_at,
     htmlUrl: pull.html_url,
   };
+}
+
+function remoteHeadSha(stdout: string): string | undefined {
+  const line = stdout.trim().split("\n").find(Boolean);
+  return line?.split(/\s+/)[0];
 }

--- a/packages/web/lib/agent/mutation-types.ts
+++ b/packages/web/lib/agent/mutation-types.ts
@@ -91,6 +91,7 @@ export type PushInput = {
   ref: string;
   sha: string;
   expectedHeadSha: string;
+  workspacePath: string;
 };
 
 export type WorkspaceHeadVerificationInput = {

--- a/packages/web/lib/agent/mutations.test.ts
+++ b/packages/web/lib/agent/mutations.test.ts
@@ -172,6 +172,130 @@ describe("executeAgentMutationRequest", () => {
     });
   });
 
+  it("allows only bounded comment and label mutations for issue webhook sessions", async () => {
+    db.prepare(
+      `UPDATE deployments
+       SET target_type = 'issue',
+           target_number = 506,
+           issue_number = 506,
+           triggered_by = 'webhook',
+           completion_token = 'token-506'
+       WHERE id = ?`,
+    ).run(deploymentId);
+    setBudget(db, deploymentId, "comment", 1);
+    setBudget(db, deploymentId, "label", 2);
+    setBudget(db, deploymentId, "create_issue", 0);
+    setBudget(db, deploymentId, "create_pr", 0);
+    setBudget(db, deploymentId, "push", 0);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const label = vi.fn().mockResolvedValue(undefined);
+    const createIssue = vi.fn().mockResolvedValue(undefined);
+    const createPr = vi.fn().mockResolvedValue(undefined);
+    const push = vi.fn().mockResolvedValue(undefined);
+
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "comment",
+      payload: { body: "Completed local pass." },
+    }, { comment })).resolves.toEqual({ allowed: true });
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "label",
+      payload: { label: "issuectl:done" },
+    }, { label })).resolves.toEqual({ allowed: true });
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "label",
+      payload: { label: "needs-review", operation: "remove" },
+    }, { label })).resolves.toEqual({ allowed: true });
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "create_issue",
+      payload: { title: "Follow-up", body: "Not allowed from issue sessions." },
+    }, { createIssue })).resolves.toEqual({ allowed: false, reason: "budget_exhausted" });
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "create_pr",
+      payload: { title: "Fix", head: "issue-506", base: "main", body: "Not allowed." },
+    }, { createPr })).resolves.toEqual({ allowed: false, reason: "budget_exhausted" });
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "push",
+      payload: {
+        expectedHeadRef: "issue-506",
+        expectedHeadSha: "head-a",
+        newSha: "head-b",
+      },
+    }, {
+      fetchPull: async () => pull(),
+      isBranchProtected: async () => false,
+      verifyWorkspaceHead: async () => ({ ok: true }),
+      push,
+    })).resolves.toEqual({ allowed: false, reason: "target_mismatch" });
+
+    expect(comment).toHaveBeenCalledTimes(1);
+    expect(label).toHaveBeenCalledTimes(2);
+    expect(createIssue).not.toHaveBeenCalled();
+    expect(createPr).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(budgetRow(db, deploymentId, "comment")).toEqual({ limit_count: 1, used_count: 1 });
+    expect(budgetRow(db, deploymentId, "label")).toEqual({ limit_count: 2, used_count: 2 });
+    expect(budgetRow(db, deploymentId, "create_issue")).toEqual({ limit_count: 0, used_count: 0 });
+    expect(budgetRow(db, deploymentId, "create_pr")).toEqual({ limit_count: 0, used_count: 0 });
+    expect(budgetRow(db, deploymentId, "push")).toEqual({ limit_count: 0, used_count: 0 });
+  });
+
+  it("keeps manual sessions denied even when a token and budget exist", async () => {
+    db.prepare(
+      `UPDATE deployments
+       SET target_type = 'issue',
+           target_number = 506,
+           issue_number = 506,
+           triggered_by = 'manual',
+           completion_token = 'token-506'
+       WHERE id = ?`,
+    ).run(deploymentId);
+    setBudget(db, deploymentId, "comment", 1);
+    const comment = vi.fn().mockResolvedValue(undefined);
+
+    await expect(executeAgentMutationRequest(db, {
+      deploymentId,
+      completionToken: "token-506",
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      actionType: "comment",
+      payload: { body: "Should be denied." },
+    }, { comment })).resolves.toEqual({ allowed: false, reason: "manual_session" });
+
+    expect(comment).not.toHaveBeenCalled();
+    expect(budgetRow(db, deploymentId, "comment")).toEqual({ limit_count: 1, used_count: 0 });
+  });
+
   it("denies fork PR pushes before consuming budget or calling the adapter", async () => {
     const push = vi.fn().mockResolvedValue(undefined);
     setBudget(db, deploymentId, "push", 1);

--- a/packages/web/lib/agent/mutations.test.ts
+++ b/packages/web/lib/agent/mutations.test.ts
@@ -442,6 +442,7 @@ describe("executeAgentMutationRequest", () => {
       ref: "heads/feature/review",
       sha: "head-b",
       expectedHeadSha: "head-a",
+      workspacePath: "/tmp/issuectl-pr-44",
     });
     expect(budgetRow(db, deploymentId, "push")).toEqual({ limit_count: 1, used_count: 1 });
   });

--- a/packages/web/lib/agent/mutations.ts
+++ b/packages/web/lib/agent/mutations.ts
@@ -309,6 +309,7 @@ async function preparePushExecution(
       ref: `heads/${payload.expectedHeadRef}`,
       sha: payload.newSha,
       expectedHeadSha: payload.expectedHeadSha,
+      workspacePath: session.workspacePath,
     }) ?? Promise.resolve(),
   };
 }

--- a/packages/web/lib/idle-checker.test.ts
+++ b/packages/web/lib/idle-checker.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { checkDeploymentLiveness, checkIdleDeployments } from "./idle-checker";
 
@@ -25,6 +26,7 @@ vi.mock("@issuectl/core", async () => {
     setIdleSince: vi.fn(),
     clearIdleSince: vi.fn(),
     getSetting: vi.fn(),
+    markActivePrReviewForDeploymentTerminal: vi.fn(),
   };
 });
 
@@ -55,6 +57,7 @@ import {
   setIdleSince,
   clearIdleSince,
   getSetting,
+  markActivePrReviewForDeploymentTerminal,
 } from "@issuectl/core";
 
 const mockGetRegisteredPorts = vi.mocked(getRegisteredPorts);
@@ -68,6 +71,7 @@ const mockRecordDiagnosticEvent = vi.mocked(recordDiagnosticEventSafely);
 const mockSetIdleSince = vi.mocked(setIdleSince);
 const mockClearIdleSince = vi.mocked(clearIdleSince);
 const mockGetSetting = vi.mocked(getSetting);
+const mockMarkActivePrReviewForDeploymentTerminal = vi.mocked(markActivePrReviewForDeploymentTerminal);
 
 describe("checkIdleDeployments", () => {
   const fakeDb = {} as ReturnType<typeof getDb>;
@@ -253,11 +257,35 @@ describe("checkDeploymentLiveness", () => {
   const fakeDb = {} as ReturnType<typeof getDb>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     mockGetDb.mockReturnValue(fakeDb);
+    mockGetSetting.mockImplementation((_db, key) => {
+      if (String(key) === "review_hard_timeout_minutes") return "30";
+      return undefined;
+    });
+    mockMarkActivePrReviewForDeploymentTerminal.mockReturnValue({
+      id: 101,
+      repoId: 1,
+      prNumber: 44,
+      deploymentId: 4,
+      startedHeadSha: "head-b",
+      completedHeadSha: null,
+      reviewBaseSha: "base-a",
+      reviewedFromSha: null,
+      reviewedToSha: "head-b",
+      headRepoFullName: "owner/repo",
+      headRef: "feature",
+      status: "in_progress",
+      triggeredBy: "webhook",
+      resultJson: null,
+      startedAt: Date.now(),
+      completedAt: null,
+    });
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -310,6 +338,278 @@ describe("checkDeploymentLiveness", () => {
         sessionName: "issuectl-repo-7",
       }),
     );
+  });
+
+  it("ends old active PR deployments as timed out and fails the linked active review", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 4,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 31 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(true);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).toHaveBeenCalledWith(fakeDb, 4, "timeout");
+    expect(mockMarkActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(fakeDb, 4, {
+      completedAt: now,
+      status: "failed",
+      reason: "timeout",
+    });
+    expect(notifyDeploymentTerminalOutcome).toHaveBeenCalledWith({ deploymentId: 4 });
+    expect(mockRecordDiagnosticEvent).toHaveBeenCalledWith(
+      fakeDb,
+      expect.objectContaining({
+        level: "warn",
+        event: "review.timeout",
+        targetType: "pr",
+        targetNumber: 44,
+        deploymentId: 4,
+      }),
+    );
+  });
+
+  it("does not time out issue deployments", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 5,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: 7,
+        targetType: "issue",
+        targetNumber: 7,
+        agent: "claude",
+        branchName: "issue-7",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 31 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(true);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).not.toHaveBeenCalled();
+    expect(mockMarkActivePrReviewForDeploymentTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not time out PR deployments without a linked active PR review", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockMarkActivePrReviewForDeploymentTerminal.mockReturnValue(undefined);
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 9,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 31 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(true);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).not.toHaveBeenCalled();
+    expect(mockMarkActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(fakeDb, 9, {
+      completedAt: now,
+      status: "failed",
+      reason: "timeout",
+    });
+  });
+
+  it("lets tmux_missing win over PR timeout in the same pass", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 6,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 31 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(false);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).toHaveBeenCalledWith(fakeDb, 6, "liveness_missing");
+    expect(mockEndDeployment).not.toHaveBeenCalledWith(fakeDb, 6, "timeout");
+    expect(mockMarkActivePrReviewForDeploymentTerminal).toHaveBeenCalledWith(fakeDb, 6, {
+      completedAt: now,
+      status: "failed",
+      reason: "liveness_missing",
+    });
+  });
+
+  it("does not time out PR deployments when review hard timeout is disabled", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockGetSetting.mockImplementation((_db, key) => {
+      if (String(key) === "review_hard_timeout_minutes") return "0";
+      return undefined;
+    });
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 7,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 60 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(true);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).not.toHaveBeenCalled();
+    expect(mockMarkActivePrReviewForDeploymentTerminal).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default timeout when the timeout setting is invalid", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    mockGetSetting.mockImplementation((_db, key) => {
+      if (String(key) === "review_hard_timeout_minutes") return "bogus";
+      return undefined;
+    });
+    mockGetActiveDeployments.mockReturnValue([
+      {
+        id: 8,
+        repoId: 1,
+        owner: "owner",
+        repoName: "repo",
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44",
+        workspaceMode: "existing",
+        workspacePath: "/tmp",
+        linkedPrNumber: null,
+        state: "active",
+        launchedAt: new Date(now - 31 * 60_000).toISOString(),
+        endedAt: null,
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7701,
+        ttydPid: 1235,
+        idleSince: null,
+      },
+    ]);
+    mockIsTmuxSessionAlive.mockReturnValue(true);
+
+    checkDeploymentLiveness();
+
+    expect(mockEndDeployment).toHaveBeenCalledWith(fakeDb, 8, "timeout");
   });
 
   it("records liveness.check_failed when querying active deployments fails", () => {

--- a/packages/web/lib/idle-checker.ts
+++ b/packages/web/lib/idle-checker.ts
@@ -25,6 +25,8 @@ import {
 
 const DEFAULT_GRACE_SECONDS = 300;
 const DEFAULT_THRESHOLD_SECONDS = 300;
+const DEFAULT_REVIEW_HARD_TIMEOUT_MINUTES = 30;
+const REVIEW_HARD_TIMEOUT_SETTING = "review_hard_timeout_minutes";
 const CHECK_INTERVAL_MS = 60_000;
 
 let timer: ReturnType<typeof setInterval> | null = null;
@@ -100,10 +102,10 @@ export function checkIdleDeployments(): void {
 
 function parseSetting(
   db: Parameters<typeof getSetting>[0],
-  key: Parameters<typeof getSetting>[1],
+  key: string,
   defaultValue: number,
 ): number {
-  const raw = getSetting(db, key);
+  const raw = getSetting(db, key as Parameters<typeof getSetting>[1]);
   if (raw === undefined) return defaultValue;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) {
@@ -143,6 +145,13 @@ export function checkDeploymentLiveness(): void {
     return;
   }
 
+  const reviewHardTimeoutMinutes = parseSetting(
+    db,
+    REVIEW_HARD_TIMEOUT_SETTING,
+    DEFAULT_REVIEW_HARD_TIMEOUT_MINUTES,
+  );
+  const now = Date.now();
+
   for (const deployment of deployments) {
     try {
       const target = getDeploymentTarget(deployment);
@@ -176,6 +185,48 @@ export function checkDeploymentLiveness(): void {
           issueNumber: target.targetType === "issue" ? target.targetNumber : undefined,
           sessionName,
         });
+        continue;
+      }
+
+      if (target.targetType === "pr" && reviewHardTimeoutMinutes > 0) {
+        const launchedAtMs = new Date(deployment.launchedAt).getTime();
+        if (!Number.isFinite(launchedAtMs)) {
+          log.warn({
+            msg: "review_timeout_invalid_launch_date",
+            deploymentId: deployment.id,
+            launchedAt: deployment.launchedAt,
+          });
+          continue;
+        }
+
+        if (now - launchedAtMs > reviewHardTimeoutMinutes * 60_000) {
+          const terminalReview = markActivePrReviewForDeploymentTerminal(db, deployment.id, {
+            completedAt: now,
+            status: "failed",
+            reason: "timeout",
+          });
+          if (!terminalReview) continue;
+
+          endDeployment(db, deployment.id, "timeout");
+          notifyDeploymentTerminalOutcome({ deploymentId: deployment.id });
+          recordDiagnosticEventSafely(db, {
+            level: "warn",
+            event: "review.timeout",
+            source: "web.idle-checker",
+            owner: deployment.owner,
+            repo: deployment.repoName,
+            targetType: target.targetType,
+            targetNumber: target.targetNumber,
+            deploymentId: deployment.id,
+            message: `PR review deployment exceeded ${reviewHardTimeoutMinutes} minute timeout`,
+          });
+          log.info({
+            msg: "review_timeout",
+            deploymentId: deployment.id,
+            targetNumber: target.targetNumber,
+            timeoutMinutes: reviewHardTimeoutMinutes,
+          });
+        }
       }
     } catch (err) {
       log.error({ msg: "liveness_check_error", deploymentId: deployment.id, err });

--- a/packages/web/lib/webhook-intent-worker-comment-command.test.ts
+++ b/packages/web/lib/webhook-intent-worker-comment-command.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 import {
   addRepo,
@@ -69,6 +69,8 @@ describe("comment-command webhook intents", () => {
   });
 
   it("launches issue intents without the auto-launch label", async () => {
+    const deps = testWorkerDeps();
+    const launchIssue = vi.fn(deps.launchIssue);
     const event = recordWebhookEvent(db, {
       deliveryId: "delivery-command",
       repoId,
@@ -88,9 +90,17 @@ describe("comment-command webhook intents", () => {
       eventId: event.deduped ? null : event.eventId,
     });
 
-    const result = await runWebhookIntentWorkerOnce(db, 2_000, testWorkerDeps());
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, { ...deps, launchIssue });
 
     expect(result).toEqual(expect.objectContaining({ claimed: 1, launched: 1 }));
+    expect(launchIssue).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ id: repoId }),
+      expect.objectContaining({ id: intentId }),
+      expect.objectContaining({ title: "Manual command launch" }),
+      "comment_command",
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+    );
     expect(getIntentStatus(db, intentId)).toEqual({ status: "launched" });
     expect(
       db.prepare("SELECT triggered_by FROM deployments WHERE id = 1").get(),

--- a/packages/web/lib/webhook-intent-worker.test.ts
+++ b/packages/web/lib/webhook-intent-worker.test.ts
@@ -114,6 +114,7 @@ describe("runWebhookIntentWorkerOnce", () => {
   });
 
   it("launches due opted-in issue intents", async () => {
+    const launchIssue = vi.fn(testWorkerDeps().launchIssue);
     const intentId = mergeWebhookIntent(db, {
       repoId,
       targetType: "issue",
@@ -123,9 +124,17 @@ describe("runWebhookIntentWorkerOnce", () => {
       requestedAgent: "codex",
     });
 
-    const result = await runWorker(db, 2_000);
+    const result = await runWorker(db, 2_000, { launchIssue });
 
     expectWorkerResult(result, { claimed: 1, launched: 1 });
+    expect(launchIssue).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ id: repoId }),
+      expect.objectContaining({ id: intentId }),
+      expect.objectContaining({ title: "Fix webhook auto launch" }),
+      "webhook",
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+    );
     expect(queryDiagnosticEvents(db, {
       target: { owner: "mean-weasel", repo: "issuectl", targetType: "issue", targetNumber: 506 },
       events: ["webhook.lock_check"],

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 import {
   claimDueWebhookIntent,
@@ -48,6 +49,7 @@ type WorkerDeps = {
     intent: WebhookIntent,
     issue: IssueState,
     triggeredBy: "webhook" | "comment_command",
+    completionToken: string,
   ) => Promise<{ deploymentId: number }>;
   launchPr?: LaunchPrReview;
   isAncestor?: PullWorkerDeps["isAncestor"];
@@ -162,7 +164,15 @@ export async function runWebhookIntentWorkerOnce(
       return result(base, { claimed: 1, [control.outcome]: 1 });
     }
 
-    const launch = await (deps.launchIssue ?? launchIssueFromWebhook)(db, repo, intent, issue, triggeredBy);
+    const completionToken = randomUUID();
+    const launch = await (deps.launchIssue ?? launchIssueFromWebhook)(
+      db,
+      repo,
+      intent,
+      issue,
+      triggeredBy,
+      completionToken,
+    );
     markIntentTerminal(db, intent.id, "launched", now, null, launch.deploymentId);
     recordIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched issue session.", launch.deploymentId);
     broadcastEventsChanged();
@@ -226,6 +236,7 @@ async function launchIssueFromWebhook(
   intent: WebhookIntent,
   issue: IssueState,
   triggeredBy: "webhook" | "comment_command",
+  completionToken: string,
 ): Promise<{ deploymentId: number }> {
   const branchPattern = repo.branchPattern ?? getSetting(db, "branch_pattern") ?? DEFAULT_BRANCH_PATTERN;
   const options = {
@@ -236,8 +247,9 @@ async function launchIssueFromWebhook(
     branchName: generateBranchName(branchPattern, intent.targetNumber, issue.title),
     workspaceMode: repo.localPath ? "worktree" : "clone", selectedComments: [], selectedFiles: [],
     triggeredBy,
+    completionToken,
     correlationId: `webhook-intent:${intent.id}`,
-  } as Parameters<typeof executeLaunch>[2] & { triggeredBy: "webhook" };
+  } as Parameters<typeof executeLaunch>[2];
   return withAuthRetry((octokit) => executeLaunch(db, octokit, options));
 }
 

--- a/packages/web/lib/webhook-pr-incremental.test.ts
+++ b/packages/web/lib/webhook-pr-incremental.test.ts
@@ -153,6 +153,13 @@ describe("incremental PR webhook intents", () => {
   });
 
   it("supersedes the completed range and launches a full review after force push", async () => {
+    seedCompletedReview(db, repoId, 49, {
+      startedHeadSha: "head-a",
+      completedHeadSha: "head-a",
+      reviewedToSha: "head-a",
+      startedAt: 500,
+      completedAt: 750,
+    });
     seedCompletedReview(db, repoId, 49);
     mergeWebhookIntent(db, {
       repoId,
@@ -174,6 +181,7 @@ describe("incremental PR webhook intents", () => {
 
     expect(result).toEqual(expect.objectContaining({ claimed: 1, launched: 1, failed: 0 }));
     expect(prReviewRows(db)).toEqual([
+      expect.objectContaining({ status: "superseded", reviewed_to_sha: "head-a" }),
       expect.objectContaining({ status: "superseded", reviewed_to_sha: "head-b" }),
       expect.objectContaining({
         status: "in_progress",
@@ -218,15 +226,31 @@ describe("incremental PR webhook intents", () => {
   });
 });
 
-function seedCompletedReview(db: Database.Database, repoId: number, prNumber: number): void {
+function seedCompletedReview(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+  options: {
+    startedHeadSha?: string;
+    completedHeadSha?: string;
+    reviewedToSha?: string;
+    startedAt?: number;
+    completedAt?: number;
+  } = {},
+): void {
+  const startedHeadSha = options.startedHeadSha ?? "head-b";
+  const completedHeadSha = options.completedHeadSha ?? "head-b";
+  const reviewedToSha = options.reviewedToSha ?? "head-b";
+  const startedAt = options.startedAt ?? 1_000;
+  const completedAt = options.completedAt ?? 1_500;
   db.prepare(
     `INSERT INTO pr_reviews (
       repo_id, pr_number, deployment_id, started_head_sha, completed_head_sha,
       review_base_sha, reviewed_to_sha, head_repo_full_name, head_ref, status,
       triggered_by, started_at, completed_at, result_json
-    ) VALUES (?, ?, NULL, 'head-b', 'head-b', 'base-a', 'head-b',
-      'mean-weasel/issuectl', 'feature/webhooks', 'completed', 'webhook', 1000, 1500, '{}')`,
-  ).run(repoId, prNumber);
+    ) VALUES (?, ?, NULL, ?, ?, 'base-a', ?,
+      'mean-weasel/issuectl', 'feature/webhooks', 'completed', 'webhook', ?, ?, '{}')`,
+  ).run(repoId, prNumber, startedHeadSha, completedHeadSha, reviewedToSha, startedAt, completedAt);
 }
 
 function recordTestDeployment(db: Database.Database, repoId: number, targetNumber: number): number {

--- a/packages/web/lib/webhook-pr-intent.test.ts
+++ b/packages/web/lib/webhook-pr-intent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 import {
@@ -58,6 +59,7 @@ const safePull = {
   headRepoFullName: "mean-weasel/issuectl",
   baseRepoFullName: "mean-weasel/issuectl",
   defaultBranch: "main",
+  headProtected: false,
 };
 
 describe("PR webhook intents", () => {
@@ -149,6 +151,31 @@ describe("PR webhook intents", () => {
     });
 
     expect(result).toEqual(expect.objectContaining({ claimed: 1, skippedOptout: 1, launched: 0 }));
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({ status: "skipped_optout", deployment_id: null }),
+    );
+    expect(db.prepare("SELECT COUNT(*) AS count FROM pr_reviews").get()).toEqual({ count: 0 });
+    expect(queryDiagnosticEvents(db, { events: ["webhook.skipped_unsafe_pr"] })).toHaveLength(1);
+  });
+
+  it("skips protected-branch webhook PR intents before reserving or launching", async () => {
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 49,
+      signalAt: 1_000,
+      scheduledAt: 2_000,
+      desiredHeadSha: "head-b",
+    });
+    const launchPr = vi.fn();
+
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, {
+      fetchPullState: async () => ({ ...safePull, headRef: "release", headProtected: true }),
+      launchPr,
+    });
+
+    expect(result).toEqual(expect.objectContaining({ claimed: 1, skippedOptout: 1, launched: 0 }));
+    expect(launchPr).not.toHaveBeenCalled();
     expect(getIntentRow(db, intentId)).toEqual(
       expect.objectContaining({ status: "skipped_optout", deployment_id: null }),
     );
@@ -290,6 +317,51 @@ describe("PR webhook intents", () => {
     expect(
       db.prepare("SELECT triggered_by FROM pr_reviews WHERE pr_number = 47").get(),
     ).toEqual({ triggered_by: "comment_command" });
+  });
+
+  it("does not apply protected-branch auto-review gating to comment-command PR intents", async () => {
+    updateRepoWebhookSettings(db, repoId, { autoReviewPrs: false });
+    const event = recordWebhookEvent(db, {
+      deliveryId: "delivery-review-protected-command",
+      repoId,
+      eventType: "issue_comment",
+      action: "created",
+      senderLogin: "octocat",
+      targetType: "pr",
+      targetNumber: 50,
+      receivedAt: 1_000,
+    });
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 50,
+      signalAt: 1_000,
+      scheduledAt: 2_000,
+      desiredHeadSha: "head-b",
+      eventId: event.deduped ? null : event.eventId,
+    });
+
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, {
+      fetchPullState: async () => ({ ...safePull, headRef: "release", headProtected: true, labels: [] }),
+      launchPr: async (_db) => {
+        const deploymentId = recordDeployment(_db, {
+          repoId,
+          issueNumber: 50,
+          branchName: "pr-50-review",
+          workspaceMode: "worktree",
+          workspacePath: "/tmp/pr-50",
+        }).id;
+        _db.prepare(
+          "UPDATE deployments SET triggered_by = 'comment_command' WHERE id = ?",
+        ).run(deploymentId);
+        return { deploymentId };
+      },
+    });
+
+    expect(result).toEqual(expect.objectContaining({ claimed: 1, launched: 1, failed: 0 }));
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({ status: "launched", deployment_id: 1 }),
+    );
   });
 
   it("marks the PR review failed when launch fails after reservation", async () => {

--- a/packages/web/lib/webhook-pr-intent.ts
+++ b/packages/web/lib/webhook-pr-intent.ts
@@ -26,6 +26,7 @@ export type PullState = {
   headRepoFullName: string;
   baseRepoFullName: string;
   defaultBranch: string;
+  headProtected?: boolean;
 };
 export type FetchPullState = (repo: Repo, prNumber: number) => Promise<PullState>;
 export type PrReviewRecord = {
@@ -74,7 +75,13 @@ export async function handlePullRequestIntent(
       broadcastEventsChanged();
       return result(base, { claimed: 1, skippedOptout: 1, endedSessions });
     }
-    if (!isSafePullForReservation(pull, intent.desiredHeadSha)) {
+    if (triggeredBy === "webhook" && !isSafeWebhookPullForReservation(pull, intent.desiredHeadSha)) {
+      recordPrIntentDiagnostic(db, repo, intent, "webhook.skipped_unsafe_pr", "PR failed auto-review safety gates.");
+      markIntentTerminal(db, intent.id, now, "PR failed safety gates");
+      broadcastEventsChanged();
+      return result(base, { claimed: 1, skippedOptout: 1 });
+    }
+    if (triggeredBy !== "webhook" && !isSafePullForReservation(pull, intent.desiredHeadSha)) {
       recordPrIntentDiagnostic(db, repo, intent, "webhook.skipped_unsafe_pr", "PR failed auto-review safety gates.");
       markIntentTerminal(db, intent.id, now, "PR failed safety gates");
       broadcastEventsChanged();
@@ -182,13 +189,23 @@ async function fetchPullState(repo: Repo, prNumber: number): Promise<PullState> 
       head: { ref: string; sha: string; repo: { full_name: string } | null };
       base: { ref: string; sha: string; repo: { full_name: string; default_branch?: string } | null };
     };
+    const headRepoFullName = d.head.repo?.full_name ?? "";
+    const baseRepoFullName = d.base.repo?.full_name ?? `${repo.owner}/${repo.name}`;
+    const headProtected = headRepoFullName === baseRepoFullName
+      ? Boolean((await octokit.rest.repos.getBranch({
+        owner: repo.owner,
+        repo: repo.name,
+        branch: d.head.ref,
+      })).data.protected)
+      : false;
     return {
       title: d.title, body: d.body ?? null, state: d.state, draft: Boolean(d.draft),
       labels: (d.labels ?? []).map((l) => typeof l === "string" ? l : l.name).filter((n): n is string => Boolean(n)),
       headRef: d.head.ref, baseRef: d.base.ref, headSha: d.head.sha, baseSha: d.base.sha,
-      headRepoFullName: d.head.repo?.full_name ?? "",
-      baseRepoFullName: d.base.repo?.full_name ?? `${repo.owner}/${repo.name}`,
+      headRepoFullName,
+      baseRepoFullName,
       defaultBranch: d.base.repo?.default_branch ?? d.base.ref,
+      headProtected,
     };
   });
 }
@@ -201,6 +218,11 @@ function isSafePullForReservation(pull: PullState, desiredHeadSha: string | null
   return pull.headRepoFullName === pull.baseRepoFullName
     && pull.headRef !== pull.defaultBranch
     && (desiredHeadSha === null || pull.headSha === desiredHeadSha);
+}
+
+function isSafeWebhookPullForReservation(pull: PullState, desiredHeadSha: string | null): boolean {
+  return isSafePullForReservation(pull, desiredHeadSha)
+    && pull.headProtected !== true;
 }
 
 function markPrReviewLaunching(db: Database.Database, reviewId: number): void {

--- a/packages/web/lib/webhook-pr-launch.test.ts
+++ b/packages/web/lib/webhook-pr-launch.test.ts
@@ -34,6 +34,7 @@ describe("launchPrFromWebhook", () => {
       headRepoFullName: "mean-weasel/issuectl",
       baseRepoFullName: "mean-weasel/issuectl",
       defaultBranch: "main",
+      headProtected: false,
     };
     const review: PrReviewRecord = {
       id: 7,

--- a/packages/web/lib/webhook-pr-review-state.ts
+++ b/packages/web/lib/webhook-pr-review-state.ts
@@ -28,7 +28,7 @@ export async function planPrReview(
   if (completed && !forceFullReview) {
     const ancestor = await (deps.isAncestor ?? defaultIsAncestor)(repo, completed.reviewedToSha, pull.headSha);
     if (ancestor) reviewedFromSha = completed.completedHeadSha ?? completed.reviewedToSha;
-    else supersedePrReview(db, completed.id, now, "force_push");
+    else supersedeCompletedPrReviews(db, repo.id, intent.targetNumber, now, "force_push");
   }
 
   return {
@@ -124,9 +124,18 @@ function coalesceDesiredHead(db: Database.Database, reviewId: number, pull: Pull
   return true;
 }
 
-function supersedePrReview(db: Database.Database, reviewId: number, now: number, reason: string): void {
-  db.prepare("UPDATE pr_reviews SET status = 'superseded', completed_at = ?, result_json = ? WHERE id = ?")
-    .run(now, JSON.stringify({ reason }), reviewId);
+function supersedeCompletedPrReviews(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+  now: number,
+  reason: string,
+): void {
+  db.prepare(
+    `UPDATE pr_reviews
+     SET status = 'superseded', completed_at = ?, result_json = ?
+     WHERE repo_id = ? AND pr_number = ? AND status = 'completed'`,
+  ).run(now, JSON.stringify({ reason }), repoId, prNumber);
 }
 
 function parseResultJson(value: string | null): Record<string, unknown> {

--- a/packages/web/lib/webhook-url-reconciler.test.ts
+++ b/packages/web/lib/webhook-url-reconciler.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Repo } from "@issuectl/core";
+
+const getDb = vi.hoisted(() => vi.fn());
+const getSetting = vi.hoisted(() => vi.fn());
+const listRepos = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
+const withAuthRetry = vi.hoisted(() => vi.fn());
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getSetting: (...args: unknown[]) => getSetting(...args),
+  listRepos: (...args: unknown[]) => listRepos(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+  withAuthRetry: (...args: unknown[]) => withAuthRetry(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: logger,
+}));
+
+import {
+  buildWebhookUrl,
+  reconcileWebhookUrlsOnce,
+} from "./webhook-url-reconciler";
+
+const db = {};
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: null,
+  branchPattern: null,
+  autoLaunchIssues: false,
+  autoReviewPrs: false,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-26T00:00:00.000Z",
+} satisfies Repo;
+
+beforeEach(() => {
+  getDb.mockReturnValue(db);
+  getSetting.mockReset();
+  listRepos.mockReset();
+  recordDiagnosticEventSafely.mockReset();
+  withAuthRetry.mockReset();
+  logger.info.mockReset();
+  logger.warn.mockReset();
+});
+
+describe("webhook URL reconciler", () => {
+  it("builds repo-scoped webhook URLs from the configured base URL", () => {
+    expect(buildWebhookUrl("https://hooks.example.test/", 42)).toBe(
+      "https://hooks.example.test/api/webhook/github/42",
+    );
+  });
+
+  it("skips when no public webhook base URL is configured", async () => {
+    const result = await reconcileWebhookUrlsOnce(db as never, {
+      getBaseUrl: () => "",
+      listConfiguredRepos: vi.fn(),
+      reconcileWebhookUrl: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      checked: 0,
+      updated: 0,
+      failed: 0,
+      skippedReason: "missing_base_url",
+    });
+  });
+
+  it("skips repos without stored webhook ids", async () => {
+    const reconcileWebhookUrl = vi.fn();
+    const result = await reconcileWebhookUrlsOnce(db as never, {
+      getBaseUrl: () => "https://hooks.example.test",
+      listConfiguredRepos: () => [{ ...repo, webhookId: null }],
+      reconcileWebhookUrl,
+    });
+
+    expect(result).toEqual({
+      checked: 0,
+      updated: 0,
+      failed: 0,
+      skippedReason: "no_configured_webhooks",
+    });
+    expect(reconcileWebhookUrl).not.toHaveBeenCalled();
+  });
+
+  it("updates drifted webhook URLs and records diagnostics", async () => {
+    const reconcileWebhookUrl = vi.fn().mockResolvedValue({
+      hookId: 123,
+      previousUrl: "https://old.example.test/api/webhook/github/1",
+      url: "https://hooks.example.test/api/webhook/github/1",
+      updated: true,
+    });
+
+    const result = await reconcileWebhookUrlsOnce(db as never, {
+      getBaseUrl: () => "https://hooks.example.test/",
+      listConfiguredRepos: () => [repo],
+      reconcileWebhookUrl,
+      recordDiagnostic: recordDiagnosticEventSafely,
+    });
+
+    expect(result).toEqual({
+      checked: 1,
+      updated: 1,
+      failed: 0,
+      skippedReason: null,
+    });
+    expect(reconcileWebhookUrl).toHaveBeenCalledWith({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      hookId: 123,
+      url: "https://hooks.example.test/api/webhook/github/1",
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      event: "webhook.url_reconciled",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({
+        hookId: 123,
+        previousUrl: "https://old.example.test/api/webhook/github/1",
+        url: "https://hooks.example.test/api/webhook/github/1",
+      }),
+    }));
+  });
+
+  it("does not record reconciliation diagnostics when URLs already match", async () => {
+    const reconcileWebhookUrl = vi.fn().mockResolvedValue({
+      hookId: 123,
+      previousUrl: "https://hooks.example.test/api/webhook/github/1",
+      url: "https://hooks.example.test/api/webhook/github/1",
+      updated: false,
+    });
+
+    const result = await reconcileWebhookUrlsOnce(db as never, {
+      getBaseUrl: () => "https://hooks.example.test",
+      listConfiguredRepos: () => [repo],
+      reconcileWebhookUrl,
+      recordDiagnostic: recordDiagnosticEventSafely,
+    });
+
+    expect(result).toEqual({
+      checked: 1,
+      updated: 0,
+      failed: 0,
+      skippedReason: null,
+    });
+    expect(recordDiagnosticEventSafely).not.toHaveBeenCalled();
+  });
+
+  it("continues after a repo reconciliation failure", async () => {
+    const reconcileWebhookUrl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("not found"))
+      .mockResolvedValueOnce({
+        hookId: 456,
+        previousUrl: "https://old.example.test/api/webhook/github/2",
+        url: "https://hooks.example.test/api/webhook/github/2",
+        updated: true,
+      });
+
+    const result = await reconcileWebhookUrlsOnce(db as never, {
+      getBaseUrl: () => "https://hooks.example.test",
+      listConfiguredRepos: () => [
+        repo,
+        { ...repo, id: 2, name: "other", webhookId: 456 },
+      ],
+      reconcileWebhookUrl,
+      recordDiagnostic: recordDiagnosticEventSafely,
+    });
+
+    expect(result).toEqual({
+      checked: 2,
+      updated: 1,
+      failed: 1,
+      skippedReason: null,
+    });
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      event: "webhook.url_reconcile_failed",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      data: expect.objectContaining({ hookId: 123, error: "not found" }),
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      event: "webhook.url_reconciled",
+      repo: "other",
+    }));
+  });
+});

--- a/packages/web/lib/webhook-url-reconciler.ts
+++ b/packages/web/lib/webhook-url-reconciler.ts
@@ -1,0 +1,183 @@
+import {
+  getDb,
+  getSetting,
+  listRepos,
+  recordDiagnosticEventSafely,
+  withAuthRetry,
+  type Repo,
+} from "@issuectl/core";
+import log from "@/lib/logger";
+
+type Db = ReturnType<typeof getDb>;
+
+type WebhookUrlReconcileInput = {
+  owner: string;
+  repo: string;
+  hookId: number;
+  url: string;
+};
+
+type WebhookUrlReconcileResult = {
+  hookId: number;
+  previousUrl: string | null;
+  url: string;
+  updated: boolean;
+};
+
+type ReconcileWebhookUrl = (
+  input: WebhookUrlReconcileInput,
+) => Promise<WebhookUrlReconcileResult>;
+
+export type WebhookUrlReconcilerSummary = {
+  checked: number;
+  updated: number;
+  failed: number;
+  skippedReason: "missing_base_url" | "no_configured_webhooks" | null;
+};
+
+type ReconcilerDependencies = {
+  getBaseUrl: (db: Db) => string | undefined;
+  listConfiguredRepos: (db: Db) => Repo[];
+  reconcileWebhookUrl: ReconcileWebhookUrl;
+  recordDiagnostic: typeof recordDiagnosticEventSafely;
+};
+
+const defaultDependencies: ReconcilerDependencies = {
+  getBaseUrl: (db) => getSetting(db, "public_webhook_base_url"),
+  listConfiguredRepos: (db) => listRepos(db),
+  reconcileWebhookUrl: reconcileGitHubWebhookUrl,
+  recordDiagnostic: recordDiagnosticEventSafely,
+};
+
+export function buildWebhookUrl(baseUrl: string, repoId: number): string {
+  return `${baseUrl.replace(/\/$/, "")}/api/webhook/github/${repoId}`;
+}
+
+export function startWebhookUrlReconciler(db: Db = getDb()): void {
+  setImmediate(() => {
+    reconcileWebhookUrlsOnce(db).catch((err) => {
+      log.warn({ err, msg: "webhook_url_reconciler_failed" });
+    });
+  }).unref();
+}
+
+export async function reconcileWebhookUrlsOnce(
+  db: Db,
+  dependencies: Partial<ReconcilerDependencies> = {},
+): Promise<WebhookUrlReconcilerSummary> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  const baseUrl = deps.getBaseUrl(db)?.trim();
+  if (!baseUrl) {
+    return { checked: 0, updated: 0, failed: 0, skippedReason: "missing_base_url" };
+  }
+
+  const repos = deps.listConfiguredRepos(db).filter((repo) => repo.webhookId !== null);
+  if (repos.length === 0) {
+    return { checked: 0, updated: 0, failed: 0, skippedReason: "no_configured_webhooks" };
+  }
+
+  const summary: WebhookUrlReconcilerSummary = {
+    checked: 0,
+    updated: 0,
+    failed: 0,
+    skippedReason: null,
+  };
+
+  for (const repo of repos) {
+    const hookId = repo.webhookId;
+    if (hookId === null) continue;
+    const url = buildWebhookUrl(baseUrl, repo.id);
+    summary.checked += 1;
+    try {
+      const result = await deps.reconcileWebhookUrl({
+        owner: repo.owner,
+        repo: repo.name,
+        hookId,
+        url,
+      });
+      if (result.updated) {
+        summary.updated += 1;
+        deps.recordDiagnostic(db, {
+          level: "info",
+          event: "webhook.url_reconciled",
+          source: "web",
+          owner: repo.owner,
+          repo: repo.name,
+          message: "Repository webhook URL reconciled at dashboard startup",
+          data: {
+            repoId: repo.id,
+            hookId: result.hookId,
+            previousUrl: result.previousUrl,
+            url: result.url,
+          },
+        });
+      }
+    } catch (err) {
+      summary.failed += 1;
+      log.warn({
+        err,
+        msg: "webhook_url_reconcile_repo_failed",
+        repoId: repo.id,
+        owner: repo.owner,
+        repo: repo.name,
+        hookId,
+      });
+      deps.recordDiagnostic(db, {
+        level: "warn",
+        event: "webhook.url_reconcile_failed",
+        source: "web",
+        owner: repo.owner,
+        repo: repo.name,
+        message: "Repository webhook URL reconciliation failed",
+        data: {
+          repoId: repo.id,
+          hookId,
+          url,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
+  log.info({
+    msg: "webhook_url_reconciler_complete",
+    checked: summary.checked,
+    updated: summary.updated,
+    failed: summary.failed,
+  });
+  return summary;
+}
+
+async function reconcileGitHubWebhookUrl(
+  input: WebhookUrlReconcileInput,
+): Promise<WebhookUrlReconcileResult> {
+  return withAuthRetry(async (octokit) => {
+    const { data: current } = await octokit.rest.repos.getWebhook({
+      owner: input.owner,
+      repo: input.repo,
+      hook_id: input.hookId,
+    });
+    const previousUrl = typeof current.config?.url === "string" ? current.config.url : null;
+    if (previousUrl === input.url) {
+      return {
+        hookId: input.hookId,
+        previousUrl,
+        url: input.url,
+        updated: false,
+      };
+    }
+
+    const { data: updated } = await octokit.rest.repos.updateWebhook({
+      owner: input.owner,
+      repo: input.repo,
+      hook_id: input.hookId,
+      config: { url: input.url },
+    });
+    return {
+      hookId: updated.id,
+      previousUrl,
+      url: input.url,
+      updated: true,
+    };
+  });
+}

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -14,6 +14,7 @@ import {
 import { refreshNetworkInfo, getPublicIp, getLanIp, getLanRedirectUrl } from "./lib/network-info.js";
 import { startIdleChecker, stopIdleChecker } from "./lib/idle-checker";
 import { startWebhookIntentWorker, stopWebhookIntentWorker } from "./lib/webhook-intent-worker";
+import { startWebhookUrlReconciler } from "./lib/webhook-url-reconciler";
 
 const TERMINAL_WS_RE = /^\/api\/terminal\/(\d+)\/ws/;
 const PTY_TERMINAL_WS_RE = /^\/api\/terminal\/pty\/(\d+)\/ws/;
@@ -293,6 +294,11 @@ server.listen(port, () => {
     startWebhookIntentWorker(getDb());
   } catch (err) {
     log.error({ msg: "webhook_intent_worker_start_failed", err });
+  }
+  try {
+    startWebhookUrlReconciler(getDb());
+  } catch (err) {
+    log.error({ msg: "webhook_url_reconciler_start_failed", err });
   }
 });
 


### PR DESCRIPTION
## Summary
- close the remaining issue #506/#507 backend gaps for PR review recovery, daemon-mediated fix pushes, incremental range context, and force-push invalidation
- harden scrubbed webhook/comment-command agent sessions against ambient Git/GitHub credentials
- update stale #506/#507 docs and record remaining replay/UX items as explicit product deferrals

## Verification
- pnpm --dir packages/core test -- ttyd-respawn pr-reviews
- pnpm --dir packages/web test -- agent/mutations mutation-adapters
- pnpm --dir packages/core test -- launch-execute-precheck context
- pnpm --dir packages/web test -- webhook-pr-incremental
- pnpm --dir packages/core test -- ttyd-spawn launch-terminal-backend
- pnpm --dir packages/core typecheck
- pnpm --dir packages/web typecheck
- pnpm --dir packages/core lint
- pnpm --dir packages/web lint
- pnpm turbo build
- pnpm turbo typecheck
- git diff --check
- GoalBuddy state validation passed

Note: an initial concurrent `pnpm turbo typecheck` failed because `next build` had not yet generated `.next/types`; after `pnpm turbo build`, rerunning `pnpm turbo typecheck` passed.