### PR TITLE
Add dashboard repo summaries

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
-import { DashboardEmptyState, RepoIssueHealth } from "./DashboardStatusBlocks";
+import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import {
   boardPresetIdForState,
   boardPresetState,
@@ -61,10 +61,7 @@ export function BoardFocus({
   );
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = boardPresetIdForState(urlState);
-  const hasDashboardFilters = query.trim() !== ""
-    || runningOnly !== DEFAULT_BOARD_URL_STATE.runningOnly
-    || sortMode !== DEFAULT_BOARD_URL_STATE.sort
-    || issueView !== DEFAULT_BOARD_URL_STATE.view;
+  const hasDashboardFilters = query.trim() !== "" || runningOnly !== DEFAULT_BOARD_URL_STATE.runningOnly || sortMode !== DEFAULT_BOARD_URL_STATE.sort || issueView !== DEFAULT_BOARD_URL_STATE.view;
 
   return (
     <div className={`${styles.focusInner} ${styles.boardFocus}`}>
@@ -166,6 +163,10 @@ export function BoardFocus({
                   {issues.length} {runningOnly ? "running" : "open"}
                 </p>
               </header>
+              <RepoDashboardSummary
+                repo={repo}
+                {...dashboardIssueSummaryCounts(issues, (issue) => isRunningIssue(repo, deployments, issue))}
+              />
               <RepoIssueHealth repo={repo} />
               {issues.length === 0 ? (
                 <p className={styles.muted}>No matching issues.</p>

--- a/packages/web/components/workbench/DashboardStatusBlocks.tsx
+++ b/packages/web/components/workbench/DashboardStatusBlocks.tsx
@@ -1,4 +1,4 @@
-import type { WorkbenchRepo } from "./workbench-types";
+import type { WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
 
 type DashboardEmptyStateProps = {
@@ -7,6 +7,12 @@ type DashboardEmptyStateProps = {
   description: string;
   onReset: () => void;
   title: string;
+};
+
+export type RepoDashboardSummaryCounts = {
+  highPriorityCount: number;
+  runningCount: number;
+  visibleCount: number;
 };
 
 export function DashboardEmptyState({
@@ -39,6 +45,41 @@ export function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
         <span>Showing cached issues{repo.issuesCachedAt ? ` from ${formatAge(repo.issuesCachedAt)}` : ""}</span>
       )}
     </div>
+  );
+}
+
+export function RepoDashboardSummary({
+  highPriorityCount,
+  repo,
+  runningCount,
+  visibleCount,
+}: RepoDashboardSummaryCounts & { repo: WorkbenchRepo }) {
+  return (
+    <div className={styles.repoIssueSummary} aria-label={`Dashboard summary for ${repo.owner}/${repo.name}`}>
+      <span className={styles.repoIssueSummaryChip}>{visibleCount} visible</span>
+      <span className={styles.repoIssueSummaryChip}>{runningCount} running</span>
+      <span className={styles.repoIssueSummaryChip}>{highPriorityCount} high priority</span>
+      {repo.issuesFromCache && (
+        <span className={styles.repoIssueSummaryChip} data-tone="cache">cached</span>
+      )}
+      {repo.issueError && (
+        <span className={styles.repoIssueSummaryChip} data-tone="error">fetch failed</span>
+      )}
+    </div>
+  );
+}
+
+export function dashboardIssueSummaryCounts(
+  issues: WorkbenchIssueSummary[],
+  isRunning: (issue: WorkbenchIssueSummary) => boolean,
+): RepoDashboardSummaryCounts {
+  return issues.reduce<RepoDashboardSummaryCounts>(
+    (summary, issue) => ({
+      highPriorityCount: summary.highPriorityCount + (issue.priority === "high" ? 1 : 0),
+      runningCount: summary.runningCount + (isRunning(issue) ? 1 : 0),
+      visibleCount: summary.visibleCount + 1,
+    }),
+    { highPriorityCount: 0, runningCount: 0, visibleCount: 0 },
   );
 }
 

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
-import { DashboardEmptyState, RepoIssueHealth } from "./DashboardStatusBlocks";
+import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import {
   globalIssuePresetIdForState,
   globalIssuePresetState,
@@ -12,11 +12,7 @@ import {
   filterDashboardIssues,
   repoMatchesDashboardView,
 } from "./dashboard-issue-views";
-import {
-  DEFAULT_GLOBAL_ISSUE_URL_STATE,
-  type GlobalIssueSortMode,
-  type GlobalIssueStatusFilter,
-} from "./dashboard-url-state";
+import { DEFAULT_GLOBAL_ISSUE_URL_STATE, type GlobalIssueSortMode, type GlobalIssueStatusFilter } from "./dashboard-url-state";
 import { useGlobalIssueDashboardUrlState } from "./dashboard-url-state-hooks";
 import { deploymentForIssue } from "./workbench-selectors";
 import type { WorkbenchDeployment, WorkbenchIssueSummary, WorkbenchRepo } from "./workbench-types";
@@ -80,10 +76,7 @@ export function GlobalIssuesFocus({
   const visibleIssues = repoRows.reduce((count, row) => count + row.issues.length, 0);
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = globalIssuePresetIdForState(urlState);
-  const hasDashboardFilters = query.trim() !== ""
-    || statusFilter !== DEFAULT_GLOBAL_ISSUE_URL_STATE.status
-    || sortMode !== DEFAULT_GLOBAL_ISSUE_URL_STATE.sort
-    || issueView !== DEFAULT_GLOBAL_ISSUE_URL_STATE.view;
+  const hasDashboardFilters = query.trim() !== "" || statusFilter !== DEFAULT_GLOBAL_ISSUE_URL_STATE.status || sortMode !== DEFAULT_GLOBAL_ISSUE_URL_STATE.sort || issueView !== DEFAULT_GLOBAL_ISSUE_URL_STATE.view;
 
   return (
     <div className={styles.focusInner}>
@@ -176,6 +169,13 @@ export function GlobalIssuesFocus({
         {repoRows.map(({ repo, issues }) => (
           <section key={repo.id} aria-label={`Issues for ${repo.owner}/${repo.name}`}>
             <h2>{repo.owner}/{repo.name}</h2>
+            <RepoDashboardSummary
+              repo={repo}
+              {...dashboardIssueSummaryCounts(
+                issues,
+                (issue) => issueStatus(issue, deploymentForIssue(repo, issue.number)) === "running",
+              )}
+            />
             <RepoIssueHealth repo={repo} />
             {issues.length === 0 ? (
               <p className={styles.muted}>No matching issues.</p>

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1634,6 +1634,34 @@
   margin-top: 2px;
 }
 
+.repoIssueSummary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 8px;
+}
+
+.repoIssueSummaryChip {
+  background: color-mix(in srgb, var(--paper-bg-warm) 76%, white);
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.repoIssueSummaryChip[data-tone="cache"] {
+  background: color-mix(in srgb, var(--paper-butter) 16%, var(--paper-bg));
+  color: color-mix(in srgb, var(--paper-butter) 55%, var(--paper-ink));
+}
+
+.repoIssueSummaryChip[data-tone="error"] {
+  background: color-mix(in srgb, var(--paper-brick) 12%, var(--paper-bg));
+  color: var(--paper-brick);
+}
+
 .boardControls .primaryButton,
 .boardControls .secondaryButton,
 .globalIssueControls .primaryButton,

--- a/packages/web/components/workbench/workbench.test.ts
+++ b/packages/web/components/workbench/workbench.test.ts
@@ -5,6 +5,7 @@ import {
   filterDashboardIssues,
   repoMatchesDashboardView,
 } from "./dashboard-issue-views";
+import { dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import {
   compactRepoInitials,
   filterIssueQueue,
@@ -239,6 +240,19 @@ describe("workbench state", () => {
       .toEqual([]);
     expect(failedRepo ? repoMatchesDashboardView(failedRepo, "errors") : false)
       .toBe(true);
+  });
+
+  it("summarizes visible dashboard issue counts for repo scan chips", () => {
+    const issues = [
+      { ...issue(1, "High active issue"), priority: "high" as const, hasActiveDeployment: true },
+      { ...issue(2, "Normal idle issue"), hasActiveDeployment: false },
+    ];
+
+    expect(dashboardIssueSummaryCounts(issues, (item) => item.hasActiveDeployment)).toEqual({
+      highPriorityCount: 1,
+      runningCount: 1,
+      visibleCount: 2,
+    });
   });
 
   it("clamps column widths to objective UI limits", () => {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2900,6 +2900,9 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(issueViews.getByRole("button", { name: "Cached 1" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Search global issues")).toHaveValue("paper-owl web");
   await expect(page.getByLabel("paper-owl/web issue #701")).toBeVisible();
+  const globalCachedSummary = page.getByLabel("Dashboard summary for paper-owl/web");
+  await expect(globalCachedSummary).toContainText("1 visible");
+  await expect(globalCachedSummary).toContainText("cached");
   const globalPresets = page.getByRole("group", { name: "Global triage presets" });
   await expect(globalPresets.getByRole("button", { name: "Stale cache" })).toHaveAttribute("aria-pressed", "false");
   await globalPresets.getByRole("button", { name: "Active work" }).click();
@@ -2929,12 +2932,16 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/issues$/);
   await expect(page.getByLabel("Search global issues")).toHaveValue("");
   await expect(issueViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
+  const globalIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
+  await expect(globalIssuectlSummary).toContainText("4 visible");
+  await expect(globalIssuectlSummary).toContainText("3 running");
 
   await page.goto(`${baseUrl}/workbench/board?view=running&running=1&q=bugdrop`);
   await page.getByRole("button", { name: "Refresh" }).click();
   await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Search board issues")).toHaveValue("bugdrop");
   await expect(page.getByLabel("Board issue mean-weasel/bugdrop #440")).toBeVisible();
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/bugdrop")).toContainText("1 visible");
   const boardPresets = page.getByRole("group", { name: "Board triage presets" });
   await boardPresets.getByRole("button", { name: "Active work" }).click();
   await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
@@ -2963,6 +2970,9 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/board$/);
   await expect(page.getByLabel("Search board issues")).toHaveValue("");
   await expect(boardViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
+  const boardIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
+  await expect(boardIssuectlSummary).toContainText("4 visible");
+  await expect(boardIssuectlSummary).toContainText("3 running");
 });
 
 test("deep links workbench subpaths without a 404", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add repo-level dashboard summary chips for visible, running, and high-priority issue counts
- surface cache and fetch-failure badges in the same scan row for global issues and board columns
- cover summary count math and WebKit-visible summary updates during filter/reset flows

## Acceptance evidence
- pnpm --dir packages/web test -- --run dashboard-url-state.test.ts workbench.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "surfaces duplicate repo names plus issue cache and error state in global dashboards"
- git diff --check
- commit hook: turbo typecheck + lint across @issuectl/cli, @issuectl/core, @issuectl/web
- pre-push hook: turbo build across @issuectl/cli, @issuectl/core, @issuectl/web

## Failure modes considered
- summary counts do not track the currently visible filtered issues
- running counts diverge between global issue rows and board columns
- cache/error repo health becomes harder to see after the summary row is added
- mobile WebKit dashboard controls regress or summary chips fail to render after reset

## Checks skipped
- none for the touched web dashboard surface