### PR TITLE
fix(ios): scope offline failure banner to recovery states

### DIFF
--- a/apple/IssueCTL/App/ContentView.swift
+++ b/apple/IssueCTL/App/ContentView.swift
@@ -116,24 +116,35 @@ struct ContentView: View {
     }
 
     private var shouldShowStatusBanners: Bool {
-        !network.isConnected || offlineSync.pendingCount > 0 || offlineSync.failedCount > 0 || offlineSync.isSyncing
+        !network.isConnected || rootOfflineQueueBannerState != nil
+    }
+
+    private var rootOfflineQueueBannerState: RootOfflineQueueBannerState? {
+        makeRootOfflineQueueBannerState(
+            pendingCount: offlineSync.pendingCount,
+            failedCount: offlineSync.failedCount,
+            isSyncing: offlineSync.isSyncing,
+            isNetworkConnected: network.isConnected
+        )
     }
 
     private var statusBanners: some View {
         VStack(spacing: 8) {
             OfflineBanner()
-            OfflineQueueBanner(
-                pendingCount: offlineSync.pendingCount,
-                failedCount: offlineSync.failedCount,
-                isSyncing: offlineSync.isSyncing,
-                onSync: {
-                    offlineSync.retryFailedActions()
-                    await offlineSync.syncPendingActions()
-                },
-                onDismissFailed: {
-                    offlineSync.clearFailedActions()
-                }
-            )
+            if let rootOfflineQueueBannerState {
+                OfflineQueueBanner(
+                    pendingCount: rootOfflineQueueBannerState.pendingCount,
+                    failedCount: rootOfflineQueueBannerState.failedCount,
+                    isSyncing: rootOfflineQueueBannerState.isSyncing,
+                    onSync: {
+                        offlineSync.retryFailedActions()
+                        await offlineSync.syncPendingActions()
+                    },
+                    onDismissFailed: {
+                        offlineSync.clearFailedActions()
+                    }
+                )
+            }
         }
         .padding(.horizontal, 12)
         .padding(.bottom, 92)
@@ -168,4 +179,38 @@ private enum AppTab: Hashable {
     case issues
     case pullRequests
     case active
+}
+
+struct RootOfflineQueueBannerState: Equatable {
+    let pendingCount: Int
+    let failedCount: Int
+    let isSyncing: Bool
+}
+
+func makeRootOfflineQueueBannerState(
+    pendingCount: Int,
+    failedCount: Int,
+    isSyncing: Bool,
+    isNetworkConnected: Bool
+) -> RootOfflineQueueBannerState? {
+    let pendingCount = max(0, pendingCount)
+    let failedCount = max(0, failedCount)
+
+    if pendingCount > 0 || isSyncing {
+        return RootOfflineQueueBannerState(
+            pendingCount: pendingCount,
+            failedCount: failedCount,
+            isSyncing: isSyncing
+        )
+    }
+
+    if failedCount > 0 && !isNetworkConnected {
+        return RootOfflineQueueBannerState(
+            pendingCount: pendingCount,
+            failedCount: failedCount,
+            isSyncing: isSyncing
+        )
+    }
+
+    return nil
 }

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -437,6 +437,48 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertTrue(store.failedActions().isEmpty)
     }
 
+    func testRootOfflineQueueBannerHidesConnectedFailedOnlyQueue() {
+        XCTAssertNil(makeRootOfflineQueueBannerState(
+            pendingCount: 0,
+            failedCount: 2,
+            isSyncing: false,
+            isNetworkConnected: true
+        ))
+    }
+
+    func testRootOfflineQueueBannerKeepsFailedQueueVisibleWhileOffline() {
+        XCTAssertEqual(
+            makeRootOfflineQueueBannerState(
+                pendingCount: 0,
+                failedCount: 2,
+                isSyncing: false,
+                isNetworkConnected: false
+            ),
+            RootOfflineQueueBannerState(pendingCount: 0, failedCount: 2, isSyncing: false)
+        )
+    }
+
+    func testRootOfflineQueueBannerShowsPendingAndSyncingWorkWhenConnected() {
+        XCTAssertEqual(
+            makeRootOfflineQueueBannerState(
+                pendingCount: 1,
+                failedCount: 0,
+                isSyncing: false,
+                isNetworkConnected: true
+            ),
+            RootOfflineQueueBannerState(pendingCount: 1, failedCount: 0, isSyncing: false)
+        )
+        XCTAssertEqual(
+            makeRootOfflineQueueBannerState(
+                pendingCount: 0,
+                failedCount: 1,
+                isSyncing: true,
+                isNetworkConnected: true
+            ),
+            RootOfflineQueueBannerState(pendingCount: 0, failedCount: 1, isSyncing: true)
+        )
+    }
+
     func testOfflineActionQueueMarkPendingPreservesRetryMetadata() throws {
         let suiteName = "issuectl.tests.offline-action-retry-metadata.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))


### PR DESCRIPTION
## Summary
- hide the global offline queue failure banner when the device is online and only failed actions remain
- keep root queue status visible for pending/syncing work and for failed actions while offline
- preserve durable failed-action inspection and cleanup in Settings > Offline Queue

## Verification
- git diff --check
- XcodeBuildMCP focused iOS tests: IssueCTLTests/ViewLogicTests, 94 passed / 0 failed
- XcodeBuildMCP build_run_sim succeeded on iOS Simulator
- Live simulator oracle: started issuectl web on :3847, applied the iOS setup link, tapped Retry on Today, and observed Today reload against live API with repo context plus 200 responses for /api/v1/repos, /api/v1/user, issues, pulls, and /api/v1/workbench; no stale offline queue overlay appeared
- Commit hook typecheck/lint passed from Turbo cache; pre-push Turbo build passed from cache