### PR TITLE
[codex] Show iOS review findings

### DIFF
--- a/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
+++ b/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
@@ -80,6 +80,20 @@ struct ReviewRunDetailSheet: View {
                 }
             }
 
+            sectionCard(title: "Findings", systemImage: "exclamationmark.bubble") {
+                if detail.findings.isEmpty {
+                    Text("No structured findings were recorded for this review.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(detail.findings) { finding in
+                            findingRow(finding)
+                        }
+                    }
+                }
+            }
+
             sectionCard(title: "Diagnostics", systemImage: "waveform.path.ecg") {
                 ReviewRunDetailDiagnosticsSummaryCard(response: detail.diagnostics)
                 if detail.diagnostics.events.isEmpty {
@@ -244,6 +258,41 @@ struct ReviewRunDetailSheet: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func findingRow(_ finding: ReviewRunFinding) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(finding.title)
+                    .font(.subheadline.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+                if let severity = finding.severity, !severity.isEmpty {
+                    Text(severity.uppercased())
+                        .font(.caption2.bold())
+                        .foregroundStyle(.orange)
+                }
+            }
+            if let location = finding.locationLabel {
+                Text(location)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            if let body = finding.body, !body.isEmpty {
+                Text(body)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+            if let htmlUrl = finding.htmlUrl {
+                linkButton(title: "Open Finding", systemImage: "arrow.up.forward", urlString: htmlUrl)
+                    .controlSize(.small)
+            }
         }
         .padding(10)
         .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -499,6 +499,7 @@ struct ReviewRunDetailResponse: Codable, Sendable {
     let deployment: ReviewRunDeployment?
     let lineage: [ReviewRunLineageItem]
     let diagnostics: DeploymentDiagnosticsResponse
+    let findings: [ReviewRunFinding]
     let banners: [ReviewRunBanner]
     let metadata: ReviewRunDetailMetadata
     let actions: ReviewRunDetailActions
@@ -535,6 +536,22 @@ struct ReviewRunBanner: Codable, Identifiable, Sendable {
     let body: String
 
     var id: String { "\(tone.rawValue)-\(title)" }
+}
+
+struct ReviewRunFinding: Codable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let body: String?
+    let path: String?
+    let line: Int?
+    let severity: String?
+    let htmlUrl: String?
+
+    var locationLabel: String? {
+        guard let path else { return nil }
+        if let line { return "\(path):\(line)" }
+        return path
+    }
 }
 
 enum ReviewRunBannerTone: String, Codable, Sendable {

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1888,6 +1888,17 @@ final class ModelDecodingTests: XCTestCase {
             "filters": {"deployment_id": null, "target_type": "pr", "target_number": 563, "limit": 1},
             "summary": {"count": 1, "level_counts": {"info": 1}, "latest_timestamp": 1780000003000, "latest_timestamp_iso": "2026-05-29T20:26:43.000Z"}
           },
+          "findings": [
+            {
+              "id": "Sources/App.swift-42",
+              "title": "Nil branch is not handled",
+              "body": "Guard the optional value before rendering.",
+              "path": "Sources/App.swift",
+              "line": 42,
+              "severity": "warning",
+              "html_url": "https://github.com/mean-weasel/issuectl/pull/563/files#diff-app"
+            }
+          ],
           "banners": [{"tone": "info", "title": "Follow-up requested", "body": "A newer PR head was coalesced."}],
           "metadata": {
             "current_review_preamble": null,
@@ -1921,6 +1932,8 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.lineage.first?.active, true)
         XCTAssertEqual(response.diagnostics.summaryText, "1 diagnostic event, no failure recorded")
         XCTAssertEqual(response.diagnostics.events.first?.targetLabel, "PR #563")
+        XCTAssertEqual(response.findings.first?.locationLabel, "Sources/App.swift:42")
+        XCTAssertEqual(response.findings.first?.title, "Nil branch is not handled")
         XCTAssertEqual(response.banners.first?.tone, .info)
         XCTAssertFalse(response.actions.mobileWriteActionsEnabled)
         XCTAssertEqual(response.links.githubPr, "https://github.com/mean-weasel/issuectl/pull/563")

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
@@ -63,6 +63,17 @@ describe("/api/v1/pr-reviews/[id]", () => {
         targetLabel: "PR #44",
       }),
     ]);
+    expect(json.findings).toEqual([
+      expect.objectContaining({
+        id: "a.ts-12",
+        title: "Guard missing",
+        body: "Check the null branch.",
+        path: "a.ts",
+        line: 12,
+        severity: "warning",
+        htmlUrl: "https://github.com/mean-weasel/issuectl/pull/44/files#diff-a",
+      }),
+    ]);
     expect(json.actions).toEqual({
       canRetry: true,
       canFullRerun: true,
@@ -143,7 +154,17 @@ function reviewDetailData() {
     headRef: "feature/mobile-contracts",
     status: "completed",
     triggeredBy: "webhook",
-    resultJson: JSON.stringify({ summary: "found one issue", findings: [{ path: "a.ts" }] }),
+    resultJson: JSON.stringify({
+      summary: "found one issue",
+      findings: [{
+        path: "a.ts",
+        line: 12,
+        title: "Guard missing",
+        body: "Check the null branch.",
+        severity: "warning",
+        html_url: "https://github.com/mean-weasel/issuectl/pull/44/files#diff-a",
+      }],
+    }),
     startedAt: 1_779_000_000_000,
     completedAt: 1_779_000_600_000,
   };

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.ts
@@ -59,6 +59,7 @@ function buildPrReviewDetailPayload(data: ReviewDetailData): unknown {
         limit: data.diagnostics.length,
       },
     }),
+    findings: mobileFindings(data.result),
     banners: data.banners,
     metadata: data.metadata,
     actions: {
@@ -146,6 +147,45 @@ function mobileDeployment(deployment: Deployment): unknown {
   };
 }
 
+function mobileFindings(result: Record<string, unknown>): unknown[] {
+  const rawFindings = arrayValue(result.findings) ?? arrayValue(result.comments) ?? [];
+  return rawFindings
+    .map((item, index) => mobileFinding(item, index))
+    .filter((item) => item !== null);
+}
+
+function mobileFinding(item: unknown, index: number): Record<string, unknown> | null {
+  if (typeof item !== "object" || item === null || Array.isArray(item)) return null;
+  const finding = item as Record<string, unknown>;
+  const path = stringValue(finding.path)
+    ?? stringValue(finding.file)
+    ?? stringValue(finding.filePath)
+    ?? stringValue(finding.file_path)
+    ?? stringValue(finding.filename);
+  const line = numberValue(finding.line)
+    ?? numberValue(finding.startLine)
+    ?? numberValue(finding.start_line)
+    ?? numberValue(finding.originalLine)
+    ?? numberValue(finding.original_line);
+  const body = stringValue(finding.body)
+    ?? stringValue(finding.message)
+    ?? stringValue(finding.comment)
+    ?? stringValue(finding.description);
+  const title = stringValue(finding.title)
+    ?? stringValue(finding.rule)
+    ?? firstLine(body)
+    ?? (path ? `${path}${line ? `:${line}` : ""}` : `Finding ${index + 1}`);
+  return {
+    id: stringValue(finding.id) ?? `${path ?? "finding"}-${line ?? index}`,
+    title,
+    body: body ?? null,
+    path: path ?? null,
+    line: line ?? null,
+    severity: stringValue(finding.severity) ?? stringValue(finding.level) ?? null,
+    htmlUrl: stringValue(finding.htmlUrl) ?? stringValue(finding.html_url) ?? stringValue(finding.url) ?? null,
+  };
+}
+
 function reviewSummary(result: Record<string, unknown>): string | null {
   return stringValue(result.summary) ?? stringValue(result.reason) ?? stringValue(result.error) ?? null;
 }
@@ -196,6 +236,14 @@ function numberValue(value: unknown): number | undefined {
 
 function arrayLength(value: unknown): number | null {
   return Array.isArray(value) ? value.length : null;
+}
+
+function arrayValue(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
+function firstLine(value: string | undefined): string | undefined {
+  return value?.split(/\r?\n/, 1)[0];
 }
 
 function toIso(value: number): string {


### PR DESCRIPTION
## Summary
- add normalized read-only findings to the mobile review detail response
- decode findings in shared Swift models and show them in the iOS review detail sheet
- cover the contract with web route and Swift decoding tests

## Verification
- pnpm --dir packages/web test -- app/api/v1/pr-reviews
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- XcodeBuildMCP test_sim -only-testing:IssueCTLTests/ModelDecodingTests/testReviewRunDetailResponseDecodingFromLiveContract
- XcodeBuildMCP build_run_sim
- git diff --check

Stacked on #570. Mobile retry/rerun/comment write actions remain intentionally deferred.