### PR TITLE
Fix PR label auto-review workflow

### DIFF
--- a/docs/workflows/webhook-auto-sessions.md
+++ b/docs/workflows/webhook-auto-sessions.md
@@ -1,0 +1,97 @@
+# Webhook Auto-Sessions Runbook
+
+This runbook covers the v1 GitHub webhook auto-session flow for issue launches and PR review sessions.
+
+## Receiver URL
+
+The local web server handles GitHub deliveries before Next.js request parsing so HMAC verification can use the raw request body.
+
+```text
+POST /api/webhook/github/<repo_id>
+```
+
+The singular `/api/webhook/...` route is intentional and matches the backend receiver contract. Some UX planning notes used plural wording for related event-stream routes, but repository webhooks should point at the singular receiver URL.
+
+## Public Tunnel
+
+`issuectl` does not manage a bundled tunnel. Use any public HTTPS endpoint that forwards to the dashboard port, usually `3847`.
+
+```bash
+cloudflared tunnel --url http://localhost:3847
+ngrok http 3847
+tailscale funnel 3847
+```
+
+Save the public base URL with either the CLI or the dashboard settings surface:
+
+```bash
+issuectl repo set mean-weasel/issuectl --webhook-base-url https://example.trycloudflare.com
+```
+
+Then install or rotate the GitHub hook:
+
+```bash
+issuectl webhook create mean-weasel/issuectl
+issuectl webhook rotate mean-weasel/issuectl --yes
+```
+
+`issuectl repo add --webhook` performs advisory checks for `gh` hook scope and `cloudflared`, but missing `cloudflared` is not fatal. Operators may use ngrok, Tailscale Funnel, a reverse proxy, or another public endpoint.
+
+## Opt-In Model
+
+Automatic work requires both a repo flag and a target label.
+
+| Target | Repo flag | GitHub label |
+| --- | --- | --- |
+| Issue | `auto_launch_issues` | `issuectl:auto-launch` |
+| PR | `auto_review_prs` | `issuectl:auto-review` |
+
+Useful setup commands:
+
+```bash
+issuectl repo add mean-weasel/issuectl --auto-launch-issues --auto-review-prs --issue-agent codex --review-agent codex
+issuectl repo show mean-weasel/issuectl
+issuectl webhook status mean-weasel/issuectl
+```
+
+Disabling a repo automation flag ends matching active webhook sessions and records diagnostics with affected session ids.
+
+## Debugging
+
+Start with the diagnostics journal for launch, terminal, and session failures:
+
+```bash
+pnpm --dir packages/cli exec issuectl diag list --limit 50
+pnpm --dir packages/cli exec issuectl diag show --deployment <deployment-id>
+pnpm --dir packages/cli exec issuectl diag tail --issue mean-weasel/issuectl#506
+```
+
+For webhook intake and debounce state:
+
+```bash
+issuectl webhook tail --repo mean-weasel/issuectl --target issue#506
+issuectl webhook intents --repo mean-weasel/issuectl --status active
+issuectl webhook intent fire 42 --yes
+issuectl webhook intent drop 42 --reason operator_dropped --yes
+```
+
+Use the dashboard routes for operator inspection:
+
+```text
+/logs/webhooks
+/sessions?tab=reviews
+/reviews/<review_id>
+/repos/<owner>/<repo>/settings
+```
+
+## Security Notes
+
+- Webhook signatures are verified before JSON parsing or event writes.
+- `webhook_secret`, raw signatures, and raw request bodies are not printed in CLI status, diagnostics, logs, or the webhook log UI.
+- The webhook log can show invalid-signature diagnostics and delivery metadata, but it intentionally does not display `X-Hub-Signature-256`.
+- Payload storage defaults to metadata-only. Raw payload mode is for short debugging windows and the dashboard redacts retained payload previews.
+- Webhook/comment-command agents must use the daemon-mediated `issuectl agent mutate` policy gateway for GitHub writes.
+
+## Deferred Product Scope
+
+The current gap-closure work intentionally does not add `issuectl issue create --auto-launch` or `issuectl pr create --auto-review`. Those flags require dedicated issue/PR creation command modules and are tracked as future product scope, separate from webhook auto-session setup and operation.

--- a/packages/core/src/data/issues.test.ts
+++ b/packages/core/src/data/issues.test.ts
@@ -79,6 +79,7 @@ function makePR(): GitHubPull {
     title: "Fix",
     body: "closes #1",
     state: "open",
+    labels: [],
     draft: false,
     merged: false,
     user: null,

--- a/packages/core/src/db/agent-completions.test.ts
+++ b/packages/core/src/db/agent-completions.test.ts
@@ -5,6 +5,7 @@ import { seedRepo } from "./deployments-test-helpers.js";
 import { recordDeployment, getDeploymentById } from "./deployments.js";
 import { queryDiagnosticEvents } from "./diagnostics.js";
 import { recordAgentCompletionCheckIn } from "./agent-completions.js";
+import { getPrReviewById, markPrReviewDeploymentStarted, reservePrReview } from "./pr-reviews.js";
 
 describe("agent completion check-ins", () => {
   let db: Database.Database;
@@ -88,5 +89,93 @@ describe("agent completion check-ins", () => {
       status: "failed",
       summary: "different",
     })).toEqual({ accepted: false, reason: "already_completed" });
+  });
+
+  it("completes the linked active PR review when a PR deployment checks in successfully", () => {
+    const repo = seedRepo(db);
+    const deployment = recordDeployment(db, {
+      repoId: repo.id,
+      targetType: "pr",
+      targetNumber: 506,
+      branchName: "pr-506",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/pr-506",
+      triggeredBy: "webhook",
+      completionToken: "token-pr-506",
+    });
+    const review = reservePrReview(db, {
+      repoId: repo.id,
+      prNumber: 506,
+      startedHeadSha: "head-a",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-a",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/pr",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    markPrReviewDeploymentStarted(db, review.id, deployment.id);
+
+    expect(recordAgentCompletionCheckIn(db, {
+      deploymentId: deployment.id,
+      completionToken: "token-pr-506",
+      status: "pushed_fixes",
+      summary: "fixed it",
+      finalHeadSha: "head-b",
+    })).toEqual({ accepted: true, duplicate: false });
+
+    expect(getPrReviewById(db, review.id)).toEqual(expect.objectContaining({
+      status: "completed",
+      completedHeadSha: "head-b",
+      completedAt: expect.any(Number),
+      resultJson: JSON.stringify({
+        status: "pushed_fixes",
+        summary: "fixed it",
+        finalHeadSha: "head-b",
+      }),
+    }));
+  });
+
+  it("fails the linked active PR review when a PR deployment reports failure", () => {
+    const repo = seedRepo(db);
+    const deployment = recordDeployment(db, {
+      repoId: repo.id,
+      targetType: "pr",
+      targetNumber: 507,
+      branchName: "pr-507",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/pr-507",
+      triggeredBy: "webhook",
+      completionToken: "token-pr-507",
+    });
+    const review = reservePrReview(db, {
+      repoId: repo.id,
+      prNumber: 507,
+      startedHeadSha: "head-a",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-a",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/pr",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    markPrReviewDeploymentStarted(db, review.id, deployment.id);
+
+    expect(recordAgentCompletionCheckIn(db, {
+      deploymentId: deployment.id,
+      completionToken: "token-pr-507",
+      status: "failed",
+      summary: "could not finish",
+    })).toEqual({ accepted: true, duplicate: false });
+
+    expect(getPrReviewById(db, review.id)).toEqual(expect.objectContaining({
+      status: "failed",
+      completedHeadSha: "head-a",
+      completedAt: expect.any(Number),
+      resultJson: JSON.stringify({
+        status: "failed",
+        summary: "could not finish",
+      }),
+    }));
   });
 });

--- a/packages/core/src/db/agent-completions.ts
+++ b/packages/core/src/db/agent-completions.ts
@@ -3,6 +3,7 @@ import type { DeploymentTerminalReason } from "../types.js";
 import { getDeploymentById } from "./deployments.js";
 import { getRepoById } from "./repos.js";
 import { recordDiagnosticEventSafely } from "./diagnostics.js";
+import { finishActivePrReviewForDeployment } from "./pr-reviews.js";
 
 export type AgentCompletionStatus =
   | "completed"
@@ -52,6 +53,14 @@ export function recordAgentCompletionCheckIn(
      WHERE id = ? AND completion_result_json IS NULL`,
   ).run(terminalReason, resultJson, input.deploymentId);
   if (result.changes > 0) {
+    if (deployment.targetType === "pr") {
+      finishActivePrReviewForDeployment(db, deployment.id, {
+        completedAt: Date.now(),
+        completedHeadSha: input.finalHeadSha ?? input.pushedCommitSha,
+        status: input.status === "failed" ? "failed" : "completed",
+        result: completionResult(input),
+      });
+    }
     recordCompletionDiagnostic(db, input, "agent.completion_recorded", "info");
     return { accepted: true, duplicate: false };
   }

--- a/packages/core/src/db/agent-mutations.test.ts
+++ b/packages/core/src/db/agent-mutations.test.ts
@@ -7,11 +7,12 @@ import { queryDiagnosticEvents } from "./diagnostics.js";
 import { initSchema, getSchemaVersion } from "./schema.js";
 import { runMigrations } from "./migrations.js";
 import {
-  evaluateAgentMutationRequest,
+  evaluateAgentMutationBudgetPreview,
   getAgentActionBudget,
   claimAgentActionBudget,
   setAgentActionBudget,
 } from "./agent-mutations.js";
+import * as agentMutations from "./agent-mutations.js";
 
 describe("agent mutation gateway foundation", () => {
   let db: Database.Database;
@@ -33,7 +34,7 @@ describe("agent mutation gateway foundation", () => {
       completionToken: "token-42",
     });
 
-    const decision = evaluateAgentMutationRequest(db, {
+    const decision = evaluateAgentMutationBudgetPreview(db, {
       deploymentId: deployment.id,
       completionToken: "token-42",
       repoId: repo.id,
@@ -74,7 +75,7 @@ describe("agent mutation gateway foundation", () => {
       completionToken: "token-42",
     });
 
-    expect(evaluateAgentMutationRequest(db, {
+    expect(evaluateAgentMutationBudgetPreview(db, {
       deploymentId: deployment.id,
       completionToken: "wrong",
       repoId: repo.id,
@@ -83,7 +84,7 @@ describe("agent mutation gateway foundation", () => {
       actionType: "comment",
     })).toEqual({ allowed: false, reason: "invalid_token" });
 
-    expect(evaluateAgentMutationRequest(db, {
+    expect(evaluateAgentMutationBudgetPreview(db, {
       deploymentId: deployment.id,
       completionToken: "token-42",
       repoId: repo.id,
@@ -104,7 +105,7 @@ describe("agent mutation gateway foundation", () => {
       completionToken: "token-42",
     });
 
-    expect(evaluateAgentMutationRequest(db, {
+    expect(evaluateAgentMutationBudgetPreview(db, {
       deploymentId: deployment.id,
       completionToken: "token-42",
       repoId: repo.id,
@@ -136,6 +137,11 @@ describe("agent mutation gateway foundation", () => {
       limitCount: 1,
       usedCount: 1,
     });
+  });
+
+  it("does not export a daemon-style mutation evaluator from core", () => {
+    expect("evaluateAgentMutationRequest" in agentMutations).toBe(false);
+    expect(typeof agentMutations.evaluateAgentMutationBudgetPreview).toBe("function");
   });
 });
 

--- a/packages/core/src/db/agent-mutations.ts
+++ b/packages/core/src/db/agent-mutations.ts
@@ -58,7 +58,7 @@ export function isAgentMutationAction(value: unknown): value is AgentMutationAct
   return typeof value === "string" && AGENT_MUTATION_ACTIONS.includes(value as AgentMutationAction);
 }
 
-export function evaluateAgentMutationRequest(
+export function evaluateAgentMutationBudgetPreview(
   db: Database.Database,
   request: AgentMutationRequest,
 ): AgentMutationDecision {

--- a/packages/core/src/db/deployments.test.ts
+++ b/packages/core/src/db/deployments.test.ts
@@ -4,7 +4,8 @@ import type Database from "better-sqlite3";
 import { createTestDb } from "./test-helpers.js";
 import { addRepo } from "./repos.js";
 import { seedRepo } from "./deployments-test-helpers.js";
-import { recordDeployment, getDeploymentById, getDeploymentsForIssue, getDeploymentsByRepo, getActiveWebhookDeploymentsForRepoTarget, listRecentTerminalDeploymentsByRepo, updateLinkedPR, endDeployment, setIdleSince, transitionDeploymentTerminal } from "./deployments.js";
+import { recordDeployment, getDeploymentById, getDeploymentsForIssue, getDeploymentsForTarget, getDeploymentsByRepo, getActiveWebhookDeploymentsForRepoTarget, listRecentTerminalDeploymentsByRepo, updateLinkedPR, endDeployment, setIdleSince, transitionDeploymentTerminal } from "./deployments.js";
+import { getPrReviewById, markPrReviewDeploymentStarted, reservePrReview } from "./pr-reviews.js";
 
 describe("recordDeployment", () => {
   let db: Database.Database;
@@ -273,6 +274,37 @@ describe("getDeploymentsForIssue", () => {
   });
 });
 
+describe("getDeploymentsForTarget", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("returns active PR target deployments without mixing issue deployments", () => {
+    const repo = seedRepo(db);
+    const prDeployment = recordDeployment(db, {
+      repoId: repo.id,
+      targetType: "pr",
+      targetNumber: 31,
+      branchName: "pr-31-review",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/pr-31",
+    });
+    recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 31,
+      branchName: "issue-31",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/issue-31",
+    });
+
+    expect(getDeploymentsForTarget(db, repo.id, "pr", 31)).toEqual([
+      expect.objectContaining({ id: prDeployment.id, targetType: "pr", targetNumber: 31 }),
+    ]);
+  });
+});
+
 describe("getDeploymentsByRepo", () => {
   let db: Database.Database;
 
@@ -400,5 +432,75 @@ describe("endDeployment", () => {
     expect(first.deployment.endedAt).toBeTruthy();
     expect(second.changed).toBe(false);
     expect(second.deployment.terminalReason).toBe("killed_by_label");
+  });
+
+  it("supersedes the linked active PR review when a PR deployment is manually ended", () => {
+    const repo = seedRepo(db);
+    const dep = recordDeployment(db, {
+      repoId: repo.id,
+      targetType: "pr",
+      targetNumber: 506,
+      branchName: "pr-506-review",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    const review = reservePrReview(db, {
+      repoId: repo.id,
+      prNumber: 506,
+      startedHeadSha: "head-a",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-a",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/pr",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    expect(markPrReviewDeploymentStarted(db, review.id, dep.id)).toEqual(expect.objectContaining({
+      id: review.id,
+      status: "in_progress",
+    }));
+
+    endDeployment(db, dep.id, "ended_manual");
+
+    expect(getPrReviewById(db, review.id)).toEqual(expect.objectContaining({
+      status: "superseded",
+      completedAt: expect.any(Number),
+      resultJson: JSON.stringify({ reason: "ended_manual" }),
+    }));
+  });
+
+  it("fails the linked active PR review when a PR deployment goes terminal for liveness", () => {
+    const repo = seedRepo(db);
+    const dep = recordDeployment(db, {
+      repoId: repo.id,
+      targetType: "pr",
+      targetNumber: 507,
+      branchName: "pr-507-review",
+      workspaceMode: "existing",
+      workspacePath: "/x",
+    });
+    const review = reservePrReview(db, {
+      repoId: repo.id,
+      prNumber: 507,
+      startedHeadSha: "head-b",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-b",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/pr",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    markPrReviewDeploymentStarted(db, review.id, dep.id);
+
+    const first = transitionDeploymentTerminal(db, dep.id, "liveness_missing");
+    const second = transitionDeploymentTerminal(db, dep.id, "failed");
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(getPrReviewById(db, review.id)).toEqual(expect.objectContaining({
+      status: "failed",
+      completedAt: expect.any(Number),
+      resultJson: JSON.stringify({ reason: "liveness_missing" }),
+    }));
   });
 });

--- a/packages/core/src/db/deployments.ts
+++ b/packages/core/src/db/deployments.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import type Database from "better-sqlite3";
 import type { Deployment, DeploymentState, DeploymentTargetType, DeploymentTerminalReason, DeploymentTriggeredBy, LaunchAgent, TerminalBackend } from "../types.js";
+import { markActivePrReviewForDeploymentTerminal } from "./pr-reviews.js";
 
 type DeploymentRow = {
   id: number; repo_id: number; issue_number: number | null; target_type: string; target_number: number; agent: string;
@@ -129,6 +130,26 @@ export function getDeploymentsForIssue(db: Database.Database, repoId: number, is
   return rows.map(rowToDeployment);
 }
 
+export function getDeploymentsForTarget(
+  db: Database.Database,
+  repoId: number,
+  targetType: DeploymentTargetType,
+  targetNumber: number,
+): Deployment[] {
+  const rows = db
+    .prepare(
+      `SELECT *
+       FROM deployments
+       WHERE repo_id = ?
+         AND target_type = ?
+         AND target_number = ?
+         AND state = 'active'
+       ORDER BY launched_at DESC`,
+    )
+    .all(repoId, targetType, targetNumber) as DeploymentRow[];
+  return rows.map(rowToDeployment);
+}
+
 export function getDeploymentsByRepo(db: Database.Database, repoId: number): Deployment[] {
   // See getDeploymentsForIssue — pending rows are excluded from all
   // callers except the launch rollback path.
@@ -241,6 +262,9 @@ export function transitionDeploymentTerminal(
     .run(terminalReason ?? null, deploymentId);
   const deployment = getDeploymentById(db, deploymentId);
   if (!deployment) throw new Error(`No deployment found with id ${deploymentId}`);
+  if (result.changes > 0) {
+    markPrDeploymentReviewTerminal(db, deployment, terminalReason);
+  }
   return { deployment, changed: result.changes > 0 };
 }
 
@@ -256,6 +280,20 @@ export function markDeploymentNotificationSent(db: Database.Database, deployment
     .prepare("UPDATE deployments SET notification_sent_at = COALESCE(notification_sent_at, datetime('now')) WHERE id = ?")
     .run(deploymentId);
   if (result.changes === 0) throw new Error(`No deployment found with id ${deploymentId}`);
+}
+
+function markPrDeploymentReviewTerminal(
+  db: Database.Database,
+  deployment: Deployment,
+  terminalReason?: DeploymentTerminalReason,
+): void {
+  if (deployment.targetType !== "pr") return;
+  const failedReasons = new Set<DeploymentTerminalReason>(["failed", "timeout", "liveness_missing"]);
+  markActivePrReviewForDeploymentTerminal(db, deployment.id, {
+    completedAt: Date.now(),
+    status: terminalReason && failedReasons.has(terminalReason) ? "failed" : "superseded",
+    reason: terminalReason ?? "deployment_terminal",
+  });
 }
 
 export function claimDeploymentNotificationSent(db: Database.Database, deploymentId: number): boolean {

--- a/packages/core/src/db/pr-reviews.test.ts
+++ b/packages/core/src/db/pr-reviews.test.ts
@@ -8,6 +8,7 @@ import { runMigrations } from "./migrations.js";
 import {
   coalescePrReviewDesiredHead,
   completePrReview,
+  finishActivePrReviewForDeployment,
   getActivePrReview,
   getActivePrReviewForDeployment,
   getLatestCompletedPrReview,
@@ -318,7 +319,7 @@ describe("pr_reviews", () => {
     expect(getActivePrReview(db, repoId, 506)).toBeUndefined();
   });
 
-  it("links a launching review only to an active deployment for the same PR target", () => {
+  it("finishes the active review for a completed agent deployment", () => {
     db.prepare(
       `INSERT INTO deployments (
         id, repo_id, issue_number, target_type, target_number, branch_name,
@@ -328,29 +329,50 @@ describe("pr_reviews", () => {
     const review = reservePrReview(db, {
       repoId,
       prNumber: 506,
-      startedHeadSha: "head-b",
+      deploymentId: 79,
+      startedHeadSha: "head-a",
       reviewBaseSha: "base-a",
-      reviewedToSha: "head-b",
+      reviewedToSha: "head-a",
       headRepoFullName: "mean-weasel/issuectl",
       headRef: "feature/webhooks",
       triggeredBy: "webhook",
       startedAt: 1_000,
     });
-    db.prepare("UPDATE pr_reviews SET status = 'launching' WHERE id = ?").run(review.id);
+    coalescePrReviewDesiredHead(db, review.id, {
+      desiredHeadSha: "head-b",
+      desiredBaseSha: "base-a",
+      desiredHeadRef: "feature/webhooks",
+    });
 
-    expect(markPrReviewDeploymentStarted(db, review.id, 79)).toEqual(expect.objectContaining({
+    const updated = finishActivePrReviewForDeployment(db, 79, {
+      completedAt: 2_000,
+      completedHeadSha: "head-b",
+      status: "completed",
+      result: { status: "pushed_fixes", summary: "fixed" },
+    });
+
+    expect(updated).toEqual(expect.objectContaining({
       id: review.id,
-      status: "in_progress",
-      deploymentId: 79,
+      status: "completed",
+      completedHeadSha: "head-b",
+      completedAt: 2_000,
+      resultJson: JSON.stringify({
+        desiredHeadSha: "head-b",
+        desiredBaseSha: "base-a",
+        desiredHeadRef: "feature/webhooks",
+        followUpGeneration: 1,
+        status: "pushed_fixes",
+        summary: "fixed",
+      }),
     }));
   });
 
-  it("refuses to link a review to a deployment for a different target", () => {
+  it("links a launching review only to an active deployment for the same PR target", () => {
     db.prepare(
       `INSERT INTO deployments (
         id, repo_id, issue_number, target_type, target_number, branch_name,
         workspace_mode, workspace_path
-      ) VALUES (80, ?, 506, 'issue', 506, 'issue-506', 'existing', '/tmp/repo')`,
+      ) VALUES (80, ?, NULL, 'pr', 506, 'pr-506', 'existing', '/tmp/repo')`,
     ).run(repoId);
     const review = reservePrReview(db, {
       repoId,
@@ -365,7 +387,34 @@ describe("pr_reviews", () => {
     });
     db.prepare("UPDATE pr_reviews SET status = 'launching' WHERE id = ?").run(review.id);
 
-    expect(markPrReviewDeploymentStarted(db, review.id, 80)).toBeUndefined();
+    expect(markPrReviewDeploymentStarted(db, review.id, 80)).toEqual(expect.objectContaining({
+      id: review.id,
+      status: "in_progress",
+      deploymentId: 80,
+    }));
+  });
+
+  it("refuses to link a review to a deployment for a different target", () => {
+    db.prepare(
+      `INSERT INTO deployments (
+        id, repo_id, issue_number, target_type, target_number, branch_name,
+        workspace_mode, workspace_path
+      ) VALUES (81, ?, 506, 'issue', 506, 'issue-506', 'existing', '/tmp/repo')`,
+    ).run(repoId);
+    const review = reservePrReview(db, {
+      repoId,
+      prNumber: 506,
+      startedHeadSha: "head-b",
+      reviewBaseSha: "base-a",
+      reviewedToSha: "head-b",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/webhooks",
+      triggeredBy: "webhook",
+      startedAt: 1_000,
+    });
+    db.prepare("UPDATE pr_reviews SET status = 'launching' WHERE id = ?").run(review.id);
+
+    expect(markPrReviewDeploymentStarted(db, review.id, 81)).toBeUndefined();
     expect(getPrReviewById(db, review.id)).toEqual(expect.objectContaining({
       status: "launching",
       deploymentId: null,
@@ -377,7 +426,7 @@ describe("pr_reviews", () => {
       `INSERT INTO deployments (
         id, repo_id, issue_number, target_type, target_number, branch_name,
         workspace_mode, workspace_path, ended_at
-      ) VALUES (81, ?, NULL, 'pr', 507, 'pr-507', 'existing', '/tmp/repo', datetime('now'))`,
+      ) VALUES (82, ?, NULL, 'pr', 507, 'pr-507', 'existing', '/tmp/repo', datetime('now'))`,
     ).run(repoId);
     const reserved = reservePrReview(db, {
       repoId,
@@ -393,7 +442,7 @@ describe("pr_reviews", () => {
     const endedDeployment = reservePrReview(db, {
       repoId,
       prNumber: 507,
-      deploymentId: 81,
+      deploymentId: 82,
       startedHeadSha: "head-c",
       reviewBaseSha: "base-a",
       reviewedToSha: "head-c",

--- a/packages/core/src/db/pr-reviews.ts
+++ b/packages/core/src/db/pr-reviews.ts
@@ -168,6 +168,37 @@ export function markActivePrReviewForDeploymentTerminal(
   return getPrReviewById(db, review.id);
 }
 
+export function finishActivePrReviewForDeployment(
+  db: Database.Database,
+  deploymentId: number,
+  input: {
+    completedAt: number;
+    completedHeadSha?: string | null;
+    status: Extract<PrReviewStatus, "completed" | "failed">;
+    result?: unknown;
+  },
+): PrReview | undefined {
+  const review = getActivePrReviewForDeployment(db, deploymentId);
+  if (!review) return undefined;
+  const previous = parseResultJson(review.resultJson);
+  const current = asResultObject(input.result);
+  db.prepare(
+    `UPDATE pr_reviews
+     SET status = ?,
+         completed_head_sha = ?,
+         completed_at = ?,
+         result_json = ?
+     WHERE id = ?`,
+  ).run(
+    input.status,
+    input.completedHeadSha ?? review.reviewedToSha,
+    input.completedAt,
+    JSON.stringify({ ...previous, ...current }),
+    review.id,
+  );
+  return getPrReviewById(db, review.id);
+}
+
 export function markPrReviewDeploymentStarted(
   db: Database.Database,
   reviewId: number,
@@ -261,4 +292,8 @@ function parseResultJson(value: string | null): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function asResultObject(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }

--- a/packages/core/src/github/pr-safety.test.ts
+++ b/packages/core/src/github/pr-safety.test.ts
@@ -15,6 +15,7 @@ function pull(overrides: Partial<GitHubPull> = {}): GitHubPull {
     title: "Webhook reviews",
     body: null,
     state: "open",
+    labels: [],
     draft: false,
     merged: false,
     user: null,

--- a/packages/core/src/github/pulls.ts
+++ b/packages/core/src/github/pulls.ts
@@ -12,6 +12,7 @@ function mapPull(raw: unknown): GitHubPull {
     draft: boolean;
     merged: boolean;
     merged_at: string | null;
+    labels?: Array<{ name?: string; color?: string; description?: string | null } | string>;
     user: RawGitHubUser;
     head: { ref: string; sha: string; repo: { full_name: string } | null };
     base: { ref: string; sha: string; repo: { full_name: string } | null };
@@ -28,6 +29,17 @@ function mapPull(raw: unknown): GitHubPull {
     title: r.title,
     body: r.body,
     state: r.state as GitHubPull["state"],
+    labels: (r.labels ?? [])
+      .map((label) =>
+        typeof label === "string"
+          ? { name: label, color: "", description: null }
+          : {
+            name: label.name ?? "",
+            color: label.color ?? "",
+            description: label.description ?? null,
+          }
+      )
+      .filter((label) => label.name.length > 0),
     draft: r.draft ?? false,
     merged: r.merged ?? r.merged_at !== null,
     user: mapUser(r.user),

--- a/packages/core/src/github/types.ts
+++ b/packages/core/src/github/types.ts
@@ -38,6 +38,7 @@ export type GitHubPull = {
   title: string;
   body: string | null;
   state: "open" | "closed";
+  labels: GitHubLabel[];
   draft: boolean;
   merged: boolean;
   user: GitHubUser | null;

--- a/packages/core/src/launch/agent-preflight.test.ts
+++ b/packages/core/src/launch/agent-preflight.test.ts
@@ -3,23 +3,36 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  shouldTrustAgentWorkspace,
   shouldTrustCodexWorkspace,
+  trustClaudeProject,
   trustCodexProject,
 } from "./agent-preflight.js";
 
 describe("agent preflight", () => {
   let codexHome: string | null = null;
+  let claudeConfigPath: string | null = null;
   const previousCodexHome = process.env.CODEX_HOME;
+  const previousClaudeConfigPath = process.env.ISSUECTL_CLAUDE_CONFIG_PATH;
 
   afterEach(async () => {
     if (codexHome) {
       await rm(codexHome, { recursive: true, force: true });
       codexHome = null;
     }
+    if (claudeConfigPath) {
+      await rm(claudeConfigPath, { force: true });
+      claudeConfigPath = null;
+    }
     if (previousCodexHome === undefined) {
       delete process.env.CODEX_HOME;
     } else {
       process.env.CODEX_HOME = previousCodexHome;
+    }
+    if (previousClaudeConfigPath === undefined) {
+      delete process.env.ISSUECTL_CLAUDE_CONFIG_PATH;
+    } else {
+      process.env.ISSUECTL_CLAUDE_CONFIG_PATH = previousClaudeConfigPath;
     }
   });
 
@@ -28,6 +41,15 @@ describe("agent preflight", () => {
     expect(shouldTrustCodexWorkspace("codex", "comment_command")).toBe(true);
     expect(shouldTrustCodexWorkspace("codex", "manual")).toBe(false);
     expect(shouldTrustCodexWorkspace("claude", "webhook")).toBe(false);
+  });
+
+  it("trusts Codex and Claude workspaces for automation-triggered launches", () => {
+    expect(shouldTrustAgentWorkspace("codex", "webhook")).toBe(true);
+    expect(shouldTrustAgentWorkspace("claude", "webhook")).toBe(true);
+    expect(shouldTrustAgentWorkspace("codex", "comment_command")).toBe(true);
+    expect(shouldTrustAgentWorkspace("claude", "comment_command")).toBe(true);
+    expect(shouldTrustAgentWorkspace("codex", "manual")).toBe(false);
+    expect(shouldTrustAgentWorkspace("claude", "manual")).toBe(false);
   });
 
   it("adds an exact Codex project trust entry", async () => {
@@ -74,5 +96,67 @@ describe("agent preflight", () => {
     await expect(readFile(configPath, "utf8")).resolves.toContain(
       `[projects.${JSON.stringify(workspacePath)}]\ntrust_level = "trusted"\n\n[tui]`,
     );
+  });
+
+  it("adds an exact Claude project trust entry", async () => {
+    claudeConfigPath = join(await mkdtemp(join(tmpdir(), "issuectl-claude-home-")), ".claude.json");
+    process.env.ISSUECTL_CLAUDE_CONFIG_PATH = claudeConfigPath;
+
+    const workspacePath = "/tmp/issuectl worktrees/repo-pr-26";
+    const result = await trustClaudeProject(workspacePath);
+
+    expect(result.changed).toBe(true);
+    const config = JSON.parse(await readFile(claudeConfigPath, "utf8"));
+    expect(config.projects[workspacePath]).toEqual(expect.objectContaining({
+      allowedTools: [],
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true,
+      projectOnboardingSeenCount: 0,
+    }));
+  });
+
+  it("updates an existing Claude project entry without dropping other fields", async () => {
+    claudeConfigPath = join(await mkdtemp(join(tmpdir(), "issuectl-claude-home-")), ".claude.json");
+    process.env.ISSUECTL_CLAUDE_CONFIG_PATH = claudeConfigPath;
+    const workspacePath = "/tmp/issuectl-worktrees/repo-pr-26";
+    await writeFile(
+      claudeConfigPath,
+      JSON.stringify({
+        userID: "user-1",
+        projects: {
+          [workspacePath]: {
+            allowedTools: ["Bash(pnpm test)"],
+            hasTrustDialogAccepted: false,
+            lastSessionId: "session-1",
+          },
+          "/tmp/other": { hasTrustDialogAccepted: true },
+        },
+      }),
+      "utf8",
+    );
+
+    const result = await trustClaudeProject(workspacePath);
+
+    expect(result.changed).toBe(true);
+    const config = JSON.parse(await readFile(claudeConfigPath, "utf8"));
+    expect(config.userID).toBe("user-1");
+    expect(config.projects["/tmp/other"]).toEqual({ hasTrustDialogAccepted: true });
+    expect(config.projects[workspacePath]).toEqual(expect.objectContaining({
+      allowedTools: ["Bash(pnpm test)"],
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true,
+      lastSessionId: "session-1",
+    }));
+  });
+
+  it("is idempotent for existing trusted Claude projects", async () => {
+    claudeConfigPath = join(await mkdtemp(join(tmpdir(), "issuectl-claude-home-")), ".claude.json");
+    process.env.ISSUECTL_CLAUDE_CONFIG_PATH = claudeConfigPath;
+
+    const workspacePath = "/tmp/issuectl-worktrees/repo-pr-26";
+    await trustClaudeProject(workspacePath);
+    const result = await trustClaudeProject(workspacePath);
+
+    expect(result.changed).toBe(false);
   });
 });

--- a/packages/core/src/launch/agent-preflight.ts
+++ b/packages/core/src/launch/agent-preflight.ts
@@ -16,7 +16,7 @@ export type AgentPreflightInput = {
 };
 
 export async function runAgentPreflight(input: AgentPreflightInput): Promise<void> {
-  if (!shouldTrustCodexWorkspace(input.agent, input.triggeredBy)) return;
+  if (!shouldTrustAgentWorkspace(input.agent, input.triggeredBy)) return;
 
   recordDiagnosticEventSafely(input.db, {
     ...diagnosticBase(input.diagnosticContext),
@@ -27,35 +27,47 @@ export async function runAgentPreflight(input: AgentPreflightInput): Promise<voi
   });
 
   try {
-    const result = await trustCodexProject(input.workspacePath);
+    const result = input.agent === "codex"
+      ? await trustCodexProject(input.workspacePath)
+      : await trustClaudeProject(input.workspacePath);
+    const eventPrefix = input.agent === "codex" ? "codex" : "claude";
     recordDiagnosticEventSafely(input.db, {
       ...diagnosticBase(input.diagnosticContext),
       level: "info",
-      event: result.changed ? "codex.trust.recorded" : "codex.trust.already_trusted",
+      event: result.changed ? `${eventPrefix}.trust.recorded` : `${eventPrefix}.trust.already_trusted`,
       deploymentId: input.deploymentId,
       data: { workspacePath: input.workspacePath, configPath: result.configPath },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const eventPrefix = input.agent === "codex" ? "codex" : "claude";
     recordDiagnosticEventSafely(input.db, {
       ...diagnosticBase(input.diagnosticContext),
       level: "error",
-      event: "codex.trust.failed",
+      event: `${eventPrefix}.trust.failed`,
       deploymentId: input.deploymentId,
       message,
       data: { workspacePath: input.workspacePath },
     });
-    throw new Error(`Failed to trust Codex workspace before launch: ${message}`, {
+    throw new Error(`Failed to trust ${input.agent} workspace before launch: ${message}`, {
       cause: err,
     });
   }
+}
+
+export function shouldTrustAgentWorkspace(
+  agent: LaunchAgent,
+  triggeredBy?: DeploymentTriggeredBy,
+): boolean {
+  return (agent === "codex" || agent === "claude")
+    && (triggeredBy === "webhook" || triggeredBy === "comment_command");
 }
 
 export function shouldTrustCodexWorkspace(
   agent: LaunchAgent,
   triggeredBy?: DeploymentTriggeredBy,
 ): boolean {
-  return agent === "codex" && (triggeredBy === "webhook" || triggeredBy === "comment_command");
+  return shouldTrustAgentWorkspace(agent, triggeredBy) && agent === "codex";
 }
 
 export async function trustCodexProject(
@@ -94,8 +106,64 @@ export async function trustCodexProject(
   return { changed: true, configPath };
 }
 
+export async function trustClaudeProject(
+  workspacePath: string,
+): Promise<{ changed: boolean; configPath: string }> {
+  const configPath = claudeConfigPath();
+  let config: ClaudeUserConfig = {};
+  try {
+    config = JSON.parse(await readFile(configPath, "utf8")) as ClaudeUserConfig;
+  } catch (err) {
+    if ((err as { code?: string }).code !== "ENOENT") throw err;
+  }
+
+  const projects = isRecord(config.projects) ? config.projects : {};
+  const existingProject = isRecord(projects[workspacePath])
+    ? projects[workspacePath]
+    : {};
+  if (
+    existingProject.hasTrustDialogAccepted === true
+    && existingProject.hasCompletedProjectOnboarding === true
+  ) {
+    return { changed: false, configPath };
+  }
+
+  config.projects = {
+    ...projects,
+    [workspacePath]: {
+      allowedTools: [],
+      mcpContextUris: [],
+      mcpServers: {},
+      enabledMcpjsonServers: [],
+      disabledMcpjsonServers: [],
+      hasClaudeMdExternalIncludesApproved: false,
+      hasClaudeMdExternalIncludesWarningShown: false,
+      projectOnboardingSeenCount: 0,
+      ...existingProject,
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true,
+    },
+  };
+
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return { changed: true, configPath };
+}
+
 function codexConfigPath(): string {
   return join(process.env.CODEX_HOME || join(homedir(), ".codex"), "config.toml");
+}
+
+function claudeConfigPath(): string {
+  return process.env.ISSUECTL_CLAUDE_CONFIG_PATH || join(homedir(), ".claude.json");
+}
+
+type ClaudeUserConfig = Record<string, unknown> & {
+  projects?: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function findTomlTable(

--- a/packages/core/src/launch/launch-agent-command.ts
+++ b/packages/core/src/launch/launch-agent-command.ts
@@ -1,10 +1,11 @@
 import type Database from "better-sqlite3";
 import { execFileSync } from "node:child_process";
 import { getSetting } from "../db/settings.js";
-import type { LaunchAgent } from "../types.js";
+import type { DeploymentTriggeredBy, LaunchAgent } from "../types.js";
 
 const DANGEROUS_METACHARS = /[;&|<>`$\n\r\t()]/;
 const LAUNCH_AGENTS = new Set<LaunchAgent>(["claude", "codex"]);
+const CLAUDE_NONINTERACTIVE_FLAG = "--dangerously-skip-permissions";
 
 export async function retryLabel<T>(fn: () => Promise<T>): Promise<T> {
   const delaysMs = [500, 1_000, 2_000];
@@ -69,6 +70,19 @@ export function buildLaunchAgentCommand(
     return command;
   }
   return `${command} ${extraArgs}`;
+}
+
+export function launchAgentExtraArgsForTrigger(
+  agent: LaunchAgent,
+  rawExtraArgs: string | undefined,
+  triggeredBy: DeploymentTriggeredBy,
+): string | undefined {
+  const trimmed = rawExtraArgs?.trim() ?? "";
+  if (agent !== "claude" || (triggeredBy !== "webhook" && triggeredBy !== "comment_command")) {
+    return trimmed || undefined;
+  }
+  if (trimmed.split(/\s+/).includes(CLAUDE_NONINTERACTIVE_FLAG)) return trimmed;
+  return [trimmed, CLAUDE_NONINTERACTIVE_FLAG].filter(Boolean).join(" ");
 }
 
 export function buildClaudeCommand(rawExtraArgs: string | undefined): string {

--- a/packages/core/src/launch/launch-execute-agents.test.ts
+++ b/packages/core/src/launch/launch-execute-agents.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Database from "better-sqlite3";
 import type { Octokit } from "@octokit/rest";
@@ -271,6 +272,37 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       .prepare("SELECT agent FROM deployments WHERE repo_id = ? AND issue_number = ?")
       .get(repo.id, 44) as { agent: string };
     expect(row.agent).toBe("codex");
+  });
+
+  it("adds Claude noninteractive permissions for webhook launches", async () => {
+    addRepo(db, {
+      owner: "acme",
+      name: "api",
+      localPath: "/tmp/fake",
+    });
+    db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(
+      "claude_extra_args",
+      "--model opus",
+    );
+
+    await withConsoleWarnSilenced(() => executeLaunch(db, {} as Octokit, {
+      owner: "acme",
+      repo: "api",
+      issueNumber: 46,
+      agent: "claude",
+      branchName: "claude-webhook",
+      workspaceMode: "existing",
+      selectedComments: [],
+      selectedFiles: [],
+      triggeredBy: "webhook",
+    }));
+
+    expect(spawnTtydSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentCommand: expect.stringMatching(/(^|\/)claude --model opus --dangerously-skip-permissions$/),
+        agentInputMode: "stdin",
+      }),
+    );
   });
 
   it("records a pty bridge deployment and skips ttyd when the experiment is enabled", async () => {

--- a/packages/core/src/launch/launch-execute-precheck.test.ts
+++ b/packages/core/src/launch/launch-execute-precheck.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type Database from "better-sqlite3";
 import type { Octokit } from "@octokit/rest";
@@ -141,7 +141,9 @@ vi.mock("../github/labels.js", async () => {
 describe("executeLaunch duplicate-deployment pre-check", () => {
   let db: Database.Database;
   let codexHome: string | null = null;
+  let claudeConfigPath: string | null = null;
   const previousCodexHome = process.env.CODEX_HOME;
+  const previousClaudeConfigPath = process.env.ISSUECTL_CLAUDE_CONFIG_PATH;
 
   beforeEach(() => {
     prepareWorkspaceSpy.mockClear();
@@ -160,10 +162,19 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       await rm(codexHome, { recursive: true, force: true });
       codexHome = null;
     }
+    if (claudeConfigPath) {
+      await rm(dirname(claudeConfigPath), { recursive: true, force: true });
+      claudeConfigPath = null;
+    }
     if (previousCodexHome === undefined) {
       delete process.env.CODEX_HOME;
     } else {
       process.env.CODEX_HOME = previousCodexHome;
+    }
+    if (previousClaudeConfigPath === undefined) {
+      delete process.env.ISSUECTL_CLAUDE_CONFIG_PATH;
+    } else {
+      process.env.ISSUECTL_CLAUDE_CONFIG_PATH = previousClaudeConfigPath;
     }
   });
 
@@ -395,9 +406,10 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
     })).toHaveLength(1);
   });
 
-  it("does not pre-trust Claude PR review workspaces", async () => {
-    codexHome = await mkdtemp(join(tmpdir(), "issuectl-codex-home-"));
-    process.env.CODEX_HOME = codexHome;
+  it("pre-trusts Claude PR review workspaces for webhook launches when Claude is selected", async () => {
+    const claudeHome = await mkdtemp(join(tmpdir(), "issuectl-claude-home-"));
+    claudeConfigPath = join(claudeHome, ".claude.json");
+    process.env.ISSUECTL_CLAUDE_CONFIG_PATH = claudeConfigPath;
     addRepo(db, {
       owner: "acme",
       name: "api",
@@ -420,13 +432,15 @@ describe("executeLaunch duplicate-deployment pre-check", () => {
       }),
     );
 
-    await expect(readFile(join(codexHome, "config.toml"), "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    const config = JSON.parse(await readFile(claudeConfigPath, "utf8"));
+    expect(config.projects["/tmp/fake-workspace"]).toEqual(expect.objectContaining({
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true,
+    }));
     expect(queryDiagnosticEvents(db, {
       target: { owner: "acme", repo: "api", targetType: "pr", targetNumber: 44 },
-      events: ["codex.trust.recorded"],
-    })).toHaveLength(0);
+      events: ["claude.trust.recorded"],
+    })).toHaveLength(1);
   });
 
   it("launches webhook issue sessions with agent env and issue-scoped mutation budgets", async () => {

--- a/packages/core/src/launch/launch.test.ts
+++ b/packages/core/src/launch/launch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildClaudeCommand, buildLaunchAgentCommand } from "./launch.js";
+import { buildClaudeCommand, buildLaunchAgentCommand, launchAgentExtraArgsForTrigger } from "./launch.js";
 
 describe("buildClaudeCommand", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -109,5 +109,26 @@ describe("buildLaunchAgentCommand", () => {
   it("falls back to plain codex for dangerous stored args", () => {
     expect(buildLaunchAgentCommand("codex", "--model gpt-5; rm -rf /")).toMatch(/(^|\/)codex$/);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("codex_extra_args"));
+  });
+});
+
+describe("launchAgentExtraArgsForTrigger", () => {
+  it("adds Claude noninteractive permissions for webhook launches", () => {
+    expect(launchAgentExtraArgsForTrigger("claude", undefined, "webhook"))
+      .toBe("--dangerously-skip-permissions");
+  });
+
+  it("preserves configured Claude args and avoids duplicate noninteractive flags", () => {
+    expect(launchAgentExtraArgsForTrigger("claude", "--model opus", "comment_command"))
+      .toBe("--model opus --dangerously-skip-permissions");
+    expect(launchAgentExtraArgsForTrigger("claude", "--dangerously-skip-permissions", "webhook"))
+      .toBe("--dangerously-skip-permissions");
+  });
+
+  it("does not alter manual Claude or Codex launches", () => {
+    expect(launchAgentExtraArgsForTrigger("claude", "--model opus", "manual"))
+      .toBe("--model opus");
+    expect(launchAgentExtraArgsForTrigger("codex", "--full-auto", "webhook"))
+      .toBe("--full-auto");
   });
 });

--- a/packages/core/src/launch/launch.ts
+++ b/packages/core/src/launch/launch.ts
@@ -15,6 +15,7 @@ import {
   buildLaunchAgentCommand,
   extraArgsSettingForAgent,
   getLaunchAgent,
+  launchAgentExtraArgsForTrigger,
   normalizeLaunchAgent,
 } from "./launch-agent-command.js";
 import {
@@ -189,9 +190,14 @@ export async function executeLaunch(
   }
 
   // 9. Spawn terminal backend
-  const agentCommand = buildLaunchAgentCommand(
+  const launchExtraArgs = launchAgentExtraArgsForTrigger(
     launchAgent,
     getSetting(db, extraArgsSettingForAgent(launchAgent)),
+    options.triggeredBy ?? "manual",
+  );
+  const agentCommand = buildLaunchAgentCommand(
+    launchAgent,
+    launchExtraArgs,
   );
   const credentialPolicy = options.triggeredBy === "webhook" || options.triggeredBy === "comment_command"
     ? "scrubbed"
@@ -300,7 +306,7 @@ export {
 } from "./branch.js";
 export { type WorkspaceMode, type WorkspaceResult } from "./workspace.js";
 export { type LaunchContext } from "./context.js";
-export { buildClaudeCommand, buildLaunchAgentCommand } from "./launch-agent-command.js";
+export { buildClaudeCommand, buildLaunchAgentCommand, launchAgentExtraArgsForTrigger } from "./launch-agent-command.js";
 export { expandHome } from "./launch-workspace-setup.js";
 
 function selectTerminalBackend(

--- a/packages/core/src/lifecycle/detect.test.ts
+++ b/packages/core/src/lifecycle/detect.test.ts
@@ -8,6 +8,7 @@ function makePR(overrides: Partial<GitHubPull> = {}): GitHubPull {
     title: "Some PR",
     body: null,
     state: "open",
+    labels: [],
     draft: false,
     merged: false,
     user: null,

--- a/packages/core/src/lifecycle/reconcile.test.ts
+++ b/packages/core/src/lifecycle/reconcile.test.ts
@@ -33,6 +33,7 @@ function makePR(overrides: Partial<GitHubPull> = {}): GitHubPull {
     title: "PR title",
     body: "closes #1",
     state: "open",
+    labels: [],
     draft: false,
     merged: false,
     user: null,

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { getDb, getOctokit, getPullDetail } from "@issuectl/core";
+import { getDb, getDeploymentsForTarget, getOctokit, getPullDetail, getRepo, listLabels } from "@issuectl/core";
 import { PrDetail } from "@/components/detail/PrDetail";
 
 export const dynamic = "force-dynamic";
@@ -35,7 +35,14 @@ export default async function PullDetailPage({
   const octokit = await getOctokit();
 
   try {
-    const detail = await getPullDetail(db, octokit, owner, repo, pullNumber);
+    const repoRecord = getRepo(db, owner, repo);
+    const [detail, availableLabels] = await Promise.all([
+      getPullDetail(db, octokit, owner, repo, pullNumber),
+      listLabels(octokit, owner, repo),
+    ]);
+    const deployments = repoRecord
+      ? getDeploymentsForTarget(db, repoRecord.id, "pr", pullNumber)
+      : [];
     return (
       <PrDetail
         owner={owner}
@@ -45,6 +52,8 @@ export default async function PullDetailPage({
         files={detail.files}
         reviews={detail.reviews}
         linkedIssue={detail.linkedIssue}
+        availableLabels={availableLabels}
+        deployments={deployments}
       />
     );
   } catch (err) {

--- a/packages/web/app/route-rendering.test.ts
+++ b/packages/web/app/route-rendering.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,11 +15,13 @@ const core = vi.hoisted(() => ({
   queryDiagnosticEvents: vi.fn(),
   getActiveDeployments: vi.fn(),
   getActiveWebhookDeploymentsForRepoTarget: vi.fn(),
+  getDeploymentsForTarget: vi.fn(),
   listPrReviewsForRepo: vi.fn(),
   listRecentTerminalDeploymentsByRepo: vi.fn(),
   listWebhookEvents: vi.fn(),
   getOctokit: vi.fn(),
   getIssueHeader: vi.fn(),
+  getPullDetail: vi.fn(),
   getPriority: vi.fn(),
   getSettings: vi.fn(),
   listLabels: vi.fn(),
@@ -57,6 +60,9 @@ vi.mock("@/components/detail/IssueDetail", () => ({
 vi.mock("@/components/detail/IssueDetailContent", () => ({
   IssueDetailContent: (props: Record<string, unknown>) => React.createElement("mock-issue-detail-content", props),
 }));
+vi.mock("@/components/detail/PrDetail", () => ({
+  PrDetail: (props: Record<string, unknown>) => React.createElement("mock-pr-detail", props),
+}));
 vi.mock("@/components/detail/ImageLightbox", () => ({
   LightboxProvider: (props: Record<string, unknown>) => React.createElement("mock-lightbox-provider", props, props.children as React.ReactNode),
 }));
@@ -93,6 +99,7 @@ beforeEach(() => {
   core.queryDiagnosticEvents.mockReturnValue([]);
   core.getActiveDeployments.mockReturnValue([]);
   core.getActiveWebhookDeploymentsForRepoTarget.mockReturnValue([]);
+  core.getDeploymentsForTarget.mockReturnValue([]);
   core.listPrReviewsForRepo.mockReturnValue([]);
   core.listRecentTerminalDeploymentsByRepo.mockReturnValue([]);
   core.listWebhookEvents.mockReturnValue([webhookEntry()]);
@@ -115,11 +122,38 @@ beforeEach(() => {
     deployments: [],
     referencedFiles: [],
   });
+  core.getPullDetail.mockResolvedValue({
+    pull: {
+      number: 44,
+      title: "Review labels",
+      body: "body",
+      state: "open",
+      labels: [{ name: "issuectl:auto-review", color: "a371f7", description: null }],
+      draft: false,
+      merged: false,
+      user: null,
+      headRef: "feature/review-labels",
+      baseRef: "main",
+      additions: 1,
+      deletions: 0,
+      changedFiles: 1,
+      createdAt: "2026-05-27T00:00:00.000Z",
+      updatedAt: "2026-05-27T00:00:00.000Z",
+      mergedAt: null,
+      closedAt: null,
+      htmlUrl: "https://github.com/mean-weasel/issuectl/pull/44",
+    },
+    checks: [],
+    files: [],
+    reviews: [],
+    linkedIssue: null,
+  });
   core.getPriority.mockReturnValue("normal");
   core.getSettings.mockReturnValue([{ key: "launch_agent", value: "codex" }]);
   core.listLabels.mockResolvedValue([
     { name: "bug", color: "d73a4a", description: null },
     { name: "issuectl:auto-launch", color: "0e8a16", description: null },
+    { name: "issuectl:auto-review", color: "a371f7", description: null },
   ]);
   data.normalizeSessionsFilters.mockReturnValue({ tab: "sessions" });
   data.getSessionsOverviewData.mockResolvedValue({ summary: { activeSessions: 1 } });
@@ -240,6 +274,62 @@ describe("operator route rendering", () => {
     expect(detail?.props.availableLabels).toEqual([
       { name: "bug", color: "d73a4a", description: null },
       { name: "issuectl:auto-launch", color: "0e8a16", description: null },
+      { name: "issuectl:auto-review", color: "a371f7", description: null },
+    ]);
+  });
+
+  it("renders PR detail with repo labels for editing PR automation labels", async () => {
+    const { default: PullDetailPage } = await import("./pulls/[owner]/[repo]/[number]/page");
+    core.getDeploymentsForTarget.mockReturnValueOnce([
+      {
+        id: 77,
+        repoId: 1,
+        issueNumber: null,
+        targetType: "pr",
+        targetNumber: 44,
+        agent: "claude",
+        branchName: "pr-44-review",
+        workspaceMode: "worktree",
+        workspacePath: "/tmp/pr-44",
+        linkedPrNumber: null,
+        state: "active",
+        terminalBackend: "ttyd",
+        triggeredBy: "webhook",
+        parentDeploymentId: null,
+        webhookDepth: 0,
+        launchedAt: "2026-05-27T00:00:00.000Z",
+        endedAt: null,
+        terminalReason: null,
+        completionToken: null,
+        completionResultJson: null,
+        notificationSentAt: null,
+        ttydPort: 7777,
+        ttydPid: 12345,
+        idleSince: null,
+      },
+    ]);
+
+    const tree = await PullDetailPage({
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl", number: "44" }),
+    });
+
+    expect(core.getPullDetail).toHaveBeenCalledWith(core.db, {}, "mean-weasel", "issuectl", 44);
+    expect(core.getDeploymentsForTarget).toHaveBeenCalledWith(core.db, 1, "pr", 44);
+    expect(core.listLabels).toHaveBeenCalledWith({}, "mean-weasel", "issuectl");
+    const detail = findElementWhere(tree, (props) => Array.isArray(props.availableLabels));
+    expect(detail?.props.availableLabels).toEqual([
+      { name: "bug", color: "d73a4a", description: null },
+      { name: "issuectl:auto-launch", color: "0e8a16", description: null },
+      { name: "issuectl:auto-review", color: "a371f7", description: null },
+    ]);
+    expect(detail?.props.pull).toEqual(
+      expect.objectContaining({
+        number: 44,
+        labels: [{ name: "issuectl:auto-review", color: "a371f7", description: null }],
+      }),
+    );
+    expect(detail?.props.deployments).toEqual([
+      expect.objectContaining({ id: 77, targetType: "pr", targetNumber: 44 }),
     ]);
   });
 });

--- a/packages/web/components/detail/PrDetail.module.css
+++ b/packages/web/components/detail/PrDetail.module.css
@@ -29,6 +29,37 @@
   margin: 0 0 14px;
 }
 
+.labelPanel {
+  margin: 16px 0 20px;
+}
+
+.sessionPanel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin: 16px 0 20px;
+  padding: 14px 0;
+  border-top: 1px solid var(--paper-line);
+  border-bottom: 1px solid var(--paper-line);
+}
+
+.sessionTitle {
+  margin: 0 0 4px;
+  font-family: var(--paper-serif);
+  font-style: italic;
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--paper-ink);
+}
+
+.sessionMeta {
+  margin: 0;
+  font-family: var(--paper-serif);
+  font-size: 13px;
+  color: var(--paper-ink-soft);
+}
+
 .mergeBtn {
   width: 100%;
   min-height: 44px;
@@ -148,6 +179,13 @@
   margin-bottom: 20px;
   background: var(--paper-accent-soft);
   border-radius: var(--paper-radius-md);
+}
+
+@media (max-width: 560px) {
+  .sessionPanel {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }
 
 @media (min-width: 768px) {

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -1,9 +1,11 @@
 import type {
+  Deployment,
   GitHubPull,
   GitHubCheck,
   GitHubPullFile,
   GitHubPullReview,
   GitHubIssue,
+  GitHubLabel,
 } from "@issuectl/core";
 import { Chip } from "@/components/paper";
 import { DetailTopBar } from "./DetailTopBar";
@@ -20,6 +22,9 @@ import { FilesChanged } from "./FilesChanged";
 import { MergeButton } from "./MergeButton";
 import { DetailKeyboardNav } from "./DetailKeyboardNav";
 import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
+import { LabelManager } from "@/components/issue/LabelManager";
+import { OpenTerminalButton } from "@/components/terminal/OpenTerminalButton";
+import { launchAgentLabel } from "@/components/launch/agent";
 import styles from "./PrDetail.module.css";
 
 type Props = {
@@ -30,6 +35,8 @@ type Props = {
   files: GitHubPullFile[];
   reviews: GitHubPullReview[];
   linkedIssue: GitHubIssue | null;
+  availableLabels: GitHubLabel[];
+  deployments: Deployment[];
 };
 
 export function PrDetail({
@@ -40,10 +47,13 @@ export function PrDetail({
   files,
   reviews,
   linkedIssue,
+  availableLabels,
+  deployments,
 }: Props) {
   const prState: "open" | "closed" | "merged" = pull.merged
     ? "merged"
     : pull.state;
+  const activeDeployment = deployments.find((deployment) => deployment.endedAt === null);
 
   return (
     <div className={styles.container}>
@@ -72,6 +82,40 @@ export function PrDetail({
             files
           </span>
         </DetailMeta>
+
+        <section className={styles.labelPanel} aria-label="PR labels">
+          <LabelManager
+            owner={owner}
+            repo={repoName}
+            issueNumber={pull.number}
+            targetType="pr"
+            currentLabels={pull.labels ?? []}
+            availableLabels={availableLabels}
+          />
+        </section>
+
+        {activeDeployment && (
+          <section className={styles.sessionPanel} aria-label="Active PR session">
+            <div>
+              <h2 className={styles.sessionTitle}>active review session</h2>
+              <p className={styles.sessionMeta}>
+                #{activeDeployment.id} · {launchAgentLabel(activeDeployment.agent)} · {activeDeployment.branchName}
+              </p>
+            </div>
+            {activeDeployment.ttydPort && (
+              <OpenTerminalButton
+                ttydPort={activeDeployment.ttydPort}
+                deploymentId={activeDeployment.id}
+                owner={owner}
+                repo={repoName}
+                issueNumber={pull.number}
+                targetType="pr"
+                targetNumber={pull.number}
+                issueTitle={pull.title}
+              />
+            )}
+          </section>
+        )}
 
         {prState === "open" && (
           <MergeButton

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { GitHubLabel } from "@issuectl/core";
-import { toggleLabel } from "@/lib/actions/issues";
+import { toggleLabel, togglePullLabel } from "@/lib/actions/issues";
 import { tryOrQueue } from "@/lib/tryOrQueue";
 import { separateLabels } from "@/lib/labels";
 import { useToast } from "@/components/ui/ToastProvider";
@@ -18,6 +18,7 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  targetType?: "issue" | "pr";
   currentLabels: GitHubLabel[];
   availableLabels: GitHubLabel[];
 };
@@ -26,6 +27,7 @@ export function LabelManager({
   owner,
   repo,
   issueNumber,
+  targetType = "issue",
   currentLabels,
   availableLabels,
 }: Props) {
@@ -62,20 +64,28 @@ export function LabelManager({
     const action = selectedNames.includes(label) ? "remove" : "add";
     startTransition(async () => {
       try {
-        const result = await tryOrQueue(
-          "toggleLabel",
-          { owner, repo, issueNumber, label, action },
-          () => toggleLabel({ owner, repo, number: issueNumber, label, action }),
-        );
+        if (targetType === "issue") {
+          const result = await tryOrQueue(
+            "toggleLabel",
+            { owner, repo, issueNumber, label, action },
+            () => toggleLabel({ owner, repo, number: issueNumber, label, action }),
+          );
 
-        if (result.outcome === "queued") {
-          showToast("Label change queued — will sync when online", "warning");
-          return;
-        }
+          if (result.outcome === "queued") {
+            showToast("Label change queued — will sync when online", "warning");
+            return;
+          }
 
-        if (result.outcome === "error") {
-          setError(result.error);
-          return;
+          if (result.outcome === "error") {
+            setError(result.error);
+            return;
+          }
+        } else {
+          const result = await togglePullLabel({ owner, repo, number: issueNumber, label, action });
+          if (!result.success) {
+            setError(result.error ?? "Failed to update label");
+            return;
+          }
         }
 
         showToast("Labels updated", "success");
@@ -127,6 +137,7 @@ export function LabelManager({
             available={availableLabels}
             selected={selectedNames}
             onToggle={handleToggle}
+            targetType={targetType}
             disabled={isPending}
           />
         </div>

--- a/packages/web/components/issue/LabelSelector.tsx
+++ b/packages/web/components/issue/LabelSelector.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import type { GitHubLabel } from "@issuectl/core";
-import { isSelectableIssueLabel } from "@/lib/labels";
+import { isSelectableIssueLabel, isSelectablePrLabel } from "@/lib/labels";
 import styles from "./LabelSelector.module.css";
 
 type Props = {
   available: GitHubLabel[];
   selected: string[];
   onToggle: (label: string) => void;
+  targetType?: "issue" | "pr";
   disabled?: boolean;
 };
 
@@ -30,9 +31,11 @@ export function LabelSelector({
   available,
   selected,
   onToggle,
+  targetType = "issue",
   disabled,
 }: Props) {
-  const toggleable = available.filter((l) => isSelectableIssueLabel(l.name));
+  const canSelect = targetType === "pr" ? isSelectablePrLabel : isSelectableIssueLabel;
+  const toggleable = available.filter((l) => canSelect(l.name));
 
   if (toggleable.length === 0) return null;
 

--- a/packages/web/components/terminal/OpenTerminalButton.tsx
+++ b/packages/web/components/terminal/OpenTerminalButton.tsx
@@ -15,6 +15,8 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  targetType?: "issue" | "pr";
+  targetNumber?: number;
   issueTitle: string;
 };
 
@@ -24,6 +26,8 @@ export function OpenTerminalButton({
   owner,
   repo,
   issueNumber,
+  targetType = "issue",
+  targetNumber = issueNumber,
   issueTitle,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -89,6 +93,8 @@ export function OpenTerminalButton({
         owner={owner}
         repo={repo}
         issueNumber={issueNumber}
+        targetType={targetType}
+        targetNumber={targetNumber}
         issueTitle={issueTitle}
       />
     </>

--- a/packages/web/components/terminal/TerminalPanel.tsx
+++ b/packages/web/components/terminal/TerminalPanel.tsx
@@ -23,6 +23,8 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  targetType?: "issue" | "pr";
+  targetNumber?: number;
   issueTitle: string;
 };
 
@@ -35,6 +37,8 @@ export function TerminalPanel({
   owner,
   repo,
   issueNumber,
+  targetType = "issue",
+  targetNumber = issueNumber,
   issueTitle,
 }: Props) {
   const [isPending, startTransition] = useTransition();
@@ -48,7 +52,14 @@ export function TerminalPanel({
   function handleEndSession() {
     setError(null);
     startTransition(async () => {
-      const result = await endSession(deploymentId, owner, repo, issueNumber);
+      const result = await endSession(
+        deploymentId,
+        owner,
+        repo,
+        issueNumber,
+        targetType,
+        targetNumber,
+      );
       if (result.success) {
         onClose();
         router.refresh();
@@ -111,10 +122,14 @@ export function TerminalPanel({
               if (window.history.length > 1) {
                 onClose();
               } else {
-                router.push(`/issues/${owner}/${repo}/${issueNumber}`);
+                router.push(
+                  targetType === "pr"
+                    ? `/pulls/${owner}/${repo}/${targetNumber}`
+                    : `/issues/${owner}/${repo}/${issueNumber}`,
+                );
               }
             }}
-            aria-label="Back to issue"
+            aria-label={targetType === "pr" ? "Back to pull request" : "Back to issue"}
           >
             <svg
               width="12"

--- a/packages/web/lib/actions/issues.test.ts
+++ b/packages/web/lib/actions/issues.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/push/notifications", () => ({
   notifyNewIssue: notifyNewIssueMock,
 }));
 
-const { createIssue, toggleLabel } = await import("./issues");
+const { createIssue, toggleLabel, togglePullLabel } = await import("./issues");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -92,6 +92,39 @@ describe("toggleLabel action", () => {
     expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(
       {},
       "issues:acme/api",
+    );
+  });
+});
+
+describe("togglePullLabel action", () => {
+  it("adds PR labels and clears PR caches used by the detail page", async () => {
+    const result = await togglePullLabel({
+      owner: "acme",
+      repo: "api",
+      number: 17,
+      label: "issuectl:auto-review",
+      action: "add",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(coreMocks.addLabel).toHaveBeenCalledWith(
+      {},
+      "acme",
+      "api",
+      17,
+      "issuectl:auto-review",
+    );
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(
+      {},
+      "pull-detail:acme/api#17",
+    );
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(
+      {},
+      "pulls-open:acme/api",
+    );
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(
+      {},
+      "pulls-with-checks:acme/api",
     );
   });
 });

--- a/packages/web/lib/actions/issues.ts
+++ b/packages/web/lib/actions/issues.ts
@@ -267,3 +267,40 @@ export async function toggleLabel(data: {
   const { stale } = revalidateSafely(`/issues/${owner}/${repo}/${number}`, "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
+
+export async function togglePullLabel(data: {
+  owner: string;
+  repo: string;
+  number: number;
+  label: string;
+  action: "add" | "remove";
+}): Promise<{ success: boolean; error?: string; cacheStale?: true }> {
+  const { owner, repo, number, label, action } = data;
+  if (!owner || !repo || !Number.isFinite(number) || number <= 0 || !label) {
+    return { success: false, error: "Valid owner, repo, PR number, and label are required" };
+  }
+
+  try {
+    const db = getDb();
+    if (!getRepo(db, owner, repo)) {
+      return { success: false, error: "Repository is not tracked" };
+    }
+    if (action === "add") {
+      await withAuthRetry((octokit) =>
+        coreAddLabel(octokit, owner, repo, number, label),
+      );
+    } else {
+      await withAuthRetry((octokit) =>
+        coreRemoveLabel(octokit, owner, repo, number, label),
+      );
+    }
+    clearCacheKey(db, `pull-detail:${owner}/${repo}#${number}`);
+    clearCacheKey(db, `pulls-open:${owner}/${repo}`);
+    clearCacheKey(db, `pulls-with-checks:${owner}/${repo}`);
+  } catch (err) {
+    console.error(`[issuectl] Failed to ${action} PR label:`, err);
+    return { success: false, error: formatErrorForUser(err) };
+  }
+  const { stale } = revalidateSafely(`/pulls/${owner}/${repo}/${number}`, "/?tab=prs");
+  return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
+}

--- a/packages/web/lib/actions/launch.ts
+++ b/packages/web/lib/actions/launch.ts
@@ -235,7 +235,7 @@ export async function endSession(
       `/launch/${owner}/${repo}/${targetNumber}`,
       "/",
     )
-    : revalidateSafely("/");
+    : revalidateSafely(`/pulls/${owner}/${repo}/${targetNumber}`, "/");
   return { success: true, ...(stale ? { cacheStale: true as const } : {}) };
 }
 

--- a/packages/web/lib/labels.ts
+++ b/packages/web/lib/labels.ts
@@ -1,6 +1,7 @@
 import type { GitHubLabel } from "@issuectl/core";
 
 const SELECTABLE_ISSUECTL_LABELS = new Set(["issuectl:auto-launch"]);
+const SELECTABLE_PR_ISSUECTL_LABELS = new Set(["issuectl:auto-review"]);
 
 export function isLifecycleLabel(name: string): boolean {
   return name.startsWith("issuectl:");
@@ -8,6 +9,10 @@ export function isLifecycleLabel(name: string): boolean {
 
 export function isSelectableIssueLabel(name: string): boolean {
   return !isLifecycleLabel(name) || SELECTABLE_ISSUECTL_LABELS.has(name);
+}
+
+export function isSelectablePrLabel(name: string): boolean {
+  return !isLifecycleLabel(name) || SELECTABLE_PR_ISSUECTL_LABELS.has(name);
 }
 
 export function separateLabels(labels: GitHubLabel[]): {

--- a/packages/web/lib/page-filters.test.ts
+++ b/packages/web/lib/page-filters.test.ts
@@ -31,6 +31,7 @@ function makePull(overrides: Partial<PullWithChecksStatus> = {}): PullWithChecks
     title: "PR",
     body: null,
     state: "open",
+    labels: [],
     draft: false,
     merged: false,
     user: { login: "me", avatarUrl: "" },

--- a/packages/web/lib/webhook-intent-worker.ts
+++ b/packages/web/lib/webhook-intent-worker.ts
@@ -128,11 +128,6 @@ export async function runWebhookIntentWorkerOnce(
   });
 
   if (intent.targetType === "pr") {
-    const control = enforceWebhookRunawayControls(db, repo, intent, now);
-    if (!control.allowed) {
-      broadcastEventsChanged();
-      return result(base, { claimed: 1, [control.outcome]: 1 });
-    }
     return handlePullRequestIntent(db, repo, intent, now, base, {
       ...deps,
       launchPr: deps.launchPr ?? launchPrFromWebhook,

--- a/packages/web/lib/webhook-pr-intent.test.ts
+++ b/packages/web/lib/webhook-pr-intent.test.ts
@@ -13,6 +13,22 @@ import {
 } from "@issuectl/core";
 import { runWebhookIntentWorkerOnce } from "./webhook-intent-worker.js";
 
+const coreMocks = vi.hoisted(() => ({
+  removeLabel: vi.fn(),
+  clearCacheKey: vi.fn(),
+  withAuthRetry: vi.fn((fn: (octokit: unknown) => Promise<unknown>) => fn({})),
+}));
+
+vi.mock("@issuectl/core", async () => {
+  const real = await vi.importActual<typeof import("@issuectl/core")>("@issuectl/core");
+  return {
+    ...real,
+    removeLabel: coreMocks.removeLabel,
+    clearCacheKey: coreMocks.clearCacheKey,
+    withAuthRetry: coreMocks.withAuthRetry,
+  };
+});
+
 const notifyDeploymentTerminalOutcome = vi.hoisted(() => vi.fn());
 vi.mock("./push/notifications", () => ({
   notifyDeploymentTerminalOutcome: (...args: unknown[]) => notifyDeploymentTerminalOutcome(...args),
@@ -73,6 +89,9 @@ describe("PR webhook intents", () => {
 
   beforeEach(() => {
     notifyDeploymentTerminalOutcome.mockReset();
+    coreMocks.removeLabel.mockReset();
+    coreMocks.clearCacheKey.mockReset();
+    coreMocks.withAuthRetry.mockImplementation((fn: (octokit: unknown) => Promise<unknown>) => fn({}));
     db = createTestDb();
     repoId = addRepo(db, { owner: "mean-weasel", name: "issuectl" }).id;
     updateRepoWebhookSettings(db, repoId, { autoReviewPrs: true });
@@ -120,6 +139,11 @@ describe("PR webhook intents", () => {
     expect(
       db.prepare("SELECT pr_number, status, deployment_id, reviewed_to_sha FROM pr_reviews").get(),
     ).toEqual({ pr_number: 44, status: "in_progress", deployment_id: 1, reviewed_to_sha: "head-b" });
+    expect(coreMocks.removeLabel).toHaveBeenCalledWith({}, "mean-weasel", "issuectl", 44, "issuectl:auto-review");
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(db, "pull-detail:mean-weasel/issuectl#44");
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(db, "pulls-open:mean-weasel/issuectl");
+    expect(coreMocks.clearCacheKey).toHaveBeenCalledWith(db, "pulls-with-checks:mean-weasel/issuectl");
+    expect(db.prepare("SELECT value FROM settings WHERE key = ?").get("webhook:consumed-auto-review:1:44")).toEqual({ value: "1" });
     const prTarget = { owner: "mean-weasel", repo: "issuectl", targetType: "pr" as const, targetNumber: 44 };
     expect(queryDiagnosticEvents(db, {
       target: prTarget,
@@ -134,6 +158,62 @@ describe("PR webhook intents", () => {
       expect.objectContaining({ issueNumber: null, targetType: "pr", targetNumber: 44, deploymentId: 1 }),
     ]);
     expect(queryDiagnosticEvents(db, { events: ["webhook.pr_launched"] })).toHaveLength(1);
+    expect(queryDiagnosticEvents(db, { events: ["webhook.auto_review_label_consumed"] })).toHaveLength(1);
+  });
+
+  it("treats the follow-up auto-review unlabeled event as consumed without ending the launched PR session", async () => {
+    db.prepare(
+      "INSERT INTO settings (key, value) VALUES ('max_concurrent_webhook_agents', '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    ).run();
+    const deploymentId = recordDeployment(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 44,
+      branchName: "pr-44-review",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/pr-44",
+    }).id;
+    db.prepare("UPDATE deployments SET triggered_by = 'webhook' WHERE id = ?").run(deploymentId);
+    db.prepare(
+      `INSERT INTO pr_reviews (
+        repo_id, pr_number, deployment_id, started_head_sha, review_base_sha,
+        reviewed_to_sha, head_repo_full_name, head_ref, status, triggered_by, started_at
+      ) VALUES (?, 44, ?, 'head-b', 'base-a', 'head-b', 'mean-weasel/issuectl',
+        'feature/webhooks', 'in_progress', 'webhook', 1000)`,
+    ).run(repoId, deploymentId);
+    db.prepare(
+      "INSERT INTO settings (key, value) VALUES ('webhook:consumed-auto-review:1:44', '1')",
+    ).run();
+    const event = recordWebhookEvent(db, {
+      deliveryId: "delivery-pr-consumed-unlabel",
+      repoId,
+      eventType: "pull_request",
+      action: "unlabeled",
+      targetType: "pr",
+      targetNumber: 44,
+      receivedAt: 2_000,
+    });
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 44,
+      signalAt: 2_000,
+      scheduledAt: 2_000,
+      desiredHeadSha: "head-b",
+      eventId: event.deduped ? null : event.eventId,
+    });
+
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, {
+      fetchPullState: async () => ({ ...safePull, labels: [] }),
+    });
+
+    expect(result).toEqual(expect.objectContaining({ claimed: 1, skippedOptout: 1, endedSessions: 0 }));
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({ status: "skipped_optout", deployment_id: null }),
+    );
+    expect(db.prepare("SELECT ended_at FROM deployments WHERE id = ?").get(deploymentId)).toEqual({ ended_at: null });
+    expect(db.prepare("SELECT value FROM settings WHERE key = ?").get("webhook:consumed-auto-review:1:44")).toBeUndefined();
+    expect(queryDiagnosticEvents(db, { events: ["webhook.auto_review_label_consumed"] })).toHaveLength(1);
   });
 
   it("skips unsafe PR intents without reserving or launching", async () => {
@@ -163,6 +243,38 @@ describe("PR webhook intents", () => {
     );
     expect(db.prepare("SELECT COUNT(*) AS count FROM pr_reviews").get()).toEqual({ count: 0 });
     expect(queryDiagnosticEvents(db, { events: ["webhook.skipped_unsafe_pr"] })).toHaveLength(1);
+  });
+
+  it("skips duplicate same-head PR review records instead of surfacing sqlite constraints", async () => {
+    db.prepare(
+      `INSERT INTO pr_reviews (
+        repo_id, pr_number, deployment_id, started_head_sha, review_base_sha,
+        reviewed_to_sha, head_repo_full_name, head_ref, status, triggered_by, started_at,
+        completed_at, result_json
+      ) VALUES (?, 44, NULL, 'head-b', 'base-a', 'head-b', 'mean-weasel/issuectl',
+        'feature/webhooks', 'superseded', 'webhook', 1000, 1500, '{"reason":"manual_retry_cleanup"}')`,
+    ).run(repoId);
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 44,
+      signalAt: 2_000,
+      scheduledAt: 2_000,
+      desiredHeadSha: "head-b",
+    });
+    const launchPr = vi.fn();
+
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, {
+      fetchPullState: async () => safePull,
+      launchPr,
+    });
+
+    expect(result).toEqual(expect.objectContaining({ claimed: 1, skippedLocked: 1, failed: 0 }));
+    expect(launchPr).not.toHaveBeenCalled();
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({ status: "skipped_locked", deployment_id: null }),
+    );
+    expect(queryDiagnosticEvents(db, { events: ["webhook.pr_already_reviewed"] })).toHaveLength(1);
   });
 
   it("skips protected-branch webhook PR intents before reserving or launching", async () => {

--- a/packages/web/lib/webhook-pr-intent.ts
+++ b/packages/web/lib/webhook-pr-intent.ts
@@ -4,6 +4,8 @@ import {
   killTmuxSession,
   killTtyd,
   recordDiagnosticEventSafely,
+  removeLabel,
+  clearCacheKey,
   tmuxSessionName,
   withAuthRetry,
 } from "@issuectl/core";
@@ -11,8 +13,11 @@ import type { Repo, WebhookIntent } from "@issuectl/core";
 import type { WebhookIntentWorkerResult } from "./webhook-intent-worker";
 import { getLatestIntentEvent, triggeredByForIntentEvent } from "./webhook-intent-source";
 import { planPrReview } from "./webhook-pr-review-state";
+import { enforceWebhookRunawayControls } from "./webhook-runaway-controls";
 import { broadcastWebhookEventsChanged } from "./webhook-events-stream";
 import { notifyDeploymentTerminalOutcome } from "./push/notifications";
+
+const PR_AUTO_REVIEW_LABEL = "issuectl:auto-review";
 
 export type PullState = {
   title: string;
@@ -70,6 +75,13 @@ export async function handlePullRequestIntent(
     const event = getLatestIntentEvent(db, intent.id);
     const triggeredBy = triggeredByForIntentEvent(event);
     if (triggeredBy === "webhook" && !isPullGatedIn(repo, pull)) {
+      if (isConsumedAutoReviewLabelEvent(db, repo.id, intent.targetNumber, event)) {
+        clearConsumedAutoReviewLabel(db, repo.id, intent.targetNumber);
+        recordPrIntentDiagnostic(db, repo, intent, "webhook.auto_review_label_consumed", "Consumed auto-review label after launch.");
+        markIntentTerminal(db, intent.id, now, "Auto-review label consumed after launch");
+        broadcastEventsChanged();
+        return result(base, { claimed: 1, skippedOptout: 1 });
+      }
       const endedSessions = endWebhookPrSessionForTarget(db, repo, intent, now, terminalReasonForPrOptOut(repo, pull, event));
       recordPrIntentDiagnostic(db, repo, intent, "webhook.skipped_optout", endedSessions > 0 ? "Ended webhook-launched PR review session." : "PR is not opted in for auto-review.");
       markIntentTerminal(db, intent.id, now, "PR is not opted in");
@@ -103,6 +115,11 @@ export async function handlePullRequestIntent(
       broadcastEventsChanged();
       return result(base, { claimed: 1, skippedLocked: 1 });
     }
+    const control = enforceWebhookRunawayControls(db, repo, intent, now);
+    if (!control.allowed) {
+      broadcastEventsChanged();
+      return result(base, { claimed: 1, [control.outcome]: 1 });
+    }
     review = plan.review;
     markPrReviewLaunching(db, review.id);
     broadcastEventsChanged();
@@ -115,6 +132,7 @@ export async function handlePullRequestIntent(
       throw new Error("PR review deployment could not be linked after launch");
     }
     markIntentLaunched(db, intent.id, now, launch.deploymentId);
+    await consumePrAutoReviewLabel(db, repo, intent, launch.deploymentId);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.launched", "Webhook launched PR review session.", launch.deploymentId);
     recordPrIntentDiagnostic(db, repo, intent, "webhook.pr_launched", "Webhook launched PR review session.", launch.deploymentId);
     broadcastEventsChanged();
@@ -271,7 +289,71 @@ async function fetchPullState(repo: Repo, prNumber: number): Promise<PullState> 
 }
 
 function isPullGatedIn(repo: Repo, pull: PullState): boolean {
-  return repo.autoReviewPrs && pull.state === "open" && !pull.draft && pull.labels.includes("issuectl:auto-review");
+  return repo.autoReviewPrs && pull.state === "open" && !pull.draft && pull.labels.includes(PR_AUTO_REVIEW_LABEL);
+}
+
+async function consumePrAutoReviewLabel(
+  db: Database.Database,
+  repo: Repo,
+  intent: WebhookIntent,
+  deploymentId: number,
+): Promise<void> {
+  try {
+    await withAuthRetry((octokit) =>
+      removeLabel(octokit, repo.owner, repo.name, intent.targetNumber, PR_AUTO_REVIEW_LABEL),
+    );
+    clearCacheKey(db, `pull-detail:${repo.owner}/${repo.name}#${intent.targetNumber}`);
+    clearCacheKey(db, `pulls-open:${repo.owner}/${repo.name}`);
+    clearCacheKey(db, `pulls-with-checks:${repo.owner}/${repo.name}`);
+    markAutoReviewLabelConsumed(db, repo.id, intent.targetNumber);
+    recordPrIntentDiagnostic(db, repo, intent, "webhook.auto_review_label_consumed", "Removed auto-review label after successful launch.", deploymentId);
+  } catch (err) {
+    recordPrIntentDiagnostic(
+      db,
+      repo,
+      intent,
+      "webhook.auto_review_label_remove_failed",
+      err instanceof Error ? err.message : String(err),
+      deploymentId,
+    );
+  }
+}
+
+function consumedAutoReviewLabelKey(repoId: number, prNumber: number): string {
+  return `webhook:consumed-auto-review:${repoId}:${prNumber}`;
+}
+
+function markAutoReviewLabelConsumed(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+): void {
+  db.prepare(
+    "INSERT INTO settings (key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+  ).run(consumedAutoReviewLabelKey(repoId, prNumber));
+}
+
+function isConsumedAutoReviewLabelEvent(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+  event: { eventType: string; action: string | null } | null,
+): boolean {
+  if (event?.eventType !== "pull_request" || event.action !== "unlabeled") return false;
+  const row = db.prepare("SELECT 1 FROM settings WHERE key = ?").get(
+    consumedAutoReviewLabelKey(repoId, prNumber),
+  );
+  return Boolean(row);
+}
+
+function clearConsumedAutoReviewLabel(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+): void {
+  db.prepare("DELETE FROM settings WHERE key = ?").run(
+    consumedAutoReviewLabelKey(repoId, prNumber),
+  );
 }
 
 function isSafePullForReservation(pull: PullState, desiredHeadSha: string | null): boolean {

--- a/packages/web/lib/webhook-pr-review-state.ts
+++ b/packages/web/lib/webhook-pr-review-state.ts
@@ -20,6 +20,10 @@ export async function planPrReview(
   if (active) return planForActiveReview(db, active, pull);
 
   const forceFullReview = intent.reviewMode === "full";
+  const existingForHead = getPrReviewForHead(db, repo.id, intent.targetNumber, pull.headSha);
+  if (existingForHead && !forceFullReview) {
+    return { action: "skip", event: "webhook.pr_already_reviewed", reason: "PR head already has a review record." };
+  }
   const completed = getLatestCompletedPrReview(db, repo.id, intent.targetNumber);
   if (!forceFullReview && completed?.reviewedToSha === pull.headSha) {
     return { action: "skip", event: "webhook.pr_already_reviewed", reason: "PR head was already reviewed." };
@@ -86,6 +90,22 @@ function getActivePrReview(db: Database.Database, repoId: number, prNumber: numb
      ORDER BY started_at DESC, id DESC LIMIT 1`,
   ).get(repoId, prNumber) as PrReviewRow | undefined;
   return active ? rowToPrReview(active) : undefined;
+}
+
+function getPrReviewForHead(
+  db: Database.Database,
+  repoId: number,
+  prNumber: number,
+  headSha: string,
+): PrReviewRecord | undefined {
+  const row = db.prepare(
+    `SELECT id, repo_id, pr_number, deployment_id, status, reviewed_from_sha,
+            reviewed_to_sha, completed_head_sha, result_json
+     FROM pr_reviews
+     WHERE repo_id = ? AND pr_number = ? AND reviewed_to_sha = ?
+     ORDER BY id DESC LIMIT 1`,
+  ).get(repoId, prNumber, headSha) as PrReviewRow | undefined;
+  return row ? rowToPrReview(row) : undefined;
 }
 
 function getLatestCompletedPrReview(db: Database.Database, repoId: number, prNumber: number): PrReviewRecord | undefined {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "start": "node --import tsx server.ts",
+    "start": "node --import ./server-polyfills.mjs --import tsx server.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint app/ components/ lib/",
-    "dev": "node --import tsx server.ts --dev",
+    "dev": "node --import ./server-polyfills.mjs --import tsx server.ts --dev",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:live-codex-workbench": "playwright test e2e/codex-workbench-live.spec.ts --project=desktop-chromium"

--- a/packages/web/server-polyfills.mjs
+++ b/packages/web/server-polyfills.mjs
@@ -1,0 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+if (!globalThis.AsyncLocalStorage) {
+  Object.defineProperty(globalThis, "AsyncLocalStorage", {
+    configurable: true,
+    enumerable: false,
+    value: AsyncLocalStorage,
+    writable: true,
+  });
+}


### PR DESCRIPTION
## Summary
- add PR label editing and active PR session visibility on the PR detail page
- make PR auto-review labels one-shot triggers with cleanup webhooks resolving as non-launching
- pre-trust Claude workspaces for webhook/comment-command launches, preserving Codex preflight
- mark PR review rows complete from agent completion and avoid same-head duplicate constraint failures
- add a webhook auto-sessions runbook and the Next custom-server AsyncLocalStorage polyfill

## Manual QA
Fresh PR: https://github.com/mean-weasel/issuectl-test-repo-2/pull/32
- started unlabelled with no PR deployment
- added `issuectl:auto-review` through the local PR detail label editor
- webhook reached local server through the Cloudflare tunnel and intent 40 launched exactly one session, deployment 148
- diagnostics show `agent.preflight.started`, `claude.trust.recorded`, `ttyd.spawned`, `deployment.activated`, `webhook.auto_review_label_consumed`, `webhook.pr_launched`, `agent.completion_recorded`, and `webhook.completed`
- terminal opened directly in Claude Code with bypass permissions on and no trust/permission prompt
- PR detail UI showed active review session #148 with Open Terminal while running
- final labels are empty; cleanup intent 41 resolved `skipped_optout`; no relaunch occurred

## Tests
- `pnpm --dir packages/web test -- route-rendering.test.ts webhook-pr-intent.test.ts webhook-runaway-controls.test.ts webhook-intent-worker.test.ts webhook-pr-incremental.test.ts actions/launch.test.ts`
- `pnpm --dir packages/core test -- db/deployments.test.ts launch/agent-preflight.test.ts launch/launch-execute-precheck.test.ts launch/launch.test.ts launch/launch-execute-agents.test.ts`
- `pnpm --dir packages/core typecheck && pnpm --dir packages/web typecheck`
- `pnpm --dir packages/core lint`
- `pnpm --dir packages/web lint`
- commit/push hooks also ran repo typecheck/lint successfully
