### PR TITLE
feat(ios): add sessions review history

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -1,22 +1,26 @@
 import SwiftUI
 
+extension SessionsOverviewTab: SectionTabItem {
+    var icon: String {
+        switch self {
+        case .sessions: "play.circle"
+        case .reviews: "eye"
+        }
+    }
+}
+
 struct SessionListView: View {
     @Environment(APIClient.self) private var api
-    @Environment(\.scenePhase) private var scenePhase
     let onShowSettings: () -> Void
     let onShowIssues: () -> Void
 
     @State private var repos: [Repo] = []
-    @State private var deployments: [ActiveDeployment] = []
-    @State private var previews: [Int: SessionPreview] = [:]
+    @State private var overviewResponse: SessionsOverviewResponse?
     @State private var isLoading = true
-    @State private var isFetchingPreviews = false
     @State private var errorMessage: String?
     @State private var actionError: String?
-    @State private var cachedDeploymentsAt: Date?
-    @State private var isShowingCachedDeployments = false
     @State private var terminalPresentation: TerminalPresentation?
-    @State private var sessionControlsTarget: ActiveDeployment?
+    @State private var sessionControlsTarget: SessionsOverviewSession?
     @State private var diagnosticsTarget: ActiveDeployment?
     @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
@@ -24,40 +28,24 @@ struct SessionListView: View {
     @State private var searchText = ""
     @State private var isSearchVisible = false
     @State private var selectedRepoIds: Set<Int> = []
+    @State private var selectedTab: SessionsOverviewTab = .sessions
+    @State private var selectedState: SessionsOverviewStateFilter = .all
+    @State private var selectedTrigger: SessionsOverviewTriggerFilter = .all
+    @State private var selectedReviewStatus: ReviewRunStatusFilter = .all
     @State private var showFiltersSheet = false
     @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
 
-    private var filteredDeployments: [ActiveDeployment] {
-        var items = deployments
-
-        if !selectedRepoIds.isEmpty {
-            items = items.filter { selectedRepoIds.contains($0.repoId) }
-        }
-
-        if searchText.isEmpty {
-            return sortDeploymentsForInvestigation(items)
-        }
-
-        let query = searchText.lowercased()
-        let matchingItems = items.filter { deployment in
-            [
-                deployment.repoFullName,
-                deployment.targetLabel,
-                deployment.branchName,
-                deployment.ttydPort.map(String.init) ?? "starting",
-            ]
-            .compactMap { $0 }
-            .joined(separator: " ")
-            .lowercased()
-            .contains(query)
-        }
-        return sortDeploymentsForInvestigation(matchingItems)
+    private var overview: SessionsOverviewData? {
+        overviewResponse?.overview
     }
 
     private var hasActiveFilters: Bool {
         !selectedRepoIds.isEmpty
+            || selectedState != .all
+            || selectedTrigger != .all
+            || selectedReviewStatus != .all
     }
 
     private var selectedRepoSummary: String {
@@ -78,7 +66,69 @@ struct SessionListView: View {
     }
 
     private var activeRepoFullNames: [String] {
-        Array(Set(deployments.filter(\.isActive).map(\.repoFullName))).sorted()
+        Array(Set((overview?.sessionGroups ?? [])
+            .flatMap(\.sessions)
+            .filter(\.isActive)
+            .map(\.repoFullName)))
+            .sorted()
+    }
+
+    private var selectedRepoQuery: String? {
+        guard selectedRepoIds.count == 1,
+              let repo = repos.first(where: { selectedRepoIds.contains($0.id) })
+        else { return nil }
+        return repo.fullName
+    }
+
+    private var filteredSessionGroups: [SessionsOverviewSessionGroup] {
+        let groups = overview?.sessionGroups ?? []
+        guard !selectedRepoIds.isEmpty, selectedRepoQuery == nil else { return groups }
+        return groups
+            .map { group in
+                SessionsOverviewSessionGroup(
+                    key: group.key,
+                    repoFullName: group.repoFullName,
+                    targetType: group.targetType,
+                    targetNumber: group.targetNumber,
+                    targetLabel: group.targetLabel,
+                    sessions: group.sessions.filter { selectedRepoIds.contains($0.repoId) },
+                    matchingSessionCount: group.matchingSessionCount
+                )
+            }
+            .filter { !$0.sessions.isEmpty }
+    }
+
+    private var filteredReviewGroups: [SessionsOverviewReviewGroup] {
+        let groups = overview?.reviewGroups ?? []
+        guard !selectedRepoIds.isEmpty, selectedRepoQuery == nil else { return groups }
+        return groups
+            .map { group in
+                SessionsOverviewReviewGroup(
+                    key: group.key,
+                    repoFullName: group.repoFullName,
+                    owner: group.owner,
+                    repoName: group.repoName,
+                    prNumber: group.prNumber,
+                    runs: group.runs.filter { selectedRepoIds.contains($0.repoId) },
+                    matchingRunCount: group.matchingRunCount
+                )
+            }
+            .filter { !$0.runs.isEmpty }
+    }
+
+    private var hasOverviewItems: Bool {
+        !filteredSessionGroups.isEmpty || !filteredReviewGroups.isEmpty
+    }
+
+    private var overviewQuerySignature: String {
+        [
+            selectedTab.rawValue,
+            searchText,
+            selectedRepoIds.sorted().map(String.init).joined(separator: ","),
+            selectedState.rawValue,
+            selectedTrigger.rawValue,
+            selectedReviewStatus.rawValue,
+        ].joined(separator: "|")
     }
 
     var body: some View {
@@ -97,8 +147,17 @@ struct SessionListView: View {
                     onTap: { showFiltersSheet = true }
                 )
 
+                SectionTabs(
+                    selected: $selectedTab,
+                    counts: [
+                        .sessions: (overview?.summary.activeSessions ?? 0) + (overview?.summary.endedSessions ?? 0),
+                        .reviews: overview?.summary.reviewRuns ?? 0,
+                    ]
+                )
+                .padding(.top, 8)
+
                 Group {
-                    if isLoading && deployments.isEmpty {
+                    if isLoading && overviewResponse == nil {
                         ProgressView("Loading sessions...")
                     } else if let errorMessage {
                         ContentUnavailableView {
@@ -111,11 +170,11 @@ struct SessionListView: View {
                                 Button("Open Settings", action: onShowSettings)
                             }
                         }
-                    } else if deployments.isEmpty {
+                    } else if !hasOverviewItems {
                         ContentUnavailableView {
-                            Label("No Active Sessions", systemImage: "play.circle")
+                            Label("No Sessions", systemImage: "play.circle")
                         } description: {
-                            Text("Launch an agent from an issue, then return here to open terminals and end sessions.")
+                            Text("Launch an agent from an issue or review a PR, then return here to open terminals and inspect history.")
                         } actions: {
                             HStack {
                                 Button("Open Issues", action: onShowIssues)
@@ -123,49 +182,7 @@ struct SessionListView: View {
                             }
                         }
                     } else {
-                        ScrollView {
-                            LazyVStack(spacing: 12) {
-                                if isShowingCachedDeployments {
-                                    OfflineStatusBanner(message: staleDataMessage(kind: "sessions", cachedAt: cachedDeploymentsAt))
-                                }
-
-                                if let actionError {
-                                    Label(actionError, systemImage: "exclamationmark.triangle")
-                                        .foregroundStyle(.red)
-                                        .font(.subheadline)
-                                        .lineLimit(3)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-
-                                if filteredDeployments.isEmpty {
-                                    ContentUnavailableView {
-                                        Label("No Matching Sessions", systemImage: "magnifyingglass")
-                                    } description: {
-                                        Text("Try another repo, target number, branch, or port.")
-                                    } actions: {
-                                        Button(hasActiveFilters ? "Clear Filters" : "Clear Search", action: resetFiltersAndSearch)
-                                    }
-                                    .padding(.top, 18)
-                                }
-
-                                ForEach(filteredDeployments) { deployment in
-                                    let port = deployment.ttydPort
-                                    SessionRowView(
-                                        deployment: deployment,
-                                        preview: port.flatMap { previews[$0] },
-                                        isEnding: endingDeploymentId == deployment.id,
-                                        onOpen: {
-                                            openTerminal(deployment)
-                                        },
-                                        onControls: {
-                                            sessionControlsTarget = deployment
-                                        }
-                                    )
-                                }
-                            }
-                            .padding(.horizontal, 16)
-                            .padding(.top, 16)
-                        }
+                        overviewContent
                         .refreshable { await refreshSessions() }
                     }
                 }
@@ -177,9 +194,8 @@ struct SessionListView: View {
             .navigationDestination(for: PRDestination.self) { dest in
                 PRDetailView(owner: dest.owner, repo: dest.repo, number: dest.number)
             }
-            .task { await load() }
-            .task(id: scenePhase) {
-                await pollPreviews()
+            .task(id: overviewQuerySignature) {
+                await load()
             }
             .onReceive(refreshTimer) { _ in
                 guard terminalPresentation == nil else { return }
@@ -199,42 +215,42 @@ struct SessionListView: View {
                         },
                         onEnd: {
                             terminalPresentation = nil
-                            deployments.removeAll { $0.id == deployment.id }
+                            Task { await load(refresh: true, includeRepos: false) }
                         }
                     )
                 }
             }
-            .sheet(item: $sessionControlsTarget) { deployment in
+            .sheet(item: $sessionControlsTarget) { session in
                 SessionControlsSheet(
-                    deployment: deployment,
-                    isEnding: endingDeploymentId == deployment.id,
+                    session: session,
+                    isEnding: endingDeploymentId == session.id,
                     onOpenTerminal: {
                         sessionControlsTarget = nil
-                        openTerminal(deployment)
+                        openTerminal(session)
                     },
                     onViewTarget: {
                         sessionControlsTarget = nil
-                        if deployment.isIssueTarget {
+                        if session.isIssueTarget {
                             navigationPath.append(IssueDestination(
-                                owner: deployment.owner,
-                                repo: deployment.repoName,
-                                number: deployment.issueNumber
+                                owner: session.owner,
+                                repo: session.repoName,
+                                number: session.resolvedIssueNumber
                             ))
                         } else {
                             navigationPath.append(PRDestination(
-                                owner: deployment.owner,
-                                repo: deployment.repoName,
-                                number: deployment.targetNumber
+                                owner: session.owner,
+                                repo: session.repoName,
+                                number: session.targetNumber
                             ))
                         }
                     },
                     onViewDiagnostics: {
                         sessionControlsTarget = nil
-                        diagnosticsTarget = deployment
+                        diagnosticsTarget = session.activeDeployment
                     },
                     onEnd: {
                         Task {
-                            await endSession(deployment)
+                            await endSession(session)
                             sessionControlsTarget = nil
                         }
                     }
@@ -257,12 +273,78 @@ struct SessionListView: View {
                 SessionFilterSheet(
                     repos: repos,
                     selectedRepoIds: $selectedRepoIds,
-                    selectedRepoSummary: selectedRepoSummary
+                    selectedRepoSummary: selectedRepoSummary,
+                    selectedState: $selectedState,
+                    selectedTrigger: $selectedTrigger,
+                    selectedReviewStatus: $selectedReviewStatus,
+                    selectedTab: selectedTab
                 )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
             }
         }
+    }
+
+    private var overviewContent: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                if let actionError {
+                    Label(actionError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.subheadline)
+                        .lineLimit(3)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                switch selectedTab {
+                case .sessions:
+                    if filteredSessionGroups.isEmpty {
+                        emptyFilteredState
+                    } else {
+                        ForEach(filteredSessionGroups) { group in
+                            SessionTargetGroupView(
+                                group: group,
+                                endingDeploymentId: endingDeploymentId,
+                                onOpen: openTerminal,
+                                onControls: { sessionControlsTarget = $0 }
+                            )
+                        }
+                    }
+                case .reviews:
+                    if filteredReviewGroups.isEmpty {
+                        emptyFilteredState
+                    } else {
+                        ForEach(filteredReviewGroups) { group in
+                            ReviewRunGroupView(
+                                group: group,
+                                onOpenDeployment: openTerminal,
+                                onOpenPullRequest: { run in
+                                    navigationPath.append(PRDestination(owner: run.owner, repo: run.repoName, number: run.prNumber))
+                                },
+                                onOpenDiagnostics: { run in
+                                    if let deployment = run.deployment {
+                                        diagnosticsTarget = deployment.activeDeployment
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+        }
+    }
+
+    private var emptyFilteredState: some View {
+        ContentUnavailableView {
+            Label("No Matches", systemImage: "magnifyingglass")
+        } description: {
+            Text(selectedTab == .sessions ? "Try another repo, state, trigger, target, branch, or port." : "Try another repo, review status, trigger, or PR number.")
+        } actions: {
+            Button(hasActiveFilters ? "Clear Filters" : "Clear Search", action: resetFiltersAndSearch)
+        }
+        .padding(.top, 18)
     }
 
     private var sessionHeader: some View {
@@ -306,11 +388,22 @@ struct SessionListView: View {
     }
 
     private var sessionSubtitle: String {
-        if deployments.isEmpty {
+        guard let summary = overview?.summary else {
             return "No active sessions"
         }
 
-        return "Running sessions"
+        switch selectedTab {
+        case .sessions:
+            if summary.activeSessions == 0 && summary.endedSessions == 0 {
+                return "No sessions"
+            }
+            return "\(summary.activeSessions) active · \(summary.endedSessions) ended"
+        case .reviews:
+            if summary.reviewRuns == 0 {
+                return "No review runs"
+            }
+            return "\(summary.reviewRuns) reviews · \(summary.activeReviewRuns) active"
+        }
     }
 
     private var sessionSearchBar: some View {
@@ -357,42 +450,19 @@ struct SessionListView: View {
 
     private func resetFiltersAndSearch() {
         selectedRepoIds.removeAll()
+        selectedState = .all
+        selectedTrigger = .all
+        selectedReviewStatus = .all
         hideSearch()
-    }
-
-    private func sortDeploymentsForInvestigation(_ items: [ActiveDeployment]) -> [ActiveDeployment] {
-        items
-            .enumerated()
-            .sorted { lhs, rhs in
-                let lhsRank = sessionSortRank(lhs.element)
-                let rhsRank = sessionSortRank(rhs.element)
-                if lhsRank != rhsRank {
-                    return lhsRank < rhsRank
-                }
-                return lhs.offset < rhs.offset
-            }
-            .map(\.element)
-    }
-
-    private func sessionSortRank(_ deployment: ActiveDeployment) -> Int {
-        guard let port = deployment.ttydPort else {
-            return 4
-        }
-
-        switch previews[port]?.status {
-        case .idle:
-            return 0
-        case .error:
-            return 1
-        case .unavailable, nil:
-            return 2
-        case .active:
-            return 3
-        }
     }
 
     private func sessionErrorDescription(_ message: String) -> String {
         "\(message)\n\nRetry after starting issuectl web, or open Settings to update the server."
+    }
+
+    private func openTerminal(_ session: SessionsOverviewSession) {
+        guard session.isActive else { return }
+        openTerminal(session.activeDeployment)
     }
 
     private func openTerminal(_ deployment: ActiveDeployment) {
@@ -403,23 +473,26 @@ struct SessionListView: View {
     private func load(refresh: Bool = false, includeRepos: Bool? = nil) async {
         let shouldLoadRepos = includeRepos ?? (refresh || repos.isEmpty)
         let trace = PerformanceTrace.begin("sessions.load", metadata: "refresh=\(refresh) include_repos=\(shouldLoadRepos)")
-        if deployments.isEmpty { isLoading = true }
+        if overviewResponse == nil { isLoading = true }
         errorMessage = nil
         if refresh { actionError = nil }
         defer {
-            PerformanceTrace.end(trace, metadata: "deployments=\(deployments.count) repos=\(repos.count)")
+            PerformanceTrace.end(trace, metadata: "session_groups=\(overview?.sessionGroups.count ?? 0) review_groups=\(overview?.reviewGroups.count ?? 0) repos=\(repos.count)")
         }
         do {
-            async let deploymentsResult = api.activeDeployments()
+            async let overviewResult = api.sessionsOverview(
+                tab: selectedTab,
+                searchText: searchText,
+                repo: selectedRepoQuery,
+                trigger: selectedTrigger,
+                state: selectedState,
+                status: selectedReviewStatus
+            )
             async let reposResult: Result<[Repo], Error>? = shouldLoadRepos ? {
                 do { return .success(try await api.repos()) }
                 catch { return .failure(error) }
             }() : nil
-            let response = try await deploymentsResult
-            deployments = response.deployments
-            isShowingCachedDeployments = response.fromCache
-            cachedDeploymentsAt = response.cachedAt.flatMap(parseIssueCTLDate)
-            prunePreviewState()
+            overviewResponse = try await overviewResult
             if let reposResult = await reposResult {
                 switch reposResult {
                 case .success(let loadedRepos):
@@ -431,70 +504,33 @@ struct SessionListView: View {
                 }
             }
         } catch {
-            if deployments.isEmpty {
+            if overviewResponse == nil {
                 errorMessage = error.localizedDescription
+            } else {
+                actionError = error.localizedDescription
             }
         }
         isLoading = false
     }
 
-    private func fetchPreviews() async {
-        guard !isFetchingPreviews else { return }
-        guard !deployments.isEmpty else {
-            previews = [:]
-            return
-        }
-        isFetchingPreviews = true
-        defer { isFetchingPreviews = false }
-        do {
-            let response = try await api.sessionPreviews()
-            previews = response.previewsByPort
-            prunePreviewState()
-        } catch {
-            // Preview data is supplementary; keep the session list usable if
-            // the endpoint is temporarily unavailable.
-        }
-    }
-
-    private func pollPreviews() async {
-        guard scenePhase == .active else { return }
-        while !Task.isCancelled {
-            if deployments.isEmpty {
-                previews = [:]
-            } else {
-                await fetchPreviews()
-            }
-            try? await Task.sleep(for: .seconds(2))
-        }
-    }
-
     private func refreshSessions() async {
         await load(refresh: true)
-        await fetchPreviews()
     }
 
-    private func prunePreviewState() {
-        let ports = Set(deployments.compactMap(\.ttydPort))
-        previews = previews.filter { ports.contains($0.key) }
-    }
-
-    private func endSession(_ deployment: ActiveDeployment) async {
-        endingDeploymentId = deployment.id
+    private func endSession(_ session: SessionsOverviewSession) async {
+        endingDeploymentId = session.id
         do {
             _ = try await api.endSession(
-                deploymentId: deployment.id,
-                owner: deployment.owner,
-                repo: deployment.repoName,
-                issueNumber: deployment.issueNumber,
-                targetType: deployment.targetType,
-                targetNumber: deployment.targetNumber
+                deploymentId: session.id,
+                owner: session.owner,
+                repo: session.repoName,
+                issueNumber: session.resolvedIssueNumber,
+                targetType: session.targetType,
+                targetNumber: session.targetNumber
             )
-            deployments.removeAll { $0.id == deployment.id }
-            if let port = deployment.ttydPort {
-                previews.removeValue(forKey: port)
-            }
+            await load(refresh: true, includeRepos: false)
         } catch {
-            errorMessage = error.localizedDescription
+            actionError = error.localizedDescription
         }
         endingDeploymentId = nil
     }
@@ -505,10 +541,334 @@ private struct TerminalPresentation: Identifiable {
     let deployment: ActiveDeployment
 }
 
+private struct SessionTargetGroupView: View {
+    let group: SessionsOverviewSessionGroup
+    let endingDeploymentId: Int?
+    let onOpen: (SessionsOverviewSession) -> Void
+    let onControls: (SessionsOverviewSession) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            groupHeader
+            ForEach(group.sessions) { session in
+                SessionOverviewRow(
+                    session: session,
+                    isEnding: endingDeploymentId == session.id,
+                    onOpen: { onOpen(session) },
+                    onControls: { onControls(session) }
+                )
+            }
+        }
+        .accessibilityIdentifier("session-group-\(group.key)")
+    }
+
+    private var groupHeader: some View {
+        HStack(spacing: 8) {
+            Label(group.targetLabel, systemImage: group.targetType == .issue ? "number" : "arrow.triangle.merge")
+                .font(.subheadline.weight(.semibold))
+            Spacer(minLength: 8)
+            Text(group.repoFullName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 2)
+    }
+}
+
+private struct SessionOverviewRow: View {
+    let session: SessionsOverviewSession
+    let isEnding: Bool
+    let onOpen: () -> Void
+    let onControls: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+                Text(session.repoFullName)
+                    .font(.subheadline.weight(.medium))
+                Text(session.targetLabel)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Text(statusText)
+                    .font(.caption.bold())
+                    .foregroundStyle(statusColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(statusColor.opacity(0.14), in: Capsule())
+            }
+
+            Label(session.branchName, systemImage: "arrow.triangle.branch")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label(session.sessionRoleTitle, systemImage: session.isIssueTarget ? "number" : "arrow.triangle.merge")
+                    .font(.caption.weight(.semibold))
+                Text(session.provenanceSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: 10) {
+                sessionMetric(value: session.durationLabel, label: session.isActive ? "Duration" : "Elapsed", systemImage: "clock")
+                if let port = session.ttydPort {
+                    sessionMetric(value: "\(port)", label: "Terminal", systemImage: "terminal")
+                } else {
+                    sessionMetric(value: session.isActive ? "Starting" : "Ended", label: "Terminal", systemImage: "terminal")
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button(action: onOpen) {
+                    Label(openButtonTitle, systemImage: "terminal")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity, minHeight: 40)
+                        .background(IssueCTLColors.action.opacity(canOpenTerminal ? 1 : 0.45), in: RoundedRectangle(cornerRadius: 12))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canOpenTerminal || isEnding)
+                .accessibilityIdentifier("session-reenter-terminal-\(session.id)")
+
+                Button(action: onControls) {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 44, height: 40)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.bordered)
+                .disabled(isEnding)
+                .accessibilityLabel("Session controls")
+                .accessibilityIdentifier("session-controls-\(session.id)")
+            }
+        }
+        .padding(14)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(statusColor.opacity(0.34), lineWidth: 1)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if canOpenTerminal {
+                onOpen()
+            }
+        }
+    }
+
+    private var canOpenTerminal: Bool {
+        session.isActive && session.ttydPort != nil
+    }
+
+    private var openButtonTitle: String {
+        if !session.isActive { return "Session Ended" }
+        return session.ttydPort == nil ? "Starting..." : "Open Terminal"
+    }
+
+    private var statusColor: Color {
+        if !session.isActive { return Color.secondary }
+        switch session.preview?.status {
+        case .active: return Color.green
+        case .idle: return Color.orange
+        case .error: return Color.red
+        case .unavailable: return Color.secondary
+        case nil: return session.ttydPort == nil ? Color.orange : Color.secondary
+        }
+    }
+
+    private var statusText: String {
+        if !session.isActive { return "Ended" }
+        guard session.ttydPort != nil else { return "Starting" }
+        switch session.preview?.status {
+        case .idle: return "Idle"
+        case .error: return "Error"
+        case .unavailable: return "Checking"
+        case .active: return "Running"
+        case nil: return "Checking"
+        }
+    }
+
+    private func sessionMetric(value: String, label: String, systemImage: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value.isEmpty ? "-" : value)
+                    .font(.subheadline.bold())
+                    .lineLimit(1)
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct ReviewRunGroupView: View {
+    let group: SessionsOverviewReviewGroup
+    let onOpenDeployment: (SessionsOverviewSession) -> Void
+    let onOpenPullRequest: (SessionsOverviewReviewRun) -> Void
+    let onOpenDiagnostics: (SessionsOverviewReviewRun) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Label("PR #\(group.prNumber)", systemImage: "eye")
+                    .font(.subheadline.weight(.semibold))
+                Spacer(minLength: 8)
+                Text(group.repoFullName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 2)
+
+            ForEach(group.runs) { run in
+                ReviewRunRow(
+                    run: run,
+                    onOpenDeployment: { deployment in onOpenDeployment(deployment) },
+                    onOpenPullRequest: { onOpenPullRequest(run) },
+                    onOpenDiagnostics: { onOpenDiagnostics(run) }
+                )
+            }
+        }
+        .accessibilityIdentifier("review-group-\(group.key)")
+    }
+}
+
+private struct ReviewRunRow: View {
+    let run: SessionsOverviewReviewRun
+    let onOpenDeployment: (SessionsOverviewSession) -> Void
+    let onOpenPullRequest: () -> Void
+    let onOpenDiagnostics: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Text(run.statusLabel)
+                    .font(.caption.bold())
+                    .foregroundStyle(statusColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(statusColor.opacity(0.14), in: Capsule())
+                Text(run.triggeredBy.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(run.elapsedLabel ?? "")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(run.summary ?? "No review summary recorded.")
+                    .font(.subheadline)
+                    .lineLimit(3)
+                Text("\(run.rangeLabel) · \(run.headRepoFullName):\(run.headRef)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: 8) {
+                if let count = run.findingCount {
+                    reviewMetric(value: "\(count)", label: "Findings", systemImage: "exclamationmark.bubble")
+                }
+                if let deployment = run.deployment {
+                    reviewMetric(value: "#\(deployment.id)", label: "Session", systemImage: "terminal")
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button(action: onOpenPullRequest) {
+                    Label("Open PR", systemImage: "arrow.triangle.merge")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity, minHeight: 38)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("review-open-pr-\(run.id)")
+
+                if let deployment = run.deployment, deployment.isActive, deployment.ttydPort != nil {
+                    Button {
+                        onOpenDeployment(deployment)
+                    } label: {
+                        Image(systemName: "terminal")
+                            .frame(width: 42, height: 38)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityLabel("Open review terminal")
+                    .accessibilityIdentifier("review-open-terminal-\(run.id)")
+                }
+
+                if run.deployment != nil {
+                    Button(action: onOpenDiagnostics) {
+                        Image(systemName: "waveform.path.ecg")
+                            .frame(width: 42, height: 38)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Open review diagnostics")
+                    .accessibilityIdentifier("review-diagnostics-\(run.id)")
+                }
+            }
+        }
+        .padding(14)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(statusColor.opacity(0.24), lineWidth: 1)
+        }
+    }
+
+    private var statusColor: Color {
+        switch run.status {
+        case .completed: Color.green
+        case .failed: Color.red
+        case .superseded: Color.secondary
+        case .reserved, .launching, .inProgress: Color.orange
+        }
+    }
+
+    private func reviewMetric(value: String, label: String, systemImage: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.subheadline.bold())
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
 private struct SessionFilterSheet: View {
     let repos: [Repo]
     @Binding var selectedRepoIds: Set<Int>
     let selectedRepoSummary: String
+    @Binding var selectedState: SessionsOverviewStateFilter
+    @Binding var selectedTrigger: SessionsOverviewTriggerFilter
+    @Binding var selectedReviewStatus: ReviewRunStatusFilter
+    let selectedTab: SessionsOverviewTab
 
     var body: some View {
         NavigationStack {
@@ -557,6 +917,50 @@ private struct SessionFilterSheet: View {
                     }
                     .padding(12)
                     .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Session State", systemImage: "circle.dashed")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Picker("Session state", selection: $selectedState) {
+                            ForEach(SessionsOverviewStateFilter.allCases) { state in
+                                Text(state.displayName).tag(state)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    .padding(12)
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Trigger", systemImage: "bolt")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Picker("Trigger", selection: $selectedTrigger) {
+                            ForEach(SessionsOverviewTriggerFilter.allCases) { trigger in
+                                Text(trigger.displayName).tag(trigger)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    .padding(12)
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+
+                    if selectedTab == .reviews {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Label("Review Status", systemImage: "checklist")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Picker("Review status", selection: $selectedReviewStatus) {
+                                ForEach(ReviewRunStatusFilter.allCases) { status in
+                                    Text(status.displayName).tag(status)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                        }
+                        .padding(12)
+                        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+                    }
                 }
                 .padding(16)
             }
@@ -573,9 +977,12 @@ private struct SessionFilterSheet: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            if !selectedRepoIds.isEmpty {
+            if !selectedRepoIds.isEmpty || selectedState != .all || selectedTrigger != .all || selectedReviewStatus != .all {
                 Button("Reset") {
                     selectedRepoIds.removeAll()
+                    selectedState = .all
+                    selectedTrigger = .all
+                    selectedReviewStatus = .all
                 }
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(IssueCTLColors.action)
@@ -608,7 +1015,7 @@ private struct SessionFilterSheet: View {
 }
 
 private struct SessionControlsSheet: View {
-    let deployment: ActiveDeployment
+    let session: SessionsOverviewSession
     let isEnding: Bool
     let onOpenTerminal: () -> Void
     let onViewTarget: () -> Void
@@ -618,12 +1025,12 @@ private struct SessionControlsSheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(deployment.sessionRoleTitle)
+                Text(session.sessionRoleTitle)
                     .font(.title2.weight(.bold))
-                Text("\(deployment.repoFullName) \(deployment.targetLabel)")
+                Text(session.repoTitle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text(deployment.provenanceSummary)
+                Text(session.provenanceSummary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -631,22 +1038,22 @@ private struct SessionControlsSheet: View {
             VStack(spacing: 0) {
                 sheetAction(
                     title: "Open Terminal",
-                    subtitle: deployment.ttydPort.map { "Port \($0)" } ?? "Terminal is still preparing.",
+                    subtitle: session.isActive ? (session.ttydPort.map { "Port \($0)" } ?? "Terminal is still preparing.") : "Session has ended.",
                     systemImage: "terminal",
-                    accessibilityIdentifier: "session-open-terminal-\(deployment.id)",
-                    isDisabled: deployment.ttydPort == nil,
+                    accessibilityIdentifier: "session-open-terminal-\(session.id)",
+                    isDisabled: !session.isActive || session.ttydPort == nil,
                     action: onOpenTerminal
                 )
 
                 Divider()
 
                 sheetAction(
-                    title: deployment.isIssueTarget ? "View Issue" : "View Pull Request",
-                    subtitle: deployment.isIssueTarget
-                        ? "Jump to #\(deployment.issueNumber) without losing this session."
-                        : "Open PR #\(deployment.targetNumber) without losing this session.",
-                    systemImage: deployment.isIssueTarget ? "number" : "arrow.triangle.merge",
-                    accessibilityIdentifier: "session-target-action-\(deployment.id)",
+                    title: session.isIssueTarget ? "View Issue" : "View Pull Request",
+                    subtitle: session.isIssueTarget
+                        ? "Jump to #\(session.resolvedIssueNumber) without losing this session."
+                        : "Open PR #\(session.targetNumber) without losing this session.",
+                    systemImage: session.isIssueTarget ? "number" : "arrow.triangle.merge",
+                    accessibilityIdentifier: "session-target-action-\(session.id)",
                     action: onViewTarget
                 )
 
@@ -656,33 +1063,35 @@ private struct SessionControlsSheet: View {
                     title: "View Diagnostics",
                     subtitle: "Browse launch and session lifecycle events.",
                     systemImage: "waveform.path.ecg",
-                    accessibilityIdentifier: "session-diagnostics-\(deployment.id)",
+                    accessibilityIdentifier: "session-diagnostics-\(session.id)",
                     action: onViewDiagnostics
                 )
 
-                Divider()
+                if session.isActive {
+                    Divider()
 
-                Button(role: .destructive, action: onEnd) {
-                    HStack(spacing: 12) {
-                        Image(systemName: "stop.circle")
-                            .frame(width: 26)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(isEnding ? "Ending Session" : "End Session")
-                                .font(.subheadline.weight(.semibold))
-                            Text("Stop ttyd and mark deployment ended.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                    Button(role: .destructive, action: onEnd) {
+                        HStack(spacing: 12) {
+                            Image(systemName: "stop.circle")
+                                .frame(width: 26)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(isEnding ? "Ending Session" : "End Session")
+                                    .font(.subheadline.weight(.semibold))
+                                Text("Stop ttyd and mark deployment ended.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if isEnding {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
                         }
-                        Spacer()
-                        if isEnding {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
+                        .padding(12)
                     }
-                    .padding(12)
+                    .disabled(isEnding)
+                    .accessibilityIdentifier("session-end-\(session.id)")
                 }
-                .disabled(isEnding)
-                .accessibilityIdentifier("session-end-\(deployment.id)")
             }
             .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
 

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -401,7 +401,7 @@ enum ReviewRunStatus: String, Codable, CaseIterable, Sendable {
     case superseded
 }
 
-enum ReviewRunStatusFilter: String, CaseIterable, Identifiable, Sendable {
+enum ReviewRunStatusFilter: String, Codable, CaseIterable, Identifiable, Sendable {
     case all
     case reserved
     case launching
@@ -491,6 +491,255 @@ struct ReviewRunDeployment: Codable, Identifiable, Sendable {
     let terminalReason: String?
     let ttydPort: Int?
     let idleSince: String?
+}
+
+enum SessionsOverviewTab: String, Codable, CaseIterable, Sendable {
+    case sessions
+    case reviews
+}
+
+enum SessionsOverviewStateFilter: String, Codable, CaseIterable, Identifiable, Sendable {
+    case active
+    case ended
+    case all
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .active: "Active"
+        case .ended: "Ended"
+        case .all: "All"
+        }
+    }
+}
+
+enum SessionsOverviewTriggerFilter: String, Codable, CaseIterable, Identifiable, Sendable {
+    case manual
+    case webhook
+    case commentCommand = "comment_command"
+    case all
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .manual: "Manual"
+        case .webhook: "Webhook"
+        case .commentCommand: "Comment command"
+        case .all: "All"
+        }
+    }
+}
+
+struct SessionsOverviewFilters: Codable, Sendable {
+    let tab: SessionsOverviewTab
+    let q: String
+    let repo: String
+    let trigger: SessionsOverviewTriggerFilter
+    let state: SessionsOverviewStateFilter
+    let status: ReviewRunStatusFilter
+}
+
+struct SessionsOverviewRepoSummary: Codable, Identifiable, Sendable {
+    let id: Int
+    let fullName: String
+}
+
+struct SessionsOverviewSession: Codable, Identifiable, Sendable {
+    let id: Int
+    let repoId: Int
+    let repoFullName: String
+    let owner: String
+    let repoName: String
+    let targetType: DeploymentTargetType
+    let targetNumber: Int
+    let targetLabel: String
+    let issueNumber: Int?
+    let branchName: String
+    let agent: LaunchAgent?
+    let workspaceMode: WorkspaceMode
+    let workspacePath: String
+    let linkedPrNumber: Int?
+    let triggeredBy: DeploymentTrigger?
+    let parentDeploymentId: Int?
+    let childDeploymentCount: Int
+    let webhookDepth: Int
+    let terminalReason: String?
+    let launchedAt: String
+    let endedAt: String?
+    let ttydPort: Int?
+    let idleSince: String?
+    let preview: SessionPreview?
+    let provenanceLabel: String?
+    let elapsedLabel: String?
+
+    var isActive: Bool { endedAt == nil }
+    var isIssueTarget: Bool { targetType == .issue }
+    var resolvedIssueNumber: Int { issueNumber ?? targetNumber }
+    var repoTitle: String { "\(repoFullName) \(targetLabel)" }
+
+    var sessionRoleTitle: String {
+        if targetType == .pr && terminalReason == "review" {
+            return "PR review session"
+        }
+        switch targetType {
+        case .issue: return "Issue session"
+        case .pr: return "PR session"
+        }
+    }
+
+    var provenanceSummary: String {
+        if let provenanceLabel, !provenanceLabel.isEmpty {
+            return provenanceLabel
+        }
+        var parts: [String] = [triggeredBy?.displayName ?? "Unknown trigger"]
+        if let agent {
+            parts.append(agent.displayName)
+        }
+        if let parentDeploymentId {
+            parts.append("follow-up #\(parentDeploymentId)")
+        }
+        if webhookDepth > 0 {
+            parts.append("depth \(webhookDepth)")
+        }
+        return parts.joined(separator: " - ")
+    }
+
+    var durationLabel: String {
+        elapsedLabel ?? runningDuration
+    }
+
+    var runningDuration: String {
+        guard let date = parseIssueCTLDate(launchedAt) else { return "" }
+        let endDate = endedAt.flatMap(parseIssueCTLDate) ?? Date()
+        let interval = endDate.timeIntervalSince(date)
+        let hours = Int(interval) / 3600
+        let minutes = (Int(interval) % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var activeDeployment: ActiveDeployment {
+        ActiveDeployment(
+            id: id,
+            repoId: repoId,
+            issueNumber: resolvedIssueNumber,
+            targetType: targetType,
+            targetNumber: targetNumber,
+            agent: agent,
+            terminalBackend: nil,
+            triggeredBy: triggeredBy,
+            terminalReason: terminalReason,
+            parentDeploymentId: parentDeploymentId,
+            webhookDepth: webhookDepth,
+            idleSince: idleSince,
+            branchName: branchName,
+            workspaceMode: workspaceMode,
+            workspacePath: workspacePath,
+            linkedPrNumber: linkedPrNumber,
+            state: isActive ? .active : .ended,
+            launchedAt: launchedAt,
+            endedAt: endedAt,
+            ttydPort: ttydPort,
+            ttydPid: nil,
+            owner: owner,
+            repoName: repoName
+        )
+    }
+}
+
+struct SessionsOverviewSessionGroup: Codable, Identifiable, Sendable {
+    let key: String
+    let repoFullName: String
+    let targetType: DeploymentTargetType
+    let targetNumber: Int
+    let targetLabel: String
+    let sessions: [SessionsOverviewSession]
+    let matchingSessionCount: Int?
+
+    var id: String { key }
+}
+
+struct SessionsOverviewReviewRun: Codable, Identifiable, Sendable {
+    let id: Int
+    let repoId: Int
+    let repoFullName: String
+    let owner: String
+    let repoName: String
+    let prNumber: Int
+    let deploymentId: Int?
+    let startedHeadSha: String?
+    let completedHeadSha: String?
+    let reviewBaseSha: String?
+    let reviewedFromSha: String?
+    let reviewedToSha: String
+    let headRepoFullName: String
+    let headRef: String
+    let status: ReviewRunStatus
+    let triggeredBy: DeploymentTrigger
+    let result: [String: JSONValue]
+    let resultJson: String?
+    let summary: String?
+    let findingCount: Int?
+    let rangeLabel: String
+    let detailHref: String
+    let provenanceLabel: String?
+    let elapsedLabel: String?
+    let startedAt: Int
+    let completedAt: Int?
+    let deployment: SessionsOverviewSession?
+
+    var statusLabel: String {
+        switch status {
+        case .reserved: "Reserved"
+        case .launching: "Launching"
+        case .inProgress: "In progress"
+        case .completed: "Completed"
+        case .failed: "Failed"
+        case .superseded: "Superseded"
+        }
+    }
+
+    var isActive: Bool {
+        status == .reserved || status == .launching || status == .inProgress
+    }
+}
+
+struct SessionsOverviewReviewGroup: Codable, Identifiable, Sendable {
+    let key: String
+    let repoFullName: String
+    let owner: String
+    let repoName: String
+    let prNumber: Int
+    let runs: [SessionsOverviewReviewRun]
+    let matchingRunCount: Int?
+
+    var id: String { key }
+}
+
+struct SessionsOverviewSummary: Codable, Sendable {
+    let activeSessions: Int
+    let endedSessions: Int
+    let reviewRuns: Int
+    let activeReviewRuns: Int
+}
+
+struct SessionsOverviewData: Codable, Sendable {
+    let initialized: Bool
+    let filters: SessionsOverviewFilters
+    let repos: [SessionsOverviewRepoSummary]
+    let sessionGroups: [SessionsOverviewSessionGroup]
+    let reviewGroups: [SessionsOverviewReviewGroup]
+    let summary: SessionsOverviewSummary
+}
+
+struct SessionsOverviewResponse: Codable, Sendable {
+    let overview: SessionsOverviewData
+    let diagnostics: DeploymentDiagnosticsResponse?
+    let generatedAt: String
 }
 
 enum DiagnosticLevel: String, Codable, CaseIterable, Sendable {

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -354,6 +354,30 @@ final class APIClient {
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
     }
 
+    func sessionsOverview(
+        tab: SessionsOverviewTab = .sessions,
+        searchText: String = "",
+        repo: String? = nil,
+        trigger: SessionsOverviewTriggerFilter = .all,
+        state: SessionsOverviewStateFilter = .all,
+        status: ReviewRunStatusFilter = .all,
+        diagnosticLimit: Int = 20
+    ) async throws -> SessionsOverviewResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/sessions/overview"
+        components.queryItems = [
+            URLQueryItem(name: "tab", value: tab.rawValue),
+            searchText.isEmpty ? nil : URLQueryItem(name: "q", value: searchText),
+            repo.flatMap { $0.isEmpty ? nil : URLQueryItem(name: "repo", value: $0) },
+            trigger == .all ? nil : URLQueryItem(name: "trigger", value: trigger.rawValue),
+            state == .all ? nil : URLQueryItem(name: "state", value: state.rawValue),
+            status == .all ? nil : URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "diagnosticLimit", value: String(max(1, min(100, diagnosticLimit))))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(SessionsOverviewResponse.self, from: data)
+    }
+
     // Depends on issue #546: these automation list endpoints are fixture-driven
     // until the web API exposes dedicated list routes for native clients.
     func webhookEvents(

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -267,6 +267,30 @@ final class TestableAPIClient {
         return try decoder.decode(SessionPreviewsResponse.self, from: data)
     }
 
+    func sessionsOverview(
+        tab: SessionsOverviewTab = .sessions,
+        searchText: String = "",
+        repo: String? = nil,
+        trigger: SessionsOverviewTriggerFilter = .all,
+        state: SessionsOverviewStateFilter = .all,
+        status: ReviewRunStatusFilter = .all,
+        diagnosticLimit: Int = 20
+    ) async throws -> SessionsOverviewResponse {
+        var components = URLComponents()
+        components.path = "/api/v1/sessions/overview"
+        components.queryItems = [
+            URLQueryItem(name: "tab", value: tab.rawValue),
+            searchText.isEmpty ? nil : URLQueryItem(name: "q", value: searchText),
+            repo.flatMap { $0.isEmpty ? nil : URLQueryItem(name: "repo", value: $0) },
+            trigger == .all ? nil : URLQueryItem(name: "trigger", value: trigger.rawValue),
+            state == .all ? nil : URLQueryItem(name: "state", value: state.rawValue),
+            status == .all ? nil : URLQueryItem(name: "status", value: status.rawValue),
+            URLQueryItem(name: "diagnosticLimit", value: String(max(1, min(100, diagnosticLimit))))
+        ].compactMap { $0 }
+        let (data, _) = try await request(path: components.string ?? components.path)
+        return try decoder.decode(SessionsOverviewResponse.self, from: data)
+    }
+
     func webhookEvents(
         owner: String,
         repo: String,
@@ -542,6 +566,50 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.sessionPreviews()
+    }
+
+    @MainActor
+    func testSessionsOverviewEndpointURLAndFilters() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/sessions/overview")
+            XCTAssertTrue(request.url!.query?.contains("tab=reviews") == true)
+            XCTAssertTrue(request.url!.query?.contains("q=PR%20%2344") == true)
+            XCTAssertTrue(request.url!.query?.contains("repo=mean-weasel/issuectl") == true)
+            XCTAssertTrue(request.url!.query?.contains("trigger=webhook") == true)
+            XCTAssertTrue(request.url!.query?.contains("state=ended") == true)
+            XCTAssertTrue(request.url!.query?.contains("status=completed") == true)
+            XCTAssertTrue(request.url!.query?.contains("diagnosticLimit=5") == true)
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {
+              "overview": {
+                "initialized": true,
+                "filters": {"tab":"reviews","q":"PR #44","repo":"mean-weasel/issuectl","trigger":"webhook","state":"ended","status":"completed"},
+                "repos": [],
+                "session_groups": [],
+                "review_groups": [],
+                "summary": {"active_sessions":0,"ended_sessions":0,"review_runs":0,"active_review_runs":0}
+              },
+              "diagnostics": {"events":[],"filters":{"deployment_id":null,"target_type":null,"target_number":null,"limit":5},"summary":{"count":0,"level_counts":{},"latest_timestamp":null,"latest_timestamp_iso":null}},
+              "generated_at": "2026-05-30T00:00:00.000Z"
+            }
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        let response = try await client.sessionsOverview(
+            tab: .reviews,
+            searchText: "PR #44",
+            repo: "mean-weasel/issuectl",
+            trigger: .webhook,
+            state: .ended,
+            status: .completed,
+            diagnosticLimit: 5
+        )
+        XCTAssertEqual(response.overview.filters.tab, .reviews)
+        XCTAssertEqual(response.overview.filters.status, .completed)
+        XCTAssertEqual(response.diagnostics?.filters?.limit, 5)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1818,4 +1818,120 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.reviewRuns[0].repoFullName, "mean-weasel/issuectl")
         XCTAssertEqual(response.reviewRuns[0].status, .completed)
     }
+
+    func testSessionsOverviewResponseDecodingFromLiveContract() throws {
+        let json = """
+        {
+          "overview": {
+            "initialized": true,
+            "filters": {
+              "tab": "reviews",
+              "q": "PR #563",
+              "repo": "mean-weasel/issuectl",
+              "trigger": "webhook",
+              "state": "all",
+              "status": "completed"
+            },
+            "repos": [{"id": 1, "full_name": "mean-weasel/issuectl"}],
+            "session_groups": [
+              {
+                "key": "1:pr:563",
+                "repo_full_name": "mean-weasel/issuectl",
+                "target_type": "pr",
+                "target_number": 563,
+                "target_label": "PR #563",
+                "matching_session_count": 1,
+                "sessions": [
+                  {
+                    "id": 42,
+                    "repo_id": 1,
+                    "repo_full_name": "mean-weasel/issuectl",
+                    "owner": "mean-weasel",
+                    "repo_name": "issuectl",
+                    "target_type": "pr",
+                    "target_number": 563,
+                    "target_label": "PR #563",
+                    "issue_number": null,
+                    "branch_name": "pr-563-review",
+                    "agent": "codex",
+                    "workspace_mode": "worktree",
+                    "workspace_path": "/tmp/review",
+                    "linked_pr_number": null,
+                    "triggered_by": "webhook",
+                    "parent_deployment_id": null,
+                    "child_deployment_count": 0,
+                    "webhook_depth": 0,
+                    "terminal_reason": "review",
+                    "launched_at": "2026-05-29 20:26:43",
+                    "ended_at": "2026-05-29 20:31:43",
+                    "ttyd_port": 7701,
+                    "idle_since": null,
+                    "preview": {"lines":["review complete"],"last_updated_ms":1780000200000,"last_changed_ms":1780000200000,"status":"idle"},
+                    "provenance_label": "webhook · root session",
+                    "elapsed_label": "5m"
+                  }
+                ]
+              }
+            ],
+            "review_groups": [
+              {
+                "key": "1:563",
+                "repo_full_name": "mean-weasel/issuectl",
+                "owner": "mean-weasel",
+                "repo_name": "issuectl",
+                "pr_number": 563,
+                "matching_run_count": 1,
+                "runs": [
+                  {
+                    "id": 33,
+                    "repo_id": 1,
+                    "repo_full_name": "mean-weasel/issuectl",
+                    "owner": "mean-weasel",
+                    "repo_name": "issuectl",
+                    "pr_number": 563,
+                    "deployment_id": 42,
+                    "started_head_sha": "abcdef123456",
+                    "completed_head_sha": "abcdef123456",
+                    "review_base_sha": "1111111",
+                    "reviewed_from_sha": "2222222",
+                    "reviewed_to_sha": "abcdef123456",
+                    "head_repo_full_name": "mean-weasel/issuectl",
+                    "head_ref": "codex/ios-repo-automation-list-api",
+                    "status": "completed",
+                    "triggered_by": "webhook",
+                    "result": {"summary": "No issues found", "findingCount": 0},
+                    "result_json": "{\\"summary\\":\\"No issues found\\"}",
+                    "summary": "No issues found",
+                    "finding_count": 0,
+                    "range_label": "2222222..abcdef1",
+                    "detail_href": "/reviews/33",
+                    "provenance_label": "webhook · session #42",
+                    "elapsed_label": "1m",
+                    "started_at": 1780000003000,
+                    "completed_at": 1780000004000,
+                    "deployment": null
+                  }
+                ]
+              }
+            ],
+            "summary": {"active_sessions": 1, "ended_sessions": 1, "review_runs": 1, "active_review_runs": 0}
+          },
+          "diagnostics": {
+            "events": [],
+            "filters": {"deployment_id": null, "target_type": "pr", "target_number": 563, "limit": 20},
+            "summary": {"count": 0, "level_counts": {}, "latest_timestamp": null, "latest_timestamp_iso": null}
+          },
+          "generated_at": "2026-05-30T00:00:00.000Z"
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(SessionsOverviewResponse.self, from: json)
+        XCTAssertEqual(response.overview.filters.tab, .reviews)
+        XCTAssertEqual(response.overview.filters.trigger, .webhook)
+        XCTAssertEqual(response.overview.summary.endedSessions, 1)
+        XCTAssertEqual(response.overview.sessionGroups.first?.sessions.first?.sessionRoleTitle, "PR review session")
+        XCTAssertEqual(response.overview.sessionGroups.first?.sessions.first?.durationLabel, "5m")
+        XCTAssertEqual(response.overview.reviewGroups.first?.runs.first?.statusLabel, "Completed")
+        XCTAssertEqual(response.diagnostics?.filters?.targetNumber, 563)
+    }
 }

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -498,6 +498,9 @@ final class MockIssueCTLServer: @unchecked Sendable {
         case ("GET", "/api/v1/sessions/previews"):
             body = ["previews": sessionPreviews()]
 
+        case ("GET", "/api/v1/sessions/overview"):
+            body = sessionsOverviewPayload()
+
         case ("GET", "/api/v1/drafts"):
             body = ["drafts": drafts]
 
@@ -1042,6 +1045,158 @@ final class MockIssueCTLServer: @unchecked Sendable {
             "ttydPid": deployment["ttyd_pid"] ?? NSNull(),
             "owner": deployment["owner"] ?? "org",
             "repoName": deployment["repo_name"] ?? "alpha",
+        ]
+    }
+
+    func sessionsOverviewPayload() -> [String: Any] {
+        let previews = sessionPreviews()
+        let sessions = activeDeployments.map { sessionOverviewSession($0, previews: previews) }
+        let groups = Dictionary(grouping: sessions) { session -> String in
+            let repoId = session["repoId"] as? Int ?? 0
+            let targetType = session["targetType"] as? String ?? "issue"
+            let targetNumber = session["targetNumber"] as? Int ?? 0
+            return "\(repoId):\(targetType):\(targetNumber)"
+        }
+        let sessionGroups = groups.keys.sorted().compactMap { key -> [String: Any]? in
+            guard let groupSessions = groups[key], let first = groupSessions.first else { return nil }
+            return [
+                "key": key,
+                "repoFullName": first["repoFullName"] ?? "org/alpha",
+                "targetType": first["targetType"] ?? "issue",
+                "targetNumber": first["targetNumber"] ?? 0,
+                "targetLabel": first["targetLabel"] ?? "#0",
+                "sessions": groupSessions,
+                "matchingSessionCount": groupSessions.count,
+            ]
+        }
+
+        let reviewRuns = activeDeployments
+            .filter { ($0["target_type"] as? String) == "pr" || ($0["terminal_reason"] as? String) == "review" }
+            .map { deployment -> [String: Any] in
+                let session = sessionOverviewSession(deployment, previews: previews)
+                let prNumber = (deployment["target_number"] as? Int) ?? (deployment["issue_number"] as? Int) ?? 7
+                let repoId = deployment["repo_id"] as? Int ?? 1
+                let owner = deployment["owner"] as? String ?? "org"
+                let name = deployment["repo_name"] as? String ?? "alpha"
+                return [
+                    "id": 30_000 + (deployment["id"] as? Int ?? 0),
+                    "repoId": repoId,
+                    "repoFullName": "\(owner)/\(name)",
+                    "owner": owner,
+                    "repoName": name,
+                    "prNumber": prNumber,
+                    "deploymentId": deployment["id"] ?? NSNull(),
+                    "startedHeadSha": "abc123",
+                    "completedHeadSha": "def456",
+                    "reviewBaseSha": "base999",
+                    "reviewedFromSha": "abc123",
+                    "reviewedToSha": "def456",
+                    "headRepoFullName": "\(owner)/\(name)",
+                    "headRef": "feature-\(prNumber)",
+                    "status": (deployment["ended_at"] is NSNull) ? "in_progress" : "completed",
+                    "triggeredBy": deployment["triggered_by"] ?? "webhook",
+                    "result": ["summary": "Review session captured", "findingCount": 0],
+                    "resultJson": "{\"summary\":\"Review session captured\",\"findingCount\":0}",
+                    "summary": "Review session captured",
+                    "findingCount": 0,
+                    "rangeLabel": "abc123..def456",
+                    "detailHref": "/reviews/\(30_000 + (deployment["id"] as? Int ?? 0))",
+                    "provenanceLabel": "webhook · session #\(deployment["id"] as? Int ?? 0)",
+                    "elapsedLabel": "5m",
+                    "startedAt": 1_777_800_000_000,
+                    "completedAt": NSNull(),
+                    "deployment": session,
+                ]
+            }
+        let reviewGroups = Dictionary(grouping: reviewRuns) { run -> String in
+            "\(run["repoId"] as? Int ?? 0):\(run["prNumber"] as? Int ?? 0)"
+        }
+        .keys
+        .sorted()
+        .compactMap { key -> [String: Any]? in
+            let runs = Dictionary(grouping: reviewRuns) { run -> String in
+                "\(run["repoId"] as? Int ?? 0):\(run["prNumber"] as? Int ?? 0)"
+            }[key] ?? []
+            guard let first = runs.first else { return nil }
+            return [
+                "key": key,
+                "repoFullName": first["repoFullName"] ?? "org/alpha",
+                "owner": first["owner"] ?? "org",
+                "repoName": first["repoName"] ?? "alpha",
+                "prNumber": first["prNumber"] ?? 0,
+                "runs": runs,
+                "matchingRunCount": runs.count,
+            ]
+        }
+
+        return [
+            "overview": [
+                "initialized": true,
+                "filters": [
+                    "tab": "sessions",
+                    "q": "",
+                    "repo": "",
+                    "trigger": "all",
+                    "state": "all",
+                    "status": "all",
+                ],
+                "repos": repos.map { repo in
+                    [
+                        "id": repo["id"] ?? 0,
+                        "fullName": "\(repo["owner"] as? String ?? "org")/\(repo["name"] as? String ?? "alpha")",
+                    ]
+                },
+                "sessionGroups": sessionGroups,
+                "reviewGroups": reviewGroups,
+                "summary": [
+                    "activeSessions": sessions.filter { ($0["endedAt"] as? NSNull) != nil }.count,
+                    "endedSessions": 0,
+                    "reviewRuns": reviewRuns.count,
+                    "activeReviewRuns": reviewRuns.filter { ($0["status"] as? String) == "in_progress" }.count,
+                ],
+            ],
+            "diagnostics": [
+                "events": [],
+                "filters": ["deploymentId": NSNull(), "targetType": NSNull(), "targetNumber": NSNull(), "limit": 20],
+                "summary": ["count": 0, "levelCounts": [:], "latestTimestamp": NSNull(), "latestTimestampIso": NSNull()],
+            ],
+            "generatedAt": isoDate,
+        ]
+    }
+
+    private func sessionOverviewSession(_ deployment: [String: Any], previews: [String: Any]) -> [String: Any] {
+        let targetType = deployment["target_type"] as? String ?? "issue"
+        let targetNumber = (deployment["target_number"] as? Int) ?? (deployment["issue_number"] as? Int) ?? 0
+        let owner = deployment["owner"] as? String ?? "org"
+        let name = deployment["repo_name"] as? String ?? "alpha"
+        let port = deployment["ttyd_port"] as? Int
+        return [
+            "id": deployment["id"] ?? 0,
+            "repoId": deployment["repo_id"] ?? 0,
+            "repoFullName": "\(owner)/\(name)",
+            "owner": owner,
+            "repoName": name,
+            "targetType": targetType,
+            "targetNumber": targetNumber,
+            "targetLabel": targetType == "pr" ? "PR #\(targetNumber)" : "Issue #\(targetNumber)",
+            "issueNumber": deployment["issue_number"] ?? NSNull(),
+            "branchName": deployment["branch_name"] ?? "",
+            "agent": deployment["agent"] ?? "codex",
+            "workspaceMode": deployment["workspace_mode"] ?? "worktree",
+            "workspacePath": deployment["workspace_path"] ?? "",
+            "linkedPrNumber": deployment["linked_pr_number"] ?? NSNull(),
+            "triggeredBy": deployment["triggered_by"] ?? "manual",
+            "parentDeploymentId": deployment["parent_deployment_id"] ?? NSNull(),
+            "childDeploymentCount": 0,
+            "webhookDepth": deployment["webhook_depth"] ?? 0,
+            "terminalReason": deployment["terminal_reason"] ?? NSNull(),
+            "launchedAt": deployment["launched_at"] ?? isoDate,
+            "endedAt": deployment["ended_at"] ?? NSNull(),
+            "ttydPort": deployment["ttyd_port"] ?? NSNull(),
+            "idleSince": deployment["idle_since"] ?? NSNull(),
+            "preview": port.flatMap { previews[String($0)] } ?? NSNull(),
+            "provenanceLabel": "\(deployment["triggered_by"] as? String ?? "manual") · root session",
+            "elapsedLabel": "5m",
         ]
     }
 


### PR DESCRIPTION
## Summary
- Add iOS session overview API models and endpoint coverage for session/review history parity.
- Surface session role labels for issue and PR sessions.
- Extend tests and mock server coverage for the sessions overview contract.

## Verification
- `test_sim` focused tests: `IssueCTLTests/APIClientTests/testSessionsOverviewEndpointURLAndFilters` and `IssueCTLTests/ModelDecodingTests/testSessionsOverviewResponseDecodingFromLiveContract`
- `build_sim` for the IssueCTL app
- `git diff --check`
