### PR TITLE
[codex] Add mobile automation API contracts

### DIFF
--- a/packages/web/app/api/v1/pr-reviews/route.test.ts
+++ b/packages/web/app/api/v1/pr-reviews/route.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const listRepos = vi.hoisted(() => vi.fn());
+const listPrReviewsForPull = vi.hoisted(() => vi.fn());
+const listPrReviewsForRepo = vi.hoisted(() => vi.fn());
+const listRecentTerminalDeploymentsByRepo = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  listRepos: (...args: unknown[]) => listRepos(...args),
+  listPrReviewsForPull: (...args: unknown[]) => listPrReviewsForPull(...args),
+  listPrReviewsForRepo: (...args: unknown[]) => listPrReviewsForRepo(...args),
+  listRecentTerminalDeploymentsByRepo: (...args: unknown[]) => listRecentTerminalDeploymentsByRepo(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: "/tmp/issuectl",
+  branchPattern: null,
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-24T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getDb.mockReset();
+  listRepos.mockReset();
+  listPrReviewsForPull.mockReset();
+  listPrReviewsForRepo.mockReset();
+  listRecentTerminalDeploymentsByRepo.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue(db);
+  listRepos.mockReturnValue([repo]);
+  listRecentTerminalDeploymentsByRepo.mockReturnValue([
+    {
+      id: 701,
+      repoId: 1,
+      issueNumber: null,
+      targetType: "pr",
+      targetNumber: 44,
+      agent: "codex",
+      branchName: "review/pr-44",
+      workspaceMode: "worktree",
+      workspacePath: "/tmp/review-pr-44",
+      linkedPrNumber: null,
+      state: "active",
+      triggeredBy: "webhook",
+      parentDeploymentId: null,
+      webhookDepth: 1,
+      launchedAt: "2026-05-16T16:00:00.000Z",
+      endedAt: "2026-05-16T16:10:00.000Z",
+      terminalReason: "completed",
+      completionToken: null,
+      completionResultJson: null,
+      notificationSentAt: null,
+      ttydPort: 7701,
+      ttydPid: null,
+      idleSince: null,
+    },
+  ]);
+  listPrReviewsForPull.mockReturnValue([
+    {
+      id: 901,
+      repoId: 1,
+      prNumber: 44,
+      deploymentId: 701,
+      startedHeadSha: "aaaabbbbcccc",
+      completedHeadSha: "ddddeeeeffff",
+      reviewBaseSha: "111122223333",
+      reviewedFromSha: "444455556666",
+      reviewedToSha: "777788889999",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/mobile-contracts",
+      status: "completed",
+      triggeredBy: "webhook",
+      resultJson: JSON.stringify({ summary: "found one issue", findings: [{ path: "a.ts" }] }),
+      startedAt: 1_779_000_000_000,
+      completedAt: 1_779_000_600_000,
+    },
+  ]);
+});
+
+describe("/api/v1/pr-reviews", () => {
+  it("returns parsed PR review runs with repo metadata and linked deployment summaries", async () => {
+    const response = await GET(new NextRequest(
+      "http://localhost/api/v1/pr-reviews?repo=mean-weasel/issuectl&pr=44&limit=12",
+    ));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listPrReviewsForPull).toHaveBeenCalledWith(db, 1, 44, 12);
+    expect(listPrReviewsForRepo).not.toHaveBeenCalled();
+    expect(json).toEqual({
+      reviews: [
+        expect.objectContaining({
+          id: 901,
+          repoId: 1,
+          repoFullName: "mean-weasel/issuectl",
+          owner: "mean-weasel",
+          repoName: "issuectl",
+          prNumber: 44,
+          status: "completed",
+          triggeredBy: "webhook",
+          deploymentId: 701,
+          startedAt: 1_779_000_000_000,
+          startedAtIso: "2026-05-17T06:40:00.000Z",
+          completedAt: 1_779_000_600_000,
+          completedAtIso: "2026-05-17T06:50:00.000Z",
+          rangeLabel: "4444555..7777888",
+          summary: "found one issue",
+          findingCount: 1,
+          detailHref: "/reviews/901",
+          deployment: expect.objectContaining({
+            id: 701,
+            targetLabel: "PR #44",
+            branchName: "review/pr-44",
+            terminalReason: "completed",
+          }),
+        }),
+      ],
+      repos: [{ id: 1, fullName: "mean-weasel/issuectl" }],
+      filters: {
+        repo: "mean-weasel/issuectl",
+        pr: 44,
+        status: "all",
+        limit: 12,
+      },
+      summary: {
+        count: 1,
+        activeCount: 0,
+        completedCount: 1,
+        failedCount: 0,
+        latestStartedAt: 1_779_000_000_000,
+        latestStartedAtIso: "2026-05-17T06:40:00.000Z",
+      },
+    });
+    expect(JSON.stringify(json)).not.toContain("resultJson");
+  });
+
+  it("rejects invalid pull number filters", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/v1/pr-reviews?pr=abc"));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Invalid pull request number" });
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/v1/pr-reviews"));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/pr-reviews/route.ts
+++ b/packages/web/app/api/v1/pr-reviews/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  formatErrorForUser,
+  getDb,
+  listPrReviewsForPull,
+  listPrReviewsForRepo,
+  listRecentTerminalDeploymentsByRepo,
+  listRepos,
+  type Deployment,
+  type PrReview,
+  type PrReviewStatus,
+  type Repo,
+} from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  buildPrReviewsPayload,
+  findRepoByFullName,
+  parseLimit,
+  parsePositiveInt,
+} from "@/lib/mobile-api-contracts";
+
+export const dynamic = "force-dynamic";
+
+const REVIEW_STATUSES: readonly PrReviewStatus[] = [
+  "reserved",
+  "launching",
+  "in_progress",
+  "completed",
+  "failed",
+  "superseded",
+];
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const params = request.nextUrl.searchParams;
+    const limit = parseLimit(params.get("limit"), 24, 100);
+    const pr = parsePositiveInt(params.get("pr"));
+    const status = parseReviewStatus(params.get("status"));
+    const repoFilter = params.get("repo");
+
+    if (pr === "invalid") {
+      return NextResponse.json({ error: "Invalid pull request number" }, { status: 400 });
+    }
+    if (status === "invalid") {
+      return NextResponse.json({ error: "Invalid review status" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const allRepos = listRepos(db);
+    const repo = repoFilter ? findRepoByFullName(allRepos, repoFilter) : undefined;
+    if (repoFilter && !repo) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const repos = repo ? [repo] : allRepos;
+    const reviews = collectReviews({ db, repos, pr, limit })
+      .filter((review) => status === "all" || review.status === status)
+      .sort((left, right) => right.startedAt - left.startedAt || right.id - left.id);
+    const deploymentsById = collectDeploymentsById(db, repos, limit);
+
+    return NextResponse.json(buildPrReviewsPayload({
+      reviews,
+      repos: allRepos,
+      deploymentsById,
+      filters: {
+        repo: repoFilter,
+        pr,
+        status,
+        limit,
+      },
+    }));
+  } catch (err) {
+    log.error({ err, msg: "api_pr_reviews_failed" });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}
+
+function collectReviews(input: {
+  db: Parameters<typeof listPrReviewsForRepo>[0];
+  repos: Repo[];
+  pr: number | null;
+  limit: number;
+}): PrReview[] {
+  return input.repos.flatMap((repo) =>
+    input.pr === null
+      ? listPrReviewsForRepo(input.db, repo.id, input.limit)
+      : listPrReviewsForPull(input.db, repo.id, input.pr, input.limit),
+  );
+}
+
+function collectDeploymentsById(
+  db: Parameters<typeof listRecentTerminalDeploymentsByRepo>[0],
+  repos: Repo[],
+  limit: number,
+): Map<number, Deployment> {
+  return new Map(
+    repos
+      .flatMap((repo) => listRecentTerminalDeploymentsByRepo(db, repo.id, limit))
+      .map((deployment) => [deployment.id, deployment]),
+  );
+}
+
+function parseReviewStatus(value: string | null): PrReviewStatus | "all" | "invalid" {
+  if (value === null || value.trim() === "") return "all";
+  if (value === "all") return "all";
+  return REVIEW_STATUSES.includes(value as PrReviewStatus) ? value as PrReviewStatus : "invalid";
+}

--- a/packages/web/app/api/v1/sessions/overview/route.test.ts
+++ b/packages/web/app/api/v1/sessions/overview/route.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getSessionsOverviewData = vi.hoisted(() => vi.fn());
+const normalizeSessionsFilters = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/sessions-data", () => ({
+  getSessionsOverviewData: (...args: unknown[]) => getSessionsOverviewData(...args),
+  normalizeSessionsFilters: (...args: unknown[]) => normalizeSessionsFilters(...args),
+}));
+
+const dbExists = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const queryDiagnosticEvents = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  dbExists: () => dbExists(),
+  getDb: () => getDb(),
+  queryDiagnosticEvents: (...args: unknown[]) => queryDiagnosticEvents(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+const overview = {
+  initialized: true,
+  filters: {
+    tab: "reviews",
+    q: "",
+    repo: "mean-weasel/issuectl",
+    trigger: "all",
+    state: "all",
+    status: "all",
+  },
+  repos: [{ id: 1, fullName: "mean-weasel/issuectl" }],
+  sessionGroups: [],
+  reviewGroups: [],
+  summary: {
+    activeSessions: 1,
+    endedSessions: 2,
+    reviewRuns: 3,
+    activeReviewRuns: 1,
+  },
+};
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getSessionsOverviewData.mockReset();
+  normalizeSessionsFilters.mockReset();
+  dbExists.mockReset();
+  getDb.mockReset();
+  queryDiagnosticEvents.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  normalizeSessionsFilters.mockReturnValue(overview.filters);
+  getSessionsOverviewData.mockResolvedValue(overview);
+  dbExists.mockReturnValue(true);
+  getDb.mockReturnValue(db);
+  queryDiagnosticEvents.mockReturnValue([
+    {
+      id: 51,
+      timestamp: 1_779_000_000_000,
+      level: "warn",
+      event: "reconcile.tmux_missing",
+      source: "lifecycle",
+      correlationId: "launch-1",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      issueNumber: null,
+      targetType: "pr",
+      targetNumber: 44,
+      deploymentId: 701,
+      sessionName: "issuectl-701",
+      ttydPort: 7701,
+      ttydPid: null,
+      status: "ended",
+      message: "tmux session disappeared",
+      data: { sessionName: "issuectl-701" },
+    },
+  ]);
+});
+
+describe("/api/v1/sessions/overview", () => {
+  it("returns session overview data with mobile-safe recent diagnostics", async () => {
+    const response = await GET(new NextRequest(
+      "http://localhost/api/v1/sessions/overview?tab=reviews&repo=mean-weasel/issuectl&targetType=pr&targetNumber=44&diagnosticLimit=5",
+    ));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(normalizeSessionsFilters).toHaveBeenCalledWith({
+      tab: "reviews",
+      repo: "mean-weasel/issuectl",
+      targetType: "pr",
+      targetNumber: "44",
+      diagnosticLimit: "5",
+    });
+    expect(getSessionsOverviewData).toHaveBeenCalledWith(overview.filters);
+    expect(queryDiagnosticEvents).toHaveBeenCalledWith(db, {
+      target: {
+        owner: "mean-weasel",
+        repo: "issuectl",
+        targetType: "pr",
+        targetNumber: 44,
+      },
+      limit: 5,
+    });
+    expect(json).toEqual({
+      overview,
+      diagnostics: {
+        events: [
+          expect.objectContaining({
+            id: 51,
+            timestamp: 1_779_000_000_000,
+            timestampIso: "2026-05-17T06:40:00.000Z",
+            level: "warn",
+            event: "reconcile.tmux_missing",
+            source: "lifecycle",
+            targetLabel: "PR #44",
+            deploymentId: 701,
+            message: "tmux session disappeared",
+          }),
+        ],
+        filters: {
+          deploymentId: null,
+          targetType: "pr",
+          targetNumber: 44,
+          limit: 5,
+        },
+        summary: {
+          count: 1,
+          levelCounts: { warn: 1 },
+          latestTimestamp: 1_779_000_000_000,
+          latestTimestampIso: "2026-05-17T06:40:00.000Z",
+        },
+      },
+      generatedAt: expect.any(String),
+    });
+  });
+
+  it("requires target owner and repo when target diagnostics are requested", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/v1/sessions/overview?targetType=pr&targetNumber=44"));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Target diagnostics require repo, targetType, and targetNumber" });
+    expect(getSessionsOverviewData).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/v1/sessions/overview"));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getSessionsOverviewData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/sessions/overview/route.ts
+++ b/packages/web/app/api/v1/sessions/overview/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  dbExists,
+  formatErrorForUser,
+  getDb,
+  queryDiagnosticEvents,
+  type DeploymentTargetType,
+  type DiagnosticQuery,
+} from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { getSessionsOverviewData, normalizeSessionsFilters } from "@/lib/sessions-data";
+import {
+  buildDiagnosticsPayload,
+  parseLimit,
+  parsePositiveInt,
+  parseTargetType,
+} from "@/lib/mobile-api-contracts";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const params = request.nextUrl.searchParams;
+    const diagnosticFilters = parseDiagnosticFilters(params);
+    if ("error" in diagnosticFilters) {
+      return NextResponse.json({ error: diagnosticFilters.error }, { status: 400 });
+    }
+
+    const filters = normalizeSessionsFilters(Object.fromEntries(params.entries()));
+    const overview = await getSessionsOverviewData(filters);
+    const diagnosticEvents = dbExists()
+      ? queryDiagnosticEvents(getDb(), diagnosticFilters.query)
+      : [];
+
+    return NextResponse.json({
+      overview,
+      diagnostics: buildDiagnosticsPayload({
+        events: diagnosticEvents,
+        filters: diagnosticFilters.responseFilters,
+      }),
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_sessions_overview_failed" });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}
+
+type DiagnosticFilters =
+  | {
+      query: DiagnosticQuery;
+      responseFilters: {
+        deploymentId: number | null;
+        targetType: DeploymentTargetType | null;
+        targetNumber: number | null;
+        limit: number;
+      };
+    }
+  | { error: string };
+
+function parseDiagnosticFilters(params: URLSearchParams): DiagnosticFilters {
+  const deploymentId = parsePositiveInt(params.get("deploymentId"));
+  const targetType = parseTargetType(params.get("targetType"));
+  const targetNumber = parsePositiveInt(params.get("targetNumber"));
+  const limit = parseLimit(params.get("diagnosticLimit") ?? params.get("limit"), 20, 100);
+
+  if (deploymentId === "invalid") return { error: "Invalid deployment id" };
+  if (targetType === "invalid") return { error: "Invalid target type" };
+  if (targetNumber === "invalid") return { error: "Invalid target number" };
+
+  const repoFilter = params.get("repo");
+  const hasTargetFilter = targetType !== null || targetNumber !== null;
+  if (hasTargetFilter && (!repoFilter || targetType === null || targetNumber === null)) {
+    return { error: "Target diagnostics require repo, targetType, and targetNumber" };
+  }
+
+  const query: DiagnosticQuery = { limit };
+  if (deploymentId !== null) {
+    query.deploymentId = deploymentId;
+  } else if (hasTargetFilter && repoFilter) {
+    const [owner, repo] = repoFilter.split("/");
+    if (!owner || !repo || targetType === null || targetNumber === null) {
+      return { error: "Target diagnostics require repo, targetType, and targetNumber" };
+    }
+    query.target = {
+      owner,
+      repo,
+      targetType,
+      targetNumber,
+    };
+  }
+
+  return {
+    query,
+    responseFilters: {
+      deploymentId,
+      targetType,
+      targetNumber,
+      limit,
+    },
+  };
+}

--- a/packages/web/app/api/v1/webhooks/events/route.test.ts
+++ b/packages/web/app/api/v1/webhooks/events/route.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const listRepos = vi.hoisted(() => vi.fn());
+const listWebhookLogEntries = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  listRepos: (...args: unknown[]) => listRepos(...args),
+  listWebhookLogEntries: (...args: unknown[]) => listWebhookLogEntries(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+const repos = [
+  {
+    id: 1,
+    owner: "mean-weasel",
+    name: "issuectl",
+    localPath: "/tmp/issuectl",
+    branchPattern: null,
+    autoLaunchIssues: true,
+    autoReviewPrs: true,
+    issueAgent: "codex",
+    reviewAgent: "codex",
+    webhookId: 123,
+    reviewPreamble: null,
+    webhookPayloadMode: "metadata",
+    createdAt: "2026-05-24T00:00:00.000Z",
+  },
+];
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getDb.mockReset();
+  listRepos.mockReset();
+  listWebhookLogEntries.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue(db);
+  listRepos.mockReturnValue(repos);
+  listWebhookLogEntries.mockReturnValue([
+    {
+      id: 801,
+      deliveryId: "delivery-801",
+      repoId: 1,
+      eventType: "pull_request",
+      action: "synchronize",
+      senderLogin: "octocat",
+      targetType: "pr",
+      targetNumber: 44,
+      payloadJson: "{\"secret\":\"do-not-return\"}",
+      receivedAt: 1_779_000_000_000,
+      intentId: 901,
+      result: "fired",
+      resultDetail: "deployment 701",
+      actionId: "dep_701",
+      intent: {
+        id: 901,
+        repoId: 1,
+        targetType: "pr",
+        targetNumber: 44,
+        firstSignalAt: 1_778_999_900_000,
+        lastSignalAt: 1_779_000_000_000,
+        scheduledAt: 1_779_000_060_000,
+        processingStartedAt: 1_779_000_070_000,
+        leaseExpiresAt: 1_779_000_130_000,
+        generation: 2,
+        desiredHeadSha: "abc123",
+        requestedAgent: "codex",
+        reviewMode: "full",
+        signalCount: 2,
+        status: "launched",
+        resolvedAt: 1_779_000_090_000,
+        deploymentId: 701,
+        failureReason: null,
+      },
+    },
+  ]);
+});
+
+describe("/api/v1/webhooks/events", () => {
+  it("returns mobile-safe webhook events with repo, target, and intent summaries", async () => {
+    const response = await GET(new NextRequest(
+      "http://localhost/api/v1/webhooks/events?repo=mean-weasel/issuectl&targetType=pr&targetNumber=44&limit=25",
+    ));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listWebhookLogEntries).toHaveBeenCalledWith(db, {
+      repoId: 1,
+      targetType: "pr",
+      targetNumber: 44,
+      limit: 25,
+    });
+    expect(json).toEqual({
+      events: [
+        expect.objectContaining({
+          id: 801,
+          deliveryId: "delivery-801",
+          repoId: 1,
+          repoFullName: "mean-weasel/issuectl",
+          owner: "mean-weasel",
+          repoName: "issuectl",
+          eventType: "pull_request",
+          action: "synchronize",
+          senderLogin: "octocat",
+          targetType: "pr",
+          targetNumber: 44,
+          targetLabel: "PR #44",
+          receivedAt: 1_779_000_000_000,
+          receivedAtIso: "2026-05-17T06:40:00.000Z",
+          result: "fired",
+          resultDetail: "deployment 701",
+          actionId: "dep_701",
+          intent: expect.objectContaining({
+            id: 901,
+            status: "launched",
+            signalCount: 2,
+            deploymentId: 701,
+            scheduledAtIso: "2026-05-17T06:41:00.000Z",
+          }),
+        }),
+      ],
+      repos: [{ id: 1, fullName: "mean-weasel/issuectl" }],
+      filters: {
+        repo: "mean-weasel/issuectl",
+        targetType: "pr",
+        targetNumber: 44,
+        limit: 25,
+      },
+      summary: {
+        count: 1,
+        latestReceivedAt: 1_779_000_000_000,
+        latestReceivedAtIso: "2026-05-17T06:40:00.000Z",
+        resultCounts: { fired: 1 },
+      },
+    });
+    expect(JSON.stringify(json)).not.toContain("do-not-return");
+    expect(JSON.stringify(json)).not.toContain("payloadJson");
+  });
+
+  it("returns a 404 for an unknown repo filter", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/v1/webhooks/events?repo=mean-weasel/missing"));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json).toEqual({ error: "Repository not tracked" });
+    expect(listWebhookLogEntries).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/v1/webhooks/events"));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/webhooks/events/route.ts
+++ b/packages/web/app/api/v1/webhooks/events/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { formatErrorForUser, getDb, listRepos, listWebhookLogEntries } from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  buildWebhookEventsPayload,
+  findRepoByFullName,
+  parseLimit,
+  parsePositiveInt,
+  parseTargetType,
+} from "@/lib/mobile-api-contracts";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const db = getDb();
+    const repos = listRepos(db);
+    const params = request.nextUrl.searchParams;
+    const repoFilter = params.get("repo");
+    const targetType = parseTargetType(params.get("targetType"));
+    const targetNumber = parsePositiveInt(params.get("targetNumber"));
+    const limit = parseLimit(params.get("limit"), 50, 100);
+
+    if (targetType === "invalid") {
+      return NextResponse.json({ error: "Invalid target type" }, { status: 400 });
+    }
+    if (targetNumber === "invalid") {
+      return NextResponse.json({ error: "Invalid target number" }, { status: 400 });
+    }
+
+    const repo = repoFilter ? findRepoByFullName(repos, repoFilter) : undefined;
+    if (repoFilter && !repo) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const entries = listWebhookLogEntries(db, {
+      ...(repo ? { repoId: repo.id } : {}),
+      ...(targetType ? { targetType } : {}),
+      ...(targetNumber ? { targetNumber } : {}),
+      limit,
+    });
+
+    return NextResponse.json(buildWebhookEventsPayload({
+      entries,
+      repos,
+      filters: {
+        repo: repoFilter,
+        targetType,
+        targetNumber,
+        limit,
+      },
+    }));
+  } catch (err) {
+    log.error({ err, msg: "api_webhook_events_failed" });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}

--- a/packages/web/lib/mobile-api-contracts.ts
+++ b/packages/web/lib/mobile-api-contracts.ts
@@ -1,0 +1,301 @@
+import type {
+  Deployment,
+  DeploymentTargetType,
+  DiagnosticEvent,
+  PrReview,
+  PrReviewStatus,
+  Repo,
+  WebhookLogEntry,
+} from "@issuectl/core";
+
+type RepoSummary = {
+  id: number;
+  fullName: string;
+};
+
+type RepoLookup = Map<number, Repo>;
+
+const ACTIVE_REVIEW_STATUSES = new Set<PrReviewStatus>(["reserved", "launching", "in_progress"]);
+
+export function repoFullName(repo: Repo): string {
+  return `${repo.owner}/${repo.name}`;
+}
+
+export function repoSummaries(repos: Repo[]): RepoSummary[] {
+  return repos.map((repo) => ({ id: repo.id, fullName: repoFullName(repo) }));
+}
+
+export function findRepoByFullName(repos: Repo[], fullName: string): Repo | undefined {
+  return repos.find((repo) => repoFullName(repo) === fullName);
+}
+
+export function repoLookupById(repos: Repo[]): RepoLookup {
+  return new Map(repos.map((repo) => [repo.id, repo]));
+}
+
+export function buildWebhookEventsPayload(input: {
+  entries: WebhookLogEntry[];
+  repos: Repo[];
+  filters: {
+    repo: string | null;
+    targetType: DeploymentTargetType | null;
+    targetNumber: number | null;
+    limit: number;
+  };
+}): unknown {
+  const reposById = repoLookupById(input.repos);
+  const events = input.entries.map((entry) => {
+    const repo = reposById.get(entry.repoId);
+    return {
+      id: entry.id,
+      deliveryId: entry.deliveryId,
+      repoId: entry.repoId,
+      repoFullName: repo ? repoFullName(repo) : null,
+      owner: repo?.owner ?? null,
+      repoName: repo?.name ?? null,
+      eventType: entry.eventType,
+      action: entry.action,
+      senderLogin: entry.senderLogin,
+      targetType: entry.targetType,
+      targetNumber: entry.targetNumber,
+      targetLabel: entry.targetType && entry.targetNumber !== null
+        ? targetLabel(entry.targetType, entry.targetNumber)
+        : null,
+      receivedAt: entry.receivedAt,
+      receivedAtIso: toIso(entry.receivedAt),
+      intentId: entry.intentId,
+      result: entry.result,
+      resultDetail: entry.resultDetail,
+      actionId: entry.actionId,
+      intent: entry.intent
+        ? {
+            id: entry.intent.id,
+            status: entry.intent.status,
+            targetType: entry.intent.targetType,
+            targetNumber: entry.intent.targetNumber,
+            targetLabel: targetLabel(entry.intent.targetType, entry.intent.targetNumber),
+            firstSignalAt: entry.intent.firstSignalAt,
+            firstSignalAtIso: toIso(entry.intent.firstSignalAt),
+            lastSignalAt: entry.intent.lastSignalAt,
+            lastSignalAtIso: toIso(entry.intent.lastSignalAt),
+            scheduledAt: entry.intent.scheduledAt,
+            scheduledAtIso: toIso(entry.intent.scheduledAt),
+            processingStartedAt: entry.intent.processingStartedAt,
+            processingStartedAtIso: nullableIso(entry.intent.processingStartedAt),
+            leaseExpiresAt: entry.intent.leaseExpiresAt,
+            leaseExpiresAtIso: nullableIso(entry.intent.leaseExpiresAt),
+            resolvedAt: entry.intent.resolvedAt,
+            resolvedAtIso: nullableIso(entry.intent.resolvedAt),
+            generation: entry.intent.generation,
+            requestedAgent: entry.intent.requestedAgent,
+            reviewMode: entry.intent.reviewMode,
+            signalCount: entry.intent.signalCount,
+            deploymentId: entry.intent.deploymentId,
+            failureReason: entry.intent.failureReason,
+          }
+        : null,
+    };
+  });
+
+  return {
+    events,
+    repos: repoSummaries(input.repos),
+    filters: input.filters,
+    summary: {
+      count: events.length,
+      latestReceivedAt: input.entries[0]?.receivedAt ?? null,
+      latestReceivedAtIso: nullableIso(input.entries[0]?.receivedAt ?? null),
+      resultCounts: countBy(input.entries, (entry) => entry.result),
+    },
+  };
+}
+
+export function buildPrReviewsPayload(input: {
+  reviews: PrReview[];
+  repos: Repo[];
+  deploymentsById: Map<number, Deployment>;
+  filters: {
+    repo: string | null;
+    pr: number | null;
+    status: PrReviewStatus | "all";
+    limit: number;
+  };
+}): unknown {
+  const reposById = repoLookupById(input.repos);
+  const reviews = input.reviews.map((review) => {
+    const repo = reposById.get(review.repoId);
+    const result = parseJsonObject(review.resultJson);
+    const deployment = review.deploymentId === null ? null : input.deploymentsById.get(review.deploymentId) ?? null;
+    return {
+      id: review.id,
+      repoId: review.repoId,
+      repoFullName: repo ? repoFullName(repo) : null,
+      owner: repo?.owner ?? null,
+      repoName: repo?.name ?? null,
+      prNumber: review.prNumber,
+      deploymentId: review.deploymentId,
+      startedHeadSha: review.startedHeadSha,
+      completedHeadSha: review.completedHeadSha,
+      reviewBaseSha: review.reviewBaseSha,
+      reviewedFromSha: review.reviewedFromSha,
+      reviewedToSha: review.reviewedToSha,
+      headRepoFullName: review.headRepoFullName,
+      headRef: review.headRef,
+      status: review.status,
+      triggeredBy: review.triggeredBy,
+      result,
+      summary: stringValue(result.summary) ?? stringValue(result.reason) ?? stringValue(result.error) ?? null,
+      findingCount: numberValue(result.findingCount)
+        ?? numberValue(result.fixedFindingCount)
+        ?? arrayLength(result.findings)
+        ?? arrayLength(result.comments),
+      rangeLabel: reviewRangeLabel(review),
+      detailHref: `/reviews/${review.id}`,
+      startedAt: review.startedAt,
+      startedAtIso: toIso(review.startedAt),
+      completedAt: review.completedAt,
+      completedAtIso: nullableIso(review.completedAt),
+      deployment: deployment ? mobileDeployment(deployment) : null,
+    };
+  });
+
+  return {
+    reviews,
+    repos: repoSummaries(input.repos),
+    filters: input.filters,
+    summary: {
+      count: reviews.length,
+      activeCount: input.reviews.filter((review) => ACTIVE_REVIEW_STATUSES.has(review.status)).length,
+      completedCount: input.reviews.filter((review) => review.status === "completed").length,
+      failedCount: input.reviews.filter((review) => review.status === "failed").length,
+      latestStartedAt: input.reviews[0]?.startedAt ?? null,
+      latestStartedAtIso: nullableIso(input.reviews[0]?.startedAt ?? null),
+    },
+  };
+}
+
+export function buildDiagnosticsPayload(input: {
+  events: DiagnosticEvent[];
+  filters: {
+    deploymentId: number | null;
+    targetType: DeploymentTargetType | null;
+    targetNumber: number | null;
+    limit: number;
+  };
+}): unknown {
+  return {
+    events: input.events.map((event) => ({
+      ...event,
+      timestampIso: toIso(event.timestamp),
+      targetLabel: event.targetType && event.targetNumber !== null
+        ? targetLabel(event.targetType, event.targetNumber)
+        : null,
+    })),
+    filters: input.filters,
+    summary: {
+      count: input.events.length,
+      levelCounts: countBy(input.events, (event) => event.level),
+      latestTimestamp: input.events[0]?.timestamp ?? null,
+      latestTimestampIso: nullableIso(input.events[0]?.timestamp ?? null),
+    },
+  };
+}
+
+export function targetLabel(targetType: DeploymentTargetType, targetNumber: number): string {
+  return targetType === "pr" ? `PR #${targetNumber}` : `Issue #${targetNumber}`;
+}
+
+export function parseLimit(value: string | null, defaultValue: number, maxValue: number): number {
+  if (value === null || value.trim() === "") return defaultValue;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.max(1, Math.min(maxValue, parsed));
+}
+
+export function parsePositiveInt(value: string | null): number | null | "invalid" {
+  if (value === null || value.trim() === "") return null;
+  if (!/^\d+$/.test(value.trim())) return "invalid";
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : "invalid";
+}
+
+export function parseTargetType(value: string | null): DeploymentTargetType | null | "invalid" {
+  if (value === null || value.trim() === "") return null;
+  return value === "issue" || value === "pr" ? value : "invalid";
+}
+
+function mobileDeployment(deployment: Deployment): unknown {
+  return {
+    id: deployment.id,
+    repoId: deployment.repoId,
+    targetType: deployment.targetType,
+    targetNumber: deployment.targetNumber,
+    targetLabel: targetLabel(deployment.targetType, deployment.targetNumber),
+    issueNumber: deployment.issueNumber,
+    branchName: deployment.branchName,
+    agent: deployment.agent,
+    workspaceMode: deployment.workspaceMode,
+    workspacePath: deployment.workspacePath,
+    linkedPrNumber: deployment.linkedPrNumber,
+    state: deployment.state,
+    terminalBackend: deployment.terminalBackend ?? "ttyd",
+    triggeredBy: deployment.triggeredBy,
+    parentDeploymentId: deployment.parentDeploymentId,
+    webhookDepth: deployment.webhookDepth,
+    launchedAt: deployment.launchedAt,
+    endedAt: deployment.endedAt,
+    terminalReason: deployment.terminalReason,
+    ttydPort: deployment.ttydPort,
+    idleSince: deployment.idleSince,
+  };
+}
+
+function reviewRangeLabel(review: PrReview): string {
+  if (review.reviewedFromSha) return `${shortSha(review.reviewedFromSha)}..${shortSha(review.reviewedToSha)}`;
+  return `full ${shortSha(review.reviewedToSha)}`;
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 7);
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function arrayLength(value: unknown): number | null {
+  return Array.isArray(value) ? value.length : null;
+}
+
+function countBy<T, K extends string>(items: T[], keyForItem: (item: T) => K): Record<K, number> {
+  const counts = {} as Record<K, number>;
+  for (const item of items) {
+    const key = keyForItem(item);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function toIso(value: number): string {
+  return new Date(value).toISOString();
+}
+
+function nullableIso(value: number | null): string | null {
+  return value === null ? null : toIso(value);
+}


### PR DESCRIPTION
## Summary
- Add mobile-safe `/api/v1/webhooks/events`, `/api/v1/pr-reviews`, and `/api/v1/sessions/overview` contracts for Apple clients.
- Centralize mobile contract mapping for repo summaries, target labels, review metadata, deployment summaries, and diagnostics summaries.
- Add focused route coverage that verifies auth, filters, summaries, and omission of raw JSON payload fields.

Closes #546.

## Verification
- `pnpm --dir packages/web test -- api/v1/webhooks/events api/v1/pr-reviews api/v1/sessions/overview`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- commit hook reran turbo typecheck and lint successfully

## Notes
- Full `packages/web` test suite was not rerun here because the worker hit the existing local `better-sqlite3.node` NODE_MODULE_VERSION mismatch; the scoped route tests above passed.