### PR TITLE
Document webhook tunnel health preflight

### DIFF
--- a/docs/workflows/webhook-auto-sessions.md
+++ b/docs/workflows/webhook-auto-sessions.md
@@ -2,6 +2,8 @@
 
 This runbook covers the v1 GitHub webhook auto-session flow for issue launches and PR review sessions.
 
+For repeatable hands-on QA with the two test repositories, including target creation, diagnostics, expected evidence, and reset commands, use [Webhook Label Manual QA](./webhook-label-manual-qa.md). To choose the smallest right QA workflow and understand complexity order, use [Webhook QA Ladder](./webhook-qa-ladder.md). For the higher-complexity issue-to-PR-to-review chain, use [Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md).
+
 ## Receiver URL
 
 The local web server handles GitHub deliveries before Next.js request parsing so HMAC verification can use the raw request body.
@@ -36,6 +38,60 @@ issuectl webhook rotate mean-weasel/issuectl --yes
 ```
 
 `issuectl repo add --webhook` performs advisory checks for `gh` hook scope and `cloudflared`, but missing `cloudflared` is not fatal. Operators may use ngrok, Tailscale Funnel, a reverse proxy, or another public endpoint.
+
+### Tunnel Health Preflight
+
+Run this before adding an automation label, especially when using a quick tunnel.
+Quick tunnel hostnames can expire or stop resolving; GitHub then records `502`
+deliveries and issuectl will not create a local webhook intent.
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+
+pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
+
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select github_webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
+Pass signal:
+
+- The GitHub hook URL matches `issuectl webhook status`.
+- The hostname resolves and reaches the local server.
+- Recent real deliveries have `status_code=200`.
+
+If the hook points at a stale quick tunnel or recent deliveries show `502`:
+
+1. Start a fresh tunnel.
+2. Save the new base URL:
+
+```bash
+pnpm --dir packages/cli exec issuectl repo set "$OWNER/$REPO" \
+  --webhook-base-url https://fresh-example.trycloudflare.com
+```
+
+3. Rotate the stored GitHub hook so GitHub uses the new URL:
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook rotate "$OWNER/$REPO" --yes
+```
+
+4. Create a fresh delivery by removing and re-adding the trigger label from the
+   local UI. If your `gh` token has `admin:repo_hook`, redelivering the failed
+   GitHub delivery is also acceptable.
+
+Do not treat missing local intents as a product launch failure until GitHub has
+delivered the relevant `issues.labeled` or `pull_request.labeled` event with
+`status_code=200`.
 
 ## Opt-In Model
 

--- a/docs/workflows/webhook-issue-to-pr-review-qa.md
+++ b/docs/workflows/webhook-issue-to-pr-review-qa.md
@@ -79,6 +79,23 @@ where key in (
 order by key;"
 ```
 
+Confirm GitHub is delivering to the current tunnel before labeling anything:
+
+```bash
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select github_webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
 Expected normal settings:
 
 ```text
@@ -93,8 +110,29 @@ Stop before labeling anything if:
 - The local dashboard is not reachable.
 - The public webhook URL is stale.
 - GitHub deliveries are not reaching this machine.
+- Recent GitHub deliveries show `502`; rotate the hook to a fresh tunnel first.
 - The repo is not tracked or automation is disabled.
 - Another webhook QA run is active for the same target.
+
+If a quick tunnel has gone stale:
+
+1. Start a fresh tunnel to `http://localhost:3847`.
+2. Save the new base URL:
+
+```bash
+pnpm --dir packages/cli exec issuectl repo set "$OWNER/$REPO" \
+  --webhook-base-url https://fresh-example.trycloudflare.com
+```
+
+3. Rotate the GitHub hook:
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook rotate "$OWNER/$REPO" --yes
+```
+
+4. Generate a fresh delivery by removing and re-adding the trigger label from
+   the local UI. Do not continue the chain until the relevant GitHub delivery
+   has `status_code=200` and appears in `issuectl webhook tail`.
 
 ## Variant A: Staged Chain
 

--- a/docs/workflows/webhook-label-manual-qa.md
+++ b/docs/workflows/webhook-label-manual-qa.md
@@ -64,7 +64,35 @@ pnpm --dir packages/cli exec issuectl webhook status mean-weasel/issuectl-test-r
 tail -f ~/.issuectl/logs/web.log
 ```
 
+5. Confirm GitHub's stored hook URL and recent deliveries are healthy before
+   adding `issuectl:auto-launch` or `issuectl:auto-review`.
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select github_webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
 Stop if GitHub deliveries are not reaching the local server. Fix the tunnel or hook before making product conclusions.
+
+If recent deliveries show `502` or the hook URL points at a dead quick tunnel:
+
+1. Start a fresh tunnel to `http://localhost:3847`.
+2. Save the new base URL with `issuectl repo set "$OWNER/$REPO" --webhook-base-url <url>`.
+3. Run `issuectl webhook rotate "$OWNER/$REPO" --yes`.
+4. Remove and re-add the trigger label from the local UI so GitHub emits a new
+   `labeled` delivery to the fresh URL.
+5. Only judge product behavior after GitHub shows `status_code=200` for that
+   `labeled` delivery and `issuectl webhook tail` shows the matching local event.
 
 ## Create A Reversible Issue Target
 

--- a/docs/workflows/webhook-qa-ladder.md
+++ b/docs/workflows/webhook-qa-ladder.md
@@ -44,6 +44,14 @@ Use this when a tunnel, webhook URL, repo setup, or local server changed.
 pnpm --dir packages/cli exec issuectl webhook status mean-weasel/issuectl-test-repo-2
 tail -f ~/.issuectl/logs/web.log
 pnpm --dir packages/cli exec issuectl webhook tail --repo mean-weasel/issuectl-test-repo-2 --limit 20
+
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select github_webhook_id
+from repos
+where owner='mean-weasel' and name='issuectl-test-repo-2';")"
+
+gh api "repos/mean-weasel/issuectl-test-repo-2/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at}'
 ```
 
 Pass signal:
@@ -51,6 +59,8 @@ Pass signal:
 - GitHub deliveries create local webhook event rows.
 - Invalid signature errors are absent for real deliveries.
 - The receiver URL points at the current public tunnel.
+- Recent GitHub deliveries have `status_code=200`; `502` means the tunnel or
+  hook URL is stale and must be fixed before judging label automation.
 
 ## Rung 2: Untagged Target No-Op
 


### PR DESCRIPTION
## Summary
- document tunnel and GitHub delivery preflight before applying webhook automation labels
- add stale quick-tunnel recovery steps for 502 deliveries across webhook QA runbooks
- connect the chained QA workflow and QA ladder to the delivery-health gate

## Verification
- `git diff --check -- docs/workflows/webhook-auto-sessions.md docs/workflows/webhook-label-manual-qa.md docs/workflows/webhook-issue-to-pr-review-qa.md docs/workflows/webhook-qa-ladder.md`
- Node markdown sanity check for relative links and fenced code block balance

## Follow-up
- Tracks product hardening in #534
