### PR TITLE
[codex] Refresh iOS from webhook stream

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -198,6 +198,9 @@ struct SessionListView: View {
             .task(id: overviewQuerySignature) {
                 await load()
             }
+            .task {
+                await streamSessionUpdates()
+            }
             .onReceive(refreshTimer) { _ in
                 guard terminalPresentation == nil else { return }
                 Task { await load(includeRepos: false) }
@@ -524,6 +527,24 @@ struct SessionListView: View {
 
     private func refreshSessions() async {
         await load(refresh: true)
+    }
+
+    private func streamSessionUpdates() async {
+        while !Task.isCancelled {
+            let task: URLSessionWebSocketTask
+            do {
+                task = try api.webhookEventsStreamTask()
+                task.resume()
+                defer { task.cancel(with: .goingAway, reason: nil) }
+                while !Task.isCancelled {
+                    _ = try await task.receive()
+                    guard terminalPresentation == nil else { continue }
+                    await load(includeRepos: false)
+                }
+            } catch {
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
     }
 
     private func endSession(_ session: SessionsOverviewSession) async {

--- a/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
@@ -13,6 +13,7 @@ struct AutomationFeedView: View {
     @State private var webhookResponse: WebhookEventsResponse?
     @State private var reviewRunsResponse: ReviewRunsResponse?
     @State private var reviewDetailTarget: ReviewRunDetailTarget?
+    @State private var isLiveStreamConnected = false
 
     var body: some View {
         Form {
@@ -37,6 +38,9 @@ struct AutomationFeedView: View {
             await loadFeed()
             await pollFeed()
         }
+        .task {
+            await streamFeedUpdates()
+        }
         .refreshable {
             await loadFeed()
         }
@@ -59,6 +63,14 @@ struct AutomationFeedView: View {
                 }
             }
             .accessibilityIdentifier("automation-feed-review-status-picker")
+
+            Label(
+                isLiveStreamConnected ? "Live webhook updates connected" : "Live webhook updates reconnecting",
+                systemImage: isLiveStreamConnected ? "dot.radiowaves.left.and.right" : "antenna.radiowaves.left.and.right.slash"
+            )
+            .font(.caption)
+            .foregroundStyle(isLiveStreamConnected ? .green : .secondary)
+            .accessibilityIdentifier("automation-feed-live-stream-status")
         }
     }
 
@@ -165,6 +177,28 @@ struct AutomationFeedView: View {
             try? await Task.sleep(for: .seconds(60))
             guard !Task.isCancelled else { return }
             await loadFeed()
+        }
+    }
+
+    private func streamFeedUpdates() async {
+        while !Task.isCancelled {
+            let task: URLSessionWebSocketTask
+            do {
+                task = try api.webhookEventsStreamTask()
+                task.resume()
+                isLiveStreamConnected = true
+                defer {
+                    task.cancel(with: .goingAway, reason: nil)
+                    isLiveStreamConnected = false
+                }
+                while !Task.isCancelled {
+                    _ = try await task.receive()
+                    await loadFeed()
+                }
+            } catch {
+                isLiveStreamConnected = false
+                try? await Task.sleep(for: .seconds(5))
+            }
         }
     }
 

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -409,6 +409,34 @@ final class APIClient {
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
+    func webhookEventsStreamURL() throws -> URL {
+        guard !apiToken.isEmpty, var components = URLComponents(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+        switch components.scheme {
+        case "http":
+            components.scheme = "ws"
+        case "https":
+            components.scheme = "wss"
+        case "ws", "wss":
+            break
+        default:
+            throw APIError.invalidPath(serverURL)
+        }
+        components.path = "/api/webhooks/events/stream"
+        components.queryItems = nil
+        guard let url = components.url else {
+            throw APIError.invalidPath("/api/webhooks/events/stream")
+        }
+        return url
+    }
+
+    func webhookEventsStreamTask() throws -> URLSessionWebSocketTask {
+        var request = URLRequest(url: try webhookEventsStreamURL())
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        return URLSession.shared.webSocketTask(with: request)
+    }
+
     func reviewRuns(
         owner: String,
         repo: String,

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -320,6 +320,28 @@ final class TestableAPIClient {
         return try decoder.decode(WebhookEventsResponse.self, from: data)
     }
 
+    func webhookEventsStreamURL() throws -> URL {
+        guard !apiToken.isEmpty, var components = URLComponents(string: serverURL) else {
+            throw APIError.notConfigured
+        }
+        switch components.scheme {
+        case "http":
+            components.scheme = "ws"
+        case "https":
+            components.scheme = "wss"
+        case "ws", "wss":
+            break
+        default:
+            throw APIError.invalidPath(serverURL)
+        }
+        components.path = "/api/webhooks/events/stream"
+        components.queryItems = nil
+        guard let url = components.url else {
+            throw APIError.invalidPath("/api/webhooks/events/stream")
+        }
+        return url
+    }
+
     func reviewRuns(
         owner: String,
         repo: String,
@@ -660,6 +682,28 @@ final class APIClientTests: XCTestCase {
 
         let response = try await client.globalWebhookEvents(limit: 50)
         XCTAssertTrue(response.events.isEmpty)
+    }
+
+    @MainActor
+    func testWebhookEventsStreamURLUsesWebSocketSchemeWithoutLeakingToken() throws {
+        let httpClient = TestableAPIClient(
+            serverURL: "http://localhost:3847",
+            apiToken: "stream-token"
+        )
+        let httpURL = try httpClient.webhookEventsStreamURL()
+        XCTAssertEqual(httpURL.scheme, "ws")
+        XCTAssertEqual(httpURL.host, "localhost")
+        XCTAssertEqual(httpURL.port, 3847)
+        XCTAssertEqual(httpURL.path, "/api/webhooks/events/stream")
+        XCTAssertNil(httpURL.query)
+
+        let httpsClient = TestableAPIClient(
+            serverURL: "https://issuectl.example.test",
+            apiToken: "stream-token"
+        )
+        let httpsURL = try httpsClient.webhookEventsStreamURL()
+        XCTAssertEqual(httpsURL.scheme, "wss")
+        XCTAssertEqual(httpsURL.host, "issuectl.example.test")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Adds a native websocket URL/task helper for the existing webhook events stream, using Authorization headers rather than leaking tokens into the URL.
- Keeps the existing polling fallback, but refreshes Sessions and Automation Feed immediately when webhook stream messages arrive.
- Adds a visible Automation Feed live-stream status row so operators can tell whether native realtime refresh is connected or reconnecting.

## Stack
- Stacked on #570 (`codex/ios-review-detail-parity`) because both slices touch the same iOS review/feed views.

## Validation
- `git diff --check`
- XcodeBuildMCP focused `test_sim`: `IssueCTLTests/APIClientTests/testWebhookEventsStreamURLUsesWebSocketSchemeWithoutLeakingToken`
- XcodeBuildMCP `build_run_sim`
- Simulator walkthrough to Settings > Automation Feed confirmed `automation-feed-live-stream-status` renders in reconnecting fallback state when the local web server is unavailable.