### PR TITLE
[codex] Add iOS review detail parity

### DIFF
--- a/apple/IssueCTL.xcodeproj/project.pbxproj
+++ b/apple/IssueCTL.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		C504A03C14E3E6E5C55E7D7B /* LabelManagementSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */; };
 		C5A556BCE60D97B50CD35D7B /* APIClient+Drafts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF8C3C59744B61C3B659ECD /* APIClient+Drafts.swift */; };
 		C5FE9A28E4BFFD481D501DEA /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB1AF798EF85A0DFAB89A4C /* MockServer.swift */; };
+		C634946ACBA6AD3F48CF0F95 /* ReviewRunDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B45CBFE81EF0180768D20EE /* ReviewRunDetailSheet.swift */; };
 		C801A25A983773F1F171E40A /* APIClient+DetailActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493D2F4114A7CD0C28DC8F76 /* APIClient+DetailActions.swift */; };
 		C8217EC2C8B846855E630648 /* IssueDetailActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */; };
 		C8222FD4B618852C6CE61ACA /* ImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39642CB180355E5C62A75E /* ImageLightbox.swift */; };
@@ -227,6 +228,7 @@
 		E30192F97F27BDAA38683254 /* APIClient+Priority.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13DA6D6632CDEBCF8A5BEB2 /* APIClient+Priority.swift */; };
 		E35D59719FABCC9A185D8366 /* EditIssueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DECFEBB9C9FEB55E9A1045 /* EditIssueSheet.swift */; };
 		E5C95BDFF0C932335E11A875 /* PullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFE58A48C5143017DDCD88 /* PullRequest.swift */; };
+		E73F4E9A20F82F5D27D31DC1 /* ReviewRunDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B45CBFE81EF0180768D20EE /* ReviewRunDetailSheet.swift */; };
 		E807BE283E8635AEE32B9058 /* IssueDetailActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9ADC50FA06EBF2CB8A11E6 /* IssueDetailActionTests.swift */; };
 		E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */; };
 		EA782E1A1F8C5112A664DAAA /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695C48F5E921940A3CBDA5A /* AppVersion.swift */; };
@@ -320,6 +322,7 @@
 		3518E82E2F76B696A0CACFEB /* LabelManagementSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelManagementSheet.swift; sourceTree = "<group>"; };
 		364C3F577D49589A381F15B4 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		39EDF1F24285C1D3795B24B1 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		3B45CBFE81EF0180768D20EE /* ReviewRunDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRunDetailSheet.swift; sourceTree = "<group>"; };
 		3C7F190EE0A4BF58DFDEA250 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		3F39642CB180355E5C62A75E /* ImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightbox.swift; sourceTree = "<group>"; };
 		4010BC691DB71B872353344A /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
@@ -794,6 +797,7 @@
 				F986D8BED54A08D7E977D0CB /* MineFilterChip.swift */,
 				6E3F3CE4A721136E587B4C67 /* NetworkErrorBanner.swift */,
 				0193FA27DDE9FE825F4DCA1B /* RepoFilterChips.swift */,
+				3B45CBFE81EF0180768D20EE /* ReviewRunDetailSheet.swift */,
 				F6E7D37C5FD046CB71BBE8BE /* SectionTabs.swift */,
 			);
 			path = Shared;
@@ -1196,6 +1200,7 @@
 				0F2044833E18AACECEA0C048 /* RepoFilterHelpers.swift in Sources */,
 				332F4D8213B6FCFB806AC6A7 /* RepoListView.swift in Sources */,
 				49EDEDB941BBD61FDAD431EB /* RequestChangesSheet.swift in Sources */,
+				C634946ACBA6AD3F48CF0F95 /* ReviewRunDetailSheet.swift in Sources */,
 				E996836A5A715FE47B402A6A /* SectionTabs.swift in Sources */,
 				1D4BC23954C05BBCC0E6F16B /* ServerHealth.swift in Sources */,
 				FC628F6EB78E8E0AAF2DCB5A /* SessionListView.swift in Sources */,
@@ -1286,6 +1291,7 @@
 				7AB66E17B8510A46A4AA9825 /* RepoFilterHelpers.swift in Sources */,
 				4BB20ADE0BE999E563444C1B /* RepoListView.swift in Sources */,
 				FA79A078516F768487A8D9D6 /* RequestChangesSheet.swift in Sources */,
+				E73F4E9A20F82F5D27D31DC1 /* ReviewRunDetailSheet.swift in Sources */,
 				F8A3608F607F4CB92B7D3385 /* SectionTabs.swift in Sources */,
 				66C83A5C0AB52D9F04D5B2EC /* ServerHealth.swift in Sources */,
 				5A6F10FC0B119DA9F4D6D7E7 /* SessionListView.swift in Sources */,

--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -22,6 +22,7 @@ struct SessionListView: View {
     @State private var terminalPresentation: TerminalPresentation?
     @State private var sessionControlsTarget: SessionsOverviewSession?
     @State private var diagnosticsTarget: ActiveDeployment?
+    @State private var reviewDetailTarget: ReviewRunDetailTarget?
     @State private var showCreateSheet = false
     @State private var endingDeploymentId: Int?
     @State private var navigationPath = NavigationPath()
@@ -263,6 +264,11 @@ struct SessionListView: View {
                     .presentationDetents([.medium, .large])
                     .presentationDragIndicator(.visible)
             }
+            .sheet(item: $reviewDetailTarget) { target in
+                ReviewRunDetailSheet(reviewId: target.id)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
             .sheet(isPresented: $showCreateSheet) {
                 QuickCreateSheet(repos: repos, onSuccess: { warning in
                     if let warning { actionError = warning }
@@ -325,6 +331,9 @@ struct SessionListView: View {
                                     if let deployment = run.deployment {
                                         diagnosticsTarget = deployment.activeDeployment
                                     }
+                                },
+                                onOpenDetail: { run in
+                                    reviewDetailTarget = ReviewRunDetailTarget(id: run.id)
                                 }
                             )
                         }
@@ -722,6 +731,7 @@ private struct ReviewRunGroupView: View {
     let onOpenDeployment: (SessionsOverviewSession) -> Void
     let onOpenPullRequest: (SessionsOverviewReviewRun) -> Void
     let onOpenDiagnostics: (SessionsOverviewReviewRun) -> Void
+    let onOpenDetail: (SessionsOverviewReviewRun) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -741,7 +751,8 @@ private struct ReviewRunGroupView: View {
                     run: run,
                     onOpenDeployment: { deployment in onOpenDeployment(deployment) },
                     onOpenPullRequest: { onOpenPullRequest(run) },
-                    onOpenDiagnostics: { onOpenDiagnostics(run) }
+                    onOpenDiagnostics: { onOpenDiagnostics(run) },
+                    onOpenDetail: { onOpenDetail(run) }
                 )
             }
         }
@@ -754,6 +765,7 @@ private struct ReviewRunRow: View {
     let onOpenDeployment: (SessionsOverviewSession) -> Void
     let onOpenPullRequest: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onOpenDetail: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -793,12 +805,20 @@ private struct ReviewRunRow: View {
             }
 
             HStack(spacing: 8) {
-                Button(action: onOpenPullRequest) {
-                    Label("Open PR", systemImage: "arrow.triangle.merge")
+                Button(action: onOpenDetail) {
+                    Label("Details", systemImage: "list.bullet.rectangle")
                         .font(.subheadline.weight(.semibold))
                         .frame(maxWidth: .infinity, minHeight: 38)
                 }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("review-detail-\(run.id)")
+
+                Button(action: onOpenPullRequest) {
+                    Image(systemName: "arrow.triangle.merge")
+                        .frame(width: 42, height: 38)
+                }
                 .buttonStyle(.bordered)
+                .accessibilityLabel("Open PR")
                 .accessibilityIdentifier("review-open-pr-\(run.id)")
 
                 if let deployment = run.deployment, deployment.isActive, deployment.ttydPort != nil {

--- a/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
@@ -37,6 +37,7 @@ struct WebhookEventActivityRow: View {
 
 struct ReviewRunActivityRow: View {
     let run: ReviewRun
+    var onOpenDetail: (() -> Void)? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -72,6 +73,16 @@ struct ReviewRunActivityRow: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if let onOpenDetail {
+                    Button(action: onOpenDetail) {
+                        Label("Details", systemImage: "list.bullet.rectangle")
+                    }
+                    .font(.caption.weight(.semibold))
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("automation-review-detail-\(run.id)")
+                }
             }
         }
         .padding(.vertical, 4)

--- a/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
@@ -12,6 +12,7 @@ struct AutomationFeedView: View {
     @State private var reviewRunsError: String?
     @State private var webhookResponse: WebhookEventsResponse?
     @State private var reviewRunsResponse: ReviewRunsResponse?
+    @State private var reviewDetailTarget: ReviewRunDetailTarget?
 
     var body: some View {
         Form {
@@ -38,6 +39,11 @@ struct AutomationFeedView: View {
         }
         .refreshable {
             await loadFeed()
+        }
+        .sheet(item: $reviewDetailTarget) { target in
+            ReviewRunDetailSheet(reviewId: target.id)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
 
@@ -98,7 +104,9 @@ struct AutomationFeedView: View {
                 }
             } else {
                 ForEach(reviewRuns) { run in
-                    ReviewRunActivityRow(run: run)
+                    ReviewRunActivityRow(run: run) {
+                        reviewDetailTarget = ReviewRunDetailTarget(id: run.id)
+                    }
                 }
             }
         } header: {

--- a/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
+++ b/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
@@ -64,6 +64,7 @@ struct RepoAutomationActivityView: View {
     @State private var reviewRunsError: String?
     @State private var webhookResponse: WebhookEventsResponse?
     @State private var reviewRunsResponse: ReviewRunsResponse?
+    @State private var reviewDetailTarget: ReviewRunDetailTarget?
 
     var body: some View {
         Form {
@@ -89,6 +90,11 @@ struct RepoAutomationActivityView: View {
         }
         .refreshable {
             await loadActivity()
+        }
+        .sheet(item: $reviewDetailTarget) { target in
+            ReviewRunDetailSheet(reviewId: target.id)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
 
@@ -185,7 +191,9 @@ struct RepoAutomationActivityView: View {
                 }
             } else {
                 ForEach(reviewRuns) { run in
-                    ReviewRunActivityRow(run: run)
+                    ReviewRunActivityRow(run: run) {
+                        reviewDetailTarget = ReviewRunDetailTarget(id: run.id)
+                    }
                 }
             }
         } header: {

--- a/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
+++ b/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
@@ -1,0 +1,390 @@
+import SwiftUI
+
+struct ReviewRunDetailTarget: Identifiable {
+    let id: Int
+}
+
+struct ReviewRunDetailSheet: View {
+    @Environment(APIClient.self) private var api
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    let reviewId: Int
+
+    @State private var detail: ReviewRunDetailResponse?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if isLoading && detail == nil {
+                        ProgressView("Loading review...")
+                            .frame(maxWidth: .infinity, minHeight: 220)
+                    } else if let errorMessage, detail == nil {
+                        unavailableState(errorMessage)
+                    } else if let detail {
+                        detailContent(detail)
+                    }
+                }
+                .padding(16)
+            }
+            .navigationTitle("Review Run")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task(id: reviewId) {
+                await load()
+            }
+        }
+    }
+
+    private func detailContent(_ detail: ReviewRunDetailResponse) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header(detail)
+
+            if !detail.banners.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(detail.banners) { banner in
+                        bannerCard(banner)
+                    }
+                }
+            }
+
+            sectionCard(title: "Run Details", systemImage: "info.circle") {
+                detailRows([
+                    ("Repository", detail.repo.fullName),
+                    ("Range", detail.review.rangeLabel ?? detail.review.reviewedToSha),
+                    ("Head", "\(detail.review.headRepoFullName ?? detail.repo.fullName):\(detail.review.headRef ?? "")"),
+                    ("Base", detail.review.reviewBaseSha ?? "Not recorded"),
+                    ("Session", detail.deployment.map { "#\($0.id) \($0.branchName)" } ?? "No linked session"),
+                    ("Trigger", detail.review.triggeredBy.displayName),
+                ])
+            }
+
+            sectionCard(title: "Lineage", systemImage: "timeline.selection") {
+                if detail.lineage.isEmpty {
+                    Text("No sibling review runs recorded.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(detail.lineage) { item in
+                            lineageRow(item)
+                        }
+                    }
+                }
+            }
+
+            sectionCard(title: "Diagnostics", systemImage: "waveform.path.ecg") {
+                ReviewRunDetailDiagnosticsSummaryCard(response: detail.diagnostics)
+                if detail.diagnostics.events.isEmpty {
+                    Text("No diagnostic events recorded for this PR target yet.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(detail.diagnostics.events.prefix(8)) { event in
+                            ReviewRunDetailDiagnosticEventCard(event: event)
+                        }
+                    }
+                }
+            }
+
+            sectionCard(title: "Links", systemImage: "link") {
+                VStack(alignment: .leading, spacing: 10) {
+                    linkButton(title: "GitHub PR", systemImage: "arrow.triangle.merge", urlString: detail.links.githubPr)
+                    if let githubReview = detail.links.githubReview {
+                        linkButton(title: "GitHub Review", systemImage: "checkmark.bubble", urlString: githubReview)
+                    }
+                    linkButton(title: "Review Files", systemImage: "doc.text.magnifyingglass", urlString: detail.links.githubReviewFiles)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("CLI fallback")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(detail.links.diagnosticsCli)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                            .lineLimit(4)
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+                }
+            }
+
+            if !detail.actions.mobileWriteActionsEnabled {
+                Label("Retry and full-rerun actions are available on the web review page for now.", systemImage: "lock")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 2)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func header(_ detail: ReviewRunDetailResponse) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text(detail.review.status.displayName)
+                    .font(.caption.bold())
+                    .foregroundStyle(detail.review.status.tint)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(detail.review.status.tint.opacity(0.14), in: Capsule())
+                Text(detail.review.triggeredBy.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Run #\(detail.review.id)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("PR #\(detail.review.prNumber)")
+                .font(.title2.weight(.bold))
+            Text(detail.repo.fullName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(detail.review.summary ?? "No review summary recorded.")
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                if let findingCount = detail.review.findingCount {
+                    metric(value: "\(findingCount)", label: "Findings", systemImage: "exclamationmark.bubble")
+                }
+                metric(value: "\(detail.lineage.count)", label: "Runs", systemImage: "timeline.selection")
+            }
+        }
+        .padding(14)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+        .accessibilityIdentifier("review-detail-header-\(detail.review.id)")
+    }
+
+    private func bannerCard(_ banner: ReviewRunBanner) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(banner.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(banner.body)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(systemName: banner.iconName)
+                .foregroundStyle(banner.tint)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(banner.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func sectionCard<Content: View>(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func detailRows(_ rows: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { row in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.element.0)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(row.element.1.isEmpty ? "Not recorded" : row.element.1)
+                        .font(.caption.monospaced())
+                        .lineLimit(3)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func lineageRow(_ item: ReviewRunLineageItem) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: item.active ? "largecircle.fill.circle" : item.status.iconName)
+                .foregroundStyle(item.active ? IssueCTLColors.action : item.status.tint)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(item.label)
+                        .font(.subheadline.weight(.semibold))
+                    if item.active {
+                        Text("current")
+                            .font(.caption.bold())
+                            .foregroundStyle(IssueCTLColors.action)
+                    }
+                }
+                Text(item.summary ?? item.status.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(item.completedAtIso ?? item.startedAtIso ?? "")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func metric(value: String, label: String, systemImage: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.subheadline.bold())
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func linkButton(title: String, systemImage: String, urlString: String) -> some View {
+        Button {
+            if let url = URL(string: urlString) {
+                openURL(url)
+            }
+        } label: {
+            Label(title, systemImage: systemImage)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.bordered)
+        .disabled(URL(string: urlString) == nil)
+    }
+
+    private func unavailableState(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("Review Unavailable", systemImage: "eye.slash")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Retry") {
+                Task { await load(force: true) }
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 260)
+    }
+
+    @MainActor
+    private func load(force: Bool = false) async {
+        guard force || detail == nil else { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            detail = try await api.reviewRunDetail(id: reviewId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}
+
+private extension ReviewRunBanner {
+    var tint: Color {
+        switch tone {
+        case .bad: .red
+        case .warn: .orange
+        case .info: IssueCTLColors.action
+        }
+    }
+
+    var iconName: String {
+        switch tone {
+        case .bad: "exclamationmark.triangle.fill"
+        case .warn: "exclamationmark.circle.fill"
+        case .info: "info.circle.fill"
+        }
+    }
+}
+
+private struct ReviewRunDetailDiagnosticsSummaryCard: View {
+    let response: DeploymentDiagnosticsResponse
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: response.hasFailure ? "exclamationmark.triangle" : "checkmark.circle")
+                    .foregroundStyle(response.hasFailure ? Color.orange : Color.green)
+                Text(response.summaryText)
+                    .font(.subheadline.weight(.semibold))
+                Spacer(minLength: 0)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 8) {
+                ForEach(Array(response.summaryRows.enumerated()), id: \.offset) { row in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.element.0)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(row.element.1)
+                            .font(.caption.monospaced())
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+    }
+}
+
+private struct ReviewRunDetailDiagnosticEventCard: View {
+    let event: DiagnosticEvent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(event.level.rawValue.uppercased())
+                    .font(.caption2.bold())
+                    .foregroundStyle(event.isFailure ? Color.red : Color.secondary)
+                Text(event.event)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            if let message = event.message, !message.isEmpty {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Text(event.timestampIso ?? "\(event.timestamp)")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .padding(10)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -493,6 +493,79 @@ struct ReviewRunDeployment: Codable, Identifiable, Sendable {
     let idleSince: String?
 }
 
+struct ReviewRunDetailResponse: Codable, Sendable {
+    let review: ReviewRun
+    let repo: ReviewRunDetailRepo
+    let deployment: ReviewRunDeployment?
+    let lineage: [ReviewRunLineageItem]
+    let diagnostics: DeploymentDiagnosticsResponse
+    let banners: [ReviewRunBanner]
+    let metadata: ReviewRunDetailMetadata
+    let actions: ReviewRunDetailActions
+    let links: ReviewRunDetailLinks
+}
+
+struct ReviewRunDetailRepo: Codable, Identifiable, Sendable {
+    let id: Int
+    let fullName: String
+    let owner: String
+    let name: String
+}
+
+struct ReviewRunLineageItem: Codable, Identifiable, Sendable {
+    let id: Int
+    let active: Bool
+    let label: String
+    let status: ReviewRunStatus
+    let triggeredBy: DeploymentTrigger
+    let deploymentId: Int?
+    let reviewedFromSha: String?
+    let reviewedToSha: String
+    let result: [String: JSONValue]?
+    let summary: String?
+    let startedAt: Int
+    let startedAtIso: String?
+    let completedAt: Int?
+    let completedAtIso: String?
+}
+
+struct ReviewRunBanner: Codable, Identifiable, Sendable {
+    let tone: ReviewRunBannerTone
+    let title: String
+    let body: String
+
+    var id: String { "\(tone.rawValue)-\(title)" }
+}
+
+enum ReviewRunBannerTone: String, Codable, Sendable {
+    case bad
+    case warn
+    case info
+}
+
+struct ReviewRunDetailMetadata: Codable, Sendable {
+    let currentReviewPreamble: String?
+    let triggerEvent: DiagnosticEvent?
+}
+
+struct ReviewRunDetailActions: Codable, Sendable {
+    let canRetry: Bool
+    let canFullRerun: Bool
+    let disabledReason: String?
+    let mobileWriteActionsEnabled: Bool
+}
+
+struct ReviewRunDetailLinks: Codable, Sendable {
+    let githubPr: String
+    let githubReview: String?
+    let githubReviewFiles: String
+    let workbench: String
+    let repoSettings: String
+    let sessions: String
+    let webhookLogs: String
+    let diagnosticsCli: String
+}
+
 enum SessionsOverviewTab: String, Codable, CaseIterable, Sendable {
     case sessions
     case reviews

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -439,6 +439,12 @@ final class APIClient {
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }
 
+    func reviewRunDetail(id: Int) async throws -> ReviewRunDetailResponse {
+        let safeId = max(1, id)
+        let (data, _) = try await request(path: "/api/v1/pr-reviews/\(safeId)")
+        return try decoder.decode(ReviewRunDetailResponse.self, from: data)
+    }
+
     func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
         let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
         return try decoder.decode(DiagnosticsResponse.self, from: data)

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -350,6 +350,12 @@ final class TestableAPIClient {
         return try decoder.decode(ReviewRunsResponse.self, from: data)
     }
 
+    func reviewRunDetail(id: Int) async throws -> ReviewRunDetailResponse {
+        let safeId = max(1, id)
+        let (data, _) = try await request(path: "/api/v1/pr-reviews/\(safeId)")
+        return try decoder.decode(ReviewRunDetailResponse.self, from: data)
+    }
+
     func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
         let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
         return try decoder.decode(DiagnosticsResponse.self, from: data)
@@ -668,6 +674,72 @@ final class APIClientTests: XCTestCase {
 
         let response = try await client.globalReviewRuns(status: .all, limit: 50)
         XCTAssertTrue(response.reviewRuns.isEmpty)
+    }
+
+    @MainActor
+    func testReviewRunDetailEndpointURL() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/pr-reviews/33")
+            XCTAssertNil(request.url!.query)
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {
+              "review": {
+                "id": 33,
+                "repo_id": 1,
+                "repo_full_name": "mean-weasel/issuectl",
+                "owner": "mean-weasel",
+                "repo_name": "issuectl",
+                "pr_number": 563,
+                "deployment_id": null,
+                "started_head_sha": "abcdef123456",
+                "completed_head_sha": "abcdef123456",
+                "review_base_sha": "1111111",
+                "reviewed_from_sha": null,
+                "reviewed_to_sha": "abcdef123456",
+                "head_repo_full_name": "mean-weasel/issuectl",
+                "head_ref": "codex/ios-review-detail-parity",
+                "status": "completed",
+                "triggered_by": "webhook",
+                "result": {"summary": "No issues found"},
+                "summary": "No issues found",
+                "finding_count": 0,
+                "range_label": "full abcdef1",
+                "detail_href": "/reviews/33",
+                "started_at": 1780000003000,
+                "started_at_iso": "2026-05-29T20:26:43.000Z",
+                "completed_at": 1780000004000,
+                "completed_at_iso": "2026-05-29T20:26:44.000Z",
+                "deployment": null
+              },
+              "repo": {"id": 1, "full_name": "mean-weasel/issuectl", "owner": "mean-weasel", "name": "issuectl"},
+              "deployment": null,
+              "lineage": [],
+              "diagnostics": {"events": [], "filters": {"deployment_id": null, "target_type": "pr", "target_number": 563, "limit": 0}, "summary": {"count": 0, "level_counts": {}, "latest_timestamp": null, "latest_timestamp_iso": null}},
+              "banners": [],
+              "metadata": {"current_review_preamble": null, "trigger_event": null},
+              "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": false},
+              "links": {
+                "github_pr": "https://github.com/mean-weasel/issuectl/pull/563",
+                "github_review": null,
+                "github_review_files": "https://github.com/mean-weasel/issuectl/pull/563/files",
+                "workbench": "/workbench?repo=mean-weasel%2Fissuectl",
+                "repo_settings": "/repos/mean-weasel/issuectl/settings",
+                "sessions": "/sessions?tab=reviews",
+                "webhook_logs": "/logs/webhooks",
+                "diagnostics_cli": "pnpm --dir packages/cli exec issuectl diag show --pr mean-weasel/issuectl#563"
+              }
+            }
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        let response = try await client.reviewRunDetail(id: 33)
+        XCTAssertEqual(response.review.id, 33)
+        XCTAssertEqual(response.repo.fullName, "mean-weasel/issuectl")
+        XCTAssertFalse(response.actions.mobileWriteActionsEnabled)
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1819,6 +1819,113 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.reviewRuns[0].status, .completed)
     }
 
+    func testReviewRunDetailResponseDecodingFromLiveContract() throws {
+        let json = """
+        {
+          "review": {
+            "id": 33,
+            "repo_id": 1,
+            "repo_full_name": "mean-weasel/issuectl",
+            "owner": "mean-weasel",
+            "repo_name": "issuectl",
+            "pr_number": 563,
+            "deployment_id": 42,
+            "started_head_sha": "abcdef123456",
+            "completed_head_sha": "abcdef123456",
+            "review_base_sha": "1111111",
+            "reviewed_from_sha": "2222222",
+            "reviewed_to_sha": "abcdef123456",
+            "head_repo_full_name": "mean-weasel/issuectl",
+            "head_ref": "codex/ios-review-detail-parity",
+            "status": "completed",
+            "triggered_by": "webhook",
+            "result": {"summary": "No issues found", "findingCount": 0},
+            "summary": "No issues found",
+            "finding_count": 0,
+            "range_label": "2222222..abcdef1",
+            "detail_href": "/reviews/33",
+            "started_at": 1780000003000,
+            "started_at_iso": "2026-05-29T20:26:43.000Z",
+            "completed_at": 1780000004000,
+            "completed_at_iso": "2026-05-29T20:26:44.000Z",
+            "deployment": null
+          },
+          "repo": {"id": 1, "full_name": "mean-weasel/issuectl", "owner": "mean-weasel", "name": "issuectl"},
+          "deployment": null,
+          "lineage": [
+            {
+              "id": 33,
+              "active": true,
+              "label": "2222222..abcdef1",
+              "status": "completed",
+              "triggered_by": "webhook",
+              "deployment_id": 42,
+              "reviewed_from_sha": "2222222",
+              "reviewed_to_sha": "abcdef123456",
+              "result": {"summary": "No issues found"},
+              "summary": "No issues found",
+              "started_at": 1780000003000,
+              "started_at_iso": "2026-05-29T20:26:43.000Z",
+              "completed_at": 1780000004000,
+              "completed_at_iso": "2026-05-29T20:26:44.000Z"
+            }
+          ],
+          "diagnostics": {
+            "events": [
+              {
+                "id": 52,
+                "timestamp": 1780000003000,
+                "timestamp_iso": "2026-05-29T20:26:43.000Z",
+                "level": "info",
+                "event": "webhook.pr_launched",
+                "target_type": "pr",
+                "target_number": 563,
+                "target_label": "PR #563",
+                "deployment_id": 42,
+                "message": "Review launched"
+              }
+            ],
+            "filters": {"deployment_id": null, "target_type": "pr", "target_number": 563, "limit": 1},
+            "summary": {"count": 1, "level_counts": {"info": 1}, "latest_timestamp": 1780000003000, "latest_timestamp_iso": "2026-05-29T20:26:43.000Z"}
+          },
+          "banners": [{"tone": "info", "title": "Follow-up requested", "body": "A newer PR head was coalesced."}],
+          "metadata": {
+            "current_review_preamble": null,
+            "trigger_event": {
+              "id": 52,
+              "timestamp": 1780000003000,
+              "level": "info",
+              "event": "webhook.pr_launched",
+              "target_type": "pr",
+              "target_number": 563,
+              "target_label": "PR #563"
+            }
+          },
+          "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": false},
+          "links": {
+            "github_pr": "https://github.com/mean-weasel/issuectl/pull/563",
+            "github_review": null,
+            "github_review_files": "https://github.com/mean-weasel/issuectl/pull/563/files",
+            "workbench": "/workbench?repo=mean-weasel%2Fissuectl",
+            "repo_settings": "/repos/mean-weasel/issuectl/settings",
+            "sessions": "/sessions?tab=reviews",
+            "webhook_logs": "/logs/webhooks",
+            "diagnostics_cli": "pnpm --dir packages/cli exec issuectl diag show --pr mean-weasel/issuectl#563"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(ReviewRunDetailResponse.self, from: json)
+        XCTAssertEqual(response.review.id, 33)
+        XCTAssertEqual(response.repo.fullName, "mean-weasel/issuectl")
+        XCTAssertEqual(response.lineage.first?.active, true)
+        XCTAssertEqual(response.diagnostics.summaryText, "1 diagnostic event, no failure recorded")
+        XCTAssertEqual(response.diagnostics.events.first?.targetLabel, "PR #563")
+        XCTAssertEqual(response.banners.first?.tone, .info)
+        XCTAssertFalse(response.actions.mobileWriteActionsEnabled)
+        XCTAssertEqual(response.links.githubPr, "https://github.com/mean-weasel/issuectl/pull/563")
+    }
+
     func testSessionsOverviewResponseDecodingFromLiveContract() throws {
         let json = """
         {

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const getReviewDetailData = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/review-detail-data", () => ({
+  getReviewDetailData: (...args: unknown[]) => getReviewDetailData(...args),
+}));
+
+vi.mock("@issuectl/core", () => ({
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  getReviewDetailData.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  getReviewDetailData.mockReturnValue(reviewDetailData());
+});
+
+describe("/api/v1/pr-reviews/[id]", () => {
+  it("returns a mobile-safe review detail payload", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/pr-reviews/901"),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getReviewDetailData).toHaveBeenCalledWith(901);
+    expect(json.review).toEqual(expect.objectContaining({
+      id: 901,
+      repoFullName: "mean-weasel/issuectl",
+      prNumber: 44,
+      summary: "found one issue",
+      findingCount: 1,
+      rangeLabel: "4444555..7777888",
+      detailHref: "/reviews/901",
+    }));
+    expect(json.lineage).toEqual([
+      expect.objectContaining({ id: 901, active: true, label: "4444555..7777888" }),
+      expect.objectContaining({ id: 900, active: false, label: "full 4444555" }),
+    ]);
+    expect(json.diagnostics.events).toEqual([
+      expect.objectContaining({
+        id: 52,
+        timestampIso: "2026-05-17T06:40:00.500Z",
+        targetLabel: "PR #44",
+      }),
+    ]);
+    expect(json.actions).toEqual({
+      canRetry: true,
+      canFullRerun: true,
+      disabledReason: null,
+      mobileWriteActionsEnabled: false,
+    });
+    expect(JSON.stringify(json)).not.toContain("resultJson");
+    expect(JSON.stringify(json)).not.toContain("completionToken");
+  });
+
+  it("rejects an invalid review id", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/pr-reviews/nope"),
+      { params: Promise.resolve({ id: "nope" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: "Invalid review id" });
+    expect(getReviewDetailData).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for missing review details", async () => {
+    getReviewDetailData.mockReturnValueOnce(null);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/pr-reviews/999"),
+      { params: Promise.resolve({ id: "999" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json).toEqual({ error: "Review not found" });
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/v1/pr-reviews/901"),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({ error: "Unauthorized" });
+    expect(getReviewDetailData).not.toHaveBeenCalled();
+  });
+});
+
+function reviewDetailData() {
+  const repo = {
+    id: 1,
+    owner: "mean-weasel",
+    name: "issuectl",
+    localPath: "/tmp/issuectl",
+    branchPattern: null,
+    autoLaunchIssues: true,
+    autoReviewPrs: true,
+    issueAgent: "codex",
+    reviewAgent: "codex",
+    webhookId: 123,
+    reviewPreamble: null,
+    webhookPayloadMode: "metadata",
+    createdAt: "2026-05-24T00:00:00.000Z",
+  };
+  const review = {
+    id: 901,
+    repoId: 1,
+    prNumber: 44,
+    deploymentId: 701,
+    startedHeadSha: "aaaabbbbcccc",
+    completedHeadSha: "ddddeeeeffff",
+    reviewBaseSha: "111122223333",
+    reviewedFromSha: "444455556666",
+    reviewedToSha: "777788889999",
+    headRepoFullName: "mean-weasel/issuectl",
+    headRef: "feature/mobile-contracts",
+    status: "completed",
+    triggeredBy: "webhook",
+    resultJson: JSON.stringify({ summary: "found one issue", findings: [{ path: "a.ts" }] }),
+    startedAt: 1_779_000_000_000,
+    completedAt: 1_779_000_600_000,
+  };
+  const deployment = {
+    id: 701,
+    repoId: 1,
+    issueNumber: null,
+    targetType: "pr",
+    targetNumber: 44,
+    agent: "codex",
+    branchName: "review/pr-44",
+    workspaceMode: "worktree",
+    workspacePath: "/tmp/review-pr-44",
+    linkedPrNumber: null,
+    state: "ended",
+    terminalBackend: "ttyd",
+    triggeredBy: "webhook",
+    parentDeploymentId: null,
+    webhookDepth: 1,
+    launchedAt: "2026-05-16T16:00:00.000Z",
+    endedAt: "2026-05-16T16:10:00.000Z",
+    terminalReason: "completed",
+    completionToken: "secret-token",
+    completionResultJson: JSON.stringify({ summary: "done" }),
+    notificationSentAt: null,
+    ttydPort: 7701,
+    ttydPid: null,
+    idleSince: null,
+  };
+  const diagnostic = {
+    id: 52,
+    timestamp: 1_779_000_000_500,
+    level: "info",
+    event: "webhook.pr_launched",
+    source: "webhook-worker",
+    correlationId: null,
+    owner: "mean-weasel",
+    repo: "issuectl",
+    issueNumber: null,
+    targetType: "pr",
+    targetNumber: 44,
+    deploymentId: 701,
+    sessionName: "issuectl-701",
+    ttydPort: 7701,
+    ttydPid: null,
+    status: "completed",
+    message: "launched",
+    data: null,
+  };
+  return {
+    initialized: true,
+    review,
+    repo,
+    deployment,
+    lineage: [
+      {
+        ...review,
+        active: true,
+        result: JSON.parse(review.resultJson),
+        label: "4444555..7777888",
+      },
+      {
+        ...review,
+        id: 900,
+        reviewedFromSha: null,
+        reviewedToSha: "444455556666",
+        active: false,
+        result: {},
+        label: "full 4444555",
+      },
+    ],
+    diagnostics: [diagnostic],
+    result: JSON.parse(review.resultJson),
+    deploymentResult: { summary: "done" },
+    metadata: {
+      currentReviewPreamble: null,
+      triggerEvent: diagnostic,
+    },
+    banners: [{ tone: "info", title: "Follow-up requested", body: "A newer PR head was coalesced while this review was active." }],
+    actions: {
+      canRetry: true,
+      canFullRerun: true,
+      disabledReason: null,
+    },
+    links: {
+      githubPr: "https://github.com/mean-weasel/issuectl/pull/44",
+      githubReview: null,
+      githubReviewFiles: "https://github.com/mean-weasel/issuectl/pull/44/files",
+      workbench: "/workbench?repo=mean-weasel%2Fissuectl",
+      repoSettings: "/repos/mean-weasel/issuectl/settings",
+      sessions: "/sessions?tab=reviews&repo=mean-weasel%2Fissuectl&q=PR%20%2344",
+      webhookLogs: "/logs/webhooks?q=mean-weasel%2Fissuectl%2344",
+      diagnosticsCli: "pnpm --dir packages/cli exec issuectl diag show --pr mean-weasel/issuectl#44",
+    },
+  };
+}

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { buildDiagnosticsPayload, repoFullName, targetLabel } from "@/lib/mobile-api-contracts";
+import { getReviewDetailData, type ReviewDetailData, type ReviewLineageItem } from "@/lib/review-detail-data";
+import { formatErrorForUser, type Deployment, type PrReview } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const reviewId = parseReviewId(id);
+  if (reviewId === null) {
+    return NextResponse.json({ error: "Invalid review id" }, { status: 400 });
+  }
+
+  try {
+    const data = getReviewDetailData(reviewId);
+    if (!data) {
+      return NextResponse.json({ error: "Review not found" }, { status: 404 });
+    }
+    return NextResponse.json(buildPrReviewDetailPayload(data));
+  } catch (err) {
+    log.error({ err, msg: "api_pr_review_detail_failed", reviewId });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}
+
+function parseReviewId(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function buildPrReviewDetailPayload(data: ReviewDetailData): unknown {
+  const fullName = repoFullName(data.repo);
+  return {
+    review: mobileReview(data.review, data.deployment, fullName),
+    repo: {
+      id: data.repo.id,
+      fullName,
+      owner: data.repo.owner,
+      name: data.repo.name,
+    },
+    deployment: data.deployment ? mobileDeployment(data.deployment) : null,
+    lineage: data.lineage.map((item) => mobileLineageItem(item)),
+    diagnostics: buildDiagnosticsPayload({
+      events: data.diagnostics,
+      filters: {
+        deploymentId: data.deployment?.id ?? null,
+        targetType: "pr",
+        targetNumber: data.review.prNumber,
+        limit: data.diagnostics.length,
+      },
+    }),
+    banners: data.banners,
+    metadata: data.metadata,
+    actions: {
+      ...data.actions,
+      mobileWriteActionsEnabled: false,
+    },
+    links: data.links,
+  };
+}
+
+function mobileReview(review: PrReview, deployment: Deployment | null, fullName: string): unknown {
+  const result = parseJsonObject(review.resultJson);
+  return {
+    id: review.id,
+    repoId: review.repoId,
+    repoFullName: fullName,
+    owner: ownerFromFullName(fullName),
+    repoName: repoNameFromFullName(fullName),
+    prNumber: review.prNumber,
+    deploymentId: review.deploymentId,
+    startedHeadSha: review.startedHeadSha,
+    completedHeadSha: review.completedHeadSha,
+    reviewBaseSha: review.reviewBaseSha,
+    reviewedFromSha: review.reviewedFromSha,
+    reviewedToSha: review.reviewedToSha,
+    headRepoFullName: review.headRepoFullName,
+    headRef: review.headRef,
+    status: review.status,
+    triggeredBy: review.triggeredBy,
+    result,
+    summary: reviewSummary(result),
+    findingCount: findingCount(result),
+    rangeLabel: reviewRangeLabel(review),
+    detailHref: `/reviews/${review.id}`,
+    startedAt: review.startedAt,
+    startedAtIso: toIso(review.startedAt),
+    completedAt: review.completedAt,
+    completedAtIso: nullableIso(review.completedAt),
+    deployment: deployment ? mobileDeployment(deployment) : null,
+  };
+}
+
+function mobileLineageItem(item: ReviewLineageItem): unknown {
+  return {
+    id: item.id,
+    active: item.active,
+    label: item.label,
+    status: item.status,
+    triggeredBy: item.triggeredBy,
+    deploymentId: item.deploymentId,
+    reviewedFromSha: item.reviewedFromSha,
+    reviewedToSha: item.reviewedToSha,
+    result: item.result,
+    summary: reviewSummary(item.result),
+    startedAt: item.startedAt,
+    startedAtIso: toIso(item.startedAt),
+    completedAt: item.completedAt,
+    completedAtIso: nullableIso(item.completedAt),
+  };
+}
+
+function mobileDeployment(deployment: Deployment): unknown {
+  return {
+    id: deployment.id,
+    repoId: deployment.repoId,
+    targetType: deployment.targetType,
+    targetNumber: deployment.targetNumber,
+    targetLabel: targetLabel(deployment.targetType, deployment.targetNumber),
+    issueNumber: deployment.issueNumber,
+    branchName: deployment.branchName,
+    agent: deployment.agent,
+    workspaceMode: deployment.workspaceMode,
+    workspacePath: deployment.workspacePath,
+    linkedPrNumber: deployment.linkedPrNumber,
+    state: deployment.state,
+    terminalBackend: deployment.terminalBackend ?? "ttyd",
+    triggeredBy: deployment.triggeredBy,
+    parentDeploymentId: deployment.parentDeploymentId,
+    webhookDepth: deployment.webhookDepth,
+    launchedAt: deployment.launchedAt,
+    endedAt: deployment.endedAt,
+    terminalReason: deployment.terminalReason,
+    ttydPort: deployment.ttydPort,
+    idleSince: deployment.idleSince,
+  };
+}
+
+function reviewSummary(result: Record<string, unknown>): string | null {
+  return stringValue(result.summary) ?? stringValue(result.reason) ?? stringValue(result.error) ?? null;
+}
+
+function findingCount(result: Record<string, unknown>): number | null {
+  return numberValue(result.findingCount)
+    ?? numberValue(result.fixedFindingCount)
+    ?? arrayLength(result.findings)
+    ?? arrayLength(result.comments);
+}
+
+function reviewRangeLabel(review: PrReview): string {
+  if (review.reviewedFromSha) return `${shortSha(review.reviewedFromSha)}..${shortSha(review.reviewedToSha)}`;
+  return `full ${shortSha(review.reviewedToSha)}`;
+}
+
+function ownerFromFullName(value: string): string | null {
+  return value.split("/")[0] ?? null;
+}
+
+function repoNameFromFullName(value: string): string | null {
+  return value.split("/")[1] ?? null;
+}
+
+function shortSha(value: string): string {
+  return value.slice(0, 7);
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function arrayLength(value: unknown): number | null {
+  return Array.isArray(value) ? value.length : null;
+}
+
+function toIso(value: number): string {
+  return new Date(value).toISOString();
+}
+
+function nullableIso(value: number | null): string | null {
+  return value === null ? null : toIso(value);
+}


### PR DESCRIPTION
## Summary
- Adds a mobile-safe `GET /api/v1/pr-reviews/[id]` review detail endpoint that reuses existing review detail data while scrubbing raw server-only fields.
- Adds Swift review detail models/API support and a native read-only review detail sheet.
- Wires Details entry points from Sessions > Reviews, Automation Feed, and repo automation activity rows.

## Validation
- `pnpm --dir packages/web test -- app/api/v1/pr-reviews lib/review-detail-data`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- XcodeBuildMCP focused `test_sim` for `testReviewRunDetailEndpointURL` and `testReviewRunDetailResponseDecodingFromLiveContract`
- XcodeBuildMCP `build_run_sim`
- Simulator walkthrough reached Today, PRs, and Board surfaces with cached/offline states rendering normally

## Notes
- Mobile retry/full-rerun write actions remain intentionally disabled and deferred.
- The local simulator did not have a visible live review row to tap, so the detail sheet is covered by contract/model/API tests and full app compile/build in this slice.