### PR TITLE
[codex] Show iOS PR review session provenance

### DIFF
--- a/apple/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/apple/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -19,6 +19,8 @@ struct PRDetailView: View {
     @State private var repoAutomation: Repo?
     @State private var automationWebhookHealth: WebhookAutomationHealth?
     @State private var isTogglingAutomationLabel = false
+    @State private var activeReviewDeployments: [ActiveDeployment] = []
+    @State private var terminalPresentation: PRTerminalPresentation?
 
     var body: some View {
         Group {
@@ -44,6 +46,9 @@ struct PRDetailView: View {
                         VStack(alignment: .leading, spacing: 20) {
                             headerSection(detail.pull)
                             branchSection(detail.pull)
+                            if !activeReviewDeployments.isEmpty {
+                                activeReviewSessionSection(activeReviewDeployments)
+                            }
                             reviewStatusSection(detail)
                             automationLabelSection(detail.pull)
                             bodySection(detail.pull)
@@ -101,6 +106,22 @@ struct PRDetailView: View {
             Button("Merge Commit") { Task { await merge(method: "merge") } }
             Button("Squash and Merge") { Task { await merge(method: "squash") } }
             Button("Rebase and Merge") { Task { await merge(method: "rebase") } }
+        }
+        .fullScreenCover(item: $terminalPresentation) { presentation in
+            let deployment = presentation.deployment
+            if let port = deployment.ttydPort {
+                TerminalView(
+                    deployment: deployment,
+                    port: port,
+                    onClose: {
+                        terminalPresentation = nil
+                    },
+                    onEnd: {
+                        terminalPresentation = nil
+                        activeReviewDeployments.removeAll { $0.id == deployment.id }
+                    }
+                )
+            }
         }
     }
 
@@ -179,6 +200,26 @@ struct PRDetailView: View {
                 }
             )
             .accessibilityIdentifier("pr-detail-review-status-card")
+        }
+    }
+
+    private func activeReviewSessionSection(_ deployments: [ActiveDeployment]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Divider()
+            PRDetailSectionHeader(
+                title: deployments.count == 1 ? "Active Review Session" : "Active Review Sessions",
+                systemImage: "terminal"
+            )
+
+            ForEach(deployments) { deployment in
+                PRReviewSessionCard(
+                    deployment: deployment,
+                    onOpenTerminal: {
+                        guard deployment.ttydPort != nil else { return }
+                        terminalPresentation = PRTerminalPresentation(deployment: deployment)
+                    }
+                )
+            }
         }
     }
 
@@ -443,6 +484,10 @@ struct PRDetailView: View {
                 do { return .success(try await api.webhookHealth(owner: owner, repo: repo)) }
                 catch { return .failure(error) }
             }()
+            async let deploymentsResult: Result<ActiveDeploymentsResponse, Error> = {
+                do { return .success(try await api.activeDeployments(refresh: refresh)) }
+                catch { return .failure(error) }
+            }()
 
             detail = try await detailResult
             switch await reposResult {
@@ -456,6 +501,13 @@ struct PRDetailView: View {
                 automationWebhookHealth = health
             case .failure:
                 automationWebhookHealth = nil
+            }
+            switch await deploymentsResult {
+            case .success(let response):
+                activeReviewDeployments = response.deployments
+                    .filter { $0.matchesPullRequest(owner: owner, repo: repo, number: number) }
+            case .failure:
+                activeReviewDeployments = []
             }
         } catch {
             errorMessage = error.localizedDescription
@@ -531,6 +583,11 @@ struct PRDetailView: View {
 }
 
 // MARK: - Supporting Views
+
+private struct PRTerminalPresentation: Identifiable {
+    let id = UUID()
+    let deployment: ActiveDeployment
+}
 
 private struct PRDetailSectionHeader: View {
     let title: String
@@ -631,6 +688,62 @@ private struct PRStatusActionCard: View {
         .buttonBorderShape(dynamicTypeSize.isAccessibilitySize ? .roundedRectangle : .circle)
         .tint(primaryTint)
         .accessibilityLabel(primaryTitle)
+    }
+}
+
+private struct PRReviewSessionCard: View {
+    let deployment: ActiveDeployment
+    let onOpenTerminal: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(IssueCTLColors.action)
+                    .frame(width: 30, height: 30)
+                    .background(IssueCTLColors.action.opacity(0.12), in: RoundedRectangle(cornerRadius: IssueCTLColors.iconCornerRadius))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(deployment.sessionRoleTitle)
+                            .font(.subheadline.weight(.semibold))
+                        Text(deployment.targetLabel)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(IssueCTLColors.action)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(IssueCTLColors.action.opacity(0.12), in: Capsule())
+                    }
+                    Text(deployment.provenanceSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    Text(deployment.workspaceSummary)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            Button(action: onOpenTerminal) {
+                Label(deployment.ttydPort == nil ? "Starting..." : "Open Terminal", systemImage: "terminal")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity, minHeight: 40)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(IssueCTLColors.action.opacity(deployment.ttydPort == nil ? 0.5 : 1))
+            .disabled(deployment.ttydPort == nil)
+            .accessibilityIdentifier("pr-review-session-open-\(deployment.id)")
+        }
+        .padding(12)
+        .background(IssueCTLColors.cardBackground, in: RoundedRectangle(cornerRadius: IssueCTLColors.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: IssueCTLColors.cardCornerRadius)
+                .stroke(IssueCTLColors.hairline, lineWidth: 0.5)
+        }
     }
 }
 

--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -607,9 +607,12 @@ private struct SessionControlsSheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 3) {
-                Text("\(deployment.targetLabel) Session")
+                Text(deployment.sessionRoleTitle)
                     .font(.title2.weight(.bold))
-                Text(deployment.repoFullName)
+                Text("\(deployment.repoFullName) \(deployment.targetLabel)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(deployment.provenanceSummary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/apple/IssueCTL/Views/Sessions/SessionRowView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionRowView.swift
@@ -33,6 +33,16 @@ struct SessionRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
 
+            VStack(alignment: .leading, spacing: 4) {
+                Label(deployment.sessionRoleTitle, systemImage: deployment.isIssueTarget ? "number" : "arrow.triangle.merge")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(deployment.provenanceSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
             HStack(spacing: 10) {
                 sessionMetric(value: deployment.runningDuration, label: "Duration", systemImage: "clock")
 

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -45,6 +45,17 @@ enum DeploymentTrigger: String, Codable, Sendable {
     case manual
     case webhook
     case commentCommand = "comment_command"
+
+    var displayName: String {
+        switch self {
+        case .manual:
+            return "Manual"
+        case .webhook:
+            return "Webhook"
+        case .commentCommand:
+            return "Comment command"
+        }
+    }
 }
 
 enum TerminalBackend: String, Codable, Sendable {
@@ -203,6 +214,55 @@ struct ActiveDeployment: Codable, Identifiable, Sendable {
 
     var isIssueTarget: Bool {
         targetType == .issue
+    }
+
+    var sessionRoleTitle: String {
+        if targetType == .pr && terminalReason == "review" {
+            return "PR review session"
+        }
+        switch targetType {
+        case .issue:
+            return "Issue session"
+        case .pr:
+            return "PR session"
+        }
+    }
+
+    var provenanceSummary: String {
+        var parts: [String] = []
+        if let triggeredBy {
+            parts.append(triggeredBy.displayName)
+        } else {
+            parts.append("Unknown trigger")
+        }
+        if let agent {
+            parts.append(agent.displayName)
+        }
+        if let parentDeploymentId {
+            parts.append("follow-up #\(parentDeploymentId)")
+        }
+        if let webhookDepth, webhookDepth > 0 {
+            parts.append("depth \(webhookDepth)")
+        }
+        return parts.joined(separator: " - ")
+    }
+
+    var workspaceSummary: String {
+        switch terminalBackend {
+        case .ptyBridge:
+            return "\(branchName) - PTY bridge"
+        case .ttyd:
+            return "\(branchName) - ttyd"
+        case nil:
+            return branchName
+        }
+    }
+
+    func matchesPullRequest(owner: String, repo: String, number: Int) -> Bool {
+        targetType == .pr
+            && targetNumber == number
+            && self.owner == owner
+            && repoName == repo
     }
 
     var launchedDate: Date? {

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -703,6 +703,42 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertFalse(deployment.isIssueTarget)
     }
 
+    func testActiveDeploymentReviewSessionPresentationIncludesProvenance() throws {
+        let json = """
+        {
+            "id": 6,
+            "repo_id": 42,
+            "issue_number": null,
+            "target_type": "pr",
+            "target_number": 44,
+            "agent": "codex",
+            "terminal_backend": "pty_bridge",
+            "triggered_by": "comment_command",
+            "terminal_reason": "review",
+            "parent_deployment_id": 5,
+            "webhook_depth": 2,
+            "idle_since": null,
+            "branch_name": "feature/webhook-review",
+            "workspace_mode": "worktree",
+            "workspace_path": "/tmp/wt",
+            "linked_pr_number": null,
+            "state": "active",
+            "launched_at": "2026-04-27T06:00:00Z",
+            "ended_at": null,
+            "ttyd_port": 7684,
+            "ttyd_pid": 1000,
+            "owner": "neonwatty",
+            "repo_name": "issuectl"
+        }
+        """.data(using: .utf8)!
+
+        let deployment = try decoder.decode(ActiveDeployment.self, from: json)
+        XCTAssertEqual(deployment.sessionRoleTitle, "PR review session")
+        XCTAssertEqual(deployment.provenanceSummary, "Comment command - Codex - follow-up #5 - depth 2")
+        XCTAssertTrue(deployment.matchesPullRequest(owner: "neonwatty", repo: "issuectl", number: 44))
+        XCTAssertFalse(deployment.matchesPullRequest(owner: "neonwatty", repo: "issuectl", number: 45))
+    }
+
     func testActiveDeploymentsResponseDecoding() throws {
         let json = """
         {

--- a/apple/IssueCTLUITests/PRBrowseTests.swift
+++ b/apple/IssueCTLUITests/PRBrowseTests.swift
@@ -44,6 +44,20 @@ final class PRBrowseTests: XCTestCase {
     }
 
     @MainActor
+    func testPRDetailShowsActiveReviewSessionProvenance() {
+        server.seedPullRequestDeployment()
+        let app = launchApp(server: server)
+
+        tapMainTab("prs-tab", label: "PRs", in: app)
+        assertElement("pr-row-7", existsIn: app, timeout: 8)
+        element("pr-row-7", in: app).tap()
+
+        XCTAssertTrue(app.staticTexts["Active Review Session"].waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Webhook - Codex - depth 1"].waitForExistence(timeout: 5), app.debugDescription)
+        assertElement("pr-review-session-open-9507", existsIn: app, timeout: 5)
+    }
+
+    @MainActor
     func testPRAutoReviewLabelControlTogglesAutomationLabel() {
         let app = launchApp(server: server)
 


### PR DESCRIPTION
## Summary
- Add ActiveDeployment presentation helpers for review-session role, provenance, workspace, and PR-target matching.
- Show provenance in session rows/controls so issue and PR review sessions are easier to distinguish.
- Add an active review-session card to PR detail when a matching deployment is active.

Closes #547.

## Verification
- `xcodebuild build-for-testing -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator' -only-testing:IssueCTLTests/ModelDecodingTests/testActiveDeploymentReviewSessionPresentationIncludesProvenance -only-testing:IssueCTLUITests/PRBrowseTests/testPRDetailShowsActiveReviewSessionProvenance`
- `git diff --check`

## Notes
- Rich historical review-run navigation should land after the contract/API PRs (#553 and #554). This slice uses currently available active deployment data.