### PR TITLE
fix(ios): preserve session action accessibility identifiers

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -589,7 +589,6 @@ private struct SessionTargetGroupView: View {
                 )
             }
         }
-        .accessibilityIdentifier("session-group-\(group.key)")
     }
 
     private var groupHeader: some View {


### PR DESCRIPTION
## Summary
- remove the accessibility identifier from the active-session group wrapper so nested Open Terminal and controls buttons expose their own stable identifiers on physical devices

## Verification
- pnpm ios:preview-device-smoke:pr on iPhone-preview (passed: 2 tests, 0 failures)
- commit hook: monorepo typecheck/lint (cached, passed)
- push hook: monorepo build (cached, passed)