### PR TITLE
Add dashboard empty state resets

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
+import { DashboardEmptyState, RepoIssueHealth } from "./DashboardStatusBlocks";
 import {
   boardPresetIdForState,
   boardPresetState,
@@ -11,9 +12,7 @@ import {
   repoMatchesDashboardView,
   type DashboardIssueView,
 } from "./dashboard-issue-views";
-import {
-  type BoardSortMode,
-} from "./dashboard-url-state";
+import { DEFAULT_BOARD_URL_STATE, type BoardSortMode } from "./dashboard-url-state";
 import { useBoardDashboardUrlState } from "./dashboard-url-state-hooks";
 import type { WorkbenchDeployment, WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
@@ -62,6 +61,10 @@ export function BoardFocus({
   );
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = boardPresetIdForState(urlState);
+  const hasDashboardFilters = query.trim() !== ""
+    || runningOnly !== DEFAULT_BOARD_URL_STATE.runningOnly
+    || sortMode !== DEFAULT_BOARD_URL_STATE.sort
+    || issueView !== DEFAULT_BOARD_URL_STATE.view;
 
   return (
     <div className={`${styles.focusInner} ${styles.boardFocus}`}>
@@ -137,6 +140,15 @@ export function BoardFocus({
           {cachedRepos > 0 && <span>{cachedRepos} repo issue lists from cache</span>}
           {refreshError && <span>Refresh failed: {refreshError}</span>}
         </div>
+      )}
+      {visibleIssues === 0 && (
+        <DashboardEmptyState
+          buttonLabel="Clear dashboard filters"
+          canReset={hasDashboardFilters}
+          description="Clear the dashboard filters to return to the full cross-repo board."
+          onReset={() => setUrlState(DEFAULT_BOARD_URL_STATE)}
+          title="No board issues match these filters."
+        />
       )}
 
       <div aria-label="Cross-repo board" className={styles.boardScroll} role="region" tabIndex={0}>
@@ -262,19 +274,6 @@ function deploymentForBoardIssue(
   return repo.deployments.find((deployment) => deployment.issueNumber === issue.number)
     ?? deployments.find((deployment) => deployment.repoId === repo.id && deployment.issueNumber === issue.number)
     ?? null;
-}
-
-function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
-  if (!repo.issueError && !repo.issuesFromCache) return null;
-
-  return (
-    <div className={styles.repoIssueHealth} role={repo.issueError ? "alert" : "status"}>
-      {repo.issueError && <span>Issue fetch failed: {repo.issueError}</span>}
-      {repo.issuesFromCache && (
-        <span>Showing cached issues{repo.issuesCachedAt ? ` from ${formatAge(repo.issuesCachedAt)}` : ""}</span>
-      )}
-    </div>
-  );
 }
 
 function matchesBoardIssue(

--- a/packages/web/components/workbench/DashboardStatusBlocks.tsx
+++ b/packages/web/components/workbench/DashboardStatusBlocks.tsx
@@ -1,0 +1,53 @@
+import type { WorkbenchRepo } from "./workbench-types";
+import styles from "./WorkbenchShell.module.css";
+
+type DashboardEmptyStateProps = {
+  buttonLabel: string;
+  canReset: boolean;
+  description: string;
+  onReset: () => void;
+  title: string;
+};
+
+export function DashboardEmptyState({
+  buttonLabel,
+  canReset,
+  description,
+  onReset,
+  title,
+}: DashboardEmptyStateProps) {
+  return (
+    <div className={styles.dashboardEmptyState} role="status">
+      <strong>{title}</strong>
+      <span>{description}</span>
+      {canReset && (
+        <button type="button" className={styles.secondaryButton} onClick={onReset}>
+          {buttonLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
+  if (!repo.issueError && !repo.issuesFromCache) return null;
+
+  return (
+    <div className={styles.repoIssueHealth} role={repo.issueError ? "alert" : "status"}>
+      {repo.issueError && <span>Issue fetch failed: {repo.issueError}</span>}
+      {repo.issuesFromCache && (
+        <span>Showing cached issues{repo.issuesCachedAt ? ` from ${formatAge(repo.issuesCachedAt)}` : ""}</span>
+      )}
+    </div>
+  );
+}
+
+function formatAge(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return "recently";
+  const elapsedMs = Date.now() - timestamp;
+  const elapsedHours = Math.max(0, Math.floor(elapsedMs / 3_600_000));
+  if (elapsedHours < 1) return "just now";
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+  return `${Math.floor(elapsedHours / 24)}d ago`;
+}

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
+import { DashboardEmptyState, RepoIssueHealth } from "./DashboardStatusBlocks";
 import {
   globalIssuePresetIdForState,
   globalIssuePresetState,
@@ -12,6 +13,7 @@ import {
   repoMatchesDashboardView,
 } from "./dashboard-issue-views";
 import {
+  DEFAULT_GLOBAL_ISSUE_URL_STATE,
   type GlobalIssueSortMode,
   type GlobalIssueStatusFilter,
 } from "./dashboard-url-state";
@@ -78,6 +80,10 @@ export function GlobalIssuesFocus({
   const visibleIssues = repoRows.reduce((count, row) => count + row.issues.length, 0);
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = globalIssuePresetIdForState(urlState);
+  const hasDashboardFilters = query.trim() !== ""
+    || statusFilter !== DEFAULT_GLOBAL_ISSUE_URL_STATE.status
+    || sortMode !== DEFAULT_GLOBAL_ISSUE_URL_STATE.sort
+    || issueView !== DEFAULT_GLOBAL_ISSUE_URL_STATE.view;
 
   return (
     <div className={styles.focusInner}>
@@ -157,6 +163,15 @@ export function GlobalIssuesFocus({
           {refreshError && <span>Refresh failed: {refreshError}</span>}
         </div>
       )}
+      {visibleIssues === 0 && (
+        <DashboardEmptyState
+          buttonLabel="Clear dashboard filters"
+          canReset={hasDashboardFilters}
+          description="Clear the dashboard filters to return to the full cross-repo issue list."
+          onReset={() => setUrlState(DEFAULT_GLOBAL_ISSUE_URL_STATE)}
+          title="No dashboard issues match these filters."
+        />
+      )}
       <div aria-label="Global issues">
         {repoRows.map(({ repo, issues }) => (
           <section key={repo.id} aria-label={`Issues for ${repo.owner}/${repo.name}`}>
@@ -227,19 +242,6 @@ function GlobalIssueRow({
         )}
       </div>
     </article>
-  );
-}
-
-function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
-  if (!repo.issueError && !repo.issuesFromCache) return null;
-
-  return (
-    <div className={styles.repoIssueHealth} role={repo.issueError ? "alert" : "status"}>
-      {repo.issueError && <span>Issue fetch failed: {repo.issueError}</span>}
-      {repo.issuesFromCache && (
-        <span>Showing cached issues{repo.issuesCachedAt ? ` from ${formatAge(repo.issuesCachedAt)}` : ""}</span>
-      )}
-    </div>
   );
 }
 

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1611,6 +1611,29 @@
   line-height: 1;
 }
 
+.dashboardEmptyState {
+  align-items: flex-start;
+  background: var(--paper-bg-warm);
+  border: 1px solid var(--paper-line);
+  border-radius: 8px;
+  color: var(--paper-ink);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 14px 0;
+  max-width: 620px;
+  padding: 12px;
+}
+
+.dashboardEmptyState span {
+  color: var(--paper-ink-muted);
+  font-size: 13px;
+}
+
+.dashboardEmptyState .secondaryButton {
+  margin-top: 2px;
+}
+
 .boardControls .primaryButton,
 .boardControls .secondaryButton,
 .globalIssueControls .primaryButton,

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2923,6 +2923,12 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await page.getByLabel("Search global issues").fill("paper-owl web #701");
   await expect(page.getByLabel("paper-owl/web issue #701")).toBeVisible();
   await expect(page.getByLabel("mean-weasel/web issue #440")).toHaveCount(0);
+  await page.getByLabel("Search global issues").fill("no-such-dashboard-result");
+  await expect(page.getByText("No dashboard issues match these filters.")).toBeVisible();
+  await page.getByRole("button", { name: "Clear dashboard filters" }).click();
+  await expect(page).toHaveURL(/\/workbench\/issues$/);
+  await expect(page.getByLabel("Search global issues")).toHaveValue("");
+  await expect(issueViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
 
   await page.goto(`${baseUrl}/workbench/board?view=running&running=1&q=bugdrop`);
   await page.getByRole("button", { name: "Refresh" }).click();
@@ -2951,6 +2957,12 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await page.getByLabel("Search board issues").fill("paper-owl web #701");
   await expect(page.getByLabel("Board issue paper-owl/web #701")).toBeVisible();
   await expect(page.getByLabel("Board issue mean-weasel/web #440")).toHaveCount(0);
+  await page.getByLabel("Search board issues").fill("no-such-board-result");
+  await expect(page.getByText("No board issues match these filters.")).toBeVisible();
+  await page.getByRole("button", { name: "Clear dashboard filters" }).click();
+  await expect(page).toHaveURL(/\/workbench\/board$/);
+  await expect(page.getByLabel("Search board issues")).toHaveValue("");
+  await expect(boardViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
 });
 
 test("deep links workbench subpaths without a 404", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add compact empty states for global issues and board dashboards when filters hide all issues
- add a clear dashboard filters action that resets each surface to its canonical default URL state
- share dashboard empty-state and repo-health UI between the two dashboard surfaces

## Acceptance evidence
- pnpm --dir packages/web test -- --run dashboard-url-state.test.ts workbench.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "surfaces duplicate repo names plus issue cache and error state in global dashboards"
- git diff --check
- commit hook: turbo typecheck + lint across @issuectl/cli, @issuectl/core, @issuectl/web
- pre-push hook: turbo build across @issuectl/cli, @issuectl/core, @issuectl/web

## Failure modes considered
- dashboard looks empty after a search/status/view combination but gives no recovery action
- reset action clears visible inputs without cleaning the shareable /workbench URL
- board and global issue surfaces drift in cache/error health rendering
- mobile WebKit dashboard controls regress after adding the empty-state panel

## Checks skipped
- none for the touched web dashboard surface