### PR TITLE
fix(ios): polish review action feedback

### DIFF
--- a/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
+++ b/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
@@ -15,6 +15,8 @@ struct ReviewRunDetailSheet: View {
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var actionInFlight: ReviewRunActionMode?
+    @State private var requestedActionModes: Set<ReviewRunActionMode> = []
+    @State private var actionConfirmation: ReviewRunActionMode?
 
     var body: some View {
         NavigationStack {
@@ -173,29 +175,40 @@ struct ReviewRunDetailSheet: View {
                         enabled: detail.actions.mobileWriteActionsEnabled && detail.actions.canFullRerun
                     )
                 }
+
+                if let actionConfirmation {
+                    Label(actionConfirmation.requestedDisplayName, systemImage: "checkmark.circle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.green)
+                        .accessibilityIdentifier("review-run-action-confirmation")
+                }
             }
         }
     }
 
     private func actionButton(title: String, systemImage: String, mode: ReviewRunActionMode, enabled: Bool) -> some View {
-        Button {
+        let wasRequested = requestedActionModes.contains(mode)
+
+        return Button {
             Task { await requestAction(mode) }
         } label: {
             HStack(spacing: 7) {
                 if actionInFlight == mode {
                     ProgressView()
                         .controlSize(.small)
+                } else if wasRequested {
+                    Image(systemName: "checkmark.circle.fill")
                 } else {
                     Image(systemName: systemImage)
                 }
-                Text(title)
+                Text(wasRequested ? mode.requestedDisplayName : title)
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.borderedProminent)
-        .disabled(!enabled || actionInFlight != nil)
+        .disabled(!enabled || actionInFlight != nil || wasRequested)
         .accessibilityIdentifier("review-run-\(mode.rawValue)-button")
     }
 
@@ -410,16 +423,19 @@ struct ReviewRunDetailSheet: View {
 
     @MainActor
     private func requestAction(_ mode: ReviewRunActionMode) async {
+        guard actionInFlight == nil, !requestedActionModes.contains(mode) else { return }
         actionInFlight = mode
+        defer { actionInFlight = nil }
         errorMessage = nil
         do {
             _ = try await api.requestReviewRunAction(id: reviewId, mode: mode)
+            requestedActionModes.insert(mode)
+            actionConfirmation = mode
             detail = nil
             await load(force: true)
         } catch {
             errorMessage = error.localizedDescription
         }
-        actionInFlight = nil
     }
 }
 
@@ -470,6 +486,13 @@ private struct ReviewRunDetailDiagnosticsSummaryCard: View {
                     .padding(.vertical, 6)
                     .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10))
                 }
+            }
+
+            if let eventLimitNotice = response.eventLimitNotice {
+                Label(eventLimitNotice, systemImage: "line.3.horizontal.decrease.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("deployment-diagnostics-limit-notice")
             }
         }
     }

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -669,6 +669,12 @@ struct DeploymentDiagnosticsResponse: Codable, Sendable {
         }
         return rows
     }
+
+    var eventLimitNotice: String? {
+        guard let limit = filters?.limit, limit > 0, events.count >= limit else { return nil }
+        let eventLabel = limit == 1 ? "event" : "events"
+        return "Showing latest \(limit) diagnostic \(eventLabel)"
+    }
 }
 
 struct DiagnosticFilters: Codable, Sendable {

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -572,9 +572,18 @@ struct ReviewRunDetailActions: Codable, Sendable {
     let mobileWriteActionsEnabled: Bool
 }
 
-enum ReviewRunActionMode: String, Codable, Sendable {
+enum ReviewRunActionMode: String, Codable, Hashable, Sendable {
     case retry
     case full
+
+    var requestedDisplayName: String {
+        switch self {
+        case .retry:
+            return "Retry requested"
+        case .full:
+            return "Full rerun requested"
+        }
+    }
 }
 
 struct ReviewRunActionRequest: Codable, Sendable {

--- a/apple/IssueCTLTests/ModelDecodingTests.swift
+++ b/apple/IssueCTLTests/ModelDecodingTests.swift
@@ -742,8 +742,26 @@ final class ModelDecodingTests: XCTestCase {
         XCTAssertEqual(response.summaryRows.map(\.1), ["3", "1", "1", "1", "Latest 1", "2026-05-29T20:26:40.000Z"])
         XCTAssertEqual(response.filters?.targetDescription, "Issue #560")
         XCTAssertEqual(response.filters?.limitDescription, "Latest 1")
+        XCTAssertEqual(response.eventLimitNotice, "Showing latest 1 diagnostic event")
         XCTAssertTrue(response.hasFailure)
         XCTAssertTrue(response.events[0].metadataRows.contains { $0.0 == "ttydPort" && $0.1 == "49152" })
+    }
+
+    func testDeploymentDiagnosticsLimitNoticeOnlyAppearsWhenResultsHitLimit() throws {
+        let json = """
+        {
+          "events": [
+            {"id": 101, "timestamp": 1780000000000, "level": "info", "event": "deployment.activated", "message": "Deployment activated"},
+            {"id": 102, "timestamp": 1780000001000, "level": "info", "event": "deployment.visible", "message": "Deployment visible"}
+          ],
+          "filters": {"deployment_id": null, "target_type": "pr", "target_number": 44, "limit": 12},
+          "summary": {"count": 2, "level_counts": {"info": 2}, "latest_timestamp": 1780000001000, "latest_timestamp_iso": "2026-05-29T20:26:41.000Z"}
+        }
+        """.data(using: .utf8)!
+
+        let response = try decoder.decode(DeploymentDiagnosticsResponse.self, from: json)
+
+        XCTAssertNil(response.eventLimitNotice)
     }
 
     // MARK: - ActiveDeployment

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -187,6 +187,13 @@ final class ViewLogicTests: XCTestCase {
         )
     }
 
+    // MARK: - Review Run Actions
+
+    func testReviewRunActionModeRequestedDisplayNames() {
+        XCTAssertEqual(ReviewRunActionMode.retry.requestedDisplayName, "Retry requested")
+        XCTAssertEqual(ReviewRunActionMode.full.requestedDisplayName, "Full rerun requested")
+    }
+
     // MARK: - Offline Action Queue
 
     func testOfflineActionQueuePersistsIssueComments() throws {


### PR DESCRIPTION
## Summary
- show an inline success confirmation after iOS review Retry or Full rerun requests
- disable and relabel the requested action to prevent accidental duplicate taps while still allowing the other action
- clarify capped diagnostics lists with a latest-events notice when the payload hits its limit

## Verification
- XcodeBuildMCP test_sim -only-testing:IssueCTLTests/ModelDecodingTests/testDeploymentDiagnosticsSummaryUsesServerSummaryAndFilters -only-testing:IssueCTLTests/ModelDecodingTests/testDeploymentDiagnosticsLimitNoticeOnlyAppearsWhenResultsHitLimit -only-testing:IssueCTLTests/ViewLogicTests/testReviewRunActionModeRequestedDisplayNames: 3 passed, 0 failed
- XcodeBuildMCP test_sim -only-testing:IssueCTLTests: 306 passed, 0 failed
- git diff --check
- pre-commit hook: turbo typecheck/lint passed from cache before commit
