### PR TITLE
Carry forward iOS parity cleanup

### DIFF
--- a/apple/IssueCTL/Views/Sessions/SessionListView.swift
+++ b/apple/IssueCTL/Views/Sessions/SessionListView.swift
@@ -39,6 +39,7 @@ struct SessionListView: View {
     @State private var selectedTrigger: SessionsOverviewTriggerFilter = .all
     @State private var selectedReviewStatus: ReviewRunStatusFilter = .all
     @State private var showFiltersSheet = false
+    @State private var streamRefreshCoalescer = RefreshCoalescer()
     @FocusState private var isSearchFocused: Bool
 
     private let refreshTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
@@ -225,6 +226,9 @@ struct SessionListView: View {
             }
             .task {
                 await streamSessionUpdates()
+            }
+            .onDisappear {
+                streamRefreshCoalescer.cancel()
             }
             .onReceive(refreshTimer) { _ in
                 guard terminalPresentation == nil else { return }
@@ -646,7 +650,9 @@ struct SessionListView: View {
                 while !Task.isCancelled {
                     _ = try await task.receive()
                     guard terminalPresentation == nil else { continue }
-                    await load(includeRepos: false)
+                    streamRefreshCoalescer.schedule {
+                        await load(includeRepos: false)
+                    }
                 }
             } catch {
                 try? await Task.sleep(for: .seconds(5))
@@ -722,6 +728,29 @@ struct SessionListView: View {
 private struct TerminalPresentation: Identifiable {
     let id = UUID()
     let deployment: ActiveDeployment
+}
+
+@MainActor
+final class RefreshCoalescer {
+    private var pendingTask: Task<Void, Never>?
+
+    func schedule(after delay: Duration = .milliseconds(350), action: @escaping @MainActor () async -> Void) {
+        pendingTask?.cancel()
+        pendingTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await action()
+        }
+    }
+
+    func cancel() {
+        pendingTask?.cancel()
+        pendingTask = nil
+    }
 }
 
 private struct RepoAutomationActivityTarget: Identifiable {
@@ -1750,7 +1779,7 @@ private struct DiagnosticEventCard: View {
     }
 }
 
-private let mobileDiagnosticsDependencyMessage = "Live mobile diagnostics require the structured /api/v1/diagnostics/deployments/:id endpoint from issue #546. This iOS browser is wired for that JSON API and does not scrape dashboard HTML."
+private let mobileDiagnosticsDependencyMessage = "Live mobile diagnostics use the structured /api/v1/diagnostics/deployments/:id endpoint. This iOS browser is wired for that JSON API and does not scrape dashboard HTML."
 
 private func diagnosticsErrorMessage(_ error: Error) -> String {
     if case APIError.serverError(let code, _) = error, code == 404 {

--- a/apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift
+++ b/apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift
@@ -18,6 +18,7 @@ struct AdvancedSettingsView: View {
     @State private var idleThreshold = ""
     @State private var branchPattern = ""
     @State private var worktreeDir = ""
+    @State private var publicWebhookBaseURL = ""
     @State private var defaultRepoId = ""
     @State private var repos: [Repo] = []
 
@@ -31,6 +32,7 @@ struct AdvancedSettingsView: View {
             ("idle_threshold", idleThreshold),
             ("branch_pattern", branchPattern),
             ("worktree_dir", worktreeDir),
+            ("public_webhook_base_url", publicWebhookBaseURL),
             ("default_repo_id", defaultRepoId),
         ]
     }
@@ -129,6 +131,19 @@ struct AdvancedSettingsView: View {
                 }
 
                 Section {
+                    TextField("Public webhook base URL", text: $publicWebhookBaseURL)
+                        .keyboardType(.URL)
+                        .textContentType(.URL)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .accessibilityIdentifier("advanced-settings-public-webhook-base-url-field")
+                } header: {
+                    Text("Webhooks")
+                } footer: {
+                    Text("Base URL used when installing GitHub webhooks, such as https://hooks.example.com.")
+                }
+
+                Section {
                     Picker("Default Repository", selection: $defaultRepoId) {
                         Text("None").tag("")
                         ForEach(repos) { repo in
@@ -185,6 +200,7 @@ struct AdvancedSettingsView: View {
             idleThreshold = settings["idle_threshold"] ?? ""
             branchPattern = settings["branch_pattern"] ?? ""
             worktreeDir = settings["worktree_dir"] ?? ""
+            publicWebhookBaseURL = settings["public_webhook_base_url"] ?? ""
             defaultRepoId = settings["default_repo_id"] ?? ""
         } catch {
             errorMessage = error.localizedDescription

--- a/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
+++ b/apple/IssueCTL/Views/Settings/AutomationFeedView.swift
@@ -14,6 +14,7 @@ struct AutomationFeedView: View {
     @State private var reviewRunsResponse: ReviewRunsResponse?
     @State private var reviewDetailTarget: ReviewRunDetailTarget?
     @State private var isLiveStreamConnected = false
+    @State private var streamRefreshCoalescer = RefreshCoalescer()
 
     var body: some View {
         Form {
@@ -43,6 +44,9 @@ struct AutomationFeedView: View {
         }
         .refreshable {
             await loadFeed()
+        }
+        .onDisappear {
+            streamRefreshCoalescer.cancel()
         }
         .sheet(item: $reviewDetailTarget) { target in
             ReviewRunDetailSheet(reviewId: target.id)
@@ -193,7 +197,9 @@ struct AutomationFeedView: View {
                 }
                 while !Task.isCancelled {
                     _ = try await task.receive()
-                    await loadFeed()
+                    streamRefreshCoalescer.schedule {
+                        await loadFeed()
+                    }
                 }
             } catch {
                 isLiveStreamConnected = false

--- a/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
+++ b/apple/IssueCTL/Views/Settings/EditRepoSheet.swift
@@ -634,17 +634,67 @@ private struct WebhookStatusSummary: View {
     }
 
     private var icon: String {
-        if let health {
-            return health.isOK ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
-        }
-        return repo.webhookId == nil ? "dot.radiowaves.left.and.right" : "checkmark.circle.fill"
+        presentation.icon
     }
 
     private var tint: Color {
-        if let health {
-            return health.isOK ? .green : .orange
+        presentation.tint
+    }
+
+    private var presentation: WebhookHealthPresentation {
+        WebhookHealthPresentation(repoHasWebhook: repo.webhookId != nil, health: health)
+    }
+}
+
+enum WebhookHealthPresentation: Equatable {
+    case ok
+    case unknown
+    case warning
+    case error
+    case uninstalled
+
+    init(repoHasWebhook: Bool, health: WebhookAutomationHealth?) {
+        guard let health else {
+            self = repoHasWebhook ? .ok : .uninstalled
+            return
         }
-        return repo.webhookId == nil ? .secondary : .green
+
+        switch health.state {
+        case "ok":
+            self = .ok
+        case "unknown":
+            self = .unknown
+        case "error":
+            self = .error
+        default:
+            self = .warning
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .ok:
+            return "checkmark.circle.fill"
+        case .unknown:
+            return "questionmark.circle.fill"
+        case .warning, .error:
+            return "exclamationmark.triangle.fill"
+        case .uninstalled:
+            return "dot.radiowaves.left.and.right"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .ok:
+            return .green
+        case .unknown, .uninstalled:
+            return .secondary
+        case .warning:
+            return .orange
+        case .error:
+            return .red
+        }
     }
 }
 

--- a/apple/IssueCTLShared/Services/APIClient.swift
+++ b/apple/IssueCTLShared/Services/APIClient.swift
@@ -484,8 +484,6 @@ final class APIClient {
     }
 
     func deploymentDiagnostics(deploymentId: Int, limit: Int = 50) async throws -> DeploymentDiagnosticsResponse {
-        // Depends on the mobile diagnostics API from issue #546. This client
-        // intentionally targets structured JSON instead of scraping web HTML.
         let safeLimit = max(1, min(200, limit))
         let (data, _) = try await request(path: "/api/v1/diagnostics/deployments/\(deploymentId)?limit=\(safeLimit)")
         return try decoder.decode(DeploymentDiagnosticsResponse.self, from: data)

--- a/apple/IssueCTLTests/APIClientExtensionTests.swift
+++ b/apple/IssueCTLTests/APIClientExtensionTests.swift
@@ -54,7 +54,7 @@ final class APIClientExtensionTests: XCTestCase {
             XCTAssertEqual(request.httpMethod, "GET")
 
             return (self.makeResponse(url: request.url!), """
-            {"settings":{"launch_agent":"codex","cache_ttl":"300","worktree_dir":"/tmp/issuectl"}}
+            {"settings":{"launch_agent":"codex","cache_ttl":"300","worktree_dir":"/tmp/issuectl","public_webhook_base_url":"https://hooks.example.test"}}
             """.data(using: .utf8)!)
         }
 
@@ -63,6 +63,7 @@ final class APIClientExtensionTests: XCTestCase {
         XCTAssertEqual(settings["launch_agent"], "codex")
         XCTAssertEqual(settings["cache_ttl"], "300")
         XCTAssertEqual(settings["worktree_dir"], "/tmp/issuectl")
+        XCTAssertEqual(settings["public_webhook_base_url"], "https://hooks.example.test")
     }
 
     @MainActor
@@ -75,6 +76,7 @@ final class APIClientExtensionTests: XCTestCase {
             let json = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
             XCTAssertEqual(json["launch_agent"] as? String, "claude")
             XCTAssertEqual(json["cache_ttl"] as? String, "600")
+            XCTAssertEqual(json["public_webhook_base_url"] as? String, "https://hooks.example.test")
 
             return (self.makeResponse(url: request.url!), """
             {"success":true,"error":null}
@@ -84,6 +86,7 @@ final class APIClientExtensionTests: XCTestCase {
         let response = try await client.updateSettings([
             "launch_agent": "claude",
             "cache_ttl": "600",
+            "public_webhook_base_url": "https://hooks.example.test",
         ])
 
         XCTAssertTrue(response.success)

--- a/apple/IssueCTLTests/ViewLogicTests.swift
+++ b/apple/IssueCTLTests/ViewLogicTests.swift
@@ -189,6 +189,42 @@ final class ViewLogicTests: XCTestCase {
         XCTAssertNil(webhookReceiverURL(publicBaseURL: nil, repoId: 42))
     }
 
+    func testWebhookUnknownHealthPresentationIsDistinct() {
+        let health = WebhookAutomationHealth(
+            state: "unknown",
+            summary: "GitHub hook inspection unavailable",
+            detail: nil,
+            recovery: nil,
+            expectedUrl: nil,
+            hookId: nil,
+            githubUrl: nil,
+            latestDelivery: nil
+        )
+
+        let presentation = WebhookHealthPresentation(repoHasWebhook: true, health: health)
+
+        XCTAssertEqual(presentation, .unknown)
+        XCTAssertEqual(presentation.icon, "questionmark.circle.fill")
+    }
+
+    func testWebhookErrorHealthPresentationUsesErrorTint() {
+        let health = WebhookAutomationHealth(
+            state: "error",
+            summary: "Latest webhook delivery failed",
+            detail: nil,
+            recovery: nil,
+            expectedUrl: nil,
+            hookId: nil,
+            githubUrl: nil,
+            latestDelivery: nil
+        )
+
+        let presentation = WebhookHealthPresentation(repoHasWebhook: true, health: health)
+
+        XCTAssertEqual(presentation, .error)
+        XCTAssertEqual(presentation.icon, "exclamationmark.triangle.fill")
+    }
+
     func testAutomationLabelCheckMessageReportsMissingLabels() {
         let labels = [
             GitHubLabel(name: "issuectl:auto-launch", color: "2f81f7", description: nil),

--- a/apple/IssueCTLUITests/Helpers/MockServer.swift
+++ b/apple/IssueCTLUITests/Helpers/MockServer.swift
@@ -381,6 +381,7 @@ final class MockIssueCTLServer: @unchecked Sendable {
                 "launch_agent": defaultLaunchAgent,
                 "claude_extra_args": "--dangerously-skip-permissions",
                 "codex_extra_args": "",
+                "public_webhook_base_url": "https://hooks.example.test",
             ]]
 
         case ("GET", "/api/v1/repos"):

--- a/apple/IssueCTLUITests/SettingsTests.swift
+++ b/apple/IssueCTLUITests/SettingsTests.swift
@@ -58,6 +58,21 @@ final class SettingsTests: XCTestCase {
     }
 
     @MainActor
+    func testAdvancedSettingsShowsPublicWebhookBaseURL() {
+        let app = launchApp(server: server)
+
+        openSettingsFromToday(in: app)
+        app.buttons["Agent Harness & Defaults"].tap()
+        XCTAssertTrue(app.navigationBars["Agent Harness & Defaults"].waitForExistence(timeout: 5), app.debugDescription)
+
+        revealElement("advanced-settings-public-webhook-base-url-field", in: app)
+        XCTAssertEqual(
+            element("advanced-settings-public-webhook-base-url-field", in: app).value as? String,
+            "https://hooks.example.test"
+        )
+    }
+
+    @MainActor
     func testRepoEditorShowsAutomationWebhookAndLabelControls() {
         let app = launchApp(server: server)
 

--- a/docs/goals/ios-parity-next-tranche/goal.md
+++ b/docs/goals/ios-parity-next-tranche/goal.md
@@ -1,0 +1,112 @@
+# iOS Parity Next Tranche
+
+## Objective
+
+Close the remaining current-main iOS parity gaps after the completed iOS/web parity conveyor: route-focused Board/Sessions/Review navigation, public webhook base URL editing, webhook health clarity, stream refresh coalescing, and any small workbench-first-read consistency work that a Judge approves as safe.
+
+## Original Request
+
+"OK, set this up."
+
+Context: the prior request asked for a fresh worktree, a deep analysis of the web app, webhooks, dashboard/workbench interface, previous sessions, GoalBuddy usage, and a detailed plan to bring the iOS app up to date with current web behavior.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: issuectl maintainers and iOS users
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: current-main iOS closes every real gap listed in `docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md`, passes focused Apple/web/core verification, records simulator or UI evidence for visible changes, and a final Judge/PM audit maps receipts back to the tranche oracle.
+- Goal oracle: a source-backed current-main gap matrix plus verified implementation receipts proving Board/Sessions/Review routes focus correctly, webhook base URL and health states are handled on iOS, stream refreshes are not bursty, and any deferred Today/Issues workbench consistency is explicitly justified.
+- Likely misfire: reimplementing already-merged workbench, repo automation, diagnostics, or PR review APIs because an older dirty checkout or stale board made iOS look further behind than `origin/main`.
+- Blind spots considered: stale root checkout drift, completed-board drift, missing `packages/web/node_modules` in fresh worktrees, Xcode simulator availability, UI test reliability for deep links, webhook health states that are unknown rather than unhealthy, and low-priority terminal backend override parity.
+- Existing plan facts: use `docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md` as the plan artifact; start from `origin/main` at `86248bc` or newer; do not continue the completed `ios-web-parity-conveyor` board.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A fresh origin/main-based worktree records a source-backed current-main gap matrix, implements the Judge-selected safe vertical slices from docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md, passes focused and final verification, and produces simulator/UI evidence for route and settings behavior before a final audit records full_outcome_complete: true.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Start with read-only current-main reconciliation and a gap matrix. Then a Judge must select the largest safe useful vertical slice with exact `allowed_files`, verification commands, and stop conditions. Expected first candidates are:
+
+1. Preserve and consume Board/Sessions/Review route context on iOS.
+2. Expose `public_webhook_base_url` editing and make `unknown` webhook health distinct.
+3. Coalesce automation stream refreshes.
+4. Conditionally share workbench issue summaries with Today/Issues only if the existing data flow can do so without a new app-wide state architecture.
+5. Remove stale comments/docs that imply automation endpoints are fixture-driven.
+
+Do not stop after the first slice if safe local work remains.
+
+## Non-Negotiable Constraints
+
+- Use a fresh worktree based on `origin/main`; record the SHA before implementation and before final completion.
+- Treat `/Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601` as the setup worktree unless the PM records a newer execution worktree.
+- Do not overwrite or revert unrelated user changes from `/Users/neonwatty/Desktop/issuectl`.
+- Do not reimplement already-merged workbench, repo automation settings, diagnostics, PR review runs, or sessions overview APIs.
+- Follow `CLAUDE.md` and `AGENTS.md`; use diagnostics-first debugging for launch/session/ttyd/workbench failures.
+- Use existing SwiftUI, APIClient, model decoding, mock server, and test patterns.
+- Use `rg` for source search and `apply_patch` for manual edits.
+- Keep Worker packages bounded, reversible, and verified.
+- Parallel Workers require disjoint worktrees and disjoint `allowed_files`.
+- If web tests are required in a fresh worktree, install dependencies or record the missing dependency as explicit verification setup, not a pass.
+
+## Stop Rule
+
+Stop only when a final audit proves the full tranche outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if safe local Worker work can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+Do not create one Worker/Judge pair per repeated helper or cosmetic cleanup. Put same-shape route, settings, or stream-refresh work into coherent vertical packages and review the package as a whole.
+
+If a slice needs owner input, credentials, production access, destructive operations, or policy decisions, mark that exact slice blocked with a receipt, create the smallest safe local follow-up, and continue all local non-destructive work that can still move the goal toward completion.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+The Judge should reject helper-only slices when enough scaffolding exists for visible iOS behavior. The first implementation package should ideally produce a user-visible improvement with tests.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/ios-parity-next-tranche/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/ios-parity-next-tranche/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the intake: original request, input shape, authority, proof, blind spots, existing plan facts, and likely misfire.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. Review at phase, risk, rejected-verification, ambiguity, or final-completion boundaries.
+11. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md
@@ -1,0 +1,104 @@
+# T001 Current Main Gap Matrix
+
+## Baseline
+
+- Worktree: `/Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601`
+- Branch: `codex/ios-web-parity-plan-20260601`
+- HEAD: `86248bc06cdae7725673b41960a2e66c264b94a5`
+- HEAD summary: `86248bc Merge pull request #582 from mean-weasel/codex/ios-workbench-api-parity-20260531`
+- `git merge-base --is-ancestor HEAD origin/main`: pass
+- Dirty status: only setup artifacts are untracked: `docs/goals/ios-parity-next-tranche/` and `docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md`
+- Verification setup: `pnpm` is available at `9.15.4`, but neither root `node_modules` nor `packages/web/node_modules` exists in this fresh worktree.
+
+## Already Satisfied On Current Main
+
+- Workbench API and payload:
+  - `packages/web/app/api/v1/workbench/route.ts` returns `getWorkbenchPayload()`.
+  - `apple/IssueCTLShared/Services/APIClient.swift` has `workbench(refresh:maxAge:)`.
+  - `apple/IssueCTLShared/Models/Repo.swift` has `WorkbenchPayload` and `WorkbenchRepo`.
+- Native iOS Board:
+  - `apple/IssueCTL/Views/Workbench/BoardView.swift` renders the Board tab from `WorkbenchStore`.
+  - `apple/IssueCTL/ViewModels/WorkbenchStore.swift` computes draft/open/running/closed board counts and visible issues.
+- Repo automation settings:
+  - `apple/IssueCTLShared/Models/Repo.swift` decodes `autoLaunchIssues`, `autoReviewPrs`, agent fields, webhook fields, payload mode, and review preamble.
+  - `apple/IssueCTLShared/Services/APIClient+Settings.swift` sends the repo automation update fields.
+  - `apple/IssueCTL/Views/Settings/EditRepoSheet.swift` exposes automation toggles and webhook controls.
+- Sessions, diagnostics, and PR review runs:
+  - `apple/IssueCTLShared/Models/Repo.swift` has `SessionsOverviewResponse`, review run models, and diagnostics payloads.
+  - `apple/IssueCTLShared/Services/APIClient.swift` has sessions overview, webhook events, review runs, review actions, and diagnostics client calls.
+  - `apple/IssueCTL/Views/Sessions/SessionListView.swift` shows sessions, reviews, diagnostics, terminals, and review details.
+- Automation feeds:
+  - `apple/IssueCTL/Views/Settings/AutomationFeedView.swift` provides the global automation feed.
+  - `apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift` provides repo-scoped automation activity.
+- Web current behavior:
+  - `packages/web/components/workbench/WorkbenchShell.tsx` has Issues, Board, PRs, Workbench, Quick Create, and Settings modes.
+  - `packages/web/components/workbench/BoardFocus.tsx` provides the web cross-repo board with running-only and sort controls.
+  - `packages/web/app/api/v1/settings/route.ts` allows `public_webhook_base_url`.
+  - `packages/web/lib/webhook-health.ts` can return webhook health states `ok`, `warning`, `error`, or `unknown`.
+
+## Real Remaining Gaps
+
+1. Board route context is parsed but dropped:
+   - `apple/IssueCTL/Services/SetupLink.swift` parses `.board(repoFullName:deploymentId:)`.
+   - `apple/IssueCTL/App/ContentView.swift` handles `.board` by selecting the Board tab and setting `pendingRoute = nil`.
+   - `apple/IssueCTL/Views/Workbench/BoardView.swift` has no route binding and no deployment/repo focus helper.
+2. Sessions and review route context is parsed but dropped:
+   - `SetupLink.swift` parses `.sessions(repoFullName:)` and `.review(id:)`.
+   - `ContentView.swift` selects the Active tab but sets `pendingRoute = nil`.
+   - `SessionListView.swift` has no route binding and no route consumer for repo filters or review detail.
+3. Public webhook base URL is not editable in iOS:
+   - `packages/web/app/api/v1/settings/route.ts` allows `public_webhook_base_url`.
+   - `apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift` can PATCH arbitrary settings keys.
+   - `apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift` omits `public_webhook_base_url` from state, editable fields, load, and form UI.
+4. Webhook health `unknown` is not distinct in iOS:
+   - `packages/web/lib/webhook-health.ts` declares `unknown`.
+   - `apple/IssueCTLShared/Models/Repo.swift` stores `WebhookAutomationHealth.state` as `String`.
+   - `EditRepoSheet.swift` maps all non-`ok` states to the same warning icon and orange tint.
+5. Stream refreshes are uncoalesced:
+   - `SessionListView.streamSessionUpdates()` calls `load(includeRepos:false)` on every websocket message.
+   - Automation feed views have similar refresh-on-message patterns.
+6. Today/Issues first-read consistency remains a conditional follow-up:
+   - Board uses `/api/v1/workbench`.
+   - Today and Issues still have their own read paths.
+   - This should only be implemented if it fits existing view-model boundaries without creating a new app-wide state container.
+7. Cleanup should be precise:
+   - The prior plan mentioned an obsolete automation-list endpoint comment, but current source shows a diagnostics dependency comment in `APIClient.deploymentDiagnostics` and a user-facing fallback string in `SessionListView`.
+   - Because current main now has diagnostics routes, cleanup can update that wording, but it should not remove useful fallback behavior for older servers.
+
+## Not This Tranche
+
+- Replacing the web Workbench shell.
+- Rewriting iOS Board into the web horizontal column layout.
+- Adding new webhook server behavior.
+- Implementing automatic issue-to-PR-to-review chaining.
+- Exposing terminal backend override in iOS without an owner product decision; web restricts it to approved test repos.
+- Building target-wide standalone diagnostics outside the existing sessions overview/diagnostics surfaces.
+
+## Recommended First Vertical Slice
+
+Pick route-focus parity first. It is the largest safe user-visible slice with bounded files:
+
+- `apple/IssueCTL/App/ContentView.swift`
+- `apple/IssueCTL/Views/Workbench/BoardView.swift`
+- `apple/IssueCTL/ViewModels/WorkbenchStore.swift`
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTLTests/ViewLogicTests.swift`
+- `apple/IssueCTLTests/WorkbenchStoreTests.swift`
+
+Focused verification:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -quiet
+```
+
+Manual/simulator proof should later open:
+
+```bash
+xcrun simctl openurl booted "issuectl://workbench?repo=org%2Fapp&deployment=42"
+xcrun simctl openurl booted "issuectl://sessions?repo=org%2Fapp"
+xcrun simctl openurl booted "issuectl://reviews/16"
+```

--- a/docs/goals/ios-parity-next-tranche/notes/T002-judge-route-focus-slice.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T002-judge-route-focus-slice.md
@@ -1,0 +1,54 @@
+# T002 Judge Decision: Route-Focus Slice
+
+## Decision
+
+Proceed with route-focus parity as the first Worker package.
+
+## Rationale
+
+This is the largest safe useful first slice because:
+
+- It closes three real user-visible gaps: `/workbench?...`, `/sessions?...`, and `/reviews/...` are parsed but their route context is dropped.
+- It does not duplicate already-merged workbench/API/automation/diagnostics/PR review contracts.
+- It is bounded to SwiftUI routing, route consumers, and model/store helper tests.
+- It creates immediate behavior users can verify with simulator deep links.
+
+## Worker Objective
+
+Preserve Board/Sessions/Review route context in `ContentView`, pass the pending route to `BoardView` and `SessionListView`, and consume it to focus board repo/deployment, sessions repo filter, and review detail.
+
+## Allowed Files
+
+- `apple/IssueCTL/App/ContentView.swift`
+- `apple/IssueCTL/Views/Workbench/BoardView.swift`
+- `apple/IssueCTL/ViewModels/WorkbenchStore.swift`
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTLTests/ViewLogicTests.swift`
+- `apple/IssueCTLTests/WorkbenchStoreTests.swift`
+
+## Verify
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -quiet
+```
+
+If the simulator name is unavailable, list simulators and use the nearest available iPhone simulator without changing the test scope.
+
+## Stop If
+
+- Implementation needs files outside `allowed_files`.
+- The route consumer requires a new app-wide state architecture.
+- Current-main code already consumes one of these routes and the Scout evidence is stale.
+- Focused tests fail twice with the same failure.
+- UI route behavior cannot be represented without a product decision.
+
+## Deferred Candidates
+
+- Public webhook base URL editing and unknown-state health presentation should be the next likely slice after route-focus.
+- Stream refresh coalescing is safe but less user-visible.
+- Today/Issues workbench first-read consistency needs a separate Judge decision because it may imply larger architecture.
+- Terminal backend override remains deferred pending owner product decision.

--- a/docs/goals/ios-parity-next-tranche/notes/T003-route-focus-worker.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T003-route-focus-worker.md
@@ -1,0 +1,46 @@
+# T003 Route-Focus Worker Receipt
+
+## Result
+
+Done.
+
+## Changes
+
+- `ContentView` now preserves pending routes for `.board`, `.sessions`, and `.review` instead of dropping them after tab selection.
+- `BoardView` accepts a pending route binding and consumes `.board(repoFullName:deploymentId:)`.
+- `WorkbenchStore` now has helpers to match repo full names, apply route repo filters, and find board issue targets by deployment ID.
+- `SessionListView` accepts a pending route binding and consumes:
+  - `.sessions(repoFullName:)` by switching to Sessions and applying the matching repo filter.
+  - `.review(id:)` by switching to Reviews and opening `ReviewRunDetailSheet` for numeric review IDs.
+- `WorkbenchStoreTests` cover repo full-name matching and deployment-to-board issue targeting.
+
+## Verification
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -quiet
+```
+
+Observed output included:
+
+```text
+Testing started
+```
+
+with exit code `0`.
+
+Passed:
+
+```bash
+git diff --check
+```
+
+## Notes
+
+- `xcodebuild` regenerated `apple/IssueCTL/Generated/AppVersion.swift`, which is outside this Worker package. That generated file was restored to `HEAD` content after the test run so the final diff stays inside the approved route-focus scope.
+- No web/core tests were needed for this slice because no web/core contracts changed.

--- a/docs/goals/ios-parity-next-tranche/notes/T004-judge-next-webhook-settings-health.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T004-judge-next-webhook-settings-health.md
@@ -1,0 +1,52 @@
+# T004 Judge Review: Accept Route Focus, Select Webhook Settings/Health
+
+## Decision
+
+Accept T003 and continue.
+
+## Rationale
+
+T003 stayed inside its allowed files, passed focused verification, and restored the generated AppVersion drift caused by Xcode. The route-focus gap is not fully final-audited until simulator deep-link proof exists, but the implementation and focused tests are sufficient to move to the next safe local slice.
+
+The next largest safe useful slice is webhook settings/health clarity:
+
+- Web settings allow `public_webhook_base_url`.
+- Swift API settings can already PATCH arbitrary allowed keys.
+- iOS Advanced Settings does not expose the field.
+- Webhook health can be `unknown`, but iOS displays all non-`ok` states as warning.
+
+## Worker Objective
+
+Expose `public_webhook_base_url` in Advanced Settings and make webhook health `unknown` visually distinct from warning/error in repo automation status.
+
+## Allowed Files
+
+- `apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift`
+- `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- `apple/IssueCTLTests/ViewLogicTests.swift`
+
+## Verify
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+## Stop If
+
+- Implementation needs files outside the allowed list.
+- Web settings no longer allow `public_webhook_base_url`.
+- The unknown health state requires server behavior changes.
+- Focused tests fail twice with the same failure.
+
+## Remaining After This Slice
+
+- Stream refresh coalescing.
+- Conditional Today/Issues workbench-first-read decision.
+- Diagnostics wording cleanup.
+- Final simulator/UI proof and final audit.

--- a/docs/goals/ios-parity-next-tranche/notes/T005-webhook-settings-health-worker.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T005-webhook-settings-health-worker.md
@@ -1,0 +1,48 @@
+# T005 Webhook Settings and Health Worker Receipt
+
+## Result
+
+Done.
+
+## Changes
+
+- `AdvancedSettingsView` now exposes `public_webhook_base_url` as an editable Webhooks setting.
+- Settings API extension tests now prove the Swift client can read and PATCH `public_webhook_base_url`.
+- `EditRepoSheet` now uses `WebhookHealthPresentation` so `unknown` webhook health is distinct from warning/error:
+  - `unknown` uses `questionmark.circle.fill` and secondary tint.
+  - `error` uses red.
+  - `warning` uses orange.
+  - `ok` remains green.
+- `ViewLogicTests` cover the unknown-state presentation mapping.
+
+## Verification
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+Observed output included:
+
+```text
+Testing started
+```
+
+with exit code `0`.
+
+Passed:
+
+```bash
+git diff --check
+```
+
+## Notes
+
+- `xcodebuild` regenerated `apple/IssueCTL/Generated/AppVersion.swift`; it was restored to `HEAD` content after the test run because it is outside this Worker package.
+- No server changes were needed because the web settings route already allows `public_webhook_base_url` and webhook health already includes `unknown`.

--- a/docs/goals/ios-parity-next-tranche/notes/T006-judge-stream-coalescing.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T006-judge-stream-coalescing.md
@@ -1,0 +1,44 @@
+# T006 Judge Review: Stream Refresh Coalescing
+
+## Decision
+
+Accept T005 and continue with stream refresh coalescing.
+
+## Evidence
+
+- `SessionListView.streamSessionUpdates()` reloads sessions after every websocket message.
+- `AutomationFeedView.streamFeedUpdates()` reloads the full automation feed after every websocket message.
+- `RepoAutomationActivityView` does not subscribe to the websocket stream; it loads on task start, refresh, and filter/apply actions. It should not be edited for this slice.
+
+## Worker Objective
+
+Coalesce websocket-triggered refreshes in `SessionListView` and `AutomationFeedView` so bursts of webhook events schedule one delayed refresh instead of one full reload per message.
+
+## Allowed Files
+
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- `apple/IssueCTL/Views/Settings/AutomationFeedView.swift`
+
+## Verify
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+Run `git diff --check`.
+
+## Stop If
+
+- Implementation needs files outside the allowed list.
+- Coalescing requires changing APIClient stream behavior.
+- The coalescer prevents manual refresh or timer refresh from loading immediately.
+- Focused compile/test fails twice with the same failure.
+
+## Remaining After This Slice
+
+- Conditional Today/Issues workbench-first-read decision.
+- Diagnostics wording cleanup.
+- Final simulator/UI proof and final audit.

--- a/docs/goals/ios-parity-next-tranche/notes/T007-stream-coalescing-worker.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T007-stream-coalescing-worker.md
@@ -1,0 +1,43 @@
+# T007 Stream Coalescing Worker Receipt
+
+## Result
+
+Done.
+
+## Changes
+
+- Added a small `RefreshCoalescer` in the app target.
+- `SessionListView` now coalesces websocket-triggered session overview reloads instead of reloading once per stream message.
+- `AutomationFeedView` now coalesces websocket-triggered feed reloads instead of reloading once per stream message.
+- Manual refresh, refreshable gestures, and polling remain immediate.
+- Coalescers are canceled on view disappearance.
+
+## Verification
+
+Passed:
+
+```bash
+git diff --check
+```
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+Observed output included:
+
+```text
+Testing started
+```
+
+with exit code `0`.
+
+## Notes
+
+- `RepoAutomationActivityView` was intentionally not edited because it does not subscribe to the websocket stream.
+- `xcodebuild` regenerated `apple/IssueCTL/Generated/AppVersion.swift`; it was restored to `HEAD` content after the test run because it is outside this Worker package.

--- a/docs/goals/ios-parity-next-tranche/notes/T008-judge-cleanup-and-deferral.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T008-judge-cleanup-and-deferral.md
@@ -1,0 +1,49 @@
+# T008 Judge Review: Cleanup and Today/Issues Decision
+
+## Decision
+
+Accept T007 and continue with diagnostics wording cleanup.
+
+## Today/Issues Workbench-First-Read Decision
+
+Defer for this tranche.
+
+Evidence:
+
+- `TodayView` reads repos, active deployments, repo issues, and repo pulls through existing endpoint-specific flows.
+- `IssueListView` reads repos, active deployments, repo issues, drafts, priorities, filters, scene storage, search, offline sync state, launch targets, and detail navigation.
+- `BoardView` already owns the `/api/v1/workbench` first-read path through `WorkbenchStore`.
+
+Replacing Today/Issues first-read behavior safely would require a new shared mapping layer or app-level store decision, not a small continuation slice. That violates this tranche's constraint to avoid inventing a new global state container. The deferral is explicit and preserves current behavior.
+
+## Worker Objective
+
+Update current-main diagnostics wording so it no longer implies the mobile diagnostics endpoint is merely a future dependency from issue `#546`, while keeping fallback copy for older connected servers that return `404`.
+
+## Allowed Files
+
+- `apple/IssueCTLShared/Services/APIClient.swift`
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+
+## Verify
+
+```bash
+git diff --check
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientTests \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+## Stop If
+
+- Cleanup changes diagnostics behavior or endpoint paths.
+- Implementation needs files outside the allowed list.
+- Focused tests fail twice with the same failure.
+
+## Remaining After This Slice
+
+- Final focused/full verification.
+- Simulator/UI proof for route/settings behavior, or an explicit PM receipt if local app configuration blocks proof.
+- Final audit.

--- a/docs/goals/ios-parity-next-tranche/notes/T009-diagnostics-wording-worker.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T009-diagnostics-wording-worker.md
@@ -1,0 +1,41 @@
+# T009 Diagnostics Wording Worker Receipt
+
+## Result
+
+Done.
+
+## Changes
+
+- Removed the stale `issue #546` dependency comment from `APIClient.deploymentDiagnostics`.
+- Updated the diagnostics sheet explanatory copy to say live diagnostics use the structured `/api/v1/diagnostics/deployments/:id` endpoint, without implying that current-main support is still future work.
+- Preserved the existing endpoint path and `404` fallback behavior for older connected servers.
+
+## Verification
+
+Passed:
+
+```bash
+git diff --check
+```
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientTests \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+Observed output included:
+
+```text
+Testing started
+```
+
+with exit code `0`.
+
+## Notes
+
+- `xcodebuild` regenerated `apple/IssueCTL/Generated/AppVersion.swift`; it was restored to `HEAD` content after the test run because it is outside this Worker package.

--- a/docs/goals/ios-parity-next-tranche/notes/T010-verification-progress.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T010-verification-progress.md
@@ -1,0 +1,68 @@
+# T010 Verification Progress
+
+## Completed Verification
+
+Passed:
+
+```bash
+git diff --check
+```
+
+Passed focused tranche verification:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess \
+  -only-testing:IssueCTLTests/APIClientTests \
+  -quiet
+```
+
+Passed full unit-test target verification:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests \
+  -quiet
+```
+
+## Full Suite Attempt
+
+Attempted:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -quiet
+```
+
+Result: interrupted after about nine minutes because it repeatedly emitted:
+
+```text
+IDELaunchParametersSnapshot: The operation couldn't be completed. (DebuggerLLDB.DebuggerVersionStore.StoreError error 0.)
+IDELaunchParametersSnapshot: no debugger version
+```
+
+The command did not complete and therefore is not counted as proof.
+
+## Simulator/UI Proof Status
+
+XcodeBuildMCP listed all available simulators as `Shutdown`; no simulator was booted for interactive UI proof. Per the iOS debugger-agent workflow, the remaining route/settings walkthrough should run after a simulator is booted.
+
+Pending proof URLs/actions:
+
+```bash
+xcrun simctl openurl booted "issuectl://workbench?repo=org%2Fapp&deployment=42"
+xcrun simctl openurl booted "issuectl://sessions?repo=org%2Fapp"
+xcrun simctl openurl booted "issuectl://reviews/16"
+```
+
+Also pending: visual confirmation that Advanced Settings shows the Public webhook base URL field.
+
+## Current Completion Status
+
+Not complete. Implementation and unit/focused tests are strong, but final simulator/UI proof is still missing.

--- a/docs/goals/ios-parity-next-tranche/notes/T011-ui-proof-worker.md
+++ b/docs/goals/ios-parity-next-tranche/notes/T011-ui-proof-worker.md
@@ -1,0 +1,64 @@
+# T011 UI Proof Worker
+
+## Objective
+
+Add targeted UI proof for Board/Sessions/Review deep-link routing and Advanced Settings public webhook base URL visibility.
+
+## Initial Scope
+
+Allowed files:
+
+- `apple/IssueCTLUITests/IssueCTLUITests.swift`
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`
+- `apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift`
+
+## Planned Proof
+
+- Launch the app against `MockIssueCTLServer`.
+- Drive real `issuectl://workbench`, `issuectl://sessions`, and `issuectl://reviews` URLs through XCTest.
+- Assert the board route focuses the repo/deployment issue, sessions route applies the repo filter, and review route opens a review detail sheet.
+- Assert Advanced Settings exposes the loaded `public_webhook_base_url` value.
+
+## Result
+
+Implemented targeted UI proof in `IssueCTLUITests` using real `XCUIApplication.open(_:)` URL handling against the mock server. Added mock fixtures for:
+
+- `GET /api/v1/settings` returning `public_webhook_base_url`.
+- `GET /api/v1/issues/org/beta/201` so the board deployment route can land on a beta issue detail.
+- `GET /api/v1/pr-reviews/:id` so the review route can open a valid detail sheet.
+
+The proof asserts:
+
+- `issuectl://workbench?repo=org%2Fbeta&deployment=9101` opens the beta issue detail `#201`.
+- `issuectl://sessions?repo=org%2Fbeta` selects the Active tab and visibly applies the beta repo route context.
+- `issuectl://reviews/39507` opens `review-detail-header-39507`.
+- Advanced Settings exposes `advanced-settings-public-webhook-base-url-field` with `https://hooks.example.test`.
+
+## Verification
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLUITests/IssueCTLUITests/testDeepLinksFocusBoardSessionsAndReviewRoutes \
+  -only-testing:IssueCTLUITests/IssueCTLUITests/testAdvancedSettingsShowsPublicWebhookBaseURL \
+  -quiet
+```
+
+Passed:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests \
+  -quiet
+```
+
+Passed:
+
+```bash
+git diff --check
+```
+
+Note: Xcode emitted repeated local `DTDKRemoteDeviceConnection`/`notification_proxy` warnings during simulator runs, but both targeted UI proof and the full `IssueCTLTests` target exited successfully after the final fixture fixes.

--- a/docs/goals/ios-parity-next-tranche/state.yaml
+++ b/docs/goals/ios-parity-next-tranche/state.yaml
@@ -1,0 +1,533 @@
+version: 2
+
+goal:
+  title: "iOS Parity Next Tranche"
+  slug: "ios-parity-next-tranche"
+  kind: existing_plan
+  tranche: "Close the remaining current-main iOS parity gaps from docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md through successive verified vertical slices."
+  status: done
+  oracle:
+    signal: "A current-main gap matrix plus verified iOS/web/core receipts prove the remaining route-focus, webhook settings/health, stream-refresh, optional workbench-first-read, and cleanup gaps are implemented or explicitly deferred."
+    cadence: "after each Scout/Judge/Worker package and at final audit"
+    final_proof: "Final audit cites current origin/main SHA, gap matrix, focused tests, full iOS simulator verification or justified deferral, web/core contract checks where touched, UI/simulator evidence for visible behavior, and post-merge verification if a PR is created."
+  intake:
+    original_request: "Set up the fresh GoalBuddy board for the iOS parity next tranche."
+    interpreted_outcome: "A fresh GoalBuddy board is ready to execute the current-main iOS parity plan without reopening completed boards or chasing stale checkout gaps."
+    input_shape: existing_plan
+    audience: "issuectl maintainers and iOS users"
+    authority: requested
+    proof_type: test
+    completion_proof: "All real gaps in docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md are implemented and verified or explicitly deferred by a Judge/PM receipt."
+    likely_misfire: "Planning or implementing against the stale root checkout instead of current origin/main, causing duplicate work for already-merged workbench and automation features."
+    blind_spots_considered:
+      - "The root checkout is dirty and was behind origin/main during the audit."
+      - "Older Scout conclusions against the stale checkout are superseded by current-main evidence."
+      - "Fresh worktrees may not have packages/web/node_modules, so web tests need setup before they can be proof."
+      - "GoalBuddy can over-slice work unless a Judge selects the largest safe vertical slice."
+      - "Webhook health unknown states and public webhook base URL editing are easy to miss because most major automation parity is already present."
+    existing_plan_facts:
+      - "Primary plan artifact: docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md"
+      - "Fresh setup branch: codex/ios-web-parity-plan-20260601"
+      - "Fresh setup worktree: /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601"
+      - "Baseline at setup: origin/main merge commit 86248bc or newer."
+      - "Do not continue completed boards such as ios-web-parity-conveyor, ios-parity-hardening, ios-parity-followup-hardening, mac-ios-parity, completed-issue-session-ux, or workbench."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/ios-parity-next-tranche/"
+    command: "npx goalbuddy board /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601/docs/goals/ios-parity-next-tranche"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Confirm the current-main baseline and create a source-backed gap matrix for this tranche."
+    inputs:
+      - "docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md"
+      - "docs/goals/ios-web-parity/notes/T009-final-parity-audit.md"
+      - "docs/goals/ios-web-parity/notes/T010-final-qa-closeout.md"
+      - "docs/goals/ios-web-parity-conveyor/state.yaml"
+      - "apple/IssueCTL/App/ContentView.swift"
+      - "apple/IssueCTL/Views/Workbench/BoardView.swift"
+      - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+      - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+    constraints:
+      - "Read-only."
+      - "Audit the fresh origin/main worktree, not the stale root checkout."
+      - "Record the exact SHA and dirty status."
+      - "Classify each possible gap as real_gap, historical_note, or not_this_tranche."
+      - "Do not propose reimplementing already-merged workbench, automation settings, diagnostics, sessions overview, or PR review APIs."
+    expected_output:
+      - "Baseline SHA and dirty status."
+      - "Already-satisfied parity evidence with file paths."
+      - "Ranked real gaps with file paths."
+      - "Verification setup notes, including whether web node_modules is present."
+      - "Recommended first vertical slice candidates."
+    receipt:
+      result: done
+      summary: "Current-main Scout audit completed. Major iOS/web parity is already satisfied on 86248bc; real remaining gaps are route-focus consumption, public webhook base URL editing, unknown webhook health presentation, stream refresh coalescing, conditional Today/Issues workbench consistency, and precise diagnostics wording cleanup."
+      note: "docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md"
+      baseline:
+        worktree: "/Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601"
+        branch: "codex/ios-web-parity-plan-20260601"
+        head: "86248bc06cdae7725673b41960a2e66c264b94a5"
+        head_summary: "86248bc Merge pull request #582 from mean-weasel/codex/ios-workbench-api-parity-20260531"
+        merge_base_origin_main: pass
+        dirty_status: "Only setup artifacts are untracked: docs/goals/ios-parity-next-tranche/ and docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md."
+      already_satisfied:
+        - "Workbench API/payload and iOS WorkbenchPayload/APIClient.workbench/BoardView exist on current main."
+        - "Repo automation settings, webhook controls, diagnostics, session overview, PR review runs/actions, and automation feeds exist on current main."
+      real_gaps:
+        - "Board route context is parsed but dropped before BoardView."
+        - "Sessions/review route context is parsed but dropped before SessionListView."
+        - "public_webhook_base_url is allowed by web settings and APIClient can PATCH it, but AdvancedSettingsView does not expose it."
+        - "Webhook health unknown state is not visually distinct from warning/error in EditRepoSheet."
+        - "Session/automation stream refreshes are uncoalesced."
+        - "Today/Issues workbench first-read consistency remains conditional."
+        - "Cleanup wording should target current diagnostics comments/fallbacks, not a nonexistent automation-list comment."
+      verification_setup:
+        pnpm_version: "9.15.4"
+        root_node_modules: missing
+        packages_web_node_modules: missing
+      recommended_first_slice: "Route-focus parity for Board/Sessions/Review."
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review T001 and select the first largest safe useful Worker slice."
+    inputs:
+      - "T001 receipt"
+      - "docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md"
+    constraints:
+      - "Do not implement."
+      - "Reject duplicate work already satisfied on current main."
+      - "Prefer a vertical user-visible iOS slice over helper-only cleanup when safe."
+      - "Return exact allowed_files, verify commands, and stop_if conditions."
+      - "Identify any slices that should be deferred rather than implemented in this tranche."
+    expected_output:
+      - "Decision: proceed | revise_board | blocked"
+      - "Chosen Worker objective."
+      - "allowed_files."
+      - "verify commands."
+      - "stop_if conditions."
+      - "Deferred or rejected candidate slices with reasons."
+    receipt:
+      result: done
+      decision: proceed
+      summary: "Judge selected route-focus parity as the first largest safe useful Worker slice. It closes parsed-but-dropped Board/Sessions/Review route context without duplicating already-merged workbench/API/automation features."
+      note: "docs/goals/ios-parity-next-tranche/notes/T002-judge-route-focus-slice.md"
+      chosen_worker_objective: "Preserve Board/Sessions/Review route context in ContentView, pass the pending route to BoardView and SessionListView, and consume it to focus board repo/deployment, sessions repo filter, and review detail."
+      allowed_files:
+        - "apple/IssueCTL/App/ContentView.swift"
+        - "apple/IssueCTL/Views/Workbench/BoardView.swift"
+        - "apple/IssueCTL/ViewModels/WorkbenchStore.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTLTests/ViewLogicTests.swift"
+        - "apple/IssueCTLTests/WorkbenchStoreTests.swift"
+      verify:
+        - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchStoreTests -quiet"
+      stop_if:
+        - "Need files outside allowed_files."
+        - "Route consumer requires a new app-wide state architecture."
+        - "Current-main code already consumes one of these routes and Scout evidence is stale."
+        - "Focused tests fail twice with the same failure."
+        - "UI route behavior cannot be represented without a product decision."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Preserve and consume Board/Sessions/Review route context on iOS."
+    allowed_files:
+      - "apple/IssueCTL/App/ContentView.swift"
+      - "apple/IssueCTL/Views/Workbench/BoardView.swift"
+      - "apple/IssueCTL/ViewModels/WorkbenchStore.swift"
+      - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      - "apple/IssueCTLTests/ViewLogicTests.swift"
+      - "apple/IssueCTLTests/WorkbenchStoreTests.swift"
+    verify:
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchStoreTests -quiet"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Current-main evidence contradicts the selected slice."
+      - "Implementation would rework already-merged parity features."
+      - "Verification fails twice with the same failure."
+      - "A needed owner policy decision appears, such as exposing a test-only terminal backend override."
+    receipt:
+      result: done
+      summary: "Route-focus parity implemented. ContentView now preserves Board/Sessions/Review pending routes, BoardView consumes workbench route context, SessionListView consumes sessions/review route context, and WorkbenchStore helper tests cover repo and deployment matching."
+      note: "docs/goals/ios-parity-next-tranche/notes/T003-route-focus-worker.md"
+      changed_files:
+        - "apple/IssueCTL/App/ContentView.swift"
+        - "apple/IssueCTL/ViewModels/WorkbenchStore.swift"
+        - "apple/IssueCTL/Views/Workbench/BoardView.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTLTests/WorkbenchStoreTests.swift"
+      verification:
+        - "PASS xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchStoreTests -quiet"
+        - "PASS git diff --check"
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchStoreTests -quiet"
+          status: pass
+      scope_note: "xcodebuild regenerated apple/IssueCTL/Generated/AppVersion.swift; it was restored to HEAD content because it is outside allowed_files."
+  - id: T004
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review the first Worker receipt and decide the next largest safe slice or final-audit readiness."
+    inputs:
+      - "T003 receipt"
+      - "Current diff"
+      - "Latest verification output"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if route-focus, webhook settings/health, stream refresh, cleanup, or explicitly deferred work has no receipt."
+      - "If safe work remains, produce the next Worker package with allowed_files, verify, and stop_if."
+    expected_output:
+      - "accept | reject | needs_fix"
+      - "Next Worker package or final-audit recommendation."
+      - "Missing evidence."
+    receipt:
+      result: done
+      decision: accept_and_continue
+      summary: "Accepted T003 route-focus worker and selected webhook settings/health clarity as the next largest safe slice."
+      note: "docs/goals/ios-parity-next-tranche/notes/T004-judge-next-webhook-settings-health.md"
+      next_worker_objective: "Expose public_webhook_base_url in Advanced Settings and make webhook health unknown visually distinct from warning/error in repo automation status."
+      allowed_files:
+        - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+        - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "apple/IssueCTLTests/ViewLogicTests.swift"
+      verify:
+        - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+      stop_if:
+        - "Need files outside allowed_files."
+        - "Web settings no longer allow public_webhook_base_url."
+        - "Unknown health state requires server behavior changes."
+        - "Focused tests fail twice with the same failure."
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Expose public_webhook_base_url in Advanced Settings and make webhook health unknown visually distinct from warning/error."
+    allowed_files:
+      - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+      - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+      - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+      - "apple/IssueCTLTests/ViewLogicTests.swift"
+    verify:
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Web settings no longer allow public_webhook_base_url."
+      - "Unknown health state requires server behavior changes."
+      - "Focused tests fail twice with the same failure."
+    receipt:
+      result: done
+      summary: "Exposed public_webhook_base_url in Advanced Settings and made webhook health unknown visually distinct from warning/error."
+      note: "docs/goals/ios-parity-next-tranche/notes/T005-webhook-settings-health-worker.md"
+      changed_files:
+        - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+        - "apple/IssueCTL/Views/Settings/EditRepoSheet.swift"
+        - "apple/IssueCTLTests/APIClientExtensionTests.swift"
+        - "apple/IssueCTLTests/ViewLogicTests.swift"
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+          status: pass
+      scope_note: "xcodebuild regenerated apple/IssueCTL/Generated/AppVersion.swift; it was restored to HEAD content because it is outside allowed_files."
+  - id: T006
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review T005 and select the next largest safe slice."
+    inputs:
+      - "T005 receipt"
+      - "Current diff"
+      - "T001 gap matrix"
+    constraints:
+      - "Do not implement."
+      - "Reject completion because stream coalescing, conditional Today/Issues decision, diagnostics wording cleanup, final simulator/UI proof, and final audit remain."
+      - "Prefer stream refresh coalescing if it can stay inside bounded view files."
+    expected_output:
+      - "accept | reject | needs_fix"
+      - "Next Worker package with allowed_files, verify, and stop_if."
+      - "Missing evidence."
+    receipt:
+      result: done
+      decision: accept_and_continue
+      summary: "Accepted T005 and selected stream refresh coalescing for websocket-driven SessionListView and AutomationFeedView reloads."
+      note: "docs/goals/ios-parity-next-tranche/notes/T006-judge-stream-coalescing.md"
+      next_worker_objective: "Coalesce websocket-triggered refreshes in SessionListView and AutomationFeedView so bursts schedule one delayed refresh instead of one full reload per message."
+      allowed_files:
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTL/Views/Settings/AutomationFeedView.swift"
+      verify:
+        - "git diff --check"
+        - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+      stop_if:
+        - "Need files outside allowed_files."
+        - "Coalescing requires changing APIClient stream behavior."
+        - "Coalescer prevents manual refresh or timer refresh from loading immediately."
+        - "Focused compile/test fails twice with the same failure."
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Coalesce websocket-triggered refreshes in SessionListView and AutomationFeedView."
+    allowed_files:
+      - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      - "apple/IssueCTL/Views/Settings/AutomationFeedView.swift"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Coalescing requires changing APIClient stream behavior."
+      - "Coalescer prevents manual refresh or timer refresh from loading immediately."
+      - "Focused compile/test fails twice with the same failure."
+    receipt:
+      result: done
+      summary: "Coalesced websocket-triggered refreshes in SessionListView and AutomationFeedView while leaving manual refresh and polling immediate."
+      note: "docs/goals/ios-parity-next-tranche/notes/T007-stream-coalescing-worker.md"
+      changed_files:
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+        - "apple/IssueCTL/Views/Settings/AutomationFeedView.swift"
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+          status: pass
+      scope_note: "xcodebuild regenerated apple/IssueCTL/Generated/AppVersion.swift; it was restored to HEAD content because it is outside allowed_files."
+  - id: T008
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review T007 and decide whether to implement diagnostics wording cleanup, investigate Today/Issues workbench-first-read consistency, or move to final proof."
+    inputs:
+      - "T007 receipt"
+      - "T001 gap matrix"
+      - "Current diff"
+    constraints:
+      - "Do not implement."
+      - "Reject final completion until diagnostics wording and Today/Issues decision have explicit receipts, and simulator/UI proof is recorded."
+      - "Prefer the smallest safe cleanup if it removes stale current-main wording without changing behavior."
+    expected_output:
+      - "accept | reject | needs_fix"
+      - "Next Worker package or final-audit recommendation."
+      - "Explicit deferrals if any."
+    receipt:
+      result: done
+      decision: accept_and_continue
+      summary: "Accepted T007, explicitly deferred Today/Issues workbench-first-read because it needs a broader shared mapping/store decision, and selected current-main diagnostics wording cleanup."
+      note: "docs/goals/ios-parity-next-tranche/notes/T008-judge-cleanup-and-deferral.md"
+      deferrals:
+        - "Today/Issues workbench-first-read consistency deferred because TodayView and IssueListView rely on endpoint-specific issue/pull/deployment/draft/priority/offline/navigation flows; replacing first-read behavior safely needs a separate architecture decision."
+      next_worker_objective: "Update diagnostics wording so it no longer implies the mobile diagnostics endpoint is only a future issue #546 dependency, while keeping fallback copy for older connected servers."
+      allowed_files:
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      verify:
+        - "git diff --check"
+        - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientTests -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+      stop_if:
+        - "Cleanup changes diagnostics behavior or endpoint paths."
+        - "Need files outside allowed_files."
+        - "Focused tests fail twice with the same failure."
+  - id: T009
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Clean up current-main diagnostics wording without changing diagnostics behavior."
+    allowed_files:
+      - "apple/IssueCTLShared/Services/APIClient.swift"
+      - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientTests -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+    stop_if:
+      - "Cleanup changes diagnostics behavior or endpoint paths."
+      - "Need files outside allowed_files."
+      - "Focused tests fail twice with the same failure."
+    receipt:
+      result: done
+      summary: "Cleaned current-main diagnostics wording without changing endpoint paths or older-server fallback behavior."
+      note: "docs/goals/ios-parity-next-tranche/notes/T009-diagnostics-wording-worker.md"
+      changed_files:
+        - "apple/IssueCTLShared/Services/APIClient.swift"
+        - "apple/IssueCTL/Views/Sessions/SessionListView.swift"
+      commands:
+        - command: "git diff --check"
+          status: pass
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/APIClientTests -only-testing:IssueCTLTests/ViewLogicTests -quiet"
+          status: pass
+      scope_note: "xcodebuild regenerated apple/IssueCTL/Generated/AppVersion.swift; it was restored to HEAD content because it is outside allowed_files."
+  - id: T010
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Run final verification and collect simulator/UI proof for the tranche."
+    inputs:
+      - "All task receipts"
+      - "Current diff"
+      - "Goal oracle"
+    constraints:
+      - "Do not mark complete without focused/full verification and route/settings proof or explicit evidence-backed deferral."
+      - "If simulator app configuration blocks deep-link proof, record the blocker and keep the goal active or create the smallest safe follow-up."
+      - "Do not include generated AppVersion drift."
+    expected_output:
+      - "Final verification commands and status."
+      - "Simulator/UI proof or explicit blocker."
+      - "Current dirty diff summary."
+      - "Recommendation for final audit or next work."
+    receipt:
+      result: done
+      summary: "Final verification found implementation/unit proof is strong, but visible route/settings proof is still missing. PM converted the vague simulator proof gap into a bounded UI-test Worker task instead of keeping the goal in a stalled manual-QA bucket."
+      note: "docs/goals/ios-parity-next-tranche/notes/T010-verification-progress.md"
+      completed:
+        - "git diff --check passed."
+        - "Focused tranche unit verification passed."
+        - "Full IssueCTLTests unit target passed."
+      not_counted:
+        - "Full scheme test was interrupted after repeated DebuggerLLDB.DebuggerVersionStore.StoreError/no debugger version warnings."
+      next_task: T011
+  - id: T011
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add targeted UI proof for Board/Sessions/Review deep-link routing and Advanced Settings public webhook base URL visibility."
+    allowed_files:
+      - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+      - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+      - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+    verify:
+      - "git diff --check"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/ParityRouteProofTests -quiet"
+      - "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests -quiet"
+    stop_if:
+      - "UI proof requires production-only secrets or a real issuectl server."
+      - "Deep-link routing cannot be driven through XCTest openURL."
+      - "Need product files outside allowed_files."
+      - "Focused UI test fails twice with the same failure."
+    receipt:
+      result: done
+      summary: "Added targeted simulator UI proof for Board/Sessions/Review deep links and Advanced Settings public webhook base URL visibility."
+      note: "docs/goals/ios-parity-next-tranche/notes/T011-ui-proof-worker.md"
+      changed_files:
+        - "apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift"
+        - "apple/IssueCTLUITests/Helpers/MockServer.swift"
+        - "apple/IssueCTLUITests/IssueCTLUITests.swift"
+      commands:
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testDeepLinksFocusBoardSessionsAndReviewRoutes -only-testing:IssueCTLUITests/IssueCTLUITests/testAdvancedSettingsShowsPublicWebhookBaseURL -quiet"
+          status: pass
+        - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests -quiet"
+          status: pass
+        - command: "git diff --check"
+          status: pass
+      scope_note: "xcodebuild regenerated apple/IssueCTL/Generated/AppVersion.swift; it was restored to HEAD content after the final build."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Final audit for the iOS parity next tranche."
+    inputs:
+      - "All task receipts"
+      - "Final dirty diff"
+      - "Focused Apple/web/core verification"
+      - "Simulator/UI evidence"
+      - "Post-merge verification if applicable"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if required Worker work is still queued or active."
+      - "Reject completion if the broader tranche still has safe local follow-up slices."
+      - "Treat passing happy-path tests without route/settings UI proof as insufficient."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Evidence mapped to each real gap."
+      - "Explicit deferrals and rationale."
+      - "Next task if not complete."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "Final audit accepts the tranche. Current-main gap matrix was created; route-focus, webhook settings/health, stream coalescing, and diagnostics wording slices have receipts and passing focused verification; Today/Issues workbench-first-read was explicitly deferred with architecture rationale; targeted simulator UI proof now covers visible route/settings behavior."
+      evidence:
+        - "T001 current-main gap matrix at 86248bc identified real gaps and already-satisfied work."
+        - "T003 implemented Board/Sessions/Review route consumption with WorkbenchStore helper coverage."
+        - "T005 exposed public_webhook_base_url and made webhook unknown health visually distinct."
+        - "T007 coalesced websocket-triggered refreshes."
+        - "T008 deferred Today/Issues workbench-first-read as a broader architecture decision."
+        - "T009 cleaned current-main diagnostics wording."
+        - "T011 added and passed targeted simulator UI proof for deep links and Advanced Settings public webhook field."
+      verification:
+        - "PASS git diff --check"
+        - "PASS focused tranche unit verification recorded in T010"
+        - "PASS xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests -quiet"
+        - "PASS xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testDeepLinksFocusBoardSessionsAndReviewRoutes -only-testing:IssueCTLUITests/IssueCTLUITests/testAdvancedSettingsShowsPublicWebhookBaseURL -quiet"
+      residual_risk:
+        - "Full unfiltered scheme test was previously interrupted by local Xcode debugger/passcode-proxy warnings; targeted UI proof plus full unit target are counted as the simulator proof for this tranche."
+
+checks:
+  dirty_fingerprint: "setup-created-board-files"
+  last_verification:
+    result: pass
+    task: T011
+    note: "docs/goals/ios-parity-next-tranche/notes/T011-ui-proof-worker.md"
+    commands:
+      - command: "git diff --check"
+        status: pass
+      - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/WorkbenchStoreTests -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess -only-testing:IssueCTLTests/APIClientTests -quiet"
+        status: pass
+      - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests -quiet"
+        status: pass
+      - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -quiet"
+        status: interrupted
+        note: "Repeated DebuggerLLDB.DebuggerVersionStore.StoreError/no debugger version warnings for about nine minutes without completing."
+      - command: "xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/IssueCTLUITests/testDeepLinksFocusBoardSessionsAndReviewRoutes -only-testing:IssueCTLUITests/IssueCTLUITests/testAdvancedSettingsShowsPublicWebhookBaseURL -quiet"
+        status: pass

--- a/docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md
+++ b/docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md
@@ -1,0 +1,916 @@
+# iOS Web Parity Next Tranche Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the iOS app from current mainline parity to the next useful level: route-focused board/session/review navigation, shared workbench-backed issue data where it reduces drift, and cleaner automation activity behavior.
+
+**Architecture:** Treat `origin/main` at `86248bc` or newer as the source of truth before doing any iOS work. The web app already exposes the cross-repo workbench, repo automation settings, webhook/review routes, diagnostics, PR review sessions, and mobile APIs; this tranche closes the smaller iOS gaps that remain after those merged slices.
+
+**Tech Stack:** SwiftUI, IssueCTLShared models/services, Xcode iOS Simulator tests, pnpm/Turborepo web/core checks, GoalBuddy for autonomous tranche execution.
+
+---
+
+## Current-State Audit
+
+This audit was done in a fresh worktree:
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601
+git rev-parse --short HEAD
+# 86248bc
+git log -1 --oneline
+# 86248bc Merge pull request #582 from mean-weasel/codex/ios-workbench-api-parity-20260531
+```
+
+The original checkout was behind `origin/main`, so several apparent iOS gaps from older sessions are already solved on main. Do not start from the dirty checkout without first rebasing or creating a clean worktree from `origin/main`.
+
+Already present on current main:
+
+- Web workbench route and payload builder: `packages/web/app/api/v1/workbench/route.ts`, `packages/web/lib/workbench-data.ts`, and `packages/web/components/workbench/*`.
+- Web dashboard navigation for Issues, Board, PRs, Workbench, Quick Create, and Settings in `packages/web/components/workbench/WorkbenchShell.tsx`.
+- Web repo automation controls and webhook activity in `packages/web/components/repos/RepoSettingsPanel.tsx` and workbench setup panels.
+- Webhook automation for issue auto-launch and PR auto-review via label-driven intents in `packages/web/lib/github-webhook-handler.ts`, `packages/web/lib/webhook-intent-worker.ts`, and `packages/web/lib/webhook-pr-intent.ts`.
+- Mobile API routes for workbench, session overview, diagnostics, repo webhook health/events, global webhook events, PR review runs, and review-run actions.
+- iOS shared models for `WorkbenchPayload`, `WorkbenchRepo`, automation settings, webhook events, review runs, session overview, and diagnostics in `apple/IssueCTLShared/Models/Repo.swift`.
+- iOS API client calls for `workbench`, `sessionsOverview`, global/repo webhook events, review runs, review actions, diagnostics, repo automation settings, webhook configuration, webhook health, label recreation, and cache invalidation in `apple/IssueCTLShared/Services/APIClient.swift` and `APIClient+Settings.swift`.
+- Native iOS Board tab backed by `/api/v1/workbench` in `apple/IssueCTL/Views/Workbench/BoardView.swift` and `apple/IssueCTL/ViewModels/WorkbenchStore.swift`.
+- iOS repo automation settings, webhook controls, and repo-scoped activity in `apple/IssueCTL/Views/Settings/EditRepoSheet.swift` and `RepoAutomationActivityView.swift`.
+- iOS global automation feed in `apple/IssueCTL/Views/Settings/AutomationFeedView.swift`.
+- iOS Active tab with session/review grouping, diagnostics, terminals, review detail, and filters in `apple/IssueCTL/Views/Sessions/SessionListView.swift`.
+- GoalBuddy closeout notes say the large parity conveyor is complete: `docs/goals/ios-web-parity/notes/T009-final-parity-audit.md`, `docs/goals/ios-web-parity/notes/T010-final-qa-closeout.md`, and `docs/goals/ios-web-parity-conveyor/state.yaml`.
+
+Remaining high-value gaps:
+
+- `apple/IssueCTL/App/ContentView.swift` deliberately drops route context for `.board`, `.sessions`, and `.review`. The comment says Board/Sessions focus can consume preserved route context later.
+- `apple/IssueCTL/Views/Workbench/BoardView.swift` can open issue cards manually, but it does not consume a workbench route like `/workbench?repo=owner%2Frepo&deployment=123` to preselect the repo and focus the running issue.
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift` can browse sessions and reviews, but it does not consume `/sessions?repo=...` or `/reviews/<id>` deep links to apply filters and open the matching review detail.
+- Today and Issues still have their own first-read paths while Board uses `/api/v1/workbench`. That was an explicit prior deferral; it is not a correctness blocker, but it is where future drift can creep in.
+- iOS settings can read and write settings through `APIClient.updateSettings`, but `AdvancedSettingsView` does not expose `public_webhook_base_url`, while web repo settings and webhook install flows depend on it.
+- iOS webhook status views treat every non-`ok` webhook health state the same. Web can return `unknown` when GitHub hook inspection lacks access; that should be visually distinct from stale or failed automation.
+- iOS launch models and API calls support `terminalBackend`, but the launch UI does not expose the web-only terminal backend override. This is a low-priority test-repo parity gap, not a broad user-facing requirement.
+- `apple/IssueCTLShared/Services/APIClient.swift` still contains a stale comment saying automation list endpoints depend on issue `#546` and are fixture-driven. Current main has the endpoints.
+- Streaming updates in Session and Automation views refresh eagerly on every websocket message. That is acceptable for correctness, but a burst of webhook/review events can cause repeated full reloads.
+
+## File Map
+
+Primary iOS files:
+
+- `apple/IssueCTL/App/ContentView.swift`: tab routing and `pendingRoute` ownership.
+- `apple/IssueCTL/Services/SetupLink.swift`: `AppRoute` parsing; add route data only if existing cases cannot express the target.
+- `apple/IssueCTL/Views/Workbench/BoardView.swift`: consume board route context and navigate to a matching issue/deployment.
+- `apple/IssueCTL/ViewModels/WorkbenchStore.swift`: add deterministic helpers to find repo, issue, and deployment matches for route focus.
+- `apple/IssueCTL/Views/Sessions/SessionListView.swift`: consume session/review route context, apply filters, and open review/session destinations.
+- `apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift`: expose `public_webhook_base_url` editing in the existing settings form.
+- `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`: distinguish `unknown` webhook health from warning/error in status copy and tint.
+- `apple/IssueCTLShared/Services/APIClient+AdvancedSettings.swift`: verify settings update already sends arbitrary allowed settings keys.
+- `apple/IssueCTLShared/Services/APIClient.swift`: remove stale comments and keep route-related cache invalidation intact.
+- `apple/IssueCTLTests/ViewLogicTests.swift`: route parsing and pure helper coverage.
+- `apple/IssueCTLTests/WorkbenchStoreTests.swift`: route-to-board-item matching.
+- `apple/IssueCTLTests/APIClientExtensionTests.swift`: add `public_webhook_base_url` settings round-trip expectations.
+- `apple/IssueCTLUITests/Helpers/MockServer.swift`: add or reuse fixture data for focused Board/Sessions deep-link tests.
+- `apple/IssueCTLUITests/IssueCTLUITests.swift` or `SessionManagementTests.swift`: smoke test the deep-link focus behavior if the app test harness supports launch URLs.
+
+Web verification files:
+
+- `packages/web/app/api/v1/workbench/route.ts`
+- `packages/web/app/api/v1/sessions/overview/route.ts`
+- `packages/web/app/api/v1/webhooks/events/route.ts`
+- `packages/web/app/api/v1/repos/[owner]/[repo]/review-runs/route.ts`
+- `packages/web/components/workbench/WorkbenchShell.tsx`
+- `packages/web/components/repos/RepoSettingsPanel.tsx`
+
+GoalBuddy files:
+
+- Create a fresh goal under `docs/goals/ios-parity-next-tranche/`.
+- Do not continue `docs/goals/mac-ios-parity/`, `docs/goals/workbench/`, `docs/goals/completed-issue-session-ux/`, `docs/goals/ios-parity-hardening/`, `docs/goals/ios-parity-followup-hardening/`, or the completed `ios-web-parity-conveyor` board.
+
+---
+
+### Task 1: Baseline Gate and Gap Matrix
+
+**Files:**
+- Create: `docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md`
+- Inspect: `docs/goals/ios-web-parity/notes/T009-final-parity-audit.md`
+- Inspect: `docs/goals/ios-web-parity/notes/T010-final-qa-closeout.md`
+- Inspect: `docs/goals/ios-web-parity-conveyor/state.yaml`
+
+- [ ] **Step 1: Verify the branch is current**
+
+Run:
+
+```bash
+cd /Users/neonwatty/Desktop/issuectl/.worktrees/ios-web-parity-plan-20260601
+git fetch origin
+git status --short --branch
+git rev-parse --short HEAD
+git merge-base --is-ancestor HEAD origin/main && echo "HEAD is on or behind origin/main"
+```
+
+Expected: the branch is clean except plan/goal files, and `HEAD` is `86248bc` or newer.
+
+- [ ] **Step 2: Re-run source-backed gap search**
+
+Run:
+
+```bash
+rg -n "Board/Sessions focus|Depends on issue #546|deferred|follow-up" \
+  apple/IssueCTL apple/IssueCTLShared docs/goals/ios-web-parity docs/goals/ios-web-parity-conveyor
+```
+
+Expected: the route-focus comment and stale API comment appear; any new hits must be classified as `real_gap`, `historical_note`, or `not_this_tranche`.
+
+- [ ] **Step 3: Write the gap matrix**
+
+Create `docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md` with this structure:
+
+```markdown
+# T001 Current Main Gap Matrix
+
+Baseline: `origin/main` at the short SHA printed by Step 1.
+
+## Already Satisfied
+
+- Workbench API parity:
+  - Evidence: `apple/IssueCTLShared/Services/APIClient.swift` has `workbench(refresh:maxAge:)`.
+  - Evidence: `apple/IssueCTL/Views/Workbench/BoardView.swift` renders the native Board tab.
+- Repo automation settings:
+  - Evidence: `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`.
+- Automation activity:
+  - Evidence: `apple/IssueCTL/Views/Settings/AutomationFeedView.swift`.
+- Session/review overview:
+  - Evidence: `apple/IssueCTL/Views/Sessions/SessionListView.swift`.
+
+## Real Remaining Gaps
+
+1. Board deep-link focus drops route context.
+2. Sessions/reviews deep-link focus drops route context.
+3. Today/Issues do not share workbench first-read data.
+4. `public_webhook_base_url` is not editable on iOS.
+5. Webhook health `unknown` is not visually distinct on iOS.
+6. Streaming reloads are uncoalesced.
+7. Stale comment in `APIClient.swift`.
+
+## Not This Tranche
+
+- Replacing the web Workbench shell.
+- Rewriting the Board visual design.
+- Adding new webhook server behavior.
+```
+
+- [ ] **Step 4: Commit the audit only if the goal run will preserve notes**
+
+```bash
+git add docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md
+git commit -m "docs: record current iOS parity gap matrix"
+```
+
+If this is being executed inside a GoalBuddy run that does not commit notes separately, keep the file unstaged until the slice commit.
+
+---
+
+### Task 2: Preserve Route Context for Board, Sessions, and Reviews
+
+**Files:**
+- Modify: `apple/IssueCTL/App/ContentView.swift`
+- Test: `apple/IssueCTLTests/ViewLogicTests.swift`
+
+- [ ] **Step 1: Write the failing route-handling test**
+
+Add a tiny pure helper in the app target instead of testing SwiftUI state directly:
+
+```swift
+enum AppRouteDestination: Equatable {
+    case tab(AppTab, pendingRoute: AppRoute?)
+}
+
+func destination(for route: AppRoute) -> AppRouteDestination {
+    switch route {
+    case .issue:
+        return .tab(.issues, pendingRoute: route)
+    case .pullRequest:
+        return .tab(.pullRequests, pendingRoute: route)
+    case .board:
+        return .tab(.board, pendingRoute: route)
+    case .sessions, .review:
+        return .tab(.active, pendingRoute: route)
+    }
+}
+```
+
+Then add tests:
+
+```swift
+func testRouteDestinationPreservesBoardContext() throws {
+    let route = AppRoute.board(repoFullName: "mean-weasel/issuectl", deploymentId: 113)
+    XCTAssertEqual(destination(for: route), .tab(.board, pendingRoute: route))
+}
+
+func testRouteDestinationPreservesReviewContext() throws {
+    let route = AppRoute.review(id: "review-123")
+    XCTAssertEqual(destination(for: route), .tab(.active, pendingRoute: route))
+}
+```
+
+- [ ] **Step 2: Run the focused failing test**
+
+Run:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+Expected: fails until the helper and handler preserve the pending route for board/session/review.
+
+- [ ] **Step 3: Implement the route helper and use it from `handle(_:)`**
+
+Keep the behavior local to `ContentView.swift`:
+
+```swift
+private func handle(_ route: AppRoute) {
+    switch destination(for: route) {
+    case .tab(let tab, let route):
+        selectedTab = tab
+        pendingRoute = route
+    }
+}
+```
+
+If `AppTab` is private and tests cannot see it, move `destination(for:)` into a testable internal helper that returns a small internal enum in `ContentView.swift`; do not make tab-routing public API.
+
+- [ ] **Step 4: Wire the route binding into tabs**
+
+Update tab construction:
+
+```swift
+BoardView(
+    onShowSettings: { showSettings = true },
+    route: $pendingRoute
+)
+
+SessionListView(
+    onShowSettings: { showSettings = true },
+    onShowIssues: { selectedTab = .issues },
+    route: $pendingRoute
+)
+```
+
+- [ ] **Step 5: Re-run route tests**
+
+Run the same `xcodebuild test` command from Step 2.
+
+Expected: route helper tests pass.
+
+---
+
+### Task 3: Board Deep-Link Focus
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Workbench/BoardView.swift`
+- Modify: `apple/IssueCTL/ViewModels/WorkbenchStore.swift`
+- Test: `apple/IssueCTLTests/WorkbenchStoreTests.swift`
+
+- [ ] **Step 1: Write matching-helper tests**
+
+Add tests for a deployment-based workbench route:
+
+```swift
+func testFindsBoardIssueForDeploymentRoute() {
+    let store = WorkbenchStore()
+    store.payload = WorkbenchStoreTests.payload(
+        issues: [
+            WorkbenchStoreTests.issue(number: 10, title: "Plain issue", state: "open", hasActiveDeployment: false),
+            WorkbenchStoreTests.issue(number: 11, title: "Running issue", state: "open", hasActiveDeployment: true),
+        ]
+    )
+
+    let match = store.boardRouteTarget(repoFullName: "mean-weasel/issuectl", deploymentId: 42)
+
+    XCTAssertEqual(match?.owner, "mean-weasel")
+    XCTAssertEqual(match?.repoName, "issuectl")
+    XCTAssertEqual(match?.issue.number, 11)
+}
+```
+
+Add a repo-only route test:
+
+```swift
+func testBoardRouteSelectsRepoWithoutDeployment() {
+    let store = WorkbenchStore()
+    store.payload = WorkbenchStoreTests.payload(issues: [])
+
+    let repoIds = store.repoIds(matchingFullName: "mean-weasel/issuectl")
+
+    XCTAssertEqual(repoIds, Set([1]))
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -quiet
+```
+
+- [ ] **Step 3: Implement store helpers**
+
+Add focused helpers to `WorkbenchStore`:
+
+```swift
+func repoIds(matchingFullName fullName: String?) -> Set<Int> {
+    guard let fullName, !fullName.isEmpty else { return [] }
+    return Set(repos.filter { $0.fullName == fullName }.map(\.id))
+}
+
+func boardRouteTarget(repoFullName: String?, deploymentId: Int?) -> WorkbenchBoardIssue? {
+    if let repoFullName {
+        selectedRepoIds = repoIds(matchingFullName: repoFullName)
+    }
+
+    guard let deploymentId else { return nil }
+    return boardIssues(filteringByRepoOnly: true).first { item in
+        item.deployment?.id == deploymentId
+    }
+}
+```
+
+If `boardIssues(filteringByRepoOnly:)` must stay private, keep the helper inside `WorkbenchStore` and expose only the route target.
+
+- [ ] **Step 4: Consume `AppRoute.board` in `BoardView`**
+
+Add a binding:
+
+```swift
+@Binding var route: AppRoute?
+```
+
+After the workbench payload loads, consume the route exactly once:
+
+```swift
+.task(id: route) {
+    await consumeRouteIfNeeded()
+}
+
+@MainActor
+private func consumeRouteIfNeeded() async {
+    guard case let .board(repoFullName, deploymentId) = route else { return }
+    if store.payload == nil {
+        await store.load(api: api)
+    }
+
+    if let target = store.boardRouteTarget(repoFullName: repoFullName, deploymentId: deploymentId) {
+        store.filter = target.isRunning ? .running : .open
+        navigationPath.append(BoardDestination.issue(
+            owner: target.owner,
+            repo: target.repoName,
+            number: target.issue.number
+        ))
+    } else if let repoFullName {
+        store.selectedRepoIds = store.repoIds(matchingFullName: repoFullName)
+    }
+
+    route = nil
+}
+```
+
+- [ ] **Step 5: Re-run Board tests**
+
+Run the command from Step 2.
+
+Expected: store helper tests pass.
+
+---
+
+### Task 4: Sessions and Review Deep-Link Focus
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Test: `apple/IssueCTLTests/ViewLogicTests.swift`
+- Optional UI Test: `apple/IssueCTLUITests/SessionManagementTests.swift`
+
+- [ ] **Step 1: Add route binding to SessionListView**
+
+Change the view signature:
+
+```swift
+@Binding var route: AppRoute?
+```
+
+- [ ] **Step 2: Add route consumption**
+
+After `load()` finishes, consume routes:
+
+```swift
+@MainActor
+private func consumeRouteIfNeeded() async {
+    guard let route else { return }
+    switch route {
+    case .sessions(let repoFullName):
+        selectedTab = .sessions
+        if let repoFullName, let repo = repos.first(where: { $0.fullName == repoFullName }) {
+            selectedRepoIds = [repo.id]
+        }
+        self.route = nil
+    case .review(let id):
+        selectedTab = .reviews
+        selectedReviewStatus = .all
+        if overviewResponse == nil {
+            await load()
+        }
+        reviewDetailTarget = ReviewRunDetailTarget(id: id)
+        self.route = nil
+    default:
+        return
+    }
+}
+```
+
+Call it with:
+
+```swift
+.task(id: route) {
+    await consumeRouteIfNeeded()
+}
+```
+
+- [ ] **Step 3: Guard against reload loops**
+
+When a route changes filters, `overviewQuerySignature` will trigger `load()`. Keep route clearing after the first filter application, and avoid setting `selectedRepoIds` repeatedly for the same route.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -quiet
+```
+
+- [ ] **Step 5: Manual/smoke verification**
+
+Launch URL examples against the simulator:
+
+```bash
+xcrun simctl openurl booted "issuectl://sessions?repo=mean-weasel%2Fissuectl"
+xcrun simctl openurl booted "issuectl://reviews/review-123"
+```
+
+Expected: the Active tab opens; sessions route applies the repo filter, and review route opens the review detail sheet.
+
+---
+
+### Task 5: Workbench First-Read Consistency for Today and Issues
+
+**Files:**
+- Inspect: `apple/IssueCTL/Views/Today/TodayView.swift`
+- Inspect: `apple/IssueCTL/Views/Issues/IssueListView.swift`
+- Modify only if the existing data flow can use `WorkbenchStore` without broad rewrites.
+- Test: existing Today/Issue list tests or a new focused view-model test.
+
+- [ ] **Step 1: Identify the existing first-read paths**
+
+Run:
+
+```bash
+rg -n "api\\.issues|api\\.activeDeployments|workbench\\(|IssueListView|TodayView" apple/IssueCTL apple/IssueCTLShared apple/IssueCTLTests
+```
+
+Expected: list which views still fetch issue/session summary data separately from `/api/v1/workbench`.
+
+- [ ] **Step 2: Decide whether this tranche should modify code**
+
+Use this decision rule:
+
+- If Today/Issues can read already-decoded `WorkbenchPayload` through `APIClient.workbench(refresh:false)` without changing public navigation behavior, proceed.
+- If the change would require a new shared app-level store, stop and create a follow-up architecture note. Do not invent a global state container in this tranche.
+
+- [ ] **Step 3: Add one targeted test before implementation**
+
+For a simple helper, test that a workbench issue summary maps to the existing issue-list row model. The test should assert issue number, title, repo full name, state, labels, and active deployment status.
+
+- [ ] **Step 4: Implement the smallest useful shared read**
+
+Prefer a helper in the existing view model layer rather than direct view mapping:
+
+```swift
+struct WorkbenchIssueListItem: Identifiable, Equatable {
+    let id: String
+    let owner: String
+    let repo: String
+    let number: Int
+    let title: String
+    let state: String
+    let isRunning: Bool
+}
+```
+
+Only keep this helper if it replaces duplicated mapping in Today or Issues. Delete it if the local code reads worse.
+
+- [ ] **Step 5: Verify no behavior regression**
+
+Run the focused Apple tests that cover issue rows and Today summaries:
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -only-testing:IssueCTLTests/APIClientTests/testWorkbenchEndpointURL \
+  -quiet
+```
+
+---
+
+### Task 6: Public Webhook Base URL and Health State Clarity
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Settings/AdvancedSettingsView.swift`
+- Modify: `apple/IssueCTL/Views/Settings/EditRepoSheet.swift`
+- Test: `apple/IssueCTLTests/APIClientExtensionTests.swift`
+- Test: `apple/IssueCTLTests/ViewLogicTests.swift`
+
+- [ ] **Step 1: Write settings round-trip coverage**
+
+Update `testGetSettingsUsesSettingsEndpointAndDecodesDictionary` to include the webhook base URL:
+
+```swift
+return (self.makeResponse(url: request.url!), """
+{"settings":{"launch_agent":"codex","cache_ttl":"300","worktree_dir":"/tmp/issuectl","public_webhook_base_url":"https://hooks.example.test"}}
+""".data(using: .utf8)!)
+```
+
+Add the assertion:
+
+```swift
+XCTAssertEqual(settings["public_webhook_base_url"], "https://hooks.example.test")
+```
+
+Update `testUpdateSettingsSendsPatchBodyAndDecodesSuccess` to assert the PATCH body can include the webhook base URL:
+
+```swift
+XCTAssertEqual(json["public_webhook_base_url"] as? String, "https://hooks.example.test")
+```
+
+and pass:
+
+```swift
+let response = try await client.updateSettings([
+    "launch_agent": "claude",
+    "cache_ttl": "600",
+    "public_webhook_base_url": "https://hooks.example.test",
+])
+```
+
+- [ ] **Step 2: Run the focused API extension tests**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testGetSettingsUsesSettingsEndpointAndDecodesDictionary \
+  -only-testing:IssueCTLTests/APIClientExtensionTests/testUpdateSettingsSendsPatchBodyAndDecodesSuccess \
+  -quiet
+```
+
+Expected: API tests already pass before UI work because the client sends arbitrary allowed keys.
+
+- [ ] **Step 3: Add the editable webhook base URL field**
+
+In `AdvancedSettingsView`, add state:
+
+```swift
+@State private var publicWebhookBaseURL = ""
+```
+
+Add it to `editableFields`:
+
+```swift
+("public_webhook_base_url", publicWebhookBaseURL),
+```
+
+Load it:
+
+```swift
+publicWebhookBaseURL = settings["public_webhook_base_url"] ?? ""
+```
+
+Add a form section near repo/webhook defaults:
+
+```swift
+Section {
+    TextField("Public webhook base URL", text: $publicWebhookBaseURL)
+        .keyboardType(.URL)
+        .textContentType(.URL)
+        .autocorrectionDisabled()
+        .textInputAutocapitalization(.never)
+} header: {
+    Text("Webhooks")
+} footer: {
+    Text("Base URL used when installing GitHub webhooks, such as https://hooks.example.com.")
+}
+```
+
+- [ ] **Step 4: Extract webhook health presentation mapping**
+
+Add a tiny mapping that makes `unknown` distinct:
+
+```swift
+private enum WebhookHealthPresentation {
+    case ok
+    case unknown
+    case warning
+    case error
+    case uninstalled
+
+    init(repoHasWebhook: Bool, health: WebhookAutomationHealth?) {
+        guard let health else {
+            self = repoHasWebhook ? .ok : .uninstalled
+            return
+        }
+        switch health.state {
+        case "ok": self = .ok
+        case "unknown": self = .unknown
+        case "error": self = .error
+        default: self = .warning
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .ok: return "checkmark.circle.fill"
+        case .unknown: return "questionmark.circle.fill"
+        case .warning, .error: return "exclamationmark.triangle.fill"
+        case .uninstalled: return "dot.radiowaves.left.and.right"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .ok: return .green
+        case .unknown: return .secondary
+        case .warning: return .orange
+        case .error: return .red
+        case .uninstalled: return .secondary
+        }
+    }
+}
+```
+
+Use this mapping from `WebhookStatusSummary` for `icon` and `tint`:
+
+```swift
+private var presentation: WebhookHealthPresentation {
+    WebhookHealthPresentation(repoHasWebhook: repo.webhookId != nil, health: health)
+}
+```
+
+- [ ] **Step 5: Add a presentation test if the mapping is internal**
+
+If `WebhookHealthPresentation` can be made testable without exposing SwiftUI internals, add:
+
+```swift
+func testWebhookUnknownHealthPresentationIsDistinct() {
+    let health = WebhookAutomationHealth(
+        state: "unknown",
+        summary: "GitHub hook inspection unavailable",
+        detail: nil,
+        recovery: nil,
+        expectedUrl: nil,
+        hookId: nil,
+        githubUrl: nil,
+        latestDelivery: nil
+    )
+
+    XCTAssertEqual(WebhookHealthPresentation(repoHasWebhook: true, health: health).icon, "questionmark.circle.fill")
+}
+```
+
+If this requires making view-only types public, skip the test and verify through UI inspection; do not widen access solely for cosmetics.
+
+- [ ] **Step 6: Run focused verification**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/APIClientExtensionTests \
+  -quiet
+```
+
+---
+
+### Task 7: Coalesce Automation Stream Refreshes
+
+**Files:**
+- Modify: `apple/IssueCTL/Views/Sessions/SessionListView.swift`
+- Modify: `apple/IssueCTL/Views/Settings/AutomationFeedView.swift`
+- Modify: `apple/IssueCTL/Views/Settings/RepoAutomationActivityView.swift`
+- Test: add a small pure helper test if a throttler object is introduced.
+
+- [ ] **Step 1: Inspect current stream loops**
+
+Run:
+
+```bash
+rg -n "stream.*Updates|webhookEventsStream|Task\\.sleep|load\\(includeRepos: false\\)|loadFeed" \
+  apple/IssueCTL/Views/Sessions apple/IssueCTL/Views/Settings
+```
+
+- [ ] **Step 2: Add a simple refresh coalescer**
+
+Keep it local and dependency-free:
+
+```swift
+@MainActor
+private final class RefreshCoalescer {
+    private var pendingTask: Task<Void, Never>?
+
+    func schedule(after delay: Duration = .milliseconds(350), action: @escaping @MainActor () async -> Void) {
+        pendingTask?.cancel()
+        pendingTask = Task {
+            do { try await Task.sleep(for: delay) } catch { return }
+            await action()
+        }
+    }
+
+    func cancel() {
+        pendingTask?.cancel()
+        pendingTask = nil
+    }
+}
+```
+
+- [ ] **Step 3: Use it in stream handlers**
+
+Replace immediate reloads like this:
+
+```swift
+guard terminalPresentation == nil else { continue }
+coalescer.schedule {
+    await load(includeRepos: false)
+}
+```
+
+For settings feeds:
+
+```swift
+coalescer.schedule {
+    await loadFeed(refresh: true)
+}
+```
+
+- [ ] **Step 4: Clean up on disappearance**
+
+If the views have `.onDisappear`, call:
+
+```swift
+coalescer.cancel()
+```
+
+If there is no existing disappearance hook, add one only to views that own long-lived stream tasks.
+
+- [ ] **Step 5: Verify focused UI tests still pass**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/RepoAutomationActivityViewTests \
+  -quiet
+```
+
+---
+
+### Task 8: Documentation and Stale Comment Cleanup
+
+**Files:**
+- Modify: `apple/IssueCTLShared/Services/APIClient.swift`
+- Modify: `docs/goals/ios-parity-next-tranche/notes/T001-current-main-gap-matrix.md`
+
+- [ ] **Step 1: Remove stale endpoint comment**
+
+Delete this obsolete comment in `APIClient.swift`:
+
+```swift
+// Depends on issue #546: these automation list endpoints are fixture-driven
+// until the web API exposes persisted automation activity.
+```
+
+Do not change endpoint behavior in this cleanup step.
+
+- [ ] **Step 2: Update the gap matrix receipt**
+
+Append:
+
+```markdown
+## Cleanup Receipt
+
+- Removed stale `#546` fixture-driven endpoint comment from `APIClient.swift`.
+- Verified current main exposes persisted automation activity routes.
+```
+
+- [ ] **Step 3: Run diff check**
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+---
+
+### Task 9: Full Tranche Verification
+
+**Files:**
+- No new files unless a verification note is desired.
+
+- [ ] **Step 1: Apple model/API/view-model tests**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:IssueCTLTests/ViewLogicTests \
+  -only-testing:IssueCTLTests/WorkbenchStoreTests \
+  -only-testing:IssueCTLTests/APIClientTests/testWorkbenchEndpointURL \
+  -only-testing:IssueCTLTests/APIClientExtensionTests \
+  -only-testing:IssueCTLTests/ModelDecodingTests/testSessionsOverviewResponseDecodingFromLiveContract \
+  -only-testing:IssueCTLTests/RepoAutomationActivityViewTests \
+  -quiet
+```
+
+- [ ] **Step 2: Full iOS test pass before PR**
+
+```bash
+xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -quiet
+```
+
+- [ ] **Step 3: Web/core regression checks for touched contracts**
+
+```bash
+pnpm --dir packages/web test -- workbench webhook labels
+pnpm --dir packages/web typecheck
+pnpm --dir packages/core test
+pnpm --dir packages/core typecheck
+```
+
+- [ ] **Step 4: Burden-of-proof attempt**
+
+Try to disprove the change:
+
+```bash
+xcrun simctl openurl booted "issuectl://workbench?repo=mean-weasel%2Fissuectl&deployment=113"
+xcrun simctl openurl booted "issuectl://sessions?repo=mean-weasel%2Fissuectl"
+xcrun simctl openurl booted "issuectl://reviews/review-123"
+xcrun simctl openurl booted "issuectl://setup?serverURL=http%3A%2F%2F127.0.0.1%3A3000&token=test-token"
+```
+
+Evidence to record:
+
+- Screenshot or UI test log showing Board opens the matching issue for a deployment route.
+- Screenshot or UI test log showing Active opens with repo-filtered sessions.
+- Screenshot or UI test log showing review detail opens for `/reviews/<id>`.
+- Screenshot or UI test log showing Advanced Settings can edit the public webhook base URL.
+- Command output for Apple focused tests, full Apple tests, and web/core checks.
+
+---
+
+## Recommended GoalBuddy Operating Model
+
+Use a fresh board named `ios-parity-next-tranche`. Do not reopen the completed boards listed in the file map.
+
+Suggested `/goal-prep` shape:
+
+```text
+Prepare a fresh GoalBuddy board for the iOS parity next tranche in /Users/neonwatty/Desktop/issuectl from origin/main. The goal is to close only the remaining current-main iOS gaps from docs/superpowers/plans/2026-06-01-ios-web-parity-next-tranche.md: board/session/review route focus, conditional workbench first-read consistency for Today/Issues if small, public webhook base URL editing, webhook health unknown-state clarity, stream refresh coalescing, and stale docs/comment cleanup. First task must be a read-only Scout confirming the current SHA and gap matrix. Second task must be a Judge selecting the largest safe vertical slice with allowed_files, verify commands, and stop_if conditions. Workers must not reimplement already-merged workbench, repo automation, diagnostics, or PR review APIs.
+```
+
+Starter execution command after prep:
+
+```text
+/goal Follow docs/goals/ios-parity-next-tranche/goal.md.
+```
+
+Use independent agents this way:
+
+- Scout agents: read-only source audits from the fresh main worktree; they must report exact file paths and SHA.
+- Judge agents: contradiction checks, stale-board detection, and slice selection.
+- Worker agents: only after a Judge assigns `allowed_files`, `verify`, and `stop_if`.
+- Do not ask workers to inspect previous sessions unless a Scout first maps those sessions to current-main evidence; this avoids repeatedly planning from superseded branches.
+
+Recommended proof oracle:
+
+- Fresh `origin/main` SHA recorded at start and before PR.
+- Source-backed gap matrix.
+- Focused iOS route/deep-link tests.
+- Full iOS simulator test pass.
+- Web/core contract checks for workbench/webhook/session routes.
+- Manual or automated simulator proof for the three route URLs.
+- Post-merge verification that `origin/main` contains the final branch.
+
+## Self-Review
+
+- Spec coverage: the plan covers the web workbench, webhook automation, dashboard interface, current iOS state, remaining gaps, GoalBuddy usage, and independent-agent usage.
+- Placeholder scan: no unresolved placeholder patterns remain.
+- Type consistency: route types match current `AppRoute` cases in `apple/IssueCTL/Services/SetupLink.swift`; iOS API and view names match current mainline files.


### PR DESCRIPTION
## Summary
- expose public_webhook_base_url in iOS Advanced Settings
- distinguish unknown/error webhook health presentation in repo automation status
- coalesce websocket-triggered refreshes in Sessions and Automation Feed
- remove stale mobile diagnostics issue #546 wording from source
- preserve the June 1 GoalBuddy iOS parity tranche receipts without generated board assets

## Failure modes considered
- settings API supports public_webhook_base_url but the iOS form still hides it
- unknown webhook health looks like a warning/error instead of an inspection/access state
- webhook/review websocket bursts trigger repeated full feed/session reloads
- stale generated AppVersion.swift from xcodebuild leaks into the branch

## Verification
- git diff --check
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests/ViewLogicTests -only-testing:IssueCTLTests/APIClientExtensionTests -quiet
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLTests -quiet
- xcodebuild test -project apple/IssueCTL.xcodeproj -scheme IssueCTL -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IssueCTLUITests/SettingsTests/testAdvancedSettingsShowsPublicWebhookBaseURL -quiet

Note: XcodeBuildMCP defaults pointed at the already-removed prior worktree, so verification used direct xcodebuild commands from this fresh worktree.