### PR TITLE
feat(ios): add global automation feed

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		3A294328BBF7D4016CC7B91E /* DraftDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3814ACC4885AAA637A3041 /* DraftDetailView.swift */; };
 		3C8E5B7EEE8B870210CB8DDC /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162B5421C0F279C8492942 /* APIClient.swift */; };
 		3D1ECFFEF7507D51F7F2E0C2 /* RepoFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */; };
+		3D4D2C49164044A49C57105E /* AutomationFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41357EAF7329A9950B0794A /* AutomationFeedView.swift */; };
 		3F98C9896C5653D619ABA40F /* OfflineCacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E7EDBC4DCA5DCEF3D3EA2D /* OfflineCacheStore.swift */; };
 		40ACA9C6A6F085A9F001A9C2 /* SetupLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1D044DCA62B13F4196F816 /* SetupLink.swift */; };
 		42EE83997C330D92A0AF72EF /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723D8CD9DD1A8317523ED863 /* WorktreeListView.swift */; };
@@ -119,6 +120,7 @@
 		730EFF3CBA2ED540A483520A /* RepoAutomationActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13DD3EAD6425B42F99E2BBBA /* RepoAutomationActivityView.swift */; };
 		7340473639227F6F40A9B792 /* APIClient+AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F92CAF45ECF0BED4F462D /* APIClient+AdvancedSettings.swift */; };
 		74BBC81070D4A029011534E6 /* PerformanceTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA90F554E1CF22EA56B51AB /* PerformanceTrace.swift */; };
+		756921D42B98FEBB1C16A7A8 /* AutomationActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9857E6F0AFD20465F77A6C5 /* AutomationActivityRows.swift */; };
 		779767D8AA5F26F07A4B7F31 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1162B5421C0F279C8492942 /* APIClient.swift */; };
 		78A07AEB3E3123D8640D060E /* CommandCenterComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B990A804E6850DD8423327 /* CommandCenterComponents.swift */; };
 		78C4075442E5AFA3CEC1CDD5 /* IssueCTLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E1C810B3BD014B117301B /* IssueCTLApp.swift */; };
@@ -167,6 +169,7 @@
 		B0B4D310A36FCCDF3F73C336 /* CacheAgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2841D89323711B68449BB980 /* CacheAgeLabel.swift */; };
 		B1F252A9CAEFE3AEBAD72627 /* APIClient+AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F92CAF45ECF0BED4F462D /* APIClient+AdvancedSettings.swift */; };
 		B3D5E3FD4EF67AE7FA0244FA /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFE58A48C5143017DDCD88 /* PullRequest.swift */; };
+		B3DE599338B4E6B79D27C378 /* AutomationFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41357EAF7329A9950B0794A /* AutomationFeedView.swift */; };
 		B46FB3602D7536C5ADB4E5CC /* WorkbenchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436AD98A6942EE0DBA6EDB1A /* WorkbenchStore.swift */; };
 		B4AE7A30FA4C9D89B7400802 /* APIClient+ImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A225C37217DC60896282FCA4 /* APIClient+ImageUpload.swift */; };
 		B4AF2A85F0768942BCD81D8C /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E556B4EF9EA078249A82EF01 /* NetworkMonitor.swift */; };
@@ -209,6 +212,7 @@
 		D1B085BF32A2BA054762456F /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC00C899D2ADA14475787AE7 /* APIClientTests.swift */; };
 		D313EE47970005D888007FBE /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2045894076CF711FE18DAA /* GitHubAccessibleRepo.swift */; };
 		D365E6F4AACBF2399319E5BC /* GitHubAccessibleRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2045894076CF711FE18DAA /* GitHubAccessibleRepo.swift */; };
+		D37D67F958F348E75F1E6D75 /* AutomationActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9857E6F0AFD20465F77A6C5 /* AutomationActivityRows.swift */; };
 		D44F79649E736044B57946F0 /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493D2F4114A7CD0C28DC8F76 /* APIClient+DetailActions.swift */; };
 		D52DC5DDE3BE88CF966B0675 /* IssueCTLUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864FC68F504BF4FA08B86548 /* IssueCTLUITests.swift */; };
 		D672987F49396A1562FEAA5B /* LaunchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF815A24660864A5AA69B05 /* LaunchProgressView.swift */; };
@@ -371,7 +375,9 @@
 		9D794FF17C025F2A3709F852 /* RequestChangesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChangesSheet.swift; sourceTree = "<group>"; };
 		9FAF141F6D9A6899512B98F4 /* OfflineSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineSyncService.swift; sourceTree = "<group>"; };
 		A225C37217DC60896282FCA4 /* APIClient+ImageUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ImageUpload.swift"; sourceTree = "<group>"; };
+		A41357EAF7329A9950B0794A /* AutomationFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationFeedView.swift; sourceTree = "<group>"; };
 		A857FE28B9D50395BE2B49FA /* APIClient+Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Assignment.swift"; sourceTree = "<group>"; };
+		A9857E6F0AFD20465F77A6C5 /* AutomationActivityRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationActivityRows.swift; sourceTree = "<group>"; };
 		AB6764D0DF2A55EB3796889D /* IssueCTL.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = IssueCTL.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD0E8C15D2965C1673B992B7 /* MacSidebarSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSidebarSmokeTests.swift; sourceTree = "<group>"; };
 		AD3C1581E55A12781F1E76A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -526,6 +532,8 @@
 			children = (
 				F327BCF6E8F284459A3256FF /* AddRepoSheet.swift */,
 				6E52120CCBF1B17E45E2DDC1 /* AdvancedSettingsView.swift */,
+				A9857E6F0AFD20465F77A6C5 /* AutomationActivityRows.swift */,
+				A41357EAF7329A9950B0794A /* AutomationFeedView.swift */,
 				9C8E526C6C760C30E3F2D535 /* EditRepoSheet.swift */,
 				87C78179FB5D86E7E107E81B /* NotificationSettingsView.swift */,
 				5CF37EEF251C5C18C03E86D4 /* OfflineQueueView.swift */,
@@ -1129,6 +1137,8 @@
 				B4D3E5DC8306990F763058B6 /* AdvancedSettingsView.swift in Sources */,
 				EA782E1A1F8C5112A664DAAA /* AppVersion.swift in Sources */,
 				916892AA5B3D923B618E6288 /* AssigneeSheet.swift in Sources */,
+				756921D42B98FEBB1C16A7A8 /* AutomationActivityRows.swift in Sources */,
+				B3DE599338B4E6B79D27C378 /* AutomationFeedView.swift in Sources */,
 				A5A40C3369B96157539628A4 /* BoardView.swift in Sources */,
 				23EAF525A8ADA655565F610F /* BranchNameHelper.swift in Sources */,
 				31F1727D0042386D7B07C93A /* CacheAgeLabel.swift in Sources */,
@@ -1217,6 +1227,8 @@
 				A9B874605B9902D25572BC69 /* AdvancedSettingsView.swift in Sources */,
 				23D942475A1170ACA34A2C42 /* AppVersion.swift in Sources */,
 				25A88772F8BE82458C3B5052 /* AssigneeSheet.swift in Sources */,
+				D37D67F958F348E75F1E6D75 /* AutomationActivityRows.swift in Sources */,
+				3D4D2C49164044A49C57105E /* AutomationFeedView.swift in Sources */,
 				0F3A28DC1E9028EB85E10458 /* BoardView.swift in Sources */,
 				9E5810655BCFC5AD8846D206 /* BranchNameHelper.swift in Sources */,
 				B0B4D310A36FCCDF3F73C336 /* CacheAgeLabel.swift in Sources */,

--- a/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+
+struct WebhookEventActivityRow: View {
+    let event: WebhookEvent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: event.iconName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(event.tint)
+                .frame(width: 30, height: 30)
+                .background(event.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(event.activityTitle)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                if let detail = event.activityDetail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(event.deliveryLine)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct ReviewRunActivityRow: View {
+    let run: ReviewRun
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: run.status.iconName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(run.status.tint)
+                .frame(width: 30, height: 30)
+                .background(run.status.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("PR #\(run.prNumber)")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer(minLength: 8)
+                    Text(run.status.displayName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(run.status.tint)
+                }
+
+                if let repoFullName = run.repoFullName, !repoFullName.isEmpty {
+                    Text(repoFullName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let summary = run.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Text(run.detailLine)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private extension WebhookEvent {
+    var activityTitle: String {
+        var parts = [eventType]
+        if let action, !action.isEmpty {
+            parts.append(action)
+        }
+        if let target = targetLabel ?? fallbackTargetLabel {
+            parts.append(target)
+        }
+        return parts.joined(separator: " ")
+    }
+
+    var activityDetail: String? {
+        var parts: [String] = []
+        if let repoFullName, !repoFullName.isEmpty {
+            parts.append(repoFullName)
+        }
+        if let senderLogin, !senderLogin.isEmpty {
+            parts.append("by \(senderLogin)")
+        }
+        if let result, !result.isEmpty {
+            if let resultDetail, !resultDetail.isEmpty {
+                parts.append("\(result): \(resultDetail)")
+            } else {
+                parts.append(result)
+            }
+        }
+        if let intent {
+            parts.append("intent \(intent.status)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    var deliveryLine: String {
+        var parts = [deliveryId]
+        if let receivedAtIso, !receivedAtIso.isEmpty {
+            parts.append(receivedAtIso)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    var iconName: String {
+        switch targetType {
+        case .issue:
+            return "smallcircle.filled.circle"
+        case .pr:
+            return "arrow.triangle.pull"
+        case nil:
+            return "dot.radiowaves.left.and.right"
+        }
+    }
+
+    var tint: Color {
+        switch result {
+        case "accepted", "scheduled", "processed":
+            return .green
+        case "ignored", "skipped":
+            return .secondary
+        case "failed", "error":
+            return .red
+        default:
+            return IssueCTLColors.action
+        }
+    }
+
+    private var fallbackTargetLabel: String? {
+        guard let targetType, let targetNumber else { return nil }
+        switch targetType {
+        case .issue:
+            return "Issue #\(targetNumber)"
+        case .pr:
+            return "PR #\(targetNumber)"
+        }
+    }
+}
+
+private extension ReviewRun {
+    var detailLine: String {
+        var parts: [String] = []
+        if let rangeLabel, !rangeLabel.isEmpty {
+            parts.append(rangeLabel)
+        }
+        if let findingCount {
+            parts.append("\(findingCount) finding\(findingCount == 1 ? "" : "s")")
+        }
+        if let headRef, !headRef.isEmpty {
+            parts.append(headRef)
+        }
+        if let completedAtIso, !completedAtIso.isEmpty {
+            parts.append(completedAtIso)
+        } else if let startedAtIso, !startedAtIso.isEmpty {
+            parts.append(startedAtIso)
+        }
+        return parts.isEmpty ? triggeredBy.displayName : parts.joined(separator: " · ")
+    }
+}
+
+extension ReviewRunStatus {
+    var displayName: String {
+        switch self {
+        case .reserved:
+            return "Reserved"
+        case .launching:
+            return "Launching"
+        case .inProgress:
+            return "In Progress"
+        case .completed:
+            return "Completed"
+        case .failed:
+            return "Failed"
+        case .superseded:
+            return "Superseded"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .reserved:
+            return "clock"
+        case .launching:
+            return "paperplane"
+        case .inProgress:
+            return "arrow.clockwise"
+        case .completed:
+            return "checkmark.circle.fill"
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        case .superseded:
+            return "arrow.uturn.backward.circle"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .reserved, .launching, .inProgress:
+            return IssueCTLColors.action
+        case .completed:
+            return .green
+        case .failed:
+            return .red
+        case .superseded:
+            return .secondary
+        }
+    }
+}
+
+extension ReviewRunStatusFilter {
+    var displayName: String {
+        switch self {
+        case .all:
+            return "All"
+        case .reserved:
+            return "Reserved"
+        case .launching:
+            return "Launching"
+        case .inProgress:
+            return "In Progress"
+        case .completed:
+            return "Completed"
+        case .failed:
+            return "Failed"
+        case .superseded:
+            return "Superseded"
+        }
+    }
+}

--- a/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
@@ -1,61 +1,9 @@
 import SwiftUI
 
-enum RepoAutomationActivityScope: String, CaseIterable, Identifiable {
-    case all
-    case issues
-    case pullRequests
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .all:
-            return "All"
-        case .issues:
-            return "Issues"
-        case .pullRequests:
-            return "PRs"
-        }
-    }
-}
-
-struct RepoAutomationActivityQuery: Equatable {
-    var scope: RepoAutomationActivityScope = .all
-    var numberText = ""
-    var reviewStatus: ReviewRunStatusFilter = .all
-
-    var webhookTargetType: DeploymentTargetType? {
-        switch scope {
-        case .all:
-            return nil
-        case .issues:
-            return .issue
-        case .pullRequests:
-            return .pr
-        }
-    }
-
-    var webhookTargetNumber: Int? {
-        parsedNumber
-    }
-
-    var reviewPRNumber: Int? {
-        scope == .pullRequests ? parsedNumber : nil
-    }
-
-    private var parsedNumber: Int? {
-        let trimmed = numberText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return Int(trimmed)
-    }
-}
-
-struct RepoAutomationActivityView: View {
+struct AutomationFeedView: View {
     @Environment(APIClient.self) private var api
 
-    let repo: Repo
-
-    @State private var query = RepoAutomationActivityQuery()
+    @State private var reviewStatus: ReviewRunStatusFilter = .all
     @State private var webhookEvents: [WebhookEvent] = []
     @State private var reviewRuns: [ReviewRun] = []
     @State private var isLoadingWebhookEvents = false
@@ -67,28 +15,29 @@ struct RepoAutomationActivityView: View {
 
     var body: some View {
         Form {
-            filterSection
+            filtersSection
             webhookEventsSection
             reviewRunsSection
         }
-        .navigationTitle("Automation Activity")
+        .navigationTitle("Automation Feed")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    Task { await loadActivity() }
+                    Task { await loadFeed() }
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
                 .disabled(isLoading)
-                .accessibilityLabel("Refresh automation activity")
+                .accessibilityLabel("Refresh automation feed")
             }
         }
-        .task {
-            await loadActivity()
+        .task(id: reviewStatus) {
+            await loadFeed()
+            await pollFeed()
         }
         .refreshable {
-            await loadActivity()
+            await loadFeed()
         }
     }
 
@@ -96,50 +45,14 @@ struct RepoAutomationActivityView: View {
         isLoadingWebhookEvents || isLoadingReviewRuns
     }
 
-    private var filterSection: some View {
+    private var filtersSection: some View {
         Section {
-            Picker("Scope", selection: $query.scope) {
-                ForEach(RepoAutomationActivityScope.allCases) { scope in
-                    Text(scope.title).tag(scope)
-                }
-            }
-            .pickerStyle(.segmented)
-            .accessibilityIdentifier("repo-automation-activity-scope-picker")
-            .onChange(of: query.scope) { _, scope in
-                if scope == .all {
-                    query.numberText = ""
-                }
-            }
-
-            TextField(numberPrompt, text: $query.numberText)
-                .keyboardType(.numberPad)
-                .disabled(query.scope == .all)
-                .accessibilityIdentifier("repo-automation-activity-number-field")
-
-            Picker("Review status", selection: $query.reviewStatus) {
+            Picker("Review status", selection: $reviewStatus) {
                 ForEach(ReviewRunStatusFilter.allCases) { status in
                     Text(status.displayName).tag(status)
                 }
             }
-            .accessibilityIdentifier("repo-automation-activity-status-picker")
-
-            Button {
-                Task { await loadActivity() }
-            } label: {
-                HStack {
-                    Label("Apply Filters", systemImage: "line.3.horizontal.decrease.circle")
-                    Spacer()
-                    if isLoading {
-                        ProgressView()
-                    }
-                }
-            }
-            .disabled(isLoading)
-            .accessibilityIdentifier("repo-automation-activity-apply-button")
-        } header: {
-            Text(repo.fullName)
-        } footer: {
-            Text("Filters apply to webhook events. PR number and review status also apply to review runs.")
+            .accessibilityIdentifier("automation-feed-review-status-picker")
         }
     }
 
@@ -155,7 +68,7 @@ struct RepoAutomationActivityView: View {
                 ContentUnavailableView {
                     Label("No Webhook Events", systemImage: "dot.radiowaves.left.and.right")
                 } description: {
-                    Text("No retained webhook deliveries match these filters.")
+                    Text("No retained webhook deliveries are available.")
                 }
             } else {
                 ForEach(webhookEvents) { event in
@@ -181,7 +94,7 @@ struct RepoAutomationActivityView: View {
                 ContentUnavailableView {
                     Label("No Review Runs", systemImage: "checkmark.shield")
                 } description: {
-                    Text("No repo automation review runs match these filters.")
+                    Text("No PR review runs match this status.")
                 }
             } else {
                 ForEach(reviewRuns) { run in
@@ -192,17 +105,6 @@ struct RepoAutomationActivityView: View {
             sectionHeader(title: "Review Runs", count: reviewRuns.count, isLoading: isLoadingReviewRuns)
         } footer: {
             cacheFooter(fromCache: reviewRunsResponse?.fromCache, cachedAt: reviewRunsResponse?.cachedAt)
-        }
-    }
-
-    private var numberPrompt: String {
-        switch query.scope {
-        case .all:
-            return "Target number"
-        case .issues:
-            return "Issue number"
-        case .pullRequests:
-            return "PR number"
         }
     }
 
@@ -250,9 +152,18 @@ struct RepoAutomationActivityView: View {
         }
     }
 
-    private func loadActivity() async {
-        await loadWebhookEvents()
-        await loadReviewRuns()
+    private func pollFeed() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(60))
+            guard !Task.isCancelled else { return }
+            await loadFeed()
+        }
+    }
+
+    private func loadFeed() async {
+        async let events: () = loadWebhookEvents()
+        async let reviews: () = loadReviewRuns()
+        _ = await (events, reviews)
     }
 
     private func loadWebhookEvents() async {
@@ -261,13 +172,7 @@ struct RepoAutomationActivityView: View {
         defer { isLoadingWebhookEvents = false }
 
         do {
-            let response = try await api.webhookEvents(
-                owner: repo.owner,
-                repo: repo.name,
-                targetType: query.webhookTargetType,
-                targetNumber: query.webhookTargetNumber,
-                limit: 50
-            )
+            let response = try await api.globalWebhookEvents(limit: 50)
             webhookResponse = response
             webhookEvents = response.events
         } catch {
@@ -283,13 +188,7 @@ struct RepoAutomationActivityView: View {
         defer { isLoadingReviewRuns = false }
 
         do {
-            let response = try await api.reviewRuns(
-                owner: repo.owner,
-                repo: repo.name,
-                pr: query.reviewPRNumber,
-                status: query.reviewStatus,
-                limit: 24
-            )
+            let response = try await api.globalReviewRuns(status: reviewStatus, limit: 50)
             reviewRunsResponse = response
             reviewRuns = response.reviewRuns
         } catch {

--- a/apple/IssueCTL/Views/Settings/SettingsView.swift
+++ b/apple/IssueCTL/Views/Settings/SettingsView.swift
@@ -40,6 +40,8 @@ struct SettingsView: View {
                 switch dest {
                 case .advancedSettings:
                     AdvancedSettingsView()
+                case .automationFeed:
+                    AutomationFeedView()
                 case .notifications:
                     NotificationSettingsView()
                 case .worktrees:
@@ -182,6 +184,10 @@ struct SettingsView: View {
             NavigationLink(value: SettingsDestination.advancedSettings) {
                 Label("Agent Harness & Defaults", systemImage: "terminal")
             }
+            NavigationLink(value: SettingsDestination.automationFeed) {
+                Label("Automation Feed", systemImage: "dot.radiowaves.left.and.right")
+            }
+            .accessibilityIdentifier("settings-automation-feed-link")
             NavigationLink(value: SettingsDestination.notifications) {
                 Label("Notifications", systemImage: "bell.badge")
             }
@@ -294,6 +300,7 @@ struct SettingsView: View {
 
 enum SettingsDestination: Hashable {
     case advancedSettings
+    case automationFeed
     case notifications
     case worktrees
     case offlineQueue

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -450,13 +450,22 @@ struct ReviewRunsResponse: Codable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        reviewRuns = try container.decode([ReviewRun].self, forKey: .reviewRuns)
+        reviewRuns = try container.decodeIfPresent([ReviewRun].self, forKey: .reviewRuns)
+            ?? container.decodeIfPresent([ReviewRun].self, forKey: .reviews)
+            ?? []
         fromCache = try container.decodeIfPresent(Bool.self, forKey: .fromCache) ?? false
         cachedAt = try container.decodeIfPresent(String.self, forKey: .cachedAt)
     }
 
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(reviewRuns, forKey: .reviewRuns)
+        try container.encode(fromCache, forKey: .fromCache)
+        try container.encodeIfPresent(cachedAt, forKey: .cachedAt)
+    }
+
     private enum CodingKeys: String, CodingKey {
-        case reviewRuns, fromCache, cachedAt
+        case reviewRuns, reviews, fromCache, cachedAt
     }
 }
 

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -374,6 +374,17 @@ final class APIClient {
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
+    func globalWebhookEvents(limit: Int = 50) async throws -> WebhookEventsResponse {
+        let safeLimit = max(1, min(100, limit))
+        var components = URLComponents()
+        components.path = "/api/v1/webhooks/events"
+        components.queryItems = [
+            URLQueryItem(name: "limit", value: String(safeLimit))
+        ]
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(WebhookEventsResponse.self, from: data)
+    }
+
     func reviewRuns(
         owner: String,
         repo: String,
@@ -388,6 +399,18 @@ final class APIClient {
             URLQueryItem(name: "status", value: status.rawValue),
             URLQueryItem(name: "limit", value: String(limit))
         ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(ReviewRunsResponse.self, from: data)
+    }
+
+    func globalReviewRuns(status: ReviewRunStatusFilter = .all, limit: Int = 50) async throws -> ReviewRunsResponse {
+        let safeLimit = max(1, min(100, limit))
+        var components = URLComponents()
+        components.path = "/api/v1/pr-reviews"
+        components.queryItems = [
+            URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "limit", value: String(safeLimit))
+        ]
         let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -280,6 +280,17 @@ final class TestableAPIClient {
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
+    func globalWebhookEvents(limit: Int = 50) async throws -> WebhookEventsResponse {
+        let safeLimit = max(1, min(100, limit))
+        var components = URLComponents()
+        components.path = "/api/v1/webhooks/events"
+        components.queryItems = [
+            URLQueryItem(name: "limit", value: String(safeLimit))
+        ]
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(WebhookEventsResponse.self, from: data)
+    }
+
     func reviewRuns(
         owner: String,
         repo: String,
@@ -294,6 +305,18 @@ final class TestableAPIClient {
             URLQueryItem(name: "status", value: status.rawValue),
             URLQueryItem(name: "limit", value: String(limit))
         ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(ReviewRunsResponse.self, from: data)
+    }
+
+    func globalReviewRuns(status: ReviewRunStatusFilter = .all, limit: Int = 50) async throws -> ReviewRunsResponse {
+        let safeLimit = max(1, min(100, limit))
+        var components = URLComponents()
+        components.path = "/api/v1/pr-reviews"
+        components.queryItems = [
+            URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "limit", value: String(safeLimit))
+        ]
         let (data, _) = try await request(path: components.string ?? components.path)
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }
@@ -545,6 +568,33 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.diagnostics(deploymentId: 42)
+    }
+
+    @MainActor
+    func testGlobalWebhookEventsEndpointURL() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/webhooks/events")
+            XCTAssertTrue(request.url!.query?.contains("limit=50") == true)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"events":[],"repos":[],"filters":{"repo":null,"target_type":null,"target_number":null,"limit":50},"summary":{"count":0,"latest_received_at":null,"latest_received_at_iso":null,"result_counts":{}}}"#.data(using: .utf8)!)
+        }
+
+        let response = try await client.globalWebhookEvents(limit: 50)
+        XCTAssertTrue(response.events.isEmpty)
+    }
+
+    @MainActor
+    func testGlobalReviewRunsEndpointURL() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/pr-reviews")
+            XCTAssertTrue(request.url!.query?.contains("status=all") == true)
+            XCTAssertTrue(request.url!.query?.contains("limit=50") == true)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, #"{"reviews":[],"repos":[],"filters":{"repo":null,"pr":null,"status":"all","limit":50},"summary":{"count":0,"active_count":0,"completed_count":0,"failed_count":0,"latest_started_at":null,"latest_started_at_iso":null}}"#.data(using: .utf8)!)
+        }
+
+        let response = try await client.globalReviewRuns(status: .all, limit: 50)
+        XCTAssertTrue(response.reviewRuns.isEmpty)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1766,4 +1766,56 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.reviewRuns[0].summary, "No issues found")
         XCTAssertEqual(response.reviewRuns[0].findingCount, 0)
     }
+
+    func testGlobalReviewRunsResponseDecodesReviewsKeyFromLiveContract() throws {
+        let json = """
+        {
+          "reviews": [
+            {
+              "id": 44,
+              "repo_id": 1,
+              "repo_full_name": "mean-weasel/issuectl",
+              "owner": "mean-weasel",
+              "repo_name": "issuectl",
+              "pr_number": 563,
+              "deployment_id": null,
+              "started_head_sha": "abcdef123456",
+              "completed_head_sha": "abcdef123456",
+              "review_base_sha": "1111111",
+              "reviewed_from_sha": null,
+              "reviewed_to_sha": "abcdef123456",
+              "head_repo_full_name": "mean-weasel/issuectl",
+              "head_ref": "codex/ios-global-automation-feed",
+              "status": "completed",
+              "triggered_by": "webhook",
+              "result": {"summary": "No issues found"},
+              "summary": "No issues found",
+              "finding_count": 0,
+              "range_label": "full abcdef1",
+              "detail_href": "/reviews/44",
+              "started_at": 1780000003000,
+              "started_at_iso": "2026-05-29T20:26:43.000Z",
+              "completed_at": 1780000004000,
+              "completed_at_iso": "2026-05-29T20:26:44.000Z",
+              "deployment": null
+            }
+          ],
+          "repos": [{"id": 1, "full_name": "mean-weasel/issuectl"}],
+          "filters": {"repo": null, "pr": null, "status": "all", "limit": 50},
+          "summary": {
+            "count": 1,
+            "active_count": 0,
+            "completed_count": 1,
+            "failed_count": 0,
+            "latest_started_at": 1780000003000,
+            "latest_started_at_iso": "2026-05-29T20:26:43.000Z"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(ReviewRunsResponse.self, from: json)
+        XCTAssertEqual(response.reviewRuns.count, 1)
+        XCTAssertEqual(response.reviewRuns[0].repoFullName, "mean-weasel/issuectl")
+        XCTAssertEqual(response.reviewRuns[0].status, .completed)
+    }
 }


### PR DESCRIPTION
## Summary
- Add iOS API support for global webhook events and review runs.
- Add a Settings automation feed with manual refresh, pull-to-refresh, and lightweight polling.
- Decode both `reviews` and repo-scoped `reviewRuns` response keys for review run parity.

## Verification
- Focused xcodebuild tests for global webhook/review endpoint URLs and live contract decoding
- Focused regression run: 7 tests, 0 failures
- `git diff --check`
