### PR TITLE
Add dashboard default presets

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -40,7 +40,7 @@ export function BoardFocus({
   refreshPending,
   refreshError,
 }: Props) {
-  const [urlState, setUrlState] = useBoardDashboardUrlState();
+  const [urlState, setUrlState, defaultControls] = useBoardDashboardUrlState();
   const { query, runningOnly, sort: sortMode, view: issueView } = urlState;
   const failedRepos = repos.filter((repo) => repo.issueError).length;
   const cachedRepos = repos.filter((repo) => repo.issuesFromCache).length;
@@ -73,10 +73,9 @@ export function BoardFocus({
       </p>
       <DashboardPresetStrip
         activePresetId={activePresetId}
-        ariaLabel="Board triage presets"
-        onApply={(id) => setUrlState(boardPresetState(id))}
+        ariaLabel="Board triage presets" onApply={(id) => setUrlState(boardPresetState(id))}
+        defaultPresetId={defaultControls.defaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
       />
-
       <div aria-label="Board controls" className={styles.boardControls}>
         <input
           aria-label="Search board issues"

--- a/packages/web/components/workbench/DashboardPresetStrip.tsx
+++ b/packages/web/components/workbench/DashboardPresetStrip.tsx
@@ -7,10 +7,20 @@ import styles from "./WorkbenchShell.module.css";
 type Props = {
   activePresetId: DashboardPresetId | null;
   ariaLabel: string;
+  defaultPresetId?: DashboardPresetId | null;
   onApply: (id: DashboardPresetId) => void;
+  onSetDefault?: (id: DashboardPresetId) => void;
 };
 
-export function DashboardPresetStrip({ activePresetId, ariaLabel, onApply }: Props) {
+export function DashboardPresetStrip({
+  activePresetId,
+  ariaLabel,
+  defaultPresetId,
+  onApply,
+  onSetDefault,
+}: Props) {
+  const defaultPreset = DASHBOARD_PRESETS.find((preset) => preset.id === defaultPresetId);
+
   return (
     <div className={styles.dashboardPresetStrip} role="group" aria-label={ariaLabel}>
       <span className={styles.dashboardPresetLabel}>Triage presets</span>
@@ -26,6 +36,18 @@ export function DashboardPresetStrip({ activePresetId, ariaLabel, onApply }: Pro
           {preset.label}
         </button>
       ))}
+      {activePresetId && onSetDefault && (
+        <button
+          type="button"
+          className={styles.secondaryButton}
+          onClick={() => onSetDefault(activePresetId)}
+        >
+          Set default
+        </button>
+      )}
+      {defaultPreset && (
+        <span className={styles.dashboardPresetDefault}>Default: {defaultPreset.label}</span>
+      )}
     </div>
   );
 }

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -51,7 +51,7 @@ export function GlobalIssuesFocus({
   refreshPending,
   refreshError,
 }: Props) {
-  const [urlState, setUrlState] = useGlobalIssueDashboardUrlState();
+  const [urlState, setUrlState, defaultControls] = useGlobalIssueDashboardUrlState();
   const { query, status: statusFilter, sort: sortMode, view: issueView } = urlState;
   const totalIssues = repos.reduce((count, repo) => count + repo.issues.length, 0);
   const failedRepos = repos.filter((repo) => repo.issueError).length;
@@ -92,6 +92,7 @@ export function GlobalIssuesFocus({
         activePresetId={activePresetId}
         ariaLabel="Global triage presets"
         onApply={(id) => setUrlState(globalIssuePresetState(id))}
+        defaultPresetId={defaultControls.defaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
       />
       <div aria-label="Global issue controls" className={styles.globalIssueControls}>
         <input

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1611,6 +1611,11 @@
   line-height: 1;
 }
 
+.dashboardPresetDefault {
+  color: var(--paper-ink-muted);
+  font-size: 12px;
+}
+
 .dashboardEmptyState {
   align-items: flex-start;
   background: var(--paper-bg-warm);

--- a/packages/web/components/workbench/dashboard-default-prefs.ts
+++ b/packages/web/components/workbench/dashboard-default-prefs.ts
@@ -1,0 +1,37 @@
+import { DASHBOARD_PRESETS, type DashboardPresetId } from "./dashboard-presets";
+import type { DashboardSurface } from "./dashboard-url-state";
+
+const DEFAULT_PRESET_STORAGE_KEYS: Record<DashboardSurface, string> = {
+  board: "issuectl.dashboard.defaultPreset.board",
+  globalIssues: "issuectl.dashboard.defaultPreset.globalIssues",
+};
+
+const PRESET_IDS = new Set<DashboardPresetId>(DASHBOARD_PRESETS.map((preset) => preset.id));
+
+export function readDashboardDefaultPreset(
+  surface: DashboardSurface,
+  storage: Storage | null | undefined = globalStorage(),
+): DashboardPresetId | null {
+  try {
+    const value = storage?.getItem(DEFAULT_PRESET_STORAGE_KEYS[surface]) ?? null;
+    return value && PRESET_IDS.has(value as DashboardPresetId) ? value as DashboardPresetId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeDashboardDefaultPreset(
+  surface: DashboardSurface,
+  presetId: DashboardPresetId,
+  storage: Storage | null | undefined = globalStorage(),
+): void {
+  try {
+    storage?.setItem(DEFAULT_PRESET_STORAGE_KEYS[surface], presetId);
+  } catch {
+    // Ignore localStorage failures; defaults are a convenience, not required state.
+  }
+}
+
+function globalStorage(): Storage | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}

--- a/packages/web/components/workbench/dashboard-url-state-hooks.ts
+++ b/packages/web/components/workbench/dashboard-url-state-hooks.ts
@@ -1,10 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { readDashboardDefaultPreset, writeDashboardDefaultPreset } from "./dashboard-default-prefs";
+import {
+  boardPresetState,
+  globalIssuePresetState,
+  type DashboardPresetId,
+} from "./dashboard-presets";
 import {
   dashboardUrlSearch,
   DEFAULT_BOARD_URL_STATE,
   DEFAULT_GLOBAL_ISSUE_URL_STATE,
+  hasDashboardUrlState,
   parseBoardUrlState,
   parseGlobalIssueUrlState,
   type BoardUrlState,
@@ -12,25 +19,34 @@ import {
   type GlobalIssueUrlState,
 } from "./dashboard-url-state";
 
+export type DashboardDefaultPresetControls = {
+  defaultPresetId: DashboardPresetId | null;
+  setDefaultPresetId: (presetId: DashboardPresetId) => void;
+};
+
 export function useGlobalIssueDashboardUrlState(): [
   GlobalIssueUrlState,
   (patch: Partial<GlobalIssueUrlState>) => void,
+  DashboardDefaultPresetControls,
 ] {
   return useDashboardUrlState(
     "globalIssues",
     DEFAULT_GLOBAL_ISSUE_URL_STATE,
     parseGlobalIssueUrlState,
+    globalIssuePresetState,
   );
 }
 
 export function useBoardDashboardUrlState(): [
   BoardUrlState,
   (patch: Partial<BoardUrlState>) => void,
+  DashboardDefaultPresetControls,
 ] {
   return useDashboardUrlState(
     "board",
     DEFAULT_BOARD_URL_STATE,
     parseBoardUrlState,
+    boardPresetState,
   );
 }
 
@@ -38,17 +54,22 @@ function useDashboardUrlState<TState extends GlobalIssueUrlState | BoardUrlState
   surface: DashboardSurface,
   fallback: TState,
   parse: (search: string) => TState,
-): [TState, (patch: Partial<TState>) => void] {
-  const [state, setState] = useState<TState>(() =>
-    typeof window === "undefined" ? fallback : parse(window.location.search),
-  );
+  presetState: (presetId: DashboardPresetId) => TState,
+): [TState, (patch: Partial<TState>) => void, DashboardDefaultPresetControls] {
+  const initialDefaultPresetId = typeof window === "undefined" ? null : readDashboardDefaultPreset(surface);
+  const [defaultPresetId, setDefaultPresetIdState] = useState<DashboardPresetId | null>(initialDefaultPresetId);
+  const [state, setState] = useState<TState>(() => {
+    if (typeof window === "undefined") return fallback;
+    return stateFromLocation(window.location.search, parse, presetState, initialDefaultPresetId);
+  });
 
   useEffect(() => {
-    const syncFromUrl = () => setState(parse(window.location.search));
+    const syncFromUrl = () =>
+      setState(stateFromLocation(window.location.search, parse, presetState, defaultPresetId));
     syncFromUrl();
     window.addEventListener("popstate", syncFromUrl);
     return () => window.removeEventListener("popstate", syncFromUrl);
-  }, [parse]);
+  }, [defaultPresetId, parse, presetState]);
 
   const updateState = (patch: Partial<TState>) => {
     setState((current) => {
@@ -61,5 +82,23 @@ function useDashboardUrlState<TState extends GlobalIssueUrlState | BoardUrlState
     });
   };
 
-  return [state, updateState];
+  const setDefaultPresetId = (presetId: DashboardPresetId) => {
+    writeDashboardDefaultPreset(surface, presetId);
+    setDefaultPresetIdState(presetId);
+    if (typeof window !== "undefined" && !hasDashboardUrlState(window.location.search)) {
+      setState(presetState(presetId));
+    }
+  };
+
+  return [state, updateState, { defaultPresetId, setDefaultPresetId }];
+}
+
+function stateFromLocation<TState>(
+  search: string,
+  parse: (search: string) => TState,
+  presetState: (presetId: DashboardPresetId) => TState,
+  defaultPresetId: DashboardPresetId | null,
+): TState {
+  if (hasDashboardUrlState(search) || !defaultPresetId) return parse(search);
+  return presetState(defaultPresetId);
 }

--- a/packages/web/components/workbench/dashboard-url-state.test.ts
+++ b/packages/web/components/workbench/dashboard-url-state.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   dashboardUrlSearch,
+  hasDashboardUrlState,
   parseBoardUrlState,
   parseGlobalIssueUrlState,
 } from "./dashboard-url-state";
+import {
+  readDashboardDefaultPreset,
+  writeDashboardDefaultPreset,
+} from "./dashboard-default-prefs";
 import {
   boardPresetState,
   boardPresetIdForState,
@@ -62,6 +67,24 @@ describe("dashboard URL state", () => {
     })).toBe("?repo=mean-weasel%2Fissuectl&running=1");
   });
 
+  it("detects when dashboard URL controls should override saved defaults", () => {
+    expect(hasDashboardUrlState("?repo=mean-weasel%2Fissuectl")).toBe(false);
+    expect(hasDashboardUrlState("?repo=mean-weasel%2Fissuectl&view=running")).toBe(true);
+    expect(hasDashboardUrlState("?q=")).toBe(true);
+  });
+
+  it("stores valid local dashboard default presets", () => {
+    const storage = memoryStorage();
+
+    writeDashboardDefaultPreset("globalIssues", "attention", storage);
+    writeDashboardDefaultPreset("board", "active", storage);
+
+    expect(readDashboardDefaultPreset("globalIssues", storage)).toBe("attention");
+    expect(readDashboardDefaultPreset("board", storage)).toBe("active");
+    storage.setItem("issuectl.dashboard.defaultPreset.board", "unknown");
+    expect(readDashboardDefaultPreset("board", storage)).toBeNull();
+  });
+
   it("maps global issue triage presets to complete dashboard states", () => {
     expect(globalIssuePresetState("attention")).toEqual({
       view: "attention",
@@ -115,3 +138,15 @@ describe("dashboard URL state", () => {
     })).toBeNull();
   });
 });
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}

--- a/packages/web/components/workbench/dashboard-url-state.ts
+++ b/packages/web/components/workbench/dashboard-url-state.ts
@@ -39,6 +39,11 @@ const GLOBAL_SORTS = new Set<GlobalIssueSortMode>(["updated", "priority"]);
 const BOARD_SORTS = new Set<BoardSortMode>(["payload", "priority"]);
 const DASHBOARD_PARAM_NAMES = ["view", "status", "sort", "running", "q"];
 
+export function hasDashboardUrlState(search: string | URLSearchParams): boolean {
+  const params = searchParams(search);
+  return DASHBOARD_PARAM_NAMES.some((name) => params.has(name));
+}
+
 export function parseGlobalIssueUrlState(search: string | URLSearchParams): GlobalIssueUrlState {
   const params = searchParams(search);
   return {

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2890,12 +2890,13 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
       }),
     });
   });
-
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await page.evaluate(() => window.localStorage.clear());
   await page.goto(`${baseUrl}/workbench/issues?view=cached&q=paper-owl%20web`);
   await expect(page.getByRole("heading", { name: "paper-owl/web" })).toBeVisible();
   await page.getByRole("button", { name: "Refresh" }).click();
   await expect(page.getByText(/Showing cached issues/)).toBeVisible();
-  const issueViews = page.getByRole("group", { name: "Operational issue views" });
+  let issueViews = page.getByRole("group", { name: "Operational issue views" });
   await expect(issueViews.getByRole("button", { name: "Attention 4" })).toBeVisible();
   await expect(issueViews.getByRole("button", { name: "Cached 1" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Search global issues")).toHaveValue("paper-owl web");
@@ -2913,6 +2914,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   ).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Global issues").locator("section").first())
     .toHaveAttribute("aria-label", "Issues for mean-weasel/issuectl");
+  await globalPresets.getByRole("button", { name: "Set default" }).click();
+  await expect(globalPresets).toContainText("Default: Active work");
   await globalPresets.getByRole("button", { name: "Stale cache" }).click();
   await page.getByLabel("Search global issues").fill("paper-owl web");
   await issueViews.getByRole("button", { name: "Cached 1" }).click();
@@ -2953,6 +2956,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(boardPresets.getByRole("button", { name: "Active work" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByLabel("Cross-repo board").locator("section").first())
     .toHaveAttribute("aria-label", "Board column mean-weasel/issuectl");
+  await boardPresets.getByRole("button", { name: "Set default" }).click();
+  await expect(boardPresets).toContainText("Default: Active work");
   await page.getByRole("button", { name: "Show running only" }).click();
   const boardViews = page.getByRole("group", { name: "Board operational views" });
   await boardViews.getByRole("button", { name: "All 8" }).click();
@@ -2979,6 +2984,24 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   const boardIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
   await expect(boardIssuectlSummary).toContainText("4 visible");
   await expect(boardIssuectlSummary).toContainText("3 running");
+
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await expect(page).toHaveURL(/\/workbench\/issues$/);
+  const savedGlobalPresets = page.getByRole("group", { name: "Global triage presets" });
+  await expect(savedGlobalPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Search global issues")).toHaveValue("");
+  await page.goto(`${baseUrl}/workbench/issues?view=cached&q=paper-owl%20web`);
+  issueViews = page.getByRole("group", { name: "Operational issue views" });
+  await expect(issueViews.getByRole("button", { name: /^Cached \d+$/ })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Search global issues")).toHaveValue("paper-owl web");
+
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(page).toHaveURL(/\/workbench\/board$/);
+  const savedBoardPresets = page.getByRole("group", { name: "Board triage presets" });
+  await expect(savedBoardPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
 });
 
 test("deep links workbench subpaths without a 404", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add per-surface saved dashboard defaults for Global Issues and Board presets, stored locally and validated before use.
- Keep explicit dashboard URL params authoritative over saved defaults, so shared links still land on their requested filters.
- Add preset strip UI to set/show the current default and extend regression coverage for persistence and URL override behavior.

## Failure modes considered
- A saved default could override an explicit shared URL with `view`, `status`, `sort`, `running`, or `q` params.
- Invalid or unavailable `localStorage` values could crash dashboard rendering or apply unknown presets.
- Bare dashboard URLs could fail to restore the preferred Global Issues or Board landing state across reloads.

## Verification
- `pnpm --filter @issuectl/web exec playwright test workbench.spec.ts --project=mobile-webkit --grep "surfaces duplicate repo names plus issue cache and error state in global dashboards"` — passed, including saved default reload and explicit URL override checks.
- `pnpm --dir packages/web test -- --run dashboard-url-state.test.ts workbench.test.ts` — 2 files passed, 28 tests passed.
- `pnpm --dir packages/web typecheck` — passed.
- `pnpm --dir packages/web lint` — passed.
- `git diff --check` — passed.
- Commit hook: turbo typecheck for `@issuectl/cli`, `@issuectl/core`, `@issuectl/web` — passed.
- Commit hook: turbo lint for `@issuectl/cli`, `@issuectl/core`, `@issuectl/web` — passed.
- Push hook: turbo build for `@issuectl/cli`, `@issuectl/core`, `@issuectl/web` including `next build` — passed.
