### PR TITLE
Bring iOS app onto live automation contracts

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		02781CCEEF582EE8519AB93C /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48746522237ABF37AF77B1DA /* APIClient+ListEnhancements.swift */; };
 		058362E154F84710C684FB0A /* MacIssueFilterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B211BFFBBC1DA50DF7B008D /* MacIssueFilterStateTests.swift */; };
 		05842C93F2A69FE0CD5A6205 /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493D2F4114A7CD0C28DC8F76 /* APIClient+DetailActions.swift */; };
+		07D7408AFD5EC8B2DD8E855F /* RepoAutomationActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DD3EAD6425B42F99E2BBBA /* RepoAutomationActivityView.swift */; };
 		0ABCC3FB2E10C1BEA6AA4BFD /* IssueDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B6A1C8520C31500949F0CF /* IssueDetailView.swift */; };
 		0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD0A91C6E351AA292D51EA2 /* QuickCreateSheet.swift */; };
 		0C49D98F7B92CA24BCC44AEB /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB04FB5543994CCE2DE041E /* KeychainService.swift */; };
@@ -94,6 +95,7 @@
 		58DDF20DA57FDC7882986CB4 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A225C37217DC60896282FCA4 /* APIClient+ImageUpload.swift */; };
 		5A6F10FC0B119DA9F4D6D7E7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4010BC691DB71B872353344A /* SessionListView.swift */; };
 		5AA1967A4E7CC1D191C872DF /* LoadMoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4497D324AB6CE09260737497 /* LoadMoreButton.swift */; };
+		5B60D8EFC835F97380547B15 /* RepoAutomationActivityViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF761F4AE3DFC8BE6E601259 /* RepoAutomationActivityViewTests.swift */; };
 		5B840823FA293BB29D5ED80E /* IssueListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D882E51722D47D736257AB4F /* IssueListView.swift */; };
 		5C8B076C5D41EB2832394E74 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9961C2183D56ACC7E5650E0 /* Issue.swift */; };
 		5E6741980731284F38AF3827 /* MacDraftsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9BFED5728AF737B76F2F26 /* MacDraftsView.swift */; };
@@ -114,6 +116,7 @@
 		6E012F4678B20E1522304F89 /* APIClient+Drafts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF8C3C59744B61C3B659ECD /* APIClient+Drafts.swift */; };
 		71AF28916BD03EBCEC063015 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
 		7288E1A84AADA68C9DE2149D /* APIClient+ListEnhancements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48746522237ABF37AF77B1DA /* APIClient+ListEnhancements.swift */; };
+		730EFF3CBA2ED540A483520A /* RepoAutomationActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DD3EAD6425B42F99E2BBBA /* RepoAutomationActivityView.swift */; };
 		7340473639227F6F40A9B792 /* APIClient+AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F92CAF45ECF0BED4F462D /* APIClient+AdvancedSettings.swift */; };
 		74BBC81070D4A029011534E6 /* PerformanceTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA90F554E1CF22EA56B51AB /* PerformanceTrace.swift */; };
 		779767D8AA5F26F07A4B7F31 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162B5421C0F279C8492942 /* APIClient.swift */; };
@@ -295,6 +298,7 @@
 		0FA58C21063864ADB4BAC822 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		134385CA01429770C742CD89 /* MacSidebarRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarRootView.swift; sourceTree = "<group>"; };
 		13760098C8ED1658B27AD54B /* CommentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentSheet.swift; sourceTree = "<group>"; };
+		13DD3EAD6425B42F99E2BBBA /* RepoAutomationActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoAutomationActivityView.swift; sourceTree = "<group>"; };
 		13EBC2D036E0950B774A3A43 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		15319A8AF148A10DF82FE6DD /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		1DE84C571530B405E4375D9C /* LocalIssueCTLConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalIssueCTLConnectionTests.swift; sourceTree = "<group>"; };
@@ -376,6 +380,7 @@
 		B3E09DBD6D633B291650EFBE /* IssueCTL.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueCTL.entitlements; sourceTree = "<group>"; };
 		BC00C899D2ADA14475787AE7 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		BC1D044DCA62B13F4196F816 /* SetupLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupLink.swift; sourceTree = "<group>"; };
+		BF761F4AE3DFC8BE6E601259 /* RepoAutomationActivityViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoAutomationActivityViewTests.swift; sourceTree = "<group>"; };
 		C1EDD5BE2AB56ED93A092C0C /* MarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownView.swift; sourceTree = "<group>"; };
 		C35F92CAF45ECF0BED4F462D /* APIClient+AdvancedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+AdvancedSettings.swift"; sourceTree = "<group>"; };
 		C48C04AAB5D9F17D9DD63684 /* RepoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoListView.swift; sourceTree = "<group>"; };
@@ -524,6 +529,7 @@
 				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
 				87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */,
 				5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */,
+				13DD3EAD6425B42F99E2BBBA /* RepoAutomationActivityView.swift */,
 				093FBA8D5D66DBDDCAB85BC4 /* SettingsView.swift */,
 				723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */,
 			);
@@ -539,6 +545,7 @@
 				2A0C921D1804F0904F029CC8 /* EnumTests.swift */,
 				533CCB5045E471F6D1675F9D /* ModelDecodingTests.swift */,
 				244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */,
+				BF761F4AE3DFC8BE6E601259 /* RepoAutomationActivityViewTests.swift */,
 				F63680089A3314AB67CE5883 /* ViewLogicTests.swift */,
 				0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */,
 				E0CFA3689097EA6A905B89C7 /* Fixtures */,
@@ -1099,6 +1106,7 @@
 				A6691865FCEEB29344BCCBAE /* EnumTests.swift in Sources */,
 				DBAAAF7B3925847446CC5E39 /* ModelDecodingTests.swift in Sources */,
 				52543EF1C7077597CC6DC8F0 /* OfflineSyncServiceTests.swift in Sources */,
+				5B60D8EFC835F97380547B15 /* RepoAutomationActivityViewTests.swift in Sources */,
 				EE5CBD61D807436206C48637 /* ViewLogicTests.swift in Sources */,
 				22192A28A190D660B52AAEDA /* WorkbenchStoreTests.swift in Sources */,
 			);
@@ -1173,6 +1181,7 @@
 				0B585381530245167B82950D /* QuickCreateSheet.swift in Sources */,
 				435164D5164B0B7D5FA9917F /* ReassignSheet.swift in Sources */,
 				14F2F9C3DAC995765C86F966 /* Repo.swift in Sources */,
+				730EFF3CBA2ED540A483520A /* RepoAutomationActivityView.swift in Sources */,
 				BB3D82F9FB758E4769B8BA58 /* RepoFilterChips.swift in Sources */,
 				0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */,
 				332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */,
@@ -1260,6 +1269,7 @@
 				9D86848D19E2C82D05E7DBC6 /* QuickCreateSheet.swift in Sources */,
 				43E594DAA101C705A5CBF4B6 /* ReassignSheet.swift in Sources */,
 				1F5CD736DCA791429CB2F501 /* Repo.swift in Sources */,
+				07D7408AFD5EC8B2DD8E855F /* RepoAutomationActivityView.swift in Sources */,
 				3D1ECFFEF7507D51F7F2E0C2 /* RepoFilterChips.swift in Sources */,
 				7AB66E17B8510A46A4AA9825 /* RepoFilterHelpers.swift in Sources */,
 				4BB20ADE0BE999E563444C1B /* RepoListView.swift in Sources */,

--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		1DACE987CE6F52ACE3A239C0 /* ImageAttachmentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894B92EC0F4DFFEE33872F28 /* ImageAttachmentButton.swift */; };
 		1F5CD736DCA791429CB2F501 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC54A0EAA1EEB03CA4C70E1E /* Repo.swift */; };
 		20B9C47DF425B4A135A52965 /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
+		213D75960BBDC6390A8C8F89 /* automation-parity-workbench.json in Resources */ = {isa = PBXBuildFile; fileRef = 341333B18AD52B87BA8F67A7 /* automation-parity-workbench.json */; };
 		22192A28A190D660B52AAEDA /* WorkbenchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */; };
 		227F5D726370EBF5F1C55F98 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD234C4632456D401809E8A5 /* OnboardingView.swift */; };
 		22B99716E42E20F0DA147C5B /* MacSidebarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E7DE3BF0A6826FE986B1D /* MacSidebarStore.swift */; };
@@ -307,6 +308,7 @@
 		2CF8C3C59744B61C3B659ECD /* APIClient+Drafts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Drafts.swift"; sourceTree = "<group>"; };
 		2D10373E745B3E9EC223B684 /* IssueCTLPreview.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTLPreview.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3403F8C644518F599E01A976 /* ReassignSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReassignSheet.swift; sourceTree = "<group>"; };
+		341333B18AD52B87BA8F67A7 /* automation-parity-workbench.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "automation-parity-workbench.json"; sourceTree = "<group>"; };
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		39EDF1F24285C1D3795B24B1 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
@@ -539,6 +541,7 @@
 				244DA774E9D8E1B7695BD3BA /* OfflineSyncServiceTests.swift */,
 				F63680089A3314AB67CE5883 /* ViewLogicTests.swift */,
 				0CEBD2A9CA0D417DCD4FFEB4 /* WorkbenchStoreTests.swift */,
+				E0CFA3689097EA6A905B89C7 /* Fixtures */,
 			);
 			path = IssueCTLTests;
 			sourceTree = "<group>";
@@ -725,6 +728,14 @@
 			path = IssueCTLMac;
 			sourceTree = "<group>";
 		};
+		E0CFA3689097EA6A905B89C7 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				341333B18AD52B87BA8F67A7 /* automation-parity-workbench.json */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
 		E149D3B1F961F064D7101362 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -829,6 +840,7 @@
 			buildConfigurationList = 188108183A585BD066C9C064 /* Build configuration list for PBXNativeTarget "IssueCTLTests" */;
 			buildPhases = (
 				0CFDDAD5B48B63CD070021C8 /* Sources */,
+				F96391E9EA82A34928D0341B /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1020,6 +1032,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				CF85E149379CEBC2696FFAF6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F96391E9EA82A34928D0341B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				213D75960BBDC6390A8C8F89 /* automation-parity-workbench.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -813,15 +813,11 @@ private struct DeploymentDiagnosticsSheet: View {
                 OfflineStatusBanner(message: staleDataMessage(kind: "diagnostics", cachedAt: response.cachedAt.flatMap(parseIssueCTLDate)))
             }
 
-            HStack(spacing: 8) {
-                Image(systemName: response.firstFailure == nil ? "checkmark.circle" : "exclamationmark.triangle")
-                    .foregroundStyle(response.firstFailure == nil ? Color.green : Color.orange)
-                Text(response.summaryText)
-                    .font(.subheadline.weight(.semibold))
+            DeploymentDiagnosticsSummaryCard(response: response)
+
+            if let filters = response.filters {
+                DeploymentDiagnosticsFiltersCard(filters: filters)
             }
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
 
             if response.events.isEmpty {
                 ContentUnavailableView {
@@ -883,6 +879,80 @@ private struct DeploymentDiagnosticsSheet: View {
     }
 }
 
+private struct DeploymentDiagnosticsSummaryCard: View {
+    let response: DeploymentDiagnosticsResponse
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: response.hasFailure ? "exclamationmark.triangle" : "checkmark.circle")
+                    .foregroundStyle(response.hasFailure ? Color.orange : Color.green)
+                Text(response.summaryText)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                Spacer(minLength: 0)
+            }
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                ForEach(Array(response.summaryRows.enumerated()), id: \.offset) { row in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.element.0)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(row.element.1)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("deployment-diagnostics-summary")
+    }
+}
+
+private struct DeploymentDiagnosticsFiltersCard: View {
+    let filters: DiagnosticFilters
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Label("Request", systemImage: "line.3.horizontal.decrease.circle")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 8)
+
+            Text(filters.targetDescription)
+                .font(.caption.monospaced())
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            Text(filters.limitDescription)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier("deployment-diagnostics-filters")
+    }
+}
+
 private struct DiagnosticEventCard: View {
     let event: DiagnosticEvent
 
@@ -897,7 +967,7 @@ private struct DiagnosticEventCard: View {
                     Text(event.event)
                         .font(.subheadline.weight(.semibold))
                         .lineLimit(2)
-                    Text("\(event.timeText) - \(event.source)")
+                    Text(eventContextText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -955,6 +1025,19 @@ private struct DiagnosticEventCard: View {
         case .warn: Color.orange
         case .error: Color.red
         }
+    }
+
+    private var eventContextText: String {
+        [
+            event.timeText,
+            event.source,
+            event.targetLabel,
+        ]
+        .compactMap { value in
+            guard let value, !value.isEmpty else { return nil }
+            return value
+        }
+        .joined(separator: " - ")
     }
 }
 

--- a/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -212,6 +212,13 @@ struct EditRepoSheet: View {
                 errorMessage: webhookActivityError
             )
 
+            NavigationLink {
+                RepoAutomationActivityView(repo: currentRepo)
+            } label: {
+                Label("Automation Activity", systemImage: "clock.arrow.circlepath")
+            }
+            .accessibilityIdentifier("edit-repo-automation-activity-link")
+
             Button {
                 Task { await checkWebhookHealth() }
             } label: {

--- a/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
+++ b/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
@@ -1,0 +1,538 @@
+import SwiftUI
+
+enum RepoAutomationActivityScope: String, CaseIterable, Identifiable {
+    case all
+    case issues
+    case pullRequests
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All"
+        case .issues:
+            return "Issues"
+        case .pullRequests:
+            return "PRs"
+        }
+    }
+}
+
+struct RepoAutomationActivityQuery: Equatable {
+    var scope: RepoAutomationActivityScope = .all
+    var numberText = ""
+    var reviewStatus: ReviewRunStatusFilter = .all
+
+    var webhookTargetType: DeploymentTargetType? {
+        switch scope {
+        case .all:
+            return nil
+        case .issues:
+            return .issue
+        case .pullRequests:
+            return .pr
+        }
+    }
+
+    var webhookTargetNumber: Int? {
+        parsedNumber
+    }
+
+    var reviewPRNumber: Int? {
+        scope == .pullRequests ? parsedNumber : nil
+    }
+
+    private var parsedNumber: Int? {
+        let trimmed = numberText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return Int(trimmed)
+    }
+}
+
+struct RepoAutomationActivityView: View {
+    @Environment(APIClient.self) private var api
+
+    let repo: Repo
+
+    @State private var query = RepoAutomationActivityQuery()
+    @State private var webhookEvents: [WebhookEvent] = []
+    @State private var reviewRuns: [ReviewRun] = []
+    @State private var isLoadingWebhookEvents = false
+    @State private var isLoadingReviewRuns = false
+    @State private var webhookEventsError: String?
+    @State private var reviewRunsError: String?
+    @State private var webhookResponse: WebhookEventsResponse?
+    @State private var reviewRunsResponse: ReviewRunsResponse?
+
+    var body: some View {
+        Form {
+            filterSection
+            webhookEventsSection
+            reviewRunsSection
+        }
+        .navigationTitle("Automation Activity")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task { await loadActivity() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .disabled(isLoading)
+                .accessibilityLabel("Refresh automation activity")
+            }
+        }
+        .task {
+            await loadActivity()
+        }
+        .refreshable {
+            await loadActivity()
+        }
+    }
+
+    private var isLoading: Bool {
+        isLoadingWebhookEvents || isLoadingReviewRuns
+    }
+
+    private var filterSection: some View {
+        Section {
+            Picker("Scope", selection: $query.scope) {
+                ForEach(RepoAutomationActivityScope.allCases) { scope in
+                    Text(scope.title).tag(scope)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("repo-automation-activity-scope-picker")
+            .onChange(of: query.scope) { _, scope in
+                if scope == .all {
+                    query.numberText = ""
+                }
+            }
+
+            TextField(numberPrompt, text: $query.numberText)
+                .keyboardType(.numberPad)
+                .disabled(query.scope == .all)
+                .accessibilityIdentifier("repo-automation-activity-number-field")
+
+            Picker("Review status", selection: $query.reviewStatus) {
+                ForEach(ReviewRunStatusFilter.allCases) { status in
+                    Text(status.displayName).tag(status)
+                }
+            }
+            .accessibilityIdentifier("repo-automation-activity-status-picker")
+
+            Button {
+                Task { await loadActivity() }
+            } label: {
+                HStack {
+                    Label("Apply Filters", systemImage: "line.3.horizontal.decrease.circle")
+                    Spacer()
+                    if isLoading {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isLoading)
+            .accessibilityIdentifier("repo-automation-activity-apply-button")
+        } header: {
+            Text(repo.fullName)
+        } footer: {
+            Text("Filters apply to webhook events. PR number and review status also apply to review runs.")
+        }
+    }
+
+    private var webhookEventsSection: some View {
+        Section {
+            if isLoadingWebhookEvents && webhookEvents.isEmpty {
+                loadingRow("Loading webhook events...")
+            } else if let webhookEventsError {
+                errorRow(message: webhookEventsError) {
+                    Task { await loadWebhookEvents() }
+                }
+            } else if webhookEvents.isEmpty {
+                ContentUnavailableView {
+                    Label("No Webhook Events", systemImage: "dot.radiowaves.left.and.right")
+                } description: {
+                    Text("No retained webhook deliveries match these filters.")
+                }
+            } else {
+                ForEach(webhookEvents) { event in
+                    WebhookEventActivityRow(event: event)
+                }
+            }
+        } header: {
+            sectionHeader(title: "Webhook Events", count: webhookEvents.count, isLoading: isLoadingWebhookEvents)
+        } footer: {
+            cacheFooter(fromCache: webhookResponse?.fromCache, cachedAt: webhookResponse?.cachedAt)
+        }
+    }
+
+    private var reviewRunsSection: some View {
+        Section {
+            if isLoadingReviewRuns && reviewRuns.isEmpty {
+                loadingRow("Loading review runs...")
+            } else if let reviewRunsError {
+                errorRow(message: reviewRunsError) {
+                    Task { await loadReviewRuns() }
+                }
+            } else if reviewRuns.isEmpty {
+                ContentUnavailableView {
+                    Label("No Review Runs", systemImage: "checkmark.shield")
+                } description: {
+                    Text("No repo automation review runs match these filters.")
+                }
+            } else {
+                ForEach(reviewRuns) { run in
+                    ReviewRunActivityRow(run: run)
+                }
+            }
+        } header: {
+            sectionHeader(title: "Review Runs", count: reviewRuns.count, isLoading: isLoadingReviewRuns)
+        } footer: {
+            cacheFooter(fromCache: reviewRunsResponse?.fromCache, cachedAt: reviewRunsResponse?.cachedAt)
+        }
+    }
+
+    private var numberPrompt: String {
+        switch query.scope {
+        case .all:
+            return "Target number"
+        case .issues:
+            return "Issue number"
+        case .pullRequests:
+            return "PR number"
+        }
+    }
+
+    private func sectionHeader(title: String, count: Int, isLoading: Bool) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            if isLoading {
+                ProgressView()
+            } else {
+                Text("\(count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cacheFooter(fromCache: Bool?, cachedAt: String?) -> some View {
+        if fromCache == true {
+            if let cachedAt {
+                Text("Showing cached data from \(cachedAt).")
+            } else {
+                Text("Showing cached data.")
+            }
+        }
+    }
+
+    private func loadingRow(_ title: String) -> some View {
+        HStack {
+            Spacer()
+            ProgressView(title)
+            Spacer()
+        }
+    }
+
+    private func errorRow(message: String, retry: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.caption)
+            Button("Retry", action: retry)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+        }
+    }
+
+    private func loadActivity() async {
+        await loadWebhookEvents()
+        await loadReviewRuns()
+    }
+
+    private func loadWebhookEvents() async {
+        isLoadingWebhookEvents = true
+        webhookEventsError = nil
+        defer { isLoadingWebhookEvents = false }
+
+        do {
+            let response = try await api.webhookEvents(
+                owner: repo.owner,
+                repo: repo.name,
+                targetType: query.webhookTargetType,
+                targetNumber: query.webhookTargetNumber,
+                limit: 50
+            )
+            webhookResponse = response
+            webhookEvents = response.events
+        } catch {
+            webhookEventsError = error.localizedDescription
+            webhookResponse = nil
+            webhookEvents = []
+        }
+    }
+
+    private func loadReviewRuns() async {
+        isLoadingReviewRuns = true
+        reviewRunsError = nil
+        defer { isLoadingReviewRuns = false }
+
+        do {
+            let response = try await api.reviewRuns(
+                owner: repo.owner,
+                repo: repo.name,
+                pr: query.reviewPRNumber,
+                status: query.reviewStatus,
+                limit: 24
+            )
+            reviewRunsResponse = response
+            reviewRuns = response.reviewRuns
+        } catch {
+            reviewRunsError = error.localizedDescription
+            reviewRunsResponse = nil
+            reviewRuns = []
+        }
+    }
+}
+
+private struct WebhookEventActivityRow: View {
+    let event: WebhookEvent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: event.iconName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(event.tint)
+                .frame(width: 30, height: 30)
+                .background(event.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(event.activityTitle)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                if let detail = event.activityDetail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(event.deliveryLine)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ReviewRunActivityRow: View {
+    let run: ReviewRun
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: run.status.iconName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(run.status.tint)
+                .frame(width: 30, height: 30)
+                .background(run.status.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("PR #\(run.prNumber)")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer(minLength: 8)
+                    Text(run.status.displayName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(run.status.tint)
+                }
+
+                if let summary = run.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(run.detailLine)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private extension WebhookEvent {
+    var activityTitle: String {
+        var parts = [eventType]
+        if let action, !action.isEmpty {
+            parts.append(action)
+        }
+        if let target = targetLabel ?? fallbackTargetLabel {
+            parts.append(target)
+        }
+        return parts.joined(separator: " ")
+    }
+
+    var activityDetail: String? {
+        var parts: [String] = []
+        if let senderLogin, !senderLogin.isEmpty {
+            parts.append("by \(senderLogin)")
+        }
+        if let result, !result.isEmpty {
+            if let resultDetail, !resultDetail.isEmpty {
+                parts.append("\(result): \(resultDetail)")
+            } else {
+                parts.append(result)
+            }
+        }
+        if let intent {
+            parts.append("intent \(intent.status)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    var deliveryLine: String {
+        var parts = [deliveryId]
+        if let receivedAtIso, !receivedAtIso.isEmpty {
+            parts.append(receivedAtIso)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    var iconName: String {
+        switch targetType {
+        case .issue:
+            return "smallcircle.filled.circle"
+        case .pr:
+            return "arrow.triangle.pull"
+        case nil:
+            return "dot.radiowaves.left.and.right"
+        }
+    }
+
+    var tint: Color {
+        switch result {
+        case "accepted", "scheduled", "processed":
+            return .green
+        case "ignored", "skipped":
+            return .secondary
+        case "failed", "error":
+            return .red
+        default:
+            return IssueCTLColors.action
+        }
+    }
+
+    private var fallbackTargetLabel: String? {
+        guard let targetType, let targetNumber else { return nil }
+        switch targetType {
+        case .issue:
+            return "Issue #\(targetNumber)"
+        case .pr:
+            return "PR #\(targetNumber)"
+        }
+    }
+}
+
+private extension ReviewRun {
+    var detailLine: String {
+        var parts: [String] = []
+        if let rangeLabel, !rangeLabel.isEmpty {
+            parts.append(rangeLabel)
+        }
+        if let findingCount {
+            parts.append("\(findingCount) finding\(findingCount == 1 ? "" : "s")")
+        }
+        if let headRef, !headRef.isEmpty {
+            parts.append(headRef)
+        }
+        if let completedAtIso, !completedAtIso.isEmpty {
+            parts.append(completedAtIso)
+        } else if let startedAtIso, !startedAtIso.isEmpty {
+            parts.append(startedAtIso)
+        }
+        return parts.isEmpty ? triggeredBy.displayName : parts.joined(separator: " · ")
+    }
+}
+
+private extension ReviewRunStatus {
+    var displayName: String {
+        switch self {
+        case .reserved:
+            return "Reserved"
+        case .launching:
+            return "Launching"
+        case .inProgress:
+            return "In Progress"
+        case .completed:
+            return "Completed"
+        case .failed:
+            return "Failed"
+        case .superseded:
+            return "Superseded"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .reserved:
+            return "clock"
+        case .launching:
+            return "paperplane"
+        case .inProgress:
+            return "arrow.clockwise"
+        case .completed:
+            return "checkmark.circle.fill"
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        case .superseded:
+            return "arrow.uturn.backward.circle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .reserved, .launching, .inProgress:
+            return IssueCTLColors.action
+        case .completed:
+            return .green
+        case .failed:
+            return .red
+        case .superseded:
+            return .secondary
+        }
+    }
+}
+
+private extension ReviewRunStatusFilter {
+    var displayName: String {
+        switch self {
+        case .all:
+            return "All"
+        case .reserved:
+            return "Reserved"
+        case .launching:
+            return "Launching"
+        case .inProgress:
+            return "In Progress"
+        case .completed:
+            return "Completed"
+        case .failed:
+            return "Failed"
+        case .superseded:
+            return "Superseded"
+        }
+    }
+}

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -543,6 +543,7 @@ extension DiagnosticEvent {
     }
 
     var targetLabel: String? {
+        if let serverTargetLabel { return serverTargetLabel }
         guard let targetType, let targetNumber else { return nil }
         switch targetType {
         case .issue: return "#\(targetNumber)"
@@ -571,17 +572,34 @@ extension DiagnosticEvent {
                 }
             }
         }
+        if let metadata {
+            for key in metadata.keys.sorted() {
+                if let value = metadata[key] {
+                    rows.append((key, value.displayValue))
+                }
+            }
+        }
         return rows
     }
 }
 
 struct DeploymentDiagnosticsResponse: Codable, Sendable {
     let events: [DiagnosticEvent]
+    let filters: DiagnosticFilters?
+    let summary: DiagnosticSummary?
     let fromCache: Bool
     let cachedAt: String?
 
-    init(events: [DiagnosticEvent], fromCache: Bool = false, cachedAt: String? = nil) {
+    init(
+        events: [DiagnosticEvent],
+        filters: DiagnosticFilters? = nil,
+        summary: DiagnosticSummary? = nil,
+        fromCache: Bool = false,
+        cachedAt: String? = nil
+    ) {
         self.events = events
+        self.filters = filters
+        self.summary = summary
         self.fromCache = fromCache
         self.cachedAt = cachedAt
     }
@@ -589,12 +607,14 @@ struct DeploymentDiagnosticsResponse: Codable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         events = try container.decode([DiagnosticEvent].self, forKey: .events)
+        filters = try container.decodeIfPresent(DiagnosticFilters.self, forKey: .filters)
+        summary = try container.decodeIfPresent(DiagnosticSummary.self, forKey: .summary)
         fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
         cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case events, fromCache, cachedAt
+        case events, filters, summary, fromCache, cachedAt
     }
 
     var firstFailure: DiagnosticEvent? {
@@ -609,6 +629,20 @@ struct DeploymentDiagnosticsResponse: Codable, Sendable {
         }
         return "\(countLabel), no failure recorded"
     }
+}
+
+struct DiagnosticFilters: Codable, Sendable {
+    let deploymentId: Int?
+    let targetType: DeploymentTargetType?
+    let targetNumber: Int?
+    let limit: Int
+}
+
+struct DiagnosticSummary: Codable, Sendable {
+    let count: Int
+    let levelCounts: [String: Int]
+    let latestTimestamp: Int?
+    let latestTimestampIso: String?
 }
 
 enum SessionPreviewStatus: String, Codable, Sendable {

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -621,13 +621,53 @@ struct DeploymentDiagnosticsResponse: Codable, Sendable {
         events.first(where: \.isFailure)
     }
 
+    var hasFailure: Bool {
+        if let errorCount = summary?.levelCount(for: .error), errorCount > 0 {
+            return true
+        }
+        return firstFailure != nil
+    }
+
+    var summaryEventCount: Int {
+        summary?.count ?? events.count
+    }
+
     var summaryText: String {
-        guard !events.isEmpty else { return "No diagnostic events recorded yet" }
-        let countLabel = events.count == 1 ? "1 diagnostic event" : "\(events.count) diagnostic events"
+        guard summaryEventCount > 0 else { return "No diagnostic events recorded yet" }
+        let countLabel = summaryEventCount == 1 ? "1 diagnostic event" : "\(summaryEventCount) diagnostic events"
+        if let errorCount = summary?.levelCount(for: .error), errorCount > 0 {
+            let errorLabel = errorCount == 1 ? "1 error" : "\(errorCount) errors"
+            return "\(countLabel), \(errorLabel)"
+        }
         if let firstFailure {
             return "\(countLabel), first failure: \(firstFailure.event)"
         }
+        if let warningCount = summary?.levelCount(for: .warn), warningCount > 0 {
+            let warningLabel = warningCount == 1 ? "1 warning" : "\(warningCount) warnings"
+            return "\(countLabel), \(warningLabel), no error recorded"
+        }
         return "\(countLabel), no failure recorded"
+    }
+
+    var summaryRows: [(String, String)] {
+        var rows: [(String, String)] = [("Events", "\(summaryEventCount)")]
+        if let summary {
+            for level in [DiagnosticLevel.error, .warn, .info, .debug] {
+                let count = summary.levelCount(for: level)
+                if count > 0 {
+                    rows.append((level.summaryLabel, "\(count)"))
+                }
+            }
+            if let filters {
+                rows.append(("Limit", filters.limitDescription))
+            }
+            if let latest = summary.latestTimestampIso ?? summary.latestTimestampText {
+                rows.append(("Latest", latest))
+            }
+        } else if let filters {
+            rows.append(("Limit", filters.limitDescription))
+        }
+        return rows
     }
 }
 
@@ -636,6 +676,20 @@ struct DiagnosticFilters: Codable, Sendable {
     let targetType: DeploymentTargetType?
     let targetNumber: Int?
     let limit: Int
+
+    var targetDescription: String {
+        guard let targetType, let targetNumber else { return "Deployment only" }
+        switch targetType {
+        case .issue:
+            return "Issue #\(targetNumber)"
+        case .pr:
+            return "PR #\(targetNumber)"
+        }
+    }
+
+    var limitDescription: String {
+        "Latest \(limit)"
+    }
 }
 
 struct DiagnosticSummary: Codable, Sendable {
@@ -643,6 +697,32 @@ struct DiagnosticSummary: Codable, Sendable {
     let levelCounts: [String: Int]
     let latestTimestamp: Int?
     let latestTimestampIso: String?
+
+    func levelCount(for level: DiagnosticLevel) -> Int {
+        levelCounts[level.rawValue] ?? 0
+    }
+
+    var latestTimestampText: String? {
+        guard let latestTimestamp else { return nil }
+        let rawTimestamp = Double(latestTimestamp)
+        let seconds = rawTimestamp > 10_000_000_000 ? rawTimestamp / 1000 : rawTimestamp
+        return DateFormatter.localizedString(
+            from: Date(timeIntervalSince1970: seconds),
+            dateStyle: .none,
+            timeStyle: .medium
+        )
+    }
+}
+
+private extension DiagnosticLevel {
+    var summaryLabel: String {
+        switch self {
+        case .debug: "Debug"
+        case .info: "Info"
+        case .warn: "Warnings"
+        case .error: "Errors"
+        }
+    }
 }
 
 enum SessionPreviewStatus: String, Codable, Sendable {

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -305,31 +305,91 @@ struct WebhookEvent: Codable, Identifiable, Sendable {
     let id: Int
     let deliveryId: String
     let repoId: Int
+    let repoFullName: String?
+    let owner: String?
+    let repoName: String?
     let eventType: String
     let action: String?
     let senderLogin: String?
     let targetType: DeploymentTargetType?
     let targetNumber: Int?
+    let targetLabel: String?
     let payloadJson: String?
     let receivedAt: Int
+    let receivedAtIso: String?
     let intentId: Int?
+    let result: String?
+    let resultDetail: String?
+    let actionId: String?
+    let intent: WebhookIntentSummary?
 }
 
 struct WebhookEventsResponse: Codable, Sendable {
     let events: [WebhookEvent]
+    let repos: [RepoContractSummary]
+    let filters: WebhookEventFilters?
+    let summary: WebhookEventSummary?
     let fromCache: Bool
     let cachedAt: String?
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         events = try container.decode([WebhookEvent].self, forKey: .events)
+        repos = try container.decodeIfPresent([RepoContractSummary].self, forKey: .repos) ?? []
+        filters = try container.decodeIfPresent(WebhookEventFilters.self, forKey: .filters)
+        summary = try container.decodeIfPresent(WebhookEventSummary.self, forKey: .summary)
         fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
         cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case events, fromCache, cachedAt
+        case events, repos, filters, summary, fromCache, cachedAt
     }
+}
+
+struct RepoContractSummary: Codable, Identifiable, Sendable {
+    let id: Int
+    let fullName: String
+}
+
+struct WebhookIntentSummary: Codable, Identifiable, Sendable {
+    let id: Int
+    let status: String
+    let targetType: DeploymentTargetType
+    let targetNumber: Int
+    let targetLabel: String
+    let firstSignalAt: Int
+    let firstSignalAtIso: String
+    let lastSignalAt: Int
+    let lastSignalAtIso: String
+    let scheduledAt: Int
+    let scheduledAtIso: String
+    let processingStartedAt: Int?
+    let processingStartedAtIso: String?
+    let leaseExpiresAt: Int?
+    let leaseExpiresAtIso: String?
+    let resolvedAt: Int?
+    let resolvedAtIso: String?
+    let generation: Int
+    let requestedAgent: String?
+    let reviewMode: String?
+    let signalCount: Int
+    let deploymentId: Int?
+    let failureReason: String?
+}
+
+struct WebhookEventFilters: Codable, Sendable {
+    let repo: String?
+    let targetType: DeploymentTargetType?
+    let targetNumber: Int?
+    let limit: Int
+}
+
+struct WebhookEventSummary: Codable, Sendable {
+    let count: Int
+    let latestReceivedAt: Int?
+    let latestReceivedAtIso: String?
+    let resultCounts: [String: Int]
 }
 
 enum ReviewRunStatus: String, Codable, CaseIterable, Sendable {
@@ -341,23 +401,46 @@ enum ReviewRunStatus: String, Codable, CaseIterable, Sendable {
     case superseded
 }
 
+enum ReviewRunStatusFilter: String, CaseIterable, Identifiable, Sendable {
+    case all
+    case reserved
+    case launching
+    case inProgress = "in_progress"
+    case completed
+    case failed
+    case superseded
+
+    var id: String { rawValue }
+}
+
 struct ReviewRun: Codable, Identifiable, Sendable {
     let id: Int
     let repoId: Int
+    let repoFullName: String?
+    let owner: String?
+    let repoName: String?
     let prNumber: Int
     let deploymentId: Int?
     let startedHeadSha: String?
     let completedHeadSha: String?
-    let reviewBaseSha: String
+    let reviewBaseSha: String?
     let reviewedFromSha: String?
     let reviewedToSha: String
-    let headRepoFullName: String
-    let headRef: String
+    let headRepoFullName: String?
+    let headRef: String?
     let status: ReviewRunStatus
     let triggeredBy: DeploymentTrigger
+    let result: [String: JSONValue]?
     let resultJson: String?
+    let summary: String?
+    let findingCount: Int?
+    let rangeLabel: String?
+    let detailHref: String?
     let startedAt: Int
+    let startedAtIso: String?
     let completedAt: Int?
+    let completedAtIso: String?
+    let deployment: ReviewRunDeployment?
 }
 
 struct ReviewRunsResponse: Codable, Sendable {
@@ -377,6 +460,30 @@ struct ReviewRunsResponse: Codable, Sendable {
     }
 }
 
+struct ReviewRunDeployment: Codable, Identifiable, Sendable {
+    let id: Int
+    let repoId: Int
+    let targetType: DeploymentTargetType
+    let targetNumber: Int
+    let targetLabel: String
+    let issueNumber: Int
+    let branchName: String
+    let agent: LaunchAgent?
+    let workspaceMode: WorkspaceMode
+    let workspacePath: String
+    let linkedPrNumber: Int?
+    let state: DeploymentState
+    let terminalBackend: String?
+    let triggeredBy: DeploymentTrigger?
+    let parentDeploymentId: Int?
+    let webhookDepth: Int?
+    let launchedAt: String
+    let endedAt: String?
+    let terminalReason: String?
+    let ttydPort: Int?
+    let idleSince: String?
+}
+
 enum DiagnosticLevel: String, Codable, CaseIterable, Sendable {
     case debug
     case info
@@ -387,9 +494,10 @@ enum DiagnosticLevel: String, Codable, CaseIterable, Sendable {
 struct DiagnosticEvent: Codable, Identifiable, Sendable {
     let id: Int
     let timestamp: Int
+    let timestampIso: String?
     let level: DiagnosticLevel
     let event: String
-    let source: String
+    let source: String?
     let correlationId: String?
     let owner: String?
     let repo: String?
@@ -402,7 +510,33 @@ struct DiagnosticEvent: Codable, Identifiable, Sendable {
     let ttydPid: Int?
     let status: String?
     let message: String?
+    let serverTargetLabel: String?
+    let metadata: [String: JSONValue]?
     let data: [String: JSONValue]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case timestamp
+        case timestampIso
+        case level
+        case event
+        case source
+        case correlationId
+        case owner
+        case repo
+        case issueNumber
+        case targetType
+        case targetNumber
+        case deploymentId
+        case sessionName
+        case ttydPort
+        case ttydPid
+        case status
+        case message
+        case serverTargetLabel = "targetLabel"
+        case metadata
+        case data
+    }
 }
 
 struct DiagnosticsResponse: Codable, Sendable {

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -356,13 +356,39 @@ final class APIClient {
 
     // Depends on issue #546: these automation list endpoints are fixture-driven
     // until the web API exposes dedicated list routes for native clients.
-    func webhookEvents(owner: String, repo: String) async throws -> WebhookEventsResponse {
-        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/webhook/events")
+    func webhookEvents(
+        owner: String,
+        repo: String,
+        targetType: DeploymentTargetType? = nil,
+        targetNumber: Int? = nil,
+        limit: Int = 50
+    ) async throws -> WebhookEventsResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/repos/\(owner)/\(repo)/webhook/events"
+        components.queryItems = [
+            targetType.map { URLQueryItem(name: "targetType", value: $0.rawValue) },
+            targetNumber.map { URLQueryItem(name: "targetNumber", value: String($0)) },
+            URLQueryItem(name: "limit", value: String(limit))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
-    func reviewRuns(owner: String, repo: String) async throws -> ReviewRunsResponse {
-        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/review-runs")
+    func reviewRuns(
+        owner: String,
+        repo: String,
+        pr: Int? = nil,
+        status: ReviewRunStatusFilter = .all,
+        limit: Int = 24
+    ) async throws -> ReviewRunsResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/repos/\(owner)/\(repo)/review-runs"
+        components.queryItems = [
+            pr.map { URLQueryItem(name: "pr", value: String($0)) },
+            URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "limit", value: String(limit))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }
 

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -262,13 +262,39 @@ final class TestableAPIClient {
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
     }
 
-    func webhookEvents(owner: String, repo: String) async throws -> WebhookEventsResponse {
-        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/webhook/events")
+    func webhookEvents(
+        owner: String,
+        repo: String,
+        targetType: DeploymentTargetType? = nil,
+        targetNumber: Int? = nil,
+        limit: Int = 50
+    ) async throws -> WebhookEventsResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/repos/\(owner)/\(repo)/webhook/events"
+        components.queryItems = [
+            targetType.map { URLQueryItem(name: "targetType", value: $0.rawValue) },
+            targetNumber.map { URLQueryItem(name: "targetNumber", value: String($0)) },
+            URLQueryItem(name: "limit", value: String(limit))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
-    func reviewRuns(owner: String, repo: String) async throws -> ReviewRunsResponse {
-        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/review-runs")
+    func reviewRuns(
+        owner: String,
+        repo: String,
+        pr: Int? = nil,
+        status: ReviewRunStatusFilter = .all,
+        limit: Int = 24
+    ) async throws -> ReviewRunsResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/repos/\(owner)/\(repo)/review-runs"
+        components.queryItems = [
+            pr.map { URLQueryItem(name: "pr", value: String($0)) },
+            URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "limit", value: String(limit))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }
 
@@ -494,16 +520,19 @@ final class APIClientTests: XCTestCase {
     func testAutomationListEndpointURLs() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url!.path, "/api/v1/repos/org/alpha/webhook/events")
+            XCTAssertTrue(request.url!.query?.contains("limit=50") == true)
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (response, #"{"events":[]}"#.data(using: .utf8)!)
+            return (response, #"{"events":[],"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
         }
 
         _ = try await client.webhookEvents(owner: "org", repo: "alpha")
 
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url!.path, "/api/v1/repos/org/alpha/review-runs")
+            XCTAssertTrue(request.url!.query?.contains("status=all") == true)
+            XCTAssertTrue(request.url!.query?.contains("limit=24") == true)
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (response, #"{"review_runs":[]}"#.data(using: .utf8)!)
+            return (response, #"{"review_runs":[],"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
         }
 
         _ = try await client.reviewRuns(owner: "org", repo: "alpha")
@@ -527,12 +556,55 @@ final class APIClientTests: XCTestCase {
 
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             let data = """
-            {"events": [], "from_cache": false, "cached_at": null}
+            {
+              "events": [],
+              "filters": {"deployment_id": 9001, "target_type": null, "target_number": null, "limit": 25},
+              "summary": {"count": 0, "level_counts": {}, "latest_timestamp": null, "latest_timestamp_iso": null}
+            }
             """.data(using: .utf8)!
             return (response, data)
         }
 
         _ = try await client.deploymentDiagnostics(deploymentId: 9001, limit: 25)
+    }
+
+    @MainActor
+    func testAutomationListEndpointFilters() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/repos/mean-weasel/issuectl/webhook/events")
+            XCTAssertTrue(request.url!.query?.contains("targetType=issue") == true)
+            XCTAssertTrue(request.url!.query?.contains("targetNumber=560") == true)
+            XCTAssertTrue(request.url!.query?.contains("limit=10") == true)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"events":[],"repos":[],"filters":{"repo":"mean-weasel/issuectl","target_type":"issue","target_number":560,"limit":10},"summary":{"count":0,"latest_received_at":null,"latest_received_at_iso":null,"result_counts":{}},"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
+        }
+
+        let webhookResponse = try await client.webhookEvents(
+            owner: "mean-weasel",
+            repo: "issuectl",
+            targetType: .issue,
+            targetNumber: 560,
+            limit: 10
+        )
+        XCTAssertEqual(webhookResponse.filters?.targetNumber, 560)
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/repos/mean-weasel/issuectl/review-runs")
+            XCTAssertTrue(request.url!.query?.contains("pr=563") == true)
+            XCTAssertTrue(request.url!.query?.contains("status=completed") == true)
+            XCTAssertTrue(request.url!.query?.contains("limit=5") == true)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"review_runs":[],"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
+        }
+
+        let reviewResponse = try await client.reviewRuns(
+            owner: "mean-weasel",
+            repo: "issuectl",
+            pr: 563,
+            status: .completed,
+            limit: 5
+        )
+        XCTAssertTrue(reviewResponse.reviewRuns.isEmpty)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -703,6 +703,49 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.summaryText, "No diagnostic events recorded yet")
     }
 
+    func testDeploymentDiagnosticsSummaryUsesServerSummaryAndFilters() throws {
+        let json = """
+        {
+          "events": [
+            {
+              "id": 101,
+              "timestamp": 1780000000000,
+              "level": "info",
+              "event": "deployment.activated",
+              "message": "Deployment activated",
+              "deployment_id": 42,
+              "target_type": "issue",
+              "target_number": 560,
+              "target_label": "Issue #560",
+              "metadata": {"ttydPort": 49152}
+            }
+          ],
+          "filters": {
+            "deployment_id": 42,
+            "target_type": "issue",
+            "target_number": 560,
+            "limit": 1
+          },
+          "summary": {
+            "count": 3,
+            "level_counts": {"info": 1, "warn": 1, "error": 1},
+            "latest_timestamp": 1780000000000,
+            "latest_timestamp_iso": "2026-05-29T20:26:40.000Z"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DeploymentDiagnosticsResponse.self, from: json)
+
+        XCTAssertEqual(response.summaryText, "3 diagnostic events, 1 error")
+        XCTAssertEqual(response.summaryRows.map(\.0), ["Events", "Errors", "Warnings", "Info", "Limit", "Latest"])
+        XCTAssertEqual(response.summaryRows.map(\.1), ["3", "1", "1", "1", "Latest 1", "2026-05-29T20:26:40.000Z"])
+        XCTAssertEqual(response.filters?.targetDescription, "Issue #560")
+        XCTAssertEqual(response.filters?.limitDescription, "Latest 1")
+        XCTAssertTrue(response.hasFailure)
+        XCTAssertTrue(response.events[0].metadataRows.contains { $0.0 == "ttydPort" && $0.1 == "49152" })
+    }
+
     // MARK: - ActiveDeployment
 
     func testActiveDeploymentDecoding() throws {

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1543,4 +1543,160 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.events[0].targetType, .pr)
         XCTAssertEqual(response.events[0].data?["actionType"], .string("push"))
     }
+
+    func testDeploymentDiagnosticsResponseDecodingFromLiveContract() throws {
+        let json = """
+        {
+          "events": [
+            {
+              "id": 101,
+              "timestamp": 1780000000000,
+              "timestamp_iso": "2026-05-29T20:26:40.000Z",
+              "level": "info",
+              "event": "deployment.activated",
+              "message": "Deployment activated",
+              "deployment_id": 42,
+              "issue_number": 560,
+              "target_type": "issue",
+              "target_number": 560,
+              "target_label": "Issue #560",
+              "metadata": {"ttydPort": 49152}
+            }
+          ],
+          "filters": {
+            "deployment_id": 42,
+            "target_type": null,
+            "target_number": null,
+            "limit": 50
+          },
+          "summary": {
+            "count": 1,
+            "level_counts": {"info": 1},
+            "latest_timestamp": 1780000000000,
+            "latest_timestamp_iso": "2026-05-29T20:26:40.000Z"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DeploymentDiagnosticsResponse.self, from: json)
+        XCTAssertEqual(response.events.count, 1)
+        XCTAssertEqual(response.events[0].deploymentId, 42)
+        XCTAssertEqual(response.events[0].event, "deployment.activated")
+        XCTAssertEqual(response.events[0].targetLabel, "Issue #560")
+        XCTAssertEqual(response.summary?.levelCounts["info"], 1)
+    }
+
+    func testWebhookEventsResponseDecodingFromLiveContract() throws {
+        let json = """
+        {
+          "events": [
+            {
+              "id": 7,
+              "delivery_id": "delivery-1",
+              "repo_id": 1,
+              "repo_full_name": "mean-weasel/issuectl",
+              "owner": "mean-weasel",
+              "repo_name": "issuectl",
+              "event_type": "issues",
+              "action": "labeled",
+              "sender_login": "neonwatty",
+              "target_type": "issue",
+              "target_number": 560,
+              "target_label": "Issue #560",
+              "received_at": 1780000001000,
+              "received_at_iso": "2026-05-29T20:26:41.000Z",
+              "intent_id": 9,
+              "result": "accepted",
+              "result_detail": "queued",
+              "action_id": "auto-session",
+              "intent": {
+                "id": 9,
+                "status": "scheduled",
+                "target_type": "issue",
+                "target_number": 560,
+                "target_label": "Issue #560",
+                "first_signal_at": 1780000001000,
+                "first_signal_at_iso": "2026-05-29T20:26:41.000Z",
+                "last_signal_at": 1780000001000,
+                "last_signal_at_iso": "2026-05-29T20:26:41.000Z",
+                "scheduled_at": 1780000002000,
+                "scheduled_at_iso": "2026-05-29T20:26:42.000Z",
+                "processing_started_at": null,
+                "processing_started_at_iso": null,
+                "lease_expires_at": null,
+                "lease_expires_at_iso": null,
+                "resolved_at": null,
+                "resolved_at_iso": null,
+                "generation": 1,
+                "requested_agent": "codex",
+                "review_mode": null,
+                "signal_count": 1,
+                "deployment_id": null,
+                "failure_reason": null
+              }
+            }
+          ],
+          "repos": [{"id": 1, "full_name": "mean-weasel/issuectl"}],
+          "filters": {"repo": "mean-weasel/issuectl", "target_type": "issue", "target_number": 560, "limit": 50},
+          "summary": {
+            "count": 1,
+            "latest_received_at": 1780000001000,
+            "latest_received_at_iso": "2026-05-29T20:26:41.000Z",
+            "result_counts": {"accepted": 1}
+          },
+          "from_cache": false,
+          "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(WebhookEventsResponse.self, from: json)
+        XCTAssertEqual(response.events.first?.targetNumber, 560)
+        XCTAssertEqual(response.events.first?.intent?.requestedAgent, "codex")
+        XCTAssertEqual(response.summary?.resultCounts["accepted"], 1)
+    }
+
+    func testReviewRunsResponseDecodingFromLiveContract() throws {
+        let json = """
+        {
+          "review_runs": [
+            {
+              "id": 33,
+              "repo_id": 1,
+              "repo_full_name": "mean-weasel/issuectl",
+              "owner": "mean-weasel",
+              "repo_name": "issuectl",
+              "pr_number": 563,
+              "deployment_id": 42,
+              "started_head_sha": "abcdef123456",
+              "completed_head_sha": "abcdef123456",
+              "review_base_sha": "1111111",
+              "reviewed_from_sha": "2222222",
+              "reviewed_to_sha": "abcdef123456",
+              "head_repo_full_name": "mean-weasel/issuectl",
+              "head_ref": "codex/ios-repo-automation-list-api",
+              "status": "completed",
+              "triggered_by": "webhook",
+              "result": {"summary": "No issues found", "findingCount": 0},
+              "summary": "No issues found",
+              "finding_count": 0,
+              "range_label": "2222222..abcdef1",
+              "detail_href": "/reviews/33",
+              "started_at": 1780000003000,
+              "started_at_iso": "2026-05-29T20:26:43.000Z",
+              "completed_at": 1780000004000,
+              "completed_at_iso": "2026-05-29T20:26:44.000Z",
+              "deployment": null
+            }
+          ],
+          "from_cache": false,
+          "cached_at": null
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(ReviewRunsResponse.self, from: json)
+        XCTAssertEqual(response.reviewRuns.count, 1)
+        XCTAssertEqual(response.reviewRuns[0].status, .completed)
+        XCTAssertEqual(response.reviewRuns[0].summary, "No issues found")
+        XCTAssertEqual(response.reviewRuns[0].findingCount, 0)
+    }
 }

--- a/apple/IssueCTLTests/RepoAutomationActivityViewTests.swift
+++ b/apple/IssueCTLTests/RepoAutomationActivityViewTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import IssueCTL
+
+final class RepoAutomationActivityViewTests: XCTestCase {
+
+    func testActivityQueryLeavesRepoWideFiltersEmptyByDefault() {
+        let query = RepoAutomationActivityQuery()
+
+        XCTAssertNil(query.webhookTargetType)
+        XCTAssertNil(query.webhookTargetNumber)
+        XCTAssertNil(query.reviewPRNumber)
+        XCTAssertEqual(query.reviewStatus, .all)
+    }
+
+    func testActivityQueryUsesPullRequestNumberForBothLists() {
+        var query = RepoAutomationActivityQuery()
+        query.scope = .pullRequests
+        query.numberText = " 563 "
+        query.reviewStatus = .completed
+
+        XCTAssertEqual(query.webhookTargetType, .pr)
+        XCTAssertEqual(query.webhookTargetNumber, 563)
+        XCTAssertEqual(query.reviewPRNumber, 563)
+        XCTAssertEqual(query.reviewStatus, .completed)
+    }
+
+    func testActivityQueryDoesNotSendIssueNumberToReviewRuns() {
+        var query = RepoAutomationActivityQuery()
+        query.scope = .issues
+        query.numberText = "560"
+
+        XCTAssertEqual(query.webhookTargetType, .issue)
+        XCTAssertEqual(query.webhookTargetNumber, 560)
+        XCTAssertNil(query.reviewPRNumber)
+    }
+
+    func testActivityQueryIgnoresInvalidNumberText() {
+        var query = RepoAutomationActivityQuery()
+        query.scope = .pullRequests
+        query.numberText = "PR-563"
+
+        XCTAssertEqual(query.webhookTargetType, .pr)
+        XCTAssertNil(query.webhookTargetNumber)
+        XCTAssertNil(query.reviewPRNumber)
+    }
+}


### PR DESCRIPTION
## Summary
- extend shared Apple models/APIClient for live diagnostics, webhook events, and review runs contracts
- surface server diagnostics summaries, filters, and event metadata in the session diagnostics sheet
- add repo Automation Activity settings view combining webhook deliveries and review runs with filters, loading, error, and empty states

## Verification
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests -only-testing:IssueCTLTests/RepoAutomationActivityViewTests
- xcodebuild build -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17'
- pnpm --dir packages/web test -- 'app/api/v1/diagnostics/route.test.ts' 'app/api/v1/diagnostics/deployments/[id]/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/webhook/events/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/review-runs/route.test.ts'
- git push hook ran workspace typecheck successfully (build skipped because dev server was detected on :3847)