### PR TITLE
Close iOS/web parity conveyor audit

### DIFF
--- a/docs/goals/ios-web-parity-conveyor/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/state.yaml
@@ -5,7 +5,7 @@ goal:
   slug: "ios-web-parity-conveyor"
   kind: existing_plan
   tranche: "Run iOS/web parity as sequential child boards, each ending in reviewed PR, green CI, merge, and handoff before the next board."
-  status: active
+  status: complete
   oracle:
     signal: "Every queued iOS/web parity child board is merged or explicitly blocked/deferred with evidence, and final Apple verification maps back to the parity plan."
     cadence: "after each child PR review, CI result, merge, and queue advancement"
@@ -51,40 +51,41 @@ visual_board:
     url: "http://goalbuddy.localhost:41737/ios-web-parity-conveyor/"
     command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-analysis-20260531/docs/goals/ios-web-parity-conveyor"
 
-active_task: T001
+active_task: T999
 
 queue:
   - slug: "ios-target-aware-sessions"
     goal_path: "docs/goals/ios-web-parity-conveyor/subgoals/ios-target-aware-sessions/goal.md"
-    status: pr_open
+    status: merged
     branch: "codex/ios-web-parity-analysis-20260531"
     pr_url: "https://github.com/mean-weasel/issuectl/pull/581"
+    merge_sha: "7b6a544986ac71e306de98b14a41c9e3c35ec00e"
   - slug: "ios-workbench-api-parity"
     goal_path: "docs/goals/ios-web-parity-conveyor/subgoals/ios-workbench-api-parity/goal.md"
-    status: queued
-    branch: null
+    status: satisfied_on_main
+    branch: "codex/ios-workbench-api-parity-20260531"
     pr_url: null
   - slug: "ios-repo-automation-settings"
     goal_path: "docs/goals/ios-web-parity-conveyor/subgoals/ios-repo-automation-settings/goal.md"
-    status: queued
-    branch: null
+    status: satisfied_on_main
+    branch: "codex/ios-workbench-api-parity-20260531"
     pr_url: null
   - slug: "ios-diagnostics-timeline"
     goal_path: "docs/goals/ios-web-parity-conveyor/subgoals/ios-diagnostics-timeline/goal.md"
-    status: queued
-    branch: null
+    status: satisfied_on_main
+    branch: "codex/ios-workbench-api-parity-20260531"
     pr_url: null
   - slug: "ios-pr-review-session-controls"
     goal_path: "docs/goals/ios-web-parity-conveyor/subgoals/ios-pr-review-session-controls/goal.md"
-    status: queued
-    branch: null
+    status: satisfied_on_main
+    branch: "codex/ios-workbench-api-parity-20260531"
     pr_url: null
 
 tasks:
   - id: T001
     type: pm
     assignee: PM
-    status: active
+    status: done
     objective: "Drive the first child board, ios-target-aware-sessions, through launch-metadata completion, adversarial review, PR, CI, merge, and queue handoff."
     child_goal: "docs/goals/ios-web-parity-conveyor/subgoals/ios-target-aware-sessions/goal.md"
     verify:
@@ -93,17 +94,73 @@ tasks:
       - "Adversarial review finds architecture-level blocker."
       - "CI repeats red after focused fixes."
       - "GitHub permissions or branch protection block merge."
-    receipt: null
+    receipt:
+      result: done
+      pr_url: "https://github.com/mean-weasel/issuectl/pull/581"
+      merge_sha: "7b6a544986ac71e306de98b14a41c9e3c35ec00e"
+      ci:
+        - "PASS PR CI: Build, Build + UI Smoke, Build Mac App, Detect changes, E2E Web, Lint, Physical iPhone Preview Smoke, Test, Typecheck."
+        - "PASS merge queue: CI merge_group and Local macOS E2E."
   - id: T002
     type: pm
     assignee: PM
-    status: queued
+    status: done
     objective: "Activate ios-workbench-api-parity after the first child merges."
     child_goal: "docs/goals/ios-web-parity-conveyor/subgoals/ios-workbench-api-parity/goal.md"
-    receipt: null
+    receipt:
+      result: done
+      summary: "Activated and audited ios-workbench-api-parity. The slice was already satisfied on merged main: Apple WorkbenchPayload models, APIClient.workbench(refresh:), WorkbenchStore, BoardView, and web /api/v1/workbench route/tests are present."
+      verification:
+        - "PASS xcodebuildmcp test_sim selected WorkbenchPayload decoding, automation parity fixture decoding, workbench endpoint URL/cache tests, and WorkbenchStoreTests."
+        - "PASS pnpm --dir packages/web test app/api/v1/workbench/route.test.ts components/workbench/workbench.test.ts."
+        - "PASS pnpm --dir packages/web typecheck."
+  - id: T003
+    type: pm
+    assignee: PM
+    status: done
+    objective: "Audit ios-repo-automation-settings after workbench parity was found satisfied."
+    child_goal: "docs/goals/ios-web-parity-conveyor/subgoals/ios-repo-automation-settings/goal.md"
+    receipt:
+      result: done
+      summary: "Native repo automation settings were already satisfied on merged main: edit sheet exposes auto-launch, auto-review, issue/review agents, payload mode, review preamble, webhook install/rotate/reinstall/ping, label recreation, label health, recent activity, and disabling-automation confirmation."
+      verification:
+        - "PASS xcodebuildmcp test_sim selected repo automation decoding, webhook health/configure/reinstall/ping/recreate labels, receiver URL, label health, and RepoAutomationActivityViewTests."
+        - "PASS pnpm --dir packages/web test quoted repo/settings/workbench automation route/component tests."
+  - id: T004
+    type: pm
+    assignee: PM
+    status: done
+    objective: "Audit ios-diagnostics-timeline after repo automation settings were found satisfied."
+    child_goal: "docs/goals/ios-web-parity-conveyor/subgoals/ios-diagnostics-timeline/goal.md"
+    receipt:
+      result: done
+      summary: "Native diagnostics-first troubleshooting was already satisfied on merged main: read-only diagnostics routes, Apple diagnostics models/client methods, deployment diagnostics sheet, PR review diagnostics summaries, and focused route/model/API tests are present."
+      verification:
+        - "PASS xcodebuildmcp test_sim selected DeploymentDiagnostics decoding/live-contract/API endpoint tests."
+        - "PASS pnpm --dir packages/web test app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts."
+  - id: T005
+    type: pm
+    assignee: PM
+    status: done
+    objective: "Audit ios-pr-review-session-controls after diagnostics parity was found satisfied."
+    child_goal: "docs/goals/ios-web-parity-conveyor/subgoals/ios-pr-review-session-controls/goal.md"
+    receipt:
+      result: done
+      summary: "Native PR review-session controls were already satisfied on merged main where daemon contracts allow them: PR detail toggles auto-review labels, shows active review sessions, opens eligible terminals, and ReviewRunDetailSheet exposes lineage, findings, diagnostics, retry, and full-rerun actions gated by server capabilities."
+      verification:
+        - "PASS xcodebuildmcp test_sim selected PR review run decoding/detail/action endpoint, pull label, and action-mode tests."
+        - "PASS pnpm --dir packages/web test pr-reviews route/detail/actions and pull-label route tests."
   - id: T999
     type: judge
     assignee: Judge
-    status: queued
+    status: done
     objective: "Final conveyor audit after all child boards are merged or explicitly blocked/deferred."
-    receipt: null
+    receipt:
+      result: approved
+      summary: "The conveyor completed after PR #581 merged the first active target-aware/PTT bridge slice. Subsequent queued child slices were adversarially audited against updated main and found already satisfied with focused green verification, so no redundant feature PRs were created."
+      final_proof:
+        - "First child merged: https://github.com/mean-weasel/issuectl/pull/581 at 7b6a544986ac71e306de98b14a41c9e3c35ec00e."
+        - "Workbench API parity verified on main."
+        - "Repo automation settings parity verified on main."
+        - "Diagnostics timeline parity verified on main."
+        - "PR review-session controls verified on main."

--- a/docs/goals/ios-web-parity-conveyor/subgoals/ios-diagnostics-timeline/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/subgoals/ios-diagnostics-timeline/state.yaml
@@ -4,12 +4,23 @@ goal:
   slug: "ios-diagnostics-timeline"
   kind: existing_plan
   tranche: "Expose diagnostics journal evidence natively for launch/session failures."
-  status: queued
+  status: complete
 active_task: null
 tasks:
   - id: T001
     type: scout
     assignee: Scout
-    status: queued
+    status: done
     objective: "Confirm diagnostics journal schema/CLI behavior and identify the safest read-only API plus native UI slice."
-    receipt: null
+    receipt:
+      result: already_satisfied_on_main
+      summary: "Merged main already contains the diagnostics-first native troubleshooting surface and read-only API: diagnostics routes, diagnostics payload helpers, Apple diagnostics models/API client, session diagnostics sheet, and PR review diagnostics summaries."
+      evidence:
+        - "packages/web/app/api/v1/diagnostics/route.ts"
+        - "packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts"
+        - "apple/IssueCTLShared/Models/Deployment.swift"
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      verification:
+        - "PASS xcodebuildmcp test_sim selected DeploymentDiagnostics decoding/live-contract/API endpoint tests."
+        - "PASS pnpm --dir packages/web test app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts."

--- a/docs/goals/ios-web-parity-conveyor/subgoals/ios-pr-review-session-controls/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/subgoals/ios-pr-review-session-controls/state.yaml
@@ -4,12 +4,23 @@ goal:
   slug: "ios-pr-review-session-controls"
   kind: existing_plan
   tranche: "Add native PR review-session actions once target-aware sessions and daemon contracts are in place."
-  status: queued
+  status: complete
 active_task: null
 tasks:
   - id: T001
     type: scout
     assignee: Scout
-    status: queued
+    status: done
     objective: "Map web PR review-session controls and identify native controls that can safely ship after target-aware sessions."
-    receipt: null
+    receipt:
+      result: already_satisfied_on_main
+      summary: "Merged main already contains native PR review-session controls where server contracts allow them: PR auto-review label toggling, active review-session cards, terminal opening for eligible sessions, review-run detail with lineage/findings/diagnostics, and retry/full-rerun actions gated by server capability flags."
+      evidence:
+        - "apple/IssueCTL/Views/PullRequests/PRDetailView.swift"
+        - "apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift"
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTLShared/Services/APIClient+DetailActions.swift"
+        - "packages/web/app/api/v1/pr-reviews/[id]/actions/route.ts"
+      verification:
+        - "PASS xcodebuildmcp test_sim selected PR review run decoding/detail/action endpoint, pull label, and action-mode tests."
+        - "PASS pnpm --dir packages/web test pr-reviews route/detail/actions and pull-label route tests."

--- a/docs/goals/ios-web-parity-conveyor/subgoals/ios-repo-automation-settings/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/subgoals/ios-repo-automation-settings/state.yaml
@@ -4,12 +4,22 @@ goal:
   slug: "ios-repo-automation-settings"
   kind: existing_plan
   tranche: "Bring native Settings up to web repo automation and webhook configuration parity."
-  status: queued
+  status: complete
 active_task: null
 tasks:
   - id: T001
     type: scout
     assignee: Scout
-    status: queued
+    status: done
     objective: "Map existing web repo automation/webhook settings contracts and native Settings gaps."
-    receipt: null
+    receipt:
+      result: already_satisfied_on_main
+      summary: "Merged main already contains native repo automation/webhook settings parity, including toggles, agents, payload mode, review preamble, webhook install/rotate/reinstall/ping, receiver URL copy, label recreation/health, recent activity, and disabling-automation confirmation."
+      evidence:
+        - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+        - "apple/IssueCTL/Views/Settings/SettingsView.swift"
+        - "apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift"
+        - "apple/IssueCTLShared/Services/APIClient+Settings.swift"
+      verification:
+        - "PASS xcodebuildmcp test_sim selected repo automation decoding, webhook health/configure/reinstall/ping/recreate labels, receiver URL, label health, and RepoAutomationActivityViewTests."
+        - "PASS pnpm --dir packages/web test quoted repo/settings/workbench automation route/component tests."

--- a/docs/goals/ios-web-parity-conveyor/subgoals/ios-target-aware-sessions/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/subgoals/ios-target-aware-sessions/state.yaml
@@ -5,7 +5,7 @@ goal:
   slug: "ios-target-aware-sessions"
   kind: existing_plan
   tranche: "Complete the remaining target-aware launch contract gap on top of current origin/main, then land it through review, PR, CI, and merge."
-  status: active
+  status: complete
   oracle:
     signal: "Apple clients can decode PR-target deployments, preserve terminal/backend/trigger metadata, display target labels, avoid treating PR sessions as issue sessions, and preserve launch correlation/backend metadata."
     cadence: "after local verification, adversarial review, PR CI, and merge"
@@ -32,7 +32,7 @@ visual_board:
     url: "http://goalbuddy.localhost:41737/ios-target-aware-sessions/"
     command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-analysis-20260531/docs/goals/ios-web-parity-conveyor/subgoals/ios-target-aware-sessions"
 
-active_task: T004
+active_task: null
 
 tasks:
   - id: T001
@@ -124,18 +124,24 @@ tasks:
   - id: T004
     type: pm
     assignee: PM
-    status: active
+    status: done
     objective: "Commit, push, open PR, monitor CI, merge when green, then activate the next conveyor child."
     verify:
       - "PR URL recorded."
       - "CI green recorded."
       - "Merge SHA recorded."
     receipt:
-      result: in_progress
+      result: done
       pr_url: "https://github.com/mean-weasel/issuectl/pull/581"
       branch: "codex/ios-web-parity-analysis-20260531"
-      commit: "7b377ae"
+      commits:
+        - "7b377ae"
+        - "a762c0c"
+      merge_sha: "7b6a544986ac71e306de98b14a41c9e3c35ec00e"
       local_checks:
         - "PASS repo pre-commit typecheck/lint hooks."
         - "PASS repo pre-push typecheck hook."
-      next: "Monitor GitHub CI, fix red checks if any, merge when green, then activate the next child board."
+      ci:
+        - "PASS PR CI: Build, Build + UI Smoke, Build Mac App, Detect changes, E2E Web, Lint, Physical iPhone Preview Smoke, Test, Typecheck."
+        - "PASS merge queue: CI merge_group and Local macOS E2E."
+      next: "Merged; parent conveyor advanced to audit remaining child boards."

--- a/docs/goals/ios-web-parity-conveyor/subgoals/ios-workbench-api-parity/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/subgoals/ios-workbench-api-parity/state.yaml
@@ -4,12 +4,24 @@ goal:
   slug: "ios-workbench-api-parity"
   kind: existing_plan
   tranche: "Add native /api/v1/workbench models, API client call, and first aggregate refresh integration."
-  status: queued
+  status: complete
 active_task: null
 tasks:
   - id: T001
     type: scout
     assignee: Scout
-    status: queued
+    status: done
     objective: "Confirm current web workbench payload fields and the smallest safe native aggregate refresh slice."
-    receipt: null
+    receipt:
+      result: already_satisfied_on_main
+      summary: "Merged main already contains native /api/v1/workbench parity: WorkbenchPayload/WorkbenchRepo models, APIClient.workbench(refresh:) with cache/offline fallback, WorkbenchStore, BoardView, and focused Apple/web tests."
+      evidence:
+        - "apple/IssueCTLShared/Models/Repo.swift"
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTL/ViewModels/WorkbenchStore.swift"
+        - "apple/IssueCTL/Views/Workbench/BoardView.swift"
+        - "packages/web/app/api/v1/workbench/route.ts"
+      verification:
+        - "PASS xcodebuildmcp test_sim selected WorkbenchPayload decoding, automation parity fixture decoding, workbench endpoint URL/cache tests, and WorkbenchStoreTests."
+        - "PASS pnpm --dir packages/web test app/api/v1/workbench/route.test.ts components/workbench/workbench.test.ts."
+        - "PASS pnpm --dir packages/web typecheck."


### PR DESCRIPTION
## Summary
- Record PR #581 as merged for the first target-aware/PT bridge slice.
- Mark the remaining GoalBuddy child boards complete after auditing merged `main` and verifying the existing native/web parity implementation.
- Capture focused verification receipts for workbench API, repo automation settings, diagnostics, and PR review-session controls.

## Verification
- `xcodebuildmcp test_sim` selected workbench API/model/store tests
- `pnpm --dir packages/web test app/api/v1/workbench/route.test.ts components/workbench/workbench.test.ts`
- `pnpm --dir packages/web typecheck`
- `xcodebuildmcp test_sim` selected repo automation/webhook/label tests
- `pnpm --dir packages/web test` quoted repo/settings/workbench automation tests
- `xcodebuildmcp test_sim` selected diagnostics model/API tests
- `pnpm --dir packages/web test app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts`
- `xcodebuildmcp test_sim` selected PR review run/action/pull-label tests
- `pnpm --dir packages/web test` pr-reviews route/detail/actions and pull-label route tests
- `ruby` YAML parse for parent and child conveyor states
- `git diff --check`
