### PR TITLE
Add live iOS diagnostics API routes

### DIFF
--- a/packages/web/app/api/v1/diagnostics/deployments/[id]/route.test.ts
+++ b/packages/web/app/api/v1/diagnostics/deployments/[id]/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const dbExists = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const queryDiagnosticEvents = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  dbExists: () => dbExists(),
+  getDb: () => getDb(),
+  queryDiagnosticEvents: (...args: unknown[]) => queryDiagnosticEvents(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  dbExists.mockReset();
+  getDb.mockReset();
+  queryDiagnosticEvents.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  dbExists.mockReturnValue(true);
+  getDb.mockReturnValue(db);
+  queryDiagnosticEvents.mockReturnValue([
+    {
+      id: 52,
+      timestamp: 1_779_000_000_500,
+      level: "error",
+      event: "ensure_ttyd.failed",
+      source: "terminal",
+      correlationId: "launch-1",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      issueNumber: 44,
+      targetType: "issue",
+      targetNumber: 44,
+      deploymentId: 701,
+      sessionName: "issuectl-701",
+      ttydPort: null,
+      ttydPid: null,
+      status: "failed",
+      message: "ttyd unavailable",
+      data: null,
+    },
+  ]);
+});
+
+describe("/api/v1/diagnostics/deployments/[id]", () => {
+  it("returns diagnostics for a deployment path with a clamped limit", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/diagnostics/deployments/701?limit=250"),
+      { params: Promise.resolve({ id: "701" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(queryDiagnosticEvents).toHaveBeenCalledWith(db, {
+      deploymentId: 701,
+      limit: 200,
+    });
+    expect(json).toEqual({
+      events: [
+        expect.objectContaining({
+          id: 52,
+          timestamp: 1_779_000_000_500,
+          timestampIso: "2026-05-17T06:40:00.500Z",
+          event: "ensure_ttyd.failed",
+          targetLabel: "Issue #44",
+          deploymentId: 701,
+        }),
+      ],
+      filters: {
+        deploymentId: 701,
+        targetType: null,
+        targetNumber: null,
+        limit: 200,
+      },
+      summary: {
+        count: 1,
+        levelCounts: { error: 1 },
+        latestTimestamp: 1_779_000_000_500,
+        latestTimestampIso: "2026-05-17T06:40:00.500Z",
+      },
+    });
+  });
+
+  it("rejects an invalid deployment id", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/diagnostics/deployments/not-a-number"),
+      { params: Promise.resolve({ id: "not-a-number" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Invalid deployment id" });
+    expect(queryDiagnosticEvents).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/diagnostics/deployments/701"),
+      { params: Promise.resolve({ id: "701" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(queryDiagnosticEvents).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts
+++ b/packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import {
+  deploymentDiagnosticsJson,
+  diagnosticsRouteError,
+  limitFromRequest,
+  parseDeploymentDiagnosticsParams,
+} from "@/lib/diagnostics-api";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+
+  try {
+    const parsed = parseDeploymentDiagnosticsParams(id, limitFromRequest(request));
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    return deploymentDiagnosticsJson(parsed.deploymentId, parsed.limit);
+  } catch (err) {
+    return diagnosticsRouteError(err, "api_deployment_diagnostics_failed");
+  }
+}

--- a/packages/web/app/api/v1/diagnostics/route.test.ts
+++ b/packages/web/app/api/v1/diagnostics/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const dbExists = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const queryDiagnosticEvents = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  dbExists: () => dbExists(),
+  getDb: () => getDb(),
+  queryDiagnosticEvents: (...args: unknown[]) => queryDiagnosticEvents(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  dbExists.mockReset();
+  getDb.mockReset();
+  queryDiagnosticEvents.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  dbExists.mockReturnValue(true);
+  getDb.mockReturnValue(db);
+  queryDiagnosticEvents.mockReturnValue([
+    {
+      id: 51,
+      timestamp: 1_779_000_000_000,
+      level: "warn",
+      event: "reconcile.tmux_missing",
+      source: "lifecycle",
+      correlationId: "launch-1",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      issueNumber: null,
+      targetType: "pr",
+      targetNumber: 44,
+      deploymentId: 701,
+      sessionName: "issuectl-701",
+      ttydPort: 7701,
+      ttydPid: null,
+      status: "ended",
+      message: "tmux session disappeared",
+      data: { sessionName: "issuectl-701" },
+    },
+  ]);
+});
+
+describe("/api/v1/diagnostics", () => {
+  it("returns deployment diagnostics for the iOS client contract", async () => {
+    const response = await GET(new NextRequest(
+      "http://localhost/api/v1/diagnostics?deploymentId=701&limit=5",
+    ));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(queryDiagnosticEvents).toHaveBeenCalledWith(db, {
+      deploymentId: 701,
+      limit: 5,
+    });
+    expect(json).toEqual({
+      events: [
+        expect.objectContaining({
+          id: 51,
+          timestamp: 1_779_000_000_000,
+          timestampIso: "2026-05-17T06:40:00.000Z",
+          event: "reconcile.tmux_missing",
+          targetLabel: "PR #44",
+          deploymentId: 701,
+        }),
+      ],
+      filters: {
+        deploymentId: 701,
+        targetType: null,
+        targetNumber: null,
+        limit: 5,
+      },
+      summary: {
+        count: 1,
+        levelCounts: { warn: 1 },
+        latestTimestamp: 1_779_000_000_000,
+        latestTimestampIso: "2026-05-17T06:40:00.000Z",
+      },
+    });
+  });
+
+  it("requires deploymentId", async () => {
+    const response = await GET(new NextRequest("http://localhost/api/v1/diagnostics"));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Missing deployment id" });
+    expect(queryDiagnosticEvents).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/v1/diagnostics?deploymentId=701"));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(queryDiagnosticEvents).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/diagnostics/route.ts
+++ b/packages/web/app/api/v1/diagnostics/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import {
+  deploymentDiagnosticsJson,
+  diagnosticsRouteError,
+  limitFromRequest,
+  parseDeploymentDiagnosticsParams,
+} from "@/lib/diagnostics-api";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  try {
+    const parsed = parseDeploymentDiagnosticsParams(
+      request.nextUrl.searchParams.get("deploymentId"),
+      limitFromRequest(request),
+    );
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    return deploymentDiagnosticsJson(parsed.deploymentId, parsed.limit);
+  } catch (err) {
+    return diagnosticsRouteError(err, "api_diagnostics_failed");
+  }
+}

--- a/packages/web/lib/diagnostics-api.ts
+++ b/packages/web/lib/diagnostics-api.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  dbExists,
+  formatErrorForUser,
+  getDb,
+  queryDiagnosticEvents,
+} from "@issuectl/core";
+import log from "@/lib/logger";
+import {
+  buildDiagnosticsPayload,
+  parseLimit,
+  parsePositiveInt,
+} from "@/lib/mobile-api-contracts";
+
+const DEFAULT_DIAGNOSTIC_LIMIT = 50;
+const MAX_DIAGNOSTIC_LIMIT = 200;
+
+export type DeploymentDiagnosticsParams =
+  | {
+      deploymentId: number;
+      limit: number;
+    }
+  | { error: string };
+
+export function parseDeploymentDiagnosticsParams(
+  deploymentIdValue: string | null,
+  limitValue: string | null,
+): DeploymentDiagnosticsParams {
+  const deploymentId = parsePositiveInt(deploymentIdValue);
+  if (deploymentId === null) return { error: "Missing deployment id" };
+  if (deploymentId === "invalid") return { error: "Invalid deployment id" };
+
+  return {
+    deploymentId,
+    limit: parseLimit(limitValue, DEFAULT_DIAGNOSTIC_LIMIT, MAX_DIAGNOSTIC_LIMIT),
+  };
+}
+
+export function deploymentDiagnosticsJson(deploymentId: number, limit: number): NextResponse {
+  const events = dbExists()
+    ? queryDiagnosticEvents(getDb(), { deploymentId, limit })
+    : [];
+
+  return NextResponse.json(buildDiagnosticsPayload({
+    events,
+    filters: {
+      deploymentId,
+      targetType: null,
+      targetNumber: null,
+      limit,
+    },
+  }));
+}
+
+export function diagnosticsRouteError(err: unknown, msg: string): NextResponse {
+  log.error({ err, msg });
+  return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+}
+
+export function limitFromRequest(request: NextRequest): string | null {
+  return request.nextUrl.searchParams.get("limit")
+    ?? request.nextUrl.searchParams.get("diagnosticLimit");
+}


### PR DESCRIPTION
## Summary
- adds authenticated `/api/v1/diagnostics?deploymentId=...` and `/api/v1/diagnostics/deployments/:id` routes for the iOS diagnostics browser
- reuses the mobile diagnostics payload builder and bounds `limit` to the iOS-safe range
- adds focused route tests for success, auth, missing/invalid deployment IDs, and limit clamping

Closes #560.

## Verification
- `pnpm --dir packages/web test -- 'app/api/v1/diagnostics/route.test.ts' 'app/api/v1/diagnostics/deployments/[id]/route.test.ts'`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- commit/push hooks ran turbo typecheck/lint successfully; push hook skipped build because a dev server is running on :3847
