### PR TITLE
Show completed issue sessions in detail

### DIFF
--- a/docs/goals/completed-issue-session-ux/goal.md
+++ b/docs/goals/completed-issue-session-ux/goal.md
@@ -1,0 +1,53 @@
+# Completed Issue Session UX
+
+## Objective
+
+Implement and verify the product UX from issue #531: issue detail pages should make completed agent work visible after a deployment ends, and should offer a completed-session/terminal affordance when terminal evidence remains available, while keeping new launch actions clearly separate.
+
+## Original Request
+
+"Plan out this using GoalBuddy" after identifying that an issue with a completed auto-launched Codex session still showed only "Launch with Codex" despite a retained tmux terminal session and a final `issuectl:deployed` label.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl users manually QAing webhook sessions and normal operators returning to an issue after agent work completed
+- Authority: `requested`
+- Proof type: `demo`
+- Interpreted outcome: Issue detail clearly distinguishes "already worked by an agent" from "ready to launch for the first time," shows completed deployment/session history, and gives access to completed terminal evidence when available.
+- Completion proof: Browser walkthrough on issue `mean-weasel/issuectl-test-repo-2#35` or a fresh equivalent fixture shows a completed deployment/history panel with result details and a completed-terminal action, while live sessions still show Open Terminal and new launches remain possible.
+- Goal oracle: Focused web tests plus manual/browser QA prove live, completed, and never-launched issue states render the right actions and labels/history.
+- Likely misfire: Hiding or replacing "Launch with Codex" without adding completed work evidence, or adding a completed state only to sessions/workbench pages while the primary issue detail remains ambiguous.
+
+## Current Tranche
+
+Discover the existing issue detail/deployment rendering path, design the smallest coherent completed-session UX slice, implement it with focused tests, and manually verify the issue detail behavior against the completed QA issue or a fresh reversible issue.
+
+## Non-Negotiable Constraints
+
+- Preserve existing live deployment behavior: live sessions still show Open Terminal.
+- Preserve new launch behavior: users can still launch again after completion when appropriate.
+- Do not treat a retained tmux session alone as a live deployment; live state remains keyed by `endedAt === null`.
+- Keep the UI clear that completed work is historical evidence, not an active terminal.
+- Do not regress issue auto-launch label lifecycle behavior.
+- Preserve unrelated dirty worktree changes.
+
+## Stop Rule
+
+Stop only after a final audit maps implementation and verification back to issue #531 and records `full_outcome_complete: true`.
+
+Do not stop after discovery, a UI sketch, or a single unit test if the primary issue detail flow still cannot demonstrate completed session history.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/completed-issue-session-ux/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/completed-issue-session-ux/goal.md.
+```

--- a/docs/goals/completed-issue-session-ux/notes/T001-scout.md
+++ b/docs/goals/completed-issue-session-ux/notes/T001-scout.md
@@ -1,0 +1,32 @@
+# T001 Scout Receipt
+
+## Current Behavior Map
+
+- `packages/web/app/issues/[owner]/[repo]/[number]/page.tsx` fetches issue header data and passes `deployments` into `IssueDetail` and `IssueDetailContent`.
+- `packages/web/components/detail/IssueDetail.tsx` computes `hasLiveDeployment` with `deployments.some((d) => d.endedAt === null)` and passes that to issue actions. This is the right live-session invariant to preserve.
+- `packages/web/components/detail/LaunchCard.tsx` currently finds only `deployments.find((d) => d.endedAt === null)` and returns `null` if no live deployment exists, so completed sessions have no primary issue-detail evidence.
+- `packages/web/components/launch/LaunchActiveBanner.tsx` can render an ended variant, but it is unreachable from issue detail because `LaunchCard` filters ended deployments out.
+- `packages/web/components/terminal/OpenTerminalButton.tsx`, `packages/web/lib/terminal-auth.ts`, and `packages/web/lib/pty-terminal-websocket.ts` intentionally require live deployments (`endedAt === null`) before terminal attach. Completed-session UX should not reuse that as a live terminal.
+- `packages/web/app/sessions/page.tsx`, `packages/web/lib/sessions-data.ts`, and `packages/web/components/sessions/SessionsReviewList.tsx` already provide a recently-ended session history surface and filters by repo, state, and query.
+
+## Data Available
+
+`Deployment` already includes enough issue-detail data for a completed card:
+
+- `id`, `agent`, `branchName`, `workspaceMode`, `workspacePath`
+- `triggeredBy`, `launchedAt`, `endedAt`, `terminalReason`
+- `completionResultJson`, `linkedPrNumber`, lineage fields
+
+## Risks And Decisions
+
+- Do not make ended deployments appear active or reusable by `OpenTerminalButton`; existing live terminal auth blocks ended deployment attach.
+- The first coherent slice should add completed work evidence and link into completed session history, while preserving "Launch with Codex" as a separate new-run action.
+- A true read-only terminal transcript is a larger product/API slice because no stable transcript endpoint exists in the inspected path.
+
+## Recommended Worker Slice
+
+Add an issue-detail completed session summary when there is no live deployment and at least one ended deployment. It should show prior agent work, completion/result metadata when present, branch/workspace evidence, and a link to filtered session history for that issue. Add focused server-rendered component tests proving:
+
+- active deployment still renders Open Terminal and not the completed summary,
+- completed deployment renders prior work evidence and the session-history link,
+- never-launched issues render no session card.

--- a/docs/goals/completed-issue-session-ux/notes/T002-judge.md
+++ b/docs/goals/completed-issue-session-ux/notes/T002-judge.md
@@ -1,0 +1,33 @@
+# T002 Judge Receipt
+
+## Decision
+
+Approved Worker slice: implement a completed-session summary on issue detail by extending the existing `LaunchCard` path.
+
+## Rationale
+
+This slice satisfies the product gap without redefining live terminal state. It makes completed work visible on the primary issue detail page, keeps `Launch with Codex` available for new work, and uses the existing sessions page as the completed session/history affordance until a dedicated terminal transcript exists.
+
+## Allowed Files
+
+- `packages/web/components/detail/LaunchCard.tsx`
+- `packages/web/components/detail/IssueDetail.module.css`
+- `packages/web/components/detail/LaunchCard.test.ts`
+- `docs/workflows/webhook-label-manual-qa.md`
+- `docs/workflows/webhook-qa-ladder.md`
+- `docs/workflows/webhook-auto-sessions.md`
+- `docs/workflows/webhook-issue-to-pr-review-qa.md`
+- `docs/goals/completed-issue-session-ux/state.yaml`
+- `docs/goals/completed-issue-session-ux/notes/**`
+
+## Verify
+
+- `pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts`
+- `pnpm --dir packages/web typecheck`
+- `git diff --check -- packages/web/components/detail docs/workflows docs/goals/completed-issue-session-ux`
+
+## Stop If
+
+- The implementation needs a live terminal attach for ended deployments.
+- The new UI hides or disables the new launch action after completion.
+- Existing live `Open Terminal` behavior changes.

--- a/docs/goals/completed-issue-session-ux/notes/T003-worker.md
+++ b/docs/goals/completed-issue-session-ux/notes/T003-worker.md
@@ -1,0 +1,27 @@
+# T003 Worker Receipt
+
+## Result
+
+Implemented completed issue session evidence on the issue detail page.
+
+## Changes
+
+- `packages/web/components/detail/LaunchCard.tsx` now keeps live deployments on the existing active banner path and renders the latest ended deployment only when no live deployment exists.
+- `packages/web/components/detail/CompletedSessionTerminalButton.tsx` opens a read-only completed terminal transcript when the retained tmux session is still available.
+- `packages/web/lib/actions/completed-terminal.ts` validates the deployment target and captures the retained tmux pane without treating the deployment as live.
+- The completed summary shows agent, deployment ID, result status, branch, ended date, duration, workspace, and completion summary.
+- The completed-session action links to filtered Sessions history for the issue.
+- `packages/web/components/detail/IssueDetail.module.css` adds responsive styling for the completed-session record.
+- `packages/web/components/detail/LaunchCard.test.ts` covers live, completed, and never-launched states.
+- `packages/web/lib/actions/completed-terminal.test.ts` covers transcript capture, missing tmux sessions, and active-session rejection.
+
+## Verification
+
+- `pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts lib/actions/completed-terminal.test.ts lib/actions/launch.test.ts` passed.
+- `pnpm --dir packages/web typecheck` passed.
+- `pnpm --dir packages/web lint` passed.
+- `git diff --check -- packages/web/components/detail docs/workflows docs/goals/completed-issue-session-ux` passed.
+
+## Notes
+
+Ended deployments are not treated as live. The completed terminal action is read-only tmux capture instead of `OpenTerminalButton`, because live terminal attach/auth still requires `endedAt === null`.

--- a/docs/goals/completed-issue-session-ux/notes/T004-docs.md
+++ b/docs/goals/completed-issue-session-ux/notes/T004-docs.md
@@ -1,0 +1,14 @@
+# T004 Docs Receipt
+
+## Result
+
+Updated repeatable webhook QA documentation to include completed issue-session behavior.
+
+## Changes
+
+- `docs/workflows/webhook-label-manual-qa.md` now checks that completed issue sessions show on issue detail after agent completion, retained tmux sessions expose a read-only transcript, and a separate new launch remains available.
+- `docs/workflows/webhook-qa-ladder.md` now includes completed issue-session history and completed terminal transcript proof in Rung 7 completion and cleanup proof.
+
+## Verification
+
+- `git diff --check -- packages/web/components/detail docs/workflows docs/goals/completed-issue-session-ux` passed.

--- a/docs/goals/completed-issue-session-ux/notes/T005-manual-qa.md
+++ b/docs/goals/completed-issue-session-ux/notes/T005-manual-qa.md
@@ -1,0 +1,55 @@
+# T005 Manual QA Receipt
+
+## Target
+
+`mean-weasel/issuectl-test-repo-2#35`
+
+## Browser Evidence
+
+Opened:
+
+```text
+http://localhost:3847/issues/mean-weasel/issuectl-test-repo-2/35
+```
+
+Observed with Playwright:
+
+- Completed session card rendered for deployment `#151`.
+- Card showed `CODEX WORKED THIS ISSUE`, `Completed session #151`, `No Changes`, branch/workspace details, and the completion summary.
+- `Launch with Codex` button count was `1`, proving a new launch remains a separate action.
+- `Open Terminal` button count was `0`, proving the ended deployment is not presented as live.
+- `View completed terminal` opened a read-only transcript dialog for `issuectl-issuectl-test-repo-2-35`.
+- The transcript included the completion text from the retained tmux pane.
+- `Session history` linked to `/sessions?tab=sessions&repo=mean-weasel%2Fissuectl-test-repo-2&state=ended&q=Issue+%2335`.
+
+Screenshot:
+
+```text
+/tmp/issuectl-completed-session-issue-35.png
+/tmp/issuectl-completed-terminal-issue-35.png
+```
+
+## DB Evidence
+
+Deployment row for issue #35:
+
+```text
+id=151
+target_type=issue
+target_number=35
+agent=codex
+triggered_by=webhook
+ended_at=2026-05-28 11:10:05
+terminal_reason=completed
+completion_result_json={"status":"no_changes","summary":"Verified issue #35 auto-launch session context and clean worktree; no code changes were requested."}
+```
+
+## Diagnostics Evidence
+
+`issuectl diag show --issue mean-weasel/issuectl-test-repo-2#35` showed:
+
+- `deployment.recorded` and `deployment.activated` for deployment `151`.
+- `codex.trust.recorded` before terminal activation.
+- `webhook.auto_launch_label_consumed`.
+- `agent.completion_recorded` with status `no_changes`.
+- `lifecycle.in_progress_label_removed`.

--- a/docs/goals/completed-issue-session-ux/notes/T999-final-audit.md
+++ b/docs/goals/completed-issue-session-ux/notes/T999-final-audit.md
@@ -1,0 +1,37 @@
+# T999 Final Audit
+
+## Decision
+
+complete
+
+`full_outcome_complete: true`
+
+## Requirement Audit
+
+- Issue detail page shows completed deployment/session history for the issue.
+  - Proven by `LaunchCard` completed-state rendering and Playwright on `mean-weasel/issuectl-test-repo-2#35`, which showed `Completed session #151` with result metadata.
+- A user can distinguish prior completed agent work from a never-worked issue.
+  - Proven by `LaunchCard.test.ts`: completed deployments render a completed session record, while no deployments render nothing.
+- If a completed terminal/transcript is available, issue detail offers a way to view it.
+  - Proven by `CompletedSessionTerminalButton`, `getCompletedSessionTranscript`, `completed-terminal.test.ts`, and Playwright click-through on issue #35 showing the retained tmux transcript for `issuectl-issuectl-test-repo-2-35`.
+- Live deployment behavior is unchanged.
+  - Proven by `LaunchCard.test.ts`: live deployments still render the active banner path with `Open Terminal`, and completed deployments do not render `Open Terminal`.
+- New launch behavior remains available and clearly separate.
+  - Proven by Playwright on issue #35: `Launch with Codex` button count was `1` while the completed terminal button and session-history link were separate.
+- Focused web tests exist for ended deployment rendering and live-vs-completed action behavior.
+  - Proven by `LaunchCard.test.ts` and `completed-terminal.test.ts`; affected tests passed.
+- Webhook QA docs include the completed issue-session check.
+  - Proven by updates to `docs/workflows/webhook-label-manual-qa.md` and `docs/workflows/webhook-qa-ladder.md`.
+
+## Verification Receipts
+
+- `pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts lib/actions/completed-terminal.test.ts lib/actions/launch.test.ts` passed.
+- `pnpm --dir packages/web typecheck` passed.
+- `pnpm --dir packages/web lint` passed.
+- `git diff --check -- packages/web/components/detail packages/web/lib/actions/completed-terminal.ts packages/web/lib/actions/completed-terminal.test.ts packages/web/lib/actions/launch.ts packages/web/lib/actions/launch.test.ts docs/workflows docs/goals/completed-issue-session-ux` passed.
+- Browser QA against `http://localhost:3847/issues/mean-weasel/issuectl-test-repo-2/35` passed.
+- DB and diagnostics for issue #35 confirmed deployment `151` ended with `terminal_reason=completed` and completion status `no_changes`.
+
+## Residual Risk
+
+The completed terminal transcript is available only while the tmux session still exists on the local machine. When it is gone, the UI reports that the completed terminal is no longer available and still preserves completed session history.

--- a/docs/goals/completed-issue-session-ux/state.yaml
+++ b/docs/goals/completed-issue-session-ux/state.yaml
@@ -1,0 +1,244 @@
+version: 2
+
+goal:
+  title: "Completed Issue Session UX"
+  slug: "completed-issue-session-ux"
+  kind: specific
+  status: done
+  created_at: "2026-05-28"
+  source: "User requested GoalBuddy prep for issue #531 completed-session issue detail UX."
+  tranche: "Discover, implement, and verify completed issue session visibility and terminal/history affordance on issue detail pages."
+  oracle:
+    signal: "Issue detail browser QA shows never-launched, live, and completed issue states with distinct correct actions; completed issues show prior agent work and completed terminal/history access when available."
+    final_proof: "Focused web tests plus a Chrome/browser walkthrough against issue #35 or a fresh equivalent issue prove completed deployment history is visible, live Open Terminal remains unchanged, and Launch with Codex remains a separate new-run action."
+  intake:
+    original_request: "Plan out this using GoalBuddy."
+    interpreted_outcome: "Issue detail clearly shows completed agent work and offers completed terminal/session history access after a deployment ends."
+    input_shape: specific
+    audience: "issuectl operators and manual webhook QA users"
+    authority: requested
+    proof_type: demo
+    completion_proof: "Browser walkthrough and tests prove the primary issue detail UI distinguishes completed agent work from live session and never-launched states."
+    likely_misfire: "Only changing labels or sessions list while issue detail still looks unworked after completion."
+    blind_spots_considered:
+      - "The current UI keys live sessions off endedAt === null and should keep doing so."
+      - "Retained tmux sessions may exist after completion, but completed terminal access may need a safe attach/read-only/transcript decision."
+      - "The deployed label may not be sufficient language for 'worked on by agent'."
+      - "Completed session evidence should not imply that the issue is closed or done."
+      - "The work should not regress auto-launch label consumption or in-progress cleanup."
+    existing_plan_facts:
+      - "GitHub issue #531 captures the product gap and acceptance criteria."
+      - "Manual QA issue mean-weasel/issuectl-test-repo-2#35 produced deployment 151 with terminal_reason completed and status no_changes."
+      - "The issue detail page showed Launch with Codex after completion while a tmux session remained."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  preserve_and_validate_existing_plan: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/completed-issue-session-ux/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.7/skills/goalbuddy/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/completed-issue-session-ux"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map the current issue detail, deployment history, terminal attachment, session list, and lifecycle label rendering paths relevant to completed issue sessions."
+    inputs:
+      - "GitHub issue #531"
+      - "Manual QA evidence for mean-weasel/issuectl-test-repo-2#35 and deployment 151"
+      - "Issue detail page and related components"
+      - "Deployment/session data access helpers"
+      - "Terminal/open-terminal UI paths"
+      - "Existing web tests for issue detail, launch, sessions, and workbench"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Separate current live-session behavior from completed-session/history behavior."
+      - "Identify whether completed terminal viewing should reuse existing terminal attach code or needs a transcript/history surface."
+    expected_output:
+      - "Current behavior map with file paths."
+      - "Data available for completed deployments."
+      - "UI surfaces that already render ended deployments, if any."
+      - "Risks and product decisions."
+      - "Recommended first Worker slice with allowed_files and verification commands."
+    receipt:
+      result: done
+      note: "docs/goals/completed-issue-session-ux/notes/T001-scout.md"
+      summary: "Mapped issue detail deployment rendering. Completed sessions are passed to detail but hidden because LaunchCard only renders live deployments."
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: medium
+    objective: "Choose the smallest coherent UX implementation slice that satisfies issue #531 without confusing completed terminals with live deployments."
+    inputs:
+      - "T001 Scout receipt"
+      - "Issue #531 acceptance criteria"
+      - "Current issue detail and terminal behavior"
+    constraints:
+      - "Read-only."
+      - "Do not approve a slice that removes or hides new launch behavior."
+      - "Do not approve a slice that treats ended deployments as live sessions."
+    expected_output:
+      - "Decision: approved Worker slice or blocked decision."
+      - "Exact Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+    receipt:
+      result: done
+      decision: approved
+      note: "docs/goals/completed-issue-session-ux/notes/T002-judge.md"
+      summary: "Approved a bounded LaunchCard-based completed-session summary linked to filtered sessions history."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement the completed issue session UX slice selected by Judge."
+    allowed_files:
+      - "packages/web/components/detail/LaunchCard.tsx"
+      - "packages/web/components/detail/CompletedSessionTerminalButton.tsx"
+      - "packages/web/components/detail/IssueDetail.module.css"
+      - "packages/web/components/detail/LaunchCard.test.ts"
+      - "packages/web/lib/actions/completed-terminal.ts"
+      - "packages/web/lib/actions/completed-terminal.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts"
+      - "pnpm --dir packages/web typecheck"
+      - "git diff --check -- packages/web/components/detail"
+    stop_if:
+      - "Need files outside Judge-approved allowed_files."
+      - "Completed terminal access requires a product/security decision not recorded by Judge."
+      - "Verification fails twice for the same reason."
+      - "Implementation would regress live Open Terminal behavior."
+    receipt:
+      result: done
+      note: "docs/goals/completed-issue-session-ux/notes/T003-worker.md"
+      summary: "Implemented and verified completed issue session summary on issue detail without changing live terminal behavior."
+      changed_files:
+        - "packages/web/components/detail/LaunchCard.tsx"
+        - "packages/web/components/detail/CompletedSessionTerminalButton.tsx"
+        - "packages/web/components/detail/IssueDetail.module.css"
+        - "packages/web/components/detail/LaunchCard.test.ts"
+        - "packages/web/lib/actions/completed-terminal.ts"
+        - "packages/web/lib/actions/completed-terminal.test.ts"
+      commands:
+        - command: "pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts lib/actions/completed-terminal.test.ts lib/actions/launch.test.ts"
+          status: pass
+        - command: "pnpm --dir packages/web typecheck"
+          status: pass
+        - command: "pnpm --dir packages/web lint"
+          status: pass
+        - command: "git diff --check -- packages/web/components/detail docs/workflows docs/goals/completed-issue-session-ux"
+          status: pass
+
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Update or add workflow QA documentation so completed-session issue detail behavior becomes part of repeatable webhook issue QA."
+    allowed_files:
+      - "docs/workflows/webhook-label-manual-qa.md"
+      - "docs/workflows/webhook-qa-ladder.md"
+      - "docs/workflows/webhook-auto-sessions.md"
+      - "docs/workflows/webhook-issue-to-pr-review-qa.md"
+    verify:
+      - "git diff --check -- docs/workflows"
+    stop_if:
+      - "Implementation behavior is not yet stable enough to document."
+      - "Need to edit product code from this docs task."
+    receipt:
+      result: done
+      note: "docs/goals/completed-issue-session-ux/notes/T004-docs.md"
+      summary: "Updated webhook manual QA docs and QA ladder with completed issue-session checks."
+      changed_files:
+        - "docs/workflows/webhook-label-manual-qa.md"
+        - "docs/workflows/webhook-qa-ladder.md"
+      commands:
+        - command: "git diff --check -- packages/web/components/detail docs/workflows docs/goals/completed-issue-session-ux"
+          status: pass
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Run manual browser QA for completed issue session behavior using issue #35 or a fresh reversible issue."
+    allowed_files:
+      - "docs/goals/completed-issue-session-ux/state.yaml"
+      - "docs/goals/completed-issue-session-ux/notes/**"
+    verify:
+      - "Browser walkthrough of issue detail completed-state UI."
+      - "SQLite query for deployment ended_at and completion result."
+      - "Diagnostics timeline for the issue."
+      - "If terminal access exists, verify completed terminal/history action works."
+    stop_if:
+      - "Local server or webhook tunnel is unavailable and cannot be safely restarted."
+      - "Manual QA would require destructive cleanup without operator approval."
+      - "The UI cannot be meaningfully tested because implementation is incomplete."
+    receipt:
+      result: done
+      note: "docs/goals/completed-issue-session-ux/notes/T005-manual-qa.md"
+      summary: "Browser QA against issue #35 proved completed session history is visible, Launch with Codex remains available, and Open Terminal is absent for the ended deployment."
+      changed_files:
+        - "docs/goals/completed-issue-session-ux/notes/T005-manual-qa.md"
+        - "docs/goals/completed-issue-session-ux/state.yaml"
+      commands:
+        - command: "Playwright browser walkthrough of http://localhost:3847/issues/mean-weasel/issuectl-test-repo-2/35"
+          status: pass
+        - command: "Playwright click-through of View completed terminal for issue #35"
+          status: pass
+        - command: "sqlite3 deployment query for mean-weasel/issuectl-test-repo-2#35"
+          status: pass
+        - command: "pnpm --dir packages/cli exec issuectl diag show --issue mean-weasel/issuectl-test-repo-2#35"
+          status: pass
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether issue #531 is fully satisfied and the completed issue session UX is ready to close or PR."
+    inputs:
+      - "All task receipts"
+      - "Final diff"
+      - "Focused test output"
+      - "Manual browser QA evidence"
+    constraints:
+      - "Read-only."
+      - "Do not call complete if issue detail cannot demonstrate completed session history."
+    expected_output:
+      - "complete or not_complete"
+      - "full_outcome_complete: true or false"
+      - "Missing evidence or residual risks"
+      - "Next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      note: "docs/goals/completed-issue-session-ux/notes/T999-final-audit.md"
+      summary: "Issue #531 acceptance criteria are satisfied with tests, browser QA, DB evidence, diagnostics, and updated webhook QA docs."

--- a/docs/workflows/webhook-label-manual-qa.md
+++ b/docs/workflows/webhook-label-manual-qa.md
@@ -1,0 +1,399 @@
+# Webhook Label Manual QA
+
+This runbook is the repeatable manual QA path for label-triggered webhook sessions in the two issuectl test repositories.
+
+Use it when you need to prove that adding an issue or PR automation label from the local web UI creates exactly one local session, starts the intended agent without a trust or permission prompt, consumes the trigger label, and leaves the target safe to test again later.
+
+## Test Repositories
+
+Default QA repositories:
+
+```text
+mean-weasel/issuectl-test-repo
+mean-weasel/issuectl-test-repo-2
+```
+
+Prefer `issuectl-test-repo-2` for destructive-looking QA because it is the secondary fixture repo. Use reversible targets:
+
+- Issues: a small documentation-only request that can be closed when done.
+- PRs: a branch that adds one timestamped file under `qa-receipts/`.
+
+## Labels And Defaults
+
+| Target | Trigger label | Default agent | Expected worktree suffix |
+| --- | --- | --- | --- |
+| Issue | `issuectl:auto-launch` | Codex | `issue-<number>` |
+| PR | `issuectl:auto-review` | Claude | `pr-<number>` |
+
+Either target can still be launched with either agent if settings are changed. The defaults are part of the product contract, not a hard limitation.
+
+## Prerequisites
+
+1. Start the local web server.
+
+```bash
+pnpm --dir packages/web dev
+```
+
+2. Confirm it is reachable.
+
+```bash
+curl -I http://localhost:3847
+```
+
+3. Confirm repo automation settings.
+
+```bash
+pnpm --dir packages/cli exec issuectl repo show mean-weasel/issuectl-test-repo-2
+pnpm --dir packages/cli exec issuectl webhook status mean-weasel/issuectl-test-repo-2
+```
+
+Expected settings for the normal QA pass:
+
+```text
+auto-launch issues: true
+auto-review PRs: true
+issue agent: codex
+review agent: claude
+```
+
+4. Confirm the public webhook URL forwards to this machine and port.
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook status mean-weasel/issuectl-test-repo-2
+tail -f ~/.issuectl/logs/web.log
+```
+
+Stop if GitHub deliveries are not reaching the local server. Fix the tunnel or hook before making product conclusions.
+
+## Create A Reversible Issue Target
+
+Create an untagged issue from GitHub or from the local issuectl UI. Keep the issue simple and easy to close.
+
+Suggested title:
+
+```text
+QA reversible issue auto-launch receipt
+```
+
+Suggested body:
+
+```text
+Manual issuectl QA target. Expected behavior: adding issuectl:auto-launch from the local issue detail UI launches one Codex session, consumes the label, and does not prompt for workspace trust.
+```
+
+Record the issue number:
+
+```bash
+ISSUE_NUMBER=<number>
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+```
+
+Open the issue detail page:
+
+```text
+http://localhost:3847/issues/mean-weasel/issuectl-test-repo-2/<issue-number>
+```
+
+## Run Issue Auto-Launch QA
+
+1. Open the issue detail page in Chrome.
+2. Confirm the issue starts without `issuectl:auto-launch`.
+3. Use the local label editor to add `issuectl:auto-launch`.
+4. Watch diagnostics until the debounce window resolves.
+
+```bash
+pnpm --dir packages/cli exec issuectl diag tail --issue "$OWNER/$REPO#$ISSUE_NUMBER"
+```
+
+5. Confirm the intent launches once.
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.first_signal_at/1000,'unixepoch') as first_signal,
+       datetime(i.scheduled_at/1000,'unixepoch') as scheduled,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='issue' and i.target_number=$ISSUE_NUMBER
+order by i.id;"
+```
+
+6. Confirm the deployment.
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.target_type,d.target_number,d.agent,d.state,d.triggered_by,
+       d.branch_name,d.workspace_path,d.launched_at,d.ended_at,d.terminal_reason
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+order by d.id;"
+```
+
+Expected issue evidence:
+
+- Exactly one intent reaches `launched`.
+- Follow-up label cleanup intents resolve as `skipped_optout`, not `launched`.
+- Deployment agent is `codex` unless this run intentionally changed the issue agent.
+- The issue detail UI changes to an active terminal state while the deployment is live.
+- The terminal does not show the Codex workspace trust prompt.
+- Final GitHub labels do not include `issuectl:auto-launch`.
+
+After the agent completes:
+
+- `deployments.ended_at` is set and `terminal_reason` records the completion outcome.
+- The issue detail UI no longer shows an active terminal state.
+- The issue detail UI shows a completed session record with the agent, deployment ID, branch, workspace, completion status, and summary when available.
+- If the completed tmux session is retained, the `View completed terminal` action opens a read-only transcript.
+- The issue detail UI still allows a separate new launch action.
+- The session history action opens the filtered Sessions history for that issue.
+
+## Create A Reversible PR Target
+
+Create a new branch in the secondary test repo and add one receipt file.
+
+```bash
+tmpdir="$(mktemp -d)"
+git clone git@github.com:mean-weasel/issuectl-test-repo-2.git "$tmpdir/issuectl-test-repo-2"
+cd "$tmpdir/issuectl-test-repo-2"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+branch="issuectl-pr-manual-qa-$stamp"
+git switch -c "$branch"
+mkdir -p qa-receipts
+printf '%s\n' \
+  "QA receipt for issuectl PR auto-review." \
+  "Expected review agent should use supplied PR JSON and local checkout before gh." \
+  "Timestamp: $stamp" \
+  > "qa-receipts/pr-auto-review-$stamp.txt"
+git add "qa-receipts/pr-auto-review-$stamp.txt"
+git commit -m "Add issuectl PR auto-review QA receipt"
+git push -u origin "$branch"
+gh pr create \
+  --repo mean-weasel/issuectl-test-repo-2 \
+  --base main \
+  --head "$branch" \
+  --title "QA PR auto-review receipt $stamp" \
+  --body "Manual issuectl QA target. Expected behavior: adding issuectl:auto-review from the local PR detail UI launches one Claude review session, consumes the label, and avoids gh authentication prompts."
+```
+
+Record the PR number:
+
+```bash
+PR_NUMBER=<number>
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+```
+
+Open the PR detail page:
+
+```text
+http://localhost:3847/pulls/mean-weasel/issuectl-test-repo-2/<pr-number>
+```
+
+## Run PR Auto-Review QA
+
+1. Open the PR detail page in Chrome.
+2. Confirm the PR starts without `issuectl:auto-review`.
+3. Use the local label editor to add `issuectl:auto-review`.
+4. Watch diagnostics until the debounce window resolves.
+
+```bash
+pnpm --dir packages/cli exec issuectl diag tail --pr "$OWNER/$REPO#$PR_NUMBER"
+```
+
+If the local CLI does not support `diag tail --pr`, use SQL:
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select e.id,e.event,e.level,e.source,e.target_type,e.target_number,e.deployment_id,
+       e.status,e.message,datetime(e.ts/1000,'unixepoch') as ts
+from diagnostic_events e
+join repos r on r.id=e.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and e.target_type='pr' and e.target_number=$PR_NUMBER
+order by e.id;"
+```
+
+5. Confirm the intent sequence.
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.first_signal_at/1000,'unixepoch') as first_signal,
+       datetime(i.scheduled_at/1000,'unixepoch') as scheduled,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='pr' and i.target_number=$PR_NUMBER
+order by i.id;"
+```
+
+6. Confirm the deployment and PR review row.
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.target_type,d.target_number,d.agent,d.state,d.triggered_by,
+       d.branch_name,d.workspace_path,d.launched_at,d.ended_at,d.terminal_reason,
+       d.completion_result_json
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+order by d.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select pr.id,pr.pr_number,pr.deployment_id,pr.status,pr.triggered_by,
+       pr.started_head_sha,pr.completed_head_sha,pr.head_ref
+from pr_reviews pr
+join repos r on r.id=pr.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and pr.pr_number=$PR_NUMBER
+order by pr.id;"
+```
+
+Expected PR evidence:
+
+- Exactly one intent reaches `launched`.
+- Follow-up unlabeled events resolve as `skipped_optout`, not `launched`.
+- Deployment agent is `claude` unless this run intentionally changed the review agent.
+- Worktree path ends in `pr-<number>`.
+- The terminal shows Claude bypass permissions and no trust prompt.
+- The agent uses supplied PR JSON and local checkout before `gh`.
+- Final GitHub labels do not include `issuectl:auto-review`.
+- A review summary comment or review result is posted through `issuectl agent mutate`.
+- The local PR detail UI no longer shows an active terminal state after completion.
+
+## Terminal Inspection
+
+Find the deployment id, then inspect the tmux pane. The session name normally follows:
+
+```text
+issuectl-<repo-name>-issue-<number>
+issuectl-<repo-name>-pr-<number>
+```
+
+Example:
+
+```bash
+tmux capture-pane -pt issuectl-issuectl-test-repo-2-pr-$PR_NUMBER -S -220 | tail -180
+```
+
+Look for:
+
+- `bypass permissions on` for Claude webhook/comment-command launches.
+- No `Do you trust the contents of this directory?` prompt.
+- No `gh auth login` blocker.
+- Agent completion routed through `issuectl agent complete`.
+
+## Reset A QA Issue
+
+Use this when an issue QA target should be safe for another manual run.
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+ISSUE_NUMBER=<number>
+
+gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-launch,issuectl:in-progress"
+
+api_token="$(sqlite3 ~/.issuectl/issuectl.db "select value from settings where key='api_token';")"
+
+deployment_ids="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+  and d.ended_at is null;")"
+
+for id in $deployment_ids; do
+  curl -sS -X POST "http://localhost:3847/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"issue\",\"targetNumber\":$ISSUE_NUMBER}"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-issue-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+```
+
+Optionally close the issue after the QA pass:
+
+```bash
+gh issue close "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --comment "Closing completed issuectl manual QA target."
+```
+
+## Reset A QA PR
+
+Use this after PR auto-review QA completes.
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+PR_NUMBER=<number>
+
+gh pr edit "$PR_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-review,issuectl:in-progress"
+
+api_token="$(sqlite3 ~/.issuectl/issuectl.db "select value from settings where key='api_token';")"
+
+deployment_ids="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+  and d.ended_at is null;")"
+
+for id in $deployment_ids; do
+  curl -sS -X POST "http://localhost:3847/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"pr\",\"targetNumber\":$PR_NUMBER}"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$PR_NUMBER" '$1 ~ "issuectl-" repo "-pr-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+```
+
+Close the QA PR and delete the branch when the run is done:
+
+```bash
+head_ref="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName --jq .headRefName)"
+gh pr close "$PR_NUMBER" --repo "$OWNER/$REPO" --comment "Closing completed issuectl manual QA target."
+git ls-remote --exit-code --heads "git@github.com:$OWNER/$REPO.git" "$head_ref" >/dev/null &&
+  git push "git@github.com:$OWNER/$REPO.git" --delete "$head_ref"
+```
+
+## Final QA Receipt
+
+Record these facts in the task thread or a goal note:
+
+```text
+Target:
+URL:
+Initial labels:
+Final labels:
+Intent ids:
+Deployment id:
+Agent:
+Worktree:
+Terminal prompt status:
+Completion status:
+Follow-up webhook result:
+Cleanup performed:
+Residual risk:
+```
+
+The run passes only when the trigger label is consumed, exactly one deployment launches, no trust or permission prompt blocks the terminal, completion is recorded, and the follow-up webhook does not launch a second session.

--- a/docs/workflows/webhook-qa-ladder.md
+++ b/docs/workflows/webhook-qa-ladder.md
@@ -1,0 +1,194 @@
+# Webhook QA Ladder
+
+This ladder orders issue and PR webhook QA workflows from lowest complexity to highest complexity. Use it to pick the smallest manual or agent-driven check that can answer the question in front of you.
+
+Prefer running the lower rungs first when the environment is fresh, the tunnel changed, the web server restarted, labels were reset, or a failure could be infrastructure instead of product behavior.
+
+## Complexity Order
+
+| Rung | Workflow | Target | What It Proves | Primary Runbook |
+| --- | --- | --- | --- | --- |
+| 0 | Local server health | None | Dashboard and API process are reachable on this machine. | This file |
+| 1 | Webhook delivery health | Repo | GitHub can reach the local receiver and HMAC verification is working. | [Webhook Auto-Sessions Runbook](./webhook-auto-sessions.md) |
+| 2 | Untagged target no-op | Issue or PR | Webhook delivery alone does not launch without the opt-in label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 3 | Label editor smoke | Issue or PR | Local UI can add/remove labels and GitHub reflects the changes. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 4 | Issue auto-launch | Issue | `issuectl:auto-launch` launches exactly one Codex issue session and consumes the label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 5 | PR auto-review | PR | `issuectl:auto-review` launches exactly one Claude review session and consumes the label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 6 | Agent matrix | Issue and PR | Both Codex and Claude can start for either target without trust or permission prompts. | Future runbook |
+| 7 | Completion and cleanup lifecycle | Issue and PR | Agent completion updates DB/UI state, removes active labels, and follow-up webhooks do not relaunch. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 8 | Failure and reset recovery | Issue and PR | Operators can clean up stale labels, stale deployments, tmux sessions, and test branches. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 9 | Full regression pass | Issue and PR | Fresh issue and fresh PR both pass the whole one-shot automation oracle in one session. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 10 | Issue-to-PR review chain | Issue then PR | Issue auto-work feeds a PR that is then auto-reviewed, with current default budget limits made explicit. | [Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md) |
+
+## Rung 0: Local Server Health
+
+Run this before debugging webhook behavior.
+
+```bash
+curl -I http://localhost:3847
+pnpm --dir packages/cli exec issuectl repo show mean-weasel/issuectl-test-repo-2
+sqlite3 -header -column ~/.issuectl/issuectl.db "select key,value from settings where key in ('public_webhook_base_url','webhook_debounce_seconds','max_concurrent_webhook_agents');"
+```
+
+Pass signal:
+
+- `curl` reaches the dashboard.
+- The test repo is tracked.
+- Settings read without DB errors.
+
+## Rung 1: Webhook Delivery Health
+
+Use this when a tunnel, webhook URL, repo setup, or local server changed.
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook status mean-weasel/issuectl-test-repo-2
+tail -f ~/.issuectl/logs/web.log
+pnpm --dir packages/cli exec issuectl webhook tail --repo mean-weasel/issuectl-test-repo-2 --limit 20
+```
+
+Pass signal:
+
+- GitHub deliveries create local webhook event rows.
+- Invalid signature errors are absent for real deliveries.
+- The receiver URL points at the current public tunnel.
+
+## Rung 2: Untagged Target No-Op
+
+Use this before labeling a new issue or PR. It proves opt-in is still required.
+
+For an untagged issue or PR, wait for any create/opened delivery to debounce and resolve.
+
+Expected status:
+
+```text
+skipped_optout
+```
+
+This is a product success, not a failure. The target should not launch until the trigger label is present.
+
+## Rung 3: Label Editor Smoke
+
+Use this when the question is whether the local UI can edit labels.
+
+Steps:
+
+1. Open the issue or PR detail page in Chrome.
+2. Add a harmless non-trigger label if available, or add then remove the trigger label while automation is disabled.
+3. Confirm GitHub and the local detail UI both show the same labels.
+
+Do not use this rung with automation enabled unless you intend to launch a session.
+
+## Rung 4: Issue Auto-Launch
+
+Use this for the default issue path.
+
+Expected proof:
+
+- `issuectl:auto-launch` is added from the local issue detail UI.
+- One webhook intent launches.
+- Agent is `codex` unless the repo setting intentionally differs.
+- Worktree path ends with `issue-<number>`.
+- Codex starts without a workspace trust prompt.
+- The trigger label is consumed.
+
+## Rung 5: PR Auto-Review
+
+Use this for the default PR path.
+
+Expected proof:
+
+- `issuectl:auto-review` is added from the local PR detail UI.
+- One webhook intent launches.
+- Agent is `claude` unless the repo setting intentionally differs.
+- Worktree path ends with `pr-<number>`.
+- Claude starts with bypass permissions and no interactive prompt.
+- The agent uses supplied PR JSON and local checkout before `gh`.
+- The trigger label is consumed.
+
+## Rung 6: Agent Matrix
+
+Use this only after the default issue and PR paths are healthy. This is higher complexity because it intentionally changes repo settings.
+
+Matrix:
+
+| Target | Agent | Expected |
+| --- | --- | --- |
+| Issue | Codex | Default issue path; no trust prompt. |
+| Issue | Claude | Non-default issue path; no permission prompt. |
+| PR | Claude | Default PR path; no permission prompt. |
+| PR | Codex | Non-default PR path; no trust prompt. |
+
+Reset repo settings after the run:
+
+```bash
+pnpm --dir packages/cli exec issuectl repo set mean-weasel/issuectl-test-repo-2 --issue-agent codex --review-agent claude
+```
+
+This deserves its own runbook when we run it more than once.
+
+## Rung 7: Completion And Cleanup Lifecycle
+
+Use this when the launch succeeded but UI state or labels look stale.
+
+Expected proof:
+
+- The agent calls `issuectl agent complete`.
+- `deployments.ended_at` is set.
+- `terminal_reason` is `completed`, `failed`, `no_changes`, or the expected terminal outcome.
+- PR runs have a `pr_reviews` row with completed or terminal status.
+- The detail UI no longer shows an active launch/open-terminal state after completion.
+- The issue detail UI shows completed issue-session history and keeps new launch as a separate action.
+- Retained completed tmux sessions can be viewed through a read-only completed terminal transcript.
+- Follow-up cleanup webhook events resolve as `skipped_optout`.
+
+## Rung 8: Failure And Reset Recovery
+
+Use this when a prior QA run left stale labels, live deployment rows, terminal sessions, or open test branches.
+
+Expected proof:
+
+- Trigger labels are removed.
+- Live deployment rows are ended through the API.
+- Stale tmux sessions are killed.
+- QA PRs are closed and branches deleted.
+- The target can be reused or the next fresh target starts untagged.
+
+## Rung 9: Full Regression Pass
+
+Use this before calling a webhook-label release or major PR ready.
+
+Run, in order:
+
+1. Rung 0 local server health.
+2. Rung 1 webhook delivery health.
+3. Rung 2 untagged issue no-op.
+4. Rung 4 issue auto-launch.
+5. Rung 8 issue reset or closure.
+6. Rung 2 untagged PR no-op.
+7. Rung 5 PR auto-review.
+8. Rung 7 completion and cleanup.
+9. Rung 8 PR reset or closure.
+
+Final pass criteria:
+
+- Fresh issue and fresh PR each launch exactly once only after labeling.
+- No trust or permission prompt blocks either default agent.
+- Trigger labels are consumed.
+- Follow-up webhook events do not relaunch.
+- Diagnostics, deployment rows, and UI state agree.
+
+## Rung 10: Issue-To-PR Review Chain
+
+Use this after rungs 0 through 9 pass.
+
+This rung is intentionally above the full regression pass because it crosses target boundaries and can touch mutation budgets, branch creation, PR creation, and review launch behavior.
+
+Important default behavior:
+
+- Webhook issue sessions currently have `create_pr=0` and `push=0` budgets.
+- Therefore the default supported chained QA is staged: auto-launch the issue, then manually create a small PR, then label that PR for auto-review.
+- A fully automatic issue-worker-created PR requires an explicit product/security decision to grant issue sessions PR creation and push authority.
+
+Primary runbook:
+
+[Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md)

--- a/packages/web/components/detail/CompletedSessionTerminalButton.tsx
+++ b/packages/web/components/detail/CompletedSessionTerminalButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/paper";
+import { getCompletedSessionTranscript } from "@/lib/actions/completed-terminal";
+import styles from "./IssueDetail.module.css";
+
+type Props = {
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+export function CompletedSessionTerminalButton({
+  deploymentId,
+  owner,
+  repo,
+  issueNumber,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [sessionName, setSessionName] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpen() {
+    setError(null);
+    startTransition(async () => {
+      const result = await getCompletedSessionTranscript({
+        deploymentId,
+        owner,
+        repo,
+        targetType: "issue",
+        targetNumber: issueNumber,
+      });
+      if (!result.success) {
+        setTranscript(null);
+        setSessionName(null);
+        setError(result.error);
+        setOpen(true);
+        return;
+      }
+      setSessionName(result.sessionName);
+      setTranscript(result.transcript);
+      setOpen(true);
+    });
+  }
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleOpen} disabled={isPending}>
+        {isPending ? "Loading..." : "View completed terminal"}
+      </Button>
+      {open && (
+        <div className={styles.completedTerminalOverlay} role="dialog" aria-modal="true" aria-label="Completed terminal transcript">
+          <button
+            type="button"
+            className={styles.completedTerminalBackdrop}
+            aria-label="Close completed terminal transcript"
+            onClick={() => setOpen(false)}
+          />
+          <div className={styles.completedTerminalPanel}>
+            <div className={styles.completedTerminalHeader}>
+              <div>
+                <p className={styles.completedSessionEyebrow}>Completed terminal</p>
+                <h2>Session #{deploymentId}</h2>
+                {sessionName && <span>{sessionName}</span>}
+              </div>
+              <button
+                type="button"
+                className={styles.completedTerminalClose}
+                onClick={() => setOpen(false)}
+                aria-label="Close completed terminal transcript"
+              >
+                {"\u00D7"}
+              </button>
+            </div>
+            {error ? (
+              <p className={styles.completedTerminalError} role="alert">{error}</p>
+            ) : (
+              <pre className={styles.completedTerminalPre}>{transcript}</pre>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/components/detail/IssueDetail.module.css
+++ b/packages/web/components/detail/IssueDetail.module.css
@@ -26,10 +26,204 @@
   border-bottom: 1px solid var(--paper-line);
 }
 
+.completedSession {
+  margin: 18px 0 20px;
+  padding: 16px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: color-mix(in srgb, var(--paper-bg-warm) 72%, white);
+  display: grid;
+  gap: 14px;
+}
+
+.completedSessionHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.completedSessionHeader h2 {
+  margin: 2px 0 0;
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.completedSessionEyebrow {
+  margin: 0;
+  font: 700 var(--paper-fs-xs) var(--paper-mono);
+  color: var(--paper-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.completedSessionStatus {
+  flex: 0 0 auto;
+  max-width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, var(--paper-green) 12%, white);
+  color: var(--paper-green);
+  font: 700 var(--paper-fs-xs) var(--paper-mono);
+  white-space: nowrap;
+}
+
+.completedSessionMeta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 14px;
+}
+
+.completedSessionMeta div {
+  min-width: 0;
+}
+
+.completedSessionMeta dt {
+  font: 700 var(--paper-fs-xs) var(--paper-mono);
+  color: var(--paper-ink-muted);
+  text-transform: uppercase;
+}
+
+.completedSessionMeta dd {
+  margin: 3px 0 0;
+  color: var(--paper-ink);
+  overflow-wrap: anywhere;
+}
+
+.completedSessionSummary {
+  margin: 0;
+  color: var(--paper-ink-muted);
+}
+
+.completedSessionActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.completedSessionLink,
+.completedSessionSecondaryLink {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border-radius: var(--paper-radius-sm);
+  font: 700 var(--paper-fs-sm) var(--paper-mono);
+  text-decoration: none;
+}
+
+.completedSessionLink {
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+  border: 1px solid var(--paper-ink);
+}
+
+.completedSessionSecondaryLink {
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  border: 1px solid var(--paper-line);
+}
+
+.completedTerminalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+}
+
+.completedTerminalBackdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(24, 22, 18, 0.38);
+}
+
+.completedTerminalPanel {
+  position: relative;
+  z-index: 1;
+  width: min(980px, 100%);
+  max-height: min(760px, calc(100dvh - 36px));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-md);
+  background: var(--paper-bg);
+  box-shadow: 0 18px 48px rgba(24, 22, 18, 0.22);
+  overflow: hidden;
+}
+
+.completedTerminalHeader {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--paper-line);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.completedTerminalHeader h2 {
+  margin: 2px 0 0;
+  font-size: 18px;
+}
+
+.completedTerminalHeader span {
+  display: block;
+  margin-top: 4px;
+  color: var(--paper-ink-muted);
+  overflow-wrap: anywhere;
+}
+
+.completedTerminalClose {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: color-mix(in srgb, white 42%, var(--paper-bg));
+  color: var(--paper-ink);
+  font-size: 22px;
+  line-height: 1;
+}
+
+.completedTerminalError {
+  margin: 0;
+  padding: 16px;
+  color: var(--paper-brick);
+}
+
+.completedTerminalPre {
+  margin: 0;
+  min-height: 300px;
+  padding: 16px;
+  overflow: auto;
+  background: #161512;
+  color: #f7f0df;
+  font: 13px/1.5 var(--paper-mono);
+  white-space: pre-wrap;
+}
+
 @media (min-width: 768px) {
   .body {
     max-width: 820px;
     margin: 0 auto;
     padding: 32px 40px 40px;
+  }
+}
+
+@media (max-width: 560px) {
+  .completedSessionHeader {
+    display: grid;
+  }
+
+  .completedSessionStatus {
+    justify-self: start;
+  }
+
+  .completedSessionMeta {
+    grid-template-columns: 1fr;
   }
 }

--- a/packages/web/components/detail/LaunchCard.test.ts
+++ b/packages/web/components/detail/LaunchCard.test.ts
@@ -1,0 +1,114 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { Deployment } from "@issuectl/core";
+import { LaunchCard } from "./LaunchCard";
+
+vi.mock("@/components/launch/LaunchActiveBanner", () => ({
+  LaunchActiveBanner: ({ deploymentId }: { deploymentId: number }) =>
+    createElement("div", null, `active banner ${deploymentId} Open Terminal`),
+}));
+
+vi.mock("@/lib/actions/completed-terminal", () => ({
+  getCompletedSessionTranscript: vi.fn(),
+}));
+
+describe("LaunchCard", () => {
+  it("keeps live deployments on the active terminal path", () => {
+    const html = renderToStaticMarkup(
+      createElement(LaunchCard, {
+        owner: "mean-weasel",
+        repo: "issuectl",
+        issueNumber: 26,
+        issueTitle: "QA issue",
+        deployments: [
+          deployment({ id: 12, endedAt: "2026-05-28T11:10:05.000Z" }),
+          deployment({ id: 33, endedAt: null, ttydPort: 7777 }),
+        ],
+      }),
+    );
+
+    expect(html).toContain("active banner 33 Open Terminal");
+    expect(html).not.toContain("Completed session");
+    expect(html).not.toContain("worked this issue");
+  });
+
+  it("renders completed session evidence when no live deployment exists", () => {
+    const html = renderToStaticMarkup(
+      createElement(LaunchCard, {
+        owner: "mean-weasel",
+        repo: "issuectl",
+        issueNumber: 26,
+        issueTitle: "QA issue",
+        deployments: [
+          deployment({
+            id: 12,
+            agent: "codex",
+            branchName: "issue-26-qa",
+            workspacePath: "/Users/neonwatty/.issuectl/worktrees/issuectl-test-repo-2-issue-26",
+            endedAt: "2026-05-28T11:10:05.000Z",
+            terminalReason: "completed",
+            completionResultJson: JSON.stringify({
+              status: "no_changes",
+              summary: "Verified context and clean worktree.",
+            }),
+          }),
+        ],
+      }),
+    );
+
+    expect(html).toContain("Codex worked this issue");
+    expect(html).toContain("Completed session #12");
+    expect(html).toContain("No Changes");
+    expect(html).toContain("Verified context and clean worktree.");
+    expect(html).toContain("issue-26-qa");
+    expect(html).toContain("View completed terminal");
+    expect(html).toContain("Session history");
+    expect(html).toContain("/sessions?tab=sessions&amp;repo=mean-weasel%2Fissuectl&amp;state=ended&amp;q=Issue+%2326");
+    expect(html).not.toContain("Open Terminal");
+  });
+
+  it("renders nothing when an issue has no deployment history", () => {
+    const html = renderToStaticMarkup(
+      createElement(LaunchCard, {
+        owner: "mean-weasel",
+        repo: "issuectl",
+        issueNumber: 26,
+        issueTitle: "QA issue",
+        deployments: [],
+      }),
+    );
+
+    expect(html).toBe("");
+  });
+});
+
+function deployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: 1,
+    repoId: 1,
+    issueNumber: 26,
+    targetType: "issue",
+    targetNumber: 26,
+    agent: "codex",
+    branchName: "issue-26",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/issue-26",
+    linkedPrNumber: null,
+    state: "active",
+    terminalBackend: "pty_bridge",
+    triggeredBy: "webhook",
+    parentDeploymentId: null,
+    webhookDepth: 0,
+    launchedAt: "2026-05-28T11:00:00.000Z",
+    endedAt: "2026-05-28T11:10:00.000Z",
+    terminalReason: "completed",
+    completionToken: null,
+    completionResultJson: null,
+    notificationSentAt: null,
+    ttydPort: null,
+    ttydPid: null,
+    idleSince: null,
+    ...overrides,
+  };
+}

--- a/packages/web/components/detail/LaunchCard.tsx
+++ b/packages/web/components/detail/LaunchCard.tsx
@@ -1,6 +1,10 @@
+import Link from "next/link";
 import type { Deployment } from "@issuectl/core";
 import { LaunchActiveBanner } from "@/components/launch/LaunchActiveBanner";
-import { deploymentLaunchAgent } from "@/components/launch/agent";
+import { deploymentLaunchAgent, launchAgentLabel } from "@/components/launch/agent";
+import { formatDate, formatDuration } from "@/lib/format";
+import { CompletedSessionTerminalButton } from "./CompletedSessionTerminalButton";
+import styles from "./IssueDetail.module.css";
 
 type Props = {
   owner: string;
@@ -12,19 +16,146 @@ type Props = {
 
 export function LaunchCard({ owner, repo, issueNumber, issueTitle, deployments }: Props) {
   const liveDeployment = deployments.find((d) => d.endedAt === null);
-  if (!liveDeployment) return null;
+  if (liveDeployment) {
+    return (
+      <LaunchActiveBanner
+        deploymentId={liveDeployment.id}
+        branchName={liveDeployment.branchName}
+        endedAt={liveDeployment.endedAt}
+        owner={owner}
+        repo={repo}
+        issueNumber={issueNumber}
+        issueTitle={issueTitle}
+        ttydPort={liveDeployment.ttydPort}
+        agent={deploymentLaunchAgent(liveDeployment)}
+      />
+    );
+  }
+
+  const completedDeployment = latestCompletedDeployment(deployments);
+  if (!completedDeployment) return null;
 
   return (
-    <LaunchActiveBanner
-      deploymentId={liveDeployment.id}
-      branchName={liveDeployment.branchName}
-      endedAt={liveDeployment.endedAt}
-      owner={owner}
-      repo={repo}
-      issueNumber={issueNumber}
-      issueTitle={issueTitle}
-      ttydPort={liveDeployment.ttydPort}
-      agent={deploymentLaunchAgent(liveDeployment)}
-    />
+    <section className={styles.completedSession} aria-label="Completed agent session">
+      <div className={styles.completedSessionHeader}>
+        <div>
+          <p className={styles.completedSessionEyebrow}>
+            {launchAgentLabel(deploymentLaunchAgent(completedDeployment))} worked this issue
+          </p>
+          <h2>Completed session #{completedDeployment.id}</h2>
+        </div>
+        <span className={styles.completedSessionStatus}>
+          {completionStatus(completedDeployment)}
+        </span>
+      </div>
+
+      <dl className={styles.completedSessionMeta}>
+        <div>
+          <dt>Branch</dt>
+          <dd>{completedDeployment.branchName}</dd>
+        </div>
+        <div>
+          <dt>Ended</dt>
+          <dd>{completedDeployment.endedAt ? formatDate(completedDeployment.endedAt) : "not recorded"}</dd>
+        </div>
+        <div>
+          <dt>Duration</dt>
+          <dd>
+            {completedDeployment.endedAt
+              ? formatDuration(completedDeployment.launchedAt, completedDeployment.endedAt)
+              : "not recorded"}
+          </dd>
+        </div>
+        <div>
+          <dt>Workspace</dt>
+          <dd>{completedDeployment.workspacePath}</dd>
+        </div>
+      </dl>
+
+      {completionSummary(completedDeployment) && (
+        <p className={styles.completedSessionSummary}>
+          {completionSummary(completedDeployment)}
+        </p>
+      )}
+
+      <div className={styles.completedSessionActions}>
+        <CompletedSessionTerminalButton
+          deploymentId={completedDeployment.id}
+          owner={owner}
+          repo={repo}
+          issueNumber={issueNumber}
+        />
+        <Link
+          className={styles.completedSessionSecondaryLink}
+          href={sessionHistoryHref(owner, repo, issueNumber)}
+        >
+          Session history
+        </Link>
+        {completedDeployment.linkedPrNumber !== null && (
+          <Link
+            className={styles.completedSessionSecondaryLink}
+            href={`/pulls/${owner}/${repo}/${completedDeployment.linkedPrNumber}`}
+          >
+            PR #{completedDeployment.linkedPrNumber}
+          </Link>
+        )}
+      </div>
+    </section>
   );
+}
+
+function latestCompletedDeployment(deployments: Deployment[]): Deployment | null {
+  return deployments
+    .filter((deployment) => deployment.endedAt !== null)
+    .sort((left, right) =>
+      Date.parse(right.endedAt ?? right.launchedAt) - Date.parse(left.endedAt ?? left.launchedAt)
+        || right.id - left.id,
+    )[0] ?? null;
+}
+
+function completionStatus(deployment: Deployment): string {
+  const result = completionResult(deployment);
+  return labelize(stringValue(result.status) ?? deployment.terminalReason ?? "completed");
+}
+
+function completionSummary(deployment: Deployment): string | null {
+  const result = completionResult(deployment);
+  return stringValue(result.summary)
+    ?? stringValue(result.reason)
+    ?? stringValue(result.error)
+    ?? null;
+}
+
+function completionResult(deployment: Deployment): Record<string, unknown> {
+  if (!deployment.completionResultJson) return {};
+  try {
+    const parsed = JSON.parse(deployment.completionResultJson) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function labelize(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function sessionHistoryHref(owner: string, repo: string, issueNumber: number): string {
+  const params = new URLSearchParams({
+    tab: "sessions",
+    repo: `${owner}/${repo}`,
+    state: "ended",
+    q: `Issue #${issueNumber}`,
+  });
+  return `/sessions?${params.toString()}`;
 }

--- a/packages/web/lib/actions/completed-terminal.test.ts
+++ b/packages/web/lib/actions/completed-terminal.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const execFileSync = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({ execFileSync }));
+
+const getDb = vi.hoisted(() => vi.fn());
+const getDeploymentById = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const isTmuxSessionAlive = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getDeploymentById: (...args: unknown[]) => getDeploymentById(...args),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  isTmuxSessionAlive: (...args: unknown[]) => isTmuxSessionAlive(...args),
+  tmuxSessionName: (repo: string, targetNumber: number, targetType = "issue") =>
+    targetType === "issue"
+      ? `issuectl-${repo}-${targetNumber}`
+      : `issuectl-${repo}-${targetType}-${targetNumber}`,
+  formatErrorForUser: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+import { getCompletedSessionTranscript } from "./completed-terminal";
+
+beforeEach(() => {
+  execFileSync.mockReset();
+  getDb.mockReset();
+  getDeploymentById.mockReset();
+  getRepo.mockReset();
+  isTmuxSessionAlive.mockReset();
+
+  getDb.mockReturnValue({});
+  getDeploymentById.mockReturnValue(deployment({ endedAt: "2026-05-28T11:10:05.000Z" }));
+  getRepo.mockReturnValue({ id: 1, owner: "owner", name: "repo" });
+  isTmuxSessionAlive.mockReturnValue(true);
+  execFileSync.mockReturnValue("terminal output\n");
+});
+
+describe("getCompletedSessionTranscript", () => {
+  it("captures a read-only transcript for ended deployments with retained tmux sessions", async () => {
+    execFileSync.mockReturnValue("done through issuectl agent complete\n");
+
+    const result = await getCompletedSessionTranscript(input());
+
+    expect(result).toEqual({
+      success: true,
+      sessionName: "issuectl-repo-7",
+      transcript: "done through issuectl agent complete",
+    });
+    expect(execFileSync).toHaveBeenCalledWith(
+      "tmux",
+      ["capture-pane", "-p", "-t", "issuectl-repo-7", "-S", "-240"],
+      { encoding: "utf8", maxBuffer: 512 * 1024 },
+    );
+  });
+
+  it("reports completed transcript unavailable when tmux session is gone", async () => {
+    isTmuxSessionAlive.mockReturnValue(false);
+
+    const result = await getCompletedSessionTranscript(input());
+
+    expect(result).toMatchObject({
+      success: false,
+      unavailable: true,
+      error: "Completed terminal is no longer available on this machine.",
+    });
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it("does not capture active sessions through the completed transcript path", async () => {
+    getDeploymentById.mockReturnValue(deployment({ endedAt: null }));
+
+    const result = await getCompletedSessionTranscript(input());
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Session is still active. Open the live terminal instead.",
+    });
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+function input() {
+  return {
+    deploymentId: 1,
+    owner: "owner",
+    repo: "repo",
+    targetType: "issue" as const,
+    targetNumber: 7,
+  };
+}
+
+function deployment(overrides: { endedAt: string | null }) {
+  return {
+    id: 1,
+    repoId: 1,
+    issueNumber: 7,
+    targetType: "issue" as const,
+    targetNumber: 7,
+    branchName: "issue-7",
+    endedAt: overrides.endedAt,
+  };
+}

--- a/packages/web/lib/actions/completed-terminal.ts
+++ b/packages/web/lib/actions/completed-terminal.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { execFileSync } from "node:child_process";
+import {
+  formatErrorForUser,
+  getDb,
+  getDeploymentById,
+  getRepo,
+  isTmuxSessionAlive,
+} from "@issuectl/core";
+import { deploymentSessionName, getDeploymentTarget } from "@/lib/deployment-target";
+
+type CompletedSessionTranscriptResponse =
+  | { success: true; sessionName: string; transcript: string }
+  | { success: false; error: string; unavailable?: true };
+
+export async function getCompletedSessionTranscript(input: {
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  targetType: "issue" | "pr";
+  targetNumber: number;
+}): Promise<CompletedSessionTranscriptResponse> {
+  const error = validateTranscriptInput(input);
+  if (error) return { success: false, error };
+
+  try {
+    const db = getDb();
+    const deployment = getDeploymentById(db, input.deploymentId);
+    if (!deployment) return { success: false, error: "Deployment not found" };
+
+    const repoRecord = getRepo(db, input.owner, input.repo);
+    if (!repoRecord) return { success: false, error: "Repository not found" };
+    if (deployment.repoId !== repoRecord.id) {
+      return { success: false, error: "Deployment does not match this repository" };
+    }
+
+    const target = getDeploymentTarget(deployment);
+    if (target.targetType !== input.targetType || target.targetNumber !== input.targetNumber) {
+      return { success: false, error: "Deployment does not match this target" };
+    }
+    if (deployment.endedAt === null) {
+      return { success: false, error: "Session is still active. Open the live terminal instead." };
+    }
+
+    const sessionName = deploymentSessionName(input.repo, deployment);
+    if (!isTmuxSessionAlive(sessionName)) {
+      return {
+        success: false,
+        unavailable: true,
+        error: "Completed terminal is no longer available on this machine.",
+      };
+    }
+
+    return {
+      success: true,
+      sessionName,
+      transcript: captureCompletedPane(sessionName),
+    };
+  } catch (err) {
+    console.error("[issuectl] Failed to load completed session transcript:", err);
+    return { success: false, error: formatErrorForUser(err) };
+  }
+}
+
+function validateTranscriptInput(input: {
+  deploymentId: number;
+  owner: string;
+  repo: string;
+  targetType: "issue" | "pr";
+  targetNumber: number;
+}): string | null {
+  if (!Number.isInteger(input.deploymentId) || input.deploymentId <= 0) return "Invalid deployment ID";
+  if (!input.owner || !input.repo) return "Invalid repository reference";
+  if (input.targetType !== "issue" && input.targetType !== "pr") return "Invalid target type";
+  if (!Number.isInteger(input.targetNumber) || input.targetNumber <= 0) return "Invalid target number";
+  return null;
+}
+
+function captureCompletedPane(sessionName: string): string {
+  const transcript = execFileSync(
+    "tmux",
+    ["capture-pane", "-p", "-t", sessionName, "-S", "-240"],
+    { encoding: "utf8", maxBuffer: 512 * 1024 },
+  ).trimEnd();
+  return transcript || "(terminal pane is empty)";
+}


### PR DESCRIPTION
## Summary

- show completed issue-session evidence on issue detail after deployments end
- add a read-only completed terminal transcript action for retained tmux sessions
- keep live Open Terminal and new Launch with Codex paths separate
- add focused tests and webhook QA documentation/GoalBuddy receipts

## Verification

- pnpm --dir packages/web test -- components/detail/LaunchCard.test.ts lib/actions/completed-terminal.test.ts lib/actions/launch.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- Browser QA on mean-weasel/issuectl-test-repo-2#35, including View completed terminal

Fixes #531