### PR TITLE
feat(ios): align board sections with web dashboard

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		1F5CD736DCA791429CB2F501 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC54A0EAA1EEB03CA4C70E1E /* Repo.swift */; };
 		20B9C47DF425B4A135A52965 /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
+		22192A28A190D660B52AAEDA /* WorkbenchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */; };
 		227F5D726370EBF5F1C55F98 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
 		22B99716E42E20F0DA147C5B /* MacSidebarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E7DE3BF0A6826FE986B1D /* MacSidebarStore.swift */; };
 		233107B6AA5A3C1BDFE9020D /* CloseIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A1E2EA43AFA474E8518F5 /* CloseIssueSheet.swift */; };
@@ -287,6 +288,7 @@
 		0B211BFFBBC1DA50DF7B008D /* MacIssueFilterStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacIssueFilterStateTests.swift; sourceTree = "<group>"; };
 		0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacDraftsView.swift; sourceTree = "<group>"; };
 		0CB1AF798EF85A0DFAB89A4C /* MockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServer.swift; sourceTree = "<group>"; };
+		0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchStoreTests.swift; sourceTree = "<group>"; };
 		0CF6456214BCA5794B4D8A25 /* IssueCTLUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IssueCTLUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D0BAA5CBBCAB0D60E199A0D /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
 		0FA58C21063864ADB4BAC822 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
@@ -536,6 +538,7 @@
 				533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */,
 				244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */,
 				F63680089A3314AB67CE5883 /* ViewLogicTests.swift */,
+				0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */,
 			);
 			path = IssueCTLTests;
 			sourceTree = "<group>";
@@ -1077,6 +1080,7 @@
 				DBAAAF7B3925847446CC5E39 /* ModelDecodingTests.swift in Sources */,
 				52543EF1C7077597CC6DC8F0 /* OfflineSyncServiceTests.swift in Sources */,
 				EE5CBD61D807436206C48637 /* ViewLogicTests.swift in Sources */,
+				22192A28A190D660B52AAEDA /* WorkbenchStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/IssueCTL/ViewModels/WorkbenchStore.swift
+++ b/apple/IssueCTL/ViewModels/WorkbenchStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum WorkbenchIssueFilter: String, CaseIterable, Identifiable, Sendable {
+    case unassigned
     case open
     case running
     case closed
@@ -9,6 +10,8 @@ enum WorkbenchIssueFilter: String, CaseIterable, Identifiable, Sendable {
 
     var title: String {
         switch self {
+        case .unassigned:
+            return "Drafts"
         case .open:
             return "Open"
         case .running:
@@ -20,6 +23,8 @@ enum WorkbenchIssueFilter: String, CaseIterable, Identifiable, Sendable {
 
     var icon: String {
         switch self {
+        case .unassigned:
+            return "doc.text"
         case .open:
             return "circle"
         case .running:
@@ -31,8 +36,10 @@ enum WorkbenchIssueFilter: String, CaseIterable, Identifiable, Sendable {
 
     func includes(_ issue: WorkbenchBoardIssue) -> Bool {
         switch self {
+        case .unassigned:
+            return false
         case .open:
-            return issue.issue.isOpen
+            return issue.issue.isOpen && !issue.isRunning
         case .running:
             return issue.issue.isOpen && issue.isRunning
         case .closed:
@@ -76,7 +83,8 @@ final class WorkbenchStore {
     var counts: [WorkbenchIssueFilter: Int] {
         let issues = boardIssues(filteringByRepoOnly: true)
         return [
-            .open: issues.filter { $0.issue.isOpen }.count,
+            .unassigned: payload?.drafts.count ?? 0,
+            .open: issues.filter { $0.issue.isOpen && !$0.isRunning }.count,
             .running: issues.filter { $0.issue.isOpen && $0.isRunning }.count,
             .closed: issues.filter { !$0.issue.isOpen }.count,
         ]
@@ -84,6 +92,11 @@ final class WorkbenchStore {
 
     var visibleIssues: [WorkbenchBoardIssue] {
         boardIssues(filteringByRepoOnly: false)
+    }
+
+    var visibleDrafts: [Draft] {
+        guard filter == .unassigned else { return [] }
+        return payload?.drafts ?? []
     }
 
     var selectedRepoSummary: String {
@@ -110,8 +123,9 @@ final class WorkbenchStore {
     var headerSubtitle: String {
         let open = counts[.open] ?? 0
         let running = counts[.running] ?? 0
+        let drafts = counts[.unassigned] ?? 0
         if open == 0 && running == 0 {
-            return "No open board work"
+            return drafts > 0 ? "\(drafts) drafts" : "No open board work"
         }
         if running > 0 {
             return "\(open) open - \(running) running"

--- a/apple/IssueCTL/Views/Workbench/BoardView.swift
+++ b/apple/IssueCTL/Views/Workbench/BoardView.swift
@@ -61,6 +61,11 @@ struct BoardView: View {
                     IssueDetailView(owner: owner, repo: repo, number: number)
                 }
             }
+            .navigationDestination(for: DraftDestination.self) { destination in
+                DraftDetailView(draft: destination.draft, onSaved: {
+                    Task { await store.load(api: api, refresh: true) }
+                })
+            }
             .sheet(isPresented: $showRepoFilters) {
                 WorkbenchRepoFilterSheet(repos: store.repos, selectedRepoIds: $store.selectedRepoIds)
                     .presentationDetents([.medium, .large])
@@ -101,7 +106,25 @@ struct BoardView: View {
 
                     BoardSummaryStrip(counts: store.counts, repoCount: store.repos.count)
 
-                    if store.visibleIssues.isEmpty {
+                    if store.filter == .unassigned {
+                        if store.visibleDrafts.isEmpty {
+                            ContentUnavailableView {
+                                Label("No Drafts", systemImage: store.filter.icon)
+                            } description: {
+                                Text(emptyDescription)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, 28)
+                        } else {
+                            ForEach(store.visibleDrafts) { draft in
+                                NavigationLink(value: DraftDestination(draft: draft)) {
+                                    WorkbenchDraftCard(draft: draft)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("board-draft-\(draft.id)")
+                            }
+                        }
+                    } else if store.visibleIssues.isEmpty {
                         ContentUnavailableView {
                             Label("No Board Issues", systemImage: store.filter.icon)
                         } description: {
@@ -134,6 +157,8 @@ struct BoardView: View {
 
     private var emptyDescription: String {
         switch store.filter {
+        case .unassigned:
+            return "Drafts from the web dashboard will appear here until they are assigned to a repository."
         case .open:
             return "No open issues matched the current repository filters."
         case .running:
@@ -197,6 +222,14 @@ private struct BoardSummaryStrip: View {
 
     var body: some View {
         HStack(spacing: 8) {
+            BoardSummaryTile(
+                title: "Drafts",
+                value: counts[.unassigned] ?? 0,
+                systemImage: "doc.text",
+                tint: .orange,
+                accessibilityIdentifier: "board-summary-unassigned"
+            )
+
             BoardSummaryTile(
                 title: "Open",
                 value: counts[.open] ?? 0,
@@ -363,6 +396,57 @@ private struct WorkbenchIssueCard: View {
         case .low:
             return .blue
         }
+    }
+}
+
+private struct WorkbenchDraftCard: View {
+    let draft: Draft
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "doc.text")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(.orange)
+                .padding(.top, 3)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    BoardIssueChip(title: "Draft", tint: .orange)
+                    if let priority = draft.priority {
+                        BoardIssueChip(title: priority.rawValue.capitalized, tint: priority == .high ? .red : .secondary)
+                    }
+                }
+
+                Text(draft.title)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+
+                if let body = draft.body, !body.isEmpty {
+                    Text(body)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.tertiary)
+                .padding(.top, 4)
+                .accessibilityHidden(true)
+        }
+        .padding(12)
+        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: IssueCTLColors.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: IssueCTLColors.cardCornerRadius)
+                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Draft, \(draft.title)")
     }
 }
 

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -75,6 +75,7 @@ struct ReposResponse: Codable, Sendable {
 }
 
 struct WorkbenchPayload: Codable, Sendable {
+    let drafts: [Draft]
     let repos: [WorkbenchRepo]
     let deployments: [ActiveDeployment]
     let previews: [String: SessionPreview]
@@ -82,6 +83,38 @@ struct WorkbenchPayload: Codable, Sendable {
     let health: WorkbenchHealth
     let user: WorkbenchUser
     let generatedAt: String
+
+    init(
+        drafts: [Draft],
+        repos: [WorkbenchRepo],
+        deployments: [ActiveDeployment],
+        previews: [String: SessionPreview],
+        settings: [String: String],
+        health: WorkbenchHealth,
+        user: WorkbenchUser,
+        generatedAt: String
+    ) {
+        self.drafts = drafts
+        self.repos = repos
+        self.deployments = deployments
+        self.previews = previews
+        self.settings = settings
+        self.health = health
+        self.user = user
+        self.generatedAt = generatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        drafts = try container.decodeIfPresent([Draft].self, forKey: .drafts) ?? []
+        repos = try container.decode([WorkbenchRepo].self, forKey: .repos)
+        deployments = try container.decode([ActiveDeployment].self, forKey: .deployments)
+        previews = try container.decode([String: SessionPreview].self, forKey: .previews)
+        settings = try container.decode([String: String].self, forKey: .settings)
+        health = try container.decode(WorkbenchHealth.self, forKey: .health)
+        user = try container.decode(WorkbenchUser.self, forKey: .user)
+        generatedAt = try container.decode(String.self, forKey: .generatedAt)
+    }
 }
 
 struct WorkbenchHealth: Codable, Sendable {

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -862,6 +862,7 @@ final class ModelDecodingTests: XCTestCase {
         """.data(using: .utf8)!
 
         let payload = try decoder.decode(WorkbenchPayload.self, from: json)
+        XCTAssertTrue(payload.drafts.isEmpty)
         XCTAssertEqual(payload.repos.count, 1)
         XCTAssertEqual(payload.repos[0].fullName, "org/alpha")
         XCTAssertTrue(payload.repos[0].autoLaunchIssues)

--- a/apple/IssueCTLTests/WorkbenchStoreTests.swift
+++ b/apple/IssueCTLTests/WorkbenchStoreTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import IssueCTL
+
+@MainActor
+final class WorkbenchStoreTests: XCTestCase {
+    func testBoardSectionsMatchWebDashboardContract() {
+        let store = WorkbenchStore()
+        store.payload = WorkbenchStoreTests.payload(issues: [
+            WorkbenchStoreTests.issue(number: 1, title: "Open work", state: "open", hasActiveDeployment: false),
+            WorkbenchStoreTests.issue(number: 2, title: "Running work", state: "open", hasActiveDeployment: true),
+            WorkbenchStoreTests.issue(number: 3, title: "Closed work", state: "closed", hasActiveDeployment: false),
+        ])
+
+        XCTAssertEqual(WorkbenchIssueFilter.allCases.map(\.rawValue), ["unassigned", "open", "running", "closed"])
+
+        XCTAssertEqual(store.counts[.open], 1)
+        XCTAssertEqual(store.counts[.running], 1)
+        XCTAssertEqual(store.counts[.closed], 1)
+
+        store.filter = .open
+        XCTAssertEqual(store.visibleIssues.map(\.issue.number), [1])
+
+        store.filter = .running
+        XCTAssertEqual(store.visibleIssues.map(\.issue.number), [2])
+    }
+
+    func testDraftsPreserveWorkbenchPayloadOrder() {
+        let store = WorkbenchStore()
+        store.payload = WorkbenchStoreTests.payload(
+            drafts: [
+                Draft(id: "recent-edit", title: "Recently edited", body: nil, priority: .low, createdAt: 1),
+                Draft(id: "older-high", title: "Older high priority", body: nil, priority: .high, createdAt: 2),
+            ],
+            issues: []
+        )
+
+        store.filter = .unassigned
+
+        XCTAssertEqual(store.counts[.unassigned], 2)
+        XCTAssertEqual(store.visibleDrafts.map(\.id), ["recent-edit", "older-high"])
+    }
+
+    private static func payload(
+        drafts: [Draft] = [],
+        issues: [WorkbenchIssueSummary]
+    ) -> WorkbenchPayload {
+        WorkbenchPayload(
+            drafts: drafts,
+            repos: [
+                WorkbenchRepo(
+                    id: 1,
+                    owner: "org",
+                    name: "app",
+                    localPath: nil,
+                    branchPattern: nil,
+                    autoLaunchIssues: false,
+                    autoReviewPrs: false,
+                    issueAgent: .codex,
+                    reviewAgent: .codex,
+                    webhookId: nil,
+                    webhookPayloadMode: .metadata,
+                    badgeCount: 0,
+                    deployedCount: 0,
+                    launchAgent: nil,
+                    terminalBackendDefault: .ttyd,
+                    issueError: nil,
+                    issuesFromCache: false,
+                    issuesCachedAt: nil,
+                    priorities: [],
+                    deployments: [],
+                    recentCompletions: [],
+                    webhookEvents: [],
+                    prReviews: [],
+                    previews: [:],
+                    issues: issues
+                ),
+            ],
+            deployments: [],
+            previews: [:],
+            settings: [:],
+            health: WorkbenchHealth(ok: true, version: "1", timestamp: nil, error: nil),
+            user: WorkbenchUser(login: "tester", error: nil),
+            generatedAt: "2026-05-29T00:00:00.000Z"
+        )
+    }
+
+    private static func issue(
+        number: Int,
+        title: String,
+        state: String,
+        hasActiveDeployment: Bool
+    ) -> WorkbenchIssueSummary {
+        WorkbenchIssueSummary(
+            number: number,
+            title: title,
+            state: state,
+            labels: [],
+            updatedAt: "2026-05-29T00:00:00.000Z",
+            priority: .normal,
+            hasActiveDeployment: hasActiveDeployment,
+            htmlUrl: "https://github.com/org/app/issues/\(number)",
+            authorLogin: "tester"
+        )
+    }
+}

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -855,6 +855,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
 
     func workbenchPayload() -> [String: Any] {
         [
+            "drafts": drafts,
             "repos": repos.map { repo in
                 let repoId = repo["id"] as? Int ?? 0
                 let owner = repo["owner"] as? String ?? "org"

--- a/apple/IssueCTLUITests/IssueCTLUITests.swift
+++ b/apple/IssueCTLUITests/IssueCTLUITests.swift
@@ -143,8 +143,11 @@ final class IssueCTLUITests: XCTestCase {
         tapMainTab("board-tab", label: "Board", in: app)
 
         assertElement("board-summary-open", existsIn: app, timeout: 8)
-        assertElement("board-issue-1-101", existsIn: app, timeout: 5)
         assertElement("board-issue-2-201", existsIn: app, timeout: 5)
+        XCTAssertFalse(
+            element("board-issue-1-101", in: app).waitForExistence(timeout: 1),
+            "Open filter should hide running alpha issue\n\(app.debugDescription)"
+        )
 
         element("board-filter-running", in: app).tap()
 

--- a/packages/web/app/api/v1/workbench/route.test.ts
+++ b/packages/web/app/api/v1/workbench/route.test.ts
@@ -24,6 +24,7 @@ const getDb = vi.hoisted(() => vi.fn());
 const listRepos = vi.hoisted(() => vi.fn());
 const getActiveDeployments = vi.hoisted(() => vi.fn());
 const getIssues = vi.hoisted(() => vi.fn());
+const listDrafts = vi.hoisted(() => vi.fn());
 const listPrReviewsForRepo = vi.hoisted(() => vi.fn());
 const listPrioritiesForRepo = vi.hoisted(() => vi.fn());
 const listRecentTerminalDeploymentsByRepo = vi.hoisted(() => vi.fn());
@@ -41,6 +42,7 @@ vi.mock("@issuectl/core", () => ({
   listRepos: (...args: unknown[]) => listRepos(...args),
   getActiveDeployments: (...args: unknown[]) => getActiveDeployments(...args),
   getIssues: (...args: unknown[]) => getIssues(...args),
+  listDrafts: (...args: unknown[]) => listDrafts(...args),
   listPrReviewsForRepo: (...args: unknown[]) => listPrReviewsForRepo(...args),
   listPrioritiesForRepo: (...args: unknown[]) => listPrioritiesForRepo(...args),
   listRecentTerminalDeploymentsByRepo: (...args: unknown[]) => listRecentTerminalDeploymentsByRepo(...args),
@@ -108,6 +110,7 @@ beforeEach(() => {
   listRepos.mockReset();
   getActiveDeployments.mockReset();
   getIssues.mockReset();
+  listDrafts.mockReset();
   listPrReviewsForRepo.mockReset();
   listPrioritiesForRepo.mockReset();
   listRecentTerminalDeploymentsByRepo.mockReset();
@@ -125,6 +128,16 @@ beforeEach(() => {
   getDb.mockReturnValue(db);
   listRepos.mockReturnValue(repos);
   getActiveDeployments.mockReturnValue(deployments);
+  listDrafts.mockReturnValue([
+    {
+      id: "draft-1",
+      title: "Draft next dashboard batch",
+      body: "Carry the web board contract into iOS.",
+      priority: "high",
+      createdAt: 1_779_000_000,
+      updatedAt: 1_779_000_100,
+    },
+  ]);
   getSettings.mockReturnValue([
     { key: "branch_pattern", value: "issue-{number}-{slug}" },
     { key: "launch_agent", value: "codex" },
@@ -225,6 +238,13 @@ describe("/api/v1/workbench", () => {
 
     expect(response.status).toBe(200);
     expect(json.repos[0].badgeCount).toBe(3);
+    expect(json.drafts).toEqual([
+      expect.objectContaining({
+        id: "draft-1",
+        title: "Draft next dashboard batch",
+        priority: "high",
+      }),
+    ]);
     expect(json.repos[0].issues).toHaveLength(4);
     expect(json.repos[0].deployments).toHaveLength(3);
     expect(json.repos[0].recentCompletions).toEqual([

--- a/packages/web/components/workbench/workbench-test-fixtures.ts
+++ b/packages/web/components/workbench/workbench-test-fixtures.ts
@@ -2,6 +2,7 @@ import type { WorkbenchPayload, WorkbenchRepo } from "./workbench-types";
 
 export function payloadFixture(): WorkbenchPayload {
   return {
+    drafts: [],
     repos: [
       repo(1, "issuectl", 3),
       repo(2, "bugdrop", 1),

--- a/packages/web/components/workbench/workbench-types.ts
+++ b/packages/web/components/workbench/workbench-types.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveDeploymentWithRepo,
   Deployment,
+  Draft,
   IssuePriority,
   LaunchAgent,
   PrReview,
@@ -85,6 +86,7 @@ export type WorkbenchRepo = {
 };
 
 export type WorkbenchPayload = {
+  drafts: Draft[];
   repos: WorkbenchRepo[];
   deployments: WorkbenchDeployment[];
   previews: Record<string, WorkbenchPreview>;

--- a/packages/web/lib/workbench-data.ts
+++ b/packages/web/lib/workbench-data.ts
@@ -17,6 +17,7 @@ import {
   getDb,
   getIssues,
   getSettings,
+  listDrafts,
   listPrReviewsForRepo,
   listPrioritiesForRepo,
   listRecentTerminalDeploymentsByRepo,
@@ -68,6 +69,7 @@ export async function getWorkbenchPayload({
   ]);
 
   return {
+    drafts: listDrafts(db),
     repos: workbenchRepos,
     deployments: activeDeployments,
     previews,


### PR DESCRIPTION
## Summary
- include drafts in the workbench payload so native clients can mirror the web dashboard's unassigned lane
- add the iOS Board Drafts section and draft cards that open DraftDetailView
- make iOS Board Open/Running counts mutually exclusive to match the web dashboard contract

## Test Plan
- pnpm --dir packages/core build
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --dir packages/web test
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'id=8A7EA28F-4690-4816-B650-38648E6F44FB' -only-testing:IssueCTLTests/ModelDecodingTests/testWorkbenchPayloadDecoding -resultBundlePath /tmp/issuectl-model-decoding-tests.xcresult CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'id=8A7EA28F-4690-4816-B650-38648E6F44FB' -only-testing:IssueCTLTests/WorkbenchStoreTests -resultBundlePath /tmp/issuectl-workbench-store-tests.xcresult CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -configuration Debug -destination 'id=8A7EA28F-4690-4816-B650-38648E6F44FB' -only-testing:IssueCTLUITests/IssueCTLUITests/testBoardTabShowsCrossRepoIssueQueueAndRunningFilter -resultBundlePath /tmp/issuectl-board-ui-tests.xcresult CODE_SIGNING_ALLOWED=NO
- git diff --check

## Review
- Codex review found and fixed: missing Swift drafts decode default, draft order divergence, stale board UI expectation.
- Final clean rerun was blocked by Codex usage limit; the fixed findings above are covered by targeted tests.