### PR TITLE
Warn before stale webhook automation labels

### DIFF
--- a/docs/goals/stale-webhook-tunnel-detection/goal.md
+++ b/docs/goals/stale-webhook-tunnel-detection/goal.md
@@ -1,0 +1,103 @@
+# Stale Webhook Tunnel Detection
+
+## Objective
+
+Build product hardening so issuectl detects and explains stale webhook tunnel URLs before operators apply auto-launch or auto-review labels.
+
+## Original Request
+
+Plan out fixing the product gap from issue #534 with GoalBuddy: detect stale webhook tunnel URLs before label automation so users do not mistake dead GitHub delivery for broken automation.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl operators manually QAing or using webhook-driven issue and PR automation
+- Authority: `requested`
+- Proof type: `demo`
+- Completion proof: a local/manual QA walkthrough shows the UI or CLI surfaces stale webhook health before applying automation labels, points to a recovery path, and the healthy path still launches issue and PR automation correctly.
+- Goal oracle: run the documented webhook QA flow with an intentionally stale quick tunnel and confirm the product identifies the stale delivery/configuration state before label automation is judged; then rotate to a fresh tunnel and confirm issue/PR automation still works.
+- Likely misfire: implementing only more documentation or a passive CLI command while the label automation UI still lets users apply labels without seeing that GitHub is delivering to a dead tunnel.
+- Blind spots considered: GitHub API permission limits, private test repos, tunnel providers beyond quick tunnels, UI placement near issue and PR label actions, avoiding false failures when GitHub delivery history is unavailable, and keeping Codex/Claude agent defaults independent from issue-vs-PR object type.
+- Existing plan facts: issue #534 records the desired behavior and acceptance criteria; PR #535 added runbook preflight and stale quick-tunnel recovery docs; the next tranche should turn that lesson into product UI/CLI behavior.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A manual QA walkthrough can intentionally stale the webhook tunnel, see issuectl report the stale webhook/delivery condition before or during label automation, follow a recovery path to rotate the webhook, then successfully run both issue auto-launch and PR auto-review without permission prompts.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Discover the existing webhook configuration, health, delivery, UI label-action, and CLI surfaces; implement the largest safe vertical slice that exposes stale webhook tunnel health and a recovery path; verify with targeted automated checks and the documented manual QA flow. Continue into follow-up slices until issue and PR label automation both make stale tunnel state obvious and the healthy path remains working.
+
+## Non-Negotiable Constraints
+
+- Preserve existing issue and PR automation semantics: Codex remains the default issue worker, Claude remains the default PR reviewer, and either agent must remain usable for either object type.
+- Do not require GitHub hook admin permissions for basic product safety; when delivery history cannot be read, report that state clearly and degrade gracefully.
+- Keep worktree and terminal trust bypass behavior unchanged except where the goal explicitly needs health or warning UI.
+- Do not stage, revert, or rewrite unrelated dirty Apple or goal files in the local worktree.
+- Follow repo diagnostics-first guidance for launch, ttyd, tmux, terminal, or workbench failures.
+- Use Node 24.14.1 for issuectl CLI/server commands when native modules are involved.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if the user asked for working software or automation and a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+Do not create one Worker/Judge pair per repeated file, table, route, or helper. Put repeated same-shape work into one Worker package and review the package as a whole.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+A Worker should finish the whole assigned slice. A Judge should judge the whole assigned slice. A PM should reorient the board when tasks are safe but not moving the outcome.
+
+Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice. Tiny tasks are bad when they keep happening, do not change behavior, only add wrappers/contracts/proof files, or avoid the real milestone.
+
+Do not stop because a slice needs owner input, credentials, production access, destructive operations, or policy decisions. Mark that exact slice blocked with a receipt, create the smallest safe follow-up or workaround task, and continue all local, non-destructive work that can still move the goal toward the full outcome.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/stale-webhook-tunnel-detection/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/stale-webhook-tunnel-detection/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the intake: original request, input shape, authority, proof, blind spots, existing plan facts, and likely misfire.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. If a problem, suggestion, or follow-up should become a repo artifact, create an approved issue/PR or ask the operator whether to create one.
+11. Review at phase, risk, rejected-verification, ambiguity, or final-completion boundaries; do not review every small Worker by habit.
+12. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.
+
+Issue and PR handoffs are supporting artifacts. `state.yaml` remains authoritative, and every external artifact decision must be recorded in a task receipt.

--- a/docs/goals/stale-webhook-tunnel-detection/state.yaml
+++ b/docs/goals/stale-webhook-tunnel-detection/state.yaml
@@ -1,0 +1,379 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "Stale Webhook Tunnel Detection"
+  slug: "stale-webhook-tunnel-detection"
+  kind: specific
+  tranche: "Detect and surface stale webhook tunnel health before label-triggered issue and PR automation, then verify stale and healthy paths."
+  status: done
+  oracle:
+    signal: "A manual QA walkthrough can intentionally stale the webhook tunnel, see issuectl report the stale webhook/delivery condition before or during label automation, follow a recovery path to rotate the webhook, then successfully run both issue auto-launch and PR auto-review without permission prompts."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Targeted tests pass, UI/CLI behavior is demonstrated in Chrome or equivalent QA, and final audit maps the behavior to issue #534 acceptance criteria."
+  intake:
+    original_request: "Plan out fixing stale webhook tunnel detection with GoalBuddy."
+    interpreted_outcome: "issuectl should make stale webhook tunnel state obvious before users apply auto-launch or auto-review labels and should guide recovery without breaking healthy issue/PR automation."
+    input_shape: specific
+    audience: "issuectl operators using local webhook automation"
+    authority: requested
+    proof_type: demo
+    completion_proof: "A local/manual QA walkthrough proves stale tunnel warning/recovery and healthy issue/PR automation behavior."
+    likely_misfire: "Only documenting the problem or adding a hidden CLI check while the issue/PR label UI still appears actionable against a dead webhook."
+    blind_spots_considered:
+      - "GitHub hook delivery APIs may require repo hook admin permissions."
+      - "The warning must work for both issues and PRs and must not hard-code agent defaults."
+      - "Quick tunnel staleness is one case; persisted webhook URL mismatch and recent failed deliveries are separate signals."
+      - "The UX should distinguish infrastructure delivery failure from product automation failure."
+      - "Manual QA needs reset instructions because stale labels and completed sessions can obscure the result."
+    existing_plan_facts:
+      - "GitHub issue #534 tracks the product hardening request."
+      - "PR #535 documented the manual preflight and stale quick-tunnel recovery flow."
+      - "Existing defaults should remain Codex for issues and Claude for PR review, while either agent remains usable for either object type."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/stale-webhook-tunnel-detection/"
+    command: "npx goalbuddy board docs/goals/stale-webhook-tunnel-detection"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Map existing webhook config, webhook health, repo settings, GitHub delivery, label editing, and issue/PR automation UI/CLI paths relevant to stale tunnel detection."
+    inputs:
+      - "GitHub issue #534"
+      - "docs/workflows/webhook-auto-sessions.md"
+      - "docs/workflows/webhook-label-manual-qa.md"
+      - "docs/workflows/webhook-issue-to-pr-review-qa.md"
+      - "Relevant web, core, and CLI files discovered by search"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Prefer concrete file-path evidence over generic advice."
+      - "Record permission assumptions for GitHub hook delivery APIs."
+    expected_output:
+      - "Existing surfaces and data flow map"
+      - "Candidate health signals and where they can be computed"
+      - "UI/CLI placement options"
+      - "Verification commands and manual QA path"
+      - "Suggested largest safe Worker slice"
+    receipt:
+      result: done
+      summary: "Mapped the stale tunnel gap to operator-facing webhook health surfaces. Existing startup reconciliation can silently update drifted GitHub hook URLs, but issue/PR label editing still has no visible GitHub hook URL or recent delivery status before applying automation labels."
+      evidence:
+        - "https://github.com/mean-weasel/issuectl/issues/534"
+        - "packages/web/lib/webhook-url-reconciler.ts"
+        - "packages/web/app/repos/[owner]/[repo]/settings/page.tsx"
+        - "packages/web/components/repos/RepoSettingsPanel.tsx"
+        - "packages/web/app/issues/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/components/issue/LabelManager.tsx"
+        - "packages/web/lib/actions/repos.ts"
+        - "packages/cli/src/commands/webhook.ts"
+      findings:
+        - "Repo settings computes the expected receiver URL from public_webhook_base_url and repo id, but only displays local webhook_events rows; GitHub delivery failures that never reach the machine are invisible."
+        - "The web server starts webhook-url-reconciler at startup, which fetches and updates GitHub hook config when public_webhook_base_url changes; reconciliation diagnostics are recorded but not surfaced on issue/PR label editing."
+        - "LabelManager is shared by issue and PR details and is exactly where auto-launch/auto-review labels are applied, but it only knows current/available labels and cannot warn about stale hook state."
+        - "Issue and PR detail pages already fetch the tracked repo and labels server-side, so they can pass a computed automation health summary into LabelManager without changing label action semantics."
+        - "The CLI webhook status command prints local expected URL and secret state but does not currently inspect GitHub hook URL or recent GitHub delivery status."
+      permission_notes:
+        - "GitHub hook config and delivery inspection require repository hook access; product behavior must degrade to an explicit unknown/permission warning rather than blocking basic label editing."
+      verification_candidates:
+        - "pnpm --dir packages/web test -- webhook-url-reconciler"
+        - "pnpm --dir packages/web test -- route-rendering"
+        - "pnpm --dir packages/web test -- actions/repos"
+        - "pnpm --dir packages/web typecheck"
+      suggested_worker_slice: "Add a shared webhook automation health helper, pass its summary into repo settings plus issue/PR label managers, and render a visible warning/recovery message when the GitHub hook URL is stale, delivery status recently failed, no public webhook base URL is configured, or hook inspection is unavailable."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Choose the first largest safe implementation slice that can make stale webhook tunnel state visible without overfitting to one tunnel provider or permission level."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle"
+      - "Issue #534 acceptance criteria"
+    constraints:
+      - "Do not implement."
+      - "Pick a vertical slice that reaches at least one user-facing surface if feasible."
+      - "Include exact allowed_files, verify commands, and stop conditions for Worker."
+      - "Defer lower-value polish rather than blocking the first useful product behavior."
+    expected_output:
+      - "Decision"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Deferred tasks or risks"
+    receipt:
+      result: done
+      decision: "approved"
+      rationale: "The highest-leverage first slice is a vertical web UI health surface: compute webhook health from local config plus GitHub hook/delivery inspection, show it in repo settings, and pass it to the shared issue/PR LabelManager so automation labels are applied with visible stale-tunnel context."
+      exact_worker_objective: "Implement webhook automation health computation and surface it in repo settings plus issue/PR label editing, with graceful unknown states when GitHub hook/delivery inspection is not permitted."
+      allowed_files:
+        - "packages/web/lib/webhook-health.ts"
+        - "packages/web/lib/webhook-health.test.ts"
+        - "packages/web/app/repos/[owner]/[repo]/settings/page.tsx"
+        - "packages/web/app/issues/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/components/detail/IssueDetail.tsx"
+        - "packages/web/components/detail/PrDetail.tsx"
+        - "packages/web/components/repos/RepoSettingsPanel.tsx"
+        - "packages/web/components/repos/RepoSettingsPanel.module.css"
+        - "packages/web/components/issue/LabelManager.tsx"
+        - "packages/web/components/issue/LabelManager.module.css"
+        - "packages/web/app/route-rendering.test.ts"
+      verify:
+        - "pnpm --dir packages/web test -- webhook-health route-rendering"
+        - "pnpm --dir packages/web typecheck"
+      stop_if:
+        - "Need core package API/type changes outside the allowed files."
+        - "GitHub hook API method names cannot be validated through tests/typecheck."
+        - "The UI change cannot cover both issue and PR label managers without widening scope."
+        - "Verification fails twice with the same unexplained failure."
+      deferred:
+        - "CLI `webhook status` live GitHub delivery inspection can follow after the first UI slice if the oracle still needs stronger CLI coverage."
+        - "A one-click rotate action directly from warning copy may follow if settings already has rotate/reinstall but issue/PR detail needs a deeper recovery affordance."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Execute the first stale webhook tunnel detection implementation slice selected by Judge."
+    allowed_files:
+      - "packages/web/lib/webhook-health.ts"
+      - "packages/web/lib/webhook-health.test.ts"
+      - "packages/web/app/repos/[owner]/[repo]/settings/page.tsx"
+      - "packages/web/app/issues/[owner]/[repo]/[number]/page.tsx"
+      - "packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx"
+      - "packages/web/components/detail/IssueDetail.tsx"
+      - "packages/web/components/detail/PrDetail.tsx"
+      - "packages/web/components/repos/RepoSettingsPanel.tsx"
+      - "packages/web/components/repos/RepoSettingsPanel.module.css"
+      - "packages/web/components/issue/LabelManager.tsx"
+      - "packages/web/components/issue/LabelManager.module.css"
+      - "packages/web/app/route-rendering.test.ts"
+    verify:
+      - "pnpm --dir packages/web test -- webhook-health route-rendering"
+      - "pnpm --dir packages/web typecheck"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "GitHub hook API permissions or token behavior make the selected design materially wrong."
+      - "The selected UX cannot cover both issue and PR automation surfaces."
+      - "Verification fails twice with the same unexplained failure."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/lib/webhook-health.ts"
+        - "packages/web/lib/webhook-health.test.ts"
+        - "packages/web/app/repos/[owner]/[repo]/settings/page.tsx"
+        - "packages/web/app/issues/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx"
+        - "packages/web/components/detail/IssueDetail.tsx"
+        - "packages/web/components/detail/PrDetail.tsx"
+        - "packages/web/components/repos/RepoSettingsPanel.tsx"
+        - "packages/web/components/repos/RepoSettingsPanel.module.css"
+        - "packages/web/components/issue/LabelManager.tsx"
+        - "packages/web/components/issue/LabelManager.module.css"
+        - "packages/web/app/route-rendering.test.ts"
+      commands:
+        - cmd: "source ~/.nvm/nvm.sh && nvm use 24.14.1 >/dev/null && pnpm --dir packages/web test -- webhook-health route-rendering"
+          status: pass
+        - cmd: "source ~/.nvm/nvm.sh && nvm use 24.14.1 >/dev/null && pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "source ~/.nvm/nvm.sh && nvm use 24.14.1 >/dev/null && pnpm --dir packages/web lint"
+          status: pass
+      summary: "Added a webhook automation health helper that compares local expected receiver URL with GitHub hook config and recent delivery status, degrades to explicit unknown/permission states, and surfaces the result in repo settings plus shared issue/PR label editing before automation labels are applied."
+  - id: T004
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the first implementation slice for correctness, permission behavior, UI clarity, and whether another Worker slice is required before manual QA."
+    inputs:
+      - "T003 receipt"
+      - "Current diff"
+      - "Verification output"
+    constraints:
+      - "Do not implement."
+      - "Reject if issue or PR automation loses existing agent configurability."
+      - "Reject if stale tunnel state is only available in docs or hidden logs."
+    expected_output:
+      - "approved | changes_required"
+      - "full_outcome_complete: true | false"
+      - "Required follow-up Worker task if not complete"
+      - "Manual QA readiness"
+    receipt:
+      result: done
+      decision: "approved"
+      full_outcome_complete: false
+      rationale: "The slice surfaces stale/unknown/error webhook health in both repo settings and the shared issue/PR label manager without changing agent defaults or label mutation semantics. It includes permission-aware degradation and recovery copy. Remaining proof must be runtime/manual QA against the stale and healthy webhook paths."
+      verification_reviewed:
+        - "pnpm --dir packages/web test -- webhook-health route-rendering: pass"
+        - "pnpm --dir packages/web typecheck: pass"
+        - "pnpm --dir packages/web lint: pass"
+      next_task: "T005"
+      manual_qa_readiness: "ready"
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: blocked
+    reasoning_hint: medium
+    objective: "Run and record the manual QA loop for stale and healthy webhook tunnel behavior after implementation is code-complete."
+    allowed_files:
+      - "docs/goals/stale-webhook-tunnel-detection/state.yaml"
+      - "docs/goals/stale-webhook-tunnel-detection/notes/**"
+    verify:
+      - "Use the documented webhook QA workflows to stale or inspect the tunnel, rotate to a fresh tunnel, and test issue plus PR label automation."
+      - "Record evidence links, issue/PR numbers, deployment ids, and any reset steps in the task receipt or notes."
+    stop_if:
+      - "Implementation is not code-complete."
+      - "Manual QA would mutate production repos instead of the configured test repos."
+      - "Need user-controlled browser action that cannot be automated safely."
+    receipt:
+      result: blocked
+      summary: "Runtime QA proved repo settings, issue label editing, and PR label editing render webhook health, but live GitHub delivery inspection returned unknown because Octokit's global `_nc` cache-busting query parameter is rejected by the webhook deliveries endpoint with 422."
+      evidence:
+        - "Playwright rendered repo settings with 'GitHub webhook health could not be checked' and expected receiver URL."
+        - "Playwright rendered issue #36 label area with the auto-launch webhook health warning."
+        - "Playwright rendered PR #37 label area with the auto-review webhook health warning."
+        - "gh api repos/mean-weasel/issuectl-test-repo-2/hooks/631428815 returned active=true and the expected hook URL."
+        - "gh api repos/mean-weasel/issuectl-test-repo-2/hooks/631428815/deliveries returned recent status_code=200 deliveries."
+        - "Direct Octokit call failed with 422: '_nc' is not a permitted key for list webhook deliveries."
+      spawned_tasks:
+        - T006
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Fix Octokit's cache-busting fetch wrapper so GitHub endpoints that reject unknown query parameters, starting with webhook deliveries, can be inspected while preserving no-store behavior."
+    allowed_files:
+      - "packages/core/src/github/client.ts"
+      - "packages/core/src/github/client.test.ts"
+      - "docs/goals/stale-webhook-tunnel-detection/state.yaml"
+      - "docs/goals/stale-webhook-tunnel-detection/notes/**"
+    verify:
+      - "pnpm --dir packages/core test -- github/client"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/web test -- webhook-health route-rendering"
+      - "pnpm --dir packages/web typecheck"
+      - "Runtime check: getWebhookAutomationHealth for mean-weasel/issuectl-test-repo-2 reports ok or a concrete non-unknown GitHub delivery state."
+    stop_if:
+      - "Need to remove cache-busting broadly without an equivalent freshness safeguard."
+      - "GitHub rejects another required webhook endpoint for a different reason."
+      - "Verification fails twice with the same unexplained failure."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/core/src/github/client.ts"
+        - "packages/core/src/github/client.test.ts"
+        - "docs/goals/stale-webhook-tunnel-detection/state.yaml"
+      commands:
+        - cmd: "pnpm --dir packages/core test -- github/client"
+          status: pass
+        - cmd: "pnpm --dir packages/core typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core lint"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- webhook-health route-rendering"
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/core build"
+          status: pass
+        - cmd: "Runtime getWebhookAutomationHealth for mean-weasel/issuectl-test-repo-2"
+          status: pass
+          detail: "ok, expected URL matched GitHub URL, latest delivery statusCode=200"
+      summary: "Skipped `_nc` cache-busting for GitHub webhook delivery listing while preserving `cache: no-store`; rebuilt core so the web runtime used the fixed client; live health inspection now returns healthy delivery data."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether stale webhook tunnel detection satisfies issue #534 and the original user outcome for both issue and PR label automation."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current dirty diff"
+      - "Manual QA evidence"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if stale tunnel state is not visible before or during label automation."
+      - "Reject completion if healthy issue or PR automation regresses."
+      - "Reject completion if required Worker work is still queued or active."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "The product now detects stale webhook tunnel state and surfaces recovery guidance before automation labels are applied, while the healthy path reports matching GitHub/local URLs and recent successful delivery."
+      evidence:
+        - "Repo settings healthy QA: WEBHOOK: OK, GitHub and Expected URLs matched, Latest issues.closed status 200."
+        - "Issue label healthy QA: opening the Issue labels editor showed 'GitHub webhook delivery looks healthy' for auto-launch labels with latest status 200."
+        - "PR label healthy QA: opening the PR labels editor showed 'GitHub webhook delivery looks healthy' for auto-review labels with latest status 200."
+        - "Stale simulation QA: temporarily set public_webhook_base_url to https://stale-webhook.example.test; repo settings showed 'GitHub webhook URL is stale', GitHub URL vs Expected URL, and `issuectl webhook rotate mean-weasel/issuectl-test-repo-2 --yes` recovery copy."
+        - "Stale issue-label QA: Issue labels editor showed the same stale warning before `issuectl:auto-launch` was applied."
+        - "Reset QA: restored public_webhook_base_url to https://volvo-tablet-centered-diana.trycloudflare.com and verified health returned ok with latest statusCode=200."
+        - "Startup reconciler after restart checked 2 configured webhooks, updated 0, failed 0."
+      verification:
+        - "pnpm --dir packages/web test -- webhook-health route-rendering: pass"
+        - "pnpm --dir packages/web typecheck: pass"
+        - "pnpm --dir packages/web lint: pass"
+        - "pnpm --dir packages/core test -- github/client: pass"
+        - "pnpm --dir packages/core typecheck: pass"
+        - "pnpm --dir packages/core lint: pass"
+      missing_evidence: []
+      next_task: null
+
+checks:
+  dirty_fingerprint: "unrelated local Apple and older goal changes existed before this goal-prep turn; do not stage or revert them"
+  last_verification:
+    result: pass
+    task: T999
+    commands:
+      - "pnpm --dir packages/web test -- webhook-health route-rendering"
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "pnpm --dir packages/core test -- github/client"
+      - "pnpm --dir packages/core typecheck"
+      - "pnpm --dir packages/core lint"

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -99,4 +99,44 @@ describe("getOctokit caching", () => {
     expect(first).not.toBe(second);
     expect(getGhTokenMock).toHaveBeenCalledTimes(2);
   });
+
+  it("adds cache-busting to ordinary GitHub GET requests", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ login: "octocat" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const octokit = await getOctokit();
+
+    await octokit.rest.users.getAuthenticated();
+
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain("_nc=");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
+    fetchMock.mockRestore();
+  });
+
+  it("does not add cache-busting query parameters to webhook delivery listing", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const octokit = await getOctokit();
+
+    await octokit.rest.repos.listWebhookDeliveries({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      hook_id: 123,
+      per_page: 5,
+    });
+
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain("/repos/mean-weasel/issuectl/hooks/123/deliveries?per_page=5");
+    expect(url).not.toContain("_nc=");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
+    fetchMock.mockRestore();
+  });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -22,8 +22,10 @@ export async function getOctokit(): Promise<Octokit> {
     const method = init?.method?.toUpperCase() ?? "GET";
     if (method === "GET") {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      const sep = url.includes("?") ? "&" : "?";
-      return globalThis.fetch(`${url}${sep}_nc=${Date.now()}`, { ...init, cache: "no-store" } as RequestInit);
+      if (!rejectsUnknownQueryParams(url)) {
+        const sep = url.includes("?") ? "&" : "?";
+        return globalThis.fetch(`${url}${sep}_nc=${Date.now()}`, { ...init, cache: "no-store" } as RequestInit);
+      }
     }
     return globalThis.fetch(input, { ...init, cache: "no-store" } as RequestInit);
   };
@@ -70,4 +72,8 @@ function isAuthError(err: unknown): boolean {
     "status" in err &&
     (err as { status?: number }).status === 401
   );
+}
+
+function rejectsUnknownQueryParams(url: string): boolean {
+  return /\/repos\/[^/]+\/[^/]+\/hooks\/\d+\/deliveries(?:\?|$)/.test(url);
 }

--- a/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/issues/[owner]/[repo]/[number]/page.tsx
@@ -17,6 +17,7 @@ import { LightboxProvider } from "@/components/detail/ImageLightbox";
 import { PullToRefreshWrapper } from "@/components/ui/PullToRefreshWrapper";
 import { refreshIssueAction } from "@/lib/actions/refresh";
 import { normalizeLaunchAgent } from "@/components/launch/agent";
+import { getWebhookAutomationHealth } from "@/lib/webhook-health";
 import styles from "./loading.module.css";
 
 export const dynamic = "force-dynamic";
@@ -69,6 +70,7 @@ export default async function IssueDetailPage({
       issueNumber,
     );
     const repoRecord = getRepo(db, owner, repo);
+    const webhookHealth = await getWebhookAutomationHealth(db, repoRecord);
     const repoId = repoRecord?.id ?? 0;
     const currentPriority = repoId > 0
       ? getPriority(db, repoId, issueNumber)
@@ -107,6 +109,7 @@ export default async function IssueDetailPage({
             referencedFiles={referencedFiles}
             defaultAgent={defaultAgent}
             availableLabels={availableLabels}
+            webhookHealth={webhookHealth}
           >
             <Suspense fallback={<ContentSkeleton />}>
               <IssueDetailContent

--- a/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
+++ b/packages/web/app/pulls/[owner]/[repo]/[number]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getDb, getDeploymentsForTarget, getOctokit, getPullDetail, getRepo, listLabels } from "@issuectl/core";
 import { PrDetail } from "@/components/detail/PrDetail";
+import { getWebhookAutomationHealth } from "@/lib/webhook-health";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ export default async function PullDetailPage({
 
   try {
     const repoRecord = getRepo(db, owner, repo);
+    const webhookHealth = await getWebhookAutomationHealth(db, repoRecord);
     const [detail, availableLabels] = await Promise.all([
       getPullDetail(db, octokit, owner, repo, pullNumber),
       listLabels(octokit, owner, repo),
@@ -54,6 +56,7 @@ export default async function PullDetailPage({
         linkedIssue={detail.linkedIssue}
         availableLabels={availableLabels}
         deployments={deployments}
+        webhookHealth={webhookHealth}
       />
     );
   } catch (err) {

--- a/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
+++ b/packages/web/app/repos/[owner]/[repo]/settings/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@issuectl/core";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { RepoSettingsPanel } from "@/components/repos/RepoSettingsPanel";
+import { getWebhookAutomationHealth } from "@/lib/webhook-health";
 import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
@@ -47,6 +48,7 @@ export default async function RepoSettingsPage({
   const activeIssueSessions = getActiveWebhookDeploymentsForRepoTarget(db, repo.id, "issue").length;
   const activePrSessions = getActiveWebhookDeploymentsForRepoTarget(db, repo.id, "pr").length;
   const recentDeliveries = listWebhookEvents(db, { repoId: repo.id, limit: 10 });
+  const webhookHealth = await getWebhookAutomationHealth(db, repo);
   const activity = {
     activeSessions,
     activeIssueSessions,
@@ -63,6 +65,7 @@ export default async function RepoSettingsPage({
         <RepoSettingsPanel
           repo={repo}
           webhookUrl={webhookUrl}
+          webhookHealth={webhookHealth}
           activity={activity}
           recentDeliveries={recentDeliveries}
           settingsHref="/settings/repos"

--- a/packages/web/app/route-rendering.test.ts
+++ b/packages/web/app/route-rendering.test.ts
@@ -33,9 +33,14 @@ const data = vi.hoisted(() => ({
   getReviewDetailData: vi.fn(),
 }));
 
+const webhookHealth = vi.hoisted(() => ({
+  getWebhookAutomationHealth: vi.fn(),
+}));
+
 vi.mock("@issuectl/core", () => core);
 vi.mock("@/lib/sessions-data", () => data);
 vi.mock("@/lib/review-detail-data", () => data);
+vi.mock("@/lib/webhook-health", () => webhookHealth);
 vi.mock("next/navigation", () => ({
   notFound: () => {
     throw new Error("NEXT_NOT_FOUND");
@@ -103,6 +108,16 @@ beforeEach(() => {
   core.listPrReviewsForRepo.mockReturnValue([]);
   core.listRecentTerminalDeploymentsByRepo.mockReturnValue([]);
   core.listWebhookEvents.mockReturnValue([webhookEntry()]);
+  webhookHealth.getWebhookAutomationHealth.mockResolvedValue({
+    state: "ok",
+    summary: "GitHub webhook delivery looks healthy",
+    detail: "The GitHub hook URL matches local settings and the latest visible delivery succeeded.",
+    recovery: null,
+    expectedUrl: "https://hooks.example.test/api/webhook/github/1",
+    hookId: 123,
+    githubUrl: "https://hooks.example.test/api/webhook/github/1",
+    latestDelivery: null,
+  });
   core.getOctokit.mockResolvedValue({});
   core.getIssueHeader.mockResolvedValue({
     issue: {
@@ -245,10 +260,12 @@ describe("operator route rendering", () => {
 
     expect(core.getRepo).toHaveBeenCalledWith(core.db, "mean-weasel", "issuectl");
     expect(core.listWebhookEvents).toHaveBeenCalledWith(core.db, { repoId: 1, limit: 10 });
+    expect(webhookHealth.getWebhookAutomationHealth).toHaveBeenCalledWith(core.db, repo);
     const panel = findElementWhere(tree, (props) => props.repo === repo);
     expect(panel?.props).toMatchObject({
       repo,
       webhookUrl: "https://hooks.example.test/api/webhook/github/1",
+      webhookHealth: expect.objectContaining({ state: "ok" }),
       activity: {
         activeSessions: 0,
         activeIssueSessions: 0,
@@ -271,6 +288,7 @@ describe("operator route rendering", () => {
 
     expect(core.listLabels).toHaveBeenCalledWith({}, "mean-weasel", "issuectl");
     const detail = findElementWhere(tree, (props) => Array.isArray(props.availableLabels));
+    expect(webhookHealth.getWebhookAutomationHealth).toHaveBeenCalledWith(core.db, repo);
     expect(detail?.props.availableLabels).toEqual([
       { name: "bug", color: "d73a4a", description: null },
       { name: "issuectl:auto-launch", color: "0e8a16", description: null },
@@ -317,6 +335,7 @@ describe("operator route rendering", () => {
     expect(core.getDeploymentsForTarget).toHaveBeenCalledWith(core.db, 1, "pr", 44);
     expect(core.listLabels).toHaveBeenCalledWith({}, "mean-weasel", "issuectl");
     const detail = findElementWhere(tree, (props) => Array.isArray(props.availableLabels));
+    expect(webhookHealth.getWebhookAutomationHealth).toHaveBeenCalledWith(core.db, repo);
     expect(detail?.props.availableLabels).toEqual([
       { name: "bug", color: "d73a4a", description: null },
       { name: "issuectl:auto-launch", color: "0e8a16", description: null },

--- a/packages/web/components/detail/IssueDetail.tsx
+++ b/packages/web/components/detail/IssueDetail.tsx
@@ -1,6 +1,7 @@
 import { Suspense, type ReactNode } from "react";
 import type { GitHubIssue, Priority, Deployment, GitHubLabel } from "@issuectl/core";
 import type { LaunchAgent } from "@/components/launch/agent";
+import type { WebhookAutomationHealth } from "@/lib/webhook-health";
 import { Chip, LabelChip } from "@/components/paper";
 import { LabelManager } from "@/components/issue/LabelManager";
 import { timeAgo } from "@/lib/format";
@@ -31,6 +32,7 @@ type Props = {
   referencedFiles: string[];
   defaultAgent: LaunchAgent;
   availableLabels: GitHubLabel[];
+  webhookHealth: WebhookAutomationHealth | null;
   /** Rendered after the body — used by the page to stream the active-deployment banner and comments. */
   children?: ReactNode;
 };
@@ -46,6 +48,7 @@ export function IssueDetail({
   referencedFiles,
   defaultAgent,
   availableLabels,
+  webhookHealth,
   children,
 }: Props) {
   const displayLabels = issue.labels.filter(
@@ -103,6 +106,7 @@ export function IssueDetail({
             issueNumber={issue.number}
             currentLabels={issue.labels}
             availableLabels={availableLabels}
+            webhookHealth={webhookHealth}
           />
         </section>
 

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -25,6 +25,7 @@ import { KeyboardHelpOverlay } from "@/components/ui/KeyboardHelpOverlay";
 import { LabelManager } from "@/components/issue/LabelManager";
 import { OpenTerminalButton } from "@/components/terminal/OpenTerminalButton";
 import { launchAgentLabel } from "@/components/launch/agent";
+import type { WebhookAutomationHealth } from "@/lib/webhook-health";
 import styles from "./PrDetail.module.css";
 
 type Props = {
@@ -37,6 +38,7 @@ type Props = {
   linkedIssue: GitHubIssue | null;
   availableLabels: GitHubLabel[];
   deployments: Deployment[];
+  webhookHealth: WebhookAutomationHealth | null;
 };
 
 export function PrDetail({
@@ -49,6 +51,7 @@ export function PrDetail({
   linkedIssue,
   availableLabels,
   deployments,
+  webhookHealth,
 }: Props) {
   const prState: "open" | "closed" | "merged" = pull.merged
     ? "merged"
@@ -91,6 +94,7 @@ export function PrDetail({
             targetType="pr"
             currentLabels={pull.labels ?? []}
             availableLabels={availableLabels}
+            webhookHealth={webhookHealth}
           />
         </section>
 

--- a/packages/web/components/issue/LabelManager.module.css
+++ b/packages/web/components/issue/LabelManager.module.css
@@ -54,3 +54,44 @@
   font-size: 11px;
   color: var(--paper-brick);
 }
+
+.automationHealth {
+  display: grid;
+  gap: 5px;
+  padding: 9px 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg-warm);
+  font-size: 12px;
+  color: var(--paper-ink-soft);
+}
+
+.automationHealth strong {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.automationHealth code {
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automationHealth[data-state="ok"] {
+  border-color: #9dc79d;
+  background: #eef8ee;
+}
+
+.automationHealth[data-state="warning"],
+.automationHealth[data-state="unknown"] {
+  border-color: #d6a33f;
+  background: #fff2c9;
+}
+
+.automationHealth[data-state="error"] {
+  border-color: #d9aaa2;
+  background: #ffe1dc;
+}

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -9,6 +9,7 @@ import { separateLabels } from "@/lib/labels";
 import { useToast } from "@/components/ui/ToastProvider";
 import { Badge } from "@/components/ui/Badge";
 import { SyncDot } from "@/components/ui/SyncDot";
+import type { WebhookAutomationHealth } from "@/lib/webhook-health";
 import { LabelSelector } from "./LabelSelector";
 import styles from "./LabelManager.module.css";
 
@@ -21,6 +22,7 @@ type Props = {
   targetType?: "issue" | "pr";
   currentLabels: GitHubLabel[];
   availableLabels: GitHubLabel[];
+  webhookHealth?: WebhookAutomationHealth | null;
 };
 
 export function LabelManager({
@@ -30,6 +32,7 @@ export function LabelManager({
   targetType = "issue",
   currentLabels,
   availableLabels,
+  webhookHealth,
 }: Props) {
   const router = useRouter();
   const { showToast } = useToast();
@@ -58,6 +61,13 @@ export function LabelManager({
   const { lifecycle: lifecycleLabels, regular: regularLabels } =
     separateLabels(currentLabels);
   const selectedNames = currentLabels.map((l) => l.name);
+  const automationLabel = targetType === "pr" ? "issuectl:auto-review" : "issuectl:auto-launch";
+  const hasAutomationLabel = selectedNames.includes(automationLabel)
+    || availableLabels.some((label) => label.name === automationLabel);
+  const showWebhookHealth = hasAutomationLabel
+    && webhookHealth !== null
+    && webhookHealth !== undefined
+    && (webhookHealth.state !== "ok" || showSelector);
 
   function handleToggle(label: string) {
     setError(null);
@@ -131,6 +141,10 @@ export function LabelManager({
         <span className={styles.empty}>No labels</span>
       )}
 
+      {showWebhookHealth && (
+        <AutomationHealthNotice health={webhookHealth} targetType={targetType} />
+      )}
+
       {showSelector && (
         <div className={styles.selector}>
           <LabelSelector
@@ -148,6 +162,31 @@ export function LabelManager({
           {error}
         </span>
       )}
+    </div>
+  );
+}
+
+function AutomationHealthNotice({
+  health,
+  targetType,
+}: {
+  health: WebhookAutomationHealth;
+  targetType: "issue" | "pr";
+}) {
+  const label = targetType === "pr" ? "auto-review" : "auto-launch";
+  return (
+    <div className={styles.automationHealth} data-state={health.state} role={health.state === "ok" ? "status" : "alert"}>
+      <strong>{health.summary}</strong>
+      <span>
+        {label} labels rely on the GitHub webhook reaching this machine. {health.detail}
+      </span>
+      {health.latestDelivery && (
+        <code>
+          latest: {health.latestDelivery.event ?? "delivery"}
+          {health.latestDelivery.action ? `.${health.latestDelivery.action}` : ""} · {health.latestDelivery.statusCode ?? "unknown"}
+        </code>
+      )}
+      {health.recovery && <span>{health.recovery}</span>}
     </div>
   );
 }

--- a/packages/web/components/repos/RepoSettingsPanel.module.css
+++ b/packages/web/components/repos/RepoSettingsPanel.module.css
@@ -192,6 +192,50 @@
   text-transform: uppercase;
 }
 
+.webhookHealth {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--text-primary);
+}
+
+.webhookHealth strong {
+  font: 700 11px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.webhookHealth span,
+.webhookHealth code {
+  font-size: 12px;
+}
+
+.webhookHealth code {
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.webhookHealth[data-state="ok"] {
+  border-color: #9dc79d;
+  background: #eef8ee;
+}
+
+.webhookHealth[data-state="warning"],
+.webhookHealth[data-state="unknown"] {
+  border-color: #d6a33f;
+  background: #fff2c9;
+}
+
+.webhookHealth[data-state="error"] {
+  border-color: #d9aaa2;
+  background: #ffe1dc;
+}
+
 .deliveryDetails {
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-sm);

--- a/packages/web/components/repos/RepoSettingsPanel.tsx
+++ b/packages/web/components/repos/RepoSettingsPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useTransition } from "react";
 import type { LaunchAgent, Repo, WebhookEvent, WebhookPayloadMode } from "@issuectl/core";
+import type { WebhookAutomationHealth, WebhookAutomationHealthState } from "@/lib/webhook-health";
 import {
   configureRepoWebhook,
   recreateRepoLabels,
@@ -24,6 +25,7 @@ export type RepoSettingsActivity = {
 export type RepoSettingsPanelProps = {
   repo: Repo;
   webhookUrl: string | null;
+  webhookHealth: WebhookAutomationHealth | null;
   activity: RepoSettingsActivity;
   recentDeliveries: WebhookEvent[];
   settingsHref?: string;
@@ -39,6 +41,7 @@ const REQUIRED_LABELS = ["issuectl:auto-launch", "issuectl:auto-review"];
 export function RepoSettingsPanel({
   repo,
   webhookUrl,
+  webhookHealth,
   activity,
   recentDeliveries,
   settingsHref,
@@ -71,6 +74,7 @@ export function RepoSettingsPanel({
     autoReviewPrs,
     webhookPayloadMode,
     labelHealth,
+    webhookHealth,
   });
 
   function saveSettings() {
@@ -320,6 +324,7 @@ export function RepoSettingsPanel({
             Waiting for first GitHub delivery
           </div>
         )}
+        {webhookHealth && <WebhookHealthCard health={webhookHealth} />}
         <label>
           <span>Receiver URL</span>
           <input value={webhookUrl ?? "Set Public Webhook Base URL first"} readOnly />
@@ -405,7 +410,7 @@ function Metric({ label, value }: { label: string; value: number }) {
 type HealthItem = {
   label: string;
   value: string;
-  state: LabelHealth["status"];
+  state: LabelHealth["status"] | WebhookAutomationHealthState;
   detail: string;
 };
 
@@ -417,6 +422,7 @@ function repoHealthItems(input: {
   autoReviewPrs: boolean;
   webhookPayloadMode: WebhookPayloadMode;
   labelHealth: LabelHealth;
+  webhookHealth: WebhookAutomationHealth | null;
 }): HealthItem[] {
   return [
     {
@@ -427,9 +433,9 @@ function repoHealthItems(input: {
     },
     {
       label: "Webhook",
-      value: input.webhookConfigured ? input.waitingForFirstPing ? "waiting" : "configured" : "missing",
-      state: input.webhookConfigured ? input.waitingForFirstPing ? "checking" : "healthy" : "missing",
-      detail: input.webhookConfigured ? "A GitHub webhook id is stored locally." : "Install the webhook before automation can receive deliveries.",
+      value: webhookHealthValue(input),
+      state: input.webhookHealth?.state ?? (input.webhookConfigured ? input.waitingForFirstPing ? "checking" : "healthy" : "missing"),
+      detail: input.webhookHealth?.detail ?? (input.webhookConfigured ? "A GitHub webhook id is stored locally." : "Install the webhook before automation can receive deliveries."),
     },
     {
       label: "Automation",
@@ -453,9 +459,39 @@ function repoHealthItems(input: {
 }
 
 function healthSummary(items: HealthItem[]): string {
-  const attention = items.filter((item) => item.state === "missing" || item.state === "error");
+  const attention = items.filter((item) =>
+    item.state === "missing" || item.state === "error" || item.state === "unknown",
+  );
   if (attention.length === 0) return "No blocking repo setup gaps detected in local settings.";
   return `${attention.length} setup item${attention.length === 1 ? "" : "s"} need attention: ${attention.map((item) => item.label).join(", ")}.`;
+}
+
+function webhookHealthValue(input: {
+  webhookConfigured: boolean;
+  waitingForFirstPing: boolean;
+  webhookHealth: WebhookAutomationHealth | null;
+}): string {
+  if (input.webhookHealth) return input.webhookHealth.state;
+  if (!input.webhookConfigured) return "missing";
+  return input.waitingForFirstPing ? "waiting" : "configured";
+}
+
+function WebhookHealthCard({ health }: { health: WebhookAutomationHealth }) {
+  return (
+    <div className={styles.webhookHealth} data-state={health.state} role={health.state === "ok" ? "status" : "alert"}>
+      <strong>{health.summary}</strong>
+      <span>{health.detail}</span>
+      {health.githubUrl && <code>GitHub: {health.githubUrl}</code>}
+      {health.expectedUrl && <code>Expected: {health.expectedUrl}</code>}
+      {health.latestDelivery && (
+        <code>
+          Latest: {health.latestDelivery.event ?? "delivery"}
+          {health.latestDelivery.action ? `.${health.latestDelivery.action}` : ""} · {health.latestDelivery.statusCode ?? "unknown"}
+        </code>
+      )}
+      {health.recovery && <span>{health.recovery}</span>}
+    </div>
+  );
 }
 
 function RecentDeliveries({ repo, deliveries }: { repo: Repo; deliveries: WebhookEvent[] }) {

--- a/packages/web/lib/webhook-health.test.ts
+++ b/packages/web/lib/webhook-health.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Repo } from "@issuectl/core";
+import { getWebhookAutomationHealth } from "./webhook-health";
+
+const db = {};
+
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: null,
+  branchPattern: null,
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "claude",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-28T00:00:00.000Z",
+} satisfies Repo;
+
+describe("getWebhookAutomationHealth", () => {
+  it("reports missing public webhook base URL", async () => {
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "",
+      inspectGitHubHook: vi.fn(),
+    });
+
+    expect(result).toMatchObject({
+      state: "error",
+      summary: "Webhook receiver URL is not configured",
+      expectedUrl: null,
+      hookId: 123,
+    });
+  });
+
+  it("reports a stored hook URL that does not match local settings", async () => {
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "https://current.example.test",
+      inspectGitHubHook: vi.fn().mockResolvedValue({
+        active: true,
+        url: "https://old.example.test/api/webhook/github/1",
+        deliveries: [{ status_code: 502, event: "issues", action: "labeled", delivered_at: "2026-05-28T00:00:00Z" }],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      state: "error",
+      summary: "GitHub webhook URL is stale",
+      expectedUrl: "https://current.example.test/api/webhook/github/1",
+      githubUrl: "https://old.example.test/api/webhook/github/1",
+    });
+    expect(result?.recovery).toContain("issuectl webhook rotate mean-weasel/issuectl --yes");
+  });
+
+  it("reports recent failed deliveries when the URL matches", async () => {
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "https://hooks.example.test",
+      inspectGitHubHook: vi.fn().mockResolvedValue({
+        active: true,
+        url: "https://hooks.example.test/api/webhook/github/1",
+        deliveries: [{ status_code: 502, event: "issues", action: "labeled", delivered_at: "2026-05-28T00:00:00Z" }],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      state: "error",
+      summary: "Recent GitHub webhook delivery failed with 502",
+      latestDelivery: {
+        event: "issues",
+        action: "labeled",
+        statusCode: 502,
+      },
+    });
+  });
+
+  it("reports healthy matching hook and successful latest delivery", async () => {
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "https://hooks.example.test",
+      inspectGitHubHook: vi.fn().mockResolvedValue({
+        active: true,
+        url: "https://hooks.example.test/api/webhook/github/1",
+        deliveries: [{ status_code: 200, event: "ping", action: null, delivered_at: "2026-05-28T00:00:00Z" }],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      state: "ok",
+      summary: "GitHub webhook delivery looks healthy",
+    });
+  });
+
+  it("degrades to unknown when GitHub hook access is forbidden", async () => {
+    const error = new Error("Resource not accessible") as Error & { status: number };
+    error.status = 403;
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "https://hooks.example.test",
+      inspectGitHubHook: vi.fn().mockRejectedValue(error),
+    });
+
+    expect(result).toMatchObject({
+      state: "unknown",
+      summary: "GitHub webhook health requires hook access",
+    });
+  });
+});

--- a/packages/web/lib/webhook-health.ts
+++ b/packages/web/lib/webhook-health.ts
@@ -1,0 +1,217 @@
+import { getSetting, withAuthRetry, type Repo } from "@issuectl/core";
+import { buildWebhookUrl } from "@/lib/webhook-url-reconciler";
+
+type Db = Parameters<typeof getSetting>[0];
+
+export type WebhookAutomationHealthState = "ok" | "warning" | "error" | "unknown";
+
+export type WebhookAutomationHealth = {
+  state: WebhookAutomationHealthState;
+  summary: string;
+  detail: string;
+  recovery: string | null;
+  expectedUrl: string | null;
+  hookId: number | null;
+  githubUrl: string | null;
+  latestDelivery: {
+    event: string | null;
+    action: string | null;
+    statusCode: number | null;
+    deliveredAt: string | null;
+  } | null;
+};
+
+type GitHubDelivery = {
+  event?: string | null;
+  action?: string | null;
+  status_code?: number | null;
+  delivered_at?: string | null;
+};
+
+type GitHubHookSnapshot = {
+  active: boolean | null;
+  url: string | null;
+  deliveries: GitHubDelivery[];
+};
+
+type WebhookHealthDependencies = {
+  getBaseUrl: (db: Db) => string | undefined;
+  inspectGitHubHook: (repo: Repo) => Promise<GitHubHookSnapshot>;
+};
+
+const defaultDependencies: WebhookHealthDependencies = {
+  getBaseUrl: (db) => getSetting(db, "public_webhook_base_url"),
+  inspectGitHubHook: inspectGitHubHookWithOctokit,
+};
+
+export async function getWebhookAutomationHealth(
+  db: Db,
+  repo: Repo | null | undefined,
+  dependencies: Partial<WebhookHealthDependencies> = {},
+): Promise<WebhookAutomationHealth | null> {
+  if (!repo) return null;
+  const deps = { ...defaultDependencies, ...dependencies };
+  const baseUrl = deps.getBaseUrl(db)?.trim();
+  const expectedUrl = baseUrl ? buildWebhookUrl(baseUrl, repo.id) : null;
+
+  if (!baseUrl) {
+    return health({
+      state: "error",
+      summary: "Webhook receiver URL is not configured",
+      detail: "Set Public Webhook Base URL before using automation labels.",
+      recovery: "Start a tunnel, set the public webhook base URL, then rotate or reinstall this repo webhook.",
+      expectedUrl,
+      hookId: repo.webhookId,
+    });
+  }
+
+  if (!repo.webhookId) {
+    return health({
+      state: "error",
+      summary: "No GitHub webhook is stored for this repo",
+      detail: "GitHub cannot deliver auto-launch or auto-review labels until the repo webhook exists.",
+      recovery: "Open repo settings and reinstall the webhook.",
+      expectedUrl,
+      hookId: null,
+    });
+  }
+
+  try {
+    const snapshot = await deps.inspectGitHubHook(repo);
+    const githubUrl = snapshot.url;
+    const latestDelivery = latestDeliverySummary(snapshot.deliveries);
+
+    if (snapshot.active === false) {
+      return health({
+        state: "error",
+        summary: "GitHub webhook is disabled",
+        detail: "Automation labels will not reach this machine while the GitHub webhook is inactive.",
+        recovery: "Open repo settings and reinstall or rotate the webhook.",
+        expectedUrl,
+        hookId: repo.webhookId,
+        githubUrl,
+        latestDelivery,
+      });
+    }
+
+    if (githubUrl && githubUrl !== expectedUrl) {
+      return health({
+        state: "error",
+        summary: "GitHub webhook URL is stale",
+        detail: `GitHub is delivering to ${githubUrl}, but this server expects ${expectedUrl}.`,
+        recovery: `Run issuectl webhook rotate ${repo.owner}/${repo.name} --yes after starting the current tunnel.`,
+        expectedUrl,
+        hookId: repo.webhookId,
+        githubUrl,
+        latestDelivery,
+      });
+    }
+
+    const latestStatusCode = latestDelivery?.statusCode ?? null;
+    if (latestStatusCode !== null && latestStatusCode >= 400) {
+      return health({
+        state: "error",
+        summary: `Recent GitHub webhook delivery failed with ${latestStatusCode}`,
+        detail: "GitHub reached the configured hook but the latest delivery was not successful.",
+        recovery: "Check the tunnel/server, then redeliver the event or remove and re-add the automation label.",
+        expectedUrl,
+        hookId: repo.webhookId,
+        githubUrl,
+        latestDelivery,
+      });
+    }
+
+    if (!latestDelivery) {
+      return health({
+        state: "warning",
+        summary: "GitHub webhook has no recent delivery history",
+        detail: "The hook URL matches local settings, but there is no recent GitHub delivery to prove the receiver is reachable.",
+        recovery: "Send a webhook ping from repo settings before relying on automation labels.",
+        expectedUrl,
+        hookId: repo.webhookId,
+        githubUrl,
+      });
+    }
+
+    return health({
+      state: "ok",
+      summary: "GitHub webhook delivery looks healthy",
+      detail: "The GitHub hook URL matches local settings and the latest visible delivery succeeded.",
+      recovery: null,
+      expectedUrl,
+      hookId: repo.webhookId,
+      githubUrl,
+      latestDelivery,
+    });
+  } catch (err) {
+    return health({
+      state: githubInspectionState(err),
+      summary: githubInspectionSummary(err),
+      detail: "issuectl could not inspect the GitHub webhook URL or delivery history, so automation label health is unverified.",
+      recovery: "If you need live delivery checks, refresh GitHub auth with repo hook access or verify the hook in GitHub settings.",
+      expectedUrl,
+      hookId: repo.webhookId,
+    });
+  }
+}
+
+function health(input: Omit<WebhookAutomationHealth, "githubUrl" | "latestDelivery"> & Partial<Pick<WebhookAutomationHealth, "githubUrl" | "latestDelivery">>): WebhookAutomationHealth {
+  return {
+    githubUrl: null,
+    latestDelivery: null,
+    ...input,
+  };
+}
+
+function latestDeliverySummary(deliveries: GitHubDelivery[]): WebhookAutomationHealth["latestDelivery"] {
+  const latest = deliveries[0];
+  if (!latest) return null;
+  return {
+    event: latest.event ?? null,
+    action: latest.action ?? null,
+    statusCode: typeof latest.status_code === "number" ? latest.status_code : null,
+    deliveredAt: latest.delivered_at ?? null,
+  };
+}
+
+function githubInspectionState(err: unknown): WebhookAutomationHealthState {
+  const status = typeof err === "object" && err !== null && "status" in err
+    ? (err as { status?: unknown }).status
+    : undefined;
+  return status === 404 ? "error" : "unknown";
+}
+
+function githubInspectionSummary(err: unknown): string {
+  const status = typeof err === "object" && err !== null && "status" in err
+    ? (err as { status?: unknown }).status
+    : undefined;
+  if (status === 404) return "Stored GitHub webhook was not found";
+  if (status === 403) return "GitHub webhook health requires hook access";
+  return "GitHub webhook health could not be checked";
+}
+
+async function inspectGitHubHookWithOctokit(repo: Repo): Promise<GitHubHookSnapshot> {
+  return withAuthRetry(async (octokit) => {
+    const { data: hook } = await octokit.rest.repos.getWebhook({
+      owner: repo.owner,
+      repo: repo.name,
+      hook_id: repo.webhookId ?? 0,
+    });
+    const deliveriesResult = await octokit.rest.repos.listWebhookDeliveries({
+      owner: repo.owner,
+      repo: repo.name,
+      hook_id: repo.webhookId ?? 0,
+      per_page: 5,
+    });
+    return {
+      active: typeof hook.active === "boolean" ? hook.active : null,
+      url: typeof hook.config?.url === "string" ? hook.config.url : null,
+      deliveries: deliveriesResult.data.map((delivery) => ({
+        event: delivery.event,
+        action: delivery.action,
+        status_code: delivery.status_code,
+        delivered_at: delivery.delivered_at,
+      })),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add webhook automation health checks comparing the configured local tunnel URL with the GitHub webhook URL and recent deliveries
- surface webhook health in repo settings and issue/PR label editors before applying `issuectl:auto-launch` or `issuectl:auto-review`
- avoid adding the GitHub client `_nc` cache-busting query to webhook delivery APIs, which reject unknown params
- record the GoalBuddy plan and final state for this work

## Verification
- `pnpm --dir packages/core build`
- `pnpm --dir packages/web test -- webhook-health route-rendering`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/core test -- github/client`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core lint`
- `pnpm turbo build`

## Manual QA
- verified healthy webhook state on repo settings and issue/PR label editors
- simulated a stale webhook base URL, confirmed stale warning and rotate recovery copy, then restored the test repo URL
