### PR TITLE
fix(ios): keep offline queue clear of top navigation

### DIFF
--- a/apple/IssueCTL/App/ContentView.swift
+++ b/apple/IssueCTL/App/ContentView.swift
@@ -70,24 +70,10 @@ struct ContentView: View {
                 .sheet(isPresented: $showSettings) {
                     SettingsView()
                 }
-                .overlay(alignment: .top) {
-                    VStack(spacing: 8) {
-                        OfflineBanner()
-                        OfflineQueueBanner(
-                            pendingCount: offlineSync.pendingCount,
-                            failedCount: offlineSync.failedCount,
-                            isSyncing: offlineSync.isSyncing,
-                            onSync: {
-                                offlineSync.retryFailedActions()
-                                await offlineSync.syncPendingActions()
-                            },
-                            onDismissFailed: {
-                                offlineSync.clearFailedActions()
-                            }
-                        )
+                .overlay(alignment: .bottom) {
+                    if shouldShowStatusBanners {
+                        statusBanners
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
                 }
                 .animation(.easeInOut(duration: 0.3), value: network.isConnected)
                 .animation(.easeInOut(duration: 0.25), value: offlineSync.pendingCount)
@@ -127,6 +113,31 @@ struct ContentView: View {
             guard let route = AppRoute(notificationUserInfo: notification.userInfo ?? [:]) else { return }
             handle(route)
         }
+    }
+
+    private var shouldShowStatusBanners: Bool {
+        !network.isConnected || offlineSync.pendingCount > 0 || offlineSync.failedCount > 0 || offlineSync.isSyncing
+    }
+
+    private var statusBanners: some View {
+        VStack(spacing: 8) {
+            OfflineBanner()
+            OfflineQueueBanner(
+                pendingCount: offlineSync.pendingCount,
+                failedCount: offlineSync.failedCount,
+                isSyncing: offlineSync.isSyncing,
+                onSync: {
+                    offlineSync.retryFailedActions()
+                    await offlineSync.syncPendingActions()
+                },
+                onDismissFailed: {
+                    offlineSync.clearFailedActions()
+                }
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 92)
+        .background(.clear)
     }
 
     private func handle(_ route: AppRoute) {

--- a/apple/IssueCTL/Views/Shared/CacheAgeLabel.swift
+++ b/apple/IssueCTL/Views/Shared/CacheAgeLabel.swift
@@ -28,13 +28,17 @@ struct CacheAgeLabel: View {
 }
 
 func staleDataMessage(kind: String, cachedAt: Date?) -> String {
+    cachedDataMessage(prefix: "Showing cached", kind: kind, cachedAt: cachedAt)
+}
+
+func cachedDataMessage(prefix: String, kind: String, cachedAt: Date?) -> String {
     guard let cachedAt else {
-        return "Showing cached \(kind)"
+        return "\(prefix) \(kind)"
     }
 
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .abbreviated
-    return "Showing cached \(kind) from \(formatter.localizedString(for: cachedAt, relativeTo: Date()))"
+    return "\(prefix) \(kind) from \(formatter.localizedString(for: cachedAt, relativeTo: Date()))"
 }
 
 func freshnessStatusMessage(
@@ -44,6 +48,9 @@ func freshnessStatusMessage(
     cachedAt: Date?
 ) -> String? {
     if isShowingCachedData {
+        if !isNetworkConnected {
+            return cachedDataMessage(prefix: "Offline - showing cached", kind: kind, cachedAt: cachedAt)
+        }
         return staleDataMessage(kind: kind, cachedAt: cachedAt)
     }
     if !isNetworkConnected {

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -141,6 +141,17 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertEqual(message, "Showing cached today data")
     }
 
+    func testFreshnessStatusDistinguishesOfflineCachedFallback() {
+        let message = freshnessStatusMessage(
+            kind: "today data",
+            isShowingCachedData: true,
+            isNetworkConnected: false,
+            cachedAt: nil
+        )
+
+        XCTAssertEqual(message, "Offline - showing cached today data")
+    }
+
     // MARK: - Repo Automation Controls
 
     func testAutomationDisableConfirmationCopyMatchesServerBehavior() {


### PR DESCRIPTION
## Summary
- Move the iOS offline/network queue status surface from the top header overlay to a bottom overlay above the tab bar so Settings/Search/Create remain tappable while failed offline actions are visible.
- Keep Sync/Dismiss actions available on the offline queue banner.
- Distinguish offline cached fallback wording from connected cached data wording.

## Verification
- `git diff --check`
- XcodeBuildMCP `test_sim -only-testing:IssueCTLTests/ViewLogicTests` (80 passed)
- XcodeBuildMCP `build_run_sim`
- Simulator walkthrough: failed offline action banner rendered near the bottom and `today-settings-button` opened Settings successfully while the banner still existed.

## GoalBuddy
- Follow-up for `docs/goals/ios-parity-followup-hardening/goal.md` T003.