### PR TITLE
[codex] Harden iOS preview dogfood automation

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -83,17 +83,18 @@ struct SessionListView: View {
 
     private var filteredSessionGroups: [SessionsOverviewSessionGroup] {
         let groups = overview?.sessionGroups ?? []
-        guard !selectedRepoIds.isEmpty, selectedRepoQuery == nil else { return groups }
+        guard !selectedRepoIds.isEmpty else { return groups }
         return groups
             .map { group in
-                SessionsOverviewSessionGroup(
+                let sessions = group.sessions.filter { selectedRepoIds.contains($0.repoId) }
+                return SessionsOverviewSessionGroup(
                     key: group.key,
                     repoFullName: group.repoFullName,
                     targetType: group.targetType,
                     targetNumber: group.targetNumber,
                     targetLabel: group.targetLabel,
-                    sessions: group.sessions.filter { selectedRepoIds.contains($0.repoId) },
-                    matchingSessionCount: group.matchingSessionCount
+                    sessions: sessions,
+                    matchingSessionCount: sessions.count
                 )
             }
             .filter { !$0.sessions.isEmpty }
@@ -101,17 +102,18 @@ struct SessionListView: View {
 
     private var filteredReviewGroups: [SessionsOverviewReviewGroup] {
         let groups = overview?.reviewGroups ?? []
-        guard !selectedRepoIds.isEmpty, selectedRepoQuery == nil else { return groups }
+        guard !selectedRepoIds.isEmpty else { return groups }
         return groups
             .map { group in
-                SessionsOverviewReviewGroup(
+                let runs = group.runs.filter { selectedRepoIds.contains($0.repoId) }
+                return SessionsOverviewReviewGroup(
                     key: group.key,
                     repoFullName: group.repoFullName,
                     owner: group.owner,
                     repoName: group.repoName,
                     prNumber: group.prNumber,
-                    runs: group.runs.filter { selectedRepoIds.contains($0.repoId) },
-                    matchingRunCount: group.matchingRunCount
+                    runs: runs,
+                    matchingRunCount: runs.count
                 )
             }
             .filter { !$0.runs.isEmpty }

--- a/apple/IssueCTLUITests/IssueCTLUITests.swift
+++ b/apple/IssueCTLUITests/IssueCTLUITests.swift
@@ -100,6 +100,39 @@ final class IssueCTLUITests: XCTestCase {
     }
 
     @MainActor
+    func testPrimarySurfacesRecoverAfterBackgroundReactivation() {
+        server.seedActiveDeployment()
+        let app = launchApp(server: server)
+
+        assertElement("today-create-issue-button", existsIn: app, timeout: 8)
+        tapMainTab("board-tab", label: "Board", in: app)
+        assertElement("board-refresh-button", existsIn: app, timeout: 5)
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("sessions-refresh-button", existsIn: app, timeout: 5)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+
+        XCUIDevice.shared.press(.home)
+        _ = app.wait(for: .runningBackgroundSuspended, timeout: 2)
+        let backgroundState = app.state
+        XCTAssertTrue(
+            backgroundState == .runningBackground || backgroundState == .runningBackgroundSuspended || backgroundState == .notRunning,
+            "Expected app to leave the foreground after pressing Home, got \(backgroundState.rawValue)"
+        )
+
+        app.activate()
+        assertElement("sessions-refresh-button", existsIn: app, timeout: 8)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+
+        tapMainTab("board-tab", label: "Board", in: app)
+        assertElement("board-refresh-button", existsIn: app, timeout: 5)
+        assertElement("board-summary-running", existsIn: app, timeout: 5)
+
+        tapMainTab("today-tab", label: "Today", in: app)
+        assertElement("today-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("today-metric-sessions", existsIn: app, timeout: 5)
+    }
+
+    @MainActor
     func testPullRequestSessionControlsOpenPullRequestDetail() {
         server.seedPullRequestDeployment()
         let app = launchApp(server: server)

--- a/apple/IssueCTLUITests/SettingsTests.swift
+++ b/apple/IssueCTLUITests/SettingsTests.swift
@@ -65,7 +65,7 @@ final class SettingsTests: XCTestCase {
         openAlphaRepoEditor(in: app)
 
         assertElement("edit-repo-auto-launch-toggle", existsIn: app, timeout: 5)
-        assertElement("edit-repo-auto-review-toggle", existsIn: app)
+        revealElement("edit-repo-auto-review-toggle", in: app)
         revealElement("edit-repo-webhook-health-button", in: app)
         tapElement("edit-repo-webhook-health-button", in: app)
         XCTAssertTrue(app.staticTexts["Webhook not verified"].waitForExistence(timeout: 5), app.debugDescription)
@@ -91,7 +91,7 @@ final class SettingsTests: XCTestCase {
 
         openSettingsFromToday(in: app)
         openAlphaRepoEditor(in: app)
-        assertElement("edit-repo-auto-review-toggle", existsIn: app, timeout: 5)
+        revealElement("edit-repo-auto-review-toggle", in: app)
         let autoReviewSwitch = app.switches["edit-repo-auto-review-toggle"]
         if autoReviewSwitch.exists {
             autoReviewSwitch.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
@@ -112,7 +112,8 @@ final class SettingsTests: XCTestCase {
         let app = launchApp(server: server)
 
         openSettingsFromToday(in: app)
-        app.buttons["settings-offline-queue-link"].tap()
+        revealElement("settings-offline-queue-link", in: app)
+        tapElement("settings-offline-queue-link", in: app)
 
         XCTAssertTrue(app.navigationBars["Offline Queue"].waitForExistence(timeout: 5), app.debugDescription)
         XCTAssertTrue(app.staticTexts["Queue Empty"].waitForExistence(timeout: 5), app.debugDescription)


### PR DESCRIPTION
## Summary

- enforce selected repo filtering locally in the iOS Active sessions overview, including single-repo filter mode
- make iPhone Settings UI tests reveal below-fold automation/offline controls before asserting or tapping them
- add a physical-device background/reactivation recovery UI test for Today, Board, and Active surfaces

## Why

The preview iPhone dogfood pass found four stable automation failures after the broader physical UI suite covered the main iOS parity surfaces. One was a product bug where Active showed `Showing beta` while still rendering an alpha session. The other settings failures were iPhone viewport reachability issues in the tests.

A final audit also found the dogfood oracle lacked a freshness/background recovery receipt, so this adds an automated physical-device test for that path.

## Validation

Physical `iPhone-preview` automation:

- `SettingsTests.testDisablingAutomationWarnsWhenWebhookSessionIsActive` passed in combined rerun
- `SettingsTests.testRepoEditorShowsAutomationWebhookAndLabelControls` passed in combined rerun
- `SettingsTests.testSettingsOpensOfflineQueue` passed in combined rerun
- `SessionManagementTests.testRepoContextChipOpensSessionFiltersAndFiltersRunningSessions` passed in focused rerun after one mock-server port collision
- `IssueCTLUITests.testPrimarySurfacesRecoverAfterBackgroundReactivation` passed after correcting the test assertion to match the Board filter state

Xcode result receipts:

- `/Users/neonwatty/Library/Developer/Xcode/DerivedData/IssueCTL-dlgbttpdyvwpchaxtdhovvdrnmsv/Logs/Test/Test-IssueCTLPreview-UISmoke-2026.06.01_20-07-03--0700.xcresult`
- `/Users/neonwatty/Library/Developer/Xcode/DerivedData/IssueCTL-dlgbttpdyvwpchaxtdhovvdrnmsv/Logs/Test/Test-IssueCTLPreview-UISmoke-2026.06.01_20-08-56--0700.xcresult`
- `/Users/neonwatty/Library/Developer/Xcode/DerivedData/IssueCTL-dlgbttpdyvwpchaxtdhovvdrnmsv/Logs/Test/Test-IssueCTLPreview-UISmoke-2026.06.01_20-13-51--0700.xcresult`

Git hooks during commit/push:

- turbo typecheck passed for cli/core/web from cache
- turbo lint passed for cli/core/web from cache
- turbo build passed for cli/core/web from cache

Generated cleanup:

- restored `apple/IssueCTL/Generated/AppVersion.swift` after Xcode build drift; no generated version diff remains in the branch
