### PR TITLE
Guide PR agents away from GitHub CLI auth

### DIFF
--- a/packages/core/src/launch/context.test.ts
+++ b/packages/core/src/launch/context.test.ts
@@ -50,6 +50,10 @@ describe("assemblePrReviewContext", () => {
     expect(context).toContain("Review for safe webhook behavior.");
     expect(context).toContain("issuectl agent mutate");
     expect(context).toContain("issuectl agent complete");
+    expect(context).toContain("## PR Review Source Material");
+    expect(context).toContain("ambient GitHub credentials are intentionally unavailable");
+    expect(context).toContain("Do not run `gh`, GitHub MCP tools, or other direct GitHub APIs unless the supplied PR data is insufficient.");
+    expect(context).toContain("read from the local checkout");
     expect(context).not.toContain("ISSUECTL_AGENT_TOKEN=");
   });
 });

--- a/packages/core/src/launch/context.ts
+++ b/packages/core/src/launch/context.ts
@@ -56,6 +56,13 @@ export function assemblePrReviewContext(data: PrReviewContext): string {
   if (data.reviewedFromSha) blocks.push(`Reviewed range: ${data.reviewedFromSha}..${data.reviewedToSha}`);
   if (data.preamble) blocks.push(`\n${data.preamble}`);
   blocks.push(agentControlInstructions("pr"));
+  blocks.push([
+    "\n## PR Review Source Material",
+    "Use the PR metadata, comments, and file patches provided below as the primary review source.",
+    "For webhook or comment-command launches, ambient GitHub credentials are intentionally unavailable.",
+    "Do not run `gh`, GitHub MCP tools, or other direct GitHub APIs unless the supplied PR data is insufficient.",
+    "When you need to inspect code beyond a patch, read from the local checkout instead.",
+  ].join("\n"));
   blocks.push("\n## Untrusted PR Data (JSON)");
   blocks.push(JSON.stringify({
     body: data.body ?? "",


### PR DESCRIPTION
## Summary
- add PR review launch guidance that supplied PR JSON and local checkout are the primary source material
- document that webhook/comment-command sessions intentionally lack ambient GitHub credentials
- cover the guidance in the PR context unit test

## Verification
- pnpm --dir packages/core test -- context.test.ts
- pnpm --dir packages/core typecheck
- commit hook: turbo typecheck + lint for cli/core/web