### PR TITLE
[codex] Add acceptance evidence guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+-
+
+## Touched Surfaces
+
+- [ ] Core / database / launch lifecycle
+- [ ] CLI
+- [ ] Web UI / API
+- [ ] Webhook automation
+- [ ] iOS app
+- [ ] macOS app
+- [ ] CI / scripts / repo tooling
+- [ ] Docs only
+
+## Acceptance Evidence
+
+Top realistic failure modes considered:
+
+-
+
+Evidence collected:
+
+-
+
+Commands run:
+
+```bash
+
+```
+
+Manual, live, or device QA:
+
+-
+
+Skipped checks / residual risk:
+
+-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,38 @@ tail -f ~/.issuectl/logs/web.log
 cat ~/.issuectl/logs/web.log | jq 'select(.level >= 50)'
 ```
 
+## Acceptance evidence
+
+Do not finish agent work with only a generic "tests pass" claim. Before handing
+off, identify the top realistic failure modes for the changed surface and collect
+evidence that would have exposed those failures.
+
+Prefer the smallest proof that exercises the real contract:
+
+- Core, CLI, or data changes: run focused package tests plus typecheck/lint for
+  the touched package.
+- Launch, terminal, ttyd, tmux, session, or workbench changes: include
+  diagnostics journal evidence from `issuectl diag ...`; use web logs only after
+  diagnostics identify the failure area.
+- Web UI changes: use Playwright CLI checks for the affected flow and viewport.
+  Follow `CLAUDE.md`: do not use browser MCP or the Claude Chrome extension for
+  UI verification.
+- Webhook automation changes: use the smallest applicable rung from
+  `docs/workflows/webhook-qa-ladder.md` and record the runbook, target, and
+  pass/fail evidence.
+- iOS or macOS client changes: use the relevant build, smoke, preview-device,
+  runner preflight, or performance commands documented in `CLAUDE.md`.
+- Performance, lifecycle, or reliability claims: include the observed timing,
+  diagnostic events, logs, screenshots, or SQL/API output that directly supports
+  the claim.
+
+In final handoffs and PRs, report:
+
+- What changed surfaces were touched.
+- The top failure modes considered.
+- Exact commands, runbooks, diagnostics, logs, or artifacts used as evidence.
+- Any checks intentionally skipped, with the reason and residual risk.
+
 ## Common verification
 
 Run focused checks for the packages you touched:


### PR DESCRIPTION
## Summary

- Adds repo-level acceptance evidence guidance for agents.
- Adds a pull request template that asks for touched surfaces, failure modes, evidence, commands, QA, and residual risk.

## Touched Surfaces

- [ ] Core / database / launch lifecycle
- [ ] CLI
- [ ] Web UI / API
- [ ] Webhook automation
- [ ] iOS app
- [ ] macOS app
- [ ] CI / scripts / repo tooling
- [x] Docs only

## Acceptance Evidence

Top realistic failure modes considered:

- Guidance could be too generic to change agent behavior.
- The PR template could add process drag without helping reviewers see proof.
- Markdown formatting could drift from repo style.

Evidence collected:

- Mapped the gist ideas to existing issuectl proof sources in `CLAUDE.md`, `AGENTS.md`, workflow docs, package scripts, and CI workflows before drafting.
- Kept the agent guidance tied to diagnostics, Playwright CLI, webhook QA ladder, Apple smoke/perf checks, and focused pnpm checks.
- Verified Markdown formatting with Prettier.

Commands run:

```bash
pnpm exec prettier --check AGENTS.md .github/pull_request_template.md
```

Manual, live, or device QA:

- Not applicable for this docs-only change.

Skipped checks / residual risk:

- Package tests, Playwright, webhook QA, and Apple smoke checks were skipped because no executable code or product behavior changed.
- Residual risk is process fit: the template may need tightening after a few PRs dogfood it.
