### PR TITLE
[codex] Add iOS automation parity fixtures

### DIFF
--- a/apple/IssueCTLTests/Fixtures/automation-parity-workbench.json
+++ b/apple/IssueCTLTests/Fixtures/automation-parity-workbench.json
@@ -1,0 +1,358 @@
+{
+  "repos": [
+    {
+      "id": 1,
+      "owner": "org",
+      "name": "alpha",
+      "localPath": "/tmp/alpha",
+      "branchPattern": null,
+      "autoLaunchIssues": true,
+      "autoReviewPrs": true,
+      "issueAgent": "codex",
+      "reviewAgent": "claude",
+      "webhookId": 123,
+      "webhookPayloadMode": "metadata",
+      "badgeCount": 3,
+      "deployedCount": 3,
+      "launchAgent": "codex",
+      "terminalBackendDefault": "ttyd",
+      "issueError": null,
+      "issuesFromCache": false,
+      "issuesCachedAt": null,
+      "priorities": [
+        {
+          "repoId": 1,
+          "issueNumber": 501,
+          "priority": "high",
+          "updatedAt": 1777440000
+        }
+      ],
+      "deployments": [
+        {
+          "id": 9401,
+          "repoId": 1,
+          "issueNumber": 501,
+          "targetType": "issue",
+          "targetNumber": 501,
+          "agent": "codex",
+          "terminalBackend": "ttyd",
+          "triggeredBy": "manual",
+          "terminalReason": null,
+          "parentDeploymentId": null,
+          "webhookDepth": 0,
+          "idleSince": null,
+          "branchName": "issue-501-manual-session",
+          "workspaceMode": "worktree",
+          "workspacePath": "/tmp/alpha-automation-501",
+          "linkedPrNumber": null,
+          "state": "active",
+          "launchedAt": "2026-04-29 08:00:00",
+          "endedAt": null,
+          "ttydPort": 19001,
+          "ttydPid": 22401,
+          "owner": "org",
+          "repoName": "alpha"
+        },
+        {
+          "id": 9402,
+          "repoId": 1,
+          "issueNumber": 502,
+          "targetType": "issue",
+          "targetNumber": 502,
+          "agent": "codex",
+          "terminalBackend": "ttyd",
+          "triggeredBy": "webhook",
+          "terminalReason": null,
+          "parentDeploymentId": 9401,
+          "webhookDepth": 1,
+          "idleSince": "2026-04-29 08:05:00",
+          "branchName": "issue-502-webhook-session",
+          "workspaceMode": "worktree",
+          "workspacePath": "/tmp/alpha-automation-502",
+          "linkedPrNumber": null,
+          "state": "active",
+          "launchedAt": "2026-04-29 08:00:00",
+          "endedAt": null,
+          "ttydPort": 19002,
+          "ttydPid": 22402,
+          "owner": "org",
+          "repoName": "alpha"
+        },
+        {
+          "id": 9407,
+          "repoId": 1,
+          "issueNumber": null,
+          "targetType": "pr",
+          "targetNumber": 7,
+          "agent": "codex",
+          "terminalBackend": "ttyd",
+          "triggeredBy": "comment_command",
+          "terminalReason": "review",
+          "parentDeploymentId": 9402,
+          "webhookDepth": 2,
+          "idleSince": null,
+          "branchName": "pr-7-review",
+          "workspaceMode": "worktree",
+          "workspacePath": "/tmp/alpha-automation-7",
+          "linkedPrNumber": null,
+          "state": "active",
+          "launchedAt": "2026-04-29 08:00:00",
+          "endedAt": null,
+          "ttydPort": 19007,
+          "ttydPid": 22407,
+          "owner": "org",
+          "repoName": "alpha"
+        }
+      ],
+      "recentCompletions": [],
+      "webhookEvents": [
+        {
+          "id": 1,
+          "deliveryId": "mock-delivery-501",
+          "eventType": "issues",
+          "action": "labeled",
+          "senderLogin": "alice",
+          "targetType": "issue",
+          "targetNumber": 501,
+          "receivedAt": 1777440000,
+          "intentId": 50
+        }
+      ],
+      "prReviews": [
+        {
+          "id": 7,
+          "repoId": 1,
+          "prNumber": 7,
+          "deploymentId": 9407,
+          "reviewedFromSha": null,
+          "reviewedToSha": "abc123",
+          "headRepoFullName": "org/alpha",
+          "headRef": "feature-7",
+          "status": "in_progress",
+          "triggeredBy": "webhook",
+          "resultJson": null,
+          "startedAt": 1777440000,
+          "completedAt": null
+        }
+      ],
+      "previews": {
+        "19001": {
+          "lines": [
+            "issue #501: manual launch",
+            "agent is running"
+          ],
+          "lastUpdatedMs": 1777800000000,
+          "lastChangedMs": 1777799999000,
+          "status": "active"
+        },
+        "19002": {
+          "lines": [
+            "issue #502: webhook label",
+            "waiting for changes"
+          ],
+          "lastUpdatedMs": 1777800000000,
+          "lastChangedMs": 1777799999000,
+          "status": "idle"
+        },
+        "19007": {
+          "lines": [
+            "PR #7: /issuectl review",
+            "automation command failed"
+          ],
+          "lastUpdatedMs": 1777800000000,
+          "lastChangedMs": 1777799999000,
+          "status": "error"
+        }
+      },
+      "issues": [
+        {
+          "number": 501,
+          "title": "Manual automation baseline",
+          "state": "open",
+          "labels": [
+            "bug"
+          ],
+          "updatedAt": "2026-04-29T08:00:00Z",
+          "priority": "high",
+          "hasActiveDeployment": true,
+          "htmlUrl": "https://github.com/org/alpha/issues/501",
+          "authorLogin": "alice"
+        },
+        {
+          "number": 502,
+          "title": "Webhook-triggered follow-up",
+          "state": "open",
+          "labels": [
+            "issuectl:auto-launch"
+          ],
+          "updatedAt": "2026-04-29T08:00:00Z",
+          "priority": "normal",
+          "hasActiveDeployment": true,
+          "htmlUrl": "https://github.com/org/alpha/issues/502",
+          "authorLogin": "alice"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "owner": "org",
+      "name": "beta",
+      "localPath": "/tmp/beta",
+      "branchPattern": null,
+      "autoLaunchIssues": false,
+      "autoReviewPrs": false,
+      "issueAgent": "claude",
+      "reviewAgent": "claude",
+      "webhookId": null,
+      "webhookPayloadMode": "metadata",
+      "badgeCount": 0,
+      "deployedCount": 0,
+      "launchAgent": "claude",
+      "terminalBackendDefault": "ttyd",
+      "issueError": null,
+      "issuesFromCache": false,
+      "issuesCachedAt": null,
+      "priorities": [],
+      "deployments": [],
+      "recentCompletions": [],
+      "webhookEvents": [],
+      "prReviews": [],
+      "previews": {},
+      "issues": [
+        {
+          "number": 601,
+          "title": "Automation disabled repo",
+          "state": "open",
+          "labels": [
+            "board"
+          ],
+          "updatedAt": "2026-04-29T08:00:00Z",
+          "priority": "normal",
+          "hasActiveDeployment": false,
+          "htmlUrl": "https://github.com/org/beta/issues/601",
+          "authorLogin": "bob"
+        }
+      ]
+    }
+  ],
+  "deployments": [
+    {
+      "id": 9401,
+      "repoId": 1,
+      "issueNumber": 501,
+      "targetType": "issue",
+      "targetNumber": 501,
+      "agent": "codex",
+      "terminalBackend": "ttyd",
+      "triggeredBy": "manual",
+      "terminalReason": null,
+      "parentDeploymentId": null,
+      "webhookDepth": 0,
+      "idleSince": null,
+      "branchName": "issue-501-manual-session",
+      "workspaceMode": "worktree",
+      "workspacePath": "/tmp/alpha-automation-501",
+      "linkedPrNumber": null,
+      "state": "active",
+      "launchedAt": "2026-04-29 08:00:00",
+      "endedAt": null,
+      "ttydPort": 19001,
+      "ttydPid": 22401,
+      "owner": "org",
+      "repoName": "alpha"
+    },
+    {
+      "id": 9402,
+      "repoId": 1,
+      "issueNumber": 502,
+      "targetType": "issue",
+      "targetNumber": 502,
+      "agent": "codex",
+      "terminalBackend": "ttyd",
+      "triggeredBy": "webhook",
+      "terminalReason": null,
+      "parentDeploymentId": 9401,
+      "webhookDepth": 1,
+      "idleSince": "2026-04-29 08:05:00",
+      "branchName": "issue-502-webhook-session",
+      "workspaceMode": "worktree",
+      "workspacePath": "/tmp/alpha-automation-502",
+      "linkedPrNumber": null,
+      "state": "active",
+      "launchedAt": "2026-04-29 08:00:00",
+      "endedAt": null,
+      "ttydPort": 19002,
+      "ttydPid": 22402,
+      "owner": "org",
+      "repoName": "alpha"
+    },
+    {
+      "id": 9407,
+      "repoId": 1,
+      "issueNumber": null,
+      "targetType": "pr",
+      "targetNumber": 7,
+      "agent": "codex",
+      "terminalBackend": "ttyd",
+      "triggeredBy": "comment_command",
+      "terminalReason": "review",
+      "parentDeploymentId": 9402,
+      "webhookDepth": 2,
+      "idleSince": null,
+      "branchName": "pr-7-review",
+      "workspaceMode": "worktree",
+      "workspacePath": "/tmp/alpha-automation-7",
+      "linkedPrNumber": null,
+      "state": "active",
+      "launchedAt": "2026-04-29 08:00:00",
+      "endedAt": null,
+      "ttydPort": 19007,
+      "ttydPid": 22407,
+      "owner": "org",
+      "repoName": "alpha"
+    }
+  ],
+  "previews": {
+    "19001": {
+      "lines": [
+        "issue #501: manual launch",
+        "agent is running"
+      ],
+      "lastUpdatedMs": 1777800000000,
+      "lastChangedMs": 1777799999000,
+      "status": "active"
+    },
+    "19002": {
+      "lines": [
+        "issue #502: webhook label",
+        "waiting for changes"
+      ],
+      "lastUpdatedMs": 1777800000000,
+      "lastChangedMs": 1777799999000,
+      "status": "idle"
+    },
+    "19007": {
+      "lines": [
+        "PR #7: /issuectl review",
+        "automation command failed"
+      ],
+      "lastUpdatedMs": 1777800000000,
+      "lastChangedMs": 1777799999000,
+      "status": "error"
+    }
+  },
+  "settings": {
+    "launch_agent": "codex"
+  },
+  "health": {
+    "ok": true,
+    "version": "ui-test",
+    "timestamp": "2026-04-29T08:00:00Z",
+    "error": null
+  },
+  "user": {
+    "login": "alice",
+    "error": null
+  },
+  "generatedAt": "2026-04-29T08:00:00Z"
+}

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -873,6 +873,22 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(payload.user.login, "alice")
     }
 
+    func testAutomationParityWorkbenchFixtureDecoding() throws {
+        let fixture = try loadFixtureData("automation-parity-workbench")
+
+        let payload = try decoder.decode(WorkbenchPayload.self, from: fixture)
+
+        XCTAssertEqual(payload.repos.count, 2)
+        XCTAssertEqual(payload.deployments.compactMap(\.triggeredBy), [.manual, .webhook, .commentCommand])
+        XCTAssertEqual(payload.deployments.map(\.targetType), [.issue, .issue, .pr])
+        XCTAssertEqual(payload.deployments[1].parentDeploymentId, 9401)
+        XCTAssertEqual(payload.deployments[1].webhookDepth, 1)
+        XCTAssertEqual(payload.previews["19002"]?.status, .idle)
+        XCTAssertEqual(payload.repos[0].webhookEvents[0].targetType, .issue)
+        XCTAssertEqual(payload.repos[0].prReviews[0].triggeredBy, .webhook)
+        XCTAssertEqual(payload.repos[1].autoLaunchIssues, false)
+    }
+
     func testSessionPreviewsResponseDecoding() throws {
         let json = """
         {
@@ -902,6 +918,15 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.previewsByPort[7701]?.status, .unavailable)
         XCTAssertEqual(response.previewsByPort[7701]?.status.displayName, "Unavailable")
         XCTAssertEqual(response.previewsByPort[7701]?.status.accessibilityName, "preview unavailable")
+    }
+
+    private func loadFixtureData(_ name: String) throws -> Data {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let fixtureURL = testFile
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("\(name).json")
+        return try Data(contentsOf: fixtureURL)
     }
 
     // MARK: - GitHubAccessibleRepo

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -173,6 +173,46 @@ final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
+    func seedAutomationParitySessions() {
+        hiddenPreviewIssueNumbers = []
+        repos = [defaultRepo, betaRepo]
+        activeDeployments = [
+            automationParityDeployment(
+                id: 9401,
+                targetType: "issue",
+                targetNumber: 501,
+                issueNumber: 501,
+                triggeredBy: "manual",
+                webhookDepth: 0,
+                previewStatus: "active",
+                previewLines: ["issue #501: manual launch", "agent is running"]
+            ),
+            automationParityDeployment(
+                id: 9402,
+                targetType: "issue",
+                targetNumber: 502,
+                issueNumber: 502,
+                triggeredBy: "webhook",
+                parentDeploymentId: 9401,
+                webhookDepth: 1,
+                previewStatus: "idle",
+                previewLines: ["issue #502: webhook label", "waiting for changes"]
+            ),
+            automationParityDeployment(
+                id: 9407,
+                targetType: "pr",
+                targetNumber: 7,
+                issueNumber: nil,
+                triggeredBy: "comment_command",
+                terminalReason: "review",
+                parentDeploymentId: 9402,
+                webhookDepth: 2,
+                previewStatus: "error",
+                previewLines: ["PR #7: /issuectl review", "automation command failed"]
+            ),
+        ]
+    }
+
     func seedDeploymentWithMissingPreview() {
         activeDeployments = [deployment(issueNumber: 101)]
         hiddenPreviewIssueNumbers = [101]
@@ -853,6 +893,47 @@ final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
+    func automationParityDeployment(
+        id: Int,
+        targetType: String,
+        targetNumber: Int,
+        issueNumber: Int?,
+        triggeredBy: String,
+        terminalReason: String? = nil,
+        parentDeploymentId: Int? = nil,
+        webhookDepth: Int,
+        previewStatus: String,
+        previewLines: [String]
+    ) -> [String: Any] {
+        [
+            "id": id,
+            "repo_id": 1,
+            "issue_number": issueNumber ?? NSNull(),
+            "target_type": targetType,
+            "target_number": targetNumber,
+            "agent": "codex",
+            "terminal_backend": "ttyd",
+            "triggered_by": triggeredBy,
+            "terminal_reason": terminalReason ?? NSNull(),
+            "parent_deployment_id": parentDeploymentId ?? NSNull(),
+            "webhook_depth": webhookDepth,
+            "idle_since": previewStatus == "idle" ? "2026-04-29 08:05:00" : NSNull(),
+            "branch_name": targetType == "pr" ? "pr-\(targetNumber)-review" : branchName(for: targetNumber),
+            "workspace_mode": "worktree",
+            "workspace_path": "/tmp/alpha-automation-\(targetNumber)",
+            "linked_pr_number": NSNull(),
+            "state": "active",
+            "launched_at": "2026-04-29 08:00:00",
+            "ended_at": NSNull(),
+            "ttyd_port": 19000 + (id - 9400),
+            "ttyd_pid": 13000 + id,
+            "owner": "org",
+            "repo_name": "alpha",
+            "preview_status": previewStatus,
+            "preview_lines": previewLines,
+        ]
+    }
+
     func workbenchPayload() -> [String: Any] {
         [
             "drafts": drafts,
@@ -1017,14 +1098,15 @@ final class MockIssueCTLServer: @unchecked Sendable {
             let targetNumber = (deployment["target_number"] as? Int) ?? (deployment["issue_number"] as? Int) ?? 0
             guard !hiddenPreviewIssueNumbers.contains(targetNumber) else { continue }
             let targetLabel = targetType == "pr" ? "PR #\(targetNumber)" : "issue #\(targetNumber)"
+            let lines = deployment["preview_lines"] as? [String] ?? [
+                "\(targetLabel): running checks",
+                targetNumber == 101 ? "pass: launch handoff" : "waiting for agent output",
+            ]
             previews[String(port)] = [
-                "lines": [
-                    "\(targetLabel): running checks",
-                    targetNumber == 101 ? "pass: launch handoff" : "waiting for agent output",
-                ],
+                "lines": lines,
                 "lastUpdatedMs": 1_777_800_000_000,
                 "lastChangedMs": 1_777_799_999_000,
-                "status": targetNumber == 102 ? "idle" : "active",
+                "status": deployment["preview_status"] as? String ?? (targetNumber == 102 ? "idle" : "active"),
             ]
         }
         return previews

--- a/apple/IssueCTLUITests/IssueCTLUITests.swift
+++ b/apple/IssueCTLUITests/IssueCTLUITests.swift
@@ -159,6 +159,30 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    func testAutomationParityFixtureShowsAvailableSessionStates() {
+        server.seedAutomationParitySessions()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("session-reenter-terminal-9401", existsIn: app, timeout: 8)
+        assertElement("session-reenter-terminal-9402", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9407", existsIn: app, timeout: 5)
+
+        XCTAssertTrue(
+            app.staticTexts["Running"].waitForExistence(timeout: 8),
+            "Manual active session state missing\n\(app.debugDescription)"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Idle"].waitForExistence(timeout: 5),
+            "Webhook idle session state missing\n\(app.debugDescription)"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Error"].waitForExistence(timeout: 5),
+            "Comment command error session state missing\n\(app.debugDescription)"
+        )
+    }
+
+    @MainActor
     func testRepoContextIsVisibleAcrossPrimaryTabs() {
         server.seedSecondRepo()
         server.seedActiveDeployment()

--- a/scripts/ios-ui-smoke.sh
+++ b/scripts/ios-ui-smoke.sh
@@ -52,6 +52,7 @@ FULL_TESTS=(
   "$UI_TEST_TARGET/IssueCTLUITests/testListToolbarActionsAreReachableFromTabs"
   "$UI_TEST_TARGET/IssueCTLUITests/testTodayActiveSessionsThumbButtonOpensSessions"
   "$UI_TEST_TARGET/IssueCTLUITests/testLaunchingIssueCanBeReenteredFromActiveSessions"
+  "$UI_TEST_TARGET/IssueCTLUITests/testAutomationParityFixtureShowsAvailableSessionStates"
   "$UI_TEST_TARGET/IssueCTLUITests/testMultipleLaunchedIssueSessionsRemainAvailableFromActiveSessions"
   "$UI_TEST_TARGET/IssueCTLUITests/testRunningIssueDetailShowsReentryInsteadOfLaunch"
 )


### PR DESCRIPTION
## Summary
- Add an automation parity workbench fixture for model decoding coverage.
- Seed MockServer with manual, webhook, and comment-command session states.
- Add a focused UI smoke test and include it in the iOS smoke script.

Closes #551.

## Verification
- `jq empty apple/IssueCTLTests/Fixtures/automation-parity-workbench.json`
- `bash -n scripts/ios-ui-smoke.sh`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:IssueCTLUITests/IssueCTLUITests/testAutomationParityFixtureShowsAvailableSessionStates`
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:IssueCTLTests/ModelDecodingTests/testAutomationParityWorkbenchFixtureDecoding`
- `git diff --check`

## Notes
- I accidentally ran the first model test concurrently with the UI test on the same simulator; that process was killed during bootstrap. Rerunning it alone passed.