### PR TITLE
feat(ios): close web parity last-mile gaps

### DIFF
--- a/apple/IssueCTL/App/ContentView.swift
+++ b/apple/IssueCTL/App/ContentView.swift
@@ -36,7 +36,10 @@ struct ContentView: View {
                     }
                     .accessibilityIdentifier("today-tab")
                     Tab("Board", systemImage: "rectangle.grid.2x2", value: AppTab.board) {
-                        BoardView(onShowSettings: { showSettings = true })
+                        BoardView(
+                            onShowSettings: { showSettings = true },
+                            route: $pendingRoute
+                        )
                             .ignoresSafeArea(.container, edges: .bottom)
                     }
                     .accessibilityIdentifier("board-tab")
@@ -59,7 +62,8 @@ struct ContentView: View {
                     Tab("Active", systemImage: "terminal", value: AppTab.active) {
                         SessionListView(
                             onShowSettings: { showSettings = true },
-                            onShowIssues: { selectedTab = .issues }
+                            onShowIssues: { selectedTab = .issues },
+                            route: $pendingRoute
                         )
                             .ignoresSafeArea(.container, edges: .bottom)
                     }
@@ -160,15 +164,14 @@ struct ContentView: View {
             selectedTab = .pullRequests
             pendingRoute = route
         case .board:
-            // Board/Sessions focus can consume the preserved route context in follow-up work.
             selectedTab = .board
-            pendingRoute = nil
+            pendingRoute = route
         case .sessions:
             selectedTab = .active
-            pendingRoute = nil
+            pendingRoute = route
         case .review:
             selectedTab = .active
-            pendingRoute = nil
+            pendingRoute = route
         }
     }
 }

--- a/apple/IssueCTL/Services/SetupLink.swift
+++ b/apple/IssueCTL/Services/SetupLink.swift
@@ -25,16 +25,17 @@ struct SetupLink: Equatable, Sendable {
 enum AppRoute: Equatable, Sendable {
     case issue(owner: String, repo: String, number: Int)
     case pullRequest(owner: String, repo: String, number: Int)
-    case sessions(repoFullName: String?)
+    case sessions(repoFullName: String?, deploymentId: Int?)
     case review(id: String)
-    case board(repoFullName: String?, deploymentId: Int?)
+    case board(repoFullName: String?, issueNumber: Int?, deploymentId: Int?)
 
     init?(url: URL) {
         let components = Self.pathComponents(from: url)
         guard let first = components.first else { return nil }
         let query = Self.queryItems(from: url)
         let repoFullName = query.first(where: { $0.name == "repo" })?.value
-        let deploymentId = query.first(where: { $0.name == "deployment" })?.value.flatMap(Int.init)
+        let deploymentId = Self.intQuery(["deploymentId", "deployment"], from: query)
+        let issueNumber = Self.intQuery(["issueNumber", "issue"], from: query)
 
         switch first {
         case "issues":
@@ -44,12 +45,13 @@ enum AppRoute: Equatable, Sendable {
             guard let target = Self.repoTarget(from: components) else { return nil }
             self = .pullRequest(owner: target.owner, repo: target.repo, number: target.number)
         case "sessions":
-            self = .sessions(repoFullName: repoFullName)
-        case "reviews":
-            guard components.count == 2, !components[1].isEmpty else { return nil }
-            self = .review(id: components[1])
+            self = .sessions(repoFullName: repoFullName, deploymentId: deploymentId)
+        case "reviews", "review":
+            let id = components.dropFirst().first ?? query.first(where: { $0.name == "id" })?.value
+            guard let id, !id.isEmpty else { return nil }
+            self = .review(id: id)
         case "workbench", "board":
-            self = .board(repoFullName: repoFullName, deploymentId: deploymentId)
+            self = .board(repoFullName: repoFullName, issueNumber: issueNumber, deploymentId: deploymentId)
         default:
             return nil
         }
@@ -74,6 +76,16 @@ enum AppRoute: Equatable, Sendable {
 
     private static func queryItems(from url: URL) -> [URLQueryItem] {
         URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    }
+
+    private static func intQuery(_ names: [String], from query: [URLQueryItem]) -> Int? {
+        for name in names {
+            if let value = query.first(where: { $0.name == name })?.value,
+               let number = Int(value) {
+                return number
+            }
+        }
+        return nil
     }
 
     private static func repoTarget(from components: [String]) -> (owner: String, repo: String, number: Int)? {

--- a/apple/IssueCTL/ViewModels/WorkbenchStore.swift
+++ b/apple/IssueCTL/ViewModels/WorkbenchStore.swift
@@ -67,6 +67,12 @@ struct WorkbenchBoardIssue: Identifiable, Sendable {
     }
 }
 
+struct WorkbenchBoardFocus: Equatable, Sendable {
+    let owner: String
+    let repo: String
+    let number: Int
+}
+
 @Observable @MainActor
 final class WorkbenchStore {
     var payload: WorkbenchPayload?
@@ -155,21 +161,51 @@ final class WorkbenchStore {
         }
     }
 
+    @discardableResult
+    func applyBoardRoute(
+        repoFullName: String?,
+        issueNumber: Int?,
+        deploymentId: Int?
+    ) -> WorkbenchBoardFocus? {
+        let routeRepos = reposForRoute(repoFullName)
+
+        if let deploymentId,
+           let match = routeRepos.lazy.compactMap({ repo in
+               repo.deployments.first(where: { $0.id == deploymentId }).map { (repo: repo, deployment: $0) }
+           }).first {
+            selectedRepoIds = [match.repo.id]
+            filter = .running
+            guard match.deployment.targetType == .issue else { return nil }
+            return WorkbenchBoardFocus(
+                owner: match.repo.owner,
+                repo: match.repo.name,
+                number: match.deployment.targetNumber
+            )
+        }
+
+        if let issueNumber,
+           let match = routeRepos.lazy.compactMap({ repo in
+               repo.issues.first(where: { $0.number == issueNumber }).map { (repo: repo, issue: $0) }
+           }).first {
+            selectedRepoIds = [match.repo.id]
+            let item = boardIssue(repo: match.repo, repoIndex: repoIndex(for: match.repo), issue: match.issue)
+            filter = filter(for: item)
+            return WorkbenchBoardFocus(owner: match.repo.owner, repo: match.repo.name, number: issueNumber)
+        }
+
+        if let repoFullName,
+           let repo = repos.first(where: { $0.fullName == repoFullName }) {
+            selectedRepoIds = [repo.id]
+        }
+
+        return nil
+    }
+
     private func boardIssues(filteringByRepoOnly: Bool) -> [WorkbenchBoardIssue] {
         var issues: [WorkbenchBoardIssue] = []
         for (index, repo) in repos.enumerated() where selectedRepoIds.isEmpty || selectedRepoIds.contains(repo.id) {
             for issue in repo.issues {
-                let deployment = repo.deployments.first {
-                    $0.targetType == .issue && $0.targetNumber == issue.number
-                }
-                let item = WorkbenchBoardIssue(
-                    repoId: repo.id,
-                    repoIndex: index,
-                    owner: repo.owner,
-                    repoName: repo.name,
-                    issue: issue,
-                    deployment: deployment
-                )
+                let item = boardIssue(repo: repo, repoIndex: index, issue: issue)
                 if filteringByRepoOnly || filter.includes(item) {
                     issues.append(item)
                 }
@@ -188,5 +224,35 @@ final class WorkbenchStore {
             }
             return left.id < right.id
         }
+    }
+
+    private func reposForRoute(_ repoFullName: String?) -> [WorkbenchRepo] {
+        guard let repoFullName else { return repos }
+        return repos.filter { $0.fullName == repoFullName }
+    }
+
+    private func repoIndex(for repo: WorkbenchRepo) -> Int {
+        repos.firstIndex(where: { $0.id == repo.id }) ?? 0
+    }
+
+    private func boardIssue(repo: WorkbenchRepo, repoIndex: Int, issue: WorkbenchIssueSummary) -> WorkbenchBoardIssue {
+        let deployment = repo.deployments.first {
+            $0.targetType == .issue && $0.targetNumber == issue.number
+        }
+        return WorkbenchBoardIssue(
+            repoId: repo.id,
+            repoIndex: repoIndex,
+            owner: repo.owner,
+            repoName: repo.name,
+            issue: issue,
+            deployment: deployment
+        )
+    }
+
+    private func filter(for issue: WorkbenchBoardIssue) -> WorkbenchIssueFilter {
+        if !issue.issue.isOpen {
+            return .closed
+        }
+        return issue.isRunning ? .running : .open
     }
 }

--- a/apple/IssueCTL/Views/Issues/IssueDetailView.swift
+++ b/apple/IssueCTL/Views/Issues/IssueDetailView.swift
@@ -22,6 +22,7 @@ struct IssueDetailView: View {
     @State private var actionError: String?
     @State private var repoAutomation: Repo?
     @State private var automationWebhookHealth: WebhookAutomationHealth?
+    @State private var automationWebhookEvent: WebhookEvent?
 
     // Comment actions and error display
     @State private var isDeletingComment = false
@@ -369,6 +370,12 @@ struct IssueDetailView: View {
             isApplied: isApplied,
             isAutomationEnabled: repoAutomation?.autoLaunchIssues ?? false,
             webhookSummary: automationWebhookSummary,
+            evidence: automationLabelEvidence(
+                kind: kind,
+                isApplied: isApplied,
+                webhookEvent: automationWebhookEvent,
+                reviewRun: nil
+            ),
             isToggling: isTogglingAutomationLabel,
             buttonIdentifier: "issue-auto-launch-label-button",
             onToggle: {
@@ -638,6 +645,19 @@ struct IssueDetailView: View {
                 do { return .success(try await api.webhookHealth(owner: owner, repo: repo)) }
                 catch { return .failure(error) }
             }()
+            async let webhookEventsResult: Result<WebhookEventsResponse, Error> = {
+                do {
+                    return .success(try await api.webhookEvents(
+                        owner: owner,
+                        repo: repo,
+                        targetType: .issue,
+                        targetNumber: number,
+                        limit: 5
+                    ))
+                } catch {
+                    return .failure(error)
+                }
+            }()
             detail = try await detailResult
             hasLoadedFullDetail = true
 
@@ -670,6 +690,12 @@ struct IssueDetailView: View {
                 automationWebhookHealth = health
             case .failure:
                 automationWebhookHealth = nil
+            }
+            switch await webhookEventsResult {
+            case .success(let response):
+                automationWebhookEvent = response.events.first
+            case .failure:
+                automationWebhookEvent = nil
             }
             if !failures.isEmpty {
                 actionError = "Failed to load: \(failures.joined(separator: ", "))"

--- a/apple/IssueCTL/Views/PullRequests/PRDetailView.swift
+++ b/apple/IssueCTL/Views/PullRequests/PRDetailView.swift
@@ -18,6 +18,8 @@ struct PRDetailView: View {
     @State private var actionError: String?
     @State private var repoAutomation: Repo?
     @State private var automationWebhookHealth: WebhookAutomationHealth?
+    @State private var automationWebhookEvent: WebhookEvent?
+    @State private var automationReviewRun: ReviewRun?
     @State private var isTogglingAutomationLabel = false
     @State private var activeReviewDeployments: [ActiveDeployment] = []
     @State private var terminalPresentation: PRTerminalPresentation?
@@ -233,6 +235,12 @@ struct PRDetailView: View {
             isApplied: isApplied,
             isAutomationEnabled: repoAutomation?.autoReviewPrs ?? false,
             webhookSummary: automationWebhookSummary,
+            evidence: automationLabelEvidence(
+                kind: kind,
+                isApplied: isApplied,
+                webhookEvent: automationWebhookEvent,
+                reviewRun: automationReviewRun
+            ),
             isToggling: isTogglingAutomationLabel,
             buttonIdentifier: "pr-auto-review-label-button",
             onToggle: {
@@ -488,6 +496,23 @@ struct PRDetailView: View {
                 do { return .success(try await api.activeDeployments(refresh: refresh)) }
                 catch { return .failure(error) }
             }()
+            async let webhookEventsResult: Result<WebhookEventsResponse, Error> = {
+                do {
+                    return .success(try await api.webhookEvents(
+                        owner: owner,
+                        repo: repo,
+                        targetType: .pr,
+                        targetNumber: number,
+                        limit: 5
+                    ))
+                } catch {
+                    return .failure(error)
+                }
+            }()
+            async let reviewRunsResult: Result<ReviewRunsResponse, Error> = {
+                do { return .success(try await api.reviewRuns(owner: owner, repo: repo, pr: number, limit: 5)) }
+                catch { return .failure(error) }
+            }()
 
             detail = try await detailResult
             switch await reposResult {
@@ -508,6 +533,18 @@ struct PRDetailView: View {
                     .filter { $0.matchesPullRequest(owner: owner, repo: repo, number: number) }
             case .failure:
                 activeReviewDeployments = []
+            }
+            switch await webhookEventsResult {
+            case .success(let response):
+                automationWebhookEvent = response.events.first
+            case .failure:
+                automationWebhookEvent = nil
+            }
+            switch await reviewRunsResult {
+            case .success(let response):
+                automationReviewRun = response.reviewRuns.first
+            case .failure:
+                automationReviewRun = nil
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 extension SessionsOverviewTab: SectionTabItem {
     var icon: String {
@@ -13,6 +14,7 @@ struct SessionListView: View {
     @Environment(APIClient.self) private var api
     let onShowSettings: () -> Void
     let onShowIssues: () -> Void
+    @Binding private var route: AppRoute?
 
     @State private var repos: [Repo] = []
     @State private var overviewResponse: SessionsOverviewResponse?
@@ -20,10 +22,13 @@ struct SessionListView: View {
     @State private var errorMessage: String?
     @State private var actionError: String?
     @State private var terminalPresentation: TerminalPresentation?
+    @State private var ptyBridgeHandoffTarget: SessionsOverviewSession?
     @State private var sessionControlsTarget: SessionsOverviewSession?
+    @State private var automationActivityTarget: RepoAutomationActivityTarget?
     @State private var diagnosticsTarget: ActiveDeployment?
     @State private var reviewDetailTarget: ReviewRunDetailTarget?
     @State private var showCreateSheet = false
+    @State private var showAutomationFeed = false
     @State private var endingDeploymentId: Int?
     @State private var navigationPath = NavigationPath()
     @State private var searchText = ""
@@ -37,6 +42,16 @@ struct SessionListView: View {
     @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
+
+    init(
+        onShowSettings: @escaping () -> Void,
+        onShowIssues: @escaping () -> Void,
+        route: Binding<AppRoute?> = .constant(nil)
+    ) {
+        self.onShowSettings = onShowSettings
+        self.onShowIssues = onShowIssues
+        self._route = route
+    }
 
     private var overview: SessionsOverviewData? {
         overviewResponse?.overview
@@ -83,8 +98,11 @@ struct SessionListView: View {
 
     private var filteredSessionGroups: [SessionsOverviewSessionGroup] {
         let groups = overview?.sessionGroups ?? []
-        guard !selectedRepoIds.isEmpty else { return groups }
-        return groups
+        let filteredGroups: [SessionsOverviewSessionGroup]
+        if selectedRepoIds.isEmpty {
+            filteredGroups = groups
+        } else {
+            filteredGroups = groups
             .map { group in
                 let sessions = group.sessions.filter { selectedRepoIds.contains($0.repoId) }
                 return SessionsOverviewSessionGroup(
@@ -98,6 +116,8 @@ struct SessionListView: View {
                 )
             }
             .filter { !$0.sessions.isEmpty }
+        }
+        return filteredGroups.sorted(by: sessionGroupSort)
     }
 
     private var filteredReviewGroups: [SessionsOverviewReviewGroup] {
@@ -200,6 +220,9 @@ struct SessionListView: View {
             .task(id: overviewQuerySignature) {
                 await load()
             }
+            .onChange(of: route) { _, _ in
+                applyPendingRoute()
+            }
             .task {
                 await streamSessionUpdates()
             }
@@ -254,6 +277,14 @@ struct SessionListView: View {
                         sessionControlsTarget = nil
                         diagnosticsTarget = session.activeDeployment
                     },
+                    onViewAutomationActivity: {
+                        sessionControlsTarget = nil
+                        automationActivityTarget = makeAutomationActivityTarget(
+                            repoId: session.repoId,
+                            targetType: session.targetType,
+                            targetNumber: session.targetNumber
+                        )
+                    },
                     onEnd: {
                         Task {
                             await endSession(session)
@@ -261,8 +292,37 @@ struct SessionListView: View {
                         }
                     }
                 )
-                .presentationDetents([.height(390), .medium])
+                .presentationDetents([.height(455), .medium])
                 .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $showAutomationFeed) {
+                NavigationStack {
+                    AutomationFeedView()
+                        .toolbar {
+                            ToolbarItem(placement: .topBarLeading) {
+                                Button("Done") {
+                                    showAutomationFeed = false
+                                }
+                            }
+                        }
+                }
+            }
+            .sheet(item: $automationActivityTarget) { target in
+                NavigationStack {
+                    RepoAutomationActivityView(repo: target.repo, initialQuery: target.query)
+                        .toolbar {
+                            ToolbarItem(placement: .topBarLeading) {
+                                Button("Done") {
+                                    automationActivityTarget = nil
+                                }
+                            }
+                        }
+                }
+            }
+            .sheet(item: $ptyBridgeHandoffTarget) { session in
+                PTYBridgeHandoffSheet(session: session)
+                    .presentationDetents([.medium])
+                    .presentationDragIndicator(.visible)
             }
             .sheet(item: $diagnosticsTarget) { deployment in
                 DeploymentDiagnosticsSheet(deployment: deployment)
@@ -317,6 +377,7 @@ struct SessionListView: View {
                                 group: group,
                                 endingDeploymentId: endingDeploymentId,
                                 onOpen: openTerminal,
+                                onWebWorkbench: { ptyBridgeHandoffTarget = $0 },
                                 onControls: { sessionControlsTarget = $0 }
                             )
                         }
@@ -336,6 +397,13 @@ struct SessionListView: View {
                                     if let deployment = run.deployment {
                                         diagnosticsTarget = deployment.activeDeployment
                                     }
+                                },
+                                onOpenAutomationActivity: { run in
+                                    automationActivityTarget = makeAutomationActivityTarget(
+                                        repoId: run.repoId,
+                                        targetType: .pr,
+                                        targetNumber: run.prNumber
+                                    )
                                 },
                                 onOpenDetail: { run in
                                     reviewDetailTarget = ReviewRunDetailTarget(id: run.id)
@@ -364,6 +432,14 @@ struct SessionListView: View {
     private var sessionHeader: some View {
         AppTopBar(title: "Sessions", subtitle: sessionSubtitle) {
             HStack(spacing: 8) {
+                TopBarIconButton(
+                    title: "Automation Feed",
+                    systemImage: "dot.radiowaves.left.and.right",
+                    accessibilityIdentifier: "sessions-automation-feed-button"
+                ) {
+                    showAutomationFeed = true
+                }
+
                 TopBarIconButton(
                     title: "Search sessions",
                     systemImage: "magnifyingglass",
@@ -411,6 +487,9 @@ struct SessionListView: View {
             if summary.activeSessions == 0 && summary.endedSessions == 0 {
                 return "No sessions"
             }
+            if summary.activeSessions > 0 && summary.endedSessions == 0 {
+                return "Running sessions"
+            }
             return "\(summary.activeSessions) active · \(summary.endedSessions) ended"
         case .reviews:
             if summary.reviewRuns == 0 {
@@ -453,6 +532,31 @@ struct SessionListView: View {
         isSearchVisible = true
         Task { @MainActor in
             isSearchFocused = true
+        }
+    }
+
+    private func sessionGroupSort(_ left: SessionsOverviewSessionGroup, _ right: SessionsOverviewSessionGroup) -> Bool {
+        let leftRank = left.sessions.map(sessionSortRank).min() ?? Int.max
+        let rightRank = right.sessions.map(sessionSortRank).min() ?? Int.max
+        if leftRank != rightRank {
+            return leftRank < rightRank
+        }
+        return left.key < right.key
+    }
+
+    private func sessionSortRank(_ session: SessionsOverviewSession) -> Int {
+        if !session.isActive {
+            return 4
+        }
+        switch session.preview?.status {
+        case .idle:
+            return 0
+        case .error:
+            return 1
+        case .active:
+            return 2
+        case .unavailable, nil:
+            return 3
         }
     }
 
@@ -525,6 +629,7 @@ struct SessionListView: View {
             }
         }
         isLoading = false
+        applyPendingRoute()
     }
 
     private func refreshSessions() async {
@@ -566,6 +671,52 @@ struct SessionListView: View {
         }
         endingDeploymentId = nil
     }
+
+    private func makeAutomationActivityTarget(
+        repoId: Int,
+        targetType: DeploymentTargetType,
+        targetNumber: Int
+    ) -> RepoAutomationActivityTarget? {
+        guard let repo = repos.first(where: { $0.id == repoId }) else { return nil }
+        var query = RepoAutomationActivityQuery()
+        query.scope = targetType == .pr ? .pullRequests : .issues
+        query.numberText = "\(targetNumber)"
+        return RepoAutomationActivityTarget(repo: repo, query: query)
+    }
+
+    private func applyPendingRoute() {
+        guard let route else { return }
+        switch route {
+        case .sessions(let repoFullName, let deploymentId):
+            selectedTab = .sessions
+            applyRepoFilter(repoFullName)
+            if let deploymentId,
+               let session = overview?.sessionGroups.flatMap(\.sessions).first(where: { $0.id == deploymentId }) {
+                sessionControlsTarget = session
+            }
+            self.route = nil
+        case .review(let id):
+            selectedTab = .reviews
+            if let reviewId = Int(id) {
+                if let run = overview?.reviewGroups.flatMap(\.runs).first(where: { $0.id == reviewId }),
+                   let repo = repos.first(where: { $0.id == run.repoId }) {
+                    selectedRepoIds = [repo.id]
+                }
+                reviewDetailTarget = ReviewRunDetailTarget(id: reviewId)
+            }
+            self.route = nil
+        case .issue, .pullRequest, .board:
+            break
+        }
+    }
+
+    private func applyRepoFilter(_ repoFullName: String?) {
+        guard let repoFullName,
+              let repo = repos.first(where: { $0.fullName == repoFullName }) else {
+            return
+        }
+        selectedRepoIds = [repo.id]
+    }
 }
 
 private struct TerminalPresentation: Identifiable {
@@ -573,10 +724,63 @@ private struct TerminalPresentation: Identifiable {
     let deployment: ActiveDeployment
 }
 
+private struct RepoAutomationActivityTarget: Identifiable {
+    let id = UUID()
+    let repo: Repo
+    let query: RepoAutomationActivityQuery
+}
+
+private struct PTYBridgeHandoffSheet: View {
+    let session: SessionsOverviewSession
+    @State private var didCopy = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Label("PTY bridge terminal", systemImage: "network")
+                    .font(.headline)
+
+                Text("This session uses the web workbench terminal bridge. Native ttyd terminal attachment is not available for this backend.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Web workbench path")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(session.webWorkbenchPath)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                        .padding(10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
+                }
+
+                Button {
+                    UIPasteboard.general.string = session.webWorkbenchPath
+                    didCopy = true
+                } label: {
+                    Label(didCopy ? "Copied" : "Copy Web Workbench Path", systemImage: didCopy ? "checkmark.circle.fill" : "doc.on.doc")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("pty-bridge-copy-workbench-path")
+
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .navigationTitle("Web Workbench")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
 private struct SessionTargetGroupView: View {
     let group: SessionsOverviewSessionGroup
     let endingDeploymentId: Int?
     let onOpen: (SessionsOverviewSession) -> Void
+    let onWebWorkbench: (SessionsOverviewSession) -> Void
     let onControls: (SessionsOverviewSession) -> Void
 
     var body: some View {
@@ -587,6 +791,7 @@ private struct SessionTargetGroupView: View {
                     session: session,
                     isEnding: endingDeploymentId == session.id,
                     onOpen: { onOpen(session) },
+                    onWebWorkbench: { onWebWorkbench(session) },
                     onControls: { onControls(session) }
                 )
             }
@@ -611,6 +816,7 @@ private struct SessionOverviewRow: View {
     let session: SessionsOverviewSession
     let isEnding: Bool
     let onOpen: () -> Void
+    let onWebWorkbench: () -> Void
     let onControls: () -> Void
 
     var body: some View {
@@ -653,17 +859,17 @@ private struct SessionOverviewRow: View {
             }
 
             HStack(spacing: 8) {
-                Button(action: onOpen) {
-                    Label(openButtonTitle, systemImage: "terminal")
+                Button(action: primaryAction) {
+                    Label(openButtonTitle, systemImage: primaryButtonImage)
                         .font(.subheadline.weight(.bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity, minHeight: 40)
-                        .background(IssueCTLColors.action.opacity(canOpenTerminal ? 1 : 0.45), in: RoundedRectangle(cornerRadius: 12))
+                        .background(IssueCTLColors.action.opacity(canUsePrimaryAction ? 1 : 0.45), in: RoundedRectangle(cornerRadius: 12))
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .disabled(!canOpenTerminal || isEnding)
-                .accessibilityIdentifier("session-reenter-terminal-\(session.id)")
+                .disabled(!canUsePrimaryAction || isEnding)
+                .accessibilityIdentifier(primaryButtonIdentifier)
 
                 Button(action: onControls) {
                     Image(systemName: "ellipsis")
@@ -687,6 +893,8 @@ private struct SessionOverviewRow: View {
         .onTapGesture {
             if canOpenTerminal {
                 onOpen()
+            } else if canOpenWebWorkbench {
+                onWebWorkbench()
             }
         }
     }
@@ -698,7 +906,34 @@ private struct SessionOverviewRow: View {
     private var openButtonTitle: String {
         if !session.isActive { return "Session Ended" }
         if session.ttydPort != nil { return "Open Terminal" }
-        return session.usesPtyBridgeTerminal ? "Web Terminal" : "Starting..."
+        return session.usesPtyBridgeTerminal ? "Open Web Workbench" : "Starting..."
+    }
+
+    private var primaryButtonImage: String {
+        session.usesPtyBridgeTerminal ? "safari" : "terminal"
+    }
+
+    private var primaryButtonIdentifier: String {
+        if canOpenWebWorkbench {
+            return "session-web-workbench-\(session.id)"
+        }
+        return "session-reenter-terminal-\(session.id)"
+    }
+
+    private var canOpenWebWorkbench: Bool {
+        session.isActive && session.usesPtyBridgeTerminal
+    }
+
+    private var canUsePrimaryAction: Bool {
+        canOpenTerminal || canOpenWebWorkbench
+    }
+
+    private func primaryAction() {
+        if canOpenTerminal {
+            onOpen()
+        } else if canOpenWebWorkbench {
+            onWebWorkbench()
+        }
     }
 
     private var statusColor: Color {
@@ -750,6 +985,7 @@ private struct ReviewRunGroupView: View {
     let onOpenDeployment: (SessionsOverviewSession) -> Void
     let onOpenPullRequest: (SessionsOverviewReviewRun) -> Void
     let onOpenDiagnostics: (SessionsOverviewReviewRun) -> Void
+    let onOpenAutomationActivity: (SessionsOverviewReviewRun) -> Void
     let onOpenDetail: (SessionsOverviewReviewRun) -> Void
 
     var body: some View {
@@ -771,6 +1007,7 @@ private struct ReviewRunGroupView: View {
                     onOpenDeployment: { deployment in onOpenDeployment(deployment) },
                     onOpenPullRequest: { onOpenPullRequest(run) },
                     onOpenDiagnostics: { onOpenDiagnostics(run) },
+                    onOpenAutomationActivity: { onOpenAutomationActivity(run) },
                     onOpenDetail: { onOpenDetail(run) }
                 )
             }
@@ -784,6 +1021,7 @@ private struct ReviewRunRow: View {
     let onOpenDeployment: (SessionsOverviewSession) -> Void
     let onOpenPullRequest: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onOpenAutomationActivity: () -> Void
     let onOpenDetail: () -> Void
 
     var body: some View {
@@ -808,6 +1046,10 @@ private struct ReviewRunRow: View {
                 Text(run.summary ?? "No review summary recorded.")
                     .font(.subheadline)
                     .lineLimit(3)
+                Text(run.status.operatorDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text("\(run.rangeLabel) · \(run.headRepoFullName):\(run.headRef)")
                     .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
@@ -839,6 +1081,14 @@ private struct ReviewRunRow: View {
                 .buttonStyle(.bordered)
                 .accessibilityLabel("Open PR")
                 .accessibilityIdentifier("review-open-pr-\(run.id)")
+
+                Button(action: onOpenAutomationActivity) {
+                    Image(systemName: "dot.radiowaves.left.and.right")
+                        .frame(width: 42, height: 38)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Open review automation activity")
+                .accessibilityIdentifier("review-automation-activity-\(run.id)")
 
                 if let deployment = run.deployment, deployment.canOpenTerminalInApp {
                     Button {
@@ -1059,6 +1309,7 @@ private struct SessionControlsSheet: View {
     let onOpenTerminal: () -> Void
     let onViewTarget: () -> Void
     let onViewDiagnostics: () -> Void
+    let onViewAutomationActivity: () -> Void
     let onEnd: () -> Void
 
     var body: some View {
@@ -1094,6 +1345,16 @@ private struct SessionControlsSheet: View {
                     systemImage: session.isIssueTarget ? "number" : "arrow.triangle.merge",
                     accessibilityIdentifier: "session-target-action-\(session.id)",
                     action: onViewTarget
+                )
+
+                Divider()
+
+                sheetAction(
+                    title: "Automation Activity",
+                    subtitle: "Open webhook events and review runs for this target.",
+                    systemImage: "dot.radiowaves.left.and.right",
+                    accessibilityIdentifier: "session-automation-activity-\(session.id)",
+                    action: onViewAutomationActivity
                 )
 
                 Divider()

--- a/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationActivityRows.swift
@@ -188,6 +188,23 @@ private extension ReviewRun {
 }
 
 extension ReviewRunStatus {
+    var operatorDescription: String {
+        switch self {
+        case .reserved:
+            return "Waiting for the review worker to claim this run."
+        case .launching:
+            return "Preparing a PR review session."
+        case .inProgress:
+            return "Review session is running."
+        case .completed:
+            return "Latest automated review completed."
+        case .failed:
+            return "Review failed; open details for diagnostics or retry."
+        case .superseded:
+            return "A newer review request replaced this run."
+        }
+    }
+
     var displayName: String {
         switch self {
         case .reserved:

--- a/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
+++ b/apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift
@@ -55,7 +55,7 @@ struct RepoAutomationActivityView: View {
 
     let repo: Repo
 
-    @State private var query = RepoAutomationActivityQuery()
+    @State private var query: RepoAutomationActivityQuery
     @State private var webhookEvents: [WebhookEvent] = []
     @State private var reviewRuns: [ReviewRun] = []
     @State private var isLoadingWebhookEvents = false
@@ -65,6 +65,11 @@ struct RepoAutomationActivityView: View {
     @State private var webhookResponse: WebhookEventsResponse?
     @State private var reviewRunsResponse: ReviewRunsResponse?
     @State private var reviewDetailTarget: ReviewRunDetailTarget?
+
+    init(repo: Repo, initialQuery: RepoAutomationActivityQuery = RepoAutomationActivityQuery()) {
+        self.repo = repo
+        _query = State(initialValue: initialQuery)
+    }
 
     var body: some View {
         Form {

--- a/apple/IssueCTL/Views/Shared/LabelPicker.swift
+++ b/apple/IssueCTL/Views/Shared/LabelPicker.swift
@@ -68,11 +68,128 @@ enum AutomationLabelKind {
     }
 }
 
+struct AutomationLabelEvidence: Equatable {
+    let title: String
+    let detail: String
+}
+
+func automationLabelEvidence(
+    kind: AutomationLabelKind,
+    isApplied: Bool,
+    webhookEvent: WebhookEvent?,
+    reviewRun: ReviewRun?
+) -> AutomationLabelEvidence? {
+    if let reviewRun {
+        return reviewAutomationEvidence(reviewRun)
+    }
+
+    if let webhookEvent {
+        if let intent = webhookEvent.intent {
+            switch intent.status {
+            case "pending", "queued", "scheduled":
+                return AutomationLabelEvidence(
+                    title: "Automation queued",
+                    detail: "\(kind.labelName) was received and the worker will launch after debounce."
+                )
+            case "processing", "claimed":
+                return AutomationLabelEvidence(
+                    title: "Automation processing",
+                    detail: "The webhook worker is preparing the session."
+                )
+            case "resolved", "completed", "launched":
+                return AutomationLabelEvidence(
+                    title: "Automation launched",
+                    detail: "issuectl removes the label after starting work so future webhook signals are intentional."
+                )
+            case "failed":
+                return AutomationLabelEvidence(
+                    title: "Automation failed",
+                    detail: intent.failureReason ?? webhookEvent.resultDetail ?? "The webhook worker could not launch the session."
+                )
+            default:
+                break
+            }
+        }
+
+        switch webhookEvent.result {
+        case "scheduled":
+            return AutomationLabelEvidence(
+                title: "Automation queued",
+                detail: "\(kind.labelName) was received and the worker will launch after debounce."
+            )
+        case "accepted", "processed":
+            return AutomationLabelEvidence(
+                title: isApplied ? "Automation signal received" : "Automation label consumed",
+                detail: "issuectl removes the label after starting work so future webhook signals are intentional."
+            )
+        case "failed", "error":
+            return AutomationLabelEvidence(
+                title: "Automation failed",
+                detail: webhookEvent.resultDetail ?? "The webhook worker could not launch the session."
+            )
+        case "ignored", "skipped":
+            return AutomationLabelEvidence(
+                title: "Automation skipped",
+                detail: webhookEvent.resultDetail ?? "The webhook delivery did not start a session."
+            )
+        default:
+            if let resultDetail = webhookEvent.resultDetail, !resultDetail.isEmpty {
+                return AutomationLabelEvidence(title: "Latest webhook event", detail: resultDetail)
+            }
+        }
+    }
+
+    if isApplied {
+        return AutomationLabelEvidence(
+            title: "Waiting for webhook",
+            detail: "The label is present. GitHub will notify issuectl, then issuectl removes the label after launch."
+        )
+    }
+
+    return nil
+}
+
+private func reviewAutomationEvidence(_ run: ReviewRun) -> AutomationLabelEvidence {
+    switch run.status {
+    case .reserved:
+        return AutomationLabelEvidence(
+            title: "Review automation queued",
+            detail: "The PR review worker has reserved this request and will launch after debounce."
+        )
+    case .launching:
+        return AutomationLabelEvidence(
+            title: "Review automation launching",
+            detail: "issuectl is preparing the PR review session."
+        )
+    case .inProgress:
+        return AutomationLabelEvidence(
+            title: "Review automation in progress",
+            detail: run.summary ?? "A PR review session is running."
+        )
+    case .completed:
+        return AutomationLabelEvidence(
+            title: "Review completed",
+            detail: run.summary ?? "The latest automated review completed."
+        )
+    case .failed:
+        return AutomationLabelEvidence(
+            title: "Review automation failed",
+            detail: run.summary ?? "The latest automated review failed."
+        )
+    case .superseded:
+        return AutomationLabelEvidence(
+            title: "Review superseded",
+            detail: run.summary ?? "A newer review request replaced this run."
+        )
+    }
+}
+
 struct AutomationLabelStatusCard: View {
     let kind: AutomationLabelKind
     let isApplied: Bool
     let isAutomationEnabled: Bool
     let webhookSummary: String?
+    let evidence: AutomationLabelEvidence?
     let isToggling: Bool
     let buttonIdentifier: String
     let onToggle: () -> Void
@@ -109,6 +226,18 @@ struct AutomationLabelStatusCard: View {
                         Text(webhookSummary)
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                    }
+                    if let evidence {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(evidence.title)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(tint)
+                            Text(evidence.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(.top, 2)
                     }
                 }
 

--- a/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
+++ b/apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift
@@ -138,10 +138,7 @@ struct ReviewRunDetailSheet: View {
             }
 
             if !detail.actions.mobileWriteActionsEnabled {
-                Label("Retry and full-rerun actions are available on the web review page for now.", systemImage: "lock")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 2)
+                disabledMobileActionsCard(detail)
             }
 
             if let errorMessage {
@@ -182,6 +179,25 @@ struct ReviewRunDetailSheet: View {
                         .foregroundStyle(.green)
                         .accessibilityIdentifier("review-run-action-confirmation")
                 }
+            }
+        }
+    }
+
+    private func disabledMobileActionsCard(_ detail: ReviewRunDetailResponse) -> some View {
+        sectionCard(title: "Mobile write actions disabled", systemImage: "lock") {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Open the web review page to retry or full rerun this review.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(detail.review.detailHref ?? detail.links.workbench)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .lineLimit(3)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.tertiarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 12))
             }
         }
     }

--- a/apple/IssueCTL/Views/Today/TodayView.swift
+++ b/apple/IssueCTL/Views/Today/TodayView.swift
@@ -26,6 +26,7 @@ struct TodayView: View {
     @State private var userFetchFailed = false
     @State private var showCreateSheet = false
     @State private var showSearchSheet = false
+    @State private var showAutomationFeed = false
     @State private var pendingSearchDestination: TodayDestination?
     @State private var actionError: String?
     @State private var navigationPath = NavigationPath()
@@ -124,6 +125,14 @@ struct TodayView: View {
                         }
 
                         TopBarIconButton(
+                            title: "Automation Feed",
+                            systemImage: "dot.radiowaves.left.and.right",
+                            accessibilityIdentifier: "today-automation-feed-button"
+                        ) {
+                            showAutomationFeed = true
+                        }
+
+                        TopBarIconButton(
                             title: "Search",
                             systemImage: "magnifyingglass",
                             accessibilityIdentifier: "today-search-button"
@@ -185,6 +194,18 @@ struct TodayView: View {
                 )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $showAutomationFeed) {
+                NavigationStack {
+                    AutomationFeedView()
+                        .toolbar {
+                            ToolbarItem(placement: .topBarLeading) {
+                                Button("Done") {
+                                    showAutomationFeed = false
+                                }
+                            }
+                        }
+                }
             }
             .autoDismissError($actionError)
             .task {

--- a/apple/IssueCTL/Views/Workbench/BoardView.swift
+++ b/apple/IssueCTL/Views/Workbench/BoardView.swift
@@ -7,6 +7,12 @@ struct BoardView: View {
     @State private var showRepoFilters = false
 
     let onShowSettings: () -> Void
+    @Binding private var route: AppRoute?
+
+    init(onShowSettings: @escaping () -> Void, route: Binding<AppRoute?> = .constant(nil)) {
+        self.onShowSettings = onShowSettings
+        self._route = route
+    }
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -75,6 +81,10 @@ struct BoardView: View {
                 if store.payload == nil {
                     await store.load(api: api)
                 }
+                applyPendingRoute()
+            }
+            .onChange(of: route) { _, _ in
+                applyPendingRoute()
             }
             .accessibilityTabBarClearance()
         }
@@ -166,6 +176,21 @@ struct BoardView: View {
         case .closed:
             return "No closed issues matched the current repository filters."
         }
+    }
+
+    private func applyPendingRoute() {
+        guard case let .board(repoFullName, issueNumber, deploymentId) = route,
+              store.payload != nil else {
+            return
+        }
+        if let focus = store.applyBoardRoute(
+            repoFullName: repoFullName,
+            issueNumber: issueNumber,
+            deploymentId: deploymentId
+        ) {
+            navigationPath.append(BoardDestination.issue(owner: focus.owner, repo: focus.repo, number: focus.number))
+        }
+        route = nil
     }
 }
 

--- a/apple/IssueCTLShared/Models/Deployment.swift
+++ b/apple/IssueCTLShared/Models/Deployment.swift
@@ -133,6 +133,10 @@ struct Deployment: Codable, Identifiable, Sendable {
         return "Terminal is still preparing."
     }
 
+    var webWorkbenchPath: String {
+        "/workbench?deployment=\(id)"
+    }
+
     var targetLabel: String {
         switch targetType {
         case .issue:

--- a/apple/IssueCTLShared/Models/Repo.swift
+++ b/apple/IssueCTLShared/Models/Repo.swift
@@ -721,6 +721,10 @@ struct SessionsOverviewSession: Codable, Identifiable, Sendable {
         return "Terminal is still preparing."
     }
 
+    var webWorkbenchPath: String {
+        "/workbench?deployment=\(id)"
+    }
+
     var sessionRoleTitle: String {
         if targetType == .pr && terminalReason == "review" {
             return "PR review session"

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -378,8 +378,6 @@ final class APIClient {
         return try decoder.decode(SessionsOverviewResponse.self, from: data)
     }
 
-    // Depends on issue #546: these automation list endpoints are fixture-driven
-    // until the web API exposes dedicated list routes for native clients.
     func webhookEvents(
         owner: String,
         repo: String,

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -279,6 +279,46 @@ final class APIClientExtensionTests: XCTestCase {
     }
 
     @MainActor
+    func testWebhookSettingsEndpointInventoryUsesNativeManagementRoutes() async throws {
+        let recorder = APIRequestRecorder()
+
+        MockURLProtocol.requestHandler = { request in
+            var action: String?
+            if let bodyData = self.readBody(from: request) {
+                let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+                action = json["action"] as? String
+            }
+            recorder.append(request, bodyAction: action)
+
+            switch request.url!.path {
+            case "/api/v1/repos/mean-weasel/issuectl/webhook/health":
+                return (self.makeResponse(url: request.url!), """
+                {"health":{"state":"ok","summary":"Webhook ready","detail":null,"recovery":null,"expectedUrl":"https://hooks.example/api/webhook/github/7","hookId":123,"githubUrl":"https://github.com/mean-weasel/issuectl/settings/hooks/123","latestDelivery":null}}
+                """.data(using: .utf8)!)
+            case "/api/v1/repos/mean-weasel/issuectl/webhook":
+                return (self.makeResponse(url: request.url!), """
+                {"success":true,"repo":null,"webhook":{"id":123,"url":"https://hooks.example/api/webhook/github/7","created_by":"alice"},"error":null}
+                """.data(using: .utf8)!)
+            default:
+                XCTFail("Unexpected webhook settings endpoint \(request.url!.path)")
+                return (self.makeResponse(url: request.url!), #"{}"#.data(using: .utf8)!)
+            }
+        }
+
+        _ = try await client.webhookHealth(owner: "mean-weasel", repo: "issuectl")
+        _ = try await client.configureWebhook(owner: "mean-weasel", repo: "issuectl", action: .create)
+
+        let observed = recorder.snapshot
+        XCTAssertEqual(observed.map(\.method), ["GET", "POST"])
+        XCTAssertEqual(observed.map(\.path), [
+            "/api/v1/repos/mean-weasel/issuectl/webhook/health",
+            "/api/v1/repos/mean-weasel/issuectl/webhook",
+        ])
+        XCTAssertNil(observed[0].bodyAction)
+        XCTAssertEqual(observed[1].bodyAction, "create")
+    }
+
+    @MainActor
     func testConfigureWebhookSendsAction() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url?.path, "/api/v1/repos/mean-weasel/issuectl/webhook")

--- a/apple/IssueCTLTests/APIClientTests.swift
+++ b/apple/IssueCTLTests/APIClientTests.swift
@@ -57,6 +57,42 @@ private func requestBodyData(_ request: URLRequest) throws -> Data {
     return data
 }
 
+struct RecordedAPIRequest {
+    let method: String
+    let path: String
+    let queryItems: [String: String]
+    let bodyAction: String?
+}
+
+final class APIRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [RecordedAPIRequest] = []
+
+    func append(_ request: URLRequest, bodyAction: String? = nil) {
+        let components = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let queryItems = (components?.queryItems ?? []).reduce(into: [String: String]()) { result, item in
+            if let value = item.value {
+                result[item.name] = value
+            }
+        }
+
+        lock.lock()
+        records.append(RecordedAPIRequest(
+            method: request.httpMethod ?? "GET",
+            path: request.url?.path ?? "",
+            queryItems: queryItems,
+            bodyAction: bodyAction
+        ))
+        lock.unlock()
+    }
+
+    var snapshot: [RecordedAPIRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return records
+    }
+}
+
 // MARK: - Testable APIClient subclass
 
 /// A testable version of APIClient that uses a custom URLSession with MockURLProtocol.
@@ -676,6 +712,65 @@ final class APIClientTests: XCTestCase {
         }
 
         _ = try await client.diagnostics(deploymentId: 42)
+    }
+
+    @MainActor
+    func testAutomationEndpointInventoryUsesNativeListRoutes() async throws {
+        let recorder = APIRequestRecorder()
+
+        MockURLProtocol.requestHandler = { request in
+            recorder.append(request)
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            switch request.url!.path {
+            case "/api/v1/webhooks/events":
+                return (response, #"{"events":[],"repos":[],"filters":{"repo":null,"target_type":null,"target_number":null,"limit":12},"summary":{"count":0,"latest_received_at":null,"latest_received_at_iso":null,"result_counts":{}}}"#.data(using: .utf8)!)
+            case "/api/v1/repos/mean-weasel/issuectl/webhook/events":
+                return (response, #"{"events":[],"repos":[],"filters":{"repo":"mean-weasel/issuectl","target_type":"issue","target_number":101,"limit":8},"summary":{"count":0,"latest_received_at":null,"latest_received_at_iso":null,"result_counts":{}},"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
+            case "/api/v1/pr-reviews":
+                return (response, #"{"review_runs":[],"repos":[],"filters":{"repo":null,"pr":null,"status":"completed","limit":9},"summary":{"count":0,"active_count":0,"completed_count":0,"failed_count":0,"latest_started_at":null,"latest_started_at_iso":null}}"#.data(using: .utf8)!)
+            case "/api/v1/repos/mean-weasel/issuectl/review-runs":
+                return (response, #"{"review_runs":[],"from_cache":false,"cached_at":null}"#.data(using: .utf8)!)
+            default:
+                XCTFail("Unexpected automation endpoint \(request.url!.path)")
+                return (response, #"{}"#.data(using: .utf8)!)
+            }
+        }
+
+        _ = try await client.globalWebhookEvents(limit: 12)
+        _ = try await client.webhookEvents(
+            owner: "mean-weasel",
+            repo: "issuectl",
+            targetType: .issue,
+            targetNumber: 101,
+            limit: 8
+        )
+        _ = try await client.globalReviewRuns(status: .completed, limit: 9)
+        _ = try await client.reviewRuns(
+            owner: "mean-weasel",
+            repo: "issuectl",
+            pr: 7,
+            status: .reserved,
+            limit: 6
+        )
+
+        let observed = recorder.snapshot
+        XCTAssertEqual(observed.map(\.method), ["GET", "GET", "GET", "GET"])
+        XCTAssertEqual(observed.map(\.path), [
+            "/api/v1/webhooks/events",
+            "/api/v1/repos/mean-weasel/issuectl/webhook/events",
+            "/api/v1/pr-reviews",
+            "/api/v1/repos/mean-weasel/issuectl/review-runs",
+        ])
+        XCTAssertEqual(observed[0].queryItems["limit"], "12")
+        XCTAssertEqual(observed[1].queryItems["targetType"], "issue")
+        XCTAssertEqual(observed[1].queryItems["targetNumber"], "101")
+        XCTAssertEqual(observed[1].queryItems["limit"], "8")
+        XCTAssertEqual(observed[2].queryItems["status"], "completed")
+        XCTAssertEqual(observed[2].queryItems["limit"], "9")
+        XCTAssertEqual(observed[3].queryItems["pr"], "7")
+        XCTAssertEqual(observed[3].queryItems["status"], "reserved")
+        XCTAssertEqual(observed[3].queryItems["limit"], "6")
     }
 
     @MainActor

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -38,7 +38,7 @@ final class ViewLogicTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "/sessions?repo=mean-weasel%2Fissuectl"))
         let route = try XCTUnwrap(AppRoute(url: url))
 
-        XCTAssertEqual(route, .sessions(repoFullName: "mean-weasel/issuectl"))
+        XCTAssertEqual(route, .sessions(repoFullName: "mean-weasel/issuectl", deploymentId: nil))
     }
 
     func testAppRouteParsesReviewIdentifier() throws {
@@ -52,13 +52,34 @@ final class ViewLogicTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "/workbench?repo=mean-weasel%2Fissuectl&deployment=113"))
         let route = try XCTUnwrap(AppRoute(url: url))
 
-        XCTAssertEqual(route, .board(repoFullName: "mean-weasel/issuectl", deploymentId: 113))
+        XCTAssertEqual(route, .board(repoFullName: "mean-weasel/issuectl", issueNumber: nil, deploymentId: 113))
+    }
+
+    func testAppRouteParsesWorkbenchIssueQuery() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl://board?repo=mean-weasel%2Fissuectl&issue=512"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .board(repoFullName: "mean-weasel/issuectl", issueNumber: 512, deploymentId: nil))
+    }
+
+    func testAppRouteParsesSessionsDeploymentQuery() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl://sessions?repo=mean-weasel%2Fissuectl&deploymentId=701"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .sessions(repoFullName: "mean-weasel/issuectl", deploymentId: 701))
+    }
+
+    func testAppRouteParsesReviewQueryIdentifier() throws {
+        let url = try XCTUnwrap(URL(string: "issuectl://review?id=9001"))
+        let route = try XCTUnwrap(AppRoute(url: url))
+
+        XCTAssertEqual(route, .review(id: "9001"))
     }
 
     func testAppRouteFallsBackForFuturePaths() throws {
-        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/sessions"))), .sessions(repoFullName: nil))
+        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/sessions"))), .sessions(repoFullName: nil, deploymentId: nil))
         XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/reviews/review-123"))), .review(id: "review-123"))
-        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/workbench/kanban"))), .board(repoFullName: nil, deploymentId: nil))
+        XCTAssertEqual(AppRoute(url: try XCTUnwrap(URL(string: "/workbench/kanban"))), .board(repoFullName: nil, issueNumber: nil, deploymentId: nil))
         XCTAssertNil(AppRoute(url: try XCTUnwrap(URL(string: "/settings"))))
     }
 
@@ -192,6 +213,15 @@ final class ViewLogicTests: XCTestCase {
     func testReviewRunActionModeRequestedDisplayNames() {
         XCTAssertEqual(ReviewRunActionMode.retry.requestedDisplayName, "Retry requested")
         XCTAssertEqual(ReviewRunActionMode.full.requestedDisplayName, "Full rerun requested")
+    }
+
+    func testReviewRunStatusOperatorDescriptions() {
+        XCTAssertEqual(ReviewRunStatus.reserved.operatorDescription, "Waiting for the review worker to claim this run.")
+        XCTAssertEqual(ReviewRunStatus.launching.operatorDescription, "Preparing a PR review session.")
+        XCTAssertEqual(ReviewRunStatus.inProgress.operatorDescription, "Review session is running.")
+        XCTAssertEqual(ReviewRunStatus.completed.operatorDescription, "Latest automated review completed.")
+        XCTAssertEqual(ReviewRunStatus.failed.operatorDescription, "Review failed; open details for diagnostics or retry.")
+        XCTAssertEqual(ReviewRunStatus.superseded.operatorDescription, "A newer review request replaced this run.")
     }
 
     // MARK: - Offline Action Queue

--- a/apple/IssueCTLTests/WorkbenchStoreTests.swift
+++ b/apple/IssueCTLTests/WorkbenchStoreTests.swift
@@ -40,9 +40,45 @@ final class WorkbenchStoreTests: XCTestCase {
         XCTAssertEqual(store.visibleDrafts.map(\.id), ["recent-edit", "older-high"])
     }
 
+    func testBoardRouteSelectsRepoAndIssueFilter() {
+        let store = WorkbenchStore()
+        store.payload = WorkbenchStoreTests.payload(
+            issues: [
+                WorkbenchStoreTests.issue(number: 1, title: "Open work", state: "open", hasActiveDeployment: false),
+                WorkbenchStoreTests.issue(number: 2, title: "Running work", state: "open", hasActiveDeployment: true),
+                WorkbenchStoreTests.issue(number: 3, title: "Closed work", state: "closed", hasActiveDeployment: false),
+            ]
+        )
+
+        let focus = store.applyBoardRoute(repoFullName: "org/app", issueNumber: 2, deploymentId: nil)
+
+        XCTAssertEqual(focus, WorkbenchBoardFocus(owner: "org", repo: "app", number: 2))
+        XCTAssertEqual(store.selectedRepoIds, [1])
+        XCTAssertEqual(store.filter, .running)
+    }
+
+    func testBoardRouteCanFocusIssueByDeployment() {
+        let store = WorkbenchStore()
+        store.payload = WorkbenchStoreTests.payload(
+            issues: [
+                WorkbenchStoreTests.issue(number: 2, title: "Running work", state: "open", hasActiveDeployment: true),
+            ],
+            deployments: [
+                WorkbenchStoreTests.deployment(id: 701, issueNumber: 2),
+            ]
+        )
+
+        let focus = store.applyBoardRoute(repoFullName: nil, issueNumber: nil, deploymentId: 701)
+
+        XCTAssertEqual(focus, WorkbenchBoardFocus(owner: "org", repo: "app", number: 2))
+        XCTAssertEqual(store.selectedRepoIds, [1])
+        XCTAssertEqual(store.filter, .running)
+    }
+
     private static func payload(
         drafts: [Draft] = [],
-        issues: [WorkbenchIssueSummary]
+        issues: [WorkbenchIssueSummary],
+        deployments: [ActiveDeployment] = []
     ) -> WorkbenchPayload {
         WorkbenchPayload(
             drafts: drafts,
@@ -67,7 +103,7 @@ final class WorkbenchStoreTests: XCTestCase {
                     issuesFromCache: false,
                     issuesCachedAt: nil,
                     priorities: [],
-                    deployments: [],
+                    deployments: deployments,
                     recentCompletions: [],
                     webhookEvents: [],
                     prReviews: [],
@@ -100,6 +136,33 @@ final class WorkbenchStoreTests: XCTestCase {
             hasActiveDeployment: hasActiveDeployment,
             htmlUrl: "https://github.com/org/app/issues/\(number)",
             authorLogin: "tester"
+        )
+    }
+
+    private static func deployment(id: Int, issueNumber: Int) -> ActiveDeployment {
+        ActiveDeployment(
+            id: id,
+            repoId: 1,
+            issueNumber: issueNumber,
+            targetType: .issue,
+            targetNumber: issueNumber,
+            agent: .codex,
+            terminalBackend: .ttyd,
+            triggeredBy: .manual,
+            parentDeploymentId: nil,
+            webhookDepth: 0,
+            idleSince: nil,
+            branchName: "issue-\(issueNumber)-running-work",
+            workspaceMode: .worktree,
+            workspacePath: "/tmp/app/.worktrees/issue-\(issueNumber)",
+            linkedPrNumber: nil,
+            state: .active,
+            launchedAt: "2026-05-29T00:00:00.000Z",
+            endedAt: nil,
+            ttydPort: 7701,
+            ttydPid: 1234,
+            owner: "org",
+            repoName: "app"
         )
     }
 }

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -21,6 +21,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
 
     // Settings controls.
     var defaultLaunchAgent = "claude"
+    var reviewDetailMobileWriteActionsEnabled = false
 
     private let stateLock = NSLock()
     private var lastLaunchPayload: [String: Any] = [:]
@@ -30,6 +31,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
     private var lastRepoLabelsPayload: [String: Any] = [:]
     private var lastIssueLabelPayload: [String: Any] = [:]
     private var lastPullLabelPayload: [String: Any] = [:]
+    private var lastReviewRunActionPayload: [String: Any] = [:]
 
     var lastLaunchAgent: String? {
         stateLock.lock()
@@ -77,6 +79,12 @@ final class MockIssueCTLServer: @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         return lastPullLabelPayload["action"] as? String
+    }
+
+    var lastReviewRunActionMode: String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return lastReviewRunActionPayload["mode"] as? String
     }
 
     // Fixture state for extended test coverage.
@@ -153,6 +161,16 @@ final class MockIssueCTLServer: @unchecked Sendable {
     func seedPullRequestDeployment() {
         hiddenPreviewIssueNumbers = []
         activeDeployments = [pullRequestDeployment(number: 7)]
+    }
+
+    func seedPtyBridgeDeployment() {
+        hiddenPreviewIssueNumbers = []
+        var deployment = deployment(issueNumber: 101)
+        deployment["id"] = 9201
+        deployment["terminal_backend"] = "pty_bridge"
+        deployment["ttyd_port"] = NSNull()
+        deployment["ttyd_pid"] = NSNull()
+        activeDeployments = [deployment]
     }
 
     func seedMixedActivityDeployments() {
@@ -486,6 +504,84 @@ final class MockIssueCTLServer: @unchecked Sendable {
                 ],
             ]
 
+        case ("GET", "/api/v1/webhooks/events"):
+            body = [
+                "events": [
+                    webhookEvent(targetType: "issue", targetNumber: 101),
+                    webhookEvent(targetType: "pr", targetNumber: 7),
+                ],
+                "repos": [["id": 1, "full_name": "org/alpha"]],
+                "filters": [
+                    "limit": 50,
+                ],
+                "summary": [
+                    "count": 2,
+                    "latest_received_at": 1_777_440_000,
+                    "latest_received_at_iso": isoDate,
+                    "result_counts": ["scheduled": 2],
+                ],
+                "from_cache": false,
+                "cached_at": NSNull(),
+            ]
+
+        case ("GET", "/api/v1/repos/org/alpha/webhook/events"):
+            let isPRTarget = rawPath.contains("targetType=pr")
+            let targetNumber = isPRTarget ? 7 : 101
+            body = [
+                "events": [
+                    webhookEvent(targetType: isPRTarget ? "pr" : "issue", targetNumber: targetNumber),
+                ],
+                "repos": [["id": 1, "full_name": "org/alpha"]],
+                "filters": [
+                    "repo": "org/alpha",
+                    "target_type": isPRTarget ? "pr" : "issue",
+                    "target_number": targetNumber,
+                    "limit": 5,
+                ],
+                "summary": [
+                    "count": 1,
+                    "latest_received_at": 1_777_440_000,
+                    "latest_received_at_iso": isoDate,
+                    "result_counts": ["scheduled": 1],
+                ],
+                "from_cache": false,
+                "cached_at": NSNull(),
+            ]
+
+        case ("GET", "/api/v1/repos/org/alpha/review-runs"):
+            body = [
+                "review_runs": [
+                    reviewRun(prNumber: 7, status: "reserved"),
+                ],
+                "from_cache": false,
+                "cached_at": NSNull(),
+            ]
+
+        case ("GET", "/api/v1/pr-reviews"):
+            body = [
+                "review_runs": [
+                    reviewRun(prNumber: 7, status: "reserved"),
+                ],
+                "from_cache": false,
+                "cached_at": NSNull(),
+            ]
+
+        case ("GET", "/api/v1/pr-reviews/39507"):
+            body = reviewRunDetail(id: 39507, deploymentId: 9507)
+
+        case ("POST", "/api/v1/pr-reviews/39507/actions"):
+            let payload = jsonBody(from: request)
+            stateLock.lock()
+            lastReviewRunActionPayload = payload
+            stateLock.unlock()
+            body = [
+                "success": true,
+                "review_id": 39507,
+                "intent_id": 99,
+                "mode": payload["mode"] as? String ?? "retry",
+                "message": "Review action queued.",
+            ]
+
         case ("GET", "/api/v1/workbench"):
             body = workbenchPayload()
 
@@ -499,6 +595,9 @@ final class MockIssueCTLServer: @unchecked Sendable {
             body = ["previews": sessionPreviews()]
 
         case ("GET", "/api/v1/sessions/overview"):
+            if failDeployments {
+                return http(status: 500, json: ["error": "sessions unavailable"])
+            }
             body = sessionsOverviewPayload()
 
         case ("GET", "/api/v1/drafts"):
@@ -1020,6 +1119,148 @@ final class MockIssueCTLServer: @unchecked Sendable {
         ]
     }
 
+    private func webhookEvent(targetType: String, targetNumber: Int) -> [String: Any] {
+        [
+            "id": targetType == "pr" ? 77 : 76,
+            "delivery_id": "mock-\(targetType)-delivery",
+            "repo_id": 1,
+            "repo_full_name": "org/alpha",
+            "owner": "org",
+            "repo_name": "alpha",
+            "event_type": targetType == "pr" ? "pull_request" : "issues",
+            "action": "labeled",
+            "sender_login": "alice",
+            "target_type": targetType,
+            "target_number": targetNumber,
+            "target_label": targetType == "pr" ? "PR #\(targetNumber)" : "Issue #\(targetNumber)",
+            "payload_json": NSNull(),
+            "received_at": 1_777_440_000,
+            "received_at_iso": isoDate,
+            "intent_id": 88,
+            "result": "scheduled",
+            "result_detail": "Automation intent queued for worker debounce.",
+            "action_id": NSNull(),
+            "intent": [
+                "id": 88,
+                "status": "scheduled",
+                "target_type": targetType,
+                "target_number": targetNumber,
+                "target_label": targetType == "pr" ? "PR #\(targetNumber)" : "Issue #\(targetNumber)",
+                "first_signal_at": 1_777_440_000,
+                "first_signal_at_iso": isoDate,
+                "last_signal_at": 1_777_440_000,
+                "last_signal_at_iso": isoDate,
+                "scheduled_at": 1_777_440_060,
+                "scheduled_at_iso": isoDate,
+                "processing_started_at": NSNull(),
+                "processing_started_at_iso": NSNull(),
+                "lease_expires_at": NSNull(),
+                "lease_expires_at_iso": NSNull(),
+                "resolved_at": NSNull(),
+                "resolved_at_iso": NSNull(),
+                "generation": 1,
+                "requested_agent": "codex",
+                "review_mode": targetType == "pr" ? "retry" : NSNull(),
+                "signal_count": 1,
+                "deployment_id": NSNull(),
+                "failure_reason": NSNull(),
+            ],
+        ]
+    }
+
+    private func reviewRun(prNumber: Int, status: String) -> [String: Any] {
+        [
+            "id": 901,
+            "repo_id": 1,
+            "repo_full_name": "org/alpha",
+            "owner": "org",
+            "repo_name": "alpha",
+            "pr_number": prNumber,
+            "deployment_id": NSNull(),
+            "started_head_sha": "abc123",
+            "completed_head_sha": NSNull(),
+            "review_base_sha": "base123",
+            "reviewed_from_sha": NSNull(),
+            "reviewed_to_sha": "abc123",
+            "head_repo_full_name": "org/alpha",
+            "head_ref": "feature-\(prNumber)",
+            "status": status,
+            "triggered_by": "webhook",
+            "result": [:],
+            "result_json": NSNull(),
+            "summary": "Review request is waiting for the automation worker.",
+            "finding_count": NSNull(),
+            "range_label": "latest head",
+            "detail_href": "/pulls/org/alpha/\(prNumber)/reviews/901",
+            "started_at": 1_777_440_000,
+            "started_at_iso": isoDate,
+            "completed_at": NSNull(),
+            "completed_at_iso": NSNull(),
+            "deployment": NSNull(),
+        ]
+    }
+
+    private func reviewRunDetail(id: Int, deploymentId: Int) -> [String: Any] {
+        [
+            "review": [
+                "id": id,
+                "repo_id": 1,
+                "repo_full_name": "org/alpha",
+                "owner": "org",
+                "repo_name": "alpha",
+                "pr_number": 7,
+                "deployment_id": deploymentId,
+                "started_head_sha": "abc123",
+                "completed_head_sha": NSNull(),
+                "review_base_sha": "base123",
+                "reviewed_from_sha": "abc123",
+                "reviewed_to_sha": "def456",
+                "head_repo_full_name": "org/alpha",
+                "head_ref": "feature-7",
+                "status": "failed",
+                "triggered_by": "webhook",
+                "result": ["summary": "Review needs a retry"],
+                "result_json": NSNull(),
+                "summary": "Review needs a retry",
+                "finding_count": NSNull(),
+                "range_label": "abc123..def456",
+                "detail_href": "/reviews/\(id)",
+                "started_at": 1_777_800_000,
+                "started_at_iso": isoDate,
+                "completed_at": NSNull(),
+                "completed_at_iso": NSNull(),
+                "deployment": NSNull(),
+            ],
+            "repo": ["id": 1, "full_name": "org/alpha", "owner": "org", "name": "alpha"],
+            "deployment": NSNull(),
+            "lineage": [],
+            "diagnostics": [
+                "events": [],
+                "filters": ["deployment_id": deploymentId, "target_type": "pr", "target_number": 7, "limit": 20],
+                "summary": ["count": 0, "level_counts": [:], "latest_timestamp": NSNull(), "latest_timestamp_iso": NSNull()],
+            ],
+            "findings": [],
+            "banners": [],
+            "metadata": ["current_review_preamble": NSNull(), "trigger_event": NSNull()],
+            "actions": [
+                "can_retry": true,
+                "can_full_rerun": true,
+                "disabled_reason": reviewDetailMobileWriteActionsEnabled ? NSNull() : ("Server disabled mobile review write actions." as Any),
+                "mobile_write_actions_enabled": reviewDetailMobileWriteActionsEnabled,
+            ],
+            "links": [
+                "github_pr": "https://github.com/org/alpha/pull/7",
+                "github_review": NSNull(),
+                "github_review_files": "https://github.com/org/alpha/pull/7/files",
+                "workbench": "/workbench?repo=org%2Falpha",
+                "repo_settings": "/repos/org/alpha/settings",
+                "sessions": "/sessions?tab=reviews",
+                "webhook_logs": "/logs/webhooks",
+                "diagnostics_cli": "pnpm --dir packages/cli exec issuectl diag show --pr org/alpha#7",
+            ],
+        ]
+    }
+
     private func workbenchDeployment(_ deployment: [String: Any]) -> [String: Any] {
         [
             "id": deployment["id"] ?? 0,
@@ -1190,6 +1431,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
             "childDeploymentCount": 0,
             "webhookDepth": deployment["webhook_depth"] ?? 0,
             "terminalReason": deployment["terminal_reason"] ?? NSNull(),
+            "terminalBackend": deployment["terminal_backend"] ?? NSNull(),
             "launchedAt": deployment["launched_at"] ?? isoDate,
             "endedAt": deployment["ended_at"] ?? NSNull(),
             "ttydPort": deployment["ttyd_port"] ?? NSNull(),

--- a/apple/IssueCTLUITests/IssueCTLUITests.swift
+++ b/apple/IssueCTLUITests/IssueCTLUITests.swift
@@ -28,6 +28,7 @@ final class IssueCTLUITests: XCTestCase {
         let app = launchApp(server: server)
 
         assertElement("today-create-issue-button", existsIn: app, timeout: 8)
+        assertElement("today-automation-feed-button", existsIn: app, timeout: 5)
         assertElement("today-metric-sessions", existsIn: app, timeout: 5)
         assertElement("today-metric-prs", existsIn: app, timeout: 5)
         assertElement("today-metric-issues", existsIn: app, timeout: 5)
@@ -46,6 +47,25 @@ final class IssueCTLUITests: XCTestCase {
         assertElement("issue-title-field", existsIn: app, timeout: 3)
         app.buttons["cancel-button"].tap()
         waitForNonexistence("issue-title-field", in: app)
+    }
+
+    @MainActor
+    func testAutomationFeedIsReachableFromTodayAndActiveTabs() {
+        let app = launchApp(server: server)
+
+        assertElement("today-automation-feed-button", existsIn: app, timeout: 8)
+        element("today-automation-feed-button", in: app).tap()
+        XCTAssertTrue(app.navigationBars["Automation Feed"].waitForExistence(timeout: 5), app.debugDescription)
+        assertElement("automation-feed-live-stream-status", existsIn: app, timeout: 5)
+        XCTAssertTrue(app.staticTexts["Webhook Events"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["Done"].tap()
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("sessions-automation-feed-button", existsIn: app, timeout: 5)
+        element("sessions-automation-feed-button", in: app).tap()
+        XCTAssertTrue(app.navigationBars["Automation Feed"].waitForExistence(timeout: 5), app.debugDescription)
+        assertElement("automation-feed-live-stream-status", existsIn: app, timeout: 5)
+        app.buttons["Done"].tap()
     }
 
     @MainActor
@@ -95,6 +115,7 @@ final class IssueCTLUITests: XCTestCase {
 
         tapMainTab("active-tab", label: "Active", in: app)
         assertElement("sessions-create-issue-button", existsIn: app, timeout: 5)
+        assertElement("sessions-automation-feed-button", existsIn: app)
         assertElement("sessions-search-button", existsIn: app)
         assertElement("sessions-refresh-button", existsIn: app)
     }

--- a/apple/IssueCTLUITests/IssueDetailActionTests.swift
+++ b/apple/IssueCTLUITests/IssueDetailActionTests.swift
@@ -185,6 +185,12 @@ final class IssueDetailActionTests: XCTestCase {
         tapElement("issue-auto-launch-label-button", in: app)
 
         XCTAssertTrue(app.staticTexts["Auto-launch label applied"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Automation queued"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(
+            app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "worker will launch after debounce")).firstMatch
+                .waitForExistence(timeout: 5),
+            app.debugDescription
+        )
         XCTAssertEqual(server.lastIssueLabelAction, "add")
     }
 

--- a/apple/IssueCTLUITests/PRBrowseTests.swift
+++ b/apple/IssueCTLUITests/PRBrowseTests.swift
@@ -69,6 +69,12 @@ final class PRBrowseTests: XCTestCase {
         tapElement("pr-auto-review-label-button", in: app)
 
         XCTAssertTrue(app.staticTexts["Auto-review label applied"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["Review automation queued"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(
+            app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "reserved this request")).firstMatch
+                .waitForExistence(timeout: 5),
+            app.debugDescription
+        )
         XCTAssertEqual(server.lastPullLabelAction, "add")
     }
 

--- a/apple/IssueCTLUITests/SessionManagementTests.swift
+++ b/apple/IssueCTLUITests/SessionManagementTests.swift
@@ -37,6 +37,25 @@ final class SessionManagementTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionControlsOpenTargetAutomationActivity() {
+        server.seedActiveDeployment()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        assertElement("session-reenter-terminal-9001", existsIn: app, timeout: 5)
+        element("session-controls-9001", in: app).tap()
+
+        assertElement("session-automation-activity-9001", existsIn: app, timeout: 5)
+        element("session-automation-activity-9001", in: app).tap()
+
+        XCTAssertTrue(app.navigationBars["Automation Activity"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["org/alpha"].waitForExistence(timeout: 5), app.debugDescription)
+        assertElement("repo-automation-activity-number-field", existsIn: app, timeout: 5)
+        XCTAssertTrue(app.staticTexts["Webhook Events"].waitForExistence(timeout: 5), app.debugDescription)
+        app.buttons["Done"].tap()
+    }
+
+    @MainActor
     func testSessionCardOmitsTerminalPreviewOutput() {
         server.seedActiveDeployment()
         let app = launchApp(server: server)
@@ -116,5 +135,66 @@ final class SessionManagementTests: XCTestCase {
 
         waitForNonexistence("session-reenter-terminal-9001", in: app, timeout: 5)
         assertElement("session-reenter-terminal-9101", existsIn: app, timeout: 5)
+    }
+
+    @MainActor
+    func testPtyBridgeSessionOffersWebWorkbenchHandoff() {
+        server.seedPtyBridgeDeployment()
+        let app = launchApp(server: server)
+
+        tapMainTab("active-tab", label: "Active", in: app)
+        XCTAssertTrue(app.staticTexts["PTY bridge"].waitForExistence(timeout: 8), app.debugDescription)
+        assertElement("session-web-workbench-9201", existsIn: app, timeout: 5)
+        element("session-web-workbench-9201", in: app).tap()
+
+        XCTAssertTrue(app.staticTexts["PTY bridge terminal"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertTrue(
+            app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "/workbench?deployment=9201")).firstMatch
+                .waitForExistence(timeout: 5),
+            app.debugDescription
+        )
+    }
+
+    @MainActor
+    func testReviewDetailExplainsDisabledMobileActionsWithWebFallback() {
+        server.seedPullRequestDeployment()
+        server.reviewDetailMobileWriteActionsEnabled = false
+        let app = launchApp(server: server)
+
+        openReviewDetail(runId: 39507, in: app)
+
+        XCTAssertTrue(app.staticTexts["Mobile write actions disabled"].waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(
+            app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", "Open the web review page")).firstMatch
+                .waitForExistence(timeout: 5),
+            app.debugDescription
+        )
+        XCTAssertFalse(app.buttons["review-run-retry-button"].isEnabled)
+        XCTAssertFalse(app.buttons["review-run-full-button"].isEnabled)
+    }
+
+    @MainActor
+    func testReviewDetailRetryActionSubmitsWhenMobileActionsEnabled() {
+        server.seedPullRequestDeployment()
+        server.reviewDetailMobileWriteActionsEnabled = true
+        let app = launchApp(server: server)
+
+        openReviewDetail(runId: 39507, in: app)
+        let retryButton = app.buttons["review-run-retry-button"]
+        XCTAssertTrue(retryButton.waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertTrue(retryButton.isEnabled, app.debugDescription)
+        retryButton.tap()
+
+        XCTAssertTrue(app.staticTexts["Retry requested"].waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertEqual(server.lastReviewRunActionMode, "retry")
+    }
+
+    @MainActor
+    private func openReviewDetail(runId: Int, in app: XCUIApplication) {
+        tapMainTab("active-tab", label: "Active", in: app)
+        tapElement("section-tab-reviews", in: app, timeout: 8)
+        let detailsButton = app.buttons.matching(NSPredicate(format: "label == %@", "Details")).firstMatch
+        XCTAssertTrue(detailsButton.waitForExistence(timeout: 8), "Missing review detail button for \(runId)\n\(app.debugDescription)")
+        detailsButton.tap()
     }
 }

--- a/docs/goals/ios-web-parity-conveyor/notes/T100-last-mile-ios-evidence.md
+++ b/docs/goals/ios-web-parity-conveyor/notes/T100-last-mile-ios-evidence.md
@@ -1,0 +1,33 @@
+# T100 Last-Mile iOS Evidence
+
+Date: 2026-06-02
+
+## Scope
+
+Recorded evidence for the fresh-worktree iOS last-mile parity pass on branch `codex/ios-web-parity-analysis-20260602`.
+
+This pass was Apple-only. No web/API package files changed, so the web checks from the plan were intentionally skipped.
+
+## Verification
+
+- PASS `IssueCTLTests`: 332 tests, 0 failures.
+- PASS `IssueCTLPreviewUITests/IssueCTLUITests`: 26 tests, 0 failures.
+- PASS `IssueCTLPreviewUITests/SessionManagementTests`: 9 tests, 0 failures.
+- PASS `IssueCTLPreviewUITests/PRBrowseTests`: 5 tests, 0 failures.
+- PASS `IssueCTLPreviewUITests/IssueDetailActionTests`: 8 tests, 0 failures.
+- PASS `IssueCTLTests/APIClientTests`: 32 tests, 0 failures.
+- PASS `IssueCTLTests/APIClientExtensionTests`: 46 tests, 0 failures.
+
+## Workflow Evidence
+
+- Cross-repo Board route context: `ViewLogicTests/testAppRouteParsesWorkbenchIssueQuery`, `ViewLogicTests/testAppRouteParsesWorkbenchDeploymentQuery`, `WorkbenchStoreTests/testBoardRouteSelectsRepoAndIssueFilter`, and `WorkbenchStoreTests/testBoardRouteCanFocusIssueByDeployment`.
+- Issue auto-launch label evidence: `IssueDetailActionTests/testIssueAutoLaunchLabelControlTogglesAutomationLabel` verifies the label control reaches the issue detail surface and shows automation evidence after toggling.
+- PR auto-review label evidence: `PRBrowseTests/testPRAutoReviewLabelControlTogglesAutomationLabel` verifies the PR label control reaches the PR detail surface and shows automation/review evidence after toggling.
+- Review-run write-action clarity: `SessionManagementTests/testReviewDetailExplainsDisabledMobileActionsWithWebFallback` and `SessionManagementTests/testReviewDetailRetryActionSubmitsWhenMobileActionsEnabled`.
+- PTY bridge handoff: `SessionManagementTests/testPtyBridgeSessionOffersWebWorkbenchHandoff` verifies PTY bridge sessions offer the web workbench handoff, while existing terminal tests keep native ttyd re-entry covered.
+- Automation activity outside Settings: `IssueCTLUITests/testAutomationFeedIsReachableFromTodayAndActiveTabs` and `SessionManagementTests/testSessionControlsOpenTargetAutomationActivity`.
+
+## Notes
+
+- `IssueCTLUITests`, `SessionManagementTests`, and `IssueDetailActionTests` exceeded the 120 second MCP call window, but their underlying `xcodebuild` processes completed successfully and were verified from their `.xcresult` bundles.
+- Xcode regenerated `apple/IssueCTL/Generated/AppVersion.swift` during verification; it was restored to the repository baseline after the test runs.

--- a/docs/goals/ios-web-parity-conveyor/state.yaml
+++ b/docs/goals/ios-web-parity-conveyor/state.yaml
@@ -164,3 +164,4 @@ tasks:
         - "Repo automation settings parity verified on main."
         - "Diagnostics timeline parity verified on main."
         - "PR review-session controls verified on main."
+        - "Last-mile iOS parity evidence recorded in docs/goals/ios-web-parity-conveyor/notes/T100-last-mile-ios-evidence.md after focused Apple verification on branch codex/ios-web-parity-analysis-20260602."

--- a/docs/superpowers/plans/2026-06-02-ios-web-parity-last-mile.md
+++ b/docs/superpowers/plans/2026-06-02-ios-web-parity-last-mile.md
@@ -1,0 +1,360 @@
+# iOS Web Parity Last-Mile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the iOS app from "mostly contract-complete" to operator-complete parity with the current web workbench, webhook automation, PR review, diagnostics, and session surfaces on `origin/main`.
+
+**Architecture:** Use the existing mobile REST contracts as the source of truth: `/api/v1/workbench`, `/api/v1/sessions/overview`, `/api/v1/webhooks/events`, `/api/v1/pr-reviews`, `/api/v1/diagnostics/**`, and repo webhook/label routes. Avoid new web APIs unless a native workflow cannot be expressed with current endpoints. Keep changes vertical: shared projection plus one user-visible iOS workflow plus focused tests per slice.
+
+**Tech Stack:** Swift 6, SwiftUI, URLSession async/await, XcodeGen project, Next.js App Router REST contracts, pnpm/Turborepo verification, GoalBuddy parent conveyor with depth-1 child boards.
+
+---
+
+## Analysis Summary
+
+The older parity notes are no longer an accurate baseline by themselves. On `origin/main` at `4afb3ec`, the web app already exposes the key mobile-friendly routes and the iOS shared layer already decodes most of them.
+
+Current web state:
+- Workbench modes are `Issues`, `Board`, `PRs`, `Workbench`, `Quick Create`, and `Settings` in `packages/web/components/workbench/WorkbenchShell.tsx`.
+- `GET /api/v1/workbench` returns repos, active deployments, previews, settings, health, user, drafts, issues, priorities, webhook events, PR reviews, and recent completions through `packages/web/lib/workbench-data.ts`.
+- Repo settings and webhook automation are REST-backed: repo PATCH can update automation and end disabled webhook sessions; webhook create/rotate/reinstall/ping and health are exposed under `/api/v1/repos/:owner/:repo/webhook`.
+- Webhook automation is asynchronous: GitHub webhook delivery records events, merges debounce intents, then a worker launches issue/PR sessions after label, repo setting, and safety gates.
+
+Current iOS state:
+- The iOS app already has Today, Board, Issues, PRs, Active, Settings, repo automation, automation feed, session diagnostics, PR review run detail, launch, terminal, issue actions, PR actions, drafts, parse, worktrees, and notifications.
+- Swift models already include `WorkbenchPayload`, `WorkbenchRepo`, `WorkbenchIssueSummary`, `WebhookAutomationHealth`, `WebhookEvent`, `ReviewRun`, `SessionsOverviewResponse`, and diagnostics.
+- Remaining gaps are last-mile workflow gaps, not foundational contract gaps: focused deep links, clearer async automation state, PTY bridge terminal expectations, review action flagging, stale comments/docs, and stronger live UI proof.
+
+## GoalBuddy Operating Plan
+
+Use a new parent conveyor board, not another broad parity board:
+
+- Parent: `docs/goals/ios-web-parity-last-mile/`
+- Child boards:
+  - `focused-deep-links`
+  - `automation-waiting-evidence`
+  - `review-and-pty-hardening`
+  - `final-live-qa`
+
+Board rules:
+- First task must be `prior_board_audit`, summarizing `ios-web-parity`, `ios-workbench-automation-parity`, `ios-web-parity-conveyor`, `workbench`, and `mac-ios-parity`, with `satisfied_on_main` and remaining gaps.
+- Second task must be `dirty_baseline_checkpoint`, confirming this fresh worktree is on `origin/main` and recording `git status --short --branch`.
+- Do not parallelize Apple workers until a Judge proves disjoint `allowed_files`. Most remaining work touches `ContentView`, shared models/API, UI tests, or mock server, so it is likely serial.
+- After at most two Scout/Judge/helper tasks, require a vertical Worker slice with user-visible UI and focused verification.
+- Final audit must include `explicit_deferrals`, `live_or_ui_evidence`, `known_red_tests`, and `merge_or_followup_status`.
+
+## Task 1: Focused iOS Route Context
+
+**Files:**
+- Modify: `apple/IssueCTL/App/ContentView.swift`
+- Modify: `apple/IssueCTL/Views/Workbench/BoardView.swift`
+- Modify: `apple/IssueCTL/ViewModels/WorkbenchStore.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Test: `apple/IssueCTLTests/WorkbenchStoreTests.swift`
+- Test: `apple/IssueCTLUITests/IssueCTLUITests.swift`
+- Test: `apple/IssueCTLUITests/SessionManagementTests.swift`
+
+- [x] **Step 1: Write route-context tests**
+
+Add tests proving that an incoming route context can select:
+- Board tab plus a repo/issue focus.
+- Active tab plus a deployment focus.
+- Active review tab plus a PR review focus.
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/WorkbenchStoreTests
+```
+
+Expected: new tests fail because `ContentView` currently preserves context but does not push Board/Sessions focus all the way through.
+
+- [x] **Step 2: Implement route context consumption**
+
+Thread route context from `ContentView` into `BoardView` and `SessionListView` using existing navigation paths and selection state. Keep this native and small: do not add a new router framework.
+
+Acceptance criteria:
+- `issuectl://board?repo=owner/name&issue=123` lands on Board with the repo/issue selected or opened.
+- `issuectl://sessions?deploymentId=701` lands on Active with deployment controls or diagnostics reachable.
+- `issuectl://review?id=9001` lands on Active reviews and opens/targets the review row.
+
+- [x] **Step 3: Verify focused routing**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/WorkbenchStoreTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueCTLUITests/testBoardTabShowsCrossRepoIssueQueueAndRunningFilter
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/SessionManagementTests
+```
+
+Expected: all focused route-context tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTL/App/ContentView.swift apple/IssueCTL/Views/Workbench/BoardView.swift apple/IssueCTL/ViewModels/WorkbenchStore.swift apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTLTests/WorkbenchStoreTests.swift apple/IssueCTLUITests/IssueCTLUITests.swift apple/IssueCTLUITests/SessionManagementTests.swift
+git commit -m "feat(ios): focus board and session deep links"
+```
+
+## Task 2: Automation Waiting Evidence
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Issues/IssueDetailView.swift`
+- Modify: `apple/IssueCTL/Views/PullRequests/PRDetailView.swift`
+- Modify: `apple/IssueCTL/Views/Settings/AutomationActivityRows.swift`
+- Modify: `apple/IssueCTLShared/Models/Repo.swift`
+- Test: `apple/IssueCTLTests/ModelDecodingTests.swift`
+- Test: `apple/IssueCTLUITests/IssueDetailActionTests.swift`
+- Test: `apple/IssueCTLUITests/PRBrowseTests.swift`
+- Test: `apple/IssueCTLUITests/Helpers/MockServer.swift`
+
+- [x] **Step 1: Write failing UI assertions**
+
+Add UI tests for the operator story:
+- Tapping `issuectl:auto-launch` on an issue shows a "waiting for webhook" or "automation queued" state.
+- Tapping `issuectl:auto-review` on a PR shows the same for PR review automation.
+- A consumed automation label is explained as intentional cleanup, not as automation being disabled.
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueDetailActionTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/PRBrowseTests
+```
+
+Expected: tests fail because current copy/actions do not fully explain debounce/intent/worker state.
+
+- [x] **Step 2: Surface webhook intent evidence**
+
+Use existing `webhookEvents` and `reviewRuns` APIs already available through `APIClient` to show recent target-scoped automation events near issue and PR automation controls.
+
+Acceptance criteria:
+- Issue detail can show latest target event for `issuectl:auto-launch`.
+- PR detail can show latest target event/review run for `issuectl:auto-review`.
+- Messages distinguish `label applied`, `intent queued`, `session launched`, `label consumed`, `skipped unsafe PR`, and `launch failed` where the current payload supports it.
+
+- [x] **Step 3: Verify automation evidence**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/ModelDecodingTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueDetailActionTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/PRBrowseTests
+```
+
+Expected: model decoding and UI automation evidence tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTL/Views/Issues/IssueDetailView.swift apple/IssueCTL/Views/PullRequests/PRDetailView.swift apple/IssueCTL/Views/Settings/AutomationActivityRows.swift apple/IssueCTLShared/Models/Repo.swift apple/IssueCTLTests/ModelDecodingTests.swift apple/IssueCTLUITests/IssueDetailActionTests.swift apple/IssueCTLUITests/PRBrowseTests.swift apple/IssueCTLUITests/Helpers/MockServer.swift
+git commit -m "feat(ios): explain automation webhook progress"
+```
+
+## Task 3: Review Run Actions And PR Session Clarity
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Modify: `apple/IssueCTLShared/Models/Repo.swift`
+- Test: `apple/IssueCTLTests/ModelDecodingTests.swift`
+- Test: `apple/IssueCTLUITests/SessionManagementTests.swift`
+- Test: `apple/IssueCTLUITests/Helpers/MockServer.swift`
+
+- [x] **Step 1: Write flag-state tests**
+
+Add tests covering both `mobileWriteActionsEnabled = true` and `false` in review detail payloads.
+
+Expected UI:
+- Enabled: retry/full rerun actions are active and submit to `/api/v1/pr-reviews/:id/actions`.
+- Disabled: the sheet states that write actions are disabled by the server and links/copies the web review page path.
+
+- [x] **Step 2: Harden PR review row explanations**
+
+Make session/review rows explain review statuses that are not simple active/completed: `reserved`, `launching`, `in_progress`, `failed`, `superseded`, `skipped`, and failed diagnostics.
+
+Acceptance criteria:
+- A skipped unsafe PR can be understood from iOS without opening the web app.
+- A superseded review due to label removal or automation disablement is visible.
+- Diagnostics entry points remain reachable from review runs with deployment IDs.
+
+- [x] **Step 3: Verify**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/ModelDecodingTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/SessionManagementTests
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTL/Views/Shared/ReviewRunDetailSheet.swift apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTLShared/Models/Repo.swift apple/IssueCTLTests/ModelDecodingTests.swift apple/IssueCTLUITests/SessionManagementTests.swift apple/IssueCTLUITests/Helpers/MockServer.swift
+git commit -m "feat(ios): clarify review run actions and states"
+```
+
+## Task 4: PTY Bridge Terminal Handoff
+
+**Files:**
+- Modify: `apple/IssueCTLShared/Models/Deployment.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionRowView.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Modify: `apple/IssueCTL/Views/Terminal/TerminalView.swift`
+- Test: `apple/IssueCTLTests/ModelDecodingTests.swift`
+- Test: `apple/IssueCTLUITests/SessionManagementTests.swift`
+
+- [x] **Step 1: Write terminal capability tests**
+
+Add tests for:
+- `ttyd` deployment with port opens native terminal.
+- `pty_bridge` deployment without `ttydPort` does not pretend native terminal is available.
+- `pty_bridge` row offers clear web workbench handoff/copy path.
+
+- [x] **Step 2: Implement operator-safe fallback**
+
+Do not implement native PTY WebSocket in this slice. Instead:
+- Keep native terminal for `ttyd`.
+- For `pty_bridge`, show a clear reason and an action to open/copy `/workbench?deployment=<id>` or the equivalent web path.
+- Keep diagnostics available for both terminal backends.
+
+- [x] **Step 3: Verify**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/ModelDecodingTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/SessionManagementTests
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTLShared/Models/Deployment.swift apple/IssueCTL/Views/Sessions/SessionRowView.swift apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTL/Views/Terminal/TerminalView.swift apple/IssueCTLTests/ModelDecodingTests.swift apple/IssueCTLUITests/SessionManagementTests.swift
+git commit -m "feat(ios): clarify pty bridge terminal handoff"
+```
+
+## Task 5: Automation Log Access Outside Settings
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Settings/AutomationFeedView.swift`
+- Modify: `apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift`
+- Modify: `apple/IssueCTL/Views/Today/TodayView.swift`
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Test: `apple/IssueCTLUITests/IssueCTLUITests.swift`
+- Test: `apple/IssueCTLUITests/SessionManagementTests.swift`
+- Test: `apple/IssueCTLUITests/Helpers/MockServer.swift`
+
+- [x] **Step 1: Write navigation tests**
+
+Add UI tests proving a user can reach webhook event/review-run history from Today and Active, not only by opening Settings.
+
+- [x] **Step 2: Add native entry points**
+
+Add lightweight navigation affordances:
+- Today: automation health/activity card opens global automation feed.
+- Active: review/session empty or summary state links to event/review history.
+- Keep Settings as the full management surface.
+
+- [x] **Step 3: Verify**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueCTLUITests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/SessionManagementTests
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTL/Views/Settings/AutomationFeedView.swift apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift apple/IssueCTL/Views/Today/TodayView.swift apple/IssueCTL/Views/Sessions/SessionListView.swift apple/IssueCTLUITests/IssueCTLUITests.swift apple/IssueCTLUITests/SessionManagementTests.swift apple/IssueCTLUITests/Helpers/MockServer.swift
+git commit -m "feat(ios): expose automation activity from main flows"
+```
+
+## Task 6: Stale Contract Cleanup
+
+**Files:**
+- Modify: `apple/IssueCTLShared/Services/APIClient.swift`
+- Modify: `apple/IssueCTLShared/Services/APIClient+Settings.swift`
+- Modify: `apple/IssueCTLTests/APIClientTests.swift`
+- Modify: `apple/IssueCTLTests/APIClientExtensionTests.swift`
+
+- [x] **Step 1: Remove stale comments**
+
+Update the comment around automation list endpoints that still says routes are fixture-driven until the web exposes native list routes. The web now exposes those routes.
+
+- [x] **Step 2: Add endpoint inventory assertions**
+
+Ensure tests cover:
+- `/api/v1/webhooks/events`
+- `/api/v1/repos/:owner/:repo/webhook/events`
+- `/api/v1/pr-reviews`
+- `/api/v1/repos/:owner/:repo/review-runs`
+- `/api/v1/repos/:owner/:repo/webhook/health`
+- `/api/v1/repos/:owner/:repo/webhook`
+
+- [x] **Step 3: Verify**
+
+Run:
+```bash
+xcodebuildmcp simulator test --only-testing IssueCTLTests/APIClientTests
+xcodebuildmcp simulator test --only-testing IssueCTLTests/APIClientExtensionTests
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apple/IssueCTLShared/Services/APIClient.swift apple/IssueCTLShared/Services/APIClient+Settings.swift apple/IssueCTLTests/APIClientTests.swift apple/IssueCTLTests/APIClientExtensionTests.swift
+git commit -m "test(ios): refresh automation API contract coverage"
+```
+
+## Task 7: Final Proof And Merge Conveyor
+
+**Files:**
+- Modify: `docs/goals/ios-web-parity-last-mile/notes/*`
+- Modify: `docs/goals/ios-web-parity-last-mile/state.yaml`
+
+- [x] **Step 1: Run focused Apple verification**
+
+Run:
+```bash
+xcodebuildmcp session_show_defaults
+xcodebuildmcp simulator test --only-testing IssueCTLTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueCTLUITests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/SessionManagementTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/PRBrowseTests
+xcodebuildmcp simulator test --only-testing IssueCTLPreviewUITests/IssueDetailActionTests
+```
+
+- [x] **Step 2: Run touched web/API checks if any route behavior changed**
+
+Run only if web/API files were changed:
+```bash
+pnpm --dir packages/web test -- app/api/v1/workbench/route.test.ts app/api/v1/webhooks/events/route.test.ts app/api/v1/pr-reviews/route.test.ts
+pnpm --dir packages/web typecheck
+pnpm --dir packages/web lint
+```
+
+- [x] **Step 3: Collect live or UI evidence**
+
+Record evidence for these workflows:
+- Cross-repo Board can be opened and focused by route context.
+- Issue auto-launch label shows queued/waiting/consumed evidence.
+- PR auto-review label shows queued/review/run evidence.
+- Review run detail explains write action availability.
+- PTY bridge sessions show correct handoff while `ttyd` sessions still open native terminal.
+- Automation activity is reachable from non-settings flows.
+
+- [ ] **Step 4: Open PR and monitor**
+
+Use the GitHub workflow, not another broad prep:
+```bash
+git status --short
+git push -u origin codex/ios-web-parity-last-mile
+```
+
+Then create a PR, wait for checks, address review, merge, and mark child boards `satisfied_on_main` after confirming `origin/main` contains the merged work.
+
+## Deferrals
+
+Do not include these in the first last-mile PR unless a Judge explicitly approves the expansion:
+- Native PTY bridge WebSocket terminal implementation.
+- Mobile fire/drop/replay controls for webhook intents.
+- A full web-style route system in iOS.
+- New REST contracts for data already covered by current endpoints.


### PR DESCRIPTION
## Summary
- Add route-context handling so iOS can focus Board/Sessions/Review surfaces from web-style setup links.
- Surface automation evidence in issue/PR label controls, review-run details, PTY bridge handoff, and non-Settings automation feed/activity entry points.
- Refresh automation API contract coverage and record last-mile parity evidence.

## Test Plan
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLTests (332 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLPreviewUITests/IssueCTLUITests (26 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLPreviewUITests/SessionManagementTests (9 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLPreviewUITests/PRBrowseTests (5 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLPreviewUITests/IssueDetailActionTests (8 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLTests/APIClientTests (32 passed)
- [x] xcodebuildmcp test_sim --only-testing:IssueCTLTests/APIClientExtensionTests (46 passed)
- [x] git diff --check

## Notes
- Web/package checks were skipped because this branch only changes Apple client and docs files.
- Some UI suites exceeded the MCP call timeout, then completed successfully; results were verified from their xcresult bundles.
