### PR TITLE
Enable iOS review rerun actions

### DIFF
--- a/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
+++ b/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
@@ -14,6 +14,7 @@ struct ReviewRunDetailSheet: View {
     @State private var detail: ReviewRunDetailResponse?
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var actionInFlight: ReviewRunActionMode?
 
     var body: some View {
         NavigationStack {
@@ -54,6 +55,8 @@ struct ReviewRunDetailSheet: View {
                     }
                 }
             }
+
+            reviewActions(detail)
 
             sectionCard(title: "Run Details", systemImage: "info.circle") {
                 detailRows([
@@ -145,6 +148,55 @@ struct ReviewRunDetailSheet: View {
                     .foregroundStyle(.orange)
             }
         }
+    }
+
+    private func reviewActions(_ detail: ReviewRunDetailResponse) -> some View {
+        sectionCard(title: "Actions", systemImage: "arrow.clockwise.circle") {
+            VStack(alignment: .leading, spacing: 10) {
+                if let disabledReason = detail.actions.disabledReason {
+                    Label(disabledReason, systemImage: "hourglass")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 10) {
+                    actionButton(
+                        title: "Retry",
+                        systemImage: "arrow.clockwise",
+                        mode: .retry,
+                        enabled: detail.actions.mobileWriteActionsEnabled && detail.actions.canRetry
+                    )
+                    actionButton(
+                        title: "Full rerun",
+                        systemImage: "arrow.triangle.2.circlepath",
+                        mode: .full,
+                        enabled: detail.actions.mobileWriteActionsEnabled && detail.actions.canFullRerun
+                    )
+                }
+            }
+        }
+    }
+
+    private func actionButton(title: String, systemImage: String, mode: ReviewRunActionMode, enabled: Bool) -> some View {
+        Button {
+            Task { await requestAction(mode) }
+        } label: {
+            HStack(spacing: 7) {
+                if actionInFlight == mode {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: systemImage)
+                }
+                Text(title)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!enabled || actionInFlight != nil)
+        .accessibilityIdentifier("review-run-\(mode.rawValue)-button")
     }
 
     private func header(_ detail: ReviewRunDetailResponse) -> some View {
@@ -354,6 +406,20 @@ struct ReviewRunDetailSheet: View {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    @MainActor
+    private func requestAction(_ mode: ReviewRunActionMode) async {
+        actionInFlight = mode
+        errorMessage = nil
+        do {
+            _ = try await api.requestReviewRunAction(id: reviewId, mode: mode)
+            detail = nil
+            await load(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        actionInFlight = nil
     }
 }
 

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -572,6 +572,23 @@ struct ReviewRunDetailActions: Codable, Sendable {
     let mobileWriteActionsEnabled: Bool
 }
 
+enum ReviewRunActionMode: String, Codable, Sendable {
+    case retry
+    case full
+}
+
+struct ReviewRunActionRequest: Codable, Sendable {
+    let mode: ReviewRunActionMode
+}
+
+struct ReviewRunActionResponse: Codable, Sendable {
+    let success: Bool
+    let reviewId: Int
+    let intentId: Int
+    let mode: ReviewRunActionMode
+    let message: String
+}
+
 struct ReviewRunDetailLinks: Codable, Sendable {
     let githubPr: String
     let githubReview: String?

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -473,6 +473,13 @@ final class APIClient {
         return try decoder.decode(ReviewRunDetailResponse.self, from: data)
     }
 
+    func requestReviewRunAction(id: Int, mode: ReviewRunActionMode) async throws -> ReviewRunActionResponse {
+        let safeId = max(1, id)
+        let bodyData = try JSONEncoder().encode(ReviewRunActionRequest(mode: mode))
+        let (data, _) = try await request(path: "/api/v1/pr-reviews/\(safeId)/actions", method: "POST", body: bodyData)
+        return try decoder.decode(ReviewRunActionResponse.self, from: data)
+    }
+
     func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
         let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
         return try decoder.decode(DiagnosticsResponse.self, from: data)

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -378,6 +378,13 @@ final class TestableAPIClient {
         return try decoder.decode(ReviewRunDetailResponse.self, from: data)
     }
 
+    func requestReviewRunAction(id: Int, mode: ReviewRunActionMode) async throws -> ReviewRunActionResponse {
+        let safeId = max(1, id)
+        let bodyData = try JSONEncoder().encode(ReviewRunActionRequest(mode: mode))
+        let (data, _) = try await request(path: "/api/v1/pr-reviews/\(safeId)/actions", method: "POST", body: bodyData)
+        return try decoder.decode(ReviewRunActionResponse.self, from: data)
+    }
+
     func diagnostics(deploymentId: Int) async throws -> DiagnosticsResponse {
         let (data, _) = try await request(path: "/api/v1/diagnostics?deploymentId=\(deploymentId)")
         return try decoder.decode(DiagnosticsResponse.self, from: data)
@@ -765,7 +772,7 @@ final class APIClientTests: XCTestCase {
               "findings": [],
               "banners": [],
               "metadata": {"current_review_preamble": null, "trigger_event": null},
-              "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": false},
+              "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": true},
               "links": {
                 "github_pr": "https://github.com/mean-weasel/issuectl/pull/563",
                 "github_review": null,
@@ -784,7 +791,32 @@ final class APIClientTests: XCTestCase {
         let response = try await client.reviewRunDetail(id: 33)
         XCTAssertEqual(response.review.id, 33)
         XCTAssertEqual(response.repo.fullName, "mean-weasel/issuectl")
-        XCTAssertFalse(response.actions.mobileWriteActionsEnabled)
+        XCTAssertTrue(response.actions.mobileWriteActionsEnabled)
+    }
+
+    @MainActor
+    func testRequestReviewRunActionEndpointURLAndBody() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url!.path, "/api/v1/pr-reviews/33/actions")
+            XCTAssertNil(request.url!.query)
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let body = try JSONSerialization.jsonObject(with: try requestBodyData(request)) as? [String: String]
+            XCTAssertEqual(body?["mode"], "full")
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = """
+            {"success":true,"review_id":33,"intent_id":501,"mode":"full","message":"Manual full PR review rerun requested."}
+            """.data(using: .utf8)!
+            return (response, data)
+        }
+
+        let response = try await client.requestReviewRunAction(id: 33, mode: .full)
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.reviewId, 33)
+        XCTAssertEqual(response.intentId, 501)
+        XCTAssertEqual(response.mode, .full)
+        XCTAssertEqual(response.message, "Manual full PR review rerun requested.")
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -1912,7 +1912,7 @@ final class ModelDecodingTests: XCTestCase {
               "target_label": "PR #563"
             }
           },
-          "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": false},
+          "actions": {"can_retry": true, "can_full_rerun": true, "disabled_reason": null, "mobile_write_actions_enabled": true},
           "links": {
             "github_pr": "https://github.com/mean-weasel/issuectl/pull/563",
             "github_review": null,
@@ -1935,7 +1935,7 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.findings.first?.locationLabel, "Sources/App.swift:42")
         XCTAssertEqual(response.findings.first?.title, "Nil branch is not handled")
         XCTAssertEqual(response.banners.first?.tone, .info)
-        XCTAssertFalse(response.actions.mobileWriteActionsEnabled)
+        XCTAssertTrue(response.actions.mobileWriteActionsEnabled)
         XCTAssertEqual(response.links.githubPr, "https://github.com/mean-weasel/issuectl/pull/563")
     }
 

--- a/packages/web/app/api/v1/pr-reviews/[id]/actions/route.test.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/actions/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const requireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: (...args: unknown[]) => requireAuth(...args),
+}));
+
+const loggerError = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => loggerError(...args),
+  },
+}));
+
+const requestPrReviewRun = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/review-actions", () => ({
+  requestPrReviewRun: (...args: unknown[]) => requestPrReviewRun(...args),
+}));
+
+vi.mock("@issuectl/core", () => ({
+  formatErrorForUser: (err: unknown) => err instanceof Error ? err.message : String(err),
+}));
+
+import { POST } from "./route";
+
+beforeEach(() => {
+  requireAuth.mockReset();
+  loggerError.mockReset();
+  requestPrReviewRun.mockReset();
+
+  requireAuth.mockReturnValue(null);
+  requestPrReviewRun.mockReturnValue({
+    ok: true,
+    reviewId: 901,
+    intentId: 44,
+    mode: "retry",
+    message: "PR review retry requested.",
+  });
+});
+
+describe("/api/v1/pr-reviews/[id]/actions", () => {
+  it("requests a review retry through the shared review action helper", async () => {
+    const response = await POST(
+      request({ mode: "retry" }),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(requestPrReviewRun).toHaveBeenCalledWith(901, "retry");
+    expect(json).toEqual({
+      success: true,
+      reviewId: 901,
+      intentId: 44,
+      mode: "retry",
+      message: "PR review retry requested.",
+    });
+  });
+
+  it("requests a full rerun", async () => {
+    requestPrReviewRun.mockReturnValueOnce({
+      ok: true,
+      reviewId: 901,
+      intentId: 45,
+      mode: "full",
+      message: "Manual full PR review rerun requested.",
+    });
+
+    const response = await POST(
+      request({ mode: "full" }),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(requestPrReviewRun).toHaveBeenCalledWith(901, "full");
+    expect(json.intentId).toBe(45);
+    expect(json.mode).toBe("full");
+  });
+
+  it("rejects invalid ids and modes before calling the helper", async () => {
+    const invalidId = await POST(
+      request({ mode: "retry" }),
+      { params: Promise.resolve({ id: "nope" }) },
+    );
+    const invalidMode = await POST(
+      request({ mode: "unknown" }),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+
+    expect(invalidId.status).toBe(400);
+    expect(await invalidId.json()).toEqual({ error: "Invalid review id" });
+    expect(invalidMode.status).toBe(400);
+    expect(await invalidMode.json()).toEqual({ error: "Invalid review action mode" });
+    expect(requestPrReviewRun).not.toHaveBeenCalled();
+  });
+
+  it("returns helper errors with their status", async () => {
+    requestPrReviewRun.mockReturnValueOnce({
+      ok: false,
+      status: 404,
+      error: "Review not found",
+    });
+
+    const response = await POST(
+      request({ mode: "retry" }),
+      { params: Promise.resolve({ id: "999" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Review not found" });
+  });
+
+  it("requires API auth", async () => {
+    requireAuth.mockReturnValueOnce(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const response = await POST(
+      request({ mode: "retry" }),
+      { params: Promise.resolve({ id: "901" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(requestPrReviewRun).not.toHaveBeenCalled();
+  });
+});
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/pr-reviews/901/actions", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}

--- a/packages/web/app/api/v1/pr-reviews/[id]/actions/route.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/actions/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
+import log from "@/lib/logger";
+import { requestPrReviewRun, type ReviewActionMode } from "@/lib/review-actions";
+import { formatErrorForUser } from "@issuectl/core";
+
+export const dynamic = "force-dynamic";
+
+type Body = {
+  mode?: unknown;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const denied = requireAuth(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const reviewId = parseReviewId(id);
+  if (reviewId === null) {
+    return NextResponse.json({ error: "Invalid review id" }, { status: 400 });
+  }
+
+  let body: Body;
+  try {
+    body = await request.json() as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const mode = parseMode(body.mode);
+  if (!mode) {
+    return NextResponse.json({ error: "Invalid review action mode" }, { status: 400 });
+  }
+
+  try {
+    const result = requestPrReviewRun(reviewId, mode);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    return NextResponse.json({
+      success: true,
+      reviewId: result.reviewId,
+      intentId: result.intentId,
+      mode: result.mode,
+      message: result.message,
+    });
+  } catch (err) {
+    log.error({ err, msg: "api_pr_review_action_failed", reviewId, mode });
+    return NextResponse.json({ error: formatErrorForUser(err) }, { status: 500 });
+  }
+}
+
+function parseReviewId(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseMode(value: unknown): ReviewActionMode | null {
+  return value === "retry" || value === "full" ? value : null;
+}

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.test.ts
@@ -78,7 +78,7 @@ describe("/api/v1/pr-reviews/[id]", () => {
       canRetry: true,
       canFullRerun: true,
       disabledReason: null,
-      mobileWriteActionsEnabled: false,
+      mobileWriteActionsEnabled: true,
     });
     expect(JSON.stringify(json)).not.toContain("resultJson");
     expect(JSON.stringify(json)).not.toContain("completionToken");

--- a/packages/web/app/api/v1/pr-reviews/[id]/route.ts
+++ b/packages/web/app/api/v1/pr-reviews/[id]/route.ts
@@ -64,7 +64,7 @@ function buildPrReviewDetailPayload(data: ReviewDetailData): unknown {
     metadata: data.metadata,
     actions: {
       ...data.actions,
-      mobileWriteActionsEnabled: false,
+      mobileWriteActionsEnabled: true,
     },
     links: data.links,
   };

--- a/packages/web/app/reviews/[reviewId]/actions.ts
+++ b/packages/web/app/reviews/[reviewId]/actions.ts
@@ -1,14 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import {
-  getDb,
-  getPrReviewById,
-  getRepoById,
-  mergeWebhookIntent,
-  recordDiagnosticEventSafely,
-} from "@issuectl/core";
-import { buildReviewActionRequest } from "@/lib/review-detail-data";
+import { requestPrReviewRun, type ReviewActionMode } from "@/lib/review-actions";
 
 export async function retryPrReviewAction(formData: FormData): Promise<void> {
   return requestReviewRun(formData, "retry");
@@ -20,39 +13,12 @@ export async function manualFullRerunPrReviewAction(formData: FormData): Promise
 
 async function requestReviewRun(
   formData: FormData,
-  mode: "retry" | "full",
+  mode: ReviewActionMode,
 ): Promise<void> {
   const reviewId = Number(formData.get("reviewId"));
-  if (!Number.isInteger(reviewId) || reviewId <= 0) {
-    return;
-  }
+  const result = requestPrReviewRun(reviewId, mode);
+  if (!result.ok) return;
 
-  const db = getDb();
-  const review = getPrReviewById(db, reviewId);
-  if (!review) return;
-  const repo = getRepoById(db, review.repoId);
-  if (!repo) return;
-
-  const request = buildReviewActionRequest({ review, repo, mode, now: Date.now() });
-  const intentId = mergeWebhookIntent(db, request.intent);
-  recordDiagnosticEventSafely(db, {
-    level: "info",
-    event: request.diagnosticEvent,
-    source: "review-detail",
-    owner: repo.owner,
-    repo: repo.name,
-    targetType: "pr",
-    targetNumber: review.prNumber,
-    deploymentId: review.deploymentId ?? undefined,
-    message: request.diagnosticMessage,
-    data: {
-      reviewId: review.id,
-      intentId,
-      reviewMode: request.intent.reviewMode,
-      desiredHeadSha: request.intent.desiredHeadSha,
-    },
-  });
-
-  revalidatePath(`/reviews/${review.id}`);
+  revalidatePath(`/reviews/${result.reviewId}`);
   revalidatePath("/sessions");
 }

--- a/packages/web/lib/review-actions.test.ts
+++ b/packages/web/lib/review-actions.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDb = vi.hoisted(() => vi.fn());
+const getPrReviewById = vi.hoisted(() => vi.fn());
+const getRepoById = vi.hoisted(() => vi.fn());
+const listPrReviewsForPull = vi.hoisted(() => vi.fn());
+const mergeWebhookIntent = vi.hoisted(() => vi.fn());
+const recordDiagnosticEventSafely = vi.hoisted(() => vi.fn());
+
+vi.mock("@issuectl/core", () => ({
+  getDb: () => getDb(),
+  getPrReviewById: (...args: unknown[]) => getPrReviewById(...args),
+  getRepoById: (...args: unknown[]) => getRepoById(...args),
+  listPrReviewsForPull: (...args: unknown[]) => listPrReviewsForPull(...args),
+  mergeWebhookIntent: (...args: unknown[]) => mergeWebhookIntent(...args),
+  recordDiagnosticEventSafely: (...args: unknown[]) => recordDiagnosticEventSafely(...args),
+}));
+
+import { requestPrReviewRun } from "./review-actions";
+
+const db = { prepare: vi.fn() };
+const repo = {
+  id: 1,
+  owner: "mean-weasel",
+  name: "issuectl",
+  reviewAgent: "codex",
+};
+const review = {
+  id: 901,
+  repoId: 1,
+  prNumber: 44,
+  deploymentId: 700,
+  reviewedToSha: "abcdef123456",
+};
+
+beforeEach(() => {
+  getDb.mockReset();
+  getPrReviewById.mockReset();
+  getRepoById.mockReset();
+  listPrReviewsForPull.mockReset();
+  mergeWebhookIntent.mockReset();
+  recordDiagnosticEventSafely.mockReset();
+
+  getDb.mockReturnValue(db);
+  getPrReviewById.mockReturnValue(review);
+  getRepoById.mockReturnValue(repo);
+  listPrReviewsForPull.mockReturnValue([{ ...review, status: "completed" }]);
+  mergeWebhookIntent.mockReturnValue(55);
+});
+
+describe("requestPrReviewRun", () => {
+  it("enqueues a retry intent and records diagnostics", () => {
+    const result = requestPrReviewRun(901, "retry");
+
+    expect(result).toEqual({
+      ok: true,
+      reviewId: 901,
+      intentId: 55,
+      mode: "retry",
+      message: "PR review retry requested.",
+    });
+    expect(mergeWebhookIntent).toHaveBeenCalledWith(db, expect.objectContaining({
+      repoId: 1,
+      targetType: "pr",
+      targetNumber: 44,
+      desiredHeadSha: "abcdef123456",
+      requestedAgent: "codex",
+      reviewMode: "auto",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      event: "pr_review.retry",
+      owner: "mean-weasel",
+      repo: "issuectl",
+      targetType: "pr",
+      targetNumber: 44,
+    }));
+  });
+
+  it("enqueues a full rerun intent", () => {
+    const result = requestPrReviewRun(901, "full");
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, mode: "full" }));
+    expect(mergeWebhookIntent).toHaveBeenCalledWith(db, expect.objectContaining({
+      reviewMode: "full",
+    }));
+    expect(recordDiagnosticEventSafely).toHaveBeenCalledWith(db, expect.objectContaining({
+      event: "pr_review.manual_rerun",
+    }));
+  });
+
+  it("rejects action requests while a sibling run is active", () => {
+    listPrReviewsForPull.mockReturnValueOnce([{ ...review, id: 902, status: "in_progress" }]);
+
+    const result = requestPrReviewRun(901, "retry");
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "Run #902 is still in progress.",
+    });
+    expect(mergeWebhookIntent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/lib/review-actions.ts
+++ b/packages/web/lib/review-actions.ts
@@ -1,0 +1,81 @@
+import {
+  getDb,
+  getPrReviewById,
+  getRepoById,
+  listPrReviewsForPull,
+  mergeWebhookIntent,
+  recordDiagnosticEventSafely,
+} from "@issuectl/core";
+import { buildReviewActionRequest } from "@/lib/review-detail-data";
+
+export type ReviewActionMode = "retry" | "full";
+
+export type RequestReviewActionResult =
+  | {
+      ok: true;
+      reviewId: number;
+      intentId: number;
+      mode: ReviewActionMode;
+      message: string;
+    }
+  | {
+      ok: false;
+      status: 400 | 404 | 409;
+      error: string;
+    };
+
+export function requestPrReviewRun(reviewId: number, mode: ReviewActionMode): RequestReviewActionResult {
+  if (!Number.isInteger(reviewId) || reviewId <= 0) {
+    return { ok: false, status: 400, error: "Invalid review id" };
+  }
+
+  const db = getDb();
+  const review = getPrReviewById(db, reviewId);
+  if (!review) return { ok: false, status: 404, error: "Review not found" };
+  const repo = getRepoById(db, review.repoId);
+  if (!repo) return { ok: false, status: 404, error: "Repository not found" };
+
+  const activeReview = listPrReviewsForPull(db, review.repoId, review.prNumber, 24)
+    .find((item) => ACTIVE_REVIEW_STATUSES.has(item.status));
+  if (activeReview) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Run #${activeReview.id} is still ${labelize(activeReview.status)}.`,
+    };
+  }
+
+  const request = buildReviewActionRequest({ review, repo, mode, now: Date.now() });
+  const intentId = mergeWebhookIntent(db, request.intent);
+  recordDiagnosticEventSafely(db, {
+    level: "info",
+    event: request.diagnosticEvent,
+    source: "review-detail",
+    owner: repo.owner,
+    repo: repo.name,
+    targetType: "pr",
+    targetNumber: review.prNumber,
+    deploymentId: review.deploymentId ?? undefined,
+    message: request.diagnosticMessage,
+    data: {
+      reviewId: review.id,
+      intentId,
+      reviewMode: request.intent.reviewMode,
+      desiredHeadSha: request.intent.desiredHeadSha,
+    },
+  });
+
+  return {
+    ok: true,
+    reviewId: review.id,
+    intentId,
+    mode,
+    message: request.diagnosticMessage,
+  };
+}
+
+function labelize(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+const ACTIVE_REVIEW_STATUSES = new Set(["reserved", "launching", "in_progress"]);


### PR DESCRIPTION
## Summary
- add a mobile POST API for PR review retry/full-rerun actions backed by the same webhook intent helper as the web page
- enable mobile write actions in the review detail contract and enforce active-run conflicts server-side
- add iOS client models/API call and native Retry / Full rerun buttons in the review detail sheet

## Verification
- pnpm --dir packages/web test -- 'app/api/v1/pr-reviews/[id]/route.test.ts' 'app/api/v1/pr-reviews/[id]/actions/route.test.ts' lib/review-detail-data.test.ts lib/review-actions.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- XcodeBuildMCP test_sim -only-testing:IssueCTLTests/APIClientTests/testReviewRunDetailEndpointURL -only-testing:IssueCTLTests/APIClientTests/testRequestReviewRunActionEndpointURLAndBody -only-testing:IssueCTLTests/ModelDecodingTests/testReviewRunDetailResponseDecodingFromLiveContract
- git diff --check