### PR TITLE
Skip closed PR intents with deleted heads

### DIFF
--- a/packages/web/lib/webhook-pr-intent.test.ts
+++ b/packages/web/lib/webhook-pr-intent.test.ts
@@ -348,6 +348,67 @@ describe("PR webhook intents", () => {
     expect(queryDiagnosticEvents(db, { events: ["webhook.pr_session_ended"] })).toHaveLength(1);
   });
 
+  it("skips closed PR intents without requiring the deleted same-repo head branch", async () => {
+    const getBranch = vi.fn(async () => {
+      throw new Error("Branch not found - https://docs.github.com/rest/branches/branches#get-a-branch");
+    });
+    coreMocks.withAuthRetry.mockImplementation((fn: (octokit: unknown) => Promise<unknown>) =>
+      fn({
+        rest: {
+          pulls: {
+            get: async () => ({
+              data: {
+                title: "Closed QA PR",
+                body: null,
+                state: "closed",
+                draft: false,
+                labels: [],
+                head: {
+                  ref: "issuectl-pr-auto-review-qa-deleted",
+                  sha: "head-b",
+                  repo: { full_name: "mean-weasel/issuectl" },
+                },
+                base: {
+                  ref: "main",
+                  sha: "base-a",
+                  repo: { full_name: "mean-weasel/issuectl", default_branch: "main" },
+                },
+              },
+            }),
+          },
+          repos: { getBranch },
+        },
+      }),
+    );
+    const event = recordWebhookEvent(db, {
+      deliveryId: "delivery-pr-close-deleted-head",
+      repoId,
+      eventType: "pull_request",
+      action: "closed",
+      targetType: "pr",
+      targetNumber: 51,
+      receivedAt: 2_000,
+    });
+    const intentId = mergeWebhookIntent(db, {
+      repoId,
+      targetType: "pr",
+      targetNumber: 51,
+      signalAt: 2_000,
+      scheduledAt: 2_000,
+      desiredHeadSha: "head-b",
+      eventId: event.deduped ? null : event.eventId,
+    });
+
+    const result = await runWebhookIntentWorkerOnce(db, 2_000, {});
+
+    expect(result).toEqual(expect.objectContaining({ claimed: 1, skippedOptout: 1, failed: 0 }));
+    expect(getBranch).not.toHaveBeenCalled();
+    expect(getIntentRow(db, intentId)).toEqual(
+      expect.objectContaining({ status: "skipped_optout", deployment_id: null }),
+    );
+    expect(queryDiagnosticEvents(db, { events: ["webhook.skipped_optout"] })).toHaveLength(1);
+  });
+
   it("does not end comment-command PR sessions on webhook opt-out", async () => {
     const deploymentId = recordDeployment(db, {
       repoId,

--- a/packages/web/lib/webhook-pr-intent.ts
+++ b/packages/web/lib/webhook-pr-intent.ts
@@ -269,7 +269,8 @@ async function fetchPullState(repo: Repo, prNumber: number): Promise<PullState> 
     };
     const headRepoFullName = d.head.repo?.full_name ?? "";
     const baseRepoFullName = d.base.repo?.full_name ?? `${repo.owner}/${repo.name}`;
-    const headProtected = headRepoFullName === baseRepoFullName
+    const shouldCheckHeadProtection = d.state === "open" && headRepoFullName === baseRepoFullName;
+    const headProtected = shouldCheckHeadProtection
       ? Boolean((await octokit.rest.repos.getBranch({
         owner: repo.owner,
         repo: repo.name,


### PR DESCRIPTION
## Summary
- Avoid same-repo head branch protection lookup for closed PRs while resolving PR webhook intents.
- Keeps normal cleanup-close events quiet when the head branch has already been deleted.
- Adds a regression test for the dogfood failure where a closed PR intent became `failed` with GitHub's branch-not-found response.

## Verification
- `pnpm --dir packages/web test -- webhook-pr-intent` (watched fail before fix, then pass)
- `pnpm --dir packages/web test -- webhook-pr-intent webhook-intent-worker`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- commit hook: turbo typecheck + lint
- pre-push hook: turbo typecheck (build skipped because dogfood dev server is active on `:3847`)

## Dogfood context
This follows PR auto-review QA on `mean-weasel/issuectl-test-repo-2#51`: the review session itself passed end-to-end, but immediate branch deletion after closing the test PR left the final close-event intent as `failed` with `Branch not found`.
