### PR TITLE
Preflight webhook health before automation labels

### DIFF
--- a/packages/web/components/issue/LabelManager.module.css
+++ b/packages/web/components/issue/LabelManager.module.css
@@ -80,6 +80,28 @@
   white-space: nowrap;
 }
 
+.checkButton {
+  width: fit-content;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg);
+  color: var(--paper-ink-soft);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.checkButton:hover:not(:disabled) {
+  border-color: var(--paper-line-strong);
+}
+
+.checkButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .automationHealth[data-state="ok"] {
   border-color: #9dc79d;
   background: #eef8ee;

--- a/packages/web/components/issue/LabelManager.test.ts
+++ b/packages/web/components/issue/LabelManager.test.ts
@@ -1,0 +1,63 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "@/components/ui/ToastProvider";
+import { LabelManager } from "./LabelManager";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/issues", () => ({
+  toggleLabel: vi.fn(),
+  togglePullLabel: vi.fn(),
+}));
+
+vi.mock("@/lib/tryOrQueue", () => ({
+  tryOrQueue: vi.fn(),
+}));
+
+const labels = [
+  { name: "bug", color: "d73a4a", description: null },
+  { name: "issuectl:auto-launch", color: "0e8a16", description: null },
+];
+
+describe("LabelManager", () => {
+  it("surfaces webhook delivery preflight before automation labels", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        ToastProvider,
+        null,
+        createElement(LabelManager, {
+          owner: "mean-weasel",
+          repo: "issuectl",
+          issueNumber: 534,
+          currentLabels: [],
+          availableLabels: labels,
+          webhookHealth: {
+            state: "error",
+            summary: "Webhook delivery infrastructure failed with 502",
+            detail: "GitHub reached the configured hook but the latest delivery failed before issuectl could rely on it.",
+            recovery: "Start a fresh tunnel and run issuectl webhook rotate mean-weasel/issuectl --yes.",
+            expectedUrl: "https://current.example.test/api/webhook/github/1",
+            hookId: 123,
+            githubUrl: "https://old.example.test/api/webhook/github/1",
+            latestDelivery: {
+              event: "issues",
+              action: "labeled",
+              status: null,
+              statusCode: 502,
+              deliveredAt: "2026-06-02T20:00:00Z",
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(html).toContain("Webhook delivery infrastructure failed with 502");
+    expect(html).toContain("auto-launch labels rely on the GitHub webhook reaching this machine");
+    expect(html).toContain("latest: issues.labeled");
+    expect(html).toContain("Check delivery");
+    expect(html).toContain("issuectl webhook rotate mean-weasel/issuectl --yes");
+  });
+});

--- a/packages/web/components/issue/LabelManager.tsx
+++ b/packages/web/components/issue/LabelManager.tsx
@@ -40,6 +40,9 @@ export function LabelManager({
   const [syncVisible, setSyncVisible] = useState(false);
   const [showSelector, setShowSelector] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [liveWebhookHealth, setLiveWebhookHealth] = useState<WebhookAutomationHealth | null | undefined>(webhookHealth);
+  const [webhookCheckError, setWebhookCheckError] = useState<string | null>(null);
+  const [isCheckingWebhook, setIsCheckingWebhook] = useState(false);
   const syncStartRef = useRef(0);
 
   // Keep the syncing dot visible for at least one full pulse cycle (1.2s
@@ -58,22 +61,67 @@ export function LabelManager({
     return () => clearTimeout(timer);
   }, [isPending]); // syncVisible intentionally omitted — it's a gate, not a reactive dep
 
+  useEffect(() => {
+    setLiveWebhookHealth(webhookHealth);
+  }, [webhookHealth]);
+
   const { lifecycle: lifecycleLabels, regular: regularLabels } =
     separateLabels(currentLabels);
   const selectedNames = currentLabels.map((l) => l.name);
   const automationLabel = targetType === "pr" ? "issuectl:auto-review" : "issuectl:auto-launch";
+  const currentWebhookHealth = liveWebhookHealth ?? webhookHealth ?? null;
   const hasAutomationLabel = selectedNames.includes(automationLabel)
     || availableLabels.some((label) => label.name === automationLabel);
   const showWebhookHealth = hasAutomationLabel
-    && webhookHealth !== null
-    && webhookHealth !== undefined
-    && (webhookHealth.state !== "ok" || showSelector);
+    && (showSelector || currentWebhookHealth?.state !== "ok" || webhookCheckError !== null);
+
+  async function refreshWebhookHealth(): Promise<{
+    health: WebhookAutomationHealth | null;
+    error: string | null;
+  }> {
+    setIsCheckingWebhook(true);
+    setWebhookCheckError(null);
+    try {
+      const response = await fetch(`/api/v1/repos/${owner}/${repo}/webhook/health`, {
+        method: "GET",
+        headers: requestHeaders(),
+      });
+      const body = await response.json().catch(() => undefined) as {
+        health?: WebhookAutomationHealth | null;
+        error?: string;
+      } | undefined;
+      if (!response.ok) throw new Error(body?.error ?? "Webhook delivery check failed");
+      const health = body?.health ?? null;
+      setLiveWebhookHealth(health);
+      return { health, error: null };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Webhook delivery check failed";
+      setWebhookCheckError(message);
+      return { health: null, error: message };
+    } finally {
+      setIsCheckingWebhook(false);
+    }
+  }
+
+  async function confirmAutomationLabelPreflight(): Promise<boolean> {
+    const result = await refreshWebhookHealth();
+    if (result.health?.state === "ok") return true;
+    const reason = result.health
+      ? `${result.health.summary}. ${result.health.detail}`
+      : `Webhook delivery health could not be checked. ${result.error ?? "The receiver state is unknown."}`;
+    return window.confirm(`${reason}\n\nThis is webhook delivery infrastructure, not an issuectl launch failure. Continue applying ${automationLabel} anyway?`);
+  }
 
   function handleToggle(label: string) {
     setError(null);
     const action = selectedNames.includes(label) ? "remove" : "add";
     startTransition(async () => {
       try {
+        if (label === automationLabel && action === "add") {
+          const ok = await confirmAutomationLabelPreflight();
+          if (!ok) return;
+        }
+
         if (targetType === "issue") {
           const result = await tryOrQueue(
             "toggleLabel",
@@ -142,7 +190,13 @@ export function LabelManager({
       )}
 
       {showWebhookHealth && (
-        <AutomationHealthNotice health={webhookHealth} targetType={targetType} />
+        <AutomationHealthNotice
+          health={currentWebhookHealth}
+          targetType={targetType}
+          checkError={webhookCheckError}
+          isChecking={isCheckingWebhook}
+          onCheck={() => void refreshWebhookHealth()}
+        />
       )}
 
       {showSelector && (
@@ -169,24 +223,43 @@ export function LabelManager({
 function AutomationHealthNotice({
   health,
   targetType,
+  checkError,
+  isChecking,
+  onCheck,
 }: {
-  health: WebhookAutomationHealth;
+  health: WebhookAutomationHealth | null;
   targetType: "issue" | "pr";
+  checkError: string | null;
+  isChecking: boolean;
+  onCheck: () => void;
 }) {
   const label = targetType === "pr" ? "auto-review" : "auto-launch";
+  const state = health?.state ?? "unknown";
   return (
-    <div className={styles.automationHealth} data-state={health.state} role={health.state === "ok" ? "status" : "alert"}>
-      <strong>{health.summary}</strong>
+    <div className={styles.automationHealth} data-state={state} role={state === "ok" ? "status" : "alert"}>
+      <strong>{health?.summary ?? "Webhook delivery health has not been checked"}</strong>
       <span>
-        {label} labels rely on the GitHub webhook reaching this machine. {health.detail}
+        {label} labels rely on the GitHub webhook reaching this machine. {health?.detail ?? "Run a delivery check before applying the automation label."}
       </span>
-      {health.latestDelivery && (
+      {health?.latestDelivery && (
         <code>
           latest: {health.latestDelivery.event ?? "delivery"}
           {health.latestDelivery.action ? `.${health.latestDelivery.action}` : ""} · {health.latestDelivery.statusCode ?? "unknown"}
         </code>
       )}
-      {health.recovery && <span>{health.recovery}</span>}
+      {health?.recovery && <span>{health.recovery}</span>}
+      {checkError && <span>{checkError}</span>}
+      <button type="button" className={styles.checkButton} onClick={onCheck} disabled={isChecking}>
+        {isChecking ? "Checking delivery" : "Check delivery"}
+      </button>
     </div>
   );
+}
+
+function requestHeaders(): Headers {
+  const headers = new Headers({ Accept: "application/json", "Content-Type": "application/json" });
+  const token = window.localStorage.getItem("issuectl.apiToken")
+    ?? window.localStorage.getItem("issuectlApiToken");
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  return headers;
 }

--- a/packages/web/lib/webhook-health.test.ts
+++ b/packages/web/lib/webhook-health.test.ts
@@ -66,13 +66,37 @@ describe("getWebhookAutomationHealth", () => {
 
     expect(result).toMatchObject({
       state: "error",
-      summary: "Recent GitHub webhook delivery failed with 502",
+      summary: "Webhook delivery infrastructure failed with 502",
       latestDelivery: {
         event: "issues",
         action: "labeled",
+        status: null,
         statusCode: 502,
       },
     });
+  });
+
+  it("reports GitHub delivery transport failures without a status code", async () => {
+    const result = await getWebhookAutomationHealth(db as never, repo, {
+      getBaseUrl: () => "https://hooks.example.test",
+      inspectGitHubHook: vi.fn().mockResolvedValue({
+        active: true,
+        url: "https://hooks.example.test/api/webhook/github/1",
+        deliveries: [{ status: "failure", status_code: null, event: "issues", action: "labeled", delivered_at: "2026-05-28T00:00:00Z" }],
+      }),
+    });
+
+    expect(result).toMatchObject({
+      state: "error",
+      summary: "Webhook delivery infrastructure failed: failure",
+      latestDelivery: {
+        event: "issues",
+        action: "labeled",
+        status: "failure",
+        statusCode: null,
+      },
+    });
+    expect(result?.detail).toContain("did not reach the receiver successfully");
   });
 
   it("reports healthy matching hook and successful latest delivery", async () => {
@@ -81,7 +105,7 @@ describe("getWebhookAutomationHealth", () => {
       inspectGitHubHook: vi.fn().mockResolvedValue({
         active: true,
         url: "https://hooks.example.test/api/webhook/github/1",
-        deliveries: [{ status_code: 200, event: "ping", action: null, delivered_at: "2026-05-28T00:00:00Z" }],
+        deliveries: [{ status: "OK", status_code: 200, event: "ping", action: null, delivered_at: "2026-05-28T00:00:00Z" }],
       }),
     });
 

--- a/packages/web/lib/webhook-health.ts
+++ b/packages/web/lib/webhook-health.ts
@@ -16,6 +16,7 @@ export type WebhookAutomationHealth = {
   latestDelivery: {
     event: string | null;
     action: string | null;
+    status: string | null;
     statusCode: number | null;
     deliveredAt: string | null;
   } | null;
@@ -24,6 +25,7 @@ export type WebhookAutomationHealth = {
 type GitHubDelivery = {
   event?: string | null;
   action?: string | null;
+  status?: string | null;
   status_code?: number | null;
   delivered_at?: string | null;
 };
@@ -111,9 +113,23 @@ export async function getWebhookAutomationHealth(
     if (latestStatusCode !== null && latestStatusCode >= 400) {
       return health({
         state: "error",
-        summary: `Recent GitHub webhook delivery failed with ${latestStatusCode}`,
-        detail: "GitHub reached the configured hook but the latest delivery was not successful.",
-        recovery: "Check the tunnel/server, then redeliver the event or remove and re-add the automation label.",
+        summary: `Webhook delivery infrastructure failed with ${latestStatusCode}`,
+        detail: "GitHub reached the configured hook but the latest delivery failed before issuectl could rely on it.",
+        recovery: "Check the tunnel/server, then redeliver the event or remove and re-add the automation label. For a quick tunnel, start a fresh tunnel and run the webhook rotate command.",
+        expectedUrl,
+        hookId: repo.webhookId,
+        githubUrl,
+        latestDelivery,
+      });
+    }
+
+    const latestStatus = latestDelivery?.status?.trim().toLowerCase() ?? "";
+    if (latestDelivery && latestStatus && latestStatus !== "ok" && latestStatus !== "success") {
+      return health({
+        state: "error",
+        summary: `Webhook delivery infrastructure failed: ${latestDelivery.status}`,
+        detail: "GitHub reported that the latest delivery did not reach the receiver successfully.",
+        recovery: "Check the tunnel/server, then redeliver the event or remove and re-add the automation label. For a quick tunnel, start a fresh tunnel and run the webhook rotate command.",
         expectedUrl,
         hookId: repo.webhookId,
         githubUrl,
@@ -169,6 +185,7 @@ function latestDeliverySummary(deliveries: GitHubDelivery[]): WebhookAutomationH
   return {
     event: latest.event ?? null,
     action: latest.action ?? null,
+    status: latest.status ?? null,
     statusCode: typeof latest.status_code === "number" ? latest.status_code : null,
     deliveredAt: latest.delivered_at ?? null,
   };
@@ -209,6 +226,7 @@ async function inspectGitHubHookWithOctokit(repo: Repo): Promise<GitHubHookSnaps
       deliveries: deliveriesResult.data.map((delivery) => ({
         event: delivery.event,
         action: delivery.action,
+        status: delivery.status,
         status_code: delivery.status_code,
         delivered_at: delivery.delivered_at,
       })),


### PR DESCRIPTION
## Summary
- Adds a live “Check delivery” preflight in the issue/PR label editor before applying issuectl automation labels.
- Automatically refreshes webhook health before adding `issuectl:auto-launch` / `issuectl:auto-review` and warns when delivery health is stale, failed, unknown, or uncheckable.
- Classifies failed GitHub delivery status/status_code as webhook delivery infrastructure failure and includes quick-tunnel rotation recovery copy.

Closes #534

## Failure Modes Considered
- A stale quick-tunnel hook URL looks like an issue/PR launch failure: covered by explicit “webhook delivery infrastructure” summaries and recovery copy.
- An operator applies an automation label using stale page state: covered by the automatic health refresh before automation-label add.
- GitHub reports transport failure text without a useful HTTP status code: covered by the new `status` handling and test.
- The label panel warning does not render on the affected UI surface: covered by `LabelManager.test.ts` static render proof.

## Verification
- `pnpm install` in the fresh worktree; initial focused checks were blocked by missing `node_modules`, then rerun after install.
- `pnpm --dir packages/core build`
- `pnpm --dir packages/web test -- webhook-health.test.ts LabelManager.test.ts` → 2 files, 7 tests passed.
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `git diff --check`
- Commit hook: Turbo typecheck and lint across CLI/core/web completed successfully.
- Pre-push hook: Turbo build across CLI/core/web completed successfully; web Next production build included `/issues/[owner]/[repo]/[number]`.

## Intentional Skip / Residual Risk
- I did not add/run a Playwright browser check for the direct issue label editor. The direct issue page fetches labels and webhook inspection server-side through the real GitHub/Octokit path, and the existing deterministic workbench E2E harness does not use `LabelManager`. The remaining risk is browser-only interaction behavior around the confirmation path; the direct UI render and production build reduce, but do not eliminate, that risk.
