### PR TITLE
Clear in-progress label when agents complete

### DIFF
--- a/packages/web/app/api/v1/agent/completion/route.test.ts
+++ b/packages/web/app/api/v1/agent/completion/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 
 const getDb = vi.hoisted(() => vi.fn());
 const recordAgentCompletionCheckIn = vi.hoisted(() => vi.fn());
+const cleanupCompletedIssueLifecycleLabels = vi.hoisted(() => vi.fn());
 
 vi.mock("@issuectl/core", () => ({
   getDb: () => getDb(),
@@ -11,6 +12,8 @@ vi.mock("@issuectl/core", () => ({
 vi.mock("@/lib/agent/completion", () => ({
   recordAgentCompletionCheckIn: (...args: unknown[]) =>
     recordAgentCompletionCheckIn(...args),
+  cleanupCompletedIssueLifecycleLabels: (...args: unknown[]) =>
+    cleanupCompletedIssueLifecycleLabels(...args),
   isAgentCompletionStatus: (value: unknown) =>
     ["completed", "failed", "no_changes", "pushed_fixes"].includes(String(value)),
 }));
@@ -27,6 +30,7 @@ function request(body: unknown): NextRequest {
 beforeEach(() => {
   getDb.mockReturnValue("db");
   recordAgentCompletionCheckIn.mockReset();
+  cleanupCompletedIssueLifecycleLabels.mockReset();
 });
 
 describe("/api/v1/agent/completion", () => {
@@ -61,6 +65,7 @@ describe("/api/v1/agent/completion", () => {
       fixedFindingCount: 2,
       errorMessage: "non-blocking warning",
     });
+    expect(cleanupCompletedIssueLifecycleLabels).toHaveBeenCalledWith("db", 12);
   });
 
   it("rejects malformed rich metadata", async () => {

--- a/packages/web/app/api/v1/agent/completion/route.ts
+++ b/packages/web/app/api/v1/agent/completion/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@issuectl/core";
 import {
+  cleanupCompletedIssueLifecycleLabels,
   isAgentCompletionStatus,
   recordAgentCompletionCheckIn,
 } from "@/lib/agent/completion";
@@ -32,7 +33,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const result = recordAgentCompletionCheckIn(getDb(), parsed);
+  const db = getDb();
+  const result = recordAgentCompletionCheckIn(db, parsed);
+  if (result.accepted && !result.duplicate) {
+    await cleanupCompletedIssueLifecycleLabels(db, parsed.deploymentId);
+  }
   return NextResponse.json(result, { status: result.accepted ? 200 : 403 });
 }
 

--- a/packages/web/lib/agent/completion.ts
+++ b/packages/web/lib/agent/completion.ts
@@ -1,7 +1,11 @@
 import type Database from "better-sqlite3";
 import {
+  clearCacheKey,
   getRepoById,
+  LIFECYCLE_LABEL,
   recordDiagnosticEventSafely,
+  removeLabel,
+  withAuthRetry,
 } from "@issuectl/core";
 import { notifyDeploymentTerminalOutcome } from "@/lib/push/notifications";
 
@@ -88,6 +92,54 @@ export function recordAgentCompletionCheckIn(
   return deny(db, input, "already_completed");
 }
 
+export async function cleanupCompletedIssueLifecycleLabels(
+  db: Database.Database,
+  deploymentId: number,
+): Promise<void> {
+  const session = getCompletionSession(db, deploymentId);
+  if (!session || session.targetType !== "issue" || session.targetNumber <= 0) return;
+  const repo = getRepoById(db, session.repoId);
+  if (!repo) return;
+
+  try {
+    await withAuthRetry((octokit) =>
+      removeLabel(
+        octokit,
+        repo.owner,
+        repo.name,
+        session.targetNumber,
+        LIFECYCLE_LABEL.inProgress,
+      ),
+    );
+    clearIssueCaches(db, repo.owner, repo.name, session.targetNumber);
+    recordDiagnosticEventSafely(db, {
+      level: "info",
+      event: "lifecycle.in_progress_label_removed",
+      source: "agent.completion",
+      owner: repo.owner,
+      repo: repo.name,
+      issueNumber: session.targetNumber,
+      targetType: "issue",
+      targetNumber: session.targetNumber,
+      deploymentId,
+      message: "Removed in-progress label after agent completion",
+    });
+  } catch (err) {
+    recordDiagnosticEventSafely(db, {
+      level: "warn",
+      event: "lifecycle.in_progress_label_cleanup_failed",
+      source: "agent.completion",
+      owner: repo.owner,
+      repo: repo.name,
+      issueNumber: session.targetNumber,
+      targetType: "issue",
+      targetNumber: session.targetNumber,
+      deploymentId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 function getCompletionSession(
   db: Database.Database,
   deploymentId: number,
@@ -143,6 +195,18 @@ function recordCompletionDiagnostic(
     message: reason ? `Agent completion denied: ${reason}` : "Agent completion recorded",
     data: { status: input.status, reason, targetType, targetNumber },
   });
+}
+
+function clearIssueCaches(
+  db: Database.Database,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): void {
+  clearCacheKey(db, `issue-detail:${owner}/${repo}#${issueNumber}`);
+  clearCacheKey(db, `issue-header:${owner}/${repo}#${issueNumber}`);
+  clearCacheKey(db, `issue-content:${owner}/${repo}#${issueNumber}`);
+  clearCacheKey(db, `issues:${owner}/${repo}`);
 }
 
 function completionResult(input: AgentCompletionInput): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- remove `issuectl:in-progress` when an agent completion check-in is first accepted for an issue deployment
- clear issue caches after lifecycle cleanup so the issue detail UI reflects the completed state
- record diagnostics for successful or failed lifecycle cleanup

## Context
Manual QA on `mean-weasel/issuectl-test-repo-2#28` confirmed Codex preflight/trust worked and the terminal launched without a permission prompt, but the issue kept `issuectl:in-progress` after the no-op agent completed. This fixes that stale label path.

## Tests
- `pnpm --dir packages/web test agent/completion.test.ts route.test.ts`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- pre-commit hook: turbo typecheck/build/lint passed
- push hook: turbo typecheck passed; web build skipped because local dev server was running on `:3847`
