### PR TITLE
Pass agent controls into webhook launches

### DIFF
--- a/packages/core/src/launch/launch-contexts.test.ts
+++ b/packages/core/src/launch/launch-contexts.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAgentEnvironment,
+  resolveIssuectlCliPath,
+} from "./launch-contexts.js";
+
+describe("buildAgentEnvironment", () => {
+  const previousIssuectlCli = process.env.ISSUECTL_CLI;
+  const previousIssuectlServerUrl = process.env.ISSUECTL_SERVER_URL;
+  const previousPort = process.env.PORT;
+
+  afterEach(() => {
+    restoreEnv("ISSUECTL_CLI", previousIssuectlCli);
+    restoreEnv("ISSUECTL_SERVER_URL", previousIssuectlServerUrl);
+    restoreEnv("PORT", previousPort);
+  });
+
+  it("provides the local dashboard URL when the web process has no explicit server URL", () => {
+    process.env.ISSUECTL_CLI = "/opt/issuectl/bin/issuectl";
+    delete process.env.ISSUECTL_SERVER_URL;
+    process.env.PORT = "4999";
+
+    expect(buildAgentEnvironment({
+      completionToken: "token-1",
+      deploymentId: 17,
+      repoId: 3,
+      targetType: "issue",
+      targetNumber: 506,
+    })).toMatchObject({
+      ISSUECTL_CLI: "/opt/issuectl/bin/issuectl",
+      ISSUECTL_SERVER_URL: "http://localhost:4999",
+      ISSUECTL_DEPLOYMENT_ID: "17",
+      ISSUECTL_REPO_ID: "3",
+      ISSUECTL_TARGET_TYPE: "issue",
+      ISSUECTL_TARGET_NUMBER: "506",
+    });
+  });
+});
+
+describe("resolveIssuectlCliPath", () => {
+  it("resolves the sibling CLI dist file from a built core dist module", async () => {
+    const root = await mkdtemp(join(tmpdir(), "issuectl-cli-path-"));
+    try {
+      const coreDist = join(root, "packages", "core", "dist");
+      const cliDist = join(root, "packages", "cli", "dist");
+      await mkdir(coreDist, { recursive: true });
+      await mkdir(cliDist, { recursive: true });
+      const cliPath = join(cliDist, "index.js");
+      await writeFile(cliPath, "#!/usr/bin/env node\n");
+
+      expect(resolveIssuectlCliPath(
+        {},
+        pathToFileURL(join(coreDist, "index.js")).href,
+      )).toBe(cliPath);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}

--- a/packages/core/src/launch/launch-contexts.ts
+++ b/packages/core/src/launch/launch-contexts.ts
@@ -121,7 +121,7 @@ export function buildAgentEnvironment(input: {
 }): Record<string, string> {
   if (!input.completionToken) return {};
   const issuectlCli = resolveIssuectlCliPath();
-  const issuectlServerUrl = process.env.ISSUECTL_SERVER_URL?.trim();
+  const issuectlServerUrl = resolveIssuectlServerUrl();
   return {
     ISSUECTL_AGENT_TOKEN: input.completionToken,
     ISSUECTL_DEPLOYMENT_ID: String(input.deploymentId),
@@ -135,12 +135,23 @@ export function buildAgentEnvironment(input: {
   };
 }
 
-export function resolveIssuectlCliPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+export function resolveIssuectlCliPath(
+  env: NodeJS.ProcessEnv = process.env,
+  moduleUrl = import.meta.url,
+): string | undefined {
   const configured = env.ISSUECTL_CLI?.trim();
   if (configured) return configured;
-  const bundledCli = resolve(
-    dirname(fileURLToPath(import.meta.url)),
-    "../../../cli/dist/index.js",
-  );
-  return existsSync(bundledCli) ? bundledCli : undefined;
+  const moduleDir = dirname(fileURLToPath(moduleUrl));
+  const candidates = [
+    resolve(moduleDir, "../../cli/dist/index.js"),
+    resolve(moduleDir, "../../../cli/dist/index.js"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function resolveIssuectlServerUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.ISSUECTL_SERVER_URL?.trim();
+  if (configured) return configured.replace(/\/$/, "");
+  const port = env.PORT?.trim() || "3847";
+  return `http://localhost:${port}`;
 }


### PR DESCRIPTION
## Summary
- default webhook/comment-command agent environments to the local dashboard URL when ISSUECTL_SERVER_URL is not explicitly set
- resolve the bundled issuectl CLI from built core dist to sibling packages/cli/dist
- add regression coverage for direct `packages/web dev` dogfood launches and built-dist CLI path resolution

## Live dogfood evidence
- First issue run (#49) proved webhook delivery/launch but exposed missing ISSUECTL_CLI and ISSUECTL_SERVER_URL in the spawned Codex session.
- After this fix and rebuilding core, issue #50 launched from the local label editor through the fresh tunnel, the spawned Codex session saw ISSUECTL_CLI + ISSUECTL_SERVER_URL, `issuectl agent --help` worked, and `issuectl agent complete` recorded `no_changes` on deployment 165.
- UI showed completed session #165 with the no_changes summary; follow-up intent 92 resolved `skipped_optout`; active webhook deployments/intents were 0 after completion.

## Verification
- `pnpm --dir packages/core test -- launch-contexts` red before fix, green after
- `pnpm --dir packages/core test -- launch-contexts launch-execute-precheck ttyd-spawn`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core lint`
- commit hook: turbo typecheck/lint
- pre-push: dev server was active on :3847, so hook skipped full build and ran turbo typecheck only
