### PR TITLE
[codex] Add iOS webhook recovery controls

### DIFF
--- a/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -45,6 +45,7 @@ struct EditRepoSheet: View {
     @State private var isCheckingWebhookHealth = false
     @State private var isLoadingWebhookActivity = false
     @State private var isConfiguringWebhook = false
+    @State private var isSendingWebhookPing = false
     @State private var isRecreatingLabels = false
     @State private var isCopyingWebhookURL = false
     @State private var isCheckingLabels = false
@@ -282,6 +283,30 @@ struct EditRepoSheet: View {
             .accessibilityIdentifier("edit-repo-webhook-configure-button")
 
             Button {
+                Task { await configureWebhook(action: .reinstall) }
+            } label: {
+                settingsActionLabel(
+                    title: "Reinstall Webhook",
+                    systemImage: "arrow.triangle.2.circlepath",
+                    isLoading: isConfiguringWebhook
+                )
+            }
+            .disabled(isConfiguringWebhook)
+            .accessibilityIdentifier("edit-repo-webhook-reinstall-button")
+
+            Button {
+                Task { await sendWebhookPing() }
+            } label: {
+                settingsActionLabel(
+                    title: "Re-send Webhook Ping",
+                    systemImage: "antenna.radiowaves.left.and.right",
+                    isLoading: isSendingWebhookPing
+                )
+            }
+            .disabled(isSendingWebhookPing || currentRepo.webhookId == nil)
+            .accessibilityIdentifier("edit-repo-webhook-ping-button")
+
+            Button {
                 Task { await checkLabels() }
             } label: {
                 settingsActionLabel(
@@ -417,14 +442,14 @@ struct EditRepoSheet: View {
         }
     }
 
-    private func configureWebhook() async {
+    private func configureWebhook(action requestedAction: WebhookAction? = nil) async {
         isConfiguringWebhook = true
         actionMessage = nil
         actionWarning = nil
         actionError = nil
         defer { isConfiguringWebhook = false }
 
-        let action: WebhookAction = currentRepo.webhookId == nil ? .create : .rotate
+        let action: WebhookAction = requestedAction ?? (currentRepo.webhookId == nil ? .create : .rotate)
 
         do {
             let response = try await api.configureWebhook(owner: currentRepo.owner, repo: currentRepo.name, action: action)
@@ -432,7 +457,32 @@ struct EditRepoSheet: View {
                 currentRepo = updated
                 onUpdated(updated)
             }
-            actionMessage = action == .create ? "Webhook installed." : "Webhook rotated."
+            switch action {
+            case .create:
+                actionMessage = "Webhook installed."
+            case .rotate:
+                actionMessage = "Webhook rotated."
+            case .reinstall:
+                actionMessage = "Webhook reinstalled."
+            case .ping:
+                actionMessage = "Webhook ping sent."
+            }
+            await loadWebhookActivity(refresh: true)
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func sendWebhookPing() async {
+        isSendingWebhookPing = true
+        actionMessage = nil
+        actionWarning = nil
+        actionError = nil
+        defer { isSendingWebhookPing = false }
+
+        do {
+            _ = try await api.configureWebhook(owner: currentRepo.owner, repo: currentRepo.name, action: .ping)
+            actionMessage = "Webhook ping sent."
             await loadWebhookActivity(refresh: true)
         } catch {
             actionError = error.localizedDescription

--- a/apple/IssueCTLShared/Services/APIClient+Settings.swift
+++ b/apple/IssueCTLShared/Services/APIClient+Settings.swift
@@ -96,6 +96,8 @@ struct RecreateRepoLabelsRequest: Encodable, Sendable {
 enum WebhookAction: String, Encodable, Sendable {
     case create
     case rotate
+    case reinstall
+    case ping
 }
 
 struct WebhookActionRequest: Encodable, Sendable {

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -300,6 +300,46 @@ final class APIClientExtensionTests: XCTestCase {
     }
 
     @MainActor
+    func testConfigureWebhookSendsReinstallAction() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl/webhook")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(json["action"] as? String, "reinstall")
+
+            return (self.makeResponse(url: request.url!), """
+            {"success":true,"repo":null,"webhook":{"id":124,"url":"https://hooks.example/api/webhook/github/7","created_by":"alice"},"error":null}
+            """.data(using: .utf8)!)
+        }
+
+        let response = try await client.configureWebhook(owner: "mean-weasel", repo: "issuectl", action: .reinstall)
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.webhook?.id, 124)
+    }
+
+    @MainActor
+    func testConfigureWebhookSendsPingAction() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl/webhook")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let bodyData = try XCTUnwrap(self.readBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(json["action"] as? String, "ping")
+
+            return (self.makeResponse(url: request.url!), #"{"success":true,"repo":null,"webhook":null,"error":null}"#.data(using: .utf8)!)
+        }
+
+        let response = try await client.configureWebhook(owner: "mean-weasel", repo: "issuectl", action: .ping)
+
+        XCTAssertTrue(response.success)
+        XCTAssertNil(response.webhook)
+    }
+
+    @MainActor
     func testRecreateRepoLabelsSendsAction() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl/labels")

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.test.ts
@@ -19,7 +19,14 @@ const listRepos = vi.hoisted(() => vi.fn());
 const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
 const rotateIssuectlWebhook = vi.hoisted(() => vi.fn());
 const updateRepoWebhookSettings = vi.hoisted(() => vi.fn());
-const withAuthRetry = vi.hoisted(() => vi.fn((fn: (octokit: unknown) => unknown) => fn({})));
+const pingWebhook = vi.hoisted(() => vi.fn());
+const withAuthRetry = vi.hoisted(() => vi.fn((fn: (octokit: unknown) => unknown) => fn({
+  rest: {
+    repos: {
+      pingWebhook,
+    },
+  },
+})));
 
 vi.mock("@issuectl/core", () => ({
   createIssuectlWebhook: (...args: unknown[]) => createIssuectlWebhook(...args),
@@ -61,6 +68,8 @@ beforeEach(() => {
   createIssuectlWebhook.mockResolvedValue({ id: 123, createdBy: "jeremy" });
   rotateIssuectlWebhook.mockReset();
   rotateIssuectlWebhook.mockResolvedValue({ id: 456, createdBy: "jeremy" });
+  pingWebhook.mockReset();
+  pingWebhook.mockResolvedValue({});
   recordDiagnosticEventSafely.mockReset();
   updateRepoWebhookSettings.mockReset();
   updateRepoWebhookSettings.mockReturnValue({ ...repo, webhookId: 123 });
@@ -132,6 +141,62 @@ describe("/api/v1/repos/[owner]/[repo]/webhook", () => {
       event: "webhook.url_reconciled",
       data: expect.objectContaining({ hookId: 456 }),
     }));
+  });
+
+  it("reinstalls by rotating an existing webhook id", async () => {
+    getRepoWebhookConfigById.mockReturnValue({ ...repo, webhookId: 77, webhookSecret: "old" });
+    updateRepoWebhookSettings.mockReturnValue({ ...repo, webhookId: 456 });
+
+    const response = await POST(request({ action: "reinstall" }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(rotateIssuectlWebhook).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      hookId: 77,
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_reinstalled",
+    }));
+  });
+
+  it("reinstalls by creating when the stored webhook id is stale", async () => {
+    getRepoWebhookConfigById.mockReturnValue({ ...repo, webhookId: 77, webhookSecret: "old" });
+    rotateIssuectlWebhook.mockRejectedValue({ status: 404 });
+
+    const response = await POST(request({ action: "reinstall" }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createIssuectlWebhook).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      owner: "mean-weasel",
+      repo: "issuectl",
+    }));
+    expect(json.webhook.id).toBe(123);
+  });
+
+  it("sends a webhook ping without exposing secrets", async () => {
+    getRepoWebhookConfigById.mockReturnValue({ ...repo, webhookId: 77, webhookSecret: "old" });
+
+    const response = await POST(request({ action: "ping" }), {
+      params: Promise.resolve({ owner: "mean-weasel", repo: "issuectl" }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(pingWebhook).toHaveBeenCalledWith({
+      owner: "mean-weasel",
+      repo: "issuectl",
+      hook_id: 77,
+    });
+    expect(rotateIssuectlWebhook).not.toHaveBeenCalled();
+    expect(createIssuectlWebhook).not.toHaveBeenCalled();
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      event: "repo.webhook_ping_sent",
+    }));
+    expect(JSON.stringify(json)).not.toContain("webhookSecret");
   });
 
   it("rejects rotate when no webhook id is stored", async () => {

--- a/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
+++ b/packages/web/app/api/v1/repos/[owner]/[repo]/webhook/route.ts
@@ -19,7 +19,7 @@ import {
 export const dynamic = "force-dynamic";
 
 type WebhookActionBody = {
-  action?: "create" | "rotate";
+  action?: "create" | "rotate" | "reinstall" | "ping";
 };
 
 export async function POST(
@@ -33,8 +33,8 @@ export async function POST(
   const body = await readBody(request);
   if (body instanceof NextResponse) return body;
   const action = body.action;
-  if (action !== "create" && action !== "rotate") {
-    return NextResponse.json({ success: false, error: "action must be create or rotate" }, { status: 400 });
+  if (action !== "create" && action !== "rotate" && action !== "reinstall" && action !== "ping") {
+    return NextResponse.json({ success: false, error: "action must be create, rotate, reinstall, or ping" }, { status: 400 });
   }
 
   try {
@@ -47,6 +47,29 @@ export async function POST(
     if (!config) {
       return NextResponse.json({ success: false, error: "Repository not found" }, { status: 404 });
     }
+    if (action === "ping") {
+      if (!config.webhookId) {
+        return NextResponse.json({ success: false, error: "No webhook id is stored for this repo" }, { status: 400 });
+      }
+      await withAuthRetry((octokit) =>
+        octokit.rest.repos.pingWebhook({
+          owner,
+          repo: repoName,
+          hook_id: config.webhookId ?? 0,
+        }));
+      recordDiagnosticEventSafely(db, {
+        level: "info",
+        event: "repo.webhook_ping_sent",
+        source: "web",
+        owner,
+        repo: repoName,
+        message: "Repository webhook ping sent",
+        data: { repoId: repo.id, hookId: config.webhookId },
+      });
+      log.info({ msg: "api_repo_webhook_ping_sent", repoId: repo.id, owner, name: repoName, hookId: config.webhookId });
+      return NextResponse.json({ success: true, repo, webhook: null });
+    }
+
     if (action === "create" && config.webhookId) {
       return NextResponse.json({ success: false, error: "Webhook already exists; rotate it instead" }, { status: 409 });
     }
@@ -56,20 +79,28 @@ export async function POST(
 
     const url = webhookUrl(db, repo.id);
     const secret = randomBytes(32).toString("hex");
-    const result = await withAuthRetry((octokit) => action === "create"
-      ? createIssuectlWebhook(octokit, { owner, repo: repoName, url, secret })
-      : rotateIssuectlWebhook(octokit, { owner, repo: repoName, hookId: config.webhookId ?? 0, url, secret }));
+    const result = await withAuthRetry(async (octokit) => {
+      if (action === "create" || (action === "reinstall" && !config.webhookId)) {
+        return createIssuectlWebhook(octokit, { owner, repo: repoName, url, secret });
+      }
+      try {
+        return await rotateIssuectlWebhook(octokit, { owner, repo: repoName, hookId: config.webhookId ?? 0, url, secret });
+      } catch (err) {
+        if (action !== "reinstall" || (err as { status?: number }).status !== 404) throw err;
+        return createIssuectlWebhook(octokit, { owner, repo: repoName, url, secret });
+      }
+    });
     const updated = updateRepoWebhookSettings(db, repo.id, {
       webhookId: result.id,
       webhookSecret: secret,
     });
     recordDiagnosticEventSafely(db, {
       level: "info",
-      event: action === "create" ? "repo.webhook_reinstalled" : "repo.webhook_secret_rotated",
+      event: action === "rotate" ? "repo.webhook_secret_rotated" : "repo.webhook_reinstalled",
       source: "web",
       owner,
       repo: repoName,
-      message: action === "create" ? "Repository webhook installed" : "Repository webhook secret rotated",
+      message: action === "rotate" ? "Repository webhook secret rotated" : "Repository webhook reinstalled",
       data: { repoId: repo.id, hookId: result.id, url },
     });
     recordDiagnosticEventSafely(db, {


### PR DESCRIPTION
## Summary
- extend the mobile-safe repo webhook route with reinstall fallback and ping actions
- add iOS webhook action cases and Edit Repository recovery buttons for reinstall and re-send ping
- cover server actions and Swift request contracts with focused tests

## Verification
- pnpm --dir packages/core build
- pnpm --dir packages/web test -- app/api/v1/repos
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- XcodeBuildMCP test_sim -only-testing:IssueCTLTests/APIClientExtensionTests/testConfigureWebhookSendsReinstallAction -only-testing:IssueCTLTests/APIClientExtensionTests/testConfigureWebhookSendsPingAction
- XcodeBuildMCP build_run_sim
- git diff --check

This is the T009 GoalBuddy repo automation recovery-control slice.