### PR TITLE
Allow auto-launch label when creating issues

### DIFF
--- a/packages/web/app/new/NewIssuePage.tsx
+++ b/packages/web/app/new/NewIssuePage.tsx
@@ -7,7 +7,7 @@ import type { GitHubLabel } from "@issuectl/core";
 import { createIssue } from "@/lib/actions/issues";
 import { useToast } from "@/components/ui/ToastProvider";
 import { newIdempotencyKey } from "@/lib/idempotency-key";
-import { isLifecycleLabel } from "@/lib/labels";
+import { isSelectableIssueLabel } from "@/lib/labels";
 import { useImageUpload } from "@/hooks/useImageUpload";
 import type { RepoOption } from "@/lib/types";
 import styles from "./NewIssuePage.module.css";
@@ -70,7 +70,7 @@ export function NewIssuePage({ repos, defaultRepo, labelsPerRepo, initError }: P
   const repoKey = `${selectedRepo.owner}/${selectedRepo.repo}`;
   const availableLabels = useMemo(() => {
     const repoLabels = (labelsPerRepo[repoKey] ?? []).filter(
-      (l) => !isLifecycleLabel(l.name),
+      (l) => isSelectableIssueLabel(l.name),
     );
     return repoLabels.length > 0 ? repoLabels : STANDARD_LABELS;
   }, [labelsPerRepo, repoKey]);

--- a/packages/web/components/issue/LabelSelector.tsx
+++ b/packages/web/components/issue/LabelSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { GitHubLabel } from "@issuectl/core";
-import { isLifecycleLabel } from "@/lib/labels";
+import { isSelectableIssueLabel } from "@/lib/labels";
 import styles from "./LabelSelector.module.css";
 
 type Props = {
@@ -32,7 +32,7 @@ export function LabelSelector({
   onToggle,
   disabled,
 }: Props) {
-  const toggleable = available.filter((l) => !isLifecycleLabel(l.name));
+  const toggleable = available.filter((l) => isSelectableIssueLabel(l.name));
 
   if (toggleable.length === 0) return null;
 

--- a/packages/web/lib/labels.test.ts
+++ b/packages/web/lib/labels.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isLifecycleLabel, isSelectableIssueLabel } from "./labels";
+
+describe("label helpers", () => {
+  it("treats issuectl labels as lifecycle labels", () => {
+    expect(isLifecycleLabel("issuectl:auto-launch")).toBe(true);
+    expect(isLifecycleLabel("bug")).toBe(false);
+  });
+
+  it("allows issue creation to select auto-launch but not runtime labels", () => {
+    expect(isSelectableIssueLabel("issuectl:auto-launch")).toBe(true);
+    expect(isSelectableIssueLabel("issuectl:deployed")).toBe(false);
+    expect(isSelectableIssueLabel("issuectl:in-progress")).toBe(false);
+    expect(isSelectableIssueLabel("bug")).toBe(true);
+  });
+});

--- a/packages/web/lib/labels.ts
+++ b/packages/web/lib/labels.ts
@@ -1,7 +1,13 @@
 import type { GitHubLabel } from "@issuectl/core";
 
+const SELECTABLE_ISSUECTL_LABELS = new Set(["issuectl:auto-launch"]);
+
 export function isLifecycleLabel(name: string): boolean {
   return name.startsWith("issuectl:");
+}
+
+export function isSelectableIssueLabel(name: string): boolean {
+  return !isLifecycleLabel(name) || SELECTABLE_ISSUECTL_LABELS.has(name);
 }
 
 export function separateLabels(labels: GitHubLabel[]): {


### PR DESCRIPTION
## Summary
- allow `issuectl:auto-launch` to appear in issue creation label pickers
- keep runtime lifecycle labels such as `issuectl:deployed` hidden
- add focused tests for selectable issue labels

## Verification
- `pnpm --dir packages/web test labels.test.ts`
- `pnpm --dir packages/web typecheck`
- commit hooks: repo typecheck + lint
- Playwright check confirmed `/new` shows `issuectl:auto-launch` for `mean-weasel/issuectl-test-repo-2`
