### PR TITLE
Add dashboard triage presets

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -1,4 +1,9 @@
 import { useMemo } from "react";
+import { DashboardPresetStrip } from "./DashboardPresetStrip";
+import {
+  boardPresetIdForState,
+  boardPresetState,
+} from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
   filterDashboardIssues,
@@ -56,6 +61,7 @@ export function BoardFocus({
     [deployments, issueView, query, runningOnly, sortMode, visibleRepos],
   );
   const currentView = viewSummaries.find((view) => view.id === issueView);
+  const activePresetId = boardPresetIdForState(urlState);
 
   return (
     <div className={`${styles.focusInner} ${styles.boardFocus}`}>
@@ -64,6 +70,11 @@ export function BoardFocus({
       <p className={styles.muted}>
         {visibleIssues} {runningOnly ? "running" : "open"} issues in {currentView?.label.toLowerCase() ?? "all"} view across {repos.length} tracked repositories.
       </p>
+      <DashboardPresetStrip
+        activePresetId={activePresetId}
+        ariaLabel="Board triage presets"
+        onApply={(id) => setUrlState(boardPresetState(id))}
+      />
 
       <div aria-label="Board controls" className={styles.boardControls}>
         <input

--- a/packages/web/components/workbench/DashboardPresetStrip.tsx
+++ b/packages/web/components/workbench/DashboardPresetStrip.tsx
@@ -1,0 +1,31 @@
+import {
+  DASHBOARD_PRESETS,
+  type DashboardPresetId,
+} from "./dashboard-presets";
+import styles from "./WorkbenchShell.module.css";
+
+type Props = {
+  activePresetId: DashboardPresetId | null;
+  ariaLabel: string;
+  onApply: (id: DashboardPresetId) => void;
+};
+
+export function DashboardPresetStrip({ activePresetId, ariaLabel, onApply }: Props) {
+  return (
+    <div className={styles.dashboardPresetStrip} role="group" aria-label={ariaLabel}>
+      <span className={styles.dashboardPresetLabel}>Triage presets</span>
+      {DASHBOARD_PRESETS.map((preset) => (
+        <button
+          key={preset.id}
+          type="button"
+          className={activePresetId === preset.id ? styles.primaryButton : styles.secondaryButton}
+          aria-pressed={activePresetId === preset.id}
+          title={preset.description}
+          onClick={() => onApply(preset.id)}
+        >
+          {preset.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useMemo } from "react";
+import { DashboardPresetStrip } from "./DashboardPresetStrip";
+import {
+  globalIssuePresetIdForState,
+  globalIssuePresetState,
+} from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
   filterDashboardIssues,
@@ -72,6 +77,7 @@ export function GlobalIssuesFocus({
   );
   const visibleIssues = repoRows.reduce((count, row) => count + row.issues.length, 0);
   const currentView = viewSummaries.find((view) => view.id === issueView);
+  const activePresetId = globalIssuePresetIdForState(urlState);
 
   return (
     <div className={styles.focusInner}>
@@ -82,6 +88,11 @@ export function GlobalIssuesFocus({
           ? "No matching issues."
           : `${visibleIssues} shown in ${currentView?.label.toLowerCase() ?? "all"} view across ${repos.length} tracked repositories.`}
       </p>
+      <DashboardPresetStrip
+        activePresetId={activePresetId}
+        ariaLabel="Global triage presets"
+        onApply={(id) => setUrlState(globalIssuePresetState(id))}
+      />
       <div aria-label="Global issue controls" className={styles.globalIssueControls}>
         <input
           aria-label="Search global issues"

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1591,6 +1591,26 @@
   flex-wrap: wrap;
 }
 
+.dashboardPresetStrip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 14px 0 4px;
+}
+
+.dashboardPresetStrip .primaryButton,
+.dashboardPresetStrip .secondaryButton {
+  margin-top: 0;
+}
+
+.dashboardPresetLabel {
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  font-style: italic;
+  line-height: 1;
+}
+
 .boardControls .primaryButton,
 .boardControls .secondaryButton,
 .globalIssueControls .primaryButton,

--- a/packages/web/components/workbench/dashboard-presets.ts
+++ b/packages/web/components/workbench/dashboard-presets.ts
@@ -1,0 +1,78 @@
+import type {
+  BoardUrlState,
+  GlobalIssueUrlState,
+} from "./dashboard-url-state";
+
+export type DashboardPresetId = "attention" | "active" | "cached" | "errors";
+
+export type DashboardPreset = {
+  id: DashboardPresetId;
+  label: string;
+  description: string;
+};
+
+export const DASHBOARD_PRESETS: DashboardPreset[] = [
+  {
+    id: "attention",
+    label: "Needs attention",
+    description: "High-priority issues plus repos with fetch problems.",
+  },
+  {
+    id: "active",
+    label: "Active work",
+    description: "Issues with running sessions.",
+  },
+  {
+    id: "cached",
+    label: "Stale cache",
+    description: "Repos currently showing cached issue data.",
+  },
+  {
+    id: "errors",
+    label: "Broken repos",
+    description: "Repos where issue fetches are failing.",
+  },
+];
+
+export function globalIssuePresetState(id: DashboardPresetId): GlobalIssueUrlState {
+  switch (id) {
+    case "attention":
+      return { view: "attention", status: "all", sort: "priority", query: "" };
+    case "active":
+      return { view: "running", status: "running", sort: "updated", query: "" };
+    case "cached":
+      return { view: "cached", status: "all", sort: "updated", query: "" };
+    case "errors":
+      return { view: "errors", status: "all", sort: "updated", query: "" };
+  }
+}
+
+export function boardPresetState(id: DashboardPresetId): BoardUrlState {
+  switch (id) {
+    case "attention":
+      return { view: "attention", sort: "priority", runningOnly: false, query: "" };
+    case "active":
+      return { view: "running", sort: "payload", runningOnly: true, query: "" };
+    case "cached":
+      return { view: "cached", sort: "payload", runningOnly: false, query: "" };
+    case "errors":
+      return { view: "errors", sort: "payload", runningOnly: false, query: "" };
+  }
+}
+
+export function globalIssuePresetIdForState(state: GlobalIssueUrlState): DashboardPresetId | null {
+  return presetIdForState(state, globalIssuePresetState);
+}
+
+export function boardPresetIdForState(state: BoardUrlState): DashboardPresetId | null {
+  return presetIdForState(state, boardPresetState);
+}
+
+function presetIdForState<TState>(
+  state: TState,
+  presetState: (id: DashboardPresetId) => TState,
+): DashboardPresetId | null {
+  return DASHBOARD_PRESETS.find((preset) =>
+    JSON.stringify(presetState(preset.id)) === JSON.stringify(state),
+  )?.id ?? null;
+}

--- a/packages/web/components/workbench/dashboard-url-state.test.ts
+++ b/packages/web/components/workbench/dashboard-url-state.test.ts
@@ -4,6 +4,12 @@ import {
   parseBoardUrlState,
   parseGlobalIssueUrlState,
 } from "./dashboard-url-state";
+import {
+  boardPresetState,
+  boardPresetIdForState,
+  globalIssuePresetState,
+  globalIssuePresetIdForState,
+} from "./dashboard-presets";
 
 describe("dashboard URL state", () => {
   it("parses shareable global issue dashboard controls from URLs", () => {
@@ -54,5 +60,58 @@ describe("dashboard URL state", () => {
       runningOnly: true,
       query: "",
     })).toBe("?repo=mean-weasel%2Fissuectl&running=1");
+  });
+
+  it("maps global issue triage presets to complete dashboard states", () => {
+    expect(globalIssuePresetState("attention")).toEqual({
+      view: "attention",
+      status: "all",
+      sort: "priority",
+      query: "",
+    });
+    expect(globalIssuePresetState("active")).toEqual({
+      view: "running",
+      status: "running",
+      sort: "updated",
+      query: "",
+    });
+    expect(globalIssuePresetState("errors")).toEqual({
+      view: "errors",
+      status: "all",
+      sort: "updated",
+      query: "",
+    });
+  });
+
+  it("maps board triage presets to complete dashboard states", () => {
+    expect(boardPresetState("attention")).toEqual({
+      view: "attention",
+      sort: "priority",
+      runningOnly: false,
+      query: "",
+    });
+    expect(boardPresetState("active")).toEqual({
+      view: "running",
+      sort: "payload",
+      runningOnly: true,
+      query: "",
+    });
+    expect(boardPresetState("cached")).toEqual({
+      view: "cached",
+      sort: "payload",
+      runningOnly: false,
+      query: "",
+    });
+  });
+
+  it("recognizes the active triage preset from dashboard state", () => {
+    expect(globalIssuePresetIdForState(globalIssuePresetState("active"))).toBe("active");
+    expect(boardPresetIdForState(boardPresetState("attention"))).toBe("attention");
+    expect(globalIssuePresetIdForState({
+      view: "running",
+      status: "all",
+      sort: "updated",
+      query: "",
+    })).toBeNull();
   });
 });

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2900,6 +2900,16 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(issueViews.getByRole("button", { name: "Cached 1" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Search global issues")).toHaveValue("paper-owl web");
   await expect(page.getByLabel("paper-owl/web issue #701")).toBeVisible();
+  const globalPresets = page.getByRole("group", { name: "Global triage presets" });
+  await expect(globalPresets.getByRole("button", { name: "Stale cache" })).toHaveAttribute("aria-pressed", "false");
+  await globalPresets.getByRole("button", { name: "Active work" }).click();
+  await expect(page).toHaveURL(/\/workbench\/issues\?view=running&status=running$/);
+  await expect(page.getByLabel("Search global issues")).toHaveValue("");
+  await expect(
+    page.getByRole("group", { name: "Global issue status" }).getByRole("button", { name: "Running" }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await globalPresets.getByRole("button", { name: "Stale cache" }).click();
+  await page.getByLabel("Search global issues").fill("paper-owl web");
   await issueViews.getByRole("button", { name: "Cached 1" }).click();
   await expect(page.getByLabel("paper-owl/web issue #701")).toBeVisible();
   await expect(page.getByLabel("mean-weasel/issuectl issue #447")).toHaveCount(0);
@@ -2919,7 +2929,11 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Search board issues")).toHaveValue("bugdrop");
   await expect(page.getByLabel("Board issue mean-weasel/bugdrop #440")).toBeVisible();
-  await page.getByLabel("Search board issues").fill("");
+  const boardPresets = page.getByRole("group", { name: "Board triage presets" });
+  await boardPresets.getByRole("button", { name: "Active work" }).click();
+  await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
+  await expect(page.getByLabel("Search board issues")).toHaveValue("");
+  await expect(boardPresets.getByRole("button", { name: "Active work" })).toHaveAttribute("aria-pressed", "true");
   await page.getByRole("button", { name: "Show running only" }).click();
   const boardViews = page.getByRole("group", { name: "Board operational views" });
   await boardViews.getByRole("button", { name: "All 8" }).click();


### PR DESCRIPTION
## Summary
- add reusable dashboard triage presets for Needs attention, Active work, Stale cache, and Broken repos
- surface the preset strip on both global issues and board dashboard views
- cover preset-to-URL state mapping and the mobile WebKit dashboard flow

## Acceptance evidence
- pnpm --dir packages/web test -- --run dashboard-url-state.test.ts workbench.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "surfaces duplicate repo names plus issue cache and error state in global dashboards"
- git diff --check
- commit hook: turbo typecheck + lint across @issuectl/cli, @issuectl/core, @issuectl/web
- pre-push hook: turbo build across @issuectl/cli, @issuectl/core, @issuectl/web

## Failure modes considered
- applying a preset leaves stale search/status filters behind, hiding the expected issues
- preset buttons update local UI without writing the shareable /workbench URL
- active preset detection marks a preset while the URL state has been manually customized
- mobile WebKit dashboard controls regress while adding another compact control row

## Checks skipped
- none for the touched web dashboard surface