### PR TITLE
[codex] Record iOS workbench automation parity closeout

### DIFF
--- a/docs/goals/ios-workbench-automation-parity/goal.md
+++ b/docs/goals/ios-workbench-automation-parity/goal.md
@@ -1,0 +1,105 @@
+# iOS Workbench Automation Parity
+
+## Objective
+
+Bring the iOS app up to date with the current web workbench, cross-repo issue board, webhook automation, PR auto-review sessions, repo automation health, and diagnostics-first session failure model.
+
+## Original Request
+
+Make a GoalBuddy prep board to knock out the remaining iOS parity work after a deep analysis of the current web app, web hooks, new dashboard interface, automatic issue and PR working sessions via labels, and previous GoalBuddy usage.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: issuectl maintainers and iOS users
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: From the iOS app alone, a user can see all tracked repo work, understand issue and PR automation/session state, configure or repair automation labels and webhooks, drive PR auto-review label workflows through stable REST contracts, open the correct issue or PR terminal sessions, and inspect diagnostics for failed launch/session states, with focused web and iOS checks passing.
+- Goal oracle: iOS can answer, from the app alone, what work exists across tracked repos, which issues and PRs have active or completed automation sessions, whether webhook automation is healthy, how to apply or remove trigger labels safely, and how to diagnose failed launch, terminal, and session states.
+- Likely misfire: GoalBuddy produces more analysis, a board-looking artifact, or a narrow model-only patch while the iOS app still cannot operate the web workbench and automation flows end to end.
+- Blind spots considered: the root checkout is dirty with relevant WIP; PR label toggles appear web-only; diagnostics have CLI support but no discovered REST API; the simple native `Repo` model lags the server contract; planned `/api/v1/sessions/overview` was not found; webhook cleanup events can look like failures unless modeled carefully.
+- Existing plan facts: `docs/superpowers/plans/2026-06-02-ios-workbench-automation-parity.md` is the current source-backed parity plan; the current checkout contains uncommitted web webhook-health and iOS PR-target session work; implementation should preserve that baseline before creating fresh worktrees; shared Workbench projections and missing REST contracts should land before broad UI work.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`The iOS app independently supports the current web workbench and automation model: cross-repo board visibility, issue and PR session state, PR auto-review labels through REST, repo automation setup and health, diagnostics-first launch/session failure inspection, and focused verification that tries to disprove each slice.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+This tranche should advance from the existing plan into implementation. The first gate is to preserve and validate the current dirty baseline, then complete the missing REST contracts and shared iOS projections that unblock the larger mobile UX work. After that, the PM should activate the largest safe verified UI packages, using separate worktrees or delegated agents only after write scopes are disjoint and the shared contract gate has passed.
+
+## Non-Negotiable Constraints
+
+- Follow `CLAUDE.md` and `AGENTS.md`, including diagnostics-first debugging and burden-of-proof verification.
+- Do not revert or normalize unrelated dirty work. Treat current uncommitted changes as potential user/WIP changes until Scout/Judge classify them.
+- Do not start implementation worktrees from `origin/main` until the current WIP baseline is preserved, committed, stashed, or otherwise intentionally accounted for.
+- Prefer `/api/v1/workbench` and stable REST contracts as source of truth for iOS; do not let each SwiftUI view invent private interpretations of web state.
+- Add or verify PR label REST support before requiring iOS to trigger PR auto-review label workflows.
+- Add or verify diagnostics API support before claiming iOS diagnostics-first parity.
+- Keep Worker slices large enough to change behavior, but bounded by explicit `allowed_files`, focused verification, and stop conditions.
+- For every Worker package, try to disprove the change with a command, test, trace, diff, screenshot, or direct source inspection and record that evidence.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+Do not create one Worker/Judge pair per repeated file, table, route, or helper. Put repeated same-shape work into one Worker package and review the package as a whole.
+
+Do not stop because a slice needs owner input, credentials, production access, destructive operations, or policy decisions. Mark that exact slice blocked with a receipt, create the smallest safe follow-up or workaround task, and continue all local, non-destructive work that can still move the goal toward the full outcome.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+A Worker should finish the whole assigned slice. A Judge should judge the whole assigned slice. A PM should reorient the board when tasks are safe but not moving the outcome.
+
+Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice. Tiny tasks are bad when they keep happening, do not change behavior, only add wrappers/contracts/proof files, or avoid the real milestone.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/ios-workbench-automation-parity/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/ios-workbench-automation-parity/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the intake: original request, input shape, authority, proof, blind spots, existing plan facts, and likely misfire.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. If a problem, suggestion, or follow-up should become a repo artifact, create an approved issue/PR or ask the operator whether to create one.
+11. Review at phase, risk, rejected-verification, ambiguity, or final-completion boundaries; do not review every small Worker by habit.
+12. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.
+
+Issue and PR handoffs are supporting artifacts. `state.yaml` remains authoritative, and every external artifact decision must be recorded in a task receipt.

--- a/docs/goals/ios-workbench-automation-parity/notes/T001-baseline-and-gap-map.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T001-baseline-and-gap-map.md
@@ -1,0 +1,111 @@
+# T001 Baseline And Gap Map
+
+## Baseline
+
+- Root: `/Users/neonwatty/Desktop/issuectl`
+- HEAD: `184ed943a2715c6d5ea8ffbe90075238c0aa67e1`
+- Branch: `codex/webhook-tunnel-qa-hardening`
+- Upstream: `origin/codex/webhook-tunnel-qa-hardening [gone]`
+- Current checkout is dirty: `git diff --stat` reports 43 modified tracked files with 1122 insertions and 684 deletions, plus many untracked goal/docs/webhook files.
+
+Relevant dirty WIP in the root checkout:
+
+- Apple PR-target/session support:
+  - `apple/IssueCTLShared/Models/Deployment.swift` adds `DeploymentTargetType`, `ActiveDeployment.targetType`, `targetNumber`, `targetLabel`, `targetTitle`, PR-target decoding, and target-aware `EndSessionRequestBody`.
+  - `apple/IssueCTL/Views/Sessions/SessionListView.swift` and `apple/IssueCTL/Views/Terminal/TerminalView.swift` already pass `targetType` and `targetNumber` into `api.endSession`.
+  - `apple/IssueCTL/Views/Sessions/SessionRowView.swift` shows `deployment.targetLabel`.
+- Web webhook health UI:
+  - `packages/web/lib/webhook-health.ts` and `packages/web/lib/webhook-health.test.ts` are untracked in the root.
+  - `packages/web/components/issue/LabelManager.tsx`, `packages/web/components/repos/RepoSettingsPanel.tsx`, and their CSS modules are modified to surface webhook health.
+- Repo/diagnostics instructions:
+  - `AGENTS.md` and `CLAUDE.md` were modified to emphasize diagnostics-first debugging and burden-of-proof verification.
+
+Baseline preservation recommendation:
+
+- Do not create implementation worktrees from `origin/main` or any clean remote branch yet. The local branch exists, but the upstream is gone and the important parity work is not fully committed.
+- Earliest safe action for Judge/PM: either checkpoint the current WIP on a new local baseline branch with the `codex/` prefix or explicitly choose to continue implementation in the current dirty root. A separate fresh worktree is unsafe until the current root WIP is committed, stashed, or intentionally ported.
+
+## Existing Worktrees
+
+`git worktree list --porcelain` shows many older iOS parity branches. The most relevant ones are also on gone upstream branches, but they contain useful contract implementations:
+
+- `.worktrees/ios-review-actions-api`
+  - Contains `packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.ts` and `.test.ts`.
+  - Contains `packages/web/app/api/v1/diagnostics/route.ts`, `diagnostics/deployments/[id]/route.ts`, route tests, and `packages/web/lib/diagnostics-api.ts`.
+- `.worktrees/ios-diagnostics-api-contract`
+  - Contains diagnostics routes, `sessions/overview`, `webhooks/events`, `pr-reviews`, repo webhook health route, PR labels route, and `mobile-api-contracts.ts`.
+  - Also contains a much broader older Apple model shape that does not match the current root exactly, so porting should be selective.
+- `.worktrees/ios-automation-contracts`, `.worktrees/ios-dashboard-parity`
+  - Contain PR label route/test work.
+
+These worktrees should be treated as source-backed references for the foundation Worker, not as clean execution baselines.
+
+## Contract Gap Matrix
+
+| Area | Current root evidence | Status | Next action |
+| --- | --- | --- | --- |
+| Workbench aggregate | `packages/web/app/api/v1/workbench/route.ts` returns `getWorkbenchPayload()`. `packages/web/lib/workbench-data.ts` includes repos, deployments, previews, settings, health, user, repo issues, priorities, recent completions, webhook events, and PR reviews. | Present | Use as iOS source of truth. |
+| Workbench Swift decoding | `apple/IssueCTLShared/Models/WorkbenchPayload.swift` decodes repo automation fields, webhook events, PR reviews, recent completions, target-aware deployments. `WorkbenchPayloadDecodingTests.swift` covers PR webhook/review/completion decoding. | Partially present | Extend projections, not core payload decoding. |
+| Workbench Swift projections | `WorkbenchBootstrap.swift` indexes issue summaries, active issue deployments, priorities, and issue-target `ActiveDeployment` values only. | Missing PR/review/webhook/completion projections | Add active PR deployments, automation repo groups, recent completions, webhook events, PR reviews, and usable sorted board projections. |
+| PR label REST | Current root has `/api/v1/issues/.../labels`, but route listing shows no `/api/v1/pulls/.../labels`; web PR detail uses `togglePullLabel` Server Action. | Missing | Port or reimplement PR label REST route and tests before iOS auto-review label controls. |
+| Diagnostics REST | Current root route listing has no `/api/v1/diagnostics/**`. Core and CLI diagnostics exist in `packages/core/src/db/diagnostics.ts` and `packages/cli/src/commands/diag.ts`. | Missing | Port or reimplement diagnostics REST route and tests before iOS diagnostics UI. |
+| Sessions overview | Current root route listing has only `/api/v1/sessions/previews`; old plan referenced `sessions/overview`, and the diagnostics worktree has an implementation. | Missing | Defer or port selectively after deciding whether workbench is enough for ended sessions/review history. |
+| Repo automation settings | Current root `POST /api/v1/repos` and `PATCH /api/v1/repos/:owner/:repo` accept `autoLaunchIssues`, `autoReviewPrs`, agents, `reviewPreamble`, `webhookPayloadMode`, and webhook install fields. | Present server-side | Update Swift `Repo`, add/update request bodies, Add/Edit repo UI later. |
+| Repo webhook install/rotate | Current root has `/api/v1/repos/:owner/:repo/webhook`. | Present server-side | Add Swift API and UI later. |
+| Repo label repair | Current root has `/api/v1/repos/:owner/:repo/labels` GET and POST `action: recreate`. | Present server-side | Existing Swift lists labels; add recreate API/UI later. |
+| Repo webhook health | Current root has untracked `packages/web/lib/webhook-health.ts` and web UI usage, but no REST route. Diagnostics worktree has `/api/v1/repos/:owner/:repo/webhook/health`. | Missing as stable API | Add route or fold health into workbench repo payload before iOS health UI. |
+
+## UI Gap Matrix
+
+| Surface | Current iOS evidence | Gap |
+| --- | --- | --- |
+| Today | `TodayView.swift` already loads endpoint data and merges some `WorkbenchBootstrap.activeDeployments`; `ViewLogicTests` cover fallback/merge behavior. | Not a first-class web workbench command center; PR/webhook/review/diagnostic state not surfaced. |
+| Issues | `IssueListView.swift` supports sections, filters, search, active issue sessions, quick create, parse, and some workbench fallback. | No dedicated cross-repo Board mode matching web running-only/payload/priority board behavior. |
+| PRs | `PRListView.swift`/`PRDetailView.swift` support list/detail/review/merge/comment. | No stable REST-backed PR label toggle for `issuectl:auto-review`; automation/review session state not first-class. |
+| Sessions/Terminal | Dirty root already makes sessions/terminal target-aware for PR labels and end-session bodies. | Needs verification plus PR-detail navigation and diagnostics affordances. |
+| Settings/Repos | `Repo.swift`, `AddRepoSheet.swift`, and `EditRepoSheet.swift` only expose owner/name/localPath/branchPattern. | Missing auto-launch, auto-review, agents, review preamble, payload mode, webhook install/rotate/health, label repair. |
+| Diagnostics | No Apple diagnostics models, API client, or views found in current root. | Needs API contract first, then UI surface. |
+
+## Recommended First Worker Package
+
+The first Worker should be a foundation package, not broad UI:
+
+1. Add/port stable PR label REST route and tests from `.worktrees/ios-review-actions-api`.
+2. Add/port diagnostics REST route and tests from `.worktrees/ios-review-actions-api` or the richer `.worktrees/ios-diagnostics-api-contract`, keeping the current root's style.
+3. Extend `WorkbenchBootstrap` with pure projections for:
+   - active PR deployments by repo/PR key
+   - automation-enabled repos
+   - recent completions by repo
+   - webhook events by repo and target
+   - PR reviews by repo and PR number
+4. Update Swift tests to prove those projections and route paths before any broad SwiftUI work.
+
+Candidate `allowed_files`:
+
+- `packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.ts`
+- `packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts`
+- `packages/web/app/api/v1/diagnostics/**`
+- `packages/web/lib/diagnostics-api.ts`
+- `packages/web/lib/mobile-api-contracts.ts` if shared payload formatting is chosen
+- `apple/IssueCTLShared/Models/WorkbenchBootstrap.swift`
+- `apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift` if adding client path coverage
+- `docs/goals/ios-workbench-automation-parity/notes/**`
+
+Candidate verification:
+
+- `git diff --check`
+- `pnpm --dir packages/web test -- app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts`
+- `pnpm --dir packages/web test -- app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests`
+
+Candidate stop conditions:
+
+- Need to revert unrelated dirty work.
+- Need live GitHub credentials for route-level behavior that can be mocked.
+- Diagnostics payload shape conflicts with CLI/core diagnostics in a way that requires product input.
+- Need to touch broad SwiftUI surfaces before contracts/projections are verified.
+
+## Strongest T001 Disproof Attempt
+
+I tried to disprove the plan's claim that diagnostics and PR label REST are missing in the current root by listing `packages/web/app/api/v1`. The route listing showed no `diagnostics` route and no `pulls/[owner]/[repo]/[number]/labels` route. I then checked existing worktrees and found those contracts in older branches, proving the work is not imaginary but also not present in the current authoritative root.

--- a/docs/goals/ios-workbench-automation-parity/notes/T002-foundation-slice-decision.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T002-foundation-slice-decision.md
@@ -1,0 +1,73 @@
+# T002 Foundation Slice Decision
+
+## Decision
+
+`proceed`
+
+Execute the first Worker package in the current root checkout, not in a new implementation worktree yet.
+
+## Baseline Handling
+
+The current dirty root is the authoritative baseline for this tranche because it already contains relevant uncommitted iOS PR-target session work and web webhook-health UI work. A fresh worktree from `origin/main` would lose that current product state.
+
+Do not create parallel implementation worktrees until after the foundation package is verified and the WIP baseline is checkpointed. For this first package, continue in the current root while respecting `allowed_files` and preserving unrelated dirty changes.
+
+## Approved Worker Objective
+
+Implement the foundation contracts and projections that unblock iOS workbench automation parity:
+
+1. Add stable REST support for PR label toggling at `/api/v1/pulls/:owner/:repo/:number/labels`.
+2. Add API-backed diagnostics read endpoints for deployment timelines:
+   - `/api/v1/diagnostics?deploymentId=<id>&limit=<n>`
+   - `/api/v1/diagnostics/deployments/:id?limit=<n>`
+3. Add a stable repo webhook health API at `/api/v1/repos/:owner/:repo/webhook/health`, using the existing current-root `webhook-health.ts`.
+4. Extend `WorkbenchBootstrap` with pure projections for automation repos, active PR deployments, recent completions, webhook events, and PR reviews.
+5. Add focused tests/path checks for those contracts and projections.
+
+## Approved Allowed Files
+
+- `packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.ts`
+- `packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts`
+- `packages/web/app/api/v1/diagnostics/route.ts`
+- `packages/web/app/api/v1/diagnostics/route.test.ts`
+- `packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts`
+- `packages/web/app/api/v1/diagnostics/deployments/[id]/route.test.ts`
+- `packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.ts`
+- `packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts`
+- `packages/web/lib/diagnostics-api.ts`
+- `packages/web/lib/mobile-api-contracts.ts`
+- `apple/IssueCTLShared/Models/WorkbenchBootstrap.swift`
+- `apple/IssueCTLShared/Services/APIClient+DetailActions.swift`
+- `apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift`
+- `apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- `docs/goals/ios-workbench-automation-parity/notes/**`
+- `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+## Verification
+
+- `git diff --check`
+- `pnpm --dir packages/web test -- app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests -only-testing:IssueCTLTests/APIClientExtensionTests`
+- Direct inspection that the current-root route listing now includes PR labels, diagnostics, deployment diagnostics, and repo webhook health.
+
+## Stop If
+
+- The Worker needs to revert or normalize unrelated dirty work.
+- The Worker needs files outside the approved list.
+- Diagnostics payload shape conflicts with core/CLI diagnostics and cannot be resolved from existing code.
+- Route tests require live GitHub credentials instead of mocks.
+- A broad SwiftUI change becomes necessary before contracts/projections are verified.
+- The same verification failure repeats twice for the same underlying cause.
+
+## Deferred
+
+- Cross-repo Board UI.
+- PR automation UI affordances.
+- Repo automation settings UI.
+- Diagnostics UI.
+- Sessions overview, webhooks/events, and PR-reviews list APIs unless the foundation Worker discovers they are required for this package.
+
+## Rationale
+
+This is the largest safe useful slice because it changes behavior at the contract/projection layer, unlocks multiple later UI workers, and is verifiable with route tests and Swift model/client tests. Broad SwiftUI work before these contracts would increase churn and could recreate the same private interpretation drift the board is trying to eliminate.

--- a/docs/goals/ios-workbench-automation-parity/notes/T003-foundation-worker.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T003-foundation-worker.md
@@ -1,0 +1,42 @@
+# T003 Foundation Worker Receipt
+
+## Result
+
+`done`
+
+The foundation package is implemented in the current dirty root checkout. It adds the missing stable REST contracts for PR labels, diagnostics, deployment diagnostics, and repo webhook health, then exposes the iOS-side API/client types and shared `WorkbenchBootstrap` projections needed by later UI workers.
+
+## Changes
+
+- Added `/api/v1/pulls/:owner/:repo/:number/labels` with route tests for auth, request validation, and GitHub label toggling.
+- Added shared diagnostics payload helpers plus:
+  - `/api/v1/diagnostics?deploymentId=<id>&limit=<n>`
+  - `/api/v1/diagnostics/deployments/:id?limit=<n>`
+- Added `/api/v1/repos/:owner/:repo/webhook/health` backed by current-root webhook health inspection.
+- Added iOS API support for PR label toggles, deployment diagnostics, and repo webhook health decoding.
+- Extended `WorkbenchBootstrap` with projections for automation-enabled repos, active PR deployments, all active deployments, recent completions, webhook events, and PR reviews.
+- Added focused Swift tests for the new endpoint contracts and projection indexes.
+
+## Red Proof
+
+- `pnpm --dir packages/web test -- 'app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts' 'app/api/v1/diagnostics/route.test.ts' 'app/api/v1/diagnostics/deployments/[id]/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts'`
+  - Initial result: 4 failed suites because the new route modules did not exist.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests -only-testing:IssueCTLTests/APIClientExtensionTests`
+  - Initial result: compile failed on missing `WorkbenchBootstrap` projections and `WorkbenchTargetKey`.
+
+## Green Proof
+
+- `git diff --check`
+  - Passed.
+- `pnpm --dir packages/web test -- 'app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts' 'app/api/v1/diagnostics/route.test.ts' 'app/api/v1/diagnostics/deployments/[id]/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts'`
+  - Passed: 4 files, 13 tests.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests -only-testing:IssueCTLTests/APIClientExtensionTests`
+  - Passed: 45 selected tests, 0 failures.
+- `rg --files packages/web/app/api/v1 | rg 'diagnostics|pulls/.*/labels|webhook/health'`
+  - Confirmed the current-root route listing includes PR labels, diagnostics, deployment diagnostics, and repo webhook health.
+
+## Notes
+
+- The board's original verifier named `iPhone 16`, but this machine has `iPhone 17`; the first simulator attempt failed only because the requested simulator was unavailable.
+- No production GitHub credentials were needed; web route behavior is covered through mocks.
+- Broad SwiftUI work remains deferred to the next Judge-selected Worker packages.

--- a/docs/goals/ios-workbench-automation-parity/notes/T004-foundation-judge.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T004-foundation-judge.md
@@ -1,0 +1,53 @@
+# T004 Foundation Judge Receipt
+
+## Verdict
+
+`approved`
+
+The T003 foundation package is acceptable. It added the missing current-root REST contracts, shared diagnostics helpers, iOS API/client decoding, and `WorkbenchBootstrap` projections with focused red/green proof.
+
+## Evidence Reviewed
+
+- T001 proved the current dirty root is the authoritative parity baseline and a fresh `origin/main` worktree would drop relevant WIP.
+- T002 correctly required contracts and projections before broad SwiftUI work.
+- T003 receipt includes red proof for missing route modules and missing Swift projections, then green proof:
+  - `git diff --check` passed.
+  - Focused web route tests passed: 4 files, 13 tests.
+  - Focused iOS tests passed on iPhone 17: 45 selected tests, 0 failures.
+  - Route listing includes PR labels, diagnostics, deployment diagnostics, and repo webhook health.
+
+## Parallelization Decision
+
+`single_worker_now`
+
+Do not fan out into multiple implementation worktrees yet. The repo is still a dirty root with relevant uncommitted WIP and a gone upstream, so parallel worktrees should wait until this baseline is checkpointed or intentionally branched. The next safe step is one Worker in the current root.
+
+After the next single Worker slice is verified and the baseline is checkpointed, larger parallel work can be split across:
+
+- PR automation/session UI
+- repo automation health/settings UI
+- diagnostics-first UI
+
+## Approved Next Worker
+
+Activate T005 before T006.
+
+Rationale: the independent GoalBuddy Judge found T005 can be made a cleaner single-worker slice than T006 because it can avoid Sessions, Terminal, APIClient, and shared model churn. T006/T007/T008 should wait until the dirty foundation/baseline is checkpointed and their file scopes are rewritten to avoid overlaps.
+
+The Worker should prove:
+
+- The iOS app has a first-class cross-repo board/workbench surface driven by verified `WorkbenchBootstrap` projections.
+- The board groups work across repos and shows active issue/PR session state without editing shared API/model files.
+- Repo filtering, priority/status sorting, and existing issue navigation remain intact.
+- The Worker stops if it needs to edit `WorkbenchBootstrap.swift`, `WorkbenchPayload.swift`, `Deployment.swift`, `Repo.swift`, API clients, Sessions, Terminal, Settings, Repos, PullRequests, or Diagnostics views.
+
+## Process Recommendations
+
+The independent explorer found the same process risk: stop rerunning broad iOS parity prompts as fresh discovery. Continue this durable board, use GoalBuddy as PM/proof pressure, and use subagent/worktree fanout only after the dirty baseline is checkpointed.
+
+Concrete improvements:
+
+- Treat broad prompts as board updates, not new prep boards.
+- Keep Scout/Judge/Worker receipts, but bias Judges toward the largest safe vertical slice.
+- Require every Worker receipt to include red proof, green proof, changed files, commands with statuses, and strongest attempted disproof.
+- Use parallel agents for disjoint UI packages only after shared contracts and branch hygiene are stable.

--- a/docs/goals/ios-workbench-automation-parity/notes/T005-cross-repo-board.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T005-cross-repo-board.md
@@ -1,0 +1,45 @@
+# T005 Cross-Repo Board Receipt
+
+## Result
+
+Implemented the iOS cross-repo work board as a new Issues section backed by the verified `WorkbenchBootstrap` projections. The board groups open workbench issues by repo, preserves repo payload order, shows running issue state, counts active PR sessions per repo, supports existing repo filters, search, sort order, and a running-only toggle, and navigates rows through the existing issue-detail route.
+
+## Changed Files
+
+- `apple/IssueCTL/Views/Shared/SectionTabs.swift`
+- `apple/IssueCTL/Views/Issues/IssueListView.swift`
+- `apple/IssueCTLTests/ViewLogicTests.swift`
+- `apple/IssueCTLUITests/IssueCTLUITests.swift`
+- `docs/goals/ios-workbench-automation-parity/notes/T005-cross-repo-board.md`
+- `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+## Implementation Notes
+
+- Kept the board inside the existing Issues source files because the Xcode project uses explicit source membership, and adding new Swift files would have required `.pbxproj` edits outside the T005 allowed scope.
+- Added `IssueSection.board` with a stable accessibility identifier `section-tab-board`.
+- Added `issueListWorkbenchBoardSections(...)` as testable view logic for repo grouping, active issue deployment detection, active PR deployment counts, running-only filtering, search, and sort behavior.
+- Added Board UI controls with `issues-board-running-toggle` and row identifiers shaped as `board-issue-row-<repo>-<issue>`.
+
+## Verification
+
+- `git diff --check`: pass.
+- Red proof: focused `ViewLogicTests` failed before implementation because `issueListWorkbenchBoardSections` did not exist.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests`: pass, 80 tests.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testIssuesBoardSectionIsReachable`: pass.
+- Direct inspection with `rg` found the board section enum, board grouping helper, board toggle, board row identifiers, section header, active PR session count, and T005 tests.
+
+## Broad UI Suite Blocker
+
+The board's planned broad UI verifier:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests
+```
+
+ran 17 UI tests and failed only `IssueCTLUITests.testRepoContextIsVisibleAcrossPrimaryTabs`. A focused rerun of that single test failed the same way. The failure is not in the T005 board path: the Active tab renders `repo-context-filter-button` and active session row `session-reenter-terminal-9001`, but no `repo-context-active` chip.
+
+Source inspection shows `apple/IssueCTL/Views/Sessions/SessionListView.swift` passes `showsActiveSummary: false` to `RepoContextStrip`, while the test expects `repo-context-active`. T005 explicitly stopped before editing Sessions, Terminal, shared models, or API clients, so this is recorded as an out-of-scope verifier blocker for the next Judge/PM decision rather than silently widening the Worker slice.
+
+## Strongest Disproof Attempt
+
+The most realistic failure mode was that adding a new Issues section would break existing tab navigation or hide the board in the horizontal section picker. The focused Board UI test proved `Issues -> Board -> Running only` is reachable on iPhone 17, while the full UI suite exercised existing issue, PR, draft, launch, active-session, toolbar, and recovery flows before hitting the separate Active-tab repo-context assertion.

--- a/docs/goals/ios-workbench-automation-parity/notes/T006-pr-target-sessions.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T006-pr-target-sessions.md
@@ -1,0 +1,35 @@
+# T006 PR Target Sessions Receipt
+
+## Result
+
+Completed the PR-target active-session parity slice for existing deployments. The iOS session surface now treats active deployments as issue or PR targets, shows PR labels in session rows and controls, guards issue-only navigation for PR sessions, preserves target metadata when ending sessions, and keeps Terminal titles target-aware.
+
+## Changed files
+
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTL/Views/Sessions/SessionRowView.swift`
+- `apple/IssueCTL/Views/Terminal/TerminalView.swift`
+- `apple/IssueCTLShared/Models/Deployment.swift`
+- `apple/IssueCTLShared/Services/APIClient.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- `apple/IssueCTLTests/EnumTests.swift`
+- `apple/IssueCTLTests/ModelDecodingTests.swift`
+- `apple/IssueCTLTests/ViewLogicTests.swift`
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`
+- `apple/IssueCTLUITests/SessionManagementTests.swift`
+- `docs/goals/ios-workbench-automation-parity/notes/T006-pr-target-sessions.md`
+- `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+## Verification
+
+- `git diff --check`: passed.
+- Focused model/API/view logic tests passed: 162 tests and 0 failures.
+- `EnumTests` passed: 29 tests and 0 failures, including `testEndSessionRequestBodyIncludesTargetFields`.
+- Focused PR-session UI test passed.
+- Full `SessionManagementTests` passed with the new PR case included: 6 tests and 0 failures.
+- Model/API/WorkbenchBootstrap mapper verifier passed: 92 tests and 0 failures.
+- Direct inspection found target labels in session rows/sheets, issue-only navigation guards, target-aware Terminal title and end-session call sites, and the PR UI fixture.
+
+## Strongest disproof
+
+The strongest realistic failure mode was that model decoding and source inspection would look target-aware while the Active tab still rendered PR sessions as issues. I added a PR-target active deployment UI fixture and a focused UI test that opens the session controls sheet, verifies `PR #44` and `PR #44 Session`, confirms `View Issue` is absent, and confirms the replacement `PR Review` action is disabled. The focused test and the full `SessionManagementTests` suite both passed.

--- a/docs/goals/ios-workbench-automation-parity/notes/T007-repo-automation-health.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T007-repo-automation-health.md
@@ -1,0 +1,38 @@
+# T007 - Repo Automation Status And Webhook Health
+
+## Result
+
+Done for the read-only iOS parity slice.
+
+## Summary
+
+The iOS Settings repo list and edit sheet now consume the native repo automation fields and show whether issue sessions, PR reviews, webhook installation, agents, payload mode, and review preamble are configured. The edit sheet calls the repo webhook-health REST contract and renders the health state, summary, details, expected URL, hook ID, and latest delivery metadata.
+
+Mutating setup controls remain intentionally deferred to T011: enabling/disabling automation, webhook install/rotate, label repair, and active-session disable warnings require a separate write-path slice with server mutation proof.
+
+## Changed Files
+
+- `apple/IssueCTLShared/Models/Repo.swift`
+- `apple/IssueCTL/Views/Settings/SettingsView.swift`
+- `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- `apple/IssueCTLTests/ModelDecodingTests.swift`
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`
+- `apple/IssueCTLUITests/SettingsTests.swift`
+
+## Verification
+
+- `git diff --check` passed.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests/testRepoDecodesAutomationFields -only-testing:IssueCTLTests/APIClientExtensionTests/testRepoWebhookHealthUsesHealthEndpoint` passed: 2 tests, 0 failures.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests/testSettingsShowsRepoAutomationAndWebhookHealth` passed: 1 test, 0 failures.
+- Direct inspection found native repo automation fields, Settings repo-row summaries, Edit Repository automation/webhook-health rows, the webhook-health API call, and the mock webhook-health route.
+
+## Strongest Disproof Attempt
+
+The UI smoke test tapped the `org/alpha` Settings row, verified its accessibility label included `Issues + PR reviews` and `Webhook #123`, opened Edit Repository, and waited for `GitHub webhook delivery looks healthy` from the mock `/api/v1/repos/org/alpha/webhook/health` route. This disproves the main failure mode where the model decodes fields but the user-facing Settings UI never renders or fetches webhook health.
+
+## Deferred
+
+- Repo automation write controls for issue and PR automation settings.
+- Webhook install/rotate controls.
+- Trigger-label repair controls.
+- Active-session warnings that disable unsafe repo automation edits while sessions are running.

--- a/docs/goals/ios-workbench-automation-parity/notes/T008-diagnostics-first-session-surface.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T008-diagnostics-first-session-surface.md
@@ -1,0 +1,30 @@
+# T008 Diagnostics-First Session Surface
+
+## Result
+
+Done. The iOS app now has an API-backed diagnostics surface for active sessions and terminal connection failures.
+
+## What Changed
+
+- Added a Diagnostics action to the iOS session controls sheet so users can inspect launch, ttyd, tmux, activation, and webhook lifecycle events for a deployment without leaving the session list.
+- Added `DeploymentDiagnosticsView`, which calls `APIClient.deploymentDiagnostics(deploymentId:)`, sorts events by timestamp, shows a summary, and renders level/status/message/timestamp details.
+- Added a Diagnostics action to terminal connection failure UI so a failed attach/respawn can jump straight to the deployment timeline.
+- Mapped launch and failure event names to human-readable labels, including `launch.requested`, `workspace.prepared`, `deployment.recorded`, `ttyd.spawned`, `deployment.activated`, `launch.spawn_failed`, `launch.activation_failed`, `reconcile.tmux_missing`, `liveness.tmux_missing`, and `ensure_ttyd.failed`.
+- Mapped the PR webhook event names found in the web implementation, including `webhook.launched`, `webhook.pr_launched`, `webhook.auto_review_label_consumed`, `webhook.pr_session_ended`, `webhook.pr_coalesced`, `webhook.pr_followup_capped`, `webhook.pr_already_reviewed`, `webhook.pr_review_recovered`, `webhook.skipped_unsafe_pr`, and `webhook.launch_failed`.
+- Added UI mock diagnostics routes for deployment timelines and a focused UI test that opens diagnostics from an active issue session and proves the failure message is visible.
+
+## Evidence
+
+- Red test observed before implementation: `testSessionDiagnosticsShowsLaunchFailureTimeline` reached the session controls sheet and failed with `Diagnostics action missing`.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests/testSessionDiagnosticsShowsLaunchFailureTimeline` passed after implementation.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests` passed: 7 tests, 0 failures.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testDeploymentDiagnosticsUsesDiagnosticsEndpoint` passed.
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests` passed: 269 tests, 0 failures.
+- `git diff --check` passed.
+- Direct inspection found the required launch/failure producers in `packages/core/src/launch/launch-diagnostics.ts`, `packages/core/src/launch/ttyd.ts`, `packages/web/lib/idle-checker.ts`, and `packages/web/lib/ensure-ttyd.ts`.
+- Direct inspection found PR webhook producers in `packages/web/lib/webhook-pr-intent.ts`, `packages/web/lib/webhook-pr-review-state.ts`, and `packages/web/lib/webhook-intent-worker.ts`.
+- Direct inspection found iOS label mappings in `apple/IssueCTL/Views/Sessions/SessionListView.swift`.
+
+## Notes
+
+- The board requested an iPhone 16 simulator for the broad unit-test command, but `xcrun simctl list devices available` showed only iPhone 17-family devices. Verification used the booted iPhone 17 simulator.

--- a/docs/goals/ios-workbench-automation-parity/notes/T009-cross-repo-board-judge.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T009-cross-repo-board-judge.md
@@ -1,0 +1,49 @@
+# T009 Cross-Repo Board Judge
+
+## Verdict
+
+T005 is accepted as a completed cross-repo Board slice. It moved the iOS app closer to the goal oracle by adding a Board section that groups workbench issues across repos, shows running issue state, counts active PR sessions, supports existing filters/search/sort, and preserves issue navigation.
+
+## Active-Tab Verifier Disposition
+
+The failed broad UI-suite check should be treated as a real verifier blocker, not as a reason to reject T005. The evidence is specific:
+
+- The focused Board UI smoke passed.
+- The full `IssueCTLUITests` run failed only `testRepoContextIsVisibleAcrossPrimaryTabs`.
+- A focused rerun of `testRepoContextIsVisibleAcrossPrimaryTabs` reproduced the same failure.
+- The Active tab renders `repo-context-filter-button` and an active session row, but not `repo-context-active`.
+- Source inspection shows `SessionListView` passes `showsActiveSummary: false` to `RepoContextStrip`, contradicting the test's expectation.
+
+Because Sessions were explicitly outside T005's allowed files, the right next move is a narrow Worker package that fixes the Active-tab repo context surface and reruns the focused and broad UI verification before PR/session parity work.
+
+## Parallelization Decision
+
+Do not fan out T006/T007/T008 yet. The root worktree is still dirty, several queued scopes overlap shared Swift and UI-test files, and the broad UI verifier is currently blocked by a deterministic Sessions issue. Run one Worker in the current root.
+
+## Next Worker Package
+
+Activate T010: restore Active-tab active repo context summary.
+
+Allowed files:
+
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTLUITests/IssueCTLUITests.swift`
+- `docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md`
+- `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+Verification:
+
+- `git diff --check`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testRepoContextIsVisibleAcrossPrimaryTabs`
+- `xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testIssuesBoardSectionIsReachable`
+- Run the full `IssueCTLUITests` suite if the focused tests pass, because T005's broad verifier was the thing this worker is unlocking.
+
+Stop if:
+
+- The fix requires shared model/API changes.
+- The failure is caused by test server data instead of the Sessions view.
+- A second unrelated UI failure appears in the full suite and cannot be isolated with a focused rerun.
+
+## Full Outcome
+
+Not complete. T006 PR automation/session parity, T007 repo automation health, T008 diagnostics, and T999 final audit remain queued.

--- a/docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md
@@ -1,0 +1,23 @@
+# T010 Active Repo Context Receipt
+
+## Result
+
+Restored the Active tab repo-context summary by deriving active repo full names from active deployments and passing them into `RepoContextStrip`.
+
+## Changed files
+
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md`
+- `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+## Verification
+
+- `git diff --check`: passed.
+- Focused repo-context UI test: passed.
+- Focused Board UI smoke: passed.
+- Full `IssueCTLUITests` suite: passed, 17 tests and 0 failures.
+- Direct inspection confirmed `SessionListView` now computes `activeRepoFullNames` and supplies them to `RepoContextStrip`.
+
+## Strongest disproof
+
+The strongest realistic failure mode was that the broad iOS UI suite would still fail outside the focused repo-context test after the Active-tab chip was restored. I reran the full `IssueCTLUITests` target on iPhone 17; it completed with 17 tests and 0 failures.

--- a/docs/goals/ios-workbench-automation-parity/notes/T011-repo-automation-write-controls.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T011-repo-automation-write-controls.md
@@ -1,0 +1,37 @@
+# T011 - Repo Automation Write Controls
+
+## Result
+
+Done.
+
+## Summary
+
+The iOS Edit Repository sheet now exposes native write-path controls for the web repo automation model: issue auto-launch, PR auto-review, issue/review agents, review preamble, webhook payload mode, webhook install/rotate, and required-label check/repair. The controls use the stable REST contracts:
+
+- `PATCH /api/v1/repos/:owner/:repo`
+- `POST /api/v1/repos/:owner/:repo/webhook`
+- `GET /api/v1/repos/:owner/:repo/labels`
+- `POST /api/v1/repos/:owner/:repo/labels`
+
+The sheet also warns that disabling automation can end active webhook-launched sessions on the server.
+
+## Changed Files
+
+- `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- `apple/IssueCTLShared/Services/APIClient+Settings.swift`
+- `apple/IssueCTLTests/APIClientTests.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`
+- `apple/IssueCTLUITests/SettingsTests.swift`
+
+## Verification
+
+- `git diff --check` passed.
+- Focused API tests passed: `testUpdateRepoSendsPatchBodyAndDecodesRepo`, `testUpdateRepoAutomationSendsFullPatchBody`, `testConfigureRepoWebhookUsesWebhookEndpoint`, and `testRecreateRepoLabelsUsesLabelsEndpoint`.
+- Focused UI test passed: `IssueCTLUITests/SettingsTests/testEditRepoAutomationControlsSaveAndRepairLabels`.
+- Full Settings UI tests passed: 6 tests, 0 failures.
+- Direct inspection found typed API methods, the automation warning, label repair controls, webhook-health call, webhook configure call, and label repair call sites.
+
+## Strongest Disproof Attempt
+
+The UI test starts with a repo missing all required issuectl labels, toggles PR review automation, checks labels, observes `Missing issuectl:deployed`, repairs labels through the mocked POST route, observes `Repaired`, and saves. This disproves the main failure mode where the buttons exist but are disconnected from REST-backed behavior.

--- a/docs/goals/ios-workbench-automation-parity/notes/T999-final-audit.md
+++ b/docs/goals/ios-workbench-automation-parity/notes/T999-final-audit.md
@@ -1,0 +1,31 @@
+# T999 Final Audit
+
+## Decision
+
+complete
+
+`full_outcome_complete: true`
+
+## Evidence Map
+
+- Cross-repo work visibility: T005 added the iOS Workbench Board section, grouped open work by repo, showed running issue state and active PR session counts, and verified the focused Board UI path. T009 accepted that slice after reviewing the broad-suite blocker as unrelated.
+- Active issue and PR session state: T006 made active deployments target-aware for issue and PR sessions, preserved target metadata on end-session requests, updated Terminal titles, and verified PR session UI plus full SessionManagementTests. T010 restored the Active-tab repo context and proved the full iOS UI suite passed.
+- Stable REST foundations: T003 added current-root REST contracts for PR labels, diagnostics, deployment diagnostics, and repo webhook health, plus iOS client/model support and WorkbenchBootstrap projections.
+- Repo automation setup and health: T007 surfaced read-only automation and webhook-health state in Settings, and T011 added REST-backed write controls for issue auto-launch, PR auto-review, agent selection, review preamble, payload mode, webhook install/rotate, and label check/repair.
+- Trigger-label safety: T011 verified required-label check/repair through UI and API tests, and surfaced the active-session warning when disabling automation.
+- Diagnostics-first launch/session failure inspection: T008 added API-backed diagnostics from session controls and terminal connection failures, mapped launch/ttyd/tmux/activation/failure events and PR webhook events, and verified the UI timeline, API endpoint, full session UI suite, and full iOS unit suite.
+
+## Verification Reviewed
+
+- Web contract verification from T003 passed for PR labels, diagnostics, deployment diagnostics, and webhook health routes.
+- Focused iOS UI and unit checks passed across T005, T006, T007, T010, T011, and T008.
+- T008 final broad checks passed on iPhone 17: `SessionManagementTests` 7 tests, 0 failures; `IssueCTLTests` 269 tests, 0 failures; `git diff --check`.
+- GoalBuddy state checker passed with T008 done and T999 active before this final audit.
+
+## Strongest Disproof Attempt
+
+The strongest realistic failure mode was that the board had many green receipts but still missed one oracle clause: either PR auto-review labels were not operable through stable REST, repo automation was only readable, or diagnostics were only model-level. The receipts and direct inspection disproved those gaps: T003/T011 provide stable PR label and repo automation write contracts and UI tests, while T008 proves the diagnostics surface calls `/api/v1/diagnostics/deployments/:id` and renders a real failure timeline.
+
+## Residual Risk
+
+The repository is still broadly dirty with unrelated WIP from earlier slices and parallel work. This audit only claims the GoalBuddy tranche is complete against its oracle and receipts; it does not claim the entire repo is ready to merge without a separate PR hygiene pass.

--- a/docs/goals/ios-workbench-automation-parity/state.yaml
+++ b/docs/goals/ios-workbench-automation-parity/state.yaml
@@ -1,0 +1,692 @@
+version: 2
+
+goal:
+  title: "iOS Workbench Automation Parity"
+  slug: "ios-workbench-automation-parity"
+  kind: existing_plan
+  tranche: "Preserve the current WIP baseline, land the missing REST contracts and shared iOS projections, then complete successive verified iOS UI packages for workbench board, PR automation sessions, repo automation health, and diagnostics."
+  status: done
+  oracle:
+    signal: "The iOS app can independently show cross-repo issue and PR work, active/completed automation sessions, webhook and label health, safe trigger-label controls, and diagnostics-first launch/session failure timelines using stable web contracts."
+    cadence: "after each Worker package, after each phase boundary, and at final audit"
+    final_proof: "Final audit maps receipts, changed files, focused web/iOS commands, and direct source inspection back to the oracle; full_outcome_complete may be true only when required Worker work is done or explicitly blocked with safe follow-up."
+  intake:
+    original_request: "Make a GoalBuddy prep board to knock this out."
+    interpreted_outcome: "A fresh GoalBuddy board is ready to execute the remaining iOS parity work for web workbench, webhook automation, PR auto-review sessions, repo automation health, and diagnostics."
+    input_shape: existing_plan
+    audience: "issuectl maintainers and iOS users"
+    authority: requested
+    proof_type: test
+    completion_proof: "From the iOS app alone, users can inspect all tracked repo work, operate issue and PR automation/session flows, configure or repair automation health, and diagnose launch/session failures, with focused checks passing."
+    likely_misfire: "The board repeats broad parity analysis or lands only narrow model helpers while the iOS app still cannot operate the web workbench and automation workflows end to end."
+    blind_spots_considered:
+      - "The current checkout is dirty and contains relevant WIP; a fresh worktree from origin/main may drop important current changes."
+      - "PR auto-review labels appear to lack a stable REST route, unlike issue labels."
+      - "Diagnostics are available through CLI/core records, but no /api/v1/diagnostics route was found."
+      - "The native Repo model omits automation and webhook fields present in web contracts."
+      - "Prior plans referenced /api/v1/sessions/overview, but no route was found."
+      - "Webhook label-consumption cleanup can create expected skipped events that iOS must not present as failures."
+      - "Webhook health depends on server-side GitHub hook inspection and recent deliveries, so iOS needs a surfaced contract rather than local guesswork."
+    existing_plan_facts:
+      - "The source-backed parity plan lives at docs/superpowers/plans/2026-06-02-ios-workbench-automation-parity.md."
+      - "Web /api/v1/workbench is the aggregate source of truth for repos, issues, deployments, previews, settings, webhook events, PR reviews, and user context."
+      - "iOS already decodes WorkbenchPayload but underuses WorkbenchBootstrap projections."
+      - "Uncommitted iOS changes already add PR-aware ActiveDeployment decoding and target-aware endSession support."
+      - "Missing contracts should be resolved before broad SwiftUI work."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/ios-workbench-automation-parity/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/docs/goals/ios-workbench-automation-parity"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: high
+    objective: "Preserve and validate the current baseline before any fresh implementation worktree starts."
+    inputs:
+      - "Current git status, branch, diff summary, and worktrees."
+      - "docs/superpowers/plans/2026-06-02-ios-workbench-automation-parity.md"
+      - "docs/goals/workbench/goal.md and recent workbench receipts if needed."
+      - "docs/goals/ios-parity-hardening/goal.md and recent parity receipts if needed."
+      - "Current web workbench, webhook, repo settings, PR automation, diagnostics, and iOS model/view code."
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Do not create, delete, or switch worktrees."
+      - "Treat dirty files as user/WIP until classified; do not recommend reverting them."
+      - "Identify the earliest safe baseline preservation action for PM/Judge."
+      - "Prefer concrete file-path evidence over prior-session memory."
+    expected_output:
+      - "Baseline branch, HEAD, dirty-state summary, and relevant uncommitted WIP list."
+      - "Current contract gap matrix for workbench, PR labels, diagnostics, sessions overview, repo automation settings, and iOS projections."
+      - "UI gap matrix for cross-repo board, PR sessions, repo automation health, and diagnostics."
+      - "Fresh-worktree recommendation that preserves current WIP."
+      - "Recommended first Worker package with candidate allowed_files, verify commands, and stop_if conditions."
+    receipt:
+      result: done
+      note: "notes/T001-baseline-and-gap-map.md"
+      summary: "Mapped the current dirty baseline, missing current-root contracts, existing dormant worktrees with candidate route implementations, and iOS projection/UI gaps. The current branch tracks a gone upstream and has relevant uncommitted WIP, so fresh implementation worktrees from origin/main are unsafe until this WIP is checkpointed or intentionally ported."
+      evidence:
+        - "Root HEAD 184ed943a2715c6d5ea8ffbe90075238c0aa67e1 on codex/webhook-tunnel-qa-hardening; upstream is gone."
+        - "git diff --stat reported 43 modified tracked files with 1122 insertions and 684 deletions, plus relevant untracked webhook/goal files."
+        - "Current route listing has no packages/web/app/api/v1/diagnostics route and no packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels route."
+        - "Existing worktrees ios-review-actions-api and ios-diagnostics-api-contract contain candidate PR label, diagnostics, sessions overview, and webhook health routes."
+        - "Current Swift WorkbenchPayload decodes webhook events, PR reviews, completions, and target-aware deployments, but WorkbenchBootstrap only projects issue summaries, priorities, and active issue deployments."
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the Scout baseline and approve the largest safe foundation implementation package."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle"
+      - "Current dirty diff"
+      - "Current worktree list"
+    constraints:
+      - "Do not implement."
+      - "Reject implementation from origin/main if Scout shows current WIP is required for parity."
+      - "Reject broad UI work until missing REST contracts and shared iOS projections are either implemented or explicitly deferred with proof."
+      - "Pick the largest safe useful slice with exact allowed_files, verify commands, and stop_if conditions."
+      - "If baseline preservation requires a commit, branch, or stash, specify the safest PM action and why."
+    expected_output:
+      - "Decision: proceed | revise_board | blocked"
+      - "Baseline handling decision"
+      - "Exact first Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Deferred tasks and rationale"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      note: "notes/T002-foundation-slice-decision.md"
+      summary: "Approved one foundation Worker package in the current root checkout: PR label REST, diagnostics REST, repo webhook-health REST, WorkbenchBootstrap projections, and focused tests/path checks. Broad UI work and parallel worktrees remain deferred until this foundation passes."
+      evidence:
+        - "T001 proved current root is the authoritative dirty baseline and fresh origin/main worktrees would miss relevant WIP."
+        - "Current root has web repo automation routes and Swift WorkbenchPayload decoding, but lacks PR label REST, diagnostics REST, webhook-health REST, and full WorkbenchBootstrap projections."
+        - "Dormant worktrees contain source-backed candidate route implementations that can be ported selectively."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement the approved foundation package: missing stable REST contracts plus shared iOS workbench projections."
+    allowed_files:
+      - "packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.ts"
+      - "packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts"
+      - "packages/web/app/api/v1/diagnostics/route.ts"
+      - "packages/web/app/api/v1/diagnostics/route.test.ts"
+      - "packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts"
+      - "packages/web/app/api/v1/diagnostics/deployments/[id]/route.test.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.ts"
+      - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts"
+      - "packages/web/lib/diagnostics-api.ts"
+      - "packages/web/lib/mobile-api-contracts.ts"
+      - "apple/IssueCTLShared/Models/WorkbenchPayload.swift"
+      - "apple/IssueCTLShared/Models/WorkbenchBootstrap.swift"
+      - "apple/IssueCTLShared/Services/APIClient+DetailActions.swift"
+      - "apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift"
+      - "apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift"
+      - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      - "docs/goals/ios-workbench-automation-parity/notes/**"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "git diff --check"
+      - "pnpm --dir packages/web test -- app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts app/api/v1/diagnostics/route.test.ts app/api/v1/diagnostics/deployments/[id]/route.test.ts app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests -only-testing:IssueCTLTests/APIClientExtensionTests"
+      - "Direct inspection proves route listing includes PR labels, diagnostics, deployment diagnostics, and repo webhook health."
+    stop_if:
+      - "Need to revert unrelated dirty work."
+      - "Need files outside allowed_files."
+      - "Need credentials or production GitHub access for verification."
+      - "Diagnostics API shape requires a product decision that cannot be inferred from CLI/core diagnostics."
+      - "Broad SwiftUI changes become necessary before contracts/projections are verified."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T003-foundation-worker.md"
+      summary: "Implemented and verified the foundation contracts and shared iOS projections: PR label REST, diagnostics REST, deployment diagnostics REST, repo webhook-health REST, iOS API/client decoding, and WorkbenchBootstrap indexes for automation repos, PR deployments, completions, webhook events, and PR reviews."
+      changed_files:
+        - "packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.ts"
+        - "packages/web/app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts"
+        - "packages/web/app/api/v1/diagnostics/route.ts"
+        - "packages/web/app/api/v1/diagnostics/route.test.ts"
+        - "packages/web/app/api/v1/diagnostics/deployments/[id]/route.ts"
+        - "packages/web/app/api/v1/diagnostics/deployments/[id]/route.test.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.ts"
+        - "packages/web/app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts"
+        - "packages/web/lib/diagnostics-api.ts"
+        - "packages/web/lib/mobile-api-contracts.ts"
+        - "apple/IssueCTLShared/Models/WorkbenchBootstrap.swift"
+        - "apple/IssueCTLShared/Services/APIClient+DetailActions.swift"
+        - "apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift"
+        - "apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T003-foundation-worker.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "pnpm --dir packages/web test -- 'app/api/v1/pulls/[owner]/[repo]/[number]/labels/route.test.ts' 'app/api/v1/diagnostics/route.test.ts' 'app/api/v1/diagnostics/deployments/[id]/route.test.ts' 'app/api/v1/repos/[owner]/[repo]/webhook/health/route.test.ts'"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests -only-testing:IssueCTLTests/APIClientExtensionTests"
+          status: pass
+        - cmd: "rg --files packages/web/app/api/v1 | rg 'diagnostics|pulls/.*/labels|webhook/health'"
+          status: pass
+      evidence:
+        - "Initial web route test run failed because the route modules did not exist."
+        - "Initial focused Swift run failed compiling missing WorkbenchBootstrap projections and WorkbenchTargetKey."
+        - "git diff --check passed."
+        - "Focused web route tests passed: 4 files, 13 tests."
+        - "Focused iOS tests passed on iPhone 17: 45 selected tests, 0 failures."
+        - "Route listing includes PR labels, diagnostics, deployment diagnostics, and repo webhook health."
+
+  - id: T004
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the foundation package and decide which UI work can safely run in parallel worktrees."
+    inputs:
+      - "T003 receipt"
+      - "Current diff"
+      - "Goal oracle"
+      - "Contract/projection test results"
+    constraints:
+      - "Do not implement."
+      - "Approve parallel workers only when write scopes are disjoint and shared contracts are verified."
+      - "Prefer large vertical UI slices over tiny helper work."
+      - "Return exact allowed_files and verify commands for each approved Worker package."
+    expected_output:
+      - "Foundation verdict"
+      - "Parallelization plan or single-worker fallback"
+      - "Worker package definitions for cross-repo board, PR automation sessions, repo automation health, and diagnostics"
+      - "Any blocked or deferred scopes"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      note: "notes/T004-foundation-judge.md"
+      summary: "Accepted the T003 foundation package and chose a single-worker next step rather than immediate parallel fanout. The next active slice is T005 cross-repo board UI, because the independent Judge found it can be scoped without Sessions, Terminal, APIClient, or shared model churn while the dirty baseline remains uncheckpointed."
+      evidence:
+        - "T003 red/green proof covered missing routes, missing Swift projections, focused web route tests, focused iOS tests, diff whitespace, and route listing inspection."
+        - "T001/T002 showed the current dirty root remains the authoritative baseline, so parallel worktrees should wait for a checkpoint."
+        - "Independent explorer recommended continuing this durable board instead of rerunning broad iOS parity prep prompts."
+        - "Independent GoalBuddy Judge rejected immediate T006/T007/T008 fanout because queued scopes overlap shared Swift/API/test files and foundation web route files remain untracked."
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement the iOS cross-repo work board using verified WorkbenchBootstrap projections without changing foundation contracts or shared API/model files."
+    allowed_files:
+      - "apple/IssueCTL/App/ContentView.swift"
+      - "apple/IssueCTL/Views/Workbench/**"
+      - "apple/IssueCTL/Views/Today/TodayView.swift"
+      - "apple/IssueCTL/Views/Issues/IssueListView.swift"
+      - "apple/IssueCTL/Views/Issues/IssueRowView.swift"
+      - "apple/IssueCTL/Views/Shared/CommandCenterComponents.swift"
+      - "apple/IssueCTL/Views/Shared/RepoFilterChips.swift"
+      - "apple/IssueCTL/Views/Shared/SectionTabs.swift"
+      - "apple/IssueCTLTests/ViewLogicTests.swift"
+      - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+      - "docs/goals/ios-workbench-automation-parity/notes/T005-cross-repo-board.md"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests"
+      - "Direct inspection verifies cross-repo grouping, active issue/PR session badges, repo filtering, priority/status sorting, and existing issue navigation still work."
+    stop_if:
+      - "Need to edit WorkbenchBootstrap.swift, WorkbenchPayload.swift, Deployment.swift, Repo.swift, or APIClient*.swift."
+      - "Need to edit PullRequests, Sessions, Terminal, Settings, Repos, or Diagnostics views."
+      - "Need files outside allowed_files."
+      - "Foundation routes or projections are missing in the chosen checkout."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T005-cross-repo-board.md"
+      summary: "Implemented the iOS cross-repo work board as a new Issues section backed by WorkbenchBootstrap projections. The board groups open workbench issues by repo, shows running issue state and active PR-session counts, respects repo filtering/search/sort/running-only state, and navigates rows through the existing issue-detail route. Focused Board and view-logic proof passed; the broad UI-suite verifier is blocked by a reproduced out-of-scope Active-tab repo-context assertion mismatch in SessionListView."
+      changed_files:
+        - "apple/IssueCTL/Views/Shared/SectionTabs.swift"
+        - "apple/IssueCTL/Views/Issues/IssueListView.swift"
+        - "apple/IssueCTLTests/ViewLogicTests.swift"
+        - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T005-cross-repo-board.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testIssuesBoardSectionIsReachable"
+          status: pass
+        - cmd: "rg -n 'case board|issueListWorkbenchBoardSections|issues-board-running-toggle|board-issue-row|WorkbenchBoardSectionHeader|activePrSessionCount|testWorkbenchBoardSections|testIssuesBoardSectionIsReachable|showsActiveSummary: false' apple/IssueCTL/Views/Shared/SectionTabs.swift apple/IssueCTL/Views/Issues/IssueListView.swift apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTLTests/ViewLogicTests.swift apple/IssueCTLUITests/IssueCTLUITests.swift"
+          status: pass
+      evidence:
+        - "Initial focused ViewLogicTests run failed before implementation because issueListWorkbenchBoardSections did not exist."
+        - "Focused unit verification passed on iPhone 17: 80 tests, 0 failures."
+        - "Focused Board UI smoke passed on iPhone 17: section-tab-board was reachable and issues-board-running-toggle appeared."
+        - "Full IssueCTLUITests command executed 17 tests with 1 failure: testRepoContextIsVisibleAcrossPrimaryTabs expected repo-context-active on the Active tab."
+        - "Focused rerun of IssueCTLUITests/IssueCTLUITests/testRepoContextIsVisibleAcrossPrimaryTabs reproduced the same out-of-scope failure."
+        - "Direct inspection found SessionListView passes showsActiveSummary: false, which explains the missing repo-context-active chip without editing T005-disallowed Sessions files."
+
+  - id: T009
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review T005, decide how to handle the Active-tab repo-context verifier blocker, and approve the next safe Worker package."
+    inputs:
+      - "T005 receipt"
+      - "Current diff"
+      - "Goal oracle"
+      - "Full UI-suite failure and focused repro evidence"
+      - "Independent agent recommendations from T004"
+    constraints:
+      - "Do not implement."
+      - "Do not mark final outcome complete."
+      - "Decide whether to fix SessionListView repo-context active summary before T006 or revise the T005 broad verifier expectation."
+      - "Reject parallel fanout if dirty shared files are still uncheckpointed or if T006/T007/T008 scopes still overlap."
+      - "If approving T006, narrow allowed_files and verify commands to one PR/session vertical slice."
+    expected_output:
+      - "T005 verdict"
+      - "Disposition for the Active-tab repo-context failure"
+      - "Next active task decision"
+      - "Exact allowed_files, verify commands, and stop_if updates if the board should change"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      note: "notes/T009-cross-repo-board-judge.md"
+      summary: "Accepted T005 as a completed cross-repo Board slice, treated the Active-tab repo-context failure as a real out-of-scope verifier blocker, rejected parallel fanout, and approved one narrow T010 Worker to restore the Active-tab active repo summary before PR/session parity work."
+      evidence:
+        - "T005 focused Board UI smoke passed and unit proof covered Board grouping/filter/sort behavior."
+        - "Full IssueCTLUITests failed only testRepoContextIsVisibleAcrossPrimaryTabs."
+        - "Focused rerun reproduced the same Active-tab repo-context failure."
+        - "Direct inspection shows SessionListView passes showsActiveSummary: false while the test expects repo-context-active."
+
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Restore the Active-tab active repo context summary so the broad iOS UI verifier is no longer blocked before PR/session parity work."
+    allowed_files:
+      - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+      - "docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testRepoContextIsVisibleAcrossPrimaryTabs"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testIssuesBoardSectionIsReachable"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests"
+      - "Direct inspection verifies SessionListView supplies active repo names to RepoContextStrip without shared model/API changes."
+    stop_if:
+      - "Need to edit shared model/API files."
+      - "Need to edit PullRequests, Terminal, Settings, Repos, Diagnostics, or web files."
+      - "The failure is caused by test server data instead of the Sessions view."
+      - "A second unrelated UI failure appears in the full suite and cannot be isolated with a focused rerun."
+    receipt:
+      result: done
+      note: "notes/T010-active-repo-context.md"
+      summary: "Restored the Active tab repo-context active summary by deriving active repo names from active deployments and passing them to RepoContextStrip. This unblocked the previously failing broad iOS UI verifier before PR/session parity work."
+      changed_files:
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T010-active-repo-context.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testRepoContextIsVisibleAcrossPrimaryTabs"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testIssuesBoardSectionIsReachable"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests"
+          status: pass
+        - cmd: "rg -n 'activeRepoFullNames|RepoContextStrip\\(' apple/IssueCTL/Views/Sessions/SessionListView.swift"
+          status: pass
+      evidence:
+        - "The previously failing focused repo-context UI test passed and observed repo-context-active on the Active tab."
+        - "The focused Board UI smoke still passed after the Sessions view change."
+        - "The full IssueCTLUITests run passed on iPhone 17: 17 tests, 0 failures."
+        - "Direct inspection found SessionListView computes activeRepoFullNames and passes it to RepoContextStrip."
+
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement the iOS PR-target session parity vertical slice for existing active deployments: PR session rows and controls show PR targets, issue-only navigation is disabled for PR sessions, terminal opening still works, and end-session requests preserve target metadata."
+    allowed_files:
+      - "apple/IssueCTL/Views/PullRequests/**"
+      - "apple/IssueCTL/Views/Sessions/**"
+      - "apple/IssueCTL/Views/Terminal/**"
+      - "apple/IssueCTLShared/Models/Deployment.swift"
+      - "apple/IssueCTLShared/Services/APIClient.swift"
+      - "apple/IssueCTLTests/ModelDecodingTests.swift"
+      - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      - "apple/IssueCTLTests/EnumTests.swift"
+      - "apple/IssueCTLTests/ViewLogicTests.swift"
+      - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+      - "apple/IssueCTLUITests/SessionManagementTests.swift"
+      - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+      - "docs/goals/ios-workbench-automation-parity/notes/T006-pr-target-sessions.md"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientExtensionTests -only-testing:IssueCTLTests/ViewLogicTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/EnumTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests/testPullRequestSessionShowsPrTargetAndDisablesIssueNavigation"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientExtensionTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests"
+      - "Direct inspection verifies PR target labels, issue-only navigation guards, PR terminal opening, end-session body target support, and existing issue session behavior."
+    stop_if:
+      - "PR label REST contract is missing or unverified."
+      - "Need files outside allowed_files."
+      - "Need live GitHub credentials to verify a local UI-only behavior."
+      - "Need to implement repo automation health or diagnostics UI in the same slice."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T006-pr-target-sessions.md"
+      summary: "Completed PR-target active-session parity for existing deployments: active sessions decode issue/PR targets, rows and controls show PR labels, issue-only navigation is guarded for PR sessions, Terminal titles and end-session calls preserve target metadata, and a PR-target UI fixture proves the Active tab behavior."
+      changed_files:
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionRowView.swift"
+        - "apple/IssueCTL/Views/Terminal/TerminalView.swift"
+        - "apple/IssueCTLShared/Models/Deployment.swift"
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "apple/IssueCTLTests/EnumTests.swift"
+        - "apple/IssueCTLTests/ModelDecodingTests.swift"
+        - "apple/IssueCTLTests/ViewLogicTests.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+        - "apple/IssueCTLUITests/SessionManagementTests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T006-pr-target-sessions.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientExtensionTests -only-testing:IssueCTLTests/ViewLogicTests"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/EnumTests"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests/testPullRequestSessionShowsPrTargetAndDisablesIssueNavigation"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientExtensionTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests"
+          status: pass
+        - cmd: "rg -n 'targetLabel|targetTitle|isIssueTarget|targetType: deployment.targetType|targetNumber: deployment.targetNumber|PR #44|seedPullRequestDeployment|pullRequestDeployment|PR Review|View Issue' apple/IssueCTL/Views/Sessions apple/IssueCTL/Views/Terminal apple/IssueCTLShared/Models/Deployment.swift apple/IssueCTLShared/Services/APIClient.swift apple/IssueCTLUITests/Helpers/MockServer.swift apple/IssueCTLUITests/SessionManagementTests.swift"
+          status: pass
+      evidence:
+        - "Focused model/API/view logic tests passed: 162 tests, 0 failures."
+        - "EnumTests passed: 29 tests, 0 failures, including EndSessionRequestBody target-field encoding."
+        - "Focused PR-session UI test passed and observed PR #44 on the Active tab and PR #44 Session in controls."
+        - "Full SessionManagementTests passed with the new PR case included: 6 tests, 0 failures."
+        - "Model/API/WorkbenchBootstrap mapper verifier passed: 92 tests, 0 failures."
+        - "Direct inspection found target labels, PR navigation guards, Terminal target title, target-aware endSession call sites, and the PR fixture."
+
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement iOS repo automation status and webhook health visibility, explicitly deferring mutating setup and repair controls to a follow-up write-path worker."
+    allowed_files:
+      - "apple/IssueCTL/Views/Settings/**"
+      - "apple/IssueCTL/Views/Repos/**"
+      - "apple/IssueCTLShared/Models/Repo.swift"
+      - "apple/IssueCTLShared/Models/WorkbenchPayload.swift"
+      - "apple/IssueCTLShared/Services/APIClient+Settings.swift"
+      - "apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift"
+      - "apple/IssueCTLTests/**"
+      - "apple/IssueCTLUITests/**"
+      - "docs/goals/ios-workbench-automation-parity/notes/**"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests"
+      - "Direct inspection verifies auto-launch, auto-review, issue/review agents, review preamble, payload mode, webhook install/rotate, label repair, and active-session disable warnings are represented or explicitly deferred."
+    stop_if:
+      - "Repo settings REST contract is missing or divergent."
+      - "Need files outside allowed_files."
+      - "Need production GitHub access to verify server-side hook install."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T007-repo-automation-health.md"
+      summary: "Added native Repo automation/webhook fields with defaults, Settings repo-row automation and webhook summaries, Edit Repository read-only automation setup rows, and an API-backed webhook-health section. Mutating setup, webhook install/rotate, label repair, and active-session edit warnings were deferred to T011."
+      changed_files:
+        - "apple/IssueCTLShared/Models/Repo.swift"
+        - "apple/IssueCTL/Views/Settings/SettingsView.swift"
+        - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+        - "apple/IssueCTLTests/ModelDecodingTests.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+        - "apple/IssueCTLUITests/SettingsTests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T007-repo-automation-health.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests/testRepoDecodesAutomationFields -only-testing:IssueCTLTests/APIClientExtensionTests/testRepoWebhookHealthUsesHealthEndpoint"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests/testSettingsShowsRepoAutomationAndWebhookHealth"
+          status: pass
+        - cmd: "rg -n 'repoWebhookHealth|autoLaunchIssues|autoReviewPrs|Webhook Health|GitHub webhook delivery looks healthy|reviewPreamble|webhookPayloadMode' apple/IssueCTL apple/IssueCTLShared apple/IssueCTLTests apple/IssueCTLUITests"
+          status: pass
+      evidence:
+        - "Focused model/API tests passed and proved Repo decodes automation fields while APIClient uses /api/v1/repos/:owner/:repo/webhook/health."
+        - "Focused Settings UI test passed and observed Issues + PR reviews, Webhook #123, Automation, Webhook Health, and the mocked GitHub webhook delivery health summary."
+        - "Direct inspection found the read-only iOS surface for auto-launch, auto-review, issue/review agents, review preamble, payload mode, and webhook health."
+        - "Webhook install/rotate, label repair, and active-session disable warnings are explicitly deferred to T011 instead of claimed as complete."
+
+  - id: T011
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement safe iOS repo automation write-path controls: automation setting edits, webhook install/rotate affordances, trigger-label repair, and active-session warnings."
+    allowed_files:
+      - "apple/IssueCTL/Views/Settings/**"
+      - "apple/IssueCTL/Views/Repos/**"
+      - "apple/IssueCTLShared/Models/Repo.swift"
+      - "apple/IssueCTLShared/Services/APIClient+Settings.swift"
+      - "apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift"
+      - "apple/IssueCTLTests/**"
+      - "apple/IssueCTLUITests/**"
+      - "docs/goals/ios-workbench-automation-parity/notes/**"
+      - "docs/goals/ios-workbench-automation-parity/state.yaml"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests"
+      - "Direct inspection verifies write controls call stable REST contracts or are disabled with clear warnings when active sessions make mutation unsafe."
+    stop_if:
+      - "Repo automation mutation REST contracts are missing or divergent."
+      - "Need production GitHub access to verify server-side hook install."
+      - "Need files outside allowed_files."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T011-repo-automation-write-controls.md"
+      summary: "Added native repo automation write controls to Edit Repository: automation toggles, agent pickers, review preamble, payload mode, webhook install/rotate, required-label check/repair, and an active-session server-side consequence warning. Added typed API methods and focused API/UI verification."
+      changed_files:
+        - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+        - "apple/IssueCTLShared/Services/APIClient+Settings.swift"
+        - "apple/IssueCTLTests/APIClientTests.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+        - "apple/IssueCTLUITests/SettingsTests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T011-repo-automation-write-controls.md"
+        - "docs/goals/ios-workbench-automation-parity/state.yaml"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateRepoSendsPatchBodyAndDecodesRepo -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateRepoAutomationSendsFullPatchBody -only-testing:IssueCTLTests/APIClientExtensionTests/testConfigureRepoWebhookUsesWebhookEndpoint -only-testing:IssueCTLTests/APIClientExtensionTests/testRecreateRepoLabelsUsesLabelsEndpoint"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests/testEditRepoAutomationControlsSaveAndRepairLabels"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests"
+          status: pass
+        - cmd: "rg -n 'updateRepo\\(|UpdateRepoAutomationRequest|configureRepoWebhook|recreateRepoLabels|Label Repair|Check Required Labels|Repair Required Labels|Turning automation off|repoWebhookHealth' apple/IssueCTL apple/IssueCTLShared apple/IssueCTLTests apple/IssueCTLUITests"
+          status: pass
+      evidence:
+        - "Focused API tests passed and proved the full repo automation PATCH body, webhook POST body, and label repair POST body."
+        - "Focused UI test passed: the sheet toggled PR reviews, checked missing required labels, repaired labels, and saved."
+        - "Full SettingsTests passed: 6 tests, 0 failures."
+        - "Direct inspection found REST-backed controls and the active-session consequence warning."
+
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: high
+    objective: "Implement iOS diagnostics-first launch and session failure surface."
+    allowed_files:
+      - "apple/IssueCTL/Views/Diagnostics/**"
+      - "apple/IssueCTL/Views/Sessions/**"
+      - "apple/IssueCTL/Views/Terminal/**"
+      - "apple/IssueCTLShared/Models/**Diagnostics*.swift"
+      - "apple/IssueCTLShared/Services/APIClient*.swift"
+      - "apple/IssueCTLTests/**"
+      - "apple/IssueCTLUITests/**"
+      - "docs/goals/ios-workbench-automation-parity/notes/**"
+    verify:
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:IssueCTLTests"
+      - "Direct inspection verifies launch.requested, workspace.prepared, deployment.recorded, ttyd.spawned, deployment.activated, launch.spawn_failed, launch.activation_failed, reconcile.tmux_missing, liveness.tmux_missing, ensure_ttyd.failed, and PR webhook events are surfaced or mapped."
+    stop_if:
+      - "Diagnostics REST contract is missing or blocked by T003."
+      - "Need files outside allowed_files."
+      - "Need live failure reproduction that cannot be synthesized locally."
+      - "Verification fails twice for the same underlying cause."
+    receipt:
+      result: done
+      note: "notes/T008-diagnostics-first-session-surface.md"
+      summary: "Added an API-backed iOS diagnostics timeline reachable from session controls and terminal connection failures, with human-readable launch/session failure mappings and PR webhook event mappings."
+      changed_files:
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTL/Views/Terminal/TerminalView.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+        - "apple/IssueCTLUITests/SessionManagementTests.swift"
+        - "docs/goals/ios-workbench-automation-parity/notes/T008-diagnostics-first-session-surface.md"
+      commands:
+        - cmd: "git diff --check"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests/testSessionDiagnosticsShowsLaunchFailureTimeline"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testDeploymentDiagnosticsUsesDiagnosticsEndpoint"
+          status: pass
+        - cmd: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests"
+          status: pass
+        - cmd: "rg -n 'launch\\.requested|workspace\\.prepared|deployment\\.recorded|ttyd\\.spawned|deployment\\.activated|launch\\.spawn_failed|launch\\.activation_failed|reconcile\\.tmux_missing|liveness\\.tmux_missing|ensure_ttyd\\.failed|webhook\\.pr_launched|webhook\\.auto_review_label_consumed|webhook\\.pr_session_ended|webhook\\.pr_coalesced|webhook\\.pr_already_reviewed|webhook\\.pr_review_recovered|webhook\\.skipped_unsafe_pr|webhook\\.launch_failed' apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTL/Views/Terminal/TerminalView.swift packages/core/src/launch packages/web/lib"
+          status: pass
+        - cmd: "xcrun simctl list devices available | rg 'iPhone 16|iPhone 17'"
+          status: pass
+      evidence:
+        - "Focused UI test proved the Diagnostics action opens from a running issue session and renders Issue #101, Launch requested, Ttyd spawned, Ensure ttyd failed, and the tmux attach failure message."
+        - "Full SessionManagementTests passed after fixing an ambiguous Today shortcut tap in the end-session test."
+        - "APIClientExtensionTests proved the client calls /api/v1/diagnostics/deployments/:id."
+        - "Full IssueCTLTests passed: 269 tests, 0 failures."
+        - "Direct inspection verified required launch/session failure event producers and iOS display mappings, plus PR webhook event producers and mappings."
+        - "No iPhone 16 simulator was available; verification used the booted iPhone 17 simulator."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Final audit: prove whether iOS workbench automation parity is complete for this tranche."
+    inputs:
+      - "All done task receipts"
+      - "Current git status and diff"
+      - "Focused web and iOS verification outputs"
+      - "Direct inspection of implemented contracts and iOS surfaces"
+      - "Goal oracle"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if any required Worker task is still queued, active, or blocked without a safe follow-up."
+      - "Reject completion if the iOS app cannot operate PR auto-review labels through stable REST."
+      - "Reject completion if diagnostics-first parity is claimed without an API-backed or explicitly deferred surface."
+      - "Reject completion if verification only covers happy paths."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Evidence mapped to every oracle clause"
+      - "Strongest attempted disproof and result"
+      - "Remaining safe next task if not complete"
+    receipt:
+      result: done
+      completed_at: "2026-06-02T07:36:20-0700"
+      decision: "complete"
+      full_outcome_complete: true
+      note: "notes/T999-final-audit.md"
+      summary: "All required Worker/Judge receipts are done, no required task remains queued or active, and the evidence maps to the oracle clauses for cross-repo work visibility, issue/PR sessions, PR auto-review labels through REST, repo automation setup and health, trigger-label safety, and diagnostics-first failure inspection."
+      evidence_map:
+        - oracle_clause: "Cross-repo board visibility"
+          evidence: "T005 added the iOS Workbench Board section and T009 accepted it after focused UI proof and blocker disposition."
+        - oracle_clause: "Issue and PR session state"
+          evidence: "T006 made active sessions target-aware for issues and PRs; T010 restored Active-tab repo context and passed the full UI suite."
+        - oracle_clause: "PR auto-review labels through REST"
+          evidence: "T003 added stable PR label REST contracts and iOS client support; T011 verified REST-backed repo automation controls and label repair."
+        - oracle_clause: "Repo automation setup and health"
+          evidence: "T007 surfaced read-only automation/webhook health; T011 added write controls for automation, agents, preamble, payload mode, webhook install/rotate, and required labels."
+        - oracle_clause: "Diagnostics-first launch/session failure inspection"
+          evidence: "T008 added API-backed diagnostics from session controls and terminal failures, mapped required launch/session and PR webhook events, and passed focused UI, session UI, API, and full unit tests."
+      strongest_disproof:
+        attempt: "Check whether any oracle clause was only planned or model-level, especially PR labels, repo automation writes, and diagnostics."
+        result: "Disproved by T003/T011 REST-backed PR label and automation controls plus T008 API-backed diagnostics UI and direct event-name inspection."
+      residual_risk: "The repository remains broadly dirty with unrelated WIP; this audit completes the GoalBuddy tranche, not PR hygiene or merge readiness."
+
+checks:
+  dirty_fingerprint: "HEAD 184ed943a2715c6d5ea8ffbe90075238c0aa67e1; branch codex/webhook-tunnel-qa-hardening; upstream gone; git diff --stat 43 tracked files, 1122 insertions, 684 deletions"
+  last_verification:
+    result: passed
+    task: T008
+    commands:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests/testSessionDiagnosticsShowsLaunchFailureTimeline"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SessionManagementTests"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testDeploymentDiagnosticsUsesDiagnosticsEndpoint"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests"
+      - "rg -n 'launch\\.requested|workspace\\.prepared|deployment\\.recorded|ttyd\\.spawned|deployment\\.activated|launch\\.spawn_failed|launch\\.activation_failed|reconcile\\.tmux_missing|liveness\\.tmux_missing|ensure_ttyd\\.failed|webhook\\.pr_launched|webhook\\.auto_review_label_consumed|webhook\\.pr_session_ended|webhook\\.pr_coalesced|webhook\\.pr_already_reviewed|webhook\\.pr_review_recovered|webhook\\.skipped_unsafe_pr|webhook\\.launch_failed' apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTL/Views/Terminal/TerminalView.swift packages/core/src/launch packages/web/lib"

--- a/docs/superpowers/plans/2026-06-02-ios-workbench-automation-parity.md
+++ b/docs/superpowers/plans/2026-06-02-ios-workbench-automation-parity.md
@@ -1,0 +1,554 @@
+# iOS Workbench And Automation Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the iOS app up to date with the web workbench, cross-repo issue board, webhook label automation, PR review sessions, and diagnostics surfaces that now exist in the web app.
+
+**Architecture:** Treat the web REST API and `/api/v1/workbench` payload as the source of truth. First add shared Swift projections that make the aggregate payload useful, then split UI work into independent worktrees: board, repo automation, PR review/session routing, and diagnostics. Keep GoalBuddy as the PM/proof layer, but use parallel subagents only after shared model/API dependencies are stable.
+
+**Tech Stack:** SwiftUI, Swift 6, XCTest, XcodeBuildMCP, Next.js App Router REST routes, pnpm/Turborepo, GoalBuddy.
+
+---
+
+## Current Baseline
+
+The web app has two active dashboard surfaces:
+
+- `/` is still the older all-issues/PR list surface with tabs, sections, repo chips, mine filter, sort, search, keyboard nav, filters sheet, and quick create.
+- `/workbench` is the newer command-center surface. It exposes modes for `Issues`, `Board`, `PRs`, `Workbench`, `Quick Create`, and `Settings`, and consumes `GET /api/v1/workbench`.
+
+The workbench payload includes:
+
+- repos and repo automation settings
+- active deployments
+- session previews
+- issue summaries and priorities
+- recent completions
+- webhook events
+- PR review records
+- settings, health, user, and generated timestamp
+
+iOS already has:
+
+- Today, Issues, PRs, and Active/Sessions tabs
+- cross-repo issue list sections, search, repo/mine filters, priority sort, launch/re-enter terminal, quick create, and parse flow
+- PR list/detail/review/merge/comment flows
+- label management for issues
+- active sessions list, terminal re-entry, preview polling, and end-session flow
+- decoded `WorkbenchPayload`
+- `WorkbenchBootstrap`, currently focused on issue summaries, priorities, and active issue deployments
+
+The biggest current gap is not basic API reachability. It is that iOS has not made the workbench/webhook automation model first-class: PR-target sessions, webhook events, PR review history, repo automation health, diagnostics, and the cross-repo work board are still underexposed.
+
+## Source Of Truth Files
+
+Web contracts and UX:
+
+- `packages/web/app/api/v1/workbench/route.ts`
+- `packages/web/lib/workbench-data.ts`
+- `packages/web/components/workbench/workbench-types.ts`
+- `packages/web/components/workbench/WorkbenchShell.tsx`
+- `packages/web/components/workbench/GlobalIssuesFocus.tsx`
+- `packages/web/components/workbench/BoardFocus.tsx`
+- `packages/web/components/workbench/InstancePane.tsx`
+- `packages/web/components/workbench/IssueFocus.tsx`
+- `packages/web/components/workbench/PullRequestsFocus.tsx`
+- `packages/web/components/repos/RepoSettingsPanel.tsx`
+- `packages/web/lib/webhook-health.ts`
+- `packages/web/lib/github-webhook-handler.ts`
+- `packages/web/lib/webhook-intent-worker.ts`
+- `packages/web/lib/webhook-pr-intent.ts`
+
+iOS and shared Swift:
+
+- `apple/IssueCTL/App/ContentView.swift`
+- `apple/IssueCTL/Views/Today/TodayView.swift`
+- `apple/IssueCTL/Views/Issues/IssueListView.swift`
+- `apple/IssueCTL/Views/Issues/IssueDetailView.swift`
+- `apple/IssueCTL/Views/PullRequests/PRListView.swift`
+- `apple/IssueCTL/Views/PullRequests/PRDetailView.swift`
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTL/Views/Sessions/SessionRowView.swift`
+- `apple/IssueCTL/Views/Terminal/TerminalView.swift`
+- `apple/IssueCTL/Views/Settings/AddRepoSheet.swift`
+- `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- `apple/IssueCTLShared/Models/WorkbenchPayload.swift`
+- `apple/IssueCTLShared/Models/WorkbenchBootstrap.swift`
+- `apple/IssueCTLShared/Models/Deployment.swift`
+- `apple/IssueCTLShared/Services/APIClient+Workbench.swift`
+- `apple/IssueCTLShared/Services/APIClient+Settings.swift`
+- `apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift`
+- `apple/IssueCTLTests/WorkbenchPayloadDecodingTests.swift`
+- `apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift`
+- `apple/IssueCTLTests/ModelDecodingTests.swift`
+- `apple/IssueCTLTests/APIClientTests.swift`
+
+## Execution Setup
+
+- [ ] **Step 1: Preserve the dirty current work**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --stat
+```
+
+Expected: the current checkout is dirty. Do not create implementation worktrees from `origin/main` until these current web and Apple parity changes are committed, stashed, or intentionally rebased into the baseline branch.
+
+- [ ] **Step 2: Choose the execution baseline**
+
+If the current branch is the source of truth for recent web UX and automation work, first create a branch or commit that contains it:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+Expected: a named baseline branch exists. If not, create one with the `codex/` prefix before implementation.
+
+- [ ] **Step 3: Create one shared-model worktree**
+
+After baseline is clean enough to branch from, run:
+
+```bash
+git worktree add .worktrees/ios-workbench-shared-projections -b codex/ios-workbench-shared-projections <baseline-branch>
+```
+
+Expected: clean worktree.
+
+- [ ] **Step 4: Create parallel UI worktrees only after Task 1 passes**
+
+Run after Task 1 lands or is mergeable:
+
+```bash
+git worktree add .worktrees/ios-cross-repo-board -b codex/ios-cross-repo-board codex/ios-workbench-shared-projections
+git worktree add .worktrees/ios-pr-automation-sessions -b codex/ios-pr-automation-sessions codex/ios-workbench-shared-projections
+git worktree add .worktrees/ios-repo-automation-health -b codex/ios-repo-automation-health codex/ios-workbench-shared-projections
+git worktree add .worktrees/ios-diagnostics-surface -b codex/ios-diagnostics-surface codex/ios-workbench-shared-projections
+```
+
+Expected: four clean worktrees with disjoint UI responsibilities.
+
+## Task 1: Shared Workbench Projections
+
+**Files:**
+- Modify: `apple/IssueCTLShared/Models/WorkbenchBootstrap.swift`
+- Modify: `apple/IssueCTLShared/Models/WorkbenchPayload.swift`
+- Modify: `apple/IssueCTLTests/WorkbenchBootstrapMapperTests.swift`
+- Modify: `apple/IssueCTLTests/WorkbenchPayloadDecodingTests.swift`
+
+- [ ] **Step 1: Add failing projection tests**
+
+Add tests proving `WorkbenchBootstrap` can answer:
+
+- all repos with automation enabled/disabled
+- all active issue deployments
+- all active PR deployments
+- recent completions by repo
+- webhook events by repo and target
+- PR review runs by repo and PR number
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests
+```
+
+Expected: fail before implementation.
+
+- [ ] **Step 2: Implement pure projections**
+
+Extend `WorkbenchBootstrap` with computed indexes, keeping it model-only and UI-free:
+
+```swift
+let activePrDeploymentsByKey: [WorkbenchIssueKey: WorkbenchDeployment]
+let webhookEventsByRepo: [String: [WorkbenchWebhookEvent]]
+let prReviewsByRepo: [String: [WorkbenchPrReview]]
+let recentCompletionsByRepo: [String: [WorkbenchDeployment]]
+```
+
+Expected: no view code changes in this task.
+
+- [ ] **Step 3: Verify model tests**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/WorkbenchPayloadDecodingTests -only-testing:IssueCTLTests/WorkbenchBootstrapMapperTests
+```
+
+Expected: pass.
+
+## Task 2: Cross-Repo Mobile Work Board
+
+**Files:**
+- Create: `apple/IssueCTL/Views/Workbench/WorkbenchBoardView.swift`
+- Create: `apple/IssueCTL/Views/Workbench/WorkbenchBoardRow.swift`
+- Modify: `apple/IssueCTL/App/ContentView.swift`
+- Modify: `apple/IssueCTL/Views/Issues/IssueListView.swift`
+- Modify: `apple/IssueCTLTests/ViewLogicTests.swift`
+- Modify: `apple/IssueCTLUITests/IssueCTLUITests.swift`
+
+- [ ] **Step 1: Add a first-class Board tab or Issues board mode**
+
+Use the web distinction:
+
+- `Issues`: global issue rows across repos
+- `Board`: cross-repo board with running-only and priority/payload sort
+
+For iOS, prefer a compact Board mode inside Issues first unless the maintainer wants a fifth tab.
+
+- [ ] **Step 2: Drive the board from `api.workbench()`**
+
+The board should use workbench issue summaries and projections, not refetch every repo through older issue endpoints for the initial board.
+
+Required UI states:
+
+- loading
+- server error
+- repo issue error
+- no tracked repos
+- no matching issues
+- stale/cache timestamp
+
+- [ ] **Step 3: Match web board behavior**
+
+Implement:
+
+- grouped by repo
+- all open issues
+- running-only toggle
+- payload order and priority sort
+- status chip: open, running, closed
+- priority chip
+- tap to open issue detail
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests
+pnpm ios:ui-smoke:fast
+```
+
+Expected: unit tests and smoke flow pass.
+
+## Task 3: PR Automation And PR-Target Sessions
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionRowView.swift`
+- Modify: `apple/IssueCTL/Views/PullRequests/PRListView.swift`
+- Modify: `apple/IssueCTL/Views/PullRequests/PRDetailView.swift`
+- Modify: `apple/IssueCTLTests/ModelDecodingTests.swift`
+- Modify: `apple/IssueCTLUITests/SessionManagementTests.swift`
+- Modify: `apple/IssueCTLUITests/PRBrowseTests.swift`
+
+- [ ] **Step 1: Finish PR-target session routing**
+
+Current dirty work already moves `ActiveDeployment` toward `targetType` and `targetNumber`. Complete the UX:
+
+- issue sessions navigate to issue detail
+- PR sessions navigate to PR detail
+- terminal title uses repo plus target label
+- end-session request includes `targetType` and `targetNumber`
+
+- [ ] **Step 2: Add PR automation status**
+
+Surface per-PR signals from workbench projections:
+
+- latest review run status
+- review trigger source: webhook or comment command
+- linked deployment if in progress
+- range label or reviewed SHA pair
+- completed summary if present
+
+- [ ] **Step 3: Add safe auto-review label affordance**
+
+On PR detail, expose `issuectl:auto-review` as a deliberate action through the existing labels API only if repo automation is enabled or explain why it will not launch.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests
+pnpm ios:ui-smoke:fast
+```
+
+Expected: pass, including PR-target deployment decoding and session navigation tests.
+
+## Task 4: Repo Automation Setup And Health
+
+**Files:**
+- Modify: `apple/IssueCTLShared/Models/Repo.swift`
+- Modify: `apple/IssueCTLShared/Services/APIClient+Settings.swift`
+- Modify: `apple/IssueCTL/Views/Settings/AddRepoSheet.swift`
+- Modify: `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- Create: `apple/IssueCTL/Views/Repos/RepoAutomationHealthView.swift`
+- Modify: `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- Modify: `apple/IssueCTLUITests/SettingsTests.swift`
+
+- [ ] **Step 1: Expand repo models and requests**
+
+`POST /api/v1/repos` already accepts:
+
+- `autoLaunchIssues`
+- `autoReviewPrs`
+- `issueAgent`
+- `reviewAgent`
+- `reviewPreamble`
+- `webhookPayloadMode`
+- `installWebhook`
+- `firstPingTimeoutMs`
+
+`PATCH /api/v1/repos/:owner/:repo` already accepts:
+
+- `localPath`
+- `branchPattern`
+- `autoLaunchIssues`
+- `autoReviewPrs`
+- `issueAgent`
+- `reviewAgent`
+- `reviewPreamble`
+- `webhookPayloadMode`
+
+Update Swift request/response types to preserve these fields.
+
+- [ ] **Step 2: Add repo automation setup to Add Repo**
+
+Mirror the web wizard in a compact iOS form:
+
+- issue sessions toggle
+- PR reviews toggle
+- issue agent picker
+- review agent picker
+- webhook payload picker
+- optional review preamble
+- install webhook toggle
+- install result summary: secret, webhook, labels, first ping
+
+- [ ] **Step 3: Add repo automation editing**
+
+In `EditRepoSheet`, add:
+
+- automation toggles
+- agent pickers
+- payload mode
+- review preamble
+- explicit warning that disabling automation may end active webhook-launched sessions
+
+- [ ] **Step 4: Add webhook/label repair actions**
+
+Expose:
+
+- create webhook
+- rotate webhook
+- recreate automation labels
+
+Use existing REST routes:
+
+```text
+POST /api/v1/repos/:owner/:repo/webhook { "action": "create" | "rotate" }
+POST /api/v1/repos/:owner/:repo/labels { "action": "recreate" }
+```
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests
+pnpm ios:ui-smoke:fast
+```
+
+Expected: request body tests prove iOS sends automation fields and UI smoke can view/edit repo automation.
+
+## Task 5: Diagnostics-First iOS Failure Surface
+
+**Files:**
+- Create: `apple/IssueCTLShared/Models/Diagnostics.swift`
+- Create: `apple/IssueCTLShared/Services/APIClient+Diagnostics.swift`
+- Create: `apple/IssueCTL/Views/Diagnostics/DeploymentDiagnosticsView.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Modify: `apple/IssueCTL/Views/Terminal/TerminalView.swift`
+- Modify: `apple/IssueCTL/Views/Launch/LaunchView.swift`
+- Modify: `apple/IssueCTLTests/ModelDecodingTests.swift`
+- Modify: `apple/IssueCTLTests/APIClientTests.swift`
+
+- [ ] **Step 1: Confirm diagnostics routes in baseline**
+
+Run:
+
+```bash
+git ls-tree -r --name-only HEAD | rg 'packages/web/app/api/v1/diagnostics'
+```
+
+Expected: diagnostics routes exist before iOS client work. If not, land the live-contract route branch first.
+
+- [ ] **Step 2: Add diagnostics models and API**
+
+Support:
+
+```text
+GET /api/v1/diagnostics?deploymentId=<id>&limit=<n>
+GET /api/v1/diagnostics/deployments/<id>?limit=<n>
+```
+
+- [ ] **Step 3: Add UI entry points**
+
+Add diagnostics from:
+
+- session controls
+- terminal errors
+- launch failure card
+- stale or missing terminal state
+
+The UI should show chronological events, severity, event name, message, target, and deployment ID.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ModelDecodingTests -only-testing:IssueCTLTests/APIClientTests
+```
+
+Expected: diagnostics decoding and endpoint path tests pass.
+
+## Task 6: GoalBuddy Board Shape For Execution
+
+**Files:**
+- Create: `docs/goals/ios-workbench-automation-parity/goal.md`
+- Create: `docs/goals/ios-workbench-automation-parity/state.yaml`
+
+- [ ] **Step 1: Use one fresh GoalBuddy board**
+
+Do not continue completed parity boards. Create a new tranche board with this oracle:
+
+```text
+iOS can answer, from the app alone, what work exists across tracked repos,
+which issues/PRs have active or completed automation sessions, whether webhook
+automation is healthy, how to apply/remove trigger labels safely, and how to
+diagnose failed launch/terminal/session states.
+```
+
+- [ ] **Step 2: Seed one Scout, one Judge, then Workers**
+
+Recommended board sequence:
+
+1. Scout: produce a gap matrix against current baseline and this plan.
+2. Judge: accept/reject the matrix, select dependency order, and authorize Task 1.
+3. Worker: implement Task 1 shared projections.
+4. Judge: verify Task 1 allows parallel UI workers.
+5. Workers: run Tasks 2-5 in separate worktrees with disjoint file ownership.
+6. Judge: merge or reject each package with evidence.
+7. PM: run final audit and proof loop.
+
+- [ ] **Step 3: Record proof per package**
+
+Each Worker receipt must include:
+
+- changed files
+- exact test commands
+- pass/fail output summary
+- strongest realistic failure mode tested
+- screenshots or UI test evidence when UI changed
+
+## Task 7: Final Verification Matrix
+
+**Files:**
+- No production file ownership. This is a proof task.
+
+- [ ] **Step 1: Run Apple focused checks**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests
+pnpm ios:ui-smoke:fast
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run touched web/core checks if routes changed**
+
+Run as applicable:
+
+```bash
+pnpm --dir packages/web test
+pnpm --dir packages/web typecheck
+pnpm --dir packages/web lint
+pnpm --dir packages/core test
+pnpm --dir packages/core typecheck
+pnpm --dir packages/core lint
+```
+
+Expected: pass or explicitly document pre-existing failures.
+
+- [ ] **Step 3: Burden of proof check**
+
+Try to disprove the change:
+
+- verify a PR-target session appears in iOS Sessions and routes to PR detail
+- verify an issue auto-launch label can be applied from iOS and the app shows the automation state
+- verify a repo with missing webhook URL does not look healthy
+- verify a launch/terminal failure points to diagnostics
+- verify the board does not double count active sessions when both `/deployments` and `/workbench` return the same deployment
+
+Expected: each failure mode has command, test, screenshot, or direct inspection evidence.
+
+## Recommended Parallel Ownership
+
+Do not run all five packages at once from scratch. Use this order:
+
+1. `codex/ios-workbench-shared-projections`: Task 1 only.
+2. `codex/ios-cross-repo-board`: Task 2 after Task 1.
+3. `codex/ios-pr-automation-sessions`: Task 3 after Task 1.
+4. `codex/ios-repo-automation-health`: Task 4 after Task 1.
+5. `codex/ios-diagnostics-surface`: Task 5 after diagnostics route confirmation.
+
+Merge sequence:
+
+1. Shared projections.
+2. PR-target sessions.
+3. Repo automation health.
+4. Diagnostics.
+5. Board UI, because it should benefit from the other projections.
+
+## GoalBuddy Usage Improvements
+
+Use GoalBuddy as the owner-outcome controller, not as the implementation bottleneck.
+
+What to keep:
+
+- explicit oracle
+- Scout evidence receipts
+- Judge gates at phase boundaries
+- one active PM task
+- final proof audit
+
+What to change:
+
+- stop rerunning broad iOS parity prompts as new discovery work
+- do not continue completed boards unless their oracle still matches
+- make the first Scout produce a gap matrix, not another plan
+- let the first Judge authorize the largest safe vertical slice
+- use separate worktrees and subagents for independent UI packages after shared contracts land
+- make each Worker receipt include the strongest attempted disproof
+
+The better next command is not another broad prompt. It is:
+
+```text
+/goal Follow docs/goals/ios-workbench-automation-parity/goal.md.
+```
+
+after creating that board from this plan.
+
+## Self-Review
+
+- Spec coverage: web workbench, all-issues board, webhook automation labels, repo automation settings, PR review sessions, terminal/session state, diagnostics, and GoalBuddy process improvements are covered.
+- Placeholder scan: no task relies on undefined web routes except diagnostics, which is explicitly gated by Task 5 Step 1 because prior plans indicate those routes may live on a newer branch.
+- Type consistency: `WorkbenchPayload`, `WorkbenchRepo`, `WorkbenchDeployment`, `WorkbenchBootstrap`, `DeploymentTargetType`, `LaunchAgent`, and `WebhookPayloadMode` match current Swift/web names.


### PR DESCRIPTION
## Summary
- Reconciles the stale parity PR with current `main`, which already contains the iOS/web parity implementation from the follow-up branches.
- Keeps the unique completed GoalBuddy board artifacts for the iOS workbench automation parity effort.
- Records the detailed parity implementation plan and final board audit without reintroducing older code over newer mainline work.

## Verification
- `node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.3.8/skills/goalbuddy/scripts/check-goal-state.mjs docs/goals/ios-workbench-automation-parity/state.yaml`
- `git diff --check`

## Notes
- The original PR head was based before several parity branches had landed on `main`; attempting to merge it would have conflicted and risked overwriting newer iOS/web work. This PR branch is now current `main` plus the completed board receipts only.
