### PR TITLE
Add repo-scoped automation list API routes

### DIFF
--- a/packages/web/app/api/v1/repos/[owner]/[repo]/review-runs/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/review-runs/route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const listPrReviewsForPull = vi.hoisted(() => vi.fn());
+const listPrReviewsForRepo = vi.hoisted(() => vi.fn());
+const listRecentTerminalDeploymentsByRepo = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  listPrReviewsForPull: (...args: unknown[]) => listPrReviewsForPull(...args),
+  listPrReviewsForRepo: (...args: unknown[]) => listPrReviewsForRepo(...args),
+  listRecentTerminalDeploymentsByRepo: (...args: unknown[]) => listRecentTerminalDeploymentsByRepo(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: "/tmp/issuectl",
+  branchPattern: null,
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-24T00:00:00.000Z",
+};
+
+function request(url = "http://localhost/api/v1/repos/mean-weasel/issuectl/review-runs"): NextRequest {
+  return new NextRequest(url);
+}
+
+function context(owner = "mean-weasel", repoName = "issuectl") {
+  return {
+    params: Promise.resolve({ owner, repo: repoName }),
+  };
+}
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getDb.mockReset();
+  getRepo.mockReset();
+  listPrReviewsForPull.mockReset();
+  listPrReviewsForRepo.mockReset();
+  listRecentTerminalDeploymentsByRepo.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue(db);
+  getRepo.mockReturnValue(repo);
+  listRecentTerminalDeploymentsByRepo.mockReturnValue([]);
+  listPrReviewsForPull.mockReturnValue([
+    {
+      id: 901,
+      repoId: 1,
+      prNumber: 44,
+      deploymentId: 701,
+      startedHeadSha: "aaaabbbbcccc",
+      completedHeadSha: "ddddeeeeffff",
+      reviewBaseSha: "111122223333",
+      reviewedFromSha: "444455556666",
+      reviewedToSha: "777788889999",
+      headRepoFullName: "mean-weasel/issuectl",
+      headRef: "feature/mobile-contracts",
+      status: "completed",
+      triggeredBy: "webhook",
+      resultJson: JSON.stringify({ summary: "found one issue", findings: [{ path: "a.ts" }] }),
+      startedAt: 1_779_000_000_000,
+      completedAt: 1_779_000_600_000,
+    },
+  ]);
+});
+
+describe("/api/v1/repos/[owner]/[repo]/review-runs", () => {
+  it("returns repo-scoped PR review runs in the iOS-decoded response shape", async () => {
+    const response = await GET(request(
+      "http://localhost/api/v1/repos/mean-weasel/issuectl/review-runs?pr=44&limit=12",
+    ), context());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getRepo).toHaveBeenCalledWith(db, "mean-weasel", "issuectl");
+    expect(listPrReviewsForPull).toHaveBeenCalledWith(db, 1, 44, 12);
+    expect(listPrReviewsForRepo).not.toHaveBeenCalled();
+    expect(json).toEqual(expect.objectContaining({
+      reviewRuns: [
+        expect.objectContaining({
+          id: 901,
+          repoId: 1,
+          prNumber: 44,
+          deploymentId: 701,
+          startedHeadSha: "aaaabbbbcccc",
+          completedHeadSha: "ddddeeeeffff",
+          reviewBaseSha: "111122223333",
+          reviewedFromSha: "444455556666",
+          reviewedToSha: "777788889999",
+          headRepoFullName: "mean-weasel/issuectl",
+          headRef: "feature/mobile-contracts",
+          status: "completed",
+          triggeredBy: "webhook",
+          startedAt: 1_779_000_000_000,
+          completedAt: 1_779_000_600_000,
+        }),
+      ],
+      fromCache: false,
+      cachedAt: null,
+    }));
+    expect(JSON.stringify(json)).not.toContain("resultJson");
+  });
+
+  it("returns 404 when the repo is not tracked", async () => {
+    getRepo.mockReturnValueOnce(null);
+
+    const response = await GET(request(), context("mean-weasel", "missing"));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json).toEqual({ error: "Repository not tracked" });
+    expect(listPrReviewsForRepo).not.toHaveBeenCalled();
+    expect(listPrReviewsForPull).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(request(), context());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/review-runs/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/review-runs/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  formatErrorForUser,
+  getDb,
+  getRepo,
+  listPrReviewsForPull,
+  listPrReviewsForRepo,
+  listRecentTerminalDeploymentsByRepo,
+  type PrReviewStatus,
+} from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { buildPrReviewsPayload, parseLimit, parsePositiveInt, repoFullName } from "@/lib/mobile-api-contracts";
+
+export const dynamic = "force-dynamic";
+
+const REVIEW_STATUSES: readonly PrReviewStatus[] = [
+  "reserved",
+  "launching",
+  "in_progress",
+  "completed",
+  "failed",
+  "superseded",
+];
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo: repoName } = await params;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const limit = parseLimit(searchParams.get("limit"), 24, 100);
+    const pr = parsePositiveInt(searchParams.get("pr"));
+    const status = parseReviewStatus(searchParams.get("status"));
+
+    if (pr === "invalid") {
+      return NextResponse.json({ error: "Invalid pull request number" }, { status: 400 });
+    }
+    if (status === "invalid") {
+      return NextResponse.json({ error: "Invalid review status" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const repo = getRepo(db, owner, repoName);
+    if (!repo) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const reviews = (pr === null
+      ? listPrReviewsForRepo(db, repo.id, limit)
+      : listPrReviewsForPull(db, repo.id, pr, limit))
+      .filter((review) => status === "all" || review.status === status)
+      .sort((left, right) => right.startedAt - left.startedAt || right.id - left.id);
+    const deploymentsById = new Map(
+      listRecentTerminalDeploymentsByRepo(db, repo.id, limit)
+        .map((deployment) => [deployment.id, deployment]),
+    );
+    const payload = buildPrReviewsPayload({
+      reviews,
+      repos: [repo],
+      deploymentsById,
+      filters: {
+        repo: repoFullName(repo),
+        pr,
+        status,
+        limit,
+      },
+    }) as { reviews?: unknown };
+
+    return NextResponse.json({
+      reviewRuns: payload.reviews ?? [],
+      fromCache: false,
+      cachedAt: null,
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_repo_review_runs_failed", owner, name: repoName });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}
+
+function parseReviewStatus(value: string | null): PrReviewStatus | "all" | "invalid" {
+  if (value === null || value.trim() === "") return "all";
+  if (value === "all") return "all";
+  return REVIEW_STATUSES.includes(value as PrReviewStatus) ? value as PrReviewStatus : "invalid";
+}

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/events/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/events/route.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getDb = vi.hoisted(() => vi.fn());
+const getRepo = vi.hoisted(() => vi.fn());
+const listWebhookLogEntries = vi.hoisted(() => vi.fn());
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getRepo: (...args: unknown[]) => getRepo(...args),
+  listWebhookLogEntries: (...args: unknown[]) => listWebhookLogEntries(...args),
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+const db = { db: true };
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  localPath: "/tmp/issuectl",
+  branchPattern: null,
+  autoLaunchIssues: true,
+  autoReviewPrs: true,
+  issueAgent: "codex",
+  reviewAgent: "codex",
+  webhookId: 123,
+  reviewPreamble: null,
+  webhookPayloadMode: "metadata",
+  createdAt: "2026-05-24T00:00:00.000Z",
+};
+
+function request(url = "http://localhost/api/v1/repos/mean-weasel/issuectl/webhook/events"): NextRequest {
+  return new NextRequest(url);
+}
+
+function context(owner = "mean-weasel", repoName = "issuectl") {
+  return {
+    params: Promise.resolve({ owner, repo: repoName }),
+  };
+}
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getDb.mockReset();
+  getRepo.mockReset();
+  listWebhookLogEntries.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getDb.mockReturnValue(db);
+  getRepo.mockReturnValue(repo);
+  listWebhookLogEntries.mockReturnValue([
+    {
+      id: 801,
+      deliveryId: "delivery-801",
+      repoId: 1,
+      eventType: "pull_request",
+      action: "synchronize",
+      senderLogin: "octocat",
+      targetType: "pr",
+      targetNumber: 44,
+      payloadJson: "{\"secret\":\"do-not-return\"}",
+      receivedAt: 1_779_000_000_000,
+      intentId: 901,
+      result: "fired",
+      resultDetail: "deployment 701",
+      actionId: "dep_701",
+      intent: null,
+    },
+  ]);
+});
+
+describe("/api/v1/repos/[owner]/[repo]/webhook/events", () => {
+  it("returns repo-scoped webhook events in the iOS-decoded response shape", async () => {
+    const response = await GET(request(
+      "http://localhost/api/v1/repos/mean-weasel/issuectl/webhook/events?targetType=pr&targetNumber=44&limit=25",
+    ), context());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getRepo).toHaveBeenCalledWith(db, "mean-weasel", "issuectl");
+    expect(listWebhookLogEntries).toHaveBeenCalledWith(db, {
+      repoId: 1,
+      targetType: "pr",
+      targetNumber: 44,
+      limit: 25,
+    });
+    expect(json).toEqual(expect.objectContaining({
+      events: [
+        expect.objectContaining({
+          id: 801,
+          deliveryId: "delivery-801",
+          repoId: 1,
+          eventType: "pull_request",
+          action: "synchronize",
+          senderLogin: "octocat",
+          targetType: "pr",
+          targetNumber: 44,
+          receivedAt: 1_779_000_000_000,
+          intentId: 901,
+        }),
+      ],
+      fromCache: false,
+      cachedAt: null,
+    }));
+    expect(JSON.stringify(json)).not.toContain("do-not-return");
+    expect(JSON.stringify(json)).not.toContain("payloadJson");
+  });
+
+  it("returns 404 when the repo is not tracked", async () => {
+    getRepo.mockReturnValueOnce(null);
+
+    const response = await GET(request(), context("mean-weasel", "missing"));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json).toEqual({ error: "Repository not tracked" });
+    expect(listWebhookLogEntries).not.toHaveBeenCalled();
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(request(), context());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/events/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/events/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { formatErrorForUser, getDb, getRepo, listWebhookLogEntries } from "@issuectl/core";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import {
+  buildWebhookEventsPayload,
+  parseLimit,
+  parsePositiveInt,
+  parseTargetType,
+  repoFullName,
+} from "@/lib/mobile-api-contracts";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { owner, repo: repoName } = await params;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const targetType = parseTargetType(searchParams.get("targetType"));
+    const targetNumber = parsePositiveInt(searchParams.get("targetNumber"));
+    const limit = parseLimit(searchParams.get("limit"), 50, 100);
+
+    if (targetType === "invalid") {
+      return NextResponse.json({ error: "Invalid target type" }, { status: 400 });
+    }
+    if (targetNumber === "invalid") {
+      return NextResponse.json({ error: "Invalid target number" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const repo = getRepo(db, owner, repoName);
+    if (!repo) {
+      return NextResponse.json({ error: "Repository not tracked" }, { status: 404 });
+    }
+
+    const entries = listWebhookLogEntries(db, {
+      repoId: repo.id,
+      ...(targetType ? { targetType } : {}),
+      ...(targetNumber ? { targetNumber } : {}),
+      limit,
+    });
+    const payload = buildWebhookEventsPayload({
+      entries,
+      repos: [repo],
+      filters: {
+        repo: repoFullName(repo),
+        targetType,
+        targetNumber,
+        limit,
+      },
+    });
+
+    return NextResponse.json({
+      ...(payload as Record<string, unknown>),
+      fromCache: false,
+      cachedAt: null,
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_repo_webhook_events_failed", owner, name: repoName });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- adds authenticated repo-scoped `/webhook/events` and `/review-runs` API routes for the iOS automation surfaces
- filters webhook events by repo/target and review runs by repo/PR/status
- returns iOS-decoded response shapes without leaking raw webhook payloads or review result JSON
- adds focused route tests for success, auth, and missing tracked repos

Closes #561.

## Verification
- `pnpm --dir packages/web test -- 'app/api/v1/repos/[owner]/[repo]/webhook/events/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/review-runs/route.test.ts'`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- commit/push hooks ran turbo typecheck/lint successfully; push hook skipped build because a dev server is running on :3847
