### PR TITLE
fix(ios): decode PR review deployments without issue numbers

### DIFF
--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -466,7 +466,7 @@ struct ReviewRunDeployment: Codable, Identifiable, Sendable {
     let targetType: DeploymentTargetType
     let targetNumber: Int
     let targetLabel: String
-    let issueNumber: Int
+    let issueNumber: Int?
     let branchName: String
     let agent: LaunchAgent?
     let workspaceMode: WorkspaceMode

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1530,7 +1530,30 @@ final class ModelDecodingTests: XCTestCase {
                     "triggered_by": "webhook",
                     "result_json": "{\\"summary\\":\\"No regressions\\",\\"fixedFindingCount\\":1}",
                     "started_at": 1777440000,
-                    "completed_at": 1777440300
+                    "completed_at": 1777440300,
+                    "deployment": {
+                        "id": 42,
+                        "repo_id": 7,
+                        "target_type": "pr",
+                        "target_number": 88,
+                        "target_label": "PR #88",
+                        "issue_number": null,
+                        "branch_name": "feature/review",
+                        "agent": "claude",
+                        "workspace_mode": "worktree",
+                        "workspace_path": "/tmp/review",
+                        "linked_pr_number": null,
+                        "state": "active",
+                        "terminal_backend": "ttyd",
+                        "triggered_by": "webhook",
+                        "parent_deployment_id": null,
+                        "webhook_depth": 0,
+                        "launched_at": "2026-05-29 02:53:42",
+                        "ended_at": null,
+                        "terminal_reason": null,
+                        "ttyd_port": 7717,
+                        "idle_since": null
+                    }
                 }
             ],
             "from_cache": false,
@@ -1544,6 +1567,7 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.reviewRuns[0].triggeredBy, .webhook)
         XCTAssertEqual(response.reviewRuns[0].reviewBaseSha, "base999")
         XCTAssertEqual(response.reviewRuns[0].completedHeadSha, "def456")
+        XCTAssertNil(response.reviewRuns[0].deployment?.issueNumber)
     }
 
     func testDiagnosticEventDecodingFromAutomationFixture() throws {


### PR DESCRIPTION
## Summary
- Fix iOS decoding of review-run deployments where PR sessions have `issueNumber: null`
- Add a regression fixture covering PR review-run deployment payloads with no issue number

## QA
- `xcodebuildmcp test_sim -only-testing:IssueCTLTests/ModelDecodingTests/testReviewRunDecodingFromAutomationFixture`
- `xcodebuildmcp test_sim -only-testing:IssueCTLTests/ModelDecodingTests`
- Built/launched IssueCTL on a fresh simulator against local web server `127.0.0.1:3851`
- Verified Settings → repo → Automation Activity for `mean-weasel/issuectl-test-repo-2`, filtered to PR #51, now renders 6 webhook events and 1 completed review run instead of the decoder error

## Notes
- This was found during the post-merge live-contract QA pass after #564.
- URL-scheme setup on this simulator opened another app that also registered `issuectl://`, so simulator QA used `ISSUECTL_SERVER_URL` and `ISSUECTL_API_TOKEN` launch environment overrides instead.
