### PR TITLE
[codex] Clarify iOS freshness banner

### DIFF
--- a/apple/IssueCTL/Views/Shared/CacheAgeLabel.swift
+++ b/apple/IssueCTL/Views/Shared/CacheAgeLabel.swift
@@ -36,3 +36,18 @@ func staleDataMessage(kind: String, cachedAt: Date?) -> String {
     formatter.unitsStyle = .abbreviated
     return "Showing cached \(kind) from \(formatter.localizedString(for: cachedAt, relativeTo: Date()))"
 }
+
+func freshnessStatusMessage(
+    kind: String,
+    isShowingCachedData: Bool,
+    isNetworkConnected: Bool,
+    cachedAt: Date?
+) -> String? {
+    if isShowingCachedData {
+        return staleDataMessage(kind: kind, cachedAt: cachedAt)
+    }
+    if !isNetworkConnected {
+        return "Offline - showing latest loaded \(kind)"
+    }
+    return nil
+}

--- a/apple/IssueCTL/Views/Today/TodayView.swift
+++ b/apple/IssueCTL/Views/Today/TodayView.swift
@@ -221,8 +221,8 @@ struct TodayView: View {
         } else {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    if isShowingCachedData || !network.isConnected {
-                        OfflineStatusBanner(message: cacheMessage)
+                    if let freshnessMessage {
+                        OfflineStatusBanner(message: freshnessMessage)
                     }
 
                     metrics
@@ -382,16 +382,13 @@ struct TodayView: View {
             : "Open"
     }
 
-    private var cacheMessage: String {
-        if isShowingCachedData {
-            return staleDataMessage(kind: "today data", cachedAt: oldestCachedAt)
-        }
-        if let oldestCachedAt {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .abbreviated
-            return "Offline - showing cached data from \(formatter.localizedString(for: oldestCachedAt, relativeTo: Date()))"
-        }
-        return "Offline - showing cached data"
+    private var freshnessMessage: String? {
+        freshnessStatusMessage(
+            kind: "today data",
+            isShowingCachedData: isShowingCachedData,
+            isNetworkConnected: network.isConnected,
+            cachedAt: oldestCachedAt
+        )
     }
 
     private func load(refresh: Bool = false) async {

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -119,6 +119,28 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertNil(cache.load([Repo].self, for: "repos", serverURL: "http://two.example"))
     }
 
+    func testFreshnessStatusDoesNotCallFreshLoadedDataCachedWhenOffline() {
+        let message = freshnessStatusMessage(
+            kind: "today data",
+            isShowingCachedData: false,
+            isNetworkConnected: false,
+            cachedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(message, "Offline - showing latest loaded today data")
+    }
+
+    func testFreshnessStatusKeepsCachedDataMessageWhenCacheUsed() {
+        let message = freshnessStatusMessage(
+            kind: "today data",
+            isShowingCachedData: true,
+            isNetworkConnected: true,
+            cachedAt: nil
+        )
+
+        XCTAssertEqual(message, "Showing cached today data")
+    }
+
     // MARK: - Repo Automation Controls
 
     func testAutomationDisableConfirmationCopyMatchesServerBehavior() {


### PR DESCRIPTION
## Summary
- Replaces Today's cached/offline banner helper so fresh loaded data is not mislabeled as cached just because the device network monitor is offline.
- Keeps the existing cached-data wording when API responses actually came from cache.
- Adds focused view-logic coverage for both the fresh-offline and cached-data cases.

## Validation
- `git diff --check`
- XcodeBuildMCP focused `test_sim`: `ViewLogicTests/testFreshnessStatusDoesNotCallFreshLoadedDataCachedWhenOffline` and `ViewLogicTests/testFreshnessStatusKeepsCachedDataMessageWhenCacheUsed`
- XcodeBuildMCP `build_run_sim`
- Simulator snapshot on Today confirmed the existing true cached-data state still renders as cached.