### PR TITLE
Show completed PR review sessions on PR detail

### DIFF
--- a/packages/web/components/detail/CompletedSessionCard.tsx
+++ b/packages/web/components/detail/CompletedSessionCard.tsx
@@ -1,0 +1,159 @@
+import Link from "next/link";
+import type { Deployment } from "@issuectl/core";
+import { deploymentLaunchAgent, launchAgentLabel } from "@/components/launch/agent";
+import { formatDate, formatDuration } from "@/lib/format";
+import { CompletedSessionTerminalButton } from "./CompletedSessionTerminalButton";
+import styles from "./IssueDetail.module.css";
+
+type TargetType = "issue" | "pr";
+
+type Props = {
+  owner: string;
+  repo: string;
+  targetType: TargetType;
+  targetNumber: number;
+  deployment: Deployment;
+};
+
+export function CompletedSessionCard({
+  owner,
+  repo,
+  targetType,
+  targetNumber,
+  deployment,
+}: Props) {
+  return (
+    <section className={styles.completedSession} aria-label="Completed agent session">
+      <div className={styles.completedSessionHeader}>
+        <div>
+          <p className={styles.completedSessionEyebrow}>
+            {launchAgentLabel(deploymentLaunchAgent(deployment))} {targetActionLabel(targetType)}
+          </p>
+          <h2>Completed session #{deployment.id}</h2>
+        </div>
+        <span className={styles.completedSessionStatus}>
+          {completionStatus(deployment)}
+        </span>
+      </div>
+
+      <dl className={styles.completedSessionMeta}>
+        <div>
+          <dt>Branch</dt>
+          <dd>{deployment.branchName}</dd>
+        </div>
+        <div>
+          <dt>Ended</dt>
+          <dd>{deployment.endedAt ? formatDate(deployment.endedAt) : "not recorded"}</dd>
+        </div>
+        <div>
+          <dt>Duration</dt>
+          <dd>
+            {deployment.endedAt
+              ? formatDuration(deployment.launchedAt, deployment.endedAt)
+              : "not recorded"}
+          </dd>
+        </div>
+        <div>
+          <dt>Workspace</dt>
+          <dd>{deployment.workspacePath}</dd>
+        </div>
+      </dl>
+
+      {completionSummary(deployment) && (
+        <p className={styles.completedSessionSummary}>
+          {completionSummary(deployment)}
+        </p>
+      )}
+
+      <div className={styles.completedSessionActions}>
+        <CompletedSessionTerminalButton
+          deploymentId={deployment.id}
+          owner={owner}
+          repo={repo}
+          issueNumber={targetNumber}
+          targetType={targetType}
+          targetNumber={targetNumber}
+        />
+        <Link
+          className={styles.completedSessionSecondaryLink}
+          href={sessionHistoryHref(owner, repo, targetType, targetNumber)}
+        >
+          Session history
+        </Link>
+        {targetType === "issue" && deployment.linkedPrNumber !== null && (
+          <Link
+            className={styles.completedSessionSecondaryLink}
+            href={`/pulls/${owner}/${repo}/${deployment.linkedPrNumber}`}
+          >
+            PR #{deployment.linkedPrNumber}
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function latestCompletedDeployment(deployments: Deployment[]): Deployment | null {
+  return deployments
+    .filter((deployment) => deployment.endedAt !== null)
+    .sort((left, right) =>
+      Date.parse(right.endedAt ?? right.launchedAt) - Date.parse(left.endedAt ?? left.launchedAt)
+        || right.id - left.id,
+    )[0] ?? null;
+}
+
+function targetActionLabel(targetType: TargetType): string {
+  return targetType === "pr" ? "reviewed this PR" : "worked this issue";
+}
+
+function completionStatus(deployment: Deployment): string {
+  const result = completionResult(deployment);
+  return labelize(stringValue(result.status) ?? deployment.terminalReason ?? "completed");
+}
+
+function completionSummary(deployment: Deployment): string | null {
+  const result = completionResult(deployment);
+  return stringValue(result.summary)
+    ?? stringValue(result.reason)
+    ?? stringValue(result.error)
+    ?? null;
+}
+
+function completionResult(deployment: Deployment): Record<string, unknown> {
+  if (!deployment.completionResultJson) return {};
+  try {
+    const parsed = JSON.parse(deployment.completionResultJson) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function labelize(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function sessionHistoryHref(
+  owner: string,
+  repo: string,
+  targetType: TargetType,
+  targetNumber: number,
+): string {
+  const params = new URLSearchParams({
+    tab: "sessions",
+    repo: `${owner}/${repo}`,
+    state: "ended",
+    q: `${targetType === "pr" ? "PR" : "Issue"} #${targetNumber}`,
+  });
+  return `/sessions?${params.toString()}`;
+}

--- a/packages/web/components/detail/CompletedSessionTerminalButton.tsx
+++ b/packages/web/components/detail/CompletedSessionTerminalButton.tsx
@@ -10,6 +10,8 @@ type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  targetType?: "issue" | "pr";
+  targetNumber?: number;
 };
 
 export function CompletedSessionTerminalButton({
@@ -17,6 +19,8 @@ export function CompletedSessionTerminalButton({
   owner,
   repo,
   issueNumber,
+  targetType = "issue",
+  targetNumber = issueNumber,
 }: Props) {
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
@@ -31,8 +35,8 @@ export function CompletedSessionTerminalButton({
         deploymentId,
         owner,
         repo,
-        targetType: "issue",
-        targetNumber: issueNumber,
+        targetType,
+        targetNumber,
       });
       if (!result.success) {
         setTranscript(null);

--- a/packages/web/components/detail/LaunchCard.tsx
+++ b/packages/web/components/detail/LaunchCard.tsx
@@ -1,10 +1,10 @@
-import Link from "next/link";
 import type { Deployment } from "@issuectl/core";
 import { LaunchActiveBanner } from "@/components/launch/LaunchActiveBanner";
-import { deploymentLaunchAgent, launchAgentLabel } from "@/components/launch/agent";
-import { formatDate, formatDuration } from "@/lib/format";
-import { CompletedSessionTerminalButton } from "./CompletedSessionTerminalButton";
-import styles from "./IssueDetail.module.css";
+import { deploymentLaunchAgent } from "@/components/launch/agent";
+import {
+  CompletedSessionCard,
+  latestCompletedDeployment,
+} from "./CompletedSessionCard";
 
 type Props = {
   owner: string;
@@ -36,126 +36,12 @@ export function LaunchCard({ owner, repo, issueNumber, issueTitle, deployments }
   if (!completedDeployment) return null;
 
   return (
-    <section className={styles.completedSession} aria-label="Completed agent session">
-      <div className={styles.completedSessionHeader}>
-        <div>
-          <p className={styles.completedSessionEyebrow}>
-            {launchAgentLabel(deploymentLaunchAgent(completedDeployment))} worked this issue
-          </p>
-          <h2>Completed session #{completedDeployment.id}</h2>
-        </div>
-        <span className={styles.completedSessionStatus}>
-          {completionStatus(completedDeployment)}
-        </span>
-      </div>
-
-      <dl className={styles.completedSessionMeta}>
-        <div>
-          <dt>Branch</dt>
-          <dd>{completedDeployment.branchName}</dd>
-        </div>
-        <div>
-          <dt>Ended</dt>
-          <dd>{completedDeployment.endedAt ? formatDate(completedDeployment.endedAt) : "not recorded"}</dd>
-        </div>
-        <div>
-          <dt>Duration</dt>
-          <dd>
-            {completedDeployment.endedAt
-              ? formatDuration(completedDeployment.launchedAt, completedDeployment.endedAt)
-              : "not recorded"}
-          </dd>
-        </div>
-        <div>
-          <dt>Workspace</dt>
-          <dd>{completedDeployment.workspacePath}</dd>
-        </div>
-      </dl>
-
-      {completionSummary(completedDeployment) && (
-        <p className={styles.completedSessionSummary}>
-          {completionSummary(completedDeployment)}
-        </p>
-      )}
-
-      <div className={styles.completedSessionActions}>
-        <CompletedSessionTerminalButton
-          deploymentId={completedDeployment.id}
-          owner={owner}
-          repo={repo}
-          issueNumber={issueNumber}
-        />
-        <Link
-          className={styles.completedSessionSecondaryLink}
-          href={sessionHistoryHref(owner, repo, issueNumber)}
-        >
-          Session history
-        </Link>
-        {completedDeployment.linkedPrNumber !== null && (
-          <Link
-            className={styles.completedSessionSecondaryLink}
-            href={`/pulls/${owner}/${repo}/${completedDeployment.linkedPrNumber}`}
-          >
-            PR #{completedDeployment.linkedPrNumber}
-          </Link>
-        )}
-      </div>
-    </section>
+    <CompletedSessionCard
+      owner={owner}
+      repo={repo}
+      targetType="issue"
+      targetNumber={issueNumber}
+      deployment={completedDeployment}
+    />
   );
-}
-
-function latestCompletedDeployment(deployments: Deployment[]): Deployment | null {
-  return deployments
-    .filter((deployment) => deployment.endedAt !== null)
-    .sort((left, right) =>
-      Date.parse(right.endedAt ?? right.launchedAt) - Date.parse(left.endedAt ?? left.launchedAt)
-        || right.id - left.id,
-    )[0] ?? null;
-}
-
-function completionStatus(deployment: Deployment): string {
-  const result = completionResult(deployment);
-  return labelize(stringValue(result.status) ?? deployment.terminalReason ?? "completed");
-}
-
-function completionSummary(deployment: Deployment): string | null {
-  const result = completionResult(deployment);
-  return stringValue(result.summary)
-    ?? stringValue(result.reason)
-    ?? stringValue(result.error)
-    ?? null;
-}
-
-function completionResult(deployment: Deployment): Record<string, unknown> {
-  if (!deployment.completionResultJson) return {};
-  try {
-    const parsed = JSON.parse(deployment.completionResultJson) as unknown;
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function labelize(value: string): string {
-  return value
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function sessionHistoryHref(owner: string, repo: string, issueNumber: number): string {
-  const params = new URLSearchParams({
-    tab: "sessions",
-    repo: `${owner}/${repo}`,
-    state: "ended",
-    q: `Issue #${issueNumber}`,
-  });
-  return `/sessions?${params.toString()}`;
 }

--- a/packages/web/components/detail/PrDetail.test.ts
+++ b/packages/web/components/detail/PrDetail.test.ts
@@ -1,0 +1,177 @@
+import { createElement } from "react";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Deployment,
+  GitHubPull,
+  GitHubCheck,
+  GitHubPullFile,
+  GitHubPullReview,
+} from "@issuectl/core";
+import { PrDetail } from "./PrDetail";
+
+vi.mock("@/components/ui/KeyboardHelpOverlay", () => ({
+  KeyboardHelpOverlay: () => null,
+}));
+
+vi.mock("./DetailKeyboardNav", () => ({
+  DetailKeyboardNav: () => null,
+}));
+
+vi.mock("./DetailTopBar", () => ({
+  DetailTopBar: (props: { crumb?: unknown }) =>
+    createElement("mock-detail-top-bar", null, props.crumb as ReactNode),
+}));
+
+vi.mock("@/components/issue/LabelManager", () => ({
+  LabelManager: () => createElement("mock-label-manager"),
+}));
+
+vi.mock("@/components/terminal/OpenTerminalButton", () => ({
+  OpenTerminalButton: () => createElement("mock-open-terminal", null, "Open Terminal"),
+}));
+
+vi.mock("@/lib/actions/completed-terminal", () => ({
+  getCompletedSessionTranscript: vi.fn(),
+}));
+
+vi.mock("./CIChecks", () => ({
+  CIChecks: () => createElement("mock-ci-checks"),
+}));
+
+vi.mock("./ReviewPanel", () => ({
+  ReviewPanel: () => createElement("mock-review-panel"),
+}));
+
+vi.mock("./FilesChanged", () => ({
+  FilesChanged: () => createElement("mock-files-changed"),
+}));
+
+vi.mock("./MergeButton", () => ({
+  MergeButton: () => createElement("mock-merge-button"),
+}));
+
+describe("PrDetail", () => {
+  it("renders completed webhook review session evidence when no PR session is active", () => {
+    const html = renderToStaticMarkup(
+      createElement(PrDetail, {
+        owner: "mean-weasel",
+        repoName: "issuectl",
+        pull: pull({ number: 48, title: "QA review PR" }),
+        checks: [] satisfies GitHubCheck[],
+        files: [] satisfies GitHubPullFile[],
+        reviews: [] satisfies GitHubPullReview[],
+        linkedIssue: null,
+        availableLabels: [],
+        deployments: [
+          deployment({
+            id: 163,
+            targetType: "pr",
+            targetNumber: 48,
+            issueNumber: null,
+            agent: "claude",
+            branchName: "qa-webhook-review-20260528T193645Z",
+            workspacePath: "/Users/neonwatty/.issuectl/worktrees/issuectl-test-repo-2-pr-48",
+            endedAt: "2026-05-28T19:44:12.000Z",
+            completionResultJson: JSON.stringify({
+              status: "no_changes",
+              summary: "QA verified PR review runtime environment.",
+            }),
+          }),
+        ],
+        webhookHealth: null,
+      }),
+    );
+
+    expect(html).toContain("Claude Code reviewed this PR");
+    expect(html).toContain("Completed session #163");
+    expect(html).toContain("No Changes");
+    expect(html).toContain("QA verified PR review runtime environment.");
+    expect(html).toContain("qa-webhook-review-20260528T193645Z");
+    expect(html).toContain("View completed terminal");
+    expect(html).toContain("Session history");
+    expect(html).toContain("/sessions?tab=sessions&amp;repo=mean-weasel%2Fissuectl&amp;state=ended&amp;q=PR+%2348");
+    expect(html).not.toContain("active review session");
+  });
+
+  it("keeps active PR sessions on the live terminal path", () => {
+    const html = renderToStaticMarkup(
+      createElement(PrDetail, {
+        owner: "mean-weasel",
+        repoName: "issuectl",
+        pull: pull({ number: 48 }),
+        checks: [] satisfies GitHubCheck[],
+        files: [] satisfies GitHubPullFile[],
+        reviews: [] satisfies GitHubPullReview[],
+        linkedIssue: null,
+        availableLabels: [],
+        deployments: [
+          deployment({ id: 163, targetType: "pr", targetNumber: 48, issueNumber: null }),
+          deployment({ id: 162, targetType: "pr", targetNumber: 48, issueNumber: null, endedAt: null, ttydPort: 7715 }),
+        ],
+        webhookHealth: null,
+      }),
+    );
+
+    expect(html).toContain("active review session");
+    expect(html).toContain("#162");
+    expect(html).toContain("Open Terminal");
+    expect(html).not.toContain("Completed session #163");
+    expect(html).not.toContain("reviewed this PR");
+  });
+});
+
+function pull(overrides: Partial<GitHubPull> = {}): GitHubPull {
+  return {
+    number: 48,
+    title: "Review runtime",
+    body: "Review me",
+    state: "open",
+    labels: [],
+    draft: false,
+    merged: false,
+    user: null,
+    headRef: "feature",
+    baseRef: "main",
+    additions: 2,
+    deletions: 1,
+    changedFiles: 1,
+    createdAt: "2026-05-28T19:00:00.000Z",
+    updatedAt: "2026-05-28T19:10:00.000Z",
+    mergedAt: null,
+    closedAt: null,
+    htmlUrl: "https://github.com/mean-weasel/issuectl/pull/48",
+    ...overrides,
+  };
+}
+
+function deployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: 1,
+    repoId: 1,
+    issueNumber: 48,
+    targetType: "pr",
+    targetNumber: 48,
+    agent: "claude",
+    branchName: "pr-48",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/pr-48",
+    linkedPrNumber: null,
+    state: "active",
+    terminalBackend: "pty_bridge",
+    triggeredBy: "webhook",
+    parentDeploymentId: null,
+    webhookDepth: 0,
+    launchedAt: "2026-05-28T19:00:00.000Z",
+    endedAt: "2026-05-28T19:10:00.000Z",
+    terminalReason: "completed",
+    completionToken: null,
+    completionResultJson: null,
+    notificationSentAt: null,
+    ttydPort: null,
+    ttydPid: null,
+    idleSince: null,
+    ...overrides,
+  };
+}

--- a/packages/web/components/detail/PrDetail.tsx
+++ b/packages/web/components/detail/PrDetail.tsx
@@ -26,6 +26,10 @@ import { LabelManager } from "@/components/issue/LabelManager";
 import { OpenTerminalButton } from "@/components/terminal/OpenTerminalButton";
 import { launchAgentLabel } from "@/components/launch/agent";
 import type { WebhookAutomationHealth } from "@/lib/webhook-health";
+import {
+  CompletedSessionCard,
+  latestCompletedDeployment,
+} from "./CompletedSessionCard";
 import styles from "./PrDetail.module.css";
 
 type Props = {
@@ -57,6 +61,9 @@ export function PrDetail({
     ? "merged"
     : pull.state;
   const activeDeployment = deployments.find((deployment) => deployment.endedAt === null);
+  const completedDeployment = activeDeployment
+    ? null
+    : latestCompletedDeployment(deployments);
 
   return (
     <div className={styles.container}>
@@ -119,6 +126,16 @@ export function PrDetail({
               />
             )}
           </section>
+        )}
+
+        {completedDeployment && (
+          <CompletedSessionCard
+            owner={owner}
+            repo={repoName}
+            targetType="pr"
+            targetNumber={pull.number}
+            deployment={completedDeployment}
+          />
         )}
 
         {prState === "open" && (


### PR DESCRIPTION
## Summary
- extract the completed agent session card so issue and PR detail pages can share it
- render the latest completed PR deployment on the PR detail page when no PR session is active
- pass PR target metadata into the completed terminal transcript action

## Verification
- pnpm --dir packages/web test -- LaunchCard PrDetail
- pnpm --dir packages/web test -- LaunchCard PrDetail route-rendering
- pnpm --dir packages/web test -- completed-terminal
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- git diff --check
- pre-push: pnpm turbo build

## Dogfood diagnostics reminder
issuectl already records structured launch/webhook/session diagnostics in ~/.issuectl/issuectl.db. If dogfooding finds a rough edge, start with `pnpm --dir packages/cli exec issuectl diag list --limit 50`, then drill into `diag show --deployment <id>` or `diag show --issue <owner>/<repo>#<number>`. Raw web logs remain in ~/.issuectl/logs/web.log, and webhook delivery/replay state is visible through the app and CLI-backed DB records.