### PR TITLE
[codex] Add iOS automation contract models

### DIFF
--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -32,6 +32,7 @@ enum LaunchAgent: String, Codable, CaseIterable, Hashable, Identifiable, Sendabl
 }
 
 enum DeploymentState: String, Codable, Sendable {
+    case pending
     case active
     case ended
 }
@@ -64,6 +65,9 @@ struct Deployment: Codable, Identifiable, Sendable {
     let terminalBackend: TerminalBackend?
     let triggeredBy: DeploymentTrigger?
     let terminalReason: String?
+    let parentDeploymentId: Int?
+    let webhookDepth: Int?
+    let idleSince: String?
     let branchName: String
     let workspaceMode: WorkspaceMode
     let workspacePath: String
@@ -71,6 +75,9 @@ struct Deployment: Codable, Identifiable, Sendable {
     let state: DeploymentState
     let launchedAt: String
     let endedAt: String?
+    let completionToken: String?
+    let completionResultJson: String?
+    let notificationSentAt: String?
     let ttydPort: Int?
     let ttydPid: Int?
 
@@ -128,6 +135,9 @@ struct Deployment: Codable, Identifiable, Sendable {
         terminalBackend = try container.decodeIfPresent(TerminalBackend.self, forKey: .terminalBackend)
         triggeredBy = try container.decodeIfPresent(DeploymentTrigger.self, forKey: .triggeredBy)
         terminalReason = try container.decodeIfPresent(String.self, forKey: .terminalReason)
+        parentDeploymentId = try container.decodeIfPresent(Int.self, forKey: .parentDeploymentId)
+        webhookDepth = try container.decodeIfPresent(Int.self, forKey: .webhookDepth)
+        idleSince = try container.decodeIfPresent(String.self, forKey: .idleSince)
         branchName = try container.decode(String.self, forKey: .branchName)
         workspaceMode = try container.decode(WorkspaceMode.self, forKey: .workspaceMode)
         workspacePath = try container.decode(String.self, forKey: .workspacePath)
@@ -135,6 +145,9 @@ struct Deployment: Codable, Identifiable, Sendable {
         state = try container.decode(DeploymentState.self, forKey: .state)
         launchedAt = try container.decode(String.self, forKey: .launchedAt)
         endedAt = try container.decodeIfPresent(String.self, forKey: .endedAt)
+        completionToken = try container.decodeIfPresent(String.self, forKey: .completionToken)
+        completionResultJson = try container.decodeIfPresent(String.self, forKey: .completionResultJson)
+        notificationSentAt = try container.decodeIfPresent(String.self, forKey: .notificationSentAt)
         ttydPort = try container.decodeIfPresent(Int.self, forKey: .ttydPort)
         ttydPid = try container.decodeIfPresent(Int.self, forKey: .ttydPid)
     }
@@ -149,6 +162,9 @@ struct Deployment: Codable, Identifiable, Sendable {
         case terminalBackend
         case triggeredBy
         case terminalReason
+        case parentDeploymentId
+        case webhookDepth
+        case idleSince
         case branchName
         case workspaceMode
         case workspacePath
@@ -156,6 +172,9 @@ struct Deployment: Codable, Identifiable, Sendable {
         case state
         case launchedAt
         case endedAt
+        case completionToken
+        case completionResultJson
+        case notificationSentAt
         case ttydPort
         case ttydPid
     }
@@ -174,6 +193,9 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
     let parentDeploymentId: Int?
     let webhookDepth: Int?
     let idleSince: String?
+    let completionToken: String?
+    let completionResultJson: String?
+    let notificationSentAt: String?
     let branchName: String
     let workspaceMode: WorkspaceMode
     let workspacePath: String
@@ -235,6 +257,9 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
         parentDeploymentId: Int? = nil,
         webhookDepth: Int? = nil,
         idleSince: String? = nil,
+        completionToken: String? = nil,
+        completionResultJson: String? = nil,
+        notificationSentAt: String? = nil,
         branchName: String,
         workspaceMode: WorkspaceMode,
         workspacePath: String,
@@ -259,6 +284,9 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
         self.parentDeploymentId = parentDeploymentId
         self.webhookDepth = webhookDepth
         self.idleSince = idleSince
+        self.completionToken = completionToken
+        self.completionResultJson = completionResultJson
+        self.notificationSentAt = notificationSentAt
         self.branchName = branchName
         self.workspaceMode = workspaceMode
         self.workspacePath = workspacePath
@@ -299,6 +327,9 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
         parentDeploymentId = try container.decodeIfPresent(Int.self, forKey: .parentDeploymentId)
         webhookDepth = try container.decodeIfPresent(Int.self, forKey: .webhookDepth)
         idleSince = try container.decodeIfPresent(String.self, forKey: .idleSince)
+        completionToken = try container.decodeIfPresent(String.self, forKey: .completionToken)
+        completionResultJson = try container.decodeIfPresent(String.self, forKey: .completionResultJson)
+        notificationSentAt = try container.decodeIfPresent(String.self, forKey: .notificationSentAt)
         branchName = try container.decode(String.self, forKey: .branchName)
         workspaceMode = try container.decode(WorkspaceMode.self, forKey: .workspaceMode)
         workspacePath = try container.decode(String.self, forKey: .workspacePath)
@@ -325,6 +356,9 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
         case parentDeploymentId
         case webhookDepth
         case idleSince
+        case completionToken
+        case completionResultJson
+        case notificationSentAt
         case branchName
         case workspaceMode
         case workspacePath

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -5,6 +5,60 @@ enum WebhookPayloadMode: String, Codable, CaseIterable, Sendable {
     case raw
 }
 
+enum JSONValue: Codable, Equatable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
 struct Repo: Codable, Identifiable, Sendable {
     let id: Int
     let owner: String
@@ -177,11 +231,13 @@ struct WorkbenchIssueSummary: Codable, Identifiable, Sendable {
 struct WorkbenchWebhookEvent: Codable, Identifiable, Sendable {
     let id: Int
     let deliveryId: String
+    let repoId: Int?
     let eventType: String
     let action: String?
     let senderLogin: String?
     let targetType: DeploymentTargetType?
     let targetNumber: Int?
+    let payloadJson: String?
     let receivedAt: Int
     let intentId: Int?
 }
@@ -191,6 +247,9 @@ struct WorkbenchPrReview: Codable, Identifiable, Sendable {
     let repoId: Int
     let prNumber: Int
     let deploymentId: Int?
+    let startedHeadSha: String?
+    let completedHeadSha: String?
+    let reviewBaseSha: String?
     let reviewedFromSha: String?
     let reviewedToSha: String
     let headRepoFullName: String
@@ -240,4 +299,203 @@ struct WebhookConfiguration: Codable, Sendable {
     let id: Int
     let url: String
     let createdBy: String?
+}
+
+struct WebhookEvent: Codable, Identifiable, Sendable {
+    let id: Int
+    let deliveryId: String
+    let repoId: Int
+    let eventType: String
+    let action: String?
+    let senderLogin: String?
+    let targetType: DeploymentTargetType?
+    let targetNumber: Int?
+    let payloadJson: String?
+    let receivedAt: Int
+    let intentId: Int?
+}
+
+struct WebhookEventsResponse: Codable, Sendable {
+    let events: [WebhookEvent]
+    let fromCache: Bool
+    let cachedAt: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        events = try container.decode([WebhookEvent].self, forKey: .events)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case events, fromCache, cachedAt
+    }
+}
+
+enum ReviewRunStatus: String, Codable, CaseIterable, Sendable {
+    case reserved
+    case launching
+    case inProgress = "in_progress"
+    case completed
+    case failed
+    case superseded
+}
+
+struct ReviewRun: Codable, Identifiable, Sendable {
+    let id: Int
+    let repoId: Int
+    let prNumber: Int
+    let deploymentId: Int?
+    let startedHeadSha: String?
+    let completedHeadSha: String?
+    let reviewBaseSha: String
+    let reviewedFromSha: String?
+    let reviewedToSha: String
+    let headRepoFullName: String
+    let headRef: String
+    let status: ReviewRunStatus
+    let triggeredBy: DeploymentTrigger
+    let resultJson: String?
+    let startedAt: Int
+    let completedAt: Int?
+}
+
+struct ReviewRunsResponse: Codable, Sendable {
+    let reviewRuns: [ReviewRun]
+    let fromCache: Bool
+    let cachedAt: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        reviewRuns = try container.decode([ReviewRun].self, forKey: .reviewRuns)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case reviewRuns, fromCache, cachedAt
+    }
+}
+
+enum DiagnosticLevel: String, Codable, CaseIterable, Sendable {
+    case debug
+    case info
+    case warn
+    case error
+}
+
+struct DiagnosticEvent: Codable, Identifiable, Sendable {
+    let id: Int
+    let timestamp: Int
+    let level: DiagnosticLevel
+    let event: String
+    let source: String
+    let correlationId: String?
+    let owner: String?
+    let repo: String?
+    let issueNumber: Int?
+    let targetType: DeploymentTargetType?
+    let targetNumber: Int?
+    let deploymentId: Int?
+    let sessionName: String?
+    let ttydPort: Int?
+    let ttydPid: Int?
+    let status: String?
+    let message: String?
+    let data: [String: JSONValue]?
+}
+
+struct DiagnosticsResponse: Codable, Sendable {
+    let events: [DiagnosticEvent]
+    let fromCache: Bool
+    let cachedAt: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        events = try container.decode([DiagnosticEvent].self, forKey: .events)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case events, fromCache, cachedAt
+    }
+}
+
+enum AgentMutationAction: String, Codable, CaseIterable, Sendable {
+    case push
+    case comment
+    case label
+    case createIssue = "create_issue"
+    case createPr = "create_pr"
+}
+
+struct AgentMutationRequestBody: Codable, Sendable {
+    let deploymentId: Int
+    let completionToken: String
+    let repoId: Int
+    let targetType: DeploymentTargetType
+    let targetNumber: Int
+    let actionType: AgentMutationAction
+    let payload: JSONValue?
+
+    init(
+        deploymentId: Int,
+        completionToken: String,
+        repoId: Int,
+        targetType: DeploymentTargetType,
+        targetNumber: Int,
+        actionType: AgentMutationAction,
+        payload: JSONValue? = nil
+    ) {
+        self.deploymentId = deploymentId
+        self.completionToken = completionToken
+        self.repoId = repoId
+        self.targetType = targetType
+        self.targetNumber = targetNumber
+        self.actionType = actionType
+        self.payload = payload
+    }
+}
+
+struct AgentMutationDecision: Codable, Sendable {
+    let allowed: Bool
+    let reason: String?
+}
+
+enum AgentCompletionStatus: String, Codable, CaseIterable, Sendable {
+    case completed
+    case failed
+    case noChanges = "no_changes"
+    case pushedFixes = "pushed_fixes"
+}
+
+struct AgentCompletionRequestBody: Codable, Sendable {
+    let deploymentId: Int
+    let completionToken: String
+    let status: AgentCompletionStatus
+    let summary: String
+    let finalHeadSha: String?
+    let pushedCommitSha: String?
+    let pushedCommits: [String]?
+    let changedFileCount: Int?
+    let fixedFindingCount: Int?
+    let errorMessage: String?
+}
+
+struct AgentCompletionResponse: Codable, Sendable {
+    let accepted: Bool
+    let duplicate: Bool
+    let reason: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accepted = try container.decode(Bool.self, forKey: .accepted)
+        duplicate = try container.decodeIfPresent(Bool.self, forKey: .duplicate) ?? false
+        reason = try container.decodeIfPresent(String.self, forKey: .reason)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case accepted, duplicate, reason
+    }
 }

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -354,6 +354,37 @@ final class APIClient {
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
     }
 
+    // Depends on issue #546: these automation list endpoints are fixture-driven
+    // until the web API exposes dedicated list routes for native clients.
+    func webhookEvents(owner: String, repo: String) async throws -> WebhookEventsResponse {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/webhook/events")
+        return try decoder.decode(WebhookEventsResponse.self, from: data)
+    }
+
+    func reviewRuns(owner: String, repo: String) async throws -> ReviewRunsResponse {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/review-runs")
+        return try decoder.decode(ReviewRunsResponse.self, from: data)
+    }
+
+    func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
+        let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
+        return try decoder.decode(DiagnosticsResponse.self, from: data)
+    }
+
+    func agentMutation(body: AgentMutationRequestBody) async throws -> AgentMutationDecision {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/agent/mutations", method: "POST", body: bodyData)
+        return try decoder.decode(AgentMutationDecision.self, from: data)
+    }
+
+    func agentCompletion(body: AgentCompletionRequestBody) async throws -> AgentCompletionResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/agent/completion", method: "POST", body: bodyData)
+        clearActiveDeploymentsCache()
+        clearWorkbenchCache()
+        return try decoder.decode(AgentCompletionResponse.self, from: data)
+    }
+
     func workbench(refresh: Bool = false, maxAge: TimeInterval = 10) async throws -> WorkbenchPayload {
         let now = Date()
         if !refresh,

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -28,6 +28,35 @@ final class MockURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
+private func requestBodyData(_ request: URLRequest) throws -> Data {
+    if let httpBody = request.httpBody {
+        return httpBody
+    }
+    guard let bodyStream = request.httpBodyStream else {
+        throw NSError(domain: "IssueCTLTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Request has no body"])
+    }
+
+    bodyStream.open()
+    defer { bodyStream.close() }
+
+    var data = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+    defer { buffer.deallocate() }
+
+    while bodyStream.hasBytesAvailable {
+        let read = bodyStream.read(buffer, maxLength: 1024)
+        if read > 0 {
+            data.append(buffer, count: read)
+        } else if read < 0 {
+            throw bodyStream.streamError ?? NSError(domain: "IssueCTLTests", code: 2)
+        } else {
+            break
+        }
+    }
+
+    return data
+}
+
 // MARK: - Testable APIClient subclass
 
 /// A testable version of APIClient that uses a custom URLSession with MockURLProtocol.
@@ -233,6 +262,33 @@ final class TestableAPIClient {
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
     }
 
+    func webhookEvents(owner: String, repo: String) async throws -> WebhookEventsResponse {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/webhook/events")
+        return try decoder.decode(WebhookEventsResponse.self, from: data)
+    }
+
+    func reviewRuns(owner: String, repo: String) async throws -> ReviewRunsResponse {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/review-runs")
+        return try decoder.decode(ReviewRunsResponse.self, from: data)
+    }
+
+    func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
+        let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
+        return try decoder.decode(DiagnosticsResponse.self, from: data)
+    }
+
+    func agentMutation(body: AgentMutationRequestBody) async throws -> AgentMutationDecision {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/agent/mutations", method: "POST", body: bodyData)
+        return try decoder.decode(AgentMutationDecision.self, from: data)
+    }
+
+    func agentCompletion(body: AgentCompletionRequestBody) async throws -> AgentCompletionResponse {
+        let bodyData = try JSONEncoder().encode(body)
+        let (data, _) = try await request(path: "/api/v1/agent/completion", method: "POST", body: bodyData)
+        return try decoder.decode(AgentCompletionResponse.self, from: data)
+    }
+
     func parseNaturalLanguage(input: String) async throws -> ParsedIssuesData {
         let body = ParseRequestBody(input: input)
         let bodyData = try JSONEncoder().encode(body)
@@ -426,6 +482,99 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.sessionPreviews()
+    }
+
+    @MainActor
+    func testAutomationListEndpointURLs() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/repos/org/alpha/webhook/events")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"events":[]}"#.data(using: .utf8)!)
+        }
+
+        _ = try await client.webhookEvents(owner: "org", repo: "alpha")
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/repos/org/alpha/review-runs")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"review_runs":[]}"#.data(using: .utf8)!)
+        }
+
+        _ = try await client.reviewRuns(owner: "org", repo: "alpha")
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/diagnostics")
+            XCTAssertEqual(request.url!.query, "deploymentId=42")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"events":[]}"#.data(using: .utf8)!)
+        }
+
+        _ = try await client.diagnostics(deploymentId: 42)
+    }
+
+    @MainActor
+    func testAgentMutationEndpointEncodesAutomationContract() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/agent/mutations")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = try requestBodyData(request)
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["deploymentId"] as? Int, 42)
+            XCTAssertEqual(json["completionToken"] as? String, "token")
+            XCTAssertEqual(json["targetType"] as? String, "pr")
+            XCTAssertEqual(json["actionType"] as? String, "comment")
+            XCTAssertEqual((json["payload"] as? [String: Any])?["body"] as? String, "LGTM")
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"allowed":true}"#.data(using: .utf8)!)
+        }
+
+        let decision = try await client.agentMutation(body: AgentMutationRequestBody(
+            deploymentId: 42,
+            completionToken: "token",
+            repoId: 7,
+            targetType: .pr,
+            targetNumber: 88,
+            actionType: .comment,
+            payload: .object(["body": .string("LGTM")])
+        ))
+
+        XCTAssertTrue(decision.allowed)
+        XCTAssertNil(decision.reason)
+    }
+
+    @MainActor
+    func testAgentCompletionEndpointEncodesAutomationContract() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/agent/completion")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = try requestBodyData(request)
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["deploymentId"] as? Int, 42)
+            XCTAssertEqual(json["status"] as? String, "pushed_fixes")
+            XCTAssertEqual(json["summary"] as? String, "Fixed one finding.")
+            XCTAssertEqual(json["fixedFindingCount"] as? Int, 1)
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"accepted":true,"duplicate":false}"#.data(using: .utf8)!)
+        }
+
+        let result = try await client.agentCompletion(body: AgentCompletionRequestBody(
+            deploymentId: 42,
+            completionToken: "token",
+            status: .pushedFixes,
+            summary: "Fixed one finding.",
+            finalHeadSha: "def456",
+            pushedCommitSha: "def456",
+            pushedCommits: ["def456"],
+            changedFileCount: 2,
+            fixedFindingCount: 1,
+            errorMessage: nil
+        ))
+
+        XCTAssertTrue(result.accepted)
+        XCTAssertFalse(result.duplicate)
+        XCTAssertNil(result.reason)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1251,4 +1251,158 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertTrue(response.fromCache)
         XCTAssertEqual(response.cachedAt, "2026-04-27T00:00:00Z")
     }
+
+    // MARK: - Automation contracts
+
+    func testEnrichedDeploymentDecodingPreservesAutomationFields() throws {
+        let json = """
+        {
+            "id": 42,
+            "repo_id": 7,
+            "issue_number": null,
+            "target_type": "pr",
+            "target_number": 88,
+            "agent": "codex",
+            "terminal_backend": "pty_bridge",
+            "triggered_by": "comment_command",
+            "terminal_reason": "completed",
+            "parent_deployment_id": 12,
+            "webhook_depth": 1,
+            "idle_since": null,
+            "branch_name": "review/pr-88",
+            "workspace_mode": "worktree",
+            "workspace_path": "/tmp/issuectl/pr-88",
+            "linked_pr_number": 88,
+            "state": "pending",
+            "launched_at": "2026-05-29T10:00:00.000Z",
+            "ended_at": null,
+            "completion_token": "token-redacted",
+            "completion_result_json": "{\\"status\\":\\"completed\\",\\"summary\\":\\"Reviewed changes.\\"}",
+            "notification_sent_at": "2026-05-29T10:05:00.000Z",
+            "ttyd_port": null,
+            "ttyd_pid": null,
+            "owner": "org",
+            "repo_name": "alpha"
+        }
+        """.data(using: .utf8)!
+
+        let deployment = try decoder.decode(ActiveDeployment.self, from: json)
+        XCTAssertEqual(deployment.targetType, .pr)
+        XCTAssertEqual(deployment.targetNumber, 88)
+        XCTAssertEqual(deployment.issueNumber, 88)
+        XCTAssertEqual(deployment.state, .pending)
+        XCTAssertEqual(deployment.triggeredBy, .commentCommand)
+        XCTAssertEqual(deployment.parentDeploymentId, 12)
+        XCTAssertEqual(deployment.completionToken, "token-redacted")
+        XCTAssertEqual(deployment.completionResultJson, #"{"status":"completed","summary":"Reviewed changes."}"#)
+        XCTAssertEqual(deployment.notificationSentAt, "2026-05-29T10:05:00.000Z")
+    }
+
+    func testWebhookEventDecodingFromAutomationFixture() throws {
+        let json = """
+        {
+            "events": [
+                {
+                    "id": 1001,
+                    "delivery_id": "delivery-1",
+                    "repo_id": 7,
+                    "event_type": "pull_request",
+                    "action": "synchronize",
+                    "sender_login": "octocat",
+                    "target_type": "pr",
+                    "target_number": 88,
+                    "payload_json": "{\\"pull_request\\":{\\"number\\":88}}",
+                    "received_at": 1777440000,
+                    "intent_id": 55
+                }
+            ],
+            "from_cache": false,
+            "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(WebhookEventsResponse.self, from: json)
+        XCTAssertEqual(response.events.count, 1)
+        XCTAssertEqual(response.events[0].repoId, 7)
+        XCTAssertEqual(response.events[0].targetType, .pr)
+        XCTAssertEqual(response.events[0].payloadJson, #"{"pull_request":{"number":88}}"#)
+        XCTAssertFalse(response.fromCache)
+    }
+
+    func testReviewRunDecodingFromAutomationFixture() throws {
+        let json = """
+        {
+            "review_runs": [
+                {
+                    "id": 55,
+                    "repo_id": 7,
+                    "pr_number": 88,
+                    "deployment_id": 42,
+                    "started_head_sha": "abc123",
+                    "completed_head_sha": "def456",
+                    "review_base_sha": "base999",
+                    "reviewed_from_sha": "abc123",
+                    "reviewed_to_sha": "def456",
+                    "head_repo_full_name": "org/alpha",
+                    "head_ref": "feature/review",
+                    "status": "completed",
+                    "triggered_by": "webhook",
+                    "result_json": "{\\"summary\\":\\"No regressions\\",\\"fixedFindingCount\\":1}",
+                    "started_at": 1777440000,
+                    "completed_at": 1777440300
+                }
+            ],
+            "from_cache": false,
+            "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(ReviewRunsResponse.self, from: json)
+        XCTAssertEqual(response.reviewRuns.count, 1)
+        XCTAssertEqual(response.reviewRuns[0].status, .completed)
+        XCTAssertEqual(response.reviewRuns[0].triggeredBy, .webhook)
+        XCTAssertEqual(response.reviewRuns[0].reviewBaseSha, "base999")
+        XCTAssertEqual(response.reviewRuns[0].completedHeadSha, "def456")
+    }
+
+    func testDiagnosticEventDecodingFromAutomationFixture() throws {
+        let json = """
+        {
+            "events": [
+                {
+                    "id": 9001,
+                    "timestamp": 1777440500,
+                    "level": "warn",
+                    "event": "agent.mutation_denied",
+                    "source": "agent.mutation",
+                    "correlation_id": "corr-1",
+                    "owner": "org",
+                    "repo": "alpha",
+                    "issue_number": null,
+                    "target_type": "pr",
+                    "target_number": 88,
+                    "deployment_id": 42,
+                    "session_name": "issuectl-42",
+                    "ttyd_port": null,
+                    "ttyd_pid": null,
+                    "status": "invalid_token",
+                    "message": "Agent mutation denied: invalid_token",
+                    "data": {
+                        "actionType": "push",
+                        "targetType": "pr",
+                        "targetNumber": 88
+                    }
+                }
+            ],
+            "from_cache": false,
+            "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DiagnosticsResponse.self, from: json)
+        XCTAssertEqual(response.events.count, 1)
+        XCTAssertEqual(response.events[0].level, .warn)
+        XCTAssertEqual(response.events[0].targetType, .pr)
+        XCTAssertEqual(response.events[0].data?["actionType"], .string("push"))
+    }
 }


### PR DESCRIPTION
## Summary
- Add shared Apple Codable models for webhook events, PR review runs, diagnostics, enriched deployments, and agent mutation/completion payloads.
- Add APIClient methods for the new automation contract routes.
- Add fixture-driven model and API client coverage while the web route contract lands in #553.

Closes #548.

## Verification
- `xcodebuild -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator' build-for-testing -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests`
- `git diff --check`

## Dependency
- Drafted after #553 because the live web endpoints are introduced there; this PR keeps the Apple side fixture-driven and compile-safe.