### PR TITLE
[codex] Add iOS notification deep-link routing

### DIFF
--- a/apple/IssueCTL/App/ContentView.swift
+++ b/apple/IssueCTL/App/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @Environment(OfflineSyncService.self) private var offlineSync
     @State private var selectedTab: AppTab = .today
     @State private var showSettings = false
+    @State private var pendingRoute: AppRoute?
     private let launchNotificationSyncDelay: Duration = .seconds(1)
 
     init() {
@@ -40,12 +41,18 @@ struct ContentView: View {
                     }
                     .accessibilityIdentifier("board-tab")
                     Tab("Issues", systemImage: "list.bullet", value: AppTab.issues) {
-                        IssueListView(onShowSettings: { showSettings = true })
+                        IssueListView(
+                            onShowSettings: { showSettings = true },
+                            route: $pendingRoute
+                        )
                             .ignoresSafeArea(.container, edges: .bottom)
                     }
                     .accessibilityIdentifier("issues-tab")
                     Tab("PRs", systemImage: "arrow.triangle.merge", value: AppTab.pullRequests) {
-                        PRListView(onShowSettings: { showSettings = true })
+                        PRListView(
+                            onShowSettings: { showSettings = true },
+                            route: $pendingRoute
+                        )
                             .ignoresSafeArea(.container, edges: .bottom)
                     }
                     .accessibilityIdentifier("prs-tab")
@@ -94,9 +101,13 @@ struct ContentView: View {
             Task { await offlineSync.syncPendingActions() }
         }
         .onOpenURL { url in
-            guard let setup = SetupLink(url: url) else { return }
-            try? api.configure(url: setup.serverURL, token: setup.token)
-            Task { await notificationSettings.syncRegistration(apiClient: api) }
+            if let setup = SetupLink(url: url) {
+                try? api.configure(url: setup.serverURL, token: setup.token)
+                Task { await notificationSettings.syncRegistration(apiClient: api) }
+                return
+            }
+            guard let route = AppRoute(url: url) else { return }
+            handle(route)
         }
         .task {
             try? await Task.sleep(for: launchNotificationSyncDelay)
@@ -111,6 +122,30 @@ struct ContentView: View {
             guard let token = notification.userInfo?["token"] as? String else { return }
             notificationSettings.updateDeviceToken(token)
             Task { await notificationSettings.syncRegistration(apiClient: api) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .notificationResponseReceived)) { notification in
+            guard let route = AppRoute(notificationUserInfo: notification.userInfo ?? [:]) else { return }
+            handle(route)
+        }
+    }
+
+    private func handle(_ route: AppRoute) {
+        switch route {
+        case .issue:
+            selectedTab = .issues
+            pendingRoute = route
+        case .pullRequest:
+            selectedTab = .pullRequests
+            pendingRoute = route
+        case .board:
+            selectedTab = .board
+            pendingRoute = nil
+        case .sessions:
+            selectedTab = .active
+            pendingRoute = nil
+        case .reviews:
+            selectedTab = .today
+            pendingRoute = nil
         }
     }
 }

--- a/apple/IssueCTL/App/IssueCTLApp.swift
+++ b/apple/IssueCTL/App/IssueCTLApp.swift
@@ -1,11 +1,21 @@
 import SwiftUI
 import UIKit
+import UserNotifications
 
 extension Notification.Name {
     static let apnsDeviceTokenReceived = Notification.Name("issuectl.apnsDeviceTokenReceived")
+    static let notificationResponseReceived = Notification.Name("issuectl.notificationResponseReceived")
 }
 
-final class AppDelegate: NSObject, UIApplicationDelegate {
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
     func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
@@ -27,6 +37,19 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             object: nil,
             userInfo: ["error": error.localizedDescription]
         )
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        NotificationCenter.default.post(
+            name: .notificationResponseReceived,
+            object: nil,
+            userInfo: response.notification.request.content.userInfo
+        )
+        completionHandler()
     }
 }
 

--- a/apple/IssueCTL/Services/SetupLink.swift
+++ b/apple/IssueCTL/Services/SetupLink.swift
@@ -21,3 +21,59 @@ struct SetupLink: Equatable, Sendable {
         self.token = token
     }
 }
+
+enum AppRoute: Equatable, Sendable {
+    case issue(owner: String, repo: String, number: Int)
+    case pullRequest(owner: String, repo: String, number: Int)
+    case sessions
+    case reviews
+    case board
+
+    init?(url: URL) {
+        let components = Self.pathComponents(from: url)
+        guard let first = components.first else { return nil }
+
+        switch first {
+        case "issues":
+            guard let target = Self.repoTarget(from: components) else { return nil }
+            self = .issue(owner: target.owner, repo: target.repo, number: target.number)
+        case "pulls":
+            guard let target = Self.repoTarget(from: components) else { return nil }
+            self = .pullRequest(owner: target.owner, repo: target.repo, number: target.number)
+        case "sessions":
+            self = .sessions
+        case "reviews":
+            self = .reviews
+        case "workbench", "board":
+            self = .board
+        default:
+            return nil
+        }
+    }
+
+    init?(notificationUserInfo userInfo: [AnyHashable: Any]) {
+        guard let urlString = userInfo["url"] as? String,
+              let url = URL(string: urlString) else {
+            return nil
+        }
+        self.init(url: url)
+    }
+
+    private static func pathComponents(from url: URL) -> [String] {
+        var components: [String] = []
+        if let host = url.host, !host.isEmpty {
+            components.append(host)
+        }
+        components.append(contentsOf: url.pathComponents.filter { $0 != "/" })
+        return components.map { $0.removingPercentEncoding ?? $0 }
+    }
+
+    private static func repoTarget(from components: [String]) -> (owner: String, repo: String, number: Int)? {
+        guard components.count == 4,
+              let number = Int(components[3]),
+              number > 0 else {
+            return nil
+        }
+        return (components[1], components[2], number)
+    }
+}

--- a/apple/IssueCTL/Views/Issues/IssueListView.swift
+++ b/apple/IssueCTL/Views/Issues/IssueListView.swift
@@ -5,6 +5,7 @@ struct IssueListView: View {
     @Environment(NetworkMonitor.self) private var network
     @Environment(OfflineSyncService.self) private var offlineSync
     let onShowSettings: () -> Void
+    @Binding private var route: AppRoute?
 
     @State private var repos: [Repo] = []
     @State private var issuesByRepo: [String: [GitHubIssue]] = [:]
@@ -55,6 +56,11 @@ struct IssueListView: View {
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
     private typealias RepoIssueLoadResult = (fullName: String, name: String, issues: [GitHubIssue]?, cachedAt: String?, fromCache: Bool, error: Error?)
+
+    init(onShowSettings: @escaping () -> Void, route: Binding<AppRoute?> = .constant(nil)) {
+        self.onShowSettings = onShowSettings
+        _route = route
+    }
 
     private func isRunning(_ issue: GitHubIssue, in repoFullName: String) -> Bool {
         runningDeployment(for: issue, in: repoFullName, deployments: activeDeployments) != nil
@@ -375,6 +381,10 @@ struct IssueListView: View {
                 if let s = IssueSection(rawValue: storedSection) { section = s }
                 if let s = SortOrder(rawValue: storedSortOrder) { sortOrder = s }
                 mineOnly = storedMineOnly
+                consumeRouteIfNeeded(route)
+            }
+            .onChange(of: route) { _, newRoute in
+                consumeRouteIfNeeded(newRoute)
             }
             .onChange(of: section) { _, new in
                 displayLimit = pageSize
@@ -722,6 +732,13 @@ struct IssueListView: View {
         selectedRepoIds.removeAll()
         sortOrder = .updated
         mineOnly = false
+    }
+
+    private func consumeRouteIfNeeded(_ route: AppRoute?) {
+        guard case let .issue(owner, repo, number) = route else { return }
+        navigationPath = NavigationPath()
+        navigationPath.append(IssueDestination(owner: owner, repo: repo, number: number))
+        self.route = nil
     }
 
     private func prepareLaunch(owner: String, repo: String, number: Int, title: String) async {

--- a/apple/IssueCTL/Views/PullRequests/PRListView.swift
+++ b/apple/IssueCTL/Views/PullRequests/PRListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PRListView: View {
     @Environment(APIClient.self) private var api
     let onShowSettings: () -> Void
+    @Binding private var route: AppRoute?
 
     @State private var repos: [Repo] = []
     @State private var pullsByRepo: [String: [GitHubPull]] = [:]
@@ -36,6 +37,11 @@ struct PRListView: View {
     @FocusState private var isSearchFocused: Bool
     @State private var lastRefreshDate: Date?
     private let refreshCooldown: TimeInterval = 10
+
+    init(onShowSettings: @escaping () -> Void, route: Binding<AppRoute?> = .constant(nil)) {
+        self.onShowSettings = onShowSettings
+        _route = route
+    }
 
     private var repoFilteredPulls: [GitHubPull] {
         filterItemsByRepo(
@@ -251,6 +257,10 @@ struct PRListView: View {
                 if let s = PRSection(rawValue: storedSection) { section = s }
                 if let s = SortOrder(rawValue: storedSortOrder) { sortOrder = s }
                 mineOnly = storedMineOnly
+                consumeRouteIfNeeded(route)
+            }
+            .onChange(of: route) { _, newRoute in
+                consumeRouteIfNeeded(newRoute)
             }
             .onChange(of: section) { _, new in
                 displayLimit = pageSize
@@ -480,6 +490,13 @@ struct PRListView: View {
         selectedRepoIds.removeAll()
         sortOrder = .updated
         mineOnly = false
+    }
+
+    private func consumeRouteIfNeeded(_ route: AppRoute?) {
+        guard case let .pullRequest(owner, repo, number) = route else { return }
+        navigationPath = NavigationPath()
+        navigationPath.append(PRDestination(owner: owner, repo: repo, number: number))
+        self.route = nil
     }
 
     private func mergePull(owner: String, repo: String, number: Int, strategy: String) async {

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -5,6 +5,42 @@ final class ViewLogicTests: XCTestCase {
 
     // MARK: - iOS Setup Links
 
+    func testAppRouteParsesIssuePath() throws {
+        let url = try XCTUnwrap(URL(string: "/issues/mean-weasel/issuectl/550"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .issue(owner: "mean-weasel", repo: "issuectl", number: 550))
+    }
+
+    func testAppRouteParsesPullRequestPath() throws {
+        let url = try XCTUnwrap(URL(string: "/pulls/mean-weasel/issuectl/44"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .pullRequest(owner: "mean-weasel", repo: "issuectl", number: 44))
+    }
+
+    func testAppRouteParsesCustomSchemeTargetURL() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl://issues/mean-weasel/issuectl/550"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .issue(owner: "mean-weasel", repo: "issuectl", number: 550))
+    }
+
+    func testAppRouteParsesNotificationURLPayload() throws {
+        let route = try XCTUnwrap(AppRoute(notificationUserInfo: [
+            "url": "/pulls/mean-weasel/issuectl/44",
+        ]))
+
+        XCTAssertEqual(route, .pullRequest(owner: "mean-weasel", repo: "issuectl", number: 44))
+    }
+
+    func testAppRouteFallsBackForFuturePaths() throws {
+        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/sessions?repo=mean-weasel%2Fissuectl"))), .sessions)
+        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/reviews/review-123"))), .reviews)
+        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/workbench/kanban"))), .board)
+        XCTAssertNil(AppRoute(url: try XCTUnwrap(URL(string: "/settings"))))
+    }
+
     func testSetupLinkParsesServerURLAndToken() throws {
         let url = try XCTUnwrap(URL(string: "issuectl://setup?serverURL=http%3A%2F%2F192.0.2.10%3A3847&token=abc123"))
         let setup = try XCTUnwrap(SetupLink(url: url))


### PR DESCRIPTION
## Summary
- Add app route parsing for issue and PR targets, including custom-scheme and notification payload URLs.
- Relay notification tap URLs through the app shell.
- Consume pending issue/PR routes from the list screens and preserve graceful fallback for future route types.

Closes #550.

## Verification
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:IssueCTLTests/ViewLogicTests`
- `git diff --check`