### PR TITLE
[codex] Add iOS session diagnostics browser

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -17,6 +17,7 @@ struct SessionListView: View {
     @State private var isShowingCachedDeployments = false
     @State private var terminalPresentation: TerminalPresentation?
     @State private var sessionControlsTarget: ActiveDeployment?
+    @State private var diagnosticsTarget: ActiveDeployment?
     @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
     @State private var navigationPath = NavigationPath()
@@ -227,6 +228,10 @@ struct SessionListView: View {
                             ))
                         }
                     },
+                    onViewDiagnostics: {
+                        sessionControlsTarget = nil
+                        diagnosticsTarget = deployment
+                    },
                     onEnd: {
                         Task {
                             await endSession(deployment)
@@ -234,8 +239,13 @@ struct SessionListView: View {
                         }
                     }
                 )
-                .presentationDetents([.height(330), .medium])
+                .presentationDetents([.height(390), .medium])
                 .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $diagnosticsTarget) { deployment in
+                DeploymentDiagnosticsSheet(deployment: deployment)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
             }
             .sheet(isPresented: $showCreateSheet) {
                 QuickCreateSheet(repos: repos, onSuccess: { warning in
@@ -602,6 +612,7 @@ private struct SessionControlsSheet: View {
     let isEnding: Bool
     let onOpenTerminal: () -> Void
     let onViewTarget: () -> Void
+    let onViewDiagnostics: () -> Void
     let onEnd: () -> Void
 
     var body: some View {
@@ -637,6 +648,16 @@ private struct SessionControlsSheet: View {
                     systemImage: deployment.isIssueTarget ? "number" : "arrow.triangle.merge",
                     accessibilityIdentifier: "session-target-action-\(deployment.id)",
                     action: onViewTarget
+                )
+
+                Divider()
+
+                sheetAction(
+                    title: "View Diagnostics",
+                    subtitle: "Browse launch and session lifecycle events.",
+                    systemImage: "waveform.path.ecg",
+                    accessibilityIdentifier: "session-diagnostics-\(deployment.id)",
+                    action: onViewDiagnostics
                 )
 
                 Divider()
@@ -701,4 +722,247 @@ private struct SessionControlsSheet: View {
         .opacity(isDisabled ? 0.55 : 1)
         .accessibilityIdentifier(accessibilityIdentifier)
     }
+}
+
+private struct DeploymentDiagnosticsSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+
+    let deployment: ActiveDeployment
+
+    @State private var response: DeploymentDiagnosticsResponse?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    init(deployment: ActiveDeployment, initialResponse: DeploymentDiagnosticsResponse? = nil) {
+        self.deployment = deployment
+        _response = State(initialValue: initialResponse)
+        _isLoading = State(initialValue: initialResponse == nil)
+    }
+
+    private var diagnosticsCommand: String {
+        "pnpm --dir packages/cli exec issuectl diag show --deployment \(deployment.id)"
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    header
+
+                    if isLoading && response == nil {
+                        ProgressView("Loading diagnostics...")
+                            .frame(maxWidth: .infinity, minHeight: 160)
+                    } else if let errorMessage, response == nil {
+                        unavailableState(errorMessage)
+                    } else if let response {
+                        diagnosticsContent(response)
+                    }
+                }
+                .padding(16)
+            }
+            .navigationTitle("Diagnostics")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task(id: deployment.id) {
+                await load()
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Label(deployment.targetLabel, systemImage: deployment.isIssueTarget ? "number" : "arrow.triangle.merge")
+                    .font(.headline)
+                Spacer(minLength: 8)
+                Text("Deployment #\(deployment.id)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(deployment.repoFullName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("CLI fallback")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(diagnosticsCommand)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .lineLimit(3)
+                    .accessibilityIdentifier("deployment-diagnostics-command-\(deployment.id)")
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .padding(14)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func diagnosticsContent(_ response: DeploymentDiagnosticsResponse) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if response.fromCache {
+                OfflineStatusBanner(message: staleDataMessage(kind: "diagnostics", cachedAt: response.cachedAt.flatMap(parseIssueCTLDate)))
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: response.firstFailure == nil ? "checkmark.circle" : "exclamationmark.triangle")
+                    .foregroundStyle(response.firstFailure == nil ? Color.green : Color.orange)
+                Text(response.summaryText)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+
+            if response.events.isEmpty {
+                ContentUnavailableView {
+                    Label("No Events", systemImage: "list.bullet.rectangle")
+                } description: {
+                    Text("No launch or session diagnostics have been recorded for this deployment yet.")
+                }
+                .frame(maxWidth: .infinity, minHeight: 160)
+            } else {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(response.events) { event in
+                        DiagnosticEventCard(event: event)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(4)
+            }
+        }
+    }
+
+    private func unavailableState(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ContentUnavailableView {
+                Label("Diagnostics Unavailable", systemImage: "waveform.path.ecg")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Retry") {
+                    Task { await load() }
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 220)
+
+            Text(mobileDiagnosticsDependencyMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard response == nil else { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            response = try await api.deploymentDiagnostics(deploymentId: deployment.id)
+        } catch {
+            errorMessage = diagnosticsErrorMessage(error)
+        }
+        isLoading = false
+    }
+}
+
+private struct DiagnosticEventCard: View {
+    let event: DiagnosticEvent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: event.level.systemImage)
+                    .foregroundStyle(levelColor)
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(event.event)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(2)
+                    Text("\(event.timeText) - \(event.source)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(event.level.displayName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(levelColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(levelColor.opacity(0.14), in: Capsule())
+            }
+
+            if let message = event.message, !message.isEmpty {
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if !event.metadataRows.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(Array(event.metadataRows.enumerated()), id: \.offset) { row in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(row.element.0)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                                .frame(width: 92, alignment: .leading)
+                            Text(row.element.1)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.primary)
+                                .lineLimit(3)
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+                .padding(10)
+                .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10))
+            }
+        }
+        .padding(12)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(levelColor.opacity(event.isFailure ? 0.45 : 0.16), lineWidth: 1)
+        }
+        .accessibilityIdentifier("diagnostic-event-\(event.id)")
+    }
+
+    private var levelColor: Color {
+        switch event.level {
+        case .debug: Color.secondary
+        case .info: IssueCTLColors.action
+        case .warn: Color.orange
+        case .error: Color.red
+        }
+    }
+}
+
+private let mobileDiagnosticsDependencyMessage = "Live mobile diagnostics require the structured /api/v1/diagnostics/deployments/:id endpoint from issue #546. This iOS browser is wired for that JSON API and does not scrape dashboard HTML."
+
+private func diagnosticsErrorMessage(_ error: Error) -> String {
+    if case APIError.serverError(let code, _) = error, code == 404 {
+        return "The connected issuectl server does not expose the mobile diagnostics endpoint yet."
+    }
+    return error.localizedDescription
 }

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -456,6 +456,161 @@ struct ActiveDeploymentsResponse: Codable, Sendable {
     }
 }
 
+// MARK: - Diagnostics
+
+extension DiagnosticLevel {
+    var displayName: String {
+        switch self {
+        case .debug: "Debug"
+        case .info: "Info"
+        case .warn: "Warning"
+        case .error: "Error"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .debug: "ladybug"
+        case .info: "info.circle"
+        case .warn: "exclamationmark.triangle"
+        case .error: "xmark.octagon"
+        }
+    }
+}
+
+extension JSONValue {
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var integerValue: Int? {
+        switch self {
+        case .int(let value):
+            value
+        case .double(let value):
+            Int(value)
+        default:
+            nil
+        }
+    }
+
+    var doubleValue: Double? {
+        switch self {
+        case .int(let value):
+            Double(value)
+        case .double(let value):
+            value
+        default:
+            nil
+        }
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    var displayValue: String {
+        switch self {
+        case .string(let value):
+            value
+        case .int(let value):
+            String(value)
+        case .double(let value):
+            value.rounded() == value ? String(Int(value)) : String(value)
+        case .bool(let value):
+            value ? "true" : "false"
+        case .object(let value):
+            "\(value.count) fields"
+        case .array(let value):
+            "\(value.count) items"
+        case .null:
+            "null"
+        }
+    }
+}
+
+extension DiagnosticEvent {
+    var occurredAt: Date {
+        let rawTimestamp = Double(timestamp)
+        let seconds = rawTimestamp > 10_000_000_000 ? rawTimestamp / 1000 : rawTimestamp
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    var timeText: String {
+        DateFormatter.localizedString(from: occurredAt, dateStyle: .none, timeStyle: .medium)
+    }
+
+    var targetLabel: String? {
+        guard let targetType, let targetNumber else { return nil }
+        switch targetType {
+        case .issue: return "#\(targetNumber)"
+        case .pr: return "PR #\(targetNumber)"
+        }
+    }
+
+    var isFailure: Bool {
+        level == .error
+            || event.contains("failed")
+            || event.contains("missing")
+            || status?.lowercased() == "failed"
+    }
+
+    var metadataRows: [(String, String)] {
+        var rows: [(String, String)] = []
+        if let status { rows.append(("Status", status)) }
+        if let correlationId { rows.append(("Correlation", correlationId)) }
+        if let sessionName { rows.append(("Session", sessionName)) }
+        if let ttydPort { rows.append(("ttyd port", "\(ttydPort)")) }
+        if let ttydPid { rows.append(("ttyd pid", "\(ttydPid)")) }
+        if let data {
+            for key in data.keys.sorted() {
+                if let value = data[key] {
+                    rows.append((key, value.displayValue))
+                }
+            }
+        }
+        return rows
+    }
+}
+
+struct DeploymentDiagnosticsResponse: Codable, Sendable {
+    let events: [DiagnosticEvent]
+    let fromCache: Bool
+    let cachedAt: String?
+
+    init(events: [DiagnosticEvent], fromCache: Bool = false, cachedAt: String? = nil) {
+        self.events = events
+        self.fromCache = fromCache
+        self.cachedAt = cachedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        events = try container.decode([DiagnosticEvent].self, forKey: .events)
+        fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
+        cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case events, fromCache, cachedAt
+    }
+
+    var firstFailure: DiagnosticEvent? {
+        events.first(where: \.isFailure)
+    }
+
+    var summaryText: String {
+        guard !events.isEmpty else { return "No diagnostic events recorded yet" }
+        let countLabel = events.count == 1 ? "1 diagnostic event" : "\(events.count) diagnostic events"
+        if let firstFailure {
+            return "\(countLabel), first failure: \(firstFailure.event)"
+        }
+        return "\(countLabel), no failure recorded"
+    }
+}
+
 enum SessionPreviewStatus: String, Codable, Sendable {
     case active
     case idle

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -371,6 +371,14 @@ final class APIClient {
         return try decoder.decode(DiagnosticsResponse.self, from: data)
     }
 
+    func deploymentDiagnostics(deploymentId: Int, limit: Int = 50) async throws -> DeploymentDiagnosticsResponse {
+        // Depends on the mobile diagnostics API from issue #546. This client
+        // intentionally targets structured JSON instead of scraping web HTML.
+        let safeLimit = max(1, min(200, limit))
+        let (data, _) = try await request(path: "/api/v1/diagnostics/deployments/\(deploymentId)?limit=\(safeLimit)")
+        return try decoder.decode(DeploymentDiagnosticsResponse.self, from: data)
+    }
+
     func agentMutation(body: AgentMutationRequestBody) async throws -> AgentMutationDecision {
         let bodyData = try JSONEncoder().encode(body)
         let (data, _) = try await request(path: "/api/v1/agent/mutations", method: "POST", body: bodyData)

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -277,6 +277,12 @@ final class TestableAPIClient {
         return try decoder.decode(DiagnosticsResponse.self, from: data)
     }
 
+    func deploymentDiagnostics(deploymentId: Int, limit: Int = 50) async throws -> DeploymentDiagnosticsResponse {
+        let safeLimit = max(1, min(200, limit))
+        let (data, _) = try await request(path: "/api/v1/diagnostics/deployments/\(deploymentId)?limit=\(safeLimit)")
+        return try decoder.decode(DeploymentDiagnosticsResponse.self, from: data)
+    }
+
     func agentMutation(body: AgentMutationRequestBody) async throws -> AgentMutationDecision {
         let bodyData = try JSONEncoder().encode(body)
         let (data, _) = try await request(path: "/api/v1/agent/mutations", method: "POST", body: bodyData)
@@ -510,6 +516,23 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.diagnostics(deploymentId: 42)
+    }
+
+    @MainActor
+    func testDeploymentDiagnosticsEndpointURL() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/diagnostics/deployments/9001"))
+            XCTAssertEqual(request.url?.query, "limit=25")
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {"events": [], "from_cache": false, "cached_at": null}
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        _ = try await client.deploymentDiagnostics(deploymentId: 9001, limit: 25)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -626,6 +626,83 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertNil(deployment.ttydPid)
     }
 
+    // MARK: - Diagnostics
+
+    func testDeploymentDiagnosticsResponseDecoding() throws {
+        let json = """
+        {
+            "events": [
+                {
+                    "id": 101,
+                    "timestamp": 1778760000000,
+                    "level": "info",
+                    "event": "launch.requested",
+                    "source": "core.launch",
+                    "correlation_id": "launch-abc",
+                    "owner": "org",
+                    "repo": "alpha",
+                    "issue_number": 42,
+                    "target_type": "issue",
+                    "target_number": 42,
+                    "deployment_id": 9001,
+                    "session_name": "issuectl-alpha-42",
+                    "ttyd_port": null,
+                    "ttyd_pid": null,
+                    "status": "starting",
+                    "message": "Launch requested.",
+                    "data": {"agent": "codex", "attempt": 1}
+                },
+                {
+                    "id": 102,
+                    "timestamp": 1778760002500,
+                    "level": "error",
+                    "event": "launch.spawn_failed",
+                    "source": "core.launch",
+                    "correlation_id": "launch-abc",
+                    "owner": "org",
+                    "repo": "alpha",
+                    "issue_number": 42,
+                    "target_type": "issue",
+                    "target_number": 42,
+                    "deployment_id": 9001,
+                    "session_name": "issuectl-alpha-42",
+                    "ttyd_port": 19001,
+                    "ttyd_pid": 333,
+                    "status": "failed",
+                    "message": "tmux failed to create session.",
+                    "data": {"exit_code": 1, "retryable": false}
+                }
+            ],
+            "from_cache": false,
+            "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DeploymentDiagnosticsResponse.self, from: json)
+
+        XCTAssertEqual(response.events.count, 2)
+        XCTAssertEqual(response.events[0].level, .info)
+        XCTAssertEqual(response.events[0].correlationId, "launch-abc")
+        XCTAssertEqual(response.events[0].targetType, .issue)
+        XCTAssertEqual(response.events[0].data?["agent"]?.stringValue, "codex")
+        XCTAssertEqual(response.events[0].data?["attempt"]?.integerValue, 1)
+        XCTAssertEqual(response.events[1].level, .error)
+        XCTAssertEqual(response.events[1].data?["retryable"]?.boolValue, false)
+        XCTAssertEqual(response.firstFailure?.event, "launch.spawn_failed")
+        XCTAssertEqual(response.summaryText, "2 diagnostic events, first failure: launch.spawn_failed")
+    }
+
+    func testDeploymentDiagnosticsEmptySummary() throws {
+        let json = """
+        {"events": [], "from_cache": false, "cached_at": null}
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DeploymentDiagnosticsResponse.self, from: json)
+
+        XCTAssertNil(response.firstFailure)
+        XCTAssertEqual(response.summaryText, "No diagnostic events recorded yet")
+    }
+
     // MARK: - ActiveDeployment
 
     func testActiveDeploymentDecoding() throws {


### PR DESCRIPTION
## Summary
- Add diagnostics event/summary models and API client support for deployment diagnostics.
- Add a session controls entry point and read-only diagnostics sheet for inspecting launch/session failures.
- Add fixture-driven decoding and API client coverage.

Closes #552.

## Verification
- `xcodebuild build-for-testing -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'generic/platform=iOS Simulator' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests`
- `git diff --check`

## Dependency
- This should land after the contract/model stack (#553 and #554), or be rebased onto those branches, because it overlaps diagnostics models and API client surface area.