### PR TITLE
Add dashboard repo collapse controls

### DIFF
--- a/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/app.js
+++ b/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/app.js
@@ -1,0 +1,543 @@
+let currentBoard = null;
+let eventSource = null;
+let currentSettings = null;
+
+const boardEl = document.getElementById("board");
+const liveStateEl = document.getElementById("live-state");
+const liveDotEl = document.getElementById("live-dot");
+const boardSwitcherEl = document.getElementById("board-switcher");
+const settingsButtonEl = document.getElementById("settings-button");
+const settingsPopoverEl = document.getElementById("settings-popover");
+const githubStarsEl = document.getElementById("github-stars");
+const modalEl = document.getElementById("task-modal");
+const modalTitleEl = document.getElementById("modal-title");
+const modalKickerEl = document.getElementById("modal-kicker");
+const modalBodyEl = document.getElementById("modal-body");
+const settingsStorageKey = "goalbuddy.localBoardSettings.v1";
+const settingsDefaults = {
+  theme: "system",
+  density: "comfortable",
+  completedVisibility: "show",
+  boardOpenBehavior: "last",
+  motion: "system",
+  lastBoardPath: "",
+};
+const settingsOptions = {
+  theme: new Set(["system", "light", "dark"]),
+  density: new Set(["comfortable", "compact"]),
+  completedVisibility: new Set(["show", "collapse"]),
+  boardOpenBehavior: new Set(["last", "newest"]),
+  motion: new Set(["system", "reduce", "allow"]),
+};
+
+document.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-task-id]");
+  if (card) openTask(card.dataset.taskId);
+  if (event.target.matches("[data-close-modal]")) closeModal();
+  if (settingsPopoverEl.hidden) return;
+  if (!event.target.closest(".settings-wrap")) closeSettings();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    closeModal();
+    closeSettings();
+  }
+});
+
+boardSwitcherEl.addEventListener("change", () => {
+  if (boardSwitcherEl.value && boardSwitcherEl.value !== window.location.href) {
+    window.location.href = boardSwitcherEl.value;
+  }
+});
+
+settingsButtonEl.addEventListener("click", () => {
+  if (settingsPopoverEl.hidden) {
+    openSettings();
+  } else {
+    closeSettings();
+  }
+});
+
+settingsPopoverEl.addEventListener("change", (event) => {
+  const control = event.target.closest("[data-setting]");
+  if (!control) return;
+  saveSettings({ ...currentSettings, [control.dataset.setting]: control.value });
+});
+
+async function loadBoard() {
+  const response = await fetch("./api/board", { cache: "no-store" });
+  if (!response.ok) throw new Error("Board request failed");
+  renderBoard(await response.json());
+}
+
+async function loadBoardSwitcher() {
+  const response = await fetch("../api/boards", { cache: "no-store" });
+  if (!response.ok) return;
+  const payload = await response.json();
+  renderBoardSwitcher(payload.boards || []);
+}
+
+async function loadSettings() {
+  try {
+    const response = await fetch("../api/settings", { cache: "no-store" });
+    if (!response.ok) throw new Error("Settings request failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  } catch {
+    currentSettings = readStoredSettings();
+  }
+  applySettings(currentSettings);
+}
+
+async function saveSettings(nextSettings) {
+  currentSettings = normalizeSettings(nextSettings);
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+  applySettings(currentSettings);
+  try {
+    const response = await fetch("../api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ settings: currentSettings }),
+    });
+    if (!response.ok) throw new Error("Settings save failed");
+    const payload = await response.json();
+    currentSettings = normalizeSettings(payload.settings);
+    window.localStorage?.setItem(settingsStorageKey, JSON.stringify(currentSettings));
+    applySettings(currentSettings);
+  } catch {
+    // Keep the localStorage fallback active when the local settings API is unavailable.
+  }
+  return currentSettings;
+}
+
+function readStoredSettings() {
+  try {
+    return normalizeSettings(JSON.parse(window.localStorage?.getItem(settingsStorageKey) || "{}"));
+  } catch {
+    return { ...settingsDefaults };
+  }
+}
+
+function normalizeSettings(settings) {
+  const normalized = { ...settingsDefaults };
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return normalized;
+  for (const [key, allowed] of Object.entries(settingsOptions)) {
+    if (allowed.has(settings[key])) normalized[key] = settings[key];
+  }
+  if (typeof settings.lastBoardPath === "string" && /^\/[a-z0-9][a-z0-9-]*\/$/.test(settings.lastBoardPath)) {
+    normalized.lastBoardPath = settings.lastBoardPath;
+  }
+  return normalized;
+}
+
+function applySettings(settings) {
+  const normalized = normalizeSettings(settings);
+  document.documentElement.dataset.theme = normalized.theme;
+  document.documentElement.dataset.density = normalized.density;
+  document.documentElement.dataset.completedVisibility = normalized.completedVisibility;
+  document.documentElement.dataset.boardOpenBehavior = normalized.boardOpenBehavior;
+  document.documentElement.dataset.motion = normalized.motion;
+  for (const control of settingsPopoverEl.querySelectorAll("[data-setting]")) {
+    control.value = normalized[control.dataset.setting] || settingsDefaults[control.dataset.setting];
+  }
+}
+
+function rememberCurrentBoard() {
+  const boardPath = normalizePath(window.location.pathname);
+  if (!/^\/[a-z0-9][a-z0-9-]*\/$/.test(boardPath)) return;
+  const nextSettings = normalizeSettings({ ...currentSettings, lastBoardPath: boardPath });
+  currentSettings = nextSettings;
+  window.localStorage?.setItem(settingsStorageKey, JSON.stringify(nextSettings));
+  fetch("../api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ settings: nextSettings }),
+  }).catch(() => {});
+}
+
+function openSettings() {
+  settingsPopoverEl.hidden = false;
+  settingsButtonEl.setAttribute("aria-expanded", "true");
+  settingsPopoverEl.querySelector("[data-setting]")?.focus();
+}
+
+function closeSettings() {
+  settingsPopoverEl.hidden = true;
+  settingsButtonEl.setAttribute("aria-expanded", "false");
+}
+
+function formatStars(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  return String(count);
+}
+
+async function loadGithubStars() {
+  if (!githubStarsEl) return;
+  try {
+    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) throw new Error("GitHub API unavailable");
+    const repo = await response.json();
+    githubStarsEl.textContent = `${formatStars(repo.stargazers_count)} stars`;
+  } catch {
+    githubStarsEl.textContent = "GitHub";
+  }
+}
+
+function connectEvents() {
+  eventSource = new EventSource("./events");
+  eventSource.addEventListener("board", (event) => {
+    setLiveState("Live", true);
+    renderBoard(JSON.parse(event.data));
+  });
+  eventSource.addEventListener("error", () => {
+    setLiveState("Reconnecting", false);
+  });
+}
+
+function renderBoard(board) {
+  const previousPositions = measureCards();
+  const previousColumns = new Map();
+  for (const column of currentBoard?.columns || []) {
+    for (const task of column.tasks) previousColumns.set(task.id, column.id);
+  }
+  const movingTaskIds = tasksChangingColumns(board, previousColumns);
+  if (movingTaskIds.size) highlightMovingCards(movingTaskIds);
+  currentBoard = board;
+  document.getElementById("goal-title").textContent = board.goal.title;
+  document.title = board.goal.title ? board.goal.title + " - GoalBuddy Board" : "GoalBuddy Board";
+  document.getElementById("goal-tranche").textContent = board.goal.tranche || "";
+  document.getElementById("goal-status").textContent = board.goal.status;
+  document.getElementById("goal-active").textContent = board.goal.activeTask || "None";
+  document.getElementById("goal-updated").textContent = new Date(board.generatedAt).toLocaleTimeString();
+
+  if (board.error) {
+    boardEl.replaceChildren(renderBoardError(board.error));
+    return;
+  }
+
+  const delay = movingTaskIds.size ? 260 : 0;
+  window.setTimeout(() => {
+    boardEl.replaceChildren(...board.columns.map(renderColumn));
+    animateCardMoves(previousPositions, movingTaskIds);
+  }, delay);
+}
+
+function renderBoardError(message) {
+  const node = el("section", "board-error");
+  node.append(
+    el("h2", "", "GoalBuddy could not parse this board"),
+    el("p", "", message),
+  );
+  return node;
+}
+
+function renderBoardSwitcher(boards) {
+  boardSwitcherEl.closest(".board-switcher").classList.toggle("is-empty", boards.length <= 1);
+  const currentPath = normalizePath(window.location.pathname);
+  const options = boards.map((board) => {
+    const option = document.createElement("option");
+    option.value = board.url;
+    option.textContent = boardOptionLabel(board);
+    const boardPath = normalizePath(new URL(board.url, window.location.href).pathname);
+    if (boardPath === currentPath) option.selected = true;
+    return option;
+  });
+  boardSwitcherEl.replaceChildren(...options);
+}
+
+function renderColumn(column) {
+  const section = el("section", "column");
+  section.dataset.columnId = column.id;
+  const header = el("header", "column-header");
+  const titleWrap = el("div");
+  titleWrap.append(el("h2", "", column.title), el("p", "", column.description));
+  header.append(titleWrap, el("span", "column-count", String(column.tasks.length)));
+
+  const list = el("div", "card-list");
+  if (column.tasks.length === 0) {
+    list.append(el("p", "empty", "No cards"));
+  } else {
+    for (const task of column.tasks) list.append(renderCard(task));
+  }
+
+  section.append(header, list);
+  return section;
+}
+
+function renderCard(task) {
+  const button = el("button", `task-card ${task.active ? "is-active" : ""}`);
+  button.type = "button";
+  button.dataset.taskId = task.id;
+  button.dataset.status = task.status;
+
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.subgoal) footer.append(subgoalBadge(task.subgoal));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+
+  button.append(topline, el("h3", "task-title", task.title), footer);
+  return button;
+}
+
+function measureCards() {
+  const positions = new Map();
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const rect = card.getBoundingClientRect();
+    positions.set(card.dataset.taskId, {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      columnId: card.closest("[data-column-id]")?.dataset.columnId || "",
+    });
+  }
+  return positions;
+}
+
+function tasksChangingColumns(board, previousColumns) {
+  const moving = new Set();
+  for (const column of board.columns) {
+    for (const task of column.tasks) {
+      const previousColumn = previousColumns.get(task.id);
+      if (previousColumn && previousColumn !== column.id) moving.add(task.id);
+    }
+  }
+  return moving;
+}
+
+function highlightMovingCards(taskIds) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    if (!taskIds.has(card.dataset.taskId)) continue;
+    card.classList.add("is-moving");
+    card.animate([
+      { transform: "scale(1)", borderColor: "#eaeaea" },
+      { transform: "scale(1.025)", borderColor: "#9d8cff" },
+      { transform: "scale(1)", borderColor: "#c2b8ff" },
+    ], {
+      duration: 240,
+      easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    });
+  }
+}
+
+function animateCardMoves(previousPositions, movingTaskIds = new Set()) {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  for (const card of boardEl.querySelectorAll("[data-task-id]")) {
+    const previous = previousPositions.get(card.dataset.taskId);
+    const current = card.getBoundingClientRect();
+    const columnId = card.closest("[data-column-id]")?.dataset.columnId || "";
+
+    if (!previous) {
+      card.animate([
+        { opacity: 0, transform: "translateY(10px) scale(0.98)" },
+        { opacity: 1, transform: "translateY(0) scale(1)" },
+      ], {
+        duration: 260,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      });
+      continue;
+    }
+
+    const dx = previous.left - current.left;
+    const dy = previous.top - current.top;
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) continue;
+
+    const changedColumn = previous.columnId !== columnId;
+    const wasSelected = movingTaskIds.has(card.dataset.taskId);
+    card.animate([
+      {
+        transform: `translate(${dx}px, ${dy}px) scale(${changedColumn ? "1.015" : "1"})`,
+        opacity: changedColumn ? 0.9 : 1,
+        borderColor: wasSelected ? "#9d8cff" : "#eaeaea",
+      },
+      {
+        transform: "translate(0, 0) scale(1)",
+        opacity: 1,
+        borderColor: "#eaeaea",
+      },
+    ], {
+      duration: changedColumn ? 980 : 520,
+      easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+    });
+  }
+}
+
+function openTask(taskId) {
+  const task = currentBoard?.tasks.find((candidate) => candidate.id === taskId);
+  if (!task) return;
+
+  modalKickerEl.textContent = `${task.id} · ${task.status}`;
+  modalTitleEl.textContent = task.title;
+  modalBodyEl.replaceChildren(renderTaskDetail(task));
+  modalEl.hidden = false;
+}
+
+function closeModal() {
+  modalEl.hidden = true;
+}
+
+function renderTaskDetail(task) {
+  const root = el("div");
+  const grid = el("dl", "detail-grid");
+  for (const [label, value] of [
+    ["Status", task.status],
+    ["Assignee", task.assignee || "Unassigned"],
+    ["Type", task.type],
+    ["Receipt", task.receipt?.summary || "None"],
+  ]) {
+    const item = el("div", "detail-item");
+    item.append(el("dt", "", label), el("dd", "", value));
+    grid.append(item);
+  }
+  root.append(grid);
+  if (task.subgoal) root.append(renderSubgoal(task.subgoal));
+  root.append(detailText("Objective", task.objective));
+  root.append(detailList("Inputs", task.inputs));
+  root.append(detailList("Constraints", task.constraints));
+  root.append(detailList("Expected Output", task.expectedOutput));
+  root.append(detailList("Allowed Files", task.allowedFiles));
+  root.append(detailList("Verify", task.verify));
+  root.append(detailList("Stop If", task.stopIf));
+  if (task.receipt?.decision) root.append(detailText("Decision", task.receipt.decision));
+  if (task.receipt?.changedFiles?.length) root.append(detailList("Changed Files", task.receipt.changedFiles));
+  if (task.receipt?.commands?.length) {
+    root.append(detailList("Commands", task.receipt.commands.map((command) => command.status ? `${command.status}: ${command.cmd}` : command.cmd)));
+  }
+  if (task.note?.content) {
+    const section = el("section", "detail-section");
+    section.append(el("h3", "", task.note.title || task.note.path), el("pre", "note", task.note.content));
+    root.append(section);
+  }
+  return root;
+}
+
+function renderSubgoal(subgoal) {
+  const section = el("section", "detail-section subgoal-section");
+  const header = el("div", "subgoal-header");
+  const titleWrap = el("div");
+  const board = subgoal.board;
+  titleWrap.append(
+    el("h3", "subgoal-title", board?.goal?.title || "Sub-goal"),
+    el("p", "subgoal-meta", [
+      subgoal.path,
+      subgoal.owner ? `owner: ${subgoal.owner}` : "",
+      subgoal.depth ? `depth: ${subgoal.depth}` : "",
+    ].filter(Boolean).join(" · ")),
+  );
+  header.append(titleWrap, subgoalBadge(subgoal));
+  section.append(header);
+
+  if (!board?.columns?.length) {
+    section.append(el("p", "", "No child board payload."));
+    return section;
+  }
+
+  const boardEl = el("div", "subgoal-board");
+  for (const column of board.columns) {
+    const columnEl = el("section", "subgoal-column");
+    const columnHeader = el("header", "subgoal-column-header");
+    columnHeader.append(el("h4", "", column.title), el("span", "column-count", String(column.tasks.length)));
+    const list = el("div", "subgoal-card-list");
+    if (column.tasks.length === 0) {
+      list.append(el("p", "empty", "No cards"));
+    } else {
+      for (const task of column.tasks) list.append(renderSubgoalTask(task));
+    }
+    columnEl.append(columnHeader, list);
+    boardEl.append(columnEl);
+  }
+  section.append(boardEl);
+
+  if (subgoal.rollupReceipt) {
+    section.append(detailText("Roll-up Receipt", subgoal.rollupReceipt));
+  }
+
+  return section;
+}
+
+function renderSubgoalTask(task) {
+  const card = el("article", `subgoal-task-card ${task.active ? "is-active" : ""}`);
+  const topline = el("div", "card-topline");
+  topline.append(el("span", "task-id", task.id), statusBadge(task.status));
+  const footer = el("div", "card-footer");
+  footer.append(el("span", "badge role", task.assignee || task.type || "PM"));
+  if (task.receipt?.present) footer.append(el("span", "badge status-done", "Receipt"));
+  card.append(topline, el("h4", "subgoal-task-title", task.title), footer);
+  return card;
+}
+
+function detailText(title, value) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title), el("p", "", value || "None"));
+  return section;
+}
+
+function detailList(title, values) {
+  const section = el("section", "detail-section");
+  section.append(el("h3", "", title));
+  if (!values?.length) {
+    section.append(el("p", "", "None"));
+    return section;
+  }
+  const list = el("ul");
+  for (const value of values) list.append(el("li", "", value));
+  section.append(list);
+  return section;
+}
+
+function statusBadge(status) {
+  const label = status === "done" ? "Completed" : status === "active" ? "Active" : status === "blocked" ? "Blocked" : "Queued";
+  return el("span", `badge status-${status}`, label);
+}
+
+function subgoalBadge(subgoal) {
+  return el("span", `badge subgoal status-${subgoal.status}`, `Sub-goal ${subgoal.status || "linked"}`);
+}
+
+function setLiveState(text, live) {
+  liveStateEl.textContent = text;
+  liveDotEl.classList.toggle("offline", !live);
+  settingsButtonEl.setAttribute("aria-label", `Settings. Board status: ${text}`);
+  settingsButtonEl.title = `Settings · ${text}`;
+}
+
+function normalizePath(pathname) {
+  return pathname.endsWith("/") ? pathname : pathname + "/";
+}
+
+function boardOptionLabel(board) {
+  const title = board.title || board.slug || board.goalDir || "GoalBuddy board";
+  return /[/\\]subgoals[/\\]/.test(board.goalDir || "") ? `Child: ${title}` : title;
+}
+
+function el(tag, className = "", text = "") {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== "") node.textContent = text;
+  return node;
+}
+
+loadSettings()
+  .then(loadBoard)
+  .then(() => {
+    setLiveState("Live", true);
+    rememberCurrentBoard();
+    loadGithubStars();
+    loadBoardSwitcher();
+    window.setInterval(loadBoardSwitcher, 5000);
+    connectEvents();
+  })
+  .catch((error) => {
+    setLiveState("Offline", false);
+    boardEl.textContent = error.message;
+  });
+

--- a/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/index.html
+++ b/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GoalBuddy Board</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-primary">
+      <div class="brand" aria-label="Goal Buddy">
+        <img class="brand-mark" src="./goalbuddy-mark.png" alt="GoalBuddy">
+        <span class="brand-name">Goal Buddy</span>
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+      </div>
+      <nav class="board-switcher is-empty" aria-label="Local GoalBuddy boards">
+        <label for="board-switcher">Board</label>
+        <select id="board-switcher" aria-label="Switch local board"></select>
+      </nav>
+    </div>
+    <div class="header-tools">
+      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
+        <span id="github-stars">Stars</span>
+      </a>
+      <div class="settings-wrap">
+        <button class="settings-button" id="settings-button" type="button" aria-expanded="false" aria-controls="settings-popover">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12.2 2.75h-.4a1.6 1.6 0 0 0-1.58 1.36l-.18 1.18c-.46.16-.9.34-1.31.56l-1.02-.64a1.6 1.6 0 0 0-2.08.31l-.28.28a1.6 1.6 0 0 0-.31 2.08l.64 1.02c-.22.42-.4.86-.56 1.31l-1.18.18A1.6 1.6 0 0 0 2.58 12v.4A1.6 1.6 0 0 0 3.94 14l1.18.18c.16.46.34.9.56 1.31l-.64 1.02a1.6 1.6 0 0 0 .31 2.08l.28.28a1.6 1.6 0 0 0 2.08.31l1.02-.64c.42.22.86.4 1.31.56l.18 1.18a1.6 1.6 0 0 0 1.58 1.36h.4a1.6 1.6 0 0 0 1.58-1.36l.18-1.18c.46-.16.9-.34 1.31-.56l1.02.64a1.6 1.6 0 0 0 2.08-.31l.28-.28a1.6 1.6 0 0 0 .31-2.08l-.64-1.02c.22-.42.4-.86.56-1.31l1.18-.18a1.6 1.6 0 0 0 1.36-1.58V12a1.6 1.6 0 0 0-1.36-1.58l-1.18-.18a7.2 7.2 0 0 0-.56-1.31l.64-1.02a1.6 1.6 0 0 0-.31-2.08l-.28-.28a1.6 1.6 0 0 0-2.08-.31l-1.02.64c-.42-.22-.86-.4-1.31-.56l-.18-1.18a1.6 1.6 0 0 0-1.58-1.39Z"></path>
+            <circle cx="12" cy="12.2" r="3.15"></circle>
+          </svg>
+          <span class="visually-hidden" id="live-state">Connecting</span>
+        </button>
+        <section class="settings-popover" id="settings-popover" aria-label="Local board settings" hidden>
+          <div class="settings-heading">
+            <p class="eyebrow">Board settings</p>
+            <h2>Local preferences</h2>
+          </div>
+          <div class="setting-row">
+            <label for="setting-theme">Theme</label>
+            <select id="setting-theme" data-setting="theme">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-density">Density</label>
+            <select id="setting-density" data-setting="density">
+              <option value="comfortable">Comfortable</option>
+              <option value="compact">Compact</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-completed">Completed</label>
+            <select id="setting-completed" data-setting="completedVisibility">
+              <option value="show">Show</option>
+              <option value="collapse">Collapse</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-board-open">Open boards</label>
+            <select id="setting-board-open" data-setting="boardOpenBehavior">
+              <option value="last">Last viewed</option>
+              <option value="newest">Newest active</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label for="setting-motion">Motion</label>
+            <select id="setting-motion" data-setting="motion">
+              <option value="system">System</option>
+              <option value="reduce">Reduce</option>
+              <option value="allow">Allow</option>
+            </select>
+          </div>
+        </section>
+      </div>
+    </div>
+  </header>
+  <main class="shell">
+    <section class="goal-header" aria-labelledby="goal-title">
+      <div>
+        <p class="eyebrow">Local board</p>
+        <h1 id="goal-title">GoalBuddy Board</h1>
+        <p id="goal-tranche" class="goal-tranche"></p>
+      </div>
+      <dl class="goal-meta">
+        <div><dt>Status</dt><dd id="goal-status">Unknown</dd></div>
+        <div><dt>Active</dt><dd id="goal-active">None</dd></div>
+        <div><dt>Updated</dt><dd id="goal-updated">Waiting</dd></div>
+      </dl>
+    </section>
+    <section class="board" id="board" aria-label="Goal task board"></section>
+  </main>
+  <div class="modal" id="task-modal" hidden>
+    <button class="modal-scrim" type="button" data-close-modal aria-label="Close task detail"></button>
+    <article class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <header class="modal-header">
+        <div>
+          <p class="eyebrow" id="modal-kicker">Task</p>
+          <h2 id="modal-title">Task detail</h2>
+        </div>
+        <button class="icon-button" type="button" data-close-modal aria-label="Close task detail">x</button>
+      </header>
+      <div class="modal-body" id="modal-body"></div>
+    </article>
+  </div>
+  <script src="./app.js" type="module"></script>
+</body>
+</html>

--- a/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/styles.css
+++ b/docs/goals/dashboard-repo-grouping-controls/.goalbuddy-board/styles.css
@@ -1,0 +1,996 @@
+:root {
+  color-scheme: light;
+  --canvas: #f7f6f3;
+  --surface: #ffffff;
+  --surface-muted: #fbfbfa;
+  --ink: #111111;
+  --muted: #787774;
+  --line: #eaeaea;
+  --blue-bg: #e1f3fe;
+  --blue-text: #1f6c9f;
+  --green-bg: #edf3ec;
+  --green-text: #346538;
+  --red-bg: #fdebec;
+  --red-text: #9f2f2d;
+  --yellow-bg: #fbf3db;
+  --yellow-text: #956400;
+  --active-surface: #fbfdfe;
+  font-family: "SF Pro Display", "Geist Sans", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #07101f;
+  --surface: #101a2d;
+  --surface-muted: #0c1525;
+  --ink: #f7f9fc;
+  --muted: #9aa7bf;
+  --line: #26334a;
+  --blue-bg: #173653;
+  --blue-text: #9ed8ff;
+  --green-bg: #143929;
+  --green-text: #a6e8bf;
+  --red-bg: #3a1d22;
+  --red-text: #ffb2b9;
+  --yellow-bg: #3a3014;
+  --yellow-text: #f6d878;
+  --active-surface: #0f2031;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --canvas: #07101f;
+    --surface: #101a2d;
+    --surface-muted: #0c1525;
+    --ink: #f7f9fc;
+    --muted: #9aa7bf;
+    --line: #26334a;
+    --blue-bg: #173653;
+    --blue-text: #9ed8ff;
+    --green-bg: #143929;
+    --green-text: #a6e8bf;
+    --red-bg: #3a1d22;
+    --red-text: #ffb2b9;
+    --yellow-bg: #3a3014;
+    --yellow-text: #f6d878;
+    --active-surface: #0f2031;
+  }
+
+  :root[data-theme="system"] .topbar {
+    border-color: rgba(61, 76, 108, 0.86);
+    background: rgba(13, 23, 41, 0.84);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .brand {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .board-switcher select,
+  :root[data-theme="system"] .github-stars,
+  :root[data-theme="system"] .settings-button {
+    border-color: rgba(61, 76, 108, 0.9);
+    background: rgba(16, 26, 45, 0.78);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .settings-popover {
+    border-color: rgba(61, 76, 108, 0.96);
+    background: rgba(16, 26, 45, 0.96);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+  }
+
+  :root[data-theme="system"] .setting-row select {
+    background: var(--surface);
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .goal-tranche,
+  :root[data-theme="system"] .task-title,
+  :root[data-theme="system"] .setting-row select {
+    color: var(--ink);
+  }
+
+  :root[data-theme="system"] .task-card.is-active {
+    background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+      linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+  }
+
+  :root[data-theme="system"] .task-card.is-active::after {
+    background: var(--active-surface);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+select,
+button {
+  font: inherit;
+}
+
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1392px, calc(100% - 48px));
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(219, 226, 240, 0.86);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 48px rgba(30, 40, 72, 0.1);
+  backdrop-filter: blur(22px);
+}
+
+:root[data-theme="dark"] .topbar {
+  border-color: rgba(61, 76, 108, 0.86);
+  background: rgba(13, 23, 41, 0.84);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.topbar-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #071236;
+  font-weight: 800;
+  min-width: fit-content;
+}
+
+:root[data-theme="dark"] .brand {
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: block;
+  width: 38px;
+  height: 38px;
+  filter: drop-shadow(0 8px 13px rgba(87, 76, 210, 0.18));
+}
+
+.brand-name {
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.board-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.board-switcher label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.board-switcher select {
+  width: min(280px, 100%);
+  min-width: 0;
+  min-height: 38px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  padding: 0 34px 0 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+:root[data-theme="dark"] .board-switcher select,
+:root[data-theme="dark"] .github-stars,
+:root[data-theme="dark"] .settings-button {
+  border-color: rgba(61, 76, 108, 0.9);
+  background: rgba(16, 26, 45, 0.78);
+  color: var(--ink);
+}
+
+.board-switcher.is-empty {
+  display: none;
+}
+
+.header-tools {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: fit-content;
+}
+
+.github-stars,
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 1px solid rgba(219, 226, 240, 0.9);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #2f3c59;
+  font-weight: 800;
+  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.github-stars {
+  gap: 7px;
+  padding: 0 15px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.github-stars:hover,
+.settings-button:hover {
+  transform: translateY(-2px);
+  color: #071236;
+  border-color: rgba(79, 70, 216, 0.26);
+  background: #fff;
+}
+
+.github-stars svg {
+  width: 16px;
+  height: 16px;
+  color: #4f46d8;
+  fill: currentColor;
+}
+
+.settings-wrap {
+  position: relative;
+}
+
+.settings-button {
+  position: relative;
+  gap: 8px;
+  width: 44px;
+  padding: 0;
+  cursor: pointer;
+}
+
+.settings-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: #1f9d69;
+  box-shadow: 0 0 0 4px rgba(31, 157, 105, 0.12);
+}
+
+.live-dot.offline {
+  background: var(--yellow-text);
+  box-shadow: 0 0 0 4px rgba(149, 100, 0, 0.12);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border: 1px solid rgba(219, 226, 240, 0.96);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 64px rgba(30, 40, 72, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+:root[data-theme="dark"] .settings-popover {
+  border-color: rgba(61, 76, 108, 0.96);
+  background: rgba(16, 26, 45, 0.96);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
+}
+
+.settings-popover[hidden] {
+  display: none;
+}
+
+.settings-heading {
+  margin-bottom: 12px;
+}
+
+.settings-heading .eyebrow {
+  margin-bottom: 6px;
+}
+
+.settings-heading h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0;
+}
+
+.setting-row {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.setting-row label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.setting-row select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #2f3437;
+}
+
+:root[data-theme="dark"] .setting-row select {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--blue-bg);
+  color: var(--blue-text);
+}
+
+.live-state.offline {
+  background: var(--yellow-bg);
+  color: var(--yellow-text);
+}
+
+.shell {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.goal-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 10px;
+  max-width: 900px;
+  font-size: clamp(34px, 5vw, 68px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.goal-tranche {
+  max-width: 860px;
+  margin-bottom: 0;
+  color: #2f3437;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .goal-tranche,
+:root[data-theme="dark"] .task-title,
+:root[data-theme="dark"] .setting-row select {
+  color: var(--ink);
+}
+
+.goal-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(94px, auto));
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.goal-meta div {
+  min-width: 0;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+
+.goal-meta dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goal-meta dd {
+  margin: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  padding-top: 18px;
+}
+
+.column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.column-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.column-header h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.column-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.column-count {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 13px;
+}
+
+.card-list {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.task-card {
+  position: relative;
+  width: 100%;
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease;
+  will-change: transform, opacity;
+}
+
+.task-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.task-card:hover {
+  border-color: #d1d0cc;
+  transform: translateY(-1px);
+}
+
+.task-card:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid #2f3437;
+  outline-offset: 2px;
+}
+
+.task-card.is-active {
+  border-color: transparent;
+  background: linear-gradient(#fbfdfe, #fbfdfe) padding-box,
+    linear-gradient(110deg, #78d7ff, #4f46d8, #78f2b9, #78d7ff) border-box;
+  box-shadow: 0 14px 38px rgba(31, 108, 159, 0.12);
+}
+
+.task-card.is-active::before {
+  position: absolute;
+  inset: -2px;
+  z-index: 0;
+  content: "";
+  background: conic-gradient(from 0deg, transparent 0 58%, rgba(79, 70, 216, 0.28), rgba(120, 215, 255, 0.44), transparent 78% 100%);
+  opacity: 0.86;
+  animation: active-card-orbit 2.8s linear infinite;
+}
+
+.task-card.is-active::after {
+  position: absolute;
+  inset: 2px;
+  z-index: 0;
+  content: "";
+  border-radius: 6px;
+  background: #fbfdfe;
+}
+
+:root[data-theme="dark"] .task-card.is-active {
+  background: linear-gradient(var(--active-surface), var(--active-surface)) padding-box,
+    linear-gradient(110deg, #78d7ff, #6c63ff, #78f2b9, #78d7ff) border-box;
+}
+
+:root[data-theme="dark"] .task-card.is-active::after {
+  background: var(--active-surface);
+}
+
+:root[data-density="compact"] .shell {
+  padding-top: 20px;
+}
+
+:root[data-density="compact"] .board {
+  gap: 12px;
+}
+
+:root[data-density="compact"] .column-header {
+  padding: 12px;
+}
+
+:root[data-density="compact"] .card-list {
+  gap: 8px;
+  padding: 10px;
+}
+
+:root[data-density="compact"] .task-card {
+  min-height: 110px;
+  gap: 9px;
+  padding: 11px;
+}
+
+:root[data-density="compact"] .task-title {
+  font-size: 14px;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] .card-list {
+  display: none;
+}
+
+:root[data-completed-visibility="collapse"] .column[data-column-id="completed"] {
+  max-height: 80px;
+  overflow: hidden;
+}
+
+@keyframes active-card-orbit {
+  to { transform: rotate(360deg); }
+}
+
+.task-card.is-moving {
+  border-color: #c2b8ff;
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.task-id {
+  color: var(--muted);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+}
+
+.task-title {
+  margin: 0;
+  color: #2f3437;
+  display: -webkit-box;
+  font-size: 15px;
+  line-height: 1.35;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.badge.status-active,
+.badge.status-queued { background: var(--blue-bg); color: var(--blue-text); }
+.badge.status-done { background: var(--green-bg); color: var(--green-text); }
+.badge.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.role { background: var(--yellow-bg); color: var(--yellow-text); }
+.badge.subgoal { background: #ece8ff; color: #5c43c6; }
+.badge.subgoal.status-blocked { background: var(--red-bg); color: var(--red-text); }
+.badge.subgoal.status-done { background: var(--green-bg); color: var(--green-text); }
+
+:root[data-theme="dark"] .badge.subgoal {
+  background: #263052;
+  color: #c7d2ff;
+}
+
+.empty {
+  padding: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.board-error {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px solid var(--red-border);
+  border-radius: 8px;
+  background: var(--red-bg);
+  color: var(--text);
+}
+
+.board-error h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.board-error p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-stars,
+  .settings-button,
+  .task-card {
+    transition: none;
+  }
+
+  .task-card.is-active::before {
+    animation: none;
+    opacity: 0.26;
+  }
+}
+
+:root[data-motion="reduce"] .github-stars,
+:root[data-motion="reduce"] .settings-button,
+:root[data-motion="reduce"] .task-card {
+  transition: none;
+}
+
+:root[data-motion="reduce"] .task-card.is-active::before {
+  animation: none;
+  opacity: 0.26;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(17, 17, 17, 0.32);
+}
+
+.modal-panel {
+  position: relative;
+  width: min(1080px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.modal-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: #2f3437;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--surface-muted);
+}
+
+.detail-item dt {
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-item dd {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.detail-section {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.detail-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+
+.detail-section li {
+  color: var(--ink);
+}
+
+.subgoal-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--surface-muted);
+}
+
+.subgoal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.subgoal-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.subgoal-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.subgoal-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subgoal-column {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.subgoal-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.subgoal-column-header h4 {
+  margin: 0;
+  font-size: 12px;
+}
+
+.subgoal-card-list {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.subgoal-task-card {
+  min-height: 74px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 9px;
+  background: var(--surface);
+}
+
+.subgoal-task-card.is-active {
+  border-color: #8e9cff;
+  background: var(--active-surface);
+}
+
+.subgoal-task-title {
+  margin: 6px 0 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+pre.note {
+  overflow: auto;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: "Geist Mono", "SF Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .goal-header {
+    grid-template-columns: 1fr;
+  }
+
+  .goal-meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .subgoal-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+  }
+
+  .topbar-primary {
+    flex: 1;
+    flex-wrap: wrap;
+    gap: 10px 14px;
+  }
+
+  .board-switcher select {
+    width: 100%;
+  }
+
+  .shell {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .goal-meta,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/goals/dashboard-repo-grouping-controls/goal.md
+++ b/docs/goals/dashboard-repo-grouping-controls/goal.md
@@ -1,0 +1,97 @@
+# Dashboard Repo Grouping Controls
+
+## Objective
+
+Implement repo collapse/expand controls for the issuectl dashboard so users can scan issues across many repositories without losing repo-level context.
+
+## Original Request
+
+"plan out with goalbuddyprep and implement" for repo grouping controls.
+
+## Intake Summary
+
+- Input shape: `specific`
+- Audience: issuectl dashboard users scanning issues across multiple repos
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: focused Playwright coverage and web package checks prove repo sections can be collapsed/expanded, counts remain visible, and state persists per surface.
+- Goal oracle: a browser/E2E flow proves Global Issues and Board repo grouping controls work across single-repo toggle, collapse all, expand all, reload persistence, and filter/search changes without hiding summary context.
+- Likely misfire: adding cosmetic toggles that hide cards but break counts, search/filter behavior, accessibility, or board/global consistency.
+- Blind spots considered: persistent vs temporary state, per-surface storage keys, accessibility labels, board column behavior, empty filtered repos, mobile/compact layout, and max-lines lint constraints in the focus components.
+- Existing plan facts: use chevron-style repo-level controls, add Collapse all / Expand all toolbar controls, keep repo summary counts visible while collapsed, persist collapsed state per surface in localStorage, verify with E2E and web checks.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`Playwright evidence on the dashboard proves Global Issues and Board support repo-level collapse/expand, collapse all, expand all, persisted per-surface state after reload, visible summary counts while collapsed, hidden issue-card content while collapsed, and no regressions in existing cross-repo dashboard behavior.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, a passing tiny slice, or a clean-looking board is not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Complete one coherent dashboard grouping slice: discover the exact component/test shape, implement persisted repo collapse/expand controls for Global Issues and Board, verify with focused E2E plus web package checks, then publish through the normal PR/merge queue path when green.
+
+## Non-Negotiable Constraints
+
+- Follow `AGENTS.md` and `CLAUDE.md`; use Playwright CLI for formal web UI verification.
+- Preserve existing dashboard filters, saved defaults, operational views, and repo ordering behavior.
+- Keep repo summary counts, repo health, and headers visible when a repo is collapsed.
+- Persist collapsed state per surface, not globally across unrelated dashboard modes.
+- Do not exceed existing lint constraints such as max-lines in focus components.
+- Keep edits scoped to dashboard components, supporting hooks/helpers/styles, and E2E tests unless Scout/Judge proves a broader file is necessary.
+- Before final handoff, identify realistic failure modes and provide acceptance evidence, not just "tests pass."
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated.
+
+Do not stop after a single verified Worker package when the broader owner outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+Do not create one Worker/Judge pair per repeated file, table, route, or helper. Put repeated same-shape work into one Worker package and review the package as a whole.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good task is the largest safe useful slice.
+
+Small is not the goal. Useful is the goal.
+
+A Worker should finish the whole assigned slice. A Judge should judge the whole assigned slice. A PM should reorient the board when tasks are safe but not moving the outcome.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/dashboard-repo-grouping-controls/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/dashboard-repo-grouping-controls/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Re-check the intake: original request, input shape, authority, proof, blind spots, existing plan facts, and likely misfire.
+5. Work only on the active board task.
+6. Assign Scout, Judge, Worker, or PM according to the task.
+7. Write a compact task receipt.
+8. Update the board.
+9. If safe local work remains, choose the next largest reversible Worker package and continue unless blocked.
+10. Review at phase, risk, rejected-verification, ambiguity, or final-completion boundaries; do not review every small Worker by habit.
+11. Finish only with a Judge/PM audit receipt that maps receipts and verification back to the original user outcome and records `full_outcome_complete: true`.

--- a/docs/goals/dashboard-repo-grouping-controls/state.yaml
+++ b/docs/goals/dashboard-repo-grouping-controls/state.yaml
@@ -1,0 +1,259 @@
+# GoalBuddy v2 state.yaml
+# Board truth lives here. goal.md is the editable charter; notes/ holds long receipts only.
+
+version: 2
+
+goal:
+  title: "Dashboard Repo Grouping Controls"
+  slug: "dashboard-repo-grouping-controls"
+  kind: specific
+  tranche: "Implement persisted repo collapse/expand controls for Global Issues and Board, verify them, and publish through the normal PR/merge queue path when green."
+  status: active
+  oracle:
+    signal: "Playwright evidence proves Global Issues and Board support repo-level collapse/expand, collapse all, expand all, reload persistence, visible summaries while collapsed, hidden issue-card content while collapsed, and existing dashboard regressions still pass."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Focused E2E, existing cross-repo dashboard E2E, web package checks, and PR/merge-queue checks if publishing occurs."
+  intake:
+    original_request: "plan out with goalbuddyprep and implement"
+    interpreted_outcome: "Add useful, verified repo grouping controls to the issuectl dashboard."
+    input_shape: specific
+    audience: "issuectl dashboard users scanning issues across multiple repos"
+    authority: requested
+    proof_type: test
+    completion_proof: "Controls are implemented, verified, and merged or ready to merge with green evidence."
+    likely_misfire: "Cosmetic collapse controls hide issue cards but lose repo summaries, fail persistence, break filters, or only work on one dashboard surface."
+    blind_spots_considered:
+      - "Persistent vs temporary collapsed state."
+      - "Per-surface localStorage isolation."
+      - "Board column behavior vs Global Issues section behavior."
+      - "Accessibility labels for repo toggles and bulk controls."
+      - "Existing max-lines lint constraints in focus components."
+      - "Search/filter changes should not silently discard collapsed state."
+    existing_plan_facts:
+      - "Track collapsed repo IDs or repo keys in client state."
+      - "Persist per surface in localStorage."
+      - "Add repo-level toggle buttons and bulk Collapse all / Expand all controls."
+      - "Keep headers, health, and summary counts visible while collapsed."
+      - "Use Playwright CLI for formal web verification."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/dashboard-repo-grouping-controls/"
+    command: "npx goalbuddy board docs/goals/dashboard-repo-grouping-controls"
+
+active_task: T004
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: default
+    objective: "Map the current dashboard component/test/style structure for repo grouping controls."
+    inputs:
+      - "packages/web/components/workbench/GlobalIssuesFocus.tsx"
+      - "packages/web/components/workbench/BoardFocus.tsx"
+      - "packages/web/components/workbench/DashboardStatusBlocks.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/e2e/workbench.spec.ts"
+      - "packages/web/components/workbench/*dashboard*"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Find the smallest safe helper/hook shape that avoids max-lines regressions."
+      - "Record concrete file-path evidence."
+    expected_output:
+      - "Relevant components, hooks, styles, and tests."
+      - "Recommended state/storage helper shape."
+      - "Accessibility and persistence considerations."
+      - "Focused E2E test target and existing regression target."
+      - "Candidate Worker allowed_files and verification commands."
+    receipt:
+      result: done
+      summary: "Three Scout agents mapped dashboard components, E2E coverage, and CSS/accessibility constraints. Both Global Issues and Board already render per-repo headers, summaries, and health before issue cards, so collapse can hide only the issue-card/no-match body while preserving repo context."
+      evidence:
+        - "packages/web/components/workbench/GlobalIssuesFocus.tsx:60 derives filtered/sorted repoRows before rendering; :170 maps sections labelled Issues for owner/name; :173-181 renders h2, RepoDashboardSummary, and RepoIssueHealth before issue cards."
+        - "packages/web/components/workbench/BoardFocus.tsx:48 derives filtered/sorted visibleRows before rendering; :151 renders Cross-repo board; :154-169 renders board column header, summary, and health before issue cards."
+        - "packages/web/components/workbench/DashboardStatusBlocks.tsx:51 renders RepoDashboardSummary with visible/running/high/cache/error chips; :72 counts visible issues."
+        - "packages/web/components/workbench/dashboard-url-state-hooks.ts:29 and :42 expose separate dashboard URL state hooks; collapse state should stay separate from URL filters/default presets."
+        - "packages/web/components/workbench/WorkbenchShell.module.css:1571 controls flex-wrap; :1642 summary chips wrap; :1719 boardScroll owns horizontal scrolling; :1730 boardColumn min-width is 190px."
+        - "packages/web/e2e/workbench.spec.ts:2851 existing cross-repo dashboard regression covers duplicate repo names, cache/error states, summaries, presets, filters, and both Global Issues and Board."
+      findings:
+        - "Use stable per-surface localStorage keys for collapsed repo owner/name keys, independent for globalIssues and board."
+        - "Collapse all should target currently visible repo rows and retain stale hidden keys only when they reappear for the same surface."
+        - "Clear dashboard filters should not expand repos because existing reset semantics are URL/default-preset scoped."
+        - "Add small reusable hook/control helpers to avoid max-lines regressions in focus components."
+        - "Use accessible button names such as Collapse owner/name and Expand owner/name, with aria-expanded on the repo body."
+      spawned_tasks:
+        - T002
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: default
+    objective: "Review Scout findings and approve the largest safe implementation slice."
+    inputs:
+      - "T001 receipt"
+      - "Goal oracle"
+    constraints:
+      - "Do not implement."
+      - "Reject plans that hide repo summaries while collapsed."
+      - "Reject plans without focused E2E and existing regression verification."
+    expected_output:
+      - "Decision: approved | revise | blocked"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Deferred follow-ups, if any"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve one vertical Worker slice across both dashboard surfaces. Collapse can hide only issue-card/no-match bodies because headers, summaries, and health already render before issue bodies. Keep collapse state localStorage-only, per surface, and independent from URL filter/default-preset semantics."
+      worker_objective: "Implement persisted repo collapse/expand controls for Global Issues and Board: per-repo toggle, Collapse all, Expand all, reload-persistent collapsed state isolated per surface, repo headers/summaries/health visible while collapsed, issue-card/no-match body hidden while collapsed, and no change to dashboard URL filter or default-preset semantics."
+      evidence:
+        - "T001: Global Issues and Board render repo headers, RepoDashboardSummary, and RepoIssueHealth before issue cards."
+        - "T001: dashboard URL hooks are separate; collapse state should remain localStorage-only and per surface."
+        - "Goal oracle requires focused Playwright proof plus existing cross-repo regression evidence."
+      spawned_tasks:
+        - T003
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement persisted repo collapse/expand controls for Global Issues and Board: per-repo toggle, Collapse all, Expand all, reload-persistent collapsed state isolated per surface, repo headers/summaries/health visible while collapsed, issue-card/no-match body hidden while collapsed, and no change to dashboard URL filter or default-preset semantics."
+    allowed_files:
+      - "packages/web/components/workbench/GlobalIssuesFocus.tsx"
+      - "packages/web/components/workbench/BoardFocus.tsx"
+      - "packages/web/components/workbench/DashboardStatusBlocks.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/components/workbench/dashboard-repo-collapse*.ts"
+      - "packages/web/components/workbench/dashboard-repo-collapse*.tsx"
+      - "packages/web/e2e/workbench.spec.ts"
+    verify:
+      - "pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep \"repo grouping|collapse\""
+      - "pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep \"surfaces duplicate repo names\""
+      - "pnpm --dir packages/web typecheck"
+      - "pnpm --dir packages/web lint"
+      - "pnpm --dir packages/web test"
+    stop_if:
+      - "Need files outside allowed_files."
+      - "Implementation would hide repo summaries, health, or headers while collapsed."
+      - "Implementation requires changing dashboard URL filter hooks or default-preset semantics."
+      - "Collapsed state semantics become ambiguous for filtered-empty repos."
+      - "Formal Playwright verification cannot run."
+      - "Verification fails twice for the same unexplained reason."
+    receipt:
+      result: done
+      changed_files:
+        - "packages/web/components/workbench/dashboard-repo-collapse.tsx"
+        - "packages/web/components/workbench/GlobalIssuesFocus.tsx"
+        - "packages/web/components/workbench/BoardFocus.tsx"
+        - "packages/web/components/workbench/WorkbenchShell.module.css"
+        - "packages/web/e2e/workbench.spec.ts"
+      summary: "Added per-surface persisted repo collapse state, Global Issues and Board repo toggle/bulk controls, responsive header/button styling, focused repo grouping E2E coverage, and tightened stale drawer-collapse selectors to role-based locators."
+      failure_modes_considered:
+        - "Collapsed repos might hide summaries or health alerts; focused E2E asserts summaries remain visible while issue cards are absent."
+        - "Global and Board collapsed state might leak across surfaces; focused E2E asserts Board remains collapsed while Global Issues stays expanded."
+        - "Bulk controls might only affect one repo; focused E2E asserts issuectl and bugdrop issue cards are both hidden after Collapse all."
+        - "URL filters/default presets might regress; existing duplicate-repo dashboard E2E passed after implementation."
+        - "Focus components might violate max-lines lint; package lint passed."
+      commands:
+        - cmd: "pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep \"repo grouping\""
+          status: pass
+        - cmd: "pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep \"repo grouping|collapse\""
+          status: pass
+        - cmd: "pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep \"surfaces duplicate repo names\""
+          status: pass
+        - cmd: "pnpm --dir packages/web typecheck"
+          status: pass
+        - cmd: "pnpm --dir packages/web lint"
+          status: pass
+        - cmd: "pnpm --dir packages/web test"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      spawned_tasks:
+        - T004
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: default
+    objective: "Publish the verified dashboard grouping change through the normal branch, PR, and merge-queue workflow if T003 completes cleanly."
+    allowed_files:
+      - "packages/web/components/workbench/GlobalIssuesFocus.tsx"
+      - "packages/web/components/workbench/BoardFocus.tsx"
+      - "packages/web/components/workbench/DashboardStatusBlocks.tsx"
+      - "packages/web/components/workbench/WorkbenchShell.module.css"
+      - "packages/web/components/workbench/dashboard-repo-collapse*.ts"
+      - "packages/web/components/workbench/dashboard-repo-collapse*.tsx"
+      - "packages/web/e2e/workbench.spec.ts"
+    verify:
+      - "pnpm typecheck"
+      - "pnpm lint"
+      - "pnpm test"
+      - "push hook build"
+      - "GitHub PR checks and merge queue checks, if publishing is requested in the run"
+    stop_if:
+      - "Working tree contains unrelated changes."
+      - "GitHub auth or merge queue access is unavailable."
+      - "Any required check fails."
+    receipt: null
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: default
+    objective: "Audit whether repo grouping controls satisfy the original user outcome."
+    inputs:
+      - "All done task receipts"
+      - "Last verification"
+      - "Current git status"
+      - "PR/merge state if published"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if any required Worker task is still queued or active."
+      - "Reject completion if summaries disappear while collapsed or persistence is unverified."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "missing evidence"
+      - "next task if not complete"
+    receipt: null
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: unknown
+    task: null
+    commands: []

--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
 import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
+import { DashboardRepoGroupingControls, DashboardRepoHeader, useDashboardRepoCollapse } from "./dashboard-repo-collapse";
 import { boardPresetIdForState, boardPresetState } from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
@@ -63,6 +64,7 @@ export function BoardFocus({
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = boardPresetIdForState(urlState);
   const hasDashboardFilters = query.trim() !== "" || runningOnly !== DEFAULT_BOARD_URL_STATE.runningOnly || sortMode !== DEFAULT_BOARD_URL_STATE.sort || issueView !== DEFAULT_BOARD_URL_STATE.view;
+  const repoCollapse = useDashboardRepoCollapse("board", repos);
 
   return (
     <div className={`${styles.focusInner} ${styles.boardFocus}`}>
@@ -122,6 +124,7 @@ export function BoardFocus({
             </button>
           ))}
         </div>
+        <DashboardRepoGroupingControls ariaLabel="Board repo grouping" collapse={repoCollapse} repos={visibleRows.map(({ repo }) => repo)} />
         <button
           type="button"
           className={styles.secondaryButton}
@@ -150,26 +153,21 @@ export function BoardFocus({
 
       <div aria-label="Cross-repo board" className={styles.boardScroll} role="region" tabIndex={0}>
         {visibleRows.map(({ repo, issues }) => {
-          return (
+          const collapsed = repoCollapse.isCollapsed(repo); return (
             <section
               key={repo.id}
               aria-label={`Board column ${repo.owner}/${repo.name}`}
               className={styles.boardColumn}
             >
-              <header>
-                <h2>{repo.owner}/{repo.name}</h2>
-                <p className={`${styles.muted} ${styles.boardColumnMeta}`}>
-                  {issues.length} {runningOnly ? "running" : "open"}
-                </p>
-              </header>
+              <DashboardRepoHeader collapsed={collapsed} onToggle={() => repoCollapse.toggleRepo(repo)} repo={repo}>
+                <p className={`${styles.muted} ${styles.boardColumnMeta}`}>{issues.length} {runningOnly ? "running" : "open"}</p>
+              </DashboardRepoHeader>
               <RepoDashboardSummary
                 repo={repo}
                 {...dashboardIssueSummaryCounts(issues, (issue) => isRunningIssue(repo, deployments, issue))}
               />
               <RepoIssueHealth repo={repo} />
-              {issues.length === 0 ? (
-                <p className={styles.muted}>No matching issues.</p>
-              ) : (
+              {!collapsed && (issues.length === 0 ? <p className={styles.muted}>No matching issues.</p> : (
                 issues.map((issue) => (
                   <BoardCard
                     key={issue.number}
@@ -180,7 +178,7 @@ export function BoardFocus({
                     onJumpToSession={onJumpToSession}
                   />
                 ))
-              )}
+              ))}
             </section>
           );
         })}

--- a/packages/web/components/workbench/GlobalIssuesFocus.tsx
+++ b/packages/web/components/workbench/GlobalIssuesFocus.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { DashboardPresetStrip } from "./DashboardPresetStrip";
 import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
+import { DashboardRepoGroupingControls, DashboardRepoHeader, useDashboardRepoCollapse } from "./dashboard-repo-collapse";
 import { globalIssuePresetIdForState, globalIssuePresetState } from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
@@ -78,6 +79,7 @@ export function GlobalIssuesFocus({
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = globalIssuePresetIdForState(urlState);
   const hasDashboardFilters = query.trim() !== "" || statusFilter !== DEFAULT_GLOBAL_ISSUE_URL_STATE.status || sortMode !== DEFAULT_GLOBAL_ISSUE_URL_STATE.sort || issueView !== DEFAULT_GLOBAL_ISSUE_URL_STATE.view;
+  const repoCollapse = useDashboardRepoCollapse("globalIssues", repos);
 
   return (
     <div className={styles.focusInner}>
@@ -142,6 +144,7 @@ export function GlobalIssuesFocus({
             </button>
           ))}
         </div>
+        <DashboardRepoGroupingControls ariaLabel="Global repo grouping" collapse={repoCollapse} repos={repoRows.map(({ repo }) => repo)} />
         <button
           type="button"
           className={styles.secondaryButton}
@@ -168,20 +171,16 @@ export function GlobalIssuesFocus({
         />
       )}
       <div aria-label="Global issues">
-        {repoRows.map(({ repo, issues }) => (
+        {repoRows.map(({ repo, issues }) => {
+          const collapsed = repoCollapse.isCollapsed(repo); return (
           <section key={repo.id} aria-label={`Issues for ${repo.owner}/${repo.name}`}>
-            <h2>{repo.owner}/{repo.name}</h2>
+            <DashboardRepoHeader collapsed={collapsed} onToggle={() => repoCollapse.toggleRepo(repo)} repo={repo} />
             <RepoDashboardSummary
               repo={repo}
-              {...dashboardIssueSummaryCounts(
-                issues,
-                (issue) => issueStatus(issue, deploymentForIssue(repo, issue.number)) === "running",
-              )}
+              {...dashboardIssueSummaryCounts(issues, (issue) => issueStatus(issue, deploymentForIssue(repo, issue.number)) === "running")}
             />
             <RepoIssueHealth repo={repo} />
-            {issues.length === 0 ? (
-              <p className={styles.muted}>No matching issues.</p>
-            ) : (
+            {!collapsed && (issues.length === 0 ? <p className={styles.muted}>No matching issues.</p> : (
               <div className={styles.issueList}>
                 {issues.map((issue) => (
                   <GlobalIssueRow
@@ -193,9 +192,10 @@ export function GlobalIssuesFocus({
                   />
                 ))}
               </div>
-            )}
+            ))}
           </section>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -1667,6 +1667,34 @@
   color: var(--paper-brick);
 }
 
+.repoDashboardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.repoDashboardHeading {
+  min-width: 0;
+  flex: 1 1 150px;
+}
+
+.repoDashboardHeading h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.repoCollapseButton {
+  min-height: 32px;
+  margin-top: 0;
+  padding: 0 10px;
+  font-size: 13px;
+  line-height: 1.15;
+  text-align: left;
+  white-space: normal;
+}
+
 .boardControls .primaryButton,
 .boardControls .secondaryButton,
 .globalIssueControls .primaryButton,
@@ -1741,6 +1769,12 @@
 .boardColumn h2 {
   margin: 0;
   font-size: 18px;
+}
+
+.boardColumn .repoCollapseButton {
+  width: 100%;
+  justify-content: center;
+  text-align: center;
 }
 
 .boardColumnMeta {

--- a/packages/web/components/workbench/dashboard-repo-collapse.tsx
+++ b/packages/web/components/workbench/dashboard-repo-collapse.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { WorkbenchRepo } from "./workbench-types";
+import styles from "./WorkbenchShell.module.css";
+
+type DashboardRepoCollapseSurface = "board" | "globalIssues";
+type RepoIdentity = Pick<WorkbenchRepo, "name" | "owner">;
+
+type DashboardRepoCollapseState = {
+  collapseAll: (repos: RepoIdentity[]) => void;
+  expandAll: (repos: RepoIdentity[]) => void;
+  isCollapsed: (repo: RepoIdentity) => boolean;
+  toggleRepo: (repo: RepoIdentity) => void;
+};
+
+const STORAGE_KEYS: Record<DashboardRepoCollapseSurface, string> = {
+  board: "issuectl.dashboard.collapsedRepos.board",
+  globalIssues: "issuectl.dashboard.collapsedRepos.globalIssues",
+};
+
+export function useDashboardRepoCollapse(
+  surface: DashboardRepoCollapseSurface,
+  repos: RepoIdentity[],
+): DashboardRepoCollapseState {
+  const knownRepoKeys = useMemo(() => repos.map(dashboardRepoKey), [repos]);
+  const [collapsedRepoKeys, setCollapsedRepoKeys] = useState<Set<string>>(() => new Set());
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const knownKeys = new Set(knownRepoKeys);
+    setCollapsedRepoKeys(new Set(readCollapsedRepoKeys(surface).filter((key) => knownKeys.has(key))));
+    setHydrated(true);
+  }, [knownRepoKeys, surface]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    const knownKeys = new Set(knownRepoKeys);
+    writeCollapsedRepoKeys(surface, [...collapsedRepoKeys].filter((key) => knownKeys.has(key)));
+  }, [collapsedRepoKeys, hydrated, knownRepoKeys, surface]);
+
+  const isCollapsed = useCallback(
+    (repo: RepoIdentity) => collapsedRepoKeys.has(dashboardRepoKey(repo)),
+    [collapsedRepoKeys],
+  );
+  const toggleRepo = useCallback((repo: RepoIdentity) => {
+    const key = dashboardRepoKey(repo);
+    setCollapsedRepoKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+  const collapseAll = useCallback((visibleRepos: RepoIdentity[]) => {
+    setCollapsedRepoKeys((current) => new Set([...current, ...visibleRepos.map(dashboardRepoKey)]));
+  }, []);
+  const expandAll = useCallback((visibleRepos: RepoIdentity[]) => {
+    const visibleKeys = new Set(visibleRepos.map(dashboardRepoKey));
+    setCollapsedRepoKeys((current) => new Set([...current].filter((key) => !visibleKeys.has(key))));
+  }, []);
+
+  return { collapseAll, expandAll, isCollapsed, toggleRepo };
+}
+
+export function DashboardRepoGroupingControls({
+  ariaLabel,
+  collapse,
+  repos,
+}: {
+  ariaLabel: string;
+  collapse: DashboardRepoCollapseState;
+  repos: RepoIdentity[];
+}) {
+  const disabled = repos.length === 0;
+
+  return (
+    <div className={styles.compactButtonGroup} role="group" aria-label={ariaLabel}>
+      <button type="button" className={styles.secondaryButton} onClick={() => collapse.collapseAll(repos)} disabled={disabled}>
+        Collapse all repos
+      </button>
+      <button type="button" className={styles.secondaryButton} onClick={() => collapse.expandAll(repos)} disabled={disabled}>
+        Expand all repos
+      </button>
+    </div>
+  );
+}
+
+export function DashboardRepoHeader({
+  children,
+  collapsed,
+  onToggle,
+  repo,
+}: {
+  children?: ReactNode;
+  collapsed: boolean;
+  onToggle: () => void;
+  repo: RepoIdentity;
+}) {
+  const label = dashboardRepoKey(repo);
+
+  return (
+    <header className={styles.repoDashboardHeader}>
+      <div className={styles.repoDashboardHeading}>
+        <h2>{label}</h2>
+        {children}
+      </div>
+      <button
+        type="button"
+        className={`${styles.secondaryButton} ${styles.repoCollapseButton}`}
+        aria-expanded={!collapsed}
+        onClick={onToggle}
+      >
+        {collapsed ? "Expand" : "Collapse"} {label}
+      </button>
+    </header>
+  );
+}
+
+export function dashboardRepoKey(repo: RepoIdentity): string {
+  return `${repo.owner}/${repo.name}`;
+}
+
+function readCollapsedRepoKeys(surface: DashboardRepoCollapseSurface): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEYS[surface]) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeCollapsedRepoKeys(surface: DashboardRepoCollapseSurface, keys: string[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEYS[surface], JSON.stringify(keys));
+}

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -2246,21 +2246,21 @@ test("collapses workbench drawers and flattens active sessions", async ({ page }
 
   await page.getByRole("complementary", { name: "Active sessions" }).getByRole("button", { name: "Collapse running sessions" }).click();
   await expect(workbench).toHaveAttribute("data-instances-pane", "collapsed");
-  await expect(page.getByLabel("Active sessions")).toHaveCount(0);
-  await expect(page.getByLabel("Repo issues")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
+  await expect(page.getByRole("complementary", { name: "Repo issues" })).toBeVisible();
 
   await page.getByRole("button", { name: "Expand running sessions" }).click();
   await expect(workbench).toHaveAttribute("data-instances-pane", "visible");
-  await expect(page.getByLabel("Active sessions")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Active sessions" })).toBeVisible();
 
   await page.getByRole("complementary", { name: "Repo issues" }).getByRole("button", { name: "Collapse issues drawer" }).click();
   await expect(workbench).toHaveAttribute("data-issues-pane", "collapsed");
-  await expect(page.getByLabel("Repo issues")).toHaveCount(0);
-  await expect(page.getByLabel("Active sessions")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
+  await expect(page.getByRole("complementary", { name: "Active sessions" })).toBeVisible();
 
   await page.getByRole("button", { name: "Expand issues drawer" }).click();
   await expect(workbench).toHaveAttribute("data-issues-pane", "visible");
-  await expect(page.getByLabel("Repo issues")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Repo issues" })).toBeVisible();
 });
 
 test("keeps drawer restore controls out of issue and terminal headers", async ({ page }) => {
@@ -2846,6 +2846,51 @@ test("shows cross-repo board columns and reversible running filter", async ({ pa
   await expect(page).toHaveURL(new RegExp("/workbench\\?repo=mean-weasel%2Fissuectl&issue=512$"));
   await expect(page.getByRole("button", { name: "mean-weasel/issuectl" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
+});
+
+test("supports repo grouping collapse controls across dashboard surfaces", async ({ page }) => {
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await page.evaluate(() => window.localStorage.clear());
+  await page.goto(`${baseUrl}/workbench/issues`);
+
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
+  await page.getByRole("button", { name: "Collapse mean-weasel/issuectl" }).click();
+  await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toHaveCount(0);
+
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toHaveCount(0);
+  await page.getByRole("button", { name: "Expand mean-weasel/issuectl" }).click();
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
+
+  await page.getByRole("button", { name: "Collapse all repos" }).click();
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/bugdrop")).toContainText("1 visible");
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toHaveCount(0);
+  await expect(page.getByLabel("mean-weasel/bugdrop issue #440")).toHaveCount(0);
+  await page.getByRole("button", { name: "Expand all repos" }).click();
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
+  await expect(page.getByLabel("mean-weasel/bugdrop issue #440")).toBeVisible();
+
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
+  await page.getByRole("button", { name: "Collapse mean-weasel/issuectl" }).click();
+  await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
+  await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
+
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
+  await page.goto(`${baseUrl}/workbench/issues`);
+  await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
+  await page.goto(`${baseUrl}/workbench/board`);
+  await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
+  await page.getByRole("button", { name: "Expand all repos" }).click();
+  await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
 });
 
 test("surfaces duplicate repo names plus issue cache and error state in global dashboards", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add per-surface persisted repo collapse state for Global Issues and Board
- add per-repo toggle plus Collapse all / Expand all controls while keeping repo headers, summaries, and health visible
- add focused Playwright coverage for single toggle, bulk controls, reload persistence, and per-surface isolation
- tighten stale drawer-collapse E2E selectors to complementary-role locators

## Failure modes considered
- collapsed repos might hide summary or health context: focused E2E asserts summaries remain visible while issue cards are absent
- collapse state might leak between Global Issues and Board: focused E2E asserts Board remains collapsed while Global Issues stays expanded
- bulk controls might only affect one repo: focused E2E asserts issuectl and bugdrop issue cards are both hidden after Collapse all
- existing filters, presets, duplicate repo names, cache/error state might regress: existing cross-repo dashboard regression passed
- focus components might exceed max-lines lint: package and root lint passed

## Verification
- pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "repo grouping"
- pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "repo grouping|collapse"
- pnpm --dir packages/web test:e2e e2e/workbench.spec.ts --project=desktop-chromium --grep "surfaces duplicate repo names"
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web lint
- pnpm --dir packages/web test
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm turbo build
- git diff --check
- pre-commit hook: pnpm turbo typecheck; pnpm turbo lint
- pre-push hook: pnpm turbo build
