### PR TITLE
[codex] Add webhook QA runbooks

### DIFF
--- a/docs/workflows/webhook-auto-sessions.md
+++ b/docs/workflows/webhook-auto-sessions.md
@@ -52,7 +52,7 @@ REPO=issuectl-test-repo-2
 pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
 
 hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
-select github_webhook_id
+select webhook_id
 from repos
 where owner='$OWNER' and name='$REPO';")"
 

--- a/docs/workflows/webhook-basic-issue-label-qa.md
+++ b/docs/workflows/webhook-basic-issue-label-qa.md
@@ -1,0 +1,253 @@
+# Basic Issue Label Webhook QA
+
+Use this workflow when a future agent is asked:
+
+```text
+run the basic issue label QA
+run the issue auto-launch webhook QA
+verify issuectl:auto-launch from the UI
+```
+
+This is the smallest repeatable end-to-end check for issue label automation. It
+proves the local dashboard can apply `issuectl:auto-launch`, GitHub can deliver
+the resulting webhook to this machine, issuectl creates exactly one Codex issue
+session, the trigger label is consumed, and the issue detail UI moves through
+the expected states.
+
+## Scope
+
+Target repository:
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+BASE_URL=http://localhost:3847
+```
+
+Default expectations:
+
+| Item | Expected value |
+| --- | --- |
+| Trigger label | `issuectl:auto-launch` |
+| Agent | `codex` |
+| Worktree suffix | `issue-<number>` |
+| Trigger source | Local issuectl issue detail label editor |
+| UI surface | Codex Chrome extension or Chrome attached to the local dashboard |
+
+## Preflight
+
+Run these before touching labels. Stop if any check fails.
+
+```bash
+curl -I "$BASE_URL"
+pnpm --dir packages/cli exec issuectl repo show "$OWNER/$REPO"
+pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
+pnpm --dir packages/cli exec issuectl webhook tail --repo "$OWNER/$REPO" --limit 10
+```
+
+Confirm the repo settings show:
+
+```text
+auto-launch issues: true
+issue agent: codex
+```
+
+Confirm webhook health in GitHub and issuectl:
+
+```bash
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
+Pass signal:
+
+- The dashboard responds on `localhost:3847`.
+- The repo is tracked and issue auto-launch is enabled.
+- The repo settings page shows webhook health as healthy, or the CLI/GitHub
+  checks prove the latest visible delivery is healthy.
+- Recent GitHub delivery status is `200`. If it is `502`, rotate the webhook
+  to a fresh tunnel before continuing.
+
+## Create Or Choose The Issue
+
+Prefer a fresh issue in `issuectl-test-repo-2`.
+
+Suggested issue:
+
+```text
+Title: QA basic issue label receipt
+
+Body:
+Manual issuectl QA target. Expected behavior: adding issuectl:auto-launch from
+the local issue detail UI launches one Codex session, consumes the label, and
+does not prompt for workspace trust.
+```
+
+Record:
+
+```bash
+ISSUE_NUMBER=<issue-number>
+ISSUE_URL="$BASE_URL/issues/$OWNER/$REPO/$ISSUE_NUMBER"
+```
+
+## Browser Steps
+
+Use the Codex Chrome extension or Chrome browser automation to drive the local
+dashboard as a user would:
+
+1. Open `ISSUE_URL`.
+2. Verify the label panel is visible and the issue does not already have
+   `issuectl:auto-launch`.
+3. Verify the page does not show an active terminal/session state yet.
+4. Open the label editor and add `issuectl:auto-launch`.
+5. Confirm any webhook health warning is absent or explains a known healthy
+   state.
+6. Save the label change.
+7. Observe the issue detail UI transition:
+   - label syncing indicator appears briefly
+   - `issuectl:auto-launch` is removed after the launch is accepted
+   - the issue shows an active session or terminal action while the deployment
+     is live
+   - after completion, the issue shows completed session history and allows a
+     separate new launch
+
+Do not add the label in GitHub directly for this workflow. The point is to test
+the issuectl label editor plus webhook automation.
+
+## Confirm Webhook Delivery
+
+Watch local intake and diagnostics:
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook tail \
+  --repo "$OWNER/$REPO" \
+  --target "issue#$ISSUE_NUMBER" \
+  --limit 20
+
+pnpm --dir packages/cli exec issuectl diag tail \
+  --issue "$OWNER/$REPO#$ISSUE_NUMBER" \
+  --limit 80
+```
+
+Confirm GitHub delivery:
+
+```bash
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '
+    [.[] | select(.event == "issues" and .action == "labeled")]
+    | .[0:5]
+    | .[] | {event, action, status_code, delivered_at, redelivery}
+  '
+```
+
+Pass signal:
+
+- A local webhook event exists for `issues.labeled` on the target issue.
+- The matching GitHub delivery has `status_code=200`.
+- Diagnostics show the launch lifecycle in order: `launch.requested`,
+  `workspace.prepared`, `deployment.recorded`, terminal spawn, and
+  `deployment.activated`.
+
+## Confirm Intent And Deployment State
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.first_signal_at/1000,'unixepoch') as first_signal,
+       datetime(i.scheduled_at/1000,'unixepoch') as scheduled,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='issue' and i.target_number=$ISSUE_NUMBER
+order by i.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.target_type,d.target_number,d.agent,d.state,d.triggered_by,
+       d.branch_name,d.workspace_path,d.launched_at,d.ended_at,d.terminal_reason
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+order by d.id;"
+```
+
+Pass criteria:
+
+- Exactly one intent reaches `launched`.
+- Any follow-up unlabeled delivery caused by consuming the trigger label
+  resolves as `skipped_optout`.
+- Deployment `triggered_by` is `webhook`.
+- Deployment `agent` is `codex`.
+- `workspace_path` ends with `issue-$ISSUE_NUMBER`.
+- No `reconcile.tmux_missing`, `liveness.tmux_missing`, or
+  `ensure_ttyd.failed` diagnostic appears before the UI can attach.
+- GitHub labels no longer include `issuectl:auto-launch`.
+
+## Reset And Cleanup
+
+Use this even after a passing run so the target can be reused safely.
+
+```bash
+gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-launch,issuectl:in-progress" || true
+
+api_token="$(sqlite3 ~/.issuectl/issuectl.db "select value from settings where key='api_token';")"
+
+deployment_ids="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+  and d.ended_at is null;")"
+
+for id in $deployment_ids; do
+  curl -sS -X POST "$BASE_URL/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"issue\",\"targetNumber\":$ISSUE_NUMBER}"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+```
+
+Optional:
+
+```bash
+gh issue close "$ISSUE_NUMBER" --repo "$OWNER/$REPO" \
+  --comment "Closing completed issuectl basic issue label QA target." || true
+```
+
+## Receipt
+
+Record this in the task thread:
+
+```text
+Workflow: basic issue label QA
+Issue:
+Initial labels:
+Final labels:
+GitHub delivery:
+Webhook event id:
+Intent ids:
+Deployment id:
+Agent:
+Worktree:
+UI transition:
+Terminal prompt status:
+Completion status:
+Cleanup:
+Residual risk:
+```

--- a/docs/workflows/webhook-full-chained-issue-to-pr-qa.md
+++ b/docs/workflows/webhook-full-chained-issue-to-pr-qa.md
@@ -1,0 +1,413 @@
+# Full Chained Issue-To-PR Webhook QA
+
+Use this workflow when a future agent is asked:
+
+```text
+run the full chained issue-to-PR webhook QA
+run the full issue-to-PR auto-review chain
+verify chained webhook behavior with the Codex Chrome extension
+```
+
+This is the highest-complexity repeatable workflow for webhook and label
+automation. It uses the Codex Chrome extension as the user surface, starts with
+an issue label-triggered Codex session, then creates a small PR and verifies
+`issuectl:auto-review` launches a PR review session from the local UI.
+
+Under current default budgets, the chain is staged: the issue session is
+webhook-launched, but the QA runner creates the small PR manually. A fully
+automatic issue-worker-created PR remains a separate product/security decision
+because webhook issue sessions currently have `create_pr=0` and `push=0`.
+
+## Scope
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+BASE_URL=http://localhost:3847
+```
+
+Expected defaults:
+
+| Target | Trigger label | Agent | Worktree suffix |
+| --- | --- | --- | --- |
+| Issue | `issuectl:auto-launch` | `codex` | `issue-<number>` |
+| PR | `issuectl:auto-review` | `claude` | `pr-<number>` |
+
+## Agentic Browser Contract
+
+The QA runner should use the Codex Chrome extension or Chrome automation for all
+UI actions:
+
+- Open repo settings and target detail pages in the local dashboard.
+- Inspect webhook health before applying trigger labels.
+- Apply `issuectl:auto-launch` and `issuectl:auto-review` through the local
+  issuectl label editors.
+- Observe button/status transitions after each label save.
+- Capture the visible evidence in the task thread.
+
+Shell commands are still used for setup, diagnostics, DB checks, GitHub delivery
+checks, and cleanup.
+
+## Preflight
+
+Run these before creating targets:
+
+```bash
+curl -I "$BASE_URL"
+pnpm --dir packages/cli exec issuectl repo show "$OWNER/$REPO"
+pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
+pnpm --dir packages/cli exec issuectl webhook tail --repo "$OWNER/$REPO" --limit 10
+```
+
+Confirm repo automation:
+
+```text
+auto-launch issues: true
+auto-review PRs: true
+issue agent: codex
+review agent: claude
+```
+
+Check GitHub hook health:
+
+```bash
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
+Open repo settings in the Codex Chrome extension:
+
+```text
+http://localhost:3847/repos/mean-weasel/issuectl-test-repo-2/settings
+```
+
+Browser pass signal:
+
+- Status and health shows webhook `ok` or an equivalent healthy state.
+- Automation shows issue auto-launch and PR auto-review enabled.
+- Label health reports required labels present, or `Check labels` makes it so.
+- The webhook health card does not warn about a stale URL or failed latest
+  delivery.
+
+Stop before labeling if GitHub deliveries show `502`, the stored hook URL does
+not match the expected issuectl receiver URL, or the UI warns that the webhook
+cannot be verified. Rotate to a fresh tunnel first, then restart this workflow.
+
+## Stage 1: Create Or Choose A Fresh Issue
+
+Create a reversible issue in GitHub or the issuectl UI.
+
+Suggested issue:
+
+```text
+Title: QA chained issue-to-PR webhook receipt
+
+Body:
+Manual issuectl chained QA target. Expected behavior: adding issuectl:auto-launch
+from the local issuectl UI launches one Codex session and consumes the label.
+The follow-up PR is created manually under current webhook budgets, then reviewed
+by issuectl:auto-review.
+```
+
+Record:
+
+```bash
+ISSUE_NUMBER=<issue-number>
+ISSUE_URL="$BASE_URL/issues/$OWNER/$REPO/$ISSUE_NUMBER"
+```
+
+In the Codex Chrome extension:
+
+1. Open `ISSUE_URL`.
+2. Confirm no `issuectl:auto-launch` label is present.
+3. Confirm there is no active terminal/session state.
+4. Confirm the issue label panel includes healthy webhook context.
+5. Add `issuectl:auto-launch` through the issuectl label editor.
+6. Save and observe the issue UI:
+   - syncing indicator appears briefly
+   - active session or terminal action appears after launch
+   - trigger label is consumed
+   - no workspace trust prompt blocks the terminal
+
+Confirm webhook and diagnostics:
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook tail \
+  --repo "$OWNER/$REPO" \
+  --target "issue#$ISSUE_NUMBER" \
+  --limit 20
+
+pnpm --dir packages/cli exec issuectl diag show \
+  --issue "$OWNER/$REPO#$ISSUE_NUMBER" \
+  --limit 120
+```
+
+Confirm issue deployment:
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='issue' and i.target_number=$ISSUE_NUMBER
+order by i.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.agent,d.state,d.triggered_by,d.branch_name,d.workspace_path,
+       d.launched_at,d.ended_at,d.terminal_reason
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+order by d.id;"
+```
+
+Stage 1 pass criteria:
+
+- Exactly one issue intent reaches `launched`.
+- Deployment is webhook-triggered and uses `codex`.
+- Worktree path ends with `issue-$ISSUE_NUMBER`.
+- UI transitions from no active session to active session/terminal, then to
+  completed session history after completion.
+- Final labels do not include `issuectl:auto-launch`.
+
+## Stage 2: Create The Follow-Up PR
+
+Create a small receipt PR that links the issue.
+
+```bash
+tmpdir="$(mktemp -d)"
+git clone "git@github.com:$OWNER/$REPO.git" "$tmpdir/$REPO"
+cd "$tmpdir/$REPO"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+branch="issuectl-full-chain-qa-$stamp"
+git switch -c "$branch"
+mkdir -p qa-receipts
+printf '%s\n' \
+  "QA receipt for issuectl full chained webhook QA." \
+  "Issue: #$ISSUE_NUMBER" \
+  "Expected: PR receives issuectl:auto-review and launches one review session." \
+  "Timestamp: $stamp" \
+  > "qa-receipts/full-chain-$stamp.txt"
+git add "qa-receipts/full-chain-$stamp.txt"
+git commit -m "Add issuectl full chain QA receipt"
+git push -u origin "$branch"
+gh pr create \
+  --repo "$OWNER/$REPO" \
+  --base main \
+  --head "$branch" \
+  --title "QA full chained issue-to-PR webhook $stamp" \
+  --body "Manual issuectl full-chain QA PR. Closes #$ISSUE_NUMBER. Expected behavior: adding issuectl:auto-review from issuectl launches one Claude PR review session."
+```
+
+Record:
+
+```bash
+PR_NUMBER=<pr-number>
+PR_URL="$BASE_URL/pulls/$OWNER/$REPO/$PR_NUMBER"
+```
+
+## Stage 3: Apply PR Auto-Review In The UI
+
+In the Codex Chrome extension:
+
+1. Open `PR_URL`.
+2. Confirm the PR starts without `issuectl:auto-review`.
+3. Confirm there is no `active review session` panel.
+4. Confirm webhook health is healthy in the PR label panel.
+5. Add `issuectl:auto-review` through the issuectl label editor.
+6. Save and observe the PR UI:
+   - syncing indicator appears briefly
+   - `active review session` panel appears
+   - panel shows deployment id, agent, branch, and `Open Terminal`
+   - trigger label is consumed
+   - terminal does not block on permissions, trust, or `gh auth`
+   - after completion, the active review panel disappears and review state is
+     visible in the review surfaces
+
+Confirm webhook and diagnostics:
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook tail \
+  --repo "$OWNER/$REPO" \
+  --target "pr#$PR_NUMBER" \
+  --limit 20
+
+pnpm --dir packages/cli exec issuectl diag show \
+  --pr "$OWNER/$REPO#$PR_NUMBER" \
+  --limit 120
+```
+
+Confirm PR deployment and review row:
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='pr' and i.target_number=$PR_NUMBER
+order by i.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.agent,d.state,d.triggered_by,d.branch_name,d.workspace_path,
+       d.launched_at,d.ended_at,d.terminal_reason,d.completion_result_json
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+order by d.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select pr.id,pr.pr_number,pr.deployment_id,pr.status,pr.triggered_by,
+       pr.started_head_sha,pr.completed_head_sha,pr.head_ref
+from pr_reviews pr
+join repos r on r.id=pr.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and pr.pr_number=$PR_NUMBER
+order by pr.id;"
+```
+
+Stage 3 pass criteria:
+
+- Exactly one PR intent reaches `launched`.
+- Deployment is webhook-triggered and uses `claude`.
+- Worktree path ends with `pr-$PR_NUMBER`.
+- A `pr_reviews` row links to the deployment.
+- Final labels do not include `issuectl:auto-review`.
+- Follow-up unlabeled deliveries resolve as `skipped_optout` and do not relaunch.
+
+## Final Chain Pass Criteria
+
+The chained workflow passes only when all of these are true:
+
+- Repo settings and target label panels showed healthy webhook state before
+  automation labels were applied.
+- Both automation labels were applied through the local issuectl UI using the
+  Codex Chrome extension or Chrome automation.
+- GitHub delivered both labeled webhooks to this machine with `status_code=200`.
+- Local webhook tail shows both labeled events.
+- Diagnostics show normal launch lifecycles for both targets.
+- Issue session and PR review session each launch exactly once.
+- Both worktree paths and deployment rows match their target numbers.
+- UI button/status transitions were observed for issue and PR detail pages.
+- Both trigger labels were consumed.
+- Cleanup leaves no live deployment rows, matching tmux sessions, or QA branch.
+
+## Reset And Cleanup
+
+```bash
+gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-launch,issuectl:in-progress" || true
+
+gh pr edit "$PR_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-review,issuectl:in-progress" || true
+
+api_token="$(sqlite3 ~/.issuectl/issuectl.db "select value from settings where key='api_token';")"
+
+issue_deployments="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='issue' and d.target_number=$ISSUE_NUMBER
+  and d.ended_at is null;")"
+
+for id in $issue_deployments; do
+  curl -sS -X POST "$BASE_URL/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"issue\",\"targetNumber\":$ISSUE_NUMBER}"
+done
+
+pr_deployments="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+  and d.ended_at is null;")"
+
+for id in $pr_deployments; do
+  curl -sS -X POST "$BASE_URL/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"pr\",\"targetNumber\":$PR_NUMBER}"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$PR_NUMBER" '$1 ~ "issuectl-" repo "-pr-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+
+head_ref="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
+if [ -n "$head_ref" ]; then
+  gh pr close "$PR_NUMBER" --repo "$OWNER/$REPO" \
+    --comment "Closing completed issuectl full chained webhook QA target." || true
+
+  # Keep the head branch around until the close/unlabel webhook finishes
+  # debouncing. Deleting it immediately can turn cleanup webhooks into
+  # branch-not-found diagnostics.
+  debounce_seconds="$(sqlite3 ~/.issuectl/issuectl.db "select coalesce(value, '60') from settings where key='webhook_debounce_seconds';")"
+  sleep "$(( ${debounce_seconds:-60} + 15 ))"
+
+  git ls-remote --exit-code --heads "git@github.com:$OWNER/$REPO.git" "$head_ref" >/dev/null 2>&1 &&
+    git push "git@github.com:$OWNER/$REPO.git" --delete "$head_ref"
+fi
+
+gh issue close "$ISSUE_NUMBER" --repo "$OWNER/$REPO" \
+  --comment "Closing completed issuectl full chained webhook QA target." || true
+```
+
+Cleanup pass criteria:
+
+- Issue trigger labels are absent.
+- PR trigger labels are absent.
+- No live deployment rows remain for the issue or PR.
+- No matching tmux sessions remain.
+- The QA PR is closed and its branch is deleted.
+- The QA issue is closed or intentionally left open for another run.
+
+## Receipt
+
+Record this in the task thread:
+
+```text
+Workflow: full chained issue-to-PR webhook QA
+Repo settings webhook health:
+Issue:
+Issue UI transition:
+Issue GitHub delivery:
+Issue webhook event id:
+Issue intent ids:
+Issue deployment id:
+Issue worktree:
+Issue terminal prompt status:
+PR:
+PR UI transition:
+PR GitHub delivery:
+PR webhook event id:
+PR intent ids:
+PR deployment id:
+PR review row:
+PR worktree:
+PR terminal prompt status:
+Cleanup:
+Residual risk:
+```

--- a/docs/workflows/webhook-issue-to-pr-review-qa.md
+++ b/docs/workflows/webhook-issue-to-pr-review-qa.md
@@ -83,7 +83,7 @@ Confirm GitHub is delivering to the current tunnel before labeling anything:
 
 ```bash
 hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
-select github_webhook_id
+select webhook_id
 from repos
 where owner='$OWNER' and name='$REPO';")"
 
@@ -492,7 +492,7 @@ for id in $pr_deployments; do
     -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"pr\",\"targetNumber\":$PR_NUMBER}"
 done
 
-tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-issue-" num ":" { sub(/:$/, "", $1); print $1 }' |
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-" num ":" { sub(/:$/, "", $1); print $1 }' |
 while read -r session; do
   tmux kill-session -t "$session"
 done
@@ -505,6 +505,13 @@ done
 head_ref="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
 if [ -n "$head_ref" ]; then
   gh pr close "$PR_NUMBER" --repo "$OWNER/$REPO" --comment "Closing completed issuectl chained QA target." || true
+
+  # Keep the head branch around until the close/unlabel webhook finishes
+  # debouncing. Deleting it immediately can turn cleanup webhooks into
+  # branch-not-found diagnostics.
+  debounce_seconds="$(sqlite3 ~/.issuectl/issuectl.db "select coalesce(value, '60') from settings where key='webhook_debounce_seconds';")"
+  sleep "$(( ${debounce_seconds:-60} + 15 ))"
+
   git ls-remote --exit-code --heads "git@github.com:$OWNER/$REPO.git" "$head_ref" >/dev/null 2>&1 &&
     git push "git@github.com:$OWNER/$REPO.git" --delete "$head_ref"
 fi

--- a/docs/workflows/webhook-label-manual-qa.md
+++ b/docs/workflows/webhook-label-manual-qa.md
@@ -71,7 +71,7 @@ tail -f ~/.issuectl/logs/web.log
 OWNER=mean-weasel
 REPO=issuectl-test-repo-2
 hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
-select github_webhook_id
+select webhook_id
 from repos
 where owner='$OWNER' and name='$REPO';")"
 
@@ -302,7 +302,7 @@ Expected PR evidence:
 Find the deployment id, then inspect the tmux pane. The session name normally follows:
 
 ```text
-issuectl-<repo-name>-issue-<number>
+issuectl-<repo-name>-<number>
 issuectl-<repo-name>-pr-<number>
 ```
 
@@ -348,7 +348,7 @@ for id in $deployment_ids; do
     -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"issue\",\"targetNumber\":$ISSUE_NUMBER}"
 done
 
-tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-issue-" num ":" { sub(/:$/, "", $1); print $1 }' |
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$ISSUE_NUMBER" '$1 ~ "issuectl-" repo "-" num ":" { sub(/:$/, "", $1); print $1 }' |
 while read -r session; do
   tmux kill-session -t "$session"
 done
@@ -400,6 +400,13 @@ Close the QA PR and delete the branch when the run is done:
 ```bash
 head_ref="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName --jq .headRefName)"
 gh pr close "$PR_NUMBER" --repo "$OWNER/$REPO" --comment "Closing completed issuectl manual QA target."
+
+# Keep the head branch around until the close/unlabel webhook finishes
+# debouncing. Deleting it immediately can turn cleanup webhooks into
+# branch-not-found diagnostics.
+debounce_seconds="$(sqlite3 ~/.issuectl/issuectl.db "select coalesce(value, '60') from settings where key='webhook_debounce_seconds';")"
+sleep "$(( ${debounce_seconds:-60} + 15 ))"
+
 git ls-remote --exit-code --heads "git@github.com:$OWNER/$REPO.git" "$head_ref" >/dev/null &&
   git push "git@github.com:$OWNER/$REPO.git" --delete "$head_ref"
 ```

--- a/docs/workflows/webhook-pr-auto-review-qa.md
+++ b/docs/workflows/webhook-pr-auto-review-qa.md
@@ -1,0 +1,280 @@
+# PR Auto-Review Webhook QA
+
+Use this workflow when a future agent is asked:
+
+```text
+run the PR auto-review webhook QA
+run the PR label QA
+verify issuectl:auto-review from the UI
+```
+
+This workflow proves the local dashboard can apply `issuectl:auto-review`, the
+GitHub webhook delivery reaches this machine, issuectl creates exactly one PR
+review session, the trigger label is consumed, the review deployment and
+`pr_reviews` row agree, and the PR detail UI reflects the active review state.
+
+## Scope
+
+Target repository:
+
+```bash
+OWNER=mean-weasel
+REPO=issuectl-test-repo-2
+BASE_URL=http://localhost:3847
+```
+
+Default expectations:
+
+| Item | Expected value |
+| --- | --- |
+| Trigger label | `issuectl:auto-review` |
+| Agent | `claude` |
+| Worktree suffix | `pr-<number>` |
+| Trigger source | Local issuectl PR detail label editor |
+| UI surface | Codex Chrome extension or Chrome attached to the local dashboard |
+
+## Preflight
+
+Run these before creating or labeling a PR:
+
+```bash
+curl -I "$BASE_URL"
+pnpm --dir packages/cli exec issuectl repo show "$OWNER/$REPO"
+pnpm --dir packages/cli exec issuectl webhook status "$OWNER/$REPO"
+```
+
+Confirm the repo settings show:
+
+```text
+auto-review PRs: true
+review agent: claude
+```
+
+Check the webhook URL and recent deliveries:
+
+```bash
+hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
+select webhook_id
+from repos
+where owner='$OWNER' and name='$REPO';")"
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id" \
+  --jq '{id, active, url: .config.url, updated_at}'
+
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '.[0:8][] | {event, action, status_code, delivered_at, redelivery}'
+```
+
+Pass signal:
+
+- The dashboard responds on `localhost:3847`.
+- The repo is tracked and PR auto-review is enabled.
+- The repo settings page or CLI/GitHub checks show healthy webhook delivery.
+- Recent GitHub delivery status is `200`. If it is `502`, rotate the webhook
+  to a fresh tunnel before continuing.
+
+## Create Or Choose The PR
+
+Prefer a fresh PR that only adds a receipt file.
+
+```bash
+tmpdir="$(mktemp -d)"
+git clone "git@github.com:$OWNER/$REPO.git" "$tmpdir/$REPO"
+cd "$tmpdir/$REPO"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+branch="issuectl-pr-auto-review-qa-$stamp"
+git switch -c "$branch"
+mkdir -p qa-receipts
+printf '%s\n' \
+  "QA receipt for issuectl PR auto-review." \
+  "Expected: adding issuectl:auto-review from issuectl launches one review session." \
+  "Timestamp: $stamp" \
+  > "qa-receipts/pr-auto-review-$stamp.txt"
+git add "qa-receipts/pr-auto-review-$stamp.txt"
+git commit -m "Add issuectl PR auto-review QA receipt"
+git push -u origin "$branch"
+gh pr create \
+  --repo "$OWNER/$REPO" \
+  --base main \
+  --head "$branch" \
+  --title "QA PR auto-review receipt $stamp" \
+  --body "Manual issuectl QA target. Expected behavior: adding issuectl:auto-review from the local PR detail UI launches one Claude review session, consumes the label, and avoids interactive prompts."
+```
+
+Record:
+
+```bash
+PR_NUMBER=<pr-number>
+PR_URL="$BASE_URL/pulls/$OWNER/$REPO/$PR_NUMBER"
+```
+
+## Browser Steps
+
+Use the Codex Chrome extension or Chrome browser automation to drive the local
+dashboard:
+
+1. Open `PR_URL`.
+2. Verify the PR label panel is visible and the PR does not already have
+   `issuectl:auto-review`.
+3. Verify there is no `active review session` panel yet.
+4. Open the label editor and add `issuectl:auto-review`.
+5. Confirm any webhook health warning is absent or explains a known healthy
+   state.
+6. Save the label change.
+7. Observe the PR detail UI transition:
+   - label syncing indicator appears briefly
+   - `issuectl:auto-review` is removed after the launch is accepted
+   - the `active review session` panel appears while the deployment is live
+   - the panel shows deployment id, agent, branch, and `Open Terminal` when the
+     terminal is available
+   - after completion, the active panel disappears and review status is visible
+     through the PR review/history surfaces
+
+Do not add the label in GitHub directly for this workflow. The point is to test
+the issuectl PR label editor plus webhook automation.
+
+## Confirm Webhook Delivery
+
+```bash
+pnpm --dir packages/cli exec issuectl webhook tail \
+  --repo "$OWNER/$REPO" \
+  --target "pr#$PR_NUMBER" \
+  --limit 20
+
+pnpm --dir packages/cli exec issuectl diag tail \
+  --pr "$OWNER/$REPO#$PR_NUMBER" \
+  --limit 100
+```
+
+Confirm GitHub delivery:
+
+```bash
+gh api "repos/$OWNER/$REPO/hooks/$hook_id/deliveries" \
+  --jq '
+    [.[] | select(.event == "pull_request" and .action == "labeled")]
+    | .[0:5]
+    | .[] | {event, action, status_code, delivered_at, redelivery}
+  '
+```
+
+Pass signal:
+
+- A local webhook event exists for `pull_request.labeled` on the target PR.
+- The matching GitHub delivery has `status_code=200`.
+- Diagnostics show the launch lifecycle in order: `launch.requested`,
+  `workspace.prepared`, `deployment.recorded`, terminal spawn, and
+  `deployment.activated`.
+
+## Confirm Intent, Deployment, And Review State
+
+```bash
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select i.id,i.status,i.deployment_id,i.failure_reason,
+       datetime(i.first_signal_at/1000,'unixepoch') as first_signal,
+       datetime(i.scheduled_at/1000,'unixepoch') as scheduled,
+       datetime(i.resolved_at/1000,'unixepoch') as resolved
+from webhook_intents i
+join repos r on r.id=i.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and i.target_type='pr' and i.target_number=$PR_NUMBER
+order by i.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select d.id,d.target_type,d.target_number,d.agent,d.state,d.triggered_by,
+       d.branch_name,d.workspace_path,d.launched_at,d.ended_at,d.terminal_reason,
+       d.completion_result_json
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+order by d.id;"
+
+sqlite3 -header -column ~/.issuectl/issuectl.db "
+select pr.id,pr.pr_number,pr.deployment_id,pr.status,pr.triggered_by,
+       pr.started_head_sha,pr.completed_head_sha,pr.head_ref
+from pr_reviews pr
+join repos r on r.id=pr.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and pr.pr_number=$PR_NUMBER
+order by pr.id;"
+```
+
+Pass criteria:
+
+- Exactly one PR intent reaches `launched`.
+- Any follow-up unlabeled delivery caused by consuming the trigger label
+  resolves as `skipped_optout`.
+- Deployment `triggered_by` is `webhook`.
+- Deployment `agent` is `claude`.
+- `workspace_path` ends with `pr-$PR_NUMBER`.
+- A `pr_reviews` row exists for the PR and links to the deployment.
+- No permission prompt, workspace trust prompt, or `gh auth login` blocker
+  appears in the terminal.
+- GitHub labels no longer include `issuectl:auto-review`.
+
+## Reset And Cleanup
+
+```bash
+gh pr edit "$PR_NUMBER" --repo "$OWNER/$REPO" \
+  --remove-label "issuectl:auto-review,issuectl:in-progress" || true
+
+api_token="$(sqlite3 ~/.issuectl/issuectl.db "select value from settings where key='api_token';")"
+
+deployment_ids="$(sqlite3 ~/.issuectl/issuectl.db "
+select d.id
+from deployments d
+join repos r on r.id=d.repo_id
+where r.owner='$OWNER' and r.name='$REPO'
+  and d.target_type='pr' and d.target_number=$PR_NUMBER
+  and d.ended_at is null;")"
+
+for id in $deployment_ids; do
+  curl -sS -X POST "$BASE_URL/api/v1/deployments/$id/end" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $api_token" \
+    -d "{\"owner\":\"$OWNER\",\"repo\":\"$REPO\",\"targetType\":\"pr\",\"targetNumber\":$PR_NUMBER}"
+done
+
+tmux ls 2>/dev/null | awk -v repo="$REPO" -v num="$PR_NUMBER" '$1 ~ "issuectl-" repo "-pr-" num ":" { sub(/:$/, "", $1); print $1 }' |
+while read -r session; do
+  tmux kill-session -t "$session"
+done
+
+head_ref="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
+if [ -n "$head_ref" ]; then
+  gh pr close "$PR_NUMBER" --repo "$OWNER/$REPO" \
+    --comment "Closing completed issuectl PR auto-review QA target." || true
+
+  # Keep the head branch around until the close/unlabel webhook finishes
+  # debouncing. Deleting it immediately can turn cleanup webhooks into
+  # branch-not-found diagnostics.
+  debounce_seconds="$(sqlite3 ~/.issuectl/issuectl.db "select coalesce(value, '60') from settings where key='webhook_debounce_seconds';")"
+  sleep "$(( ${debounce_seconds:-60} + 15 ))"
+
+  git ls-remote --exit-code --heads "git@github.com:$OWNER/$REPO.git" "$head_ref" >/dev/null 2>&1 &&
+    git push "git@github.com:$OWNER/$REPO.git" --delete "$head_ref"
+fi
+```
+
+## Receipt
+
+Record this in the task thread:
+
+```text
+Workflow: PR auto-review webhook QA
+PR:
+Initial labels:
+Final labels:
+GitHub delivery:
+Webhook event id:
+Intent ids:
+Deployment id:
+Review row:
+Agent:
+Worktree:
+UI transition:
+Terminal prompt status:
+Completion/review status:
+Cleanup:
+Residual risk:
+```

--- a/docs/workflows/webhook-qa-ladder.md
+++ b/docs/workflows/webhook-qa-ladder.md
@@ -2,6 +2,16 @@
 
 This ladder orders issue and PR webhook QA workflows from lowest complexity to highest complexity. Use it to pick the smallest manual or agent-driven check that can answer the question in front of you.
 
+## Natural Language Entry Points
+
+Use these exact prompts to hand repeatable QA to a future Codex agent:
+
+| Ask | Runbook |
+| --- | --- |
+| `run the basic issue label QA` | [Basic Issue Label Webhook QA](./webhook-basic-issue-label-qa.md) |
+| `run the PR auto-review webhook QA` | [PR Auto-Review Webhook QA](./webhook-pr-auto-review-qa.md) |
+| `run the full chained issue-to-PR webhook QA` | [Full Chained Issue-To-PR Webhook QA](./webhook-full-chained-issue-to-pr-qa.md) |
+
 Prefer running the lower rungs first when the environment is fresh, the tunnel changed, the web server restarted, labels were reset, or a failure could be infrastructure instead of product behavior.
 
 ## Complexity Order
@@ -12,13 +22,13 @@ Prefer running the lower rungs first when the environment is fresh, the tunnel c
 | 1 | Webhook delivery health | Repo | GitHub can reach the local receiver and HMAC verification is working. | [Webhook Auto-Sessions Runbook](./webhook-auto-sessions.md) |
 | 2 | Untagged target no-op | Issue or PR | Webhook delivery alone does not launch without the opt-in label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
 | 3 | Label editor smoke | Issue or PR | Local UI can add/remove labels and GitHub reflects the changes. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
-| 4 | Issue auto-launch | Issue | `issuectl:auto-launch` launches exactly one Codex issue session and consumes the label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
-| 5 | PR auto-review | PR | `issuectl:auto-review` launches exactly one Claude review session and consumes the label. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
+| 4 | Issue auto-launch | Issue | `issuectl:auto-launch` launches exactly one Codex issue session and consumes the label. | [Basic Issue Label Webhook QA](./webhook-basic-issue-label-qa.md) |
+| 5 | PR auto-review | PR | `issuectl:auto-review` launches exactly one Claude review session and consumes the label. | [PR Auto-Review Webhook QA](./webhook-pr-auto-review-qa.md) |
 | 6 | Agent matrix | Issue and PR | Both Codex and Claude can start for either target without trust or permission prompts. | Future runbook |
 | 7 | Completion and cleanup lifecycle | Issue and PR | Agent completion updates DB/UI state, removes active labels, and follow-up webhooks do not relaunch. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
 | 8 | Failure and reset recovery | Issue and PR | Operators can clean up stale labels, stale deployments, tmux sessions, and test branches. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
 | 9 | Full regression pass | Issue and PR | Fresh issue and fresh PR both pass the whole one-shot automation oracle in one session. | [Webhook Label Manual QA](./webhook-label-manual-qa.md) |
-| 10 | Issue-to-PR review chain | Issue then PR | Issue auto-work feeds a PR that is then auto-reviewed, with current default budget limits made explicit. | [Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md) |
+| 10 | Issue-to-PR review chain | Issue then PR | Issue auto-work feeds a PR that is then auto-reviewed, with current default budget limits made explicit. | [Full Chained Issue-To-PR Webhook QA](./webhook-full-chained-issue-to-pr-qa.md) |
 
 ## Rung 0: Local Server Health
 
@@ -46,7 +56,7 @@ tail -f ~/.issuectl/logs/web.log
 pnpm --dir packages/cli exec issuectl webhook tail --repo mean-weasel/issuectl-test-repo-2 --limit 20
 
 hook_id="$(sqlite3 ~/.issuectl/issuectl.db "
-select github_webhook_id
+select webhook_id
 from repos
 where owner='mean-weasel' and name='issuectl-test-repo-2';")"
 
@@ -199,6 +209,7 @@ Important default behavior:
 - Therefore the default supported chained QA is staged: auto-launch the issue, then manually create a small PR, then label that PR for auto-review.
 - A fully automatic issue-worker-created PR requires an explicit product/security decision to grant issue sessions PR creation and push authority.
 
-Primary runbook:
+Primary runbooks:
 
-[Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md)
+- [Full Chained Issue-To-PR Webhook QA](./webhook-full-chained-issue-to-pr-qa.md)
+- [Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md)


### PR DESCRIPTION
## Summary

Adds repeatable Markdown QA workflows for webhook and label automation:

- basic issue label QA for `issuectl:auto-launch`
- PR auto-review webhook QA for `issuectl:auto-review`
- full staged issue-to-PR webhook chain using the Codex Chrome extension as the UI surface

Also wires the webhook QA ladder to the natural-language prompts and fixes existing webhook doc snippets to use the actual `webhook_id` DB column plus the current issue tmux session naming pattern.

## Verification

- `git diff --check`
- trailing-whitespace scan for touched workflow docs
- ASCII scan for new workflow docs
- local Markdown link check for workflow docs
- stale `github_webhook_id` / issue tmux naming scan
