### PR TITLE
fix(ios): surface cached workbench freshness on Today

### DIFF
--- a/apple/IssueCTL/Views/Today/TodayView.swift
+++ b/apple/IssueCTL/Views/Today/TodayView.swift
@@ -466,6 +466,13 @@ struct TodayView: View {
                     primary: activeDeployments,
                     workbenchBootstrap: bootstrap
                 )
+                let freshness = todayMergedFreshness(
+                    isShowingCachedData: isShowingCachedData,
+                    oldestCachedAt: oldestCachedAt,
+                    workbenchBootstrap: bootstrap
+                )
+                isShowingCachedData = freshness.isShowingCachedData
+                oldestCachedAt = freshness.oldestCachedAt
             } catch {
                 guard loadGeneration == generation else { return }
                 workbenchBootstrap = nil
@@ -575,6 +582,21 @@ func todayMergedActiveDeployments(
         seenIDs.insert(deployment.id)
     }
     return merged
+}
+
+func todayMergedFreshness(
+    isShowingCachedData: Bool,
+    oldestCachedAt: Date?,
+    workbenchBootstrap: WorkbenchBootstrap?
+) -> (isShowingCachedData: Bool, oldestCachedAt: Date?) {
+    guard let workbenchBootstrap, workbenchBootstrap.usesCachedIssues else {
+        return (isShowingCachedData, oldestCachedAt)
+    }
+
+    return (
+        true,
+        ([oldestCachedAt] + workbenchBootstrap.issueCachedDates).compactMap { $0 }.min()
+    )
 }
 
 enum TodayDestination: Hashable {

--- a/apple/IssueCTLShared/Models/WorkbenchBootstrap.swift
+++ b/apple/IssueCTLShared/Models/WorkbenchBootstrap.swift
@@ -16,6 +16,8 @@ struct WorkbenchBootstrap: Sendable {
     let issueLookup: [WorkbenchIssueKey: WorkbenchIssueSummary]
     let activeIssueDeploymentsByKey: [WorkbenchIssueKey: ActiveDeployment]
     let prioritiesByKey: [WorkbenchIssueKey: Priority]
+    let usesCachedIssues: Bool
+    let issueCachedDates: [Date]
 
     init(payload: WorkbenchPayload) {
         repos = payload.repos
@@ -25,10 +27,16 @@ struct WorkbenchBootstrap: Sendable {
         var summaries: [WorkbenchIssueKey: WorkbenchIssueSummary] = [:]
         var activeDeployments: [WorkbenchIssueKey: ActiveDeployment] = [:]
         var priorities: [WorkbenchIssueKey: Priority] = [:]
+        var cachedDates: [Date] = []
+        var didUseCachedIssues = false
 
         for repo in payload.repos {
             let repoFullName = repo.fullName
             summariesByRepo[repoFullName] = repo.issues
+            didUseCachedIssues = didUseCachedIssues || repo.issuesFromCache
+            if let cachedAt = repo.issuesCachedAt, let date = parseIssueCTLDate(cachedAt) {
+                cachedDates.append(date)
+            }
 
             for issue in repo.issues {
                 let key = WorkbenchIssueKey(owner: repo.owner, repo: repo.name, number: issue.number)
@@ -52,6 +60,8 @@ struct WorkbenchBootstrap: Sendable {
         issueLookup = summaries
         activeIssueDeploymentsByKey = activeDeployments
         prioritiesByKey = priorities
+        usesCachedIssues = didUseCachedIssues
+        issueCachedDates = cachedDates
     }
 
     func repo(owner: String, name: String) -> WorkbenchRepo? {

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -1003,6 +1003,36 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertEqual(result.map(\.id), [42_001])
     }
 
+    func testTodayMergedFreshnessIncludesCachedWorkbenchIssues() throws {
+        let bootstrap = try makeWorkbenchBootstrap()
+        let endpointCachedAt = try XCTUnwrap(parseIssueCTLDate("2026-05-16T15:40:00.000Z"))
+
+        let result = todayMergedFreshness(
+            isShowingCachedData: false,
+            oldestCachedAt: endpointCachedAt,
+            workbenchBootstrap: bootstrap
+        )
+
+        XCTAssertTrue(result.isShowingCachedData)
+        XCTAssertEqual(
+            result.oldestCachedAt.map { sharedISO8601Formatter.string(from: $0) },
+            "2026-05-16T15:30:00.000Z"
+        )
+    }
+
+    func testTodayMergedFreshnessKeepsLiveStatusWhenWorkbenchIssuesAreLive() throws {
+        let bootstrap = try makeWorkbenchBootstrap(issuesFromCache: false, issuesCachedAt: nil)
+
+        let result = todayMergedFreshness(
+            isShowingCachedData: false,
+            oldestCachedAt: nil,
+            workbenchBootstrap: bootstrap
+        )
+
+        XCTAssertFalse(result.isShowingCachedData)
+        XCTAssertNil(result.oldestCachedAt)
+    }
+
     func testTodaySearchMatchesTitleBodyRepoAndNumber() {
         XCTAssertTrue(todayMatchesSearchQuery(
             query: "login",
@@ -1162,10 +1192,19 @@ final class ViewLogicTests: XCTestCase {
         )
     }
 
-    private func makeWorkbenchBootstrap() throws -> WorkbenchBootstrap {
+    private func makeWorkbenchBootstrap(
+        issuesFromCache: Bool = true,
+        issuesCachedAt: String? = "2026-05-16T15:30:00.000Z"
+    ) throws -> WorkbenchBootstrap {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let payload = try decoder.decode(WorkbenchPayload.self, from: Self.workbenchFixture)
+        let json = String(data: Self.workbenchFixture, encoding: .utf8)?
+            .replacingOccurrences(of: "__ISSUES_FROM_CACHE__", with: issuesFromCache ? "true" : "false")
+            .replacingOccurrences(
+                of: "__ISSUES_CACHED_AT__",
+                with: issuesCachedAt.map { "\"\($0)\"" } ?? "null"
+            ) ?? ""
+        let payload = try decoder.decode(WorkbenchPayload.self, from: Data(json.utf8))
         return WorkbenchBootstrap(payload: payload)
     }
 
@@ -1189,8 +1228,8 @@ final class ViewLogicTests: XCTestCase {
           "launch_agent": "codex",
           "terminal_backend_default": "ttyd",
           "issue_error": null,
-          "issues_from_cache": false,
-          "issues_cached_at": null,
+          "issues_from_cache": __ISSUES_FROM_CACHE__,
+          "issues_cached_at": __ISSUES_CACHED_AT__,
           "priorities": [
             {"repo_id": 1, "issue_number": 42, "priority": "high", "updated_at": 1779000000},
             {"repo_id": 1, "issue_number": 43, "priority": "low", "updated_at": 1779000001}

--- a/apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift
+++ b/apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift
@@ -42,6 +42,16 @@ final class WorkbenchBootstrapMapperTests: XCTestCase {
         XCTAssertEqual(bootstrap.priority(for: WorkbenchIssueKey(owner: "neonwatty", repo: "missing", number: 99)), .normal)
     }
 
+    func testProjectsIssueCacheFreshnessFromWorkbenchRepos() throws {
+        let bootstrap = try WorkbenchBootstrap(payload: decodePayload())
+
+        XCTAssertTrue(bootstrap.usesCachedIssues)
+        XCTAssertEqual(
+            bootstrap.issueCachedDates.map { sharedISO8601Formatter.string(from: $0) },
+            ["2026-05-16T15:30:00.000Z"]
+        )
+    }
+
     private func decodePayload() throws -> WorkbenchPayload {
         try decoder.decode(WorkbenchPayload.self, from: Self.fixtureData)
     }
@@ -66,8 +76,8 @@ final class WorkbenchBootstrapMapperTests: XCTestCase {
           "launch_agent": "codex",
           "terminal_backend_default": "pty_bridge",
           "issue_error": null,
-          "issues_from_cache": false,
-          "issues_cached_at": null,
+          "issues_from_cache": true,
+          "issues_cached_at": "2026-05-16T15:30:00.000Z",
           "priorities": [
             {"repo_id": 1, "issue_number": 12, "priority": "high", "updated_at": 1779000000},
             {"repo_id": 1, "issue_number": 13, "priority": "low", "updated_at": 1779000001}


### PR DESCRIPTION
## Summary
- carry workbench repo issue-cache metadata through WorkbenchBootstrap
- merge cached workbench issue freshness into Today after the aggregate bootstrap loads
- add regression coverage for cached and live workbench freshness paths

## Verification
- git diff --check
- XcodeBuildMCP focused iOS tests: IssueCTLTests/ViewLogicTests + IssueCTLTests/WorkbenchBootstrapMapperTests, 95 passed / 0 failed

## Notes
- A broader full iOS test attempt exceeded the 120s tool timeout, continued into unrelated UI tests, showed an unrelated UI failure/hang, and was terminated so no stale xcodebuild process remained.