### PR TITLE
test(ios): align review detail mock contract

### DIFF
--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -762,6 +762,7 @@ final class APIClientTests: XCTestCase {
               "deployment": null,
               "lineage": [],
               "diagnostics": {"events": [], "filters": {"deployment_id": null, "target_type": "pr", "target_number": 563, "limit": 0}, "summary": {"count": 0, "level_counts": {}, "latest_timestamp": null, "latest_timestamp_iso": null}},
+              "findings": [],
               "banners": [],
               "metadata": {"current_review_preamble": null, "trigger_event": null},
               "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": false},


### PR DESCRIPTION
## Summary
- Add the required `findings` array to the iOS review detail endpoint mock used by `testReviewRunDetailEndpointURL`.
- Keeps the post-merge iOS review detail contract fixture aligned with the merged server response model.

## Verification
- XcodeBuildMCP focused `test_sim` for the iOS parity API/view tests: passed after this fix (7 tests).
- `git diff --check`: passed.
- Commit/push hooks ran typecheck/lint successfully.

## Notes
- This was found during clean `origin/main` post-merge verification after #570/#573/#571/#572/#574 landed.