### PR TITLE
Add adversarial proof instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@ Top realistic failure modes considered:
 
 -
 
+Strongest disproof attempt:
+
+-
+
 Evidence collected:
 
 -

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,16 @@ pnpm --dir packages/web lint
 ```
 
 Before opening a PR, run the broader checks requested in `CLAUDE.md`.
+
+## Burden Of Proof
+
+Before declaring work complete, try to disprove the change. Identify the
+strongest realistic failure mode, verify it with a command, test, trace,
+screenshot, audit record, diff, or direct inspection, and include that evidence
+in the final handoff.
+
+Treat `done`, `tests passed`, worker claims, passing happy-path tests, generated
+summaries, and optimistic UI as claims, not proof. Treat unverified assumptions
+as blockers or explicit follow-ups.
+
+Keep this section synchronized with `CLAUDE.md` whenever either file changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,3 +314,16 @@ QA skills are available for targeted quality checks. All browser-based checks us
 - Branch naming: `phase-{N}-{short-description}` for implementation work
 - Commit messages: concise, imperative, focused on the "why"
 - One commit per logical change, not one commit per file
+
+## Burden Of Proof
+
+Before declaring work complete, try to disprove the change. Identify the
+strongest realistic failure mode, verify it with a command, test, trace,
+screenshot, audit record, diff, or direct inspection, and include that evidence
+in the final handoff.
+
+Treat `done`, `tests passed`, worker claims, passing happy-path tests, generated
+summaries, and optimistic UI as claims, not proof. Treat unverified assumptions
+as blockers or explicit follow-ups.
+
+Keep this section synchronized with `AGENTS.md` whenever either file changes.

--- a/docs/ios-preview-testing.md
+++ b/docs/ios-preview-testing.md
@@ -92,6 +92,21 @@ List available device identifiers and preview destinations:
 pnpm ios:list-devices
 ```
 
+Before accepting an iOS preview/device smoke result, record one negative case
+that could have made the pass misleading. Useful disproof checks include:
+
+- routing: open a preview URL scheme or deep link for the changed surface and
+  confirm it lands on the expected screen rather than the production app
+- auth: verify stale or missing setup credentials fail visibly instead of
+  silently showing cached data
+- state drift: compare the app Settings build SHA, target device name, or smoke
+  profile against the GitHub run or local command you intended to test
+
+Include the command, simulator/device trace, screenshot, or direct inspection
+receipt in the PR handoff. If the negative case cannot be run because the
+simulator, physical phone, signing keychain, or runner is unavailable, list that
+as residual risk.
+
 ## Physical Preview Performance Timing
 
 Use the existing preview smoke wrapper to collect app-side `PerformanceTrace` timings from `iPhone-preview`. The wrapper resolves `iPhone-preview`, checks that the phone is visible and unlocked, and runs the `IssueCTLPreview-UISmoke` scheme with `ISSUECTL_UI_TESTING=1`, which mirrors timing events to device logs with a `[PerformanceTrace]` prefix.

--- a/docs/workflows/webhook-auto-sessions.md
+++ b/docs/workflows/webhook-auto-sessions.md
@@ -4,6 +4,21 @@ This runbook covers the v1 GitHub webhook auto-session flow for issue launches a
 
 For repeatable hands-on QA with the two test repositories, including target creation, diagnostics, expected evidence, and reset commands, use [Webhook Label Manual QA](./webhook-label-manual-qa.md). To choose the smallest right QA workflow and understand complexity order, use [Webhook QA Ladder](./webhook-qa-ladder.md). For the higher-complexity issue-to-PR-to-review chain, use [Webhook Issue-To-PR Review QA](./webhook-issue-to-pr-review-qa.md).
 
+## Handoff Proof
+
+Do not close a webhook automation task with only "launch worked" or "tests
+passed." Record the strongest realistic failure mode and the receipt that would
+have exposed it, such as:
+
+- `issuectl webhook tail` output for the target delivery and intent
+- `issuectl diag show` or `diag tail` output for the deployment lifecycle
+- a GitHub hook delivery query proving the labeled event returned `200`
+- a dashboard screenshot or direct inspection showing label consumption and the
+  expected active or completed session state
+
+If the disproof attempt was skipped because the tunnel, credentials, device, or
+test repo was unavailable, mark that as residual risk in the handoff.
+
 ## Receiver URL
 
 The local web server handles GitHub deliveries before Next.js request parsing so HMAC verification can use the raw request body.

--- a/docs/workflows/webhook-pr-auto-review-qa.md
+++ b/docs/workflows/webhook-pr-auto-review-qa.md
@@ -13,6 +13,13 @@ GitHub webhook delivery reaches this machine, issuectl creates exactly one PR
 review session, the trigger label is consumed, the review deployment and
 `pr_reviews` row agree, and the PR detail UI reflects the active review state.
 
+Final handoffs for this workflow must include a disproof receipt: the most
+likely way this could have been a false pass, plus the command, diagnostic
+trace, screenshot, or inspection that ruled it out. For PR review automation,
+that is usually the GitHub `pull_request.labeled` delivery status, the
+`webhook_intents`/`deployments`/`pr_reviews` SQL rows, and a PR detail UI
+inspection showing the trigger label was consumed.
+
 ## Scope
 
 Target repository:

--- a/docs/workflows/webhook-qa-ladder.md
+++ b/docs/workflows/webhook-qa-ladder.md
@@ -14,6 +14,25 @@ Use these exact prompts to hand repeatable QA to a future Codex agent:
 
 Prefer running the lower rungs first when the environment is fresh, the tunnel changed, the web server restarted, labels were reset, or a failure could be infrastructure instead of product behavior.
 
+## Proof Gate
+
+Before handing off webhook automation work, try to disprove the result with the
+lowest rung that could expose the likely failure. Record the exact runbook,
+target repo, issue or PR number, command output, diagnostic event, screenshot,
+or direct inspection receipt that proves the automation did not merely look
+done.
+
+For issue and PR automation, the most useful negative proof is usually one of:
+
+- an untagged issue or PR delivery resolving as `skipped_optout`
+- a GitHub delivery inspection showing the relevant labeled event reached the
+  current tunnel with `status_code=200`
+- diagnostics showing exactly one launch lifecycle for the target
+- DB/UI/GitHub label state agreeing after trigger-label consumption
+
+If any of those receipts are missing, list the proof gap as a blocker or
+follow-up instead of claiming the webhook path passed.
+
 ## Complexity Order
 
 | Rung | Workflow | Target | What It Proves | Primary Runbook |


### PR DESCRIPTION
## Summary
- add synchronized burden-of-proof guidance to `AGENTS.md` and `CLAUDE.md`
- add a strongest-disproof prompt to the PR template
- require concrete webhook automation receipts in the QA ladder and auto-session/PR-review runbooks
- add iOS preview/device smoke negative-case guidance for routing, auth, and state drift

Closes #580

## Failure modes considered
- agents could still claim `done` from happy-path tests without checking the most realistic failure mode
- webhook automation handoffs could omit the GitHub delivery, diagnostics, SQL, UI, or label-consumption receipt that distinguishes a real pass from a stale/tunnel failure
- iOS preview smoke could validate the wrong app, wrong device, stale auth state, or stale build SHA
- `AGENTS.md` and `CLAUDE.md` could drift and give different proof-gate instructions

## Verification
- `git diff --check origin/main...HEAD -- AGENTS.md CLAUDE.md .github/pull_request_template.md docs/ios-preview-testing.md docs/workflows/webhook-auto-sessions.md docs/workflows/webhook-pr-auto-review-qa.md docs/workflows/webhook-qa-ladder.md`
- `rg -n "Burden Of Proof|Strongest disproof attempt|Proof Gate|Handoff Proof|disproof receipt|negative case|residual risk" AGENTS.md CLAUDE.md .github/pull_request_template.md docs/ios-preview-testing.md docs/workflows/webhook-auto-sessions.md docs/workflows/webhook-pr-auto-review-qa.md docs/workflows/webhook-qa-ladder.md`

Docs-only change; package, web, and Apple runtime tests were intentionally skipped because no executable code changed.