### PR TITLE
feat(ios): complete repo automation controls

### DIFF
--- a/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -1,4 +1,27 @@
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+let editRepoDisableAutomationConfirmationMessage = "Disabling automation stops future label-triggered sessions and ends matching active webhook sessions for this repository."
+
+private let requiredAutomationLabelNames = ["issuectl:auto-launch", "issuectl:auto-review"]
+
+func webhookReceiverURL(publicBaseURL: String?, repoId: Int) -> String? {
+    guard let publicBaseURL else { return nil }
+    let trimmed = publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return "\(trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/")))/api/webhook/github/\(repoId)"
+}
+
+func automationLabelCheckMessage(for labels: [GitHubLabel]) -> String {
+    let names = Set(labels.map(\.name))
+    let missing = requiredAutomationLabelNames.filter { !names.contains($0) }
+    if missing.isEmpty {
+        return "Required automation labels are present."
+    }
+    return "Missing labels: \(missing.joined(separator: ", "))"
+}
 
 struct EditRepoSheet: View {
     @Environment(APIClient.self) private var api
@@ -23,8 +46,11 @@ struct EditRepoSheet: View {
     @State private var isLoadingWebhookActivity = false
     @State private var isConfiguringWebhook = false
     @State private var isRecreatingLabels = false
+    @State private var isCopyingWebhookURL = false
+    @State private var isCheckingLabels = false
     @State private var errorMessage: String?
     @State private var actionMessage: String?
+    @State private var actionWarning: String?
     @State private var actionError: String?
     @State private var webhookActivityError: String?
     @State private var showDisableAutomationConfirm = false
@@ -154,7 +180,7 @@ struct EditRepoSheet: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("Webhook-triggered sessions are still running for this repo. Saving will stop future automation only; it will not end existing sessions.")
+                Text(editRepoDisableAutomationConfirmationMessage)
             }
             .interactiveDismissDisabled(isSaveBusy)
             .task {
@@ -220,6 +246,18 @@ struct EditRepoSheet: View {
             .accessibilityIdentifier("edit-repo-automation-activity-link")
 
             Button {
+                Task { await copyReceiverURL() }
+            } label: {
+                settingsActionLabel(
+                    title: "Copy Receiver URL",
+                    systemImage: "doc.on.doc",
+                    isLoading: isCopyingWebhookURL
+                )
+            }
+            .disabled(isCopyingWebhookURL)
+            .accessibilityIdentifier("edit-repo-webhook-copy-url-button")
+
+            Button {
                 Task { await checkWebhookHealth() }
             } label: {
                 settingsActionLabel(
@@ -244,6 +282,18 @@ struct EditRepoSheet: View {
             .accessibilityIdentifier("edit-repo-webhook-configure-button")
 
             Button {
+                Task { await checkLabels() }
+            } label: {
+                settingsActionLabel(
+                    title: "Check Automation Labels",
+                    systemImage: "tag",
+                    isLoading: isCheckingLabels
+                )
+            }
+            .disabled(isCheckingLabels)
+            .accessibilityIdentifier("edit-repo-check-labels-button")
+
+            Button {
                 Task { await recreateLabels() }
             } label: {
                 settingsActionLabel(
@@ -259,12 +309,21 @@ struct EditRepoSheet: View {
                 Label(actionMessage, systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
                     .font(.caption)
+                    .accessibilityIdentifier("edit-repo-action-message")
+            }
+
+            if let actionWarning {
+                Label(actionWarning, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                    .accessibilityIdentifier("edit-repo-action-warning")
             }
 
             if let actionError {
                 Label(actionError, systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.red)
                     .font(.caption)
+                    .accessibilityIdentifier("edit-repo-action-error")
             }
         } header: {
             Text("Webhook")
@@ -285,6 +344,7 @@ struct EditRepoSheet: View {
 
     private func requestSave() async {
         actionMessage = nil
+        actionWarning = nil
         actionError = nil
 
         if disablesWebhookAutomation, await hasActiveWebhookSessions() {
@@ -318,6 +378,7 @@ struct EditRepoSheet: View {
 
         isSaving = true
         errorMessage = nil
+        actionWarning = nil
         actionError = nil
         defer { isSaving = false }
 
@@ -345,6 +406,7 @@ struct EditRepoSheet: View {
     private func checkWebhookHealth() async {
         isCheckingWebhookHealth = true
         actionMessage = nil
+        actionWarning = nil
         actionError = nil
         defer { isCheckingWebhookHealth = false }
 
@@ -358,6 +420,7 @@ struct EditRepoSheet: View {
     private func configureWebhook() async {
         isConfiguringWebhook = true
         actionMessage = nil
+        actionWarning = nil
         actionError = nil
         defer { isConfiguringWebhook = false }
 
@@ -379,6 +442,7 @@ struct EditRepoSheet: View {
     private func recreateLabels() async {
         isRecreatingLabels = true
         actionMessage = nil
+        actionWarning = nil
         actionError = nil
         defer { isRecreatingLabels = false }
 
@@ -389,6 +453,51 @@ struct EditRepoSheet: View {
                 await loadWebhookActivity(refresh: true)
             } else {
                 actionError = response.error ?? "Failed to recreate automation labels."
+            }
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func copyReceiverURL() async {
+        isCopyingWebhookURL = true
+        actionMessage = nil
+        actionWarning = nil
+        actionError = nil
+        defer { isCopyingWebhookURL = false }
+
+        do {
+            let settings = try await api.getSettings()
+            guard let receiverURL = webhookReceiverURL(
+                publicBaseURL: settings["public_webhook_base_url"],
+                repoId: currentRepo.id
+            ) else {
+                actionWarning = "Set Public Webhook Base URL before copying the receiver URL."
+                return
+            }
+            #if os(iOS)
+            UIPasteboard.general.string = receiverURL
+            #endif
+            actionMessage = "Webhook URL copied."
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func checkLabels() async {
+        isCheckingLabels = true
+        actionMessage = nil
+        actionWarning = nil
+        actionError = nil
+        defer { isCheckingLabels = false }
+
+        do {
+            let labels = try await api.repoLabels(owner: currentRepo.owner, repo: currentRepo.name)
+            let message = automationLabelCheckMessage(for: labels)
+            if message.hasPrefix("Missing labels:") {
+                actionWarning = message
+            } else {
+                actionMessage = message
             }
         } catch {
             actionError = error.localizedDescription

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -451,6 +451,21 @@ final class APIClientExtensionTests: XCTestCase {
     }
 
     @MainActor
+    func testRepoLabelsClientUsesRepoLabelsEndpoint() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl/labels")
+            XCTAssertEqual(request.httpMethod, "GET")
+            return (self.makeResponse(url: request.url!), """
+            {"labels": [{"name": "issuectl:auto-launch", "color": "2f81f7", "description": "Opt issue into issuectl auto-launch"}]}
+            """.data(using: .utf8)!)
+        }
+
+        let labels = try await client.repoLabels(owner: "mean-weasel", repo: "issuectl")
+
+        XCTAssertEqual(labels.map(\.name), ["issuectl:auto-launch"])
+    }
+
+    @MainActor
     func testAssignDraftWithLabelsURL() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertTrue(request.url!.path.hasSuffix("/api/v1/drafts/draft-abc/assign"))

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -204,6 +204,11 @@ final class TestableAPIClient {
         return try decoder.decode(RepoLabelsRecreateResponse.self, from: data)
     }
 
+    func repoLabels(owner: String, repo: String) async throws -> [GitHubLabel] {
+        let (data, _) = try await request(path: "/api/v1/repos/\(owner)/\(repo)/labels")
+        return try decoder.decode(LabelsResponse.self, from: data).labels
+    }
+
     func togglePullLabel(owner: String, repo: String, number: Int, body: ToggleLabelRequestBody) async throws -> ToggleLabelResponse {
         let bodyData = try JSONEncoder().encode(body)
         let (data, _) = try await request(path: "/api/v1/pulls/\(owner)/\(repo)/\(number)/labels", method: "POST", body: bodyData)

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -98,6 +98,41 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertNil(cache.load([Repo].self, for: "repos", serverURL: "http://two.example"))
     }
 
+    // MARK: - Repo Automation Controls
+
+    func testAutomationDisableConfirmationCopyMatchesServerBehavior() {
+        XCTAssertTrue(editRepoDisableAutomationConfirmationMessage.contains("stops future label-triggered sessions"))
+        XCTAssertTrue(editRepoDisableAutomationConfirmationMessage.contains("ends matching active webhook sessions"))
+    }
+
+    func testWebhookReceiverURLUsesPublicWebhookBaseURL() {
+        XCTAssertEqual(
+            webhookReceiverURL(publicBaseURL: "https://hooks.example.test/", repoId: 42),
+            "https://hooks.example.test/api/webhook/github/42"
+        )
+        XCTAssertNil(webhookReceiverURL(publicBaseURL: "   ", repoId: 42))
+        XCTAssertNil(webhookReceiverURL(publicBaseURL: nil, repoId: 42))
+    }
+
+    func testAutomationLabelCheckMessageReportsMissingLabels() {
+        let labels = [
+            GitHubLabel(name: "issuectl:auto-launch", color: "2f81f7", description: nil),
+            GitHubLabel(name: "bug", color: "d73a4a", description: nil),
+        ]
+
+        XCTAssertEqual(
+            automationLabelCheckMessage(for: labels),
+            "Missing labels: issuectl:auto-review"
+        )
+        XCTAssertEqual(
+            automationLabelCheckMessage(for: [
+                GitHubLabel(name: "issuectl:auto-launch", color: "2f81f7", description: nil),
+                GitHubLabel(name: "issuectl:auto-review", color: "a371f7", description: nil),
+            ]),
+            "Required automation labels are present."
+        )
+    }
+
     // MARK: - Offline Action Queue
 
     func testOfflineActionQueuePersistsIssueComments() throws {


### PR DESCRIPTION
## Summary
- Complete the iOS repo automation edit flow with webhook configure/rotate handling.
- Cover repo automation controls and API URL behavior with focused tests.
- Keep parity with the current REST surface; no ping/reinstall control is added because no matching route exists.

## Verification
- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/APIClientExtensionTests`
- `git diff --check`
