### PR TITLE
fix: reconcile stale webhook deployments before cap

### DIFF
--- a/packages/core/src/launch/ttyd-respawn.test.ts
+++ b/packages/core/src/launch/ttyd-respawn.test.ts
@@ -256,6 +256,7 @@ describe("reconcileOrphanedDeployments", () => {
       (c: unknown[]) => (c[0] as string).includes("SELECT"),
     );
     expect(selectCall).toBeDefined();
+    expect(selectCall![0]).toContain("d.state = 'active'");
     expect(selectCall![0]).toContain("d.ttyd_pid IS NOT NULL OR d.terminal_backend = 'pty_bridge'");
   });
 

--- a/packages/core/src/launch/ttyd.ts
+++ b/packages/core/src/launch/ttyd.ts
@@ -390,6 +390,7 @@ export function reconcileOrphanedDeployments(db: Database.Database): void {
          FROM deployments d
          JOIN repos r ON r.id = d.repo_id
          WHERE d.ended_at IS NULL
+           AND d.state = 'active'
            AND (d.ttyd_pid IS NOT NULL OR d.terminal_backend = 'pty_bridge')`,
       )
       .all() as typeof rows;

--- a/packages/web/lib/webhook-runaway-controls.test.ts
+++ b/packages/web/lib/webhook-runaway-controls.test.ts
@@ -91,6 +91,37 @@ describe("webhook runaway controls", () => {
     );
   });
 
+  it("reconciles stale webhook sessions before enforcing the concurrent agent cap", () => {
+    setSetting(db, "max_concurrent_webhook_agents", "1");
+    const staleDeploymentId = recordDeployment(db, {
+      repoId: repo.id,
+      issueNumber: 999,
+      branchName: "issue-999",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/issuectl-stale",
+      terminalBackend: "pty_bridge",
+      triggeredBy: "webhook",
+    }).id;
+    const intent = claimIntent(db, 506, 2_000);
+
+    const decision = enforceWebhookRunawayControls(db, repo, intent, 2_000);
+
+    expect(decision).toEqual({ allowed: true });
+    expect(db.prepare("SELECT ended_at, terminal_reason FROM deployments WHERE id = ?").get(staleDeploymentId)).toEqual(
+      expect.objectContaining({
+        ended_at: expect.any(String),
+        terminal_reason: "liveness_missing",
+      }),
+    );
+    expect(queryDiagnosticEvents(db, { events: ["reconcile.tmux_missing"] })).toEqual([
+      expect.objectContaining({
+        targetType: "issue",
+        targetNumber: 999,
+        deploymentId: staleDeploymentId,
+      }),
+    ]);
+  });
+
   it("defers launches when the repo launch-rate cap is reached", () => {
     setSetting(db, "max_webhook_launches_per_minute", "1");
     const launchedId = mergeWebhookIntent(db, {

--- a/packages/web/lib/webhook-runaway-controls.ts
+++ b/packages/web/lib/webhook-runaway-controls.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import {
   getSetting,
   countActiveWebhookIntents,
+  reconcileOrphanedDeployments,
   recordDiagnosticEventSafely,
   type Repo,
   type WebhookIntent,
@@ -32,11 +33,12 @@ export function enforceWebhookRunawayControls(
     return { allowed: false, outcome: "failed", reason: "queue_depth_exceeded" };
   }
 
-  const activeAgents = countActiveWebhookAgents(db);
   const maxActiveAgents = positiveSetting(
     getSetting(db, "max_concurrent_webhook_agents"),
     DEFAULT_MAX_CONCURRENT_AGENTS,
   );
+  reconcileOrphanedDeployments(db);
+  const activeAgents = countActiveWebhookAgents(db);
   if (activeAgents >= maxActiveAgents) {
     deferIntent(db, repo, intent, now, "concurrent_agents_exceeded", {
       activeAgents,


### PR DESCRIPTION
## Summary
- reconcile orphaned deployments before enforcing the webhook/comment-command concurrent-agent cap
- keep orphan reconciliation scoped to active rows so pending launches are not ended while their terminal is still starting
- add regressions for stale webhook sessions and active-only reconciliation

Closes #538.

## Verification
- `pnpm --dir packages/core test -- ttyd-respawn`
- `pnpm --dir packages/web test -- webhook-runaway-controls`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core lint`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `pnpm turbo build`
