### PR TITLE
[codex] Clear dashboard defaults when resetting filters

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -143,7 +143,7 @@ export function BoardFocus({
           buttonLabel="Clear dashboard filters"
           canReset={hasDashboardFilters}
           description="Clear the dashboard filters to return to the full cross-repo board."
-          onReset={() => setUrlState(DEFAULT_BOARD_URL_STATE)}
+          onReset={defaultControls.resetDashboardFilters}
           title="No board issues match these filters."
         />
       )}

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -163,7 +163,7 @@ export function GlobalIssuesFocus({
           buttonLabel="Clear dashboard filters"
           canReset={hasDashboardFilters}
           description="Clear the dashboard filters to return to the full cross-repo issue list."
-          onReset={() => setUrlState(DEFAULT_GLOBAL_ISSUE_URL_STATE)}
+          onReset={defaultControls.resetDashboardFilters}
           title="No dashboard issues match these filters."
         />
       )}

--- a/packages/web/components/workbench/dashboard-default-prefs.ts
+++ b/packages/web/components/workbench/dashboard-default-prefs.ts
@@ -32,6 +32,17 @@ export function writeDashboardDefaultPreset(
   }
 }
 
+export function clearDashboardDefaultPreset(
+  surface: DashboardSurface,
+  storage: Storage | null | undefined = globalStorage(),
+): void {
+  try {
+    storage?.removeItem(DEFAULT_PRESET_STORAGE_KEYS[surface]);
+  } catch {
+    // Ignore localStorage failures; defaults are a convenience, not required state.
+  }
+}
+
 function globalStorage(): Storage | null {
   return typeof window === "undefined" ? null : window.localStorage;
 }

--- a/packages/web/components/workbench/dashboard-url-state-hooks.ts
+++ b/packages/web/components/workbench/dashboard-url-state-hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { readDashboardDefaultPreset, writeDashboardDefaultPreset } from "./dashboard-default-prefs";
+import { clearDashboardDefaultPreset, readDashboardDefaultPreset, writeDashboardDefaultPreset } from "./dashboard-default-prefs";
 import {
   boardPresetState,
   globalIssuePresetState,
@@ -21,6 +21,7 @@ import {
 
 export type DashboardDefaultPresetControls = {
   defaultPresetId: DashboardPresetId | null;
+  resetDashboardFilters: () => void;
   setDefaultPresetId: (presetId: DashboardPresetId) => void;
 };
 
@@ -90,7 +91,13 @@ function useDashboardUrlState<TState extends GlobalIssueUrlState | BoardUrlState
     }
   };
 
-  return [state, updateState, { defaultPresetId, setDefaultPresetId }];
+  const resetDashboardFilters = () => {
+    clearDashboardDefaultPreset(surface);
+    setDefaultPresetIdState(null);
+    updateState(fallback);
+  };
+
+  return [state, updateState, { defaultPresetId, resetDashboardFilters, setDefaultPresetId }];
 }
 
 function stateFromLocation<TState>(

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2939,6 +2939,7 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/issues$/);
   await expect(page.getByLabel("Search global issues")).toHaveValue("");
   await expect(issueViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
+  await expect(globalPresets).not.toContainText("Default: Active work");
   const globalIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
   await expect(globalIssuectlSummary).toContainText("4 visible");
   await expect(globalIssuectlSummary).toContainText("3 running");
@@ -2981,6 +2982,7 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/board$/);
   await expect(page.getByLabel("Search board issues")).toHaveValue("");
   await expect(boardViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
+  await expect(boardPresets).not.toContainText("Default: Active work");
   const boardIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
   await expect(boardIssuectlSummary).toContainText("4 visible");
   await expect(boardIssuectlSummary).toContainText("3 running");
@@ -2989,7 +2991,8 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/issues$/);
   const savedGlobalPresets = page.getByRole("group", { name: "Global triage presets" });
   await expect(savedGlobalPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "true");
+    .toHaveAttribute("aria-pressed", "false");
+  await expect(savedGlobalPresets).not.toContainText("Default: Active work");
   await expect(page.getByLabel("Search global issues")).toHaveValue("");
   await page.goto(`${baseUrl}/workbench/issues?view=cached&q=paper-owl%20web`);
   issueViews = page.getByRole("group", { name: "Operational issue views" });
@@ -3000,8 +3003,9 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page).toHaveURL(/\/workbench\/board$/);
   const savedBoardPresets = page.getByRole("group", { name: "Board triage presets" });
   await expect(savedBoardPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
+    .toHaveAttribute("aria-pressed", "false");
+  await expect(savedBoardPresets).not.toContainText("Default: Active work");
+  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "false");
 });
 
 test("deep links workbench subpaths without a 404", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Clear the saved dashboard default when the empty-state “Clear dashboard filters” action is used.
- Route Global Issues and Board reset buttons through shared URL-state reset behavior so the default label, current state, URL, and reload behavior stay aligned.
- Add Playwright regression coverage for clearing defaults on both dashboard surfaces and for bare reloads after clearing.

## Root cause
The empty-state reset only restored the URL filter state. It left the localStorage-backed saved default intact, so the page displayed the full dashboard while still showing `Default: Active work`; a bare reload then reapplied that saved default.

## Validation
- First ran the focused Playwright regression before implementation and it failed on `Default: Active work` still being visible after clearing Global filters.
- `pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "surfaces duplicate repo names"`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Push hook: `pnpm build`

## Failure modes covered
- Clear filters leaves stale default label visible.
- Bare dashboard reload reapplies a default the user thought they cleared.
- Global Issues and Board drift in behavior.
- Explicit dashboard URL params continue to override defaults.
