### PR TITLE
Consume auto-launch labels after webhook launch

### DIFF
--- a/packages/web/lib/webhook-intent-worker.test.ts
+++ b/packages/web/lib/webhook-intent-worker.test.ts
@@ -78,6 +78,7 @@ function testWorkerDeps() {
       _db.prepare("UPDATE deployments SET triggered_by = ? WHERE id = ?").run(triggeredBy, deploymentId);
       return { deploymentId };
     },
+    consumeIssueAutoLaunchLabel: async () => {},
   };
 }
 
@@ -121,6 +122,7 @@ describe("runWebhookIntentWorkerOnce", () => {
 
   it("launches due opted-in issue intents", async () => {
     const launchIssue = vi.fn(testWorkerDeps().launchIssue);
+    const consumeIssueAutoLaunchLabel = vi.fn(testWorkerDeps().consumeIssueAutoLaunchLabel);
     const intentId = mergeWebhookIntent(db, {
       repoId,
       targetType: "issue",
@@ -130,7 +132,7 @@ describe("runWebhookIntentWorkerOnce", () => {
       requestedAgent: "codex",
     });
 
-    const result = await runWorker(db, 2_000, { launchIssue });
+    const result = await runWorker(db, 2_000, { launchIssue, consumeIssueAutoLaunchLabel });
 
     expectWorkerResult(result, { claimed: 1, launched: 1 });
     expect(launchIssue).toHaveBeenCalledWith(
@@ -140,6 +142,12 @@ describe("runWebhookIntentWorkerOnce", () => {
       expect.objectContaining({ title: "Fix webhook auto launch" }),
       "webhook",
       expect.stringMatching(/^[0-9a-f-]{36}$/),
+    );
+    expect(consumeIssueAutoLaunchLabel).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ id: repoId }),
+      expect.objectContaining({ id: intentId }),
+      1,
     );
     expect(queryDiagnosticEvents(db, {
       target: { owner: "mean-weasel", repo: "issuectl", targetType: "issue", targetNumber: 506 },
@@ -161,6 +169,67 @@ describe("runWebhookIntentWorkerOnce", () => {
       }),
     );
     expect(db.prepare("SELECT agent FROM deployments WHERE id = 1").get()).toEqual({ agent: "codex" });
+  });
+
+  it("ignores the unlabeled webhook caused by consuming auto-launch after launch", async () => {
+    const deploymentId = recordDeployment(db, {
+      repoId,
+      issueNumber: 506,
+      branchName: "issue-506",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/issuectl-live",
+    }).id;
+    db.prepare("UPDATE deployments SET triggered_by = 'webhook' WHERE id = ?").run(deploymentId);
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, '1')").run(
+      `webhook:consumed-auto-launch:${repoId}:506`,
+    );
+    const priorIntentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      signalAt: 500,
+      scheduledAt: 500,
+    });
+    db.prepare("UPDATE webhook_intents SET status = 'launched', deployment_id = ?, resolved_at = ? WHERE id = ?").run(deploymentId, 600, priorIntentId);
+    const event = recordWebhookEvent(db, {
+      deliveryId: "delivery-consumed-auto-label",
+      repoId,
+      eventType: "issues",
+      action: "unlabeled",
+      targetType: "issue",
+      targetNumber: 506,
+      receivedAt: 1_000,
+    });
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "issue",
+      targetNumber: 506,
+      signalAt: 1_000,
+      scheduledAt: 2_000,
+      eventId: event.deduped ? null : event.eventId,
+    });
+
+    const result = await runWorker(db, 2_000, {
+      fetchIssueState: async () => ({
+        title: "Fix webhook auto launch",
+        state: "open",
+        labels: ["issuectl:deployed", "issuectl:in-progress"],
+      }),
+    });
+
+    expectWorkerResult(result, { claimed: 1, skippedOptout: 1 });
+    expect(getDeploymentByIdForTest(db, deploymentId)).toEqual({ ended_at: null });
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({
+        status: "skipped_optout",
+        failure_reason: "Auto-launch label consumed after launch",
+      }),
+    );
+    expect(db.prepare("SELECT COUNT(*) AS count FROM settings WHERE key = ?").get(
+      `webhook:consumed-auto-launch:${repoId}:506`,
+    )).toEqual({ count: 0 });
+    expect(queryDiagnosticEvents(db, { events: ["webhook.kill_switch"] })).toHaveLength(0);
+    expect(queryDiagnosticEvents(db, { events: ["webhook.auto_launch_label_consumed"] })).toHaveLength(1);
   });
 
   it("broadcasts live-tail updates when issue intent state changes", async () => {

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -13,6 +13,7 @@ import {
   killTmuxSession,
   killTtyd,
   recordDiagnosticEventSafely,
+  removeLabel,
   recoverExpiredWebhookIntentLeaseRecords,
   tmuxSessionName,
   withAuthRetry,
@@ -51,6 +52,12 @@ type WorkerDeps = {
     triggeredBy: "webhook" | "comment_command",
     completionToken: string,
   ) => Promise<{ deploymentId: number }>;
+  consumeIssueAutoLaunchLabel?: (
+    db: Database.Database,
+    repo: Repo,
+    intent: WebhookIntent,
+    deploymentId: number,
+  ) => Promise<void>;
   launchPr?: LaunchPrReview;
   isAncestor?: PullWorkerDeps["isAncestor"];
   broadcastEventsChanged?: () => void;
@@ -136,6 +143,13 @@ export async function runWebhookIntentWorkerOnce(
     const event = getLatestIntentEvent(db, intent.id);
     const triggeredBy = triggeredByForIntentEvent(event);
     if (isIssueControlEvent(event) || (triggeredBy === "webhook" && repo.autoLaunchIssues === false)) {
+      if (isConsumedAutoLaunchLabelEvent(db, repo.id, intent.targetNumber, event)) {
+        clearConsumedAutoLaunchLabel(db, repo.id, intent.targetNumber);
+        recordIntentDiagnostic(db, repo, intent, "webhook.auto_launch_label_consumed", "Consumed auto-launch label after launch.");
+        markIntentTerminal(db, intent.id, "skipped_optout", now, "Auto-launch label consumed after launch");
+        broadcastEventsChanged();
+        return result(base, { claimed: 1, skippedOptout: 1 });
+      }
       const endedSessions = endWebhookSessionForTarget(db, repo, intent, terminalReasonForControl(event));
       recordIntentDiagnostic(db, repo, intent, "webhook.kill_switch", endedSessions > 0 ? "Ended webhook-launched session." : "No webhook-launched session to end.");
       markIntentTerminal(db, intent.id, "skipped_optout", now, "Control event or repo auto-launch disabled");
@@ -176,6 +190,12 @@ export async function runWebhookIntentWorkerOnce(
       issue,
       triggeredBy,
       completionToken,
+    );
+    await (deps.consumeIssueAutoLaunchLabel ?? consumeIssueAutoLaunchLabel)(
+      db,
+      repo,
+      intent,
+      launch.deploymentId,
     );
     markIntentTerminal(db, intent.id, "launched", now, null, launch.deploymentId);
     recordIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched issue session.", launch.deploymentId);
@@ -263,6 +283,67 @@ function isIssueGatedIn(repo: Repo, issue: IssueState): boolean {
 
 function isIssueControlEvent(event: IntentEventSummary): boolean {
   return event?.eventType === "issues" && (event.action === "closed" || event.action === "unlabeled");
+}
+
+async function consumeIssueAutoLaunchLabel(
+  db: Database.Database,
+  repo: Repo,
+  intent: WebhookIntent,
+  deploymentId: number,
+): Promise<void> {
+  try {
+    await withAuthRetry((octokit) =>
+      removeLabel(octokit, repo.owner, repo.name, intent.targetNumber, ISSUE_AUTO_LAUNCH_LABEL),
+    );
+    markAutoLaunchLabelConsumed(db, repo.id, intent.targetNumber);
+    recordIntentDiagnostic(db, repo, intent, "webhook.auto_launch_label_consumed", "Removed auto-launch label after successful launch.", deploymentId);
+  } catch (err) {
+    recordIntentDiagnostic(
+      db,
+      repo,
+      intent,
+      "webhook.auto_launch_label_remove_failed",
+      err instanceof Error ? err.message : String(err),
+      deploymentId,
+    );
+  }
+}
+
+function consumedAutoLaunchLabelKey(repoId: number, issueNumber: number): string {
+  return `webhook:consumed-auto-launch:${repoId}:${issueNumber}`;
+}
+
+function markAutoLaunchLabelConsumed(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): void {
+  db.prepare(
+    "INSERT INTO settings (key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+  ).run(consumedAutoLaunchLabelKey(repoId, issueNumber));
+}
+
+function isConsumedAutoLaunchLabelEvent(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+  event: IntentEventSummary,
+): boolean {
+  if (event?.eventType !== "issues" || event.action !== "unlabeled") return false;
+  const row = db.prepare("SELECT 1 FROM settings WHERE key = ?").get(
+    consumedAutoLaunchLabelKey(repoId, issueNumber),
+  );
+  return Boolean(row);
+}
+
+function clearConsumedAutoLaunchLabel(
+  db: Database.Database,
+  repoId: number,
+  issueNumber: number,
+): void {
+  db.prepare("DELETE FROM settings WHERE key = ?").run(
+    consumedAutoLaunchLabelKey(repoId, issueNumber),
+  );
 }
 
 function markIntentTerminal(


### PR DESCRIPTION
## Summary
- remove `issuectl:auto-launch` after a webhook issue launch succeeds
- record a local one-shot marker so the resulting unlabeled webhook does not end the session that was just launched
- add regression coverage for consumed-label unlabeled events

## Verification
- `pnpm --dir packages/web test webhook-intent-worker.test.ts`
- `pnpm --dir packages/web typecheck`
- commit hooks: repo typecheck + lint
- pre-push hook: repo build after rebuilding local `better-sqlite3` for Node v24
