### PR TITLE
[codex] Add dashboard clear default control

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -74,7 +74,7 @@ export function BoardFocus({
       <DashboardPresetStrip
         activePresetId={activePresetId}
         ariaLabel="Board triage presets" onApply={(id) => setUrlState(boardPresetState(id))}
-        defaultPresetId={defaultControls.defaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
+        defaultPresetId={defaultControls.defaultPresetId} onClearDefault={defaultControls.clearDefaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
       />
       <div aria-label="Board controls" className={styles.boardControls}>
         <input

--- a/packages/web/components/workbench/DashboardPresetStrip.tsx
+++ b/packages/web/components/workbench/DashboardPresetStrip.tsx
@@ -9,6 +9,7 @@ type Props = {
   ariaLabel: string;
   defaultPresetId?: DashboardPresetId | null;
   onApply: (id: DashboardPresetId) => void;
+  onClearDefault?: () => void;
   onSetDefault?: (id: DashboardPresetId) => void;
 };
 
@@ -17,6 +18,7 @@ export function DashboardPresetStrip({
   ariaLabel,
   defaultPresetId,
   onApply,
+  onClearDefault,
   onSetDefault,
 }: Props) {
   const defaultPreset = DASHBOARD_PRESETS.find((preset) => preset.id === defaultPresetId);
@@ -45,8 +47,17 @@ export function DashboardPresetStrip({
           Set default
         </button>
       )}
-      {defaultPreset && (
-        <span className={styles.dashboardPresetDefault}>Default: {defaultPreset.label}</span>
+      {defaultPreset && onClearDefault && (
+        <>
+          <span className={styles.dashboardPresetDefault}>Default: {defaultPreset.label}</span>
+          <button
+            type="button"
+            className={styles.secondaryButton}
+            onClick={onClearDefault}
+          >
+            Clear default
+          </button>
+        </>
       )}
     </div>
   );

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -92,7 +92,7 @@ export function GlobalIssuesFocus({
         activePresetId={activePresetId}
         ariaLabel="Global triage presets"
         onApply={(id) => setUrlState(globalIssuePresetState(id))}
-        defaultPresetId={defaultControls.defaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
+        defaultPresetId={defaultControls.defaultPresetId} onClearDefault={defaultControls.clearDefaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
       />
       <div aria-label="Global issue controls" className={styles.globalIssueControls}>
         <input

--- a/packages/web/components/workbench/dashboard-url-state-hooks.ts
+++ b/packages/web/components/workbench/dashboard-url-state-hooks.ts
@@ -20,6 +20,7 @@ import {
 } from "./dashboard-url-state";
 
 export type DashboardDefaultPresetControls = {
+  clearDefaultPresetId: () => void;
   defaultPresetId: DashboardPresetId | null;
   resetDashboardFilters: () => void;
   setDefaultPresetId: (presetId: DashboardPresetId) => void;
@@ -91,13 +92,26 @@ function useDashboardUrlState<TState extends GlobalIssueUrlState | BoardUrlState
     }
   };
 
+  const clearDefaultPresetId = () => {
+    clearDashboardDefaultPreset(surface);
+    setDefaultPresetIdState(null);
+    if (typeof window !== "undefined" && !hasDashboardUrlState(window.location.search)) {
+      setState(fallback);
+    }
+  };
+
   const resetDashboardFilters = () => {
     clearDashboardDefaultPreset(surface);
     setDefaultPresetIdState(null);
     updateState(fallback);
   };
 
-  return [state, updateState, { defaultPresetId, resetDashboardFilters, setDefaultPresetId }];
+  return [state, updateState, {
+    clearDefaultPresetId,
+    defaultPresetId,
+    resetDashboardFilters,
+    setDefaultPresetId,
+  }];
 }
 
 function stateFromLocation<TState>(

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -3008,6 +3008,45 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "false");
 });
 
+test("clears saved dashboard defaults from preset strips", async ({ page }) => {
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await page.evaluate(() => window.localStorage.clear());
+  await page.goto(`${baseUrl}/workbench/issues`);
+
+  const globalPresets = page.getByRole("group", { name: "Global triage presets" });
+  await globalPresets.getByRole("button", { name: "Active work" }).click();
+  await globalPresets.getByRole("button", { name: "Set default" }).click();
+  await expect(globalPresets).toContainText("Default: Active work");
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await expect(globalPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await globalPresets.getByRole("button", { name: "Clear default" }).click();
+  await expect(globalPresets).not.toContainText("Default: Active work");
+  await expect(globalPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "false");
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await expect(globalPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "false");
+
+  await page.goto(`${baseUrl}/workbench/board`);
+  const boardPresets = page.getByRole("group", { name: "Board triage presets" });
+  await boardPresets.getByRole("button", { name: "Active work" }).click();
+  await boardPresets.getByRole("button", { name: "Set default" }).click();
+  await expect(boardPresets).toContainText("Default: Active work");
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(boardPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
+  await boardPresets.getByRole("button", { name: "Clear default" }).click();
+  await expect(boardPresets).not.toContainText("Default: Active work");
+  await expect(boardPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "false");
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(boardPresets.getByRole("button", { name: "Active work" }))
+    .toHaveAttribute("aria-pressed", "false");
+});
+
 test("deep links workbench subpaths without a 404", async ({ page }) => {
   await page.goto(`${baseUrl}/workbench/settings`);
   await expect(page.getByRole("link", { name: "issuectl workbench" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Add a direct `Clear default` control beside the dashboard default preset label.
- Clear saved defaults through the shared dashboard URL-state controls, resetting bare dashboard URLs back to the full view.
- Add focused Playwright coverage for clearing Global Issues and Board defaults without relying on the empty-state reset path.

## Validation
- Red first: focused Playwright regression failed waiting for missing `Clear default` control.
- `pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "clears saved dashboard defaults"`
- `pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "surfaces duplicate repo names"`
- `pnpm --dir packages/web typecheck`
- `pnpm --dir packages/web lint`
- `pnpm --dir packages/web test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Push hook: `pnpm build`

## Failure modes covered
- Saved default label has no direct way to clear it.
- Clearing a default on a bare dashboard URL leaves the active default-applied view rendered.
- Global Issues and Board diverge in default-clearing behavior.
- Existing duplicate repo/cache/error dashboard regression remains green.
