### PR TITLE
Order dashboard repos by operational context

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
 import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
-import {
-  boardPresetIdForState,
-  boardPresetState,
-} from "./dashboard-presets";
+import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
+import { boardPresetIdForState, boardPresetState } from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
   filterDashboardIssues,
@@ -47,17 +45,20 @@ export function BoardFocus({
   const failedRepos = repos.filter((repo) => repo.issueError).length;
   const cachedRepos = repos.filter((repo) => repo.issuesFromCache).length;
   const viewSummaries = useMemo(() => dashboardIssueViewSummaries(repos, deployments), [deployments, repos]);
-  const visibleRepos = useMemo(
-    () => repos.filter((repo) => repoMatchesDashboardView(repo, issueView, deployments)),
-    [deployments, issueView, repos],
+  const visibleRows = useMemo(
+    () => sortDashboardRepoRows(
+      repos.filter((repo) => repoMatchesDashboardView(repo, issueView, deployments)).map((repo) => ({
+        repo,
+        issues: boardIssues(repo, deployments, runningOnly, sortMode, query, issueView),
+      })),
+      issueView,
+      ({ repo, issues }) => dashboardIssueSummaryCounts(issues, (issue) => isRunningIssue(repo, deployments, issue)),
+    ),
+    [deployments, issueView, query, repos, runningOnly, sortMode],
   );
   const visibleIssues = useMemo(
-    () =>
-      visibleRepos.reduce(
-        (count, repo) => count + boardIssues(repo, deployments, runningOnly, sortMode, query, issueView).length,
-        0,
-      ),
-    [deployments, issueView, query, runningOnly, sortMode, visibleRepos],
+    () => visibleRows.reduce((count, row) => count + row.issues.length, 0),
+    [visibleRows],
   );
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = boardPresetIdForState(urlState);
@@ -149,8 +150,7 @@ export function BoardFocus({
       )}
 
       <div aria-label="Cross-repo board" className={styles.boardScroll} role="region" tabIndex={0}>
-        {visibleRepos.map((repo) => {
-          const issues = boardIssues(repo, deployments, runningOnly, sortMode, query, issueView);
+        {visibleRows.map(({ repo, issues }) => {
           return (
             <section
               key={repo.id}

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -3,10 +3,8 @@
 import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
 import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
-import {
-  globalIssuePresetIdForState,
-  globalIssuePresetState,
-} from "./dashboard-presets";
+import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
+import { globalIssuePresetIdForState, globalIssuePresetState } from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
   filterDashboardIssues,
@@ -60,9 +58,8 @@ export function GlobalIssuesFocus({
   const cachedRepos = repos.filter((repo) => repo.issuesFromCache).length;
   const viewSummaries = useMemo(() => dashboardIssueViewSummaries(repos), [repos]);
   const repoRows = useMemo(
-    () => repos
-      .filter((repo) => repoMatchesDashboardView(repo, issueView))
-      .map((repo) => ({
+    () => sortDashboardRepoRows(
+      repos.filter((repo) => repoMatchesDashboardView(repo, issueView)).map((repo) => ({
         repo,
         issues: sortIssues(
           filterDashboardIssues(repo, issueView).filter((issue) =>
@@ -71,6 +68,10 @@ export function GlobalIssuesFocus({
           sortMode,
         ),
       })),
+      issueView,
+      ({ repo, issues }) => dashboardIssueSummaryCounts(issues, (issue) =>
+        issueStatus(issue, deploymentForIssue(repo, issue.number)) === "running"),
+    ),
     [issueView, query, repos, sortMode, statusFilter],
   );
   const visibleIssues = repoRows.reduce((count, row) => count + row.issues.length, 0);

--- a/packages/web/components/workbench/dashboard-repo-ordering.ts
+++ b/packages/web/components/workbench/dashboard-repo-ordering.ts
@@ -1,0 +1,60 @@
+import type { DashboardIssueView } from "./dashboard-issue-views";
+import type { RepoDashboardSummaryCounts } from "./DashboardStatusBlocks";
+import type { WorkbenchRepo } from "./workbench-types";
+
+export type DashboardRepoOrderInput = {
+  repo: WorkbenchRepo;
+  summary: RepoDashboardSummaryCounts;
+};
+
+export function sortDashboardRepoRows<T extends { repo: WorkbenchRepo }>(
+  rows: T[],
+  view: DashboardIssueView,
+  summaryForRow: (row: T) => RepoDashboardSummaryCounts,
+): T[] {
+  return [...rows].sort((left, right) =>
+    compareDashboardRepoOrder(
+      { repo: left.repo, summary: summaryForRow(left) },
+      { repo: right.repo, summary: summaryForRow(right) },
+      view,
+    ),
+  );
+}
+
+export function compareDashboardRepoOrder(
+  left: DashboardRepoOrderInput,
+  right: DashboardRepoOrderInput,
+  view: DashboardIssueView,
+): number {
+  for (const delta of dashboardRepoSortDeltas(left, right, view)) {
+    if (delta !== 0) return delta;
+  }
+  return repoName(left.repo).localeCompare(repoName(right.repo));
+}
+
+function dashboardRepoSortDeltas(
+  left: DashboardRepoOrderInput,
+  right: DashboardRepoOrderInput,
+  view: DashboardIssueView,
+): number[] {
+  if (view === "errors") return [booleanDelta(left.repo.issueError, right.repo.issueError)];
+  if (view === "cached") return [booleanDelta(left.repo.issuesFromCache, right.repo.issuesFromCache)];
+  if (view === "running") return [countDelta(left.summary.runningCount, right.summary.runningCount)];
+  return [
+    countDelta(left.summary.highPriorityCount, right.summary.highPriorityCount),
+    countDelta(left.summary.runningCount, right.summary.runningCount),
+    countDelta(left.summary.visibleCount, right.summary.visibleCount),
+  ];
+}
+
+function booleanDelta(left: unknown, right: unknown): number {
+  return Number(Boolean(right)) - Number(Boolean(left));
+}
+
+function countDelta(left: number, right: number): number {
+  return right - left;
+}
+
+function repoName(repo: WorkbenchRepo): string {
+  return `${repo.owner}/${repo.name}`;
+}

--- a/packages/web/components/workbench/workbench.test.ts
+++ b/packages/web/components/workbench/workbench.test.ts
@@ -6,6 +6,7 @@ import {
   repoMatchesDashboardView,
 } from "./dashboard-issue-views";
 import { dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
+import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
 import {
   compactRepoInitials,
   filterIssueQueue,
@@ -253,6 +254,28 @@ describe("workbench state", () => {
       runningCount: 1,
       visibleCount: 2,
     });
+  });
+
+  it("orders dashboard repos by the active operational context", () => {
+    const [issuectl, bugdrop, api] = payloadFixture().repos;
+    const rows = [
+      { repo: api, summary: { highPriorityCount: 0, runningCount: 0, visibleCount: 1 } },
+      { repo: bugdrop, summary: { highPriorityCount: 1, runningCount: 0, visibleCount: 1 } },
+      { repo: issuectl, summary: { highPriorityCount: 0, runningCount: 3, visibleCount: 4 } },
+    ];
+
+    expect(sortDashboardRepoRows(rows, "all", (row) => row.summary).map((row) => row.repo.name))
+      .toEqual(["bugdrop", "issuectl", "api"]);
+    expect(sortDashboardRepoRows(rows, "running", (row) => row.summary).map((row) => row.repo.name))
+      .toEqual(["issuectl", "api", "bugdrop"]);
+    expect(sortDashboardRepoRows(rows.map((row) =>
+      row.repo.name === "api" ? { ...row, repo: { ...row.repo, issuesFromCache: true } } : row
+    ), "cached", (row) => row.summary).map((row) => row.repo.name))
+      .toEqual(["api", "bugdrop", "issuectl"]);
+    expect(sortDashboardRepoRows(rows.map((row) =>
+      row.repo.name === "bugdrop" ? { ...row, repo: { ...row.repo, issueError: "failed" } } : row
+    ), "errors", (row) => row.summary).map((row) => row.repo.name))
+      .toEqual(["bugdrop", "api", "issuectl"]);
   });
 
   it("clamps column widths to objective UI limits", () => {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2911,6 +2911,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(
     page.getByRole("group", { name: "Global issue status" }).getByRole("button", { name: "Running" }),
   ).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Global issues").locator("section").first())
+    .toHaveAttribute("aria-label", "Issues for mean-weasel/issuectl");
   await globalPresets.getByRole("button", { name: "Stale cache" }).click();
   await page.getByLabel("Search global issues").fill("paper-owl web");
   await issueViews.getByRole("button", { name: "Cached 1" }).click();
@@ -2919,6 +2921,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await issueViews.getByRole("button", { name: "Errors 2" }).click();
   await expect(page).toHaveURL(/\/workbench\/issues\?view=errors&q=paper-owl\+web$/);
   await expect(page.getByRole("heading", { name: "paper-owl/api" })).toBeVisible();
+  await expect(page.getByLabel("Global issues").locator("section").first())
+    .toHaveAttribute("aria-label", "Issues for mean-weasel/api");
   await expect(page.getByText("Issue fetch failed: GitHub unavailable for paper-owl/api")).toBeVisible();
   await expect(page.getByLabel("paper-owl/web issue #701")).toHaveCount(0);
   await issueViews.getByRole("button", { name: "All 8" }).click();
@@ -2947,6 +2951,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
   await expect(page.getByLabel("Search board issues")).toHaveValue("");
   await expect(boardPresets.getByRole("button", { name: "Active work" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Cross-repo board").locator("section").first())
+    .toHaveAttribute("aria-label", "Board column mean-weasel/issuectl");
   await page.getByRole("button", { name: "Show running only" }).click();
   const boardViews = page.getByRole("group", { name: "Board operational views" });
   await boardViews.getByRole("button", { name: "All 8" }).click();


### PR DESCRIPTION
## Summary
- add deterministic dashboard repo ordering by active operational view
- sort all/attention by high-priority, running, then visible counts; running by running count; cached/errors by their repo health signal
- apply the ordering to global issues and board rows without changing issue-level sort controls

## Acceptance evidence
- pnpm --dir packages/web test -- --run dashboard-url-state.test.ts workbench.test.ts
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "surfaces duplicate repo names plus issue cache and error state in global dashboards"
- git diff --check
- commit hook: turbo typecheck + lint across @issuectl/cli, @issuectl/core, @issuectl/web
- pre-push hook: turbo build across @issuectl/cli, @issuectl/core, @issuectl/web

## Failure modes considered
- urgent repos stay buried after summary chips expose their priority/running counts
- repo ordering is nondeterministic when counts tie
- board and global issues diverge in ordering semantics
- mobile WebKit dashboard regressions after sorting sections/columns

## Checks skipped
- none for the touched web dashboard surface