### PR TITLE
Simplify cross-repo workbench dashboard

### DIFF
--- a/packages/web/components/workbench/BoardFocus.tsx
+++ b/packages/web/components/workbench/BoardFocus.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
-import { DashboardPresetStrip } from "./DashboardPresetStrip";
-import { DashboardEmptyState, RepoDashboardSummary, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
+import { RepoPullsSummary, repoKey, useBoardPulls } from "./BoardPulls";
+import { DashboardEmptyState, RepoIssueHealth, dashboardIssueSummaryCounts } from "./DashboardStatusBlocks";
 import { sortDashboardRepoRows } from "./dashboard-repo-ordering";
 import { DashboardRepoGroupingControls, DashboardRepoHeader, useDashboardRepoCollapse } from "./dashboard-repo-collapse";
-import { boardPresetIdForState, boardPresetState } from "./dashboard-presets";
+import { DASHBOARD_PRESETS, boardPresetIdForState, boardPresetState, type DashboardPresetId } from "./dashboard-presets";
 import {
   dashboardIssueViewSummaries,
   filterDashboardIssues,
@@ -31,6 +31,7 @@ const PRIORITY_RANK: Record<WorkbenchIssueSummary["priority"], number> = {
   normal: 1,
   low: 2,
 };
+type BoardViewOption = "all" | "custom" | DashboardPresetId;
 
 export function BoardFocus({
   repos,
@@ -57,14 +58,16 @@ export function BoardFocus({
     ),
     [deployments, issueView, query, repos, runningOnly, sortMode],
   );
-  const visibleIssues = useMemo(
-    () => visibleRows.reduce((count, row) => count + row.issues.length, 0),
-    [visibleRows],
-  );
+  const visibleIssues = visibleRows.reduce((count, row) => count + row.issues.length, 0);
+  const allOpenIssues = repos.reduce((count, repo) => count + repo.issues.filter((issue) => issue.state === "open").length, 0);
   const currentView = viewSummaries.find((view) => view.id === issueView);
   const activePresetId = boardPresetIdForState(urlState);
+  const boardViewValue: BoardViewOption = activePresetId ?? (issueView === "all" && !runningOnly ? "all" : "custom");
+  const defaultPreset = DASHBOARD_PRESETS.find((preset) => preset.id === defaultControls.defaultPresetId);
   const hasDashboardFilters = query.trim() !== "" || runningOnly !== DEFAULT_BOARD_URL_STATE.runningOnly || sortMode !== DEFAULT_BOARD_URL_STATE.sort || issueView !== DEFAULT_BOARD_URL_STATE.view;
   const repoCollapse = useDashboardRepoCollapse("board", repos);
+  const visibleRepos = useMemo(() => visibleRows.map(({ repo }) => repo), [visibleRows]);
+  const repoPulls = useBoardPulls(visibleRepos);
 
   return (
     <div className={`${styles.focusInner} ${styles.boardFocus}`}>
@@ -73,11 +76,6 @@ export function BoardFocus({
       <p className={styles.muted}>
         {visibleIssues} {runningOnly ? "running" : "open"} issues in {currentView?.label.toLowerCase() ?? "all"} view across {repos.length} tracked repositories.
       </p>
-      <DashboardPresetStrip
-        activePresetId={activePresetId}
-        ariaLabel="Board triage presets" onApply={(id) => setUrlState(boardPresetState(id))}
-        defaultPresetId={defaultControls.defaultPresetId} onClearDefault={defaultControls.clearDefaultPresetId} onSetDefault={defaultControls.setDefaultPresetId}
-      />
       <div aria-label="Board controls" className={styles.boardControls}>
         <input
           aria-label="Search board issues"
@@ -87,52 +85,50 @@ export function BoardFocus({
           placeholder="Search issue, repo, label, author, or number"
           onChange={(event) => setUrlState({ query: event.target.value })}
         />
-        <button
-          type="button"
-          className={runningOnly ? styles.primaryButton : styles.secondaryButton}
-          aria-pressed={runningOnly}
-          onClick={() => setUrlState({ runningOnly: !runningOnly })}
+        <select
+          aria-label="Board view"
+          className={styles.boardSelect}
+          value={boardViewValue}
+          onChange={(event) => {
+            const value = event.target.value as BoardViewOption;
+            if (value === "custom") return;
+            setUrlState(value === "all" ? DEFAULT_BOARD_URL_STATE : boardPresetState(value));
+          }}
         >
-          Show running only
-        </button>
-        <button
-          type="button"
-          className={sortMode === "payload" ? styles.primaryButton : styles.secondaryButton}
-          aria-pressed={sortMode === "payload"}
-          onClick={() => setUrlState({ sort: "payload" })}
-        >
-          Payload order
-        </button>
-        <button
-          type="button"
-          className={sortMode === "priority" ? styles.primaryButton : styles.secondaryButton}
-          aria-pressed={sortMode === "priority"}
-          onClick={() => setUrlState({ sort: "priority" })}
-        >
-          Sort by priority
-        </button>
-        <div className={styles.compactButtonGroup} role="group" aria-label="Board operational views">
-          {viewSummaries.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              className={issueView === item.id ? styles.primaryButton : styles.secondaryButton}
-              aria-pressed={issueView === item.id}
-              onClick={() => setUrlState({ view: item.id })}
-            >
-              {item.label} {item.count}
-            </button>
+          <option value="all">All open {allOpenIssues}</option>
+          {DASHBOARD_PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>{preset.label}</option>
           ))}
-        </div>
-        <DashboardRepoGroupingControls ariaLabel="Board repo grouping" collapse={repoCollapse} repos={visibleRows.map(({ repo }) => repo)} />
-        <button
-          type="button"
-          className={styles.secondaryButton}
-          onClick={onRefresh}
-          disabled={refreshPending}
-        >
-          {refreshPending ? "Refreshing" : "Refresh"}
-        </button>
+          {boardViewValue === "custom" && <option value="custom">Custom view</option>}
+        </select>
+        <details className={styles.boardOptions}>
+          <summary>Board options</summary>
+          <div className={styles.boardOptionsPanel}>
+            <select
+              aria-label="Sort board issues"
+              className={styles.boardSelect}
+              value={sortMode}
+              onChange={(event) => setUrlState({ sort: event.target.value as BoardSortMode })}
+            >
+              <option value="payload">Payload order</option>
+              <option value="priority">Priority order</option>
+            </select>
+            <DashboardRepoGroupingControls ariaLabel="Board repo grouping" collapse={repoCollapse} repos={visibleRows.map(({ repo }) => repo)} />
+            <button type="button" className={styles.secondaryButton} onClick={onRefresh} disabled={refreshPending}>
+              {refreshPending ? "Refreshing" : "Refresh"}
+            </button>
+            {activePresetId && (
+              <button type="button" className={styles.secondaryButton} onClick={() => defaultControls.setDefaultPresetId(activePresetId)}>
+                Set default view
+              </button>
+            )}
+            {defaultPreset && (
+              <button type="button" className={styles.secondaryButton} onClick={defaultControls.clearDefaultPresetId}>
+                Clear default: {defaultPreset.label}
+              </button>
+            )}
+          </div>
+        </details>
       </div>
       {(failedRepos > 0 || cachedRepos > 0 || refreshError) && (
         <div className={styles.globalIssueStatus} role={refreshError ? "alert" : "status"}>
@@ -150,35 +146,40 @@ export function BoardFocus({
           title="No board issues match these filters."
         />
       )}
-
       <div aria-label="Cross-repo board" className={styles.boardScroll} role="region" tabIndex={0}>
         {visibleRows.map(({ repo, issues }) => {
-          const collapsed = repoCollapse.isCollapsed(repo); return (
+          const collapsed = repoCollapse.isCollapsed(repo);
+          const counts = dashboardIssueSummaryCounts(issues, (issue) => isRunningIssue(repo, deployments, issue));
+          return (
             <section
               key={repo.id}
               aria-label={`Board column ${repo.owner}/${repo.name}`}
               className={styles.boardColumn}
             >
               <DashboardRepoHeader collapsed={collapsed} onToggle={() => repoCollapse.toggleRepo(repo)} repo={repo}>
-                <p className={`${styles.muted} ${styles.boardColumnMeta}`}>{issues.length} {runningOnly ? "running" : "open"}</p>
+                <div className={styles.boardColumnMeta} aria-label={`Board summary for ${repo.owner}/${repo.name}`}>
+                  <span>{issues.length} {runningOnly ? "running" : "issues"}</span>
+                  {counts.runningCount > 0 && <span>{counts.runningCount} running</span>}
+                  {counts.highPriorityCount > 0 && <span>{counts.highPriorityCount} high</span>}
+                  {repo.issuesFromCache && <span>cached</span>}
+                  {repo.issueError && <span title={repo.issueError}>error</span>}
+                  <RepoPullsSummary repo={repo} state={repoPulls[repoKey(repo)]} />
+                </div>
               </DashboardRepoHeader>
-              <RepoDashboardSummary
-                repo={repo}
-                {...dashboardIssueSummaryCounts(issues, (issue) => isRunningIssue(repo, deployments, issue))}
-              />
-              <RepoIssueHealth repo={repo} />
-              {!collapsed && (issues.length === 0 ? <p className={styles.muted}>No matching issues.</p> : (
-                issues.map((issue) => (
-                  <BoardCard
-                    key={issue.number}
-                    issue={issue}
-                    repo={repo}
-                    deployments={deployments}
-                    onSelectIssue={onSelectIssue}
-                    onJumpToSession={onJumpToSession}
-                  />
-                ))
-              ))}
+              <RepoIssueHealth repo={repo} showCache={false} />
+              {!collapsed && (
+                <>
+                  {issues.length === 0 ? <p className={styles.muted}>No matching issues.</p> : (
+                    issues.map((issue) => (
+                      <BoardCard
+                        key={issue.number}
+                        issue={issue} repo={repo} deployments={deployments}
+                        onSelectIssue={onSelectIssue} onJumpToSession={onJumpToSession}
+                      />
+                    ))
+                  )}
+                </>
+              )}
             </section>
           );
         })}
@@ -206,15 +207,15 @@ function BoardCard({
 
   return (
     <article
-      className={styles.issueCard}
+      className={`${styles.issueCard} ${styles.boardIssueCard}`}
       data-status={status}
       data-priority={issue.priority}
       aria-label={`Board issue ${repo.owner}/${repo.name} #${issue.number}`}
     >
       <div className={styles.issueCardHead}>
         <strong>#{issue.number}</strong>
-        <span className={styles.issueChip} data-card-chip="status" data-status={status}>{status}</span>
-        <span className={styles.issueChip} data-card-chip="priority">{issue.priority}</span>
+        {status !== "open" && <span className={styles.issueChip} data-card-chip="status" data-status={status}>{status}</span>}
+        {issue.priority === "high" && <span className={styles.issueChip} data-card-chip="priority">{issue.priority}</span>}
       </div>
       <h3>{issue.title}</h3>
       <p className={styles.issueCardMeta}>
@@ -222,12 +223,12 @@ function BoardCard({
       </p>
       <div className={styles.issueActions}>
         {deployment ? (
-          <button type="button" onClick={() => onJumpToSession(deployment.id)}>
-            Jump to session
+          <button type="button" aria-label="Jump to session" onClick={() => onJumpToSession(deployment.id)}>
+            Jump
           </button>
         ) : (
-          <button type="button" onClick={() => onSelectIssue(repo.id, issue.number)}>
-            Prepare launch
+          <button type="button" aria-label="Prepare launch" onClick={() => onSelectIssue(repo.id, issue.number)}>
+            Prepare
           </button>
         )}
       </div>
@@ -295,15 +296,13 @@ function matchesBoardIssue(
     issue.authorLogin ?? "",
     ...issue.labels,
   ].join(" ").toLowerCase();
-
   return query.split(/\s+/).every((term) => haystack.includes(term));
 }
 
 function formatAge(value: string): string {
   const timestamp = new Date(value).getTime();
   if (Number.isNaN(timestamp)) return "recently";
-  const elapsedMs = Date.now() - timestamp;
-  const elapsedHours = Math.max(0, Math.floor(elapsedMs / 3_600_000));
+  const elapsedHours = Math.max(0, Math.floor((Date.now() - timestamp) / 3_600_000));
   if (elapsedHours < 1) return "just now";
   if (elapsedHours < 24) return `${elapsedHours}h ago`;
   const elapsedDays = Math.floor(elapsedHours / 24);

--- a/packages/web/components/workbench/BoardPulls.tsx
+++ b/packages/web/components/workbench/BoardPulls.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from "react";
+import { requestJson, type ListResponse, type PullSummary } from "./pull-requests-data";
+import type { WorkbenchRepo } from "./workbench-types";
+import styles from "./WorkbenchShell.module.css";
+
+type RepoPullState = {
+  status: "idle" | "loading" | "loaded" | "error";
+  pulls: PullSummary[];
+  error: string | null;
+};
+
+export function useBoardPulls(repos: WorkbenchRepo[]): Record<string, RepoPullState> {
+  const repoKeys = useMemo(() => repos.map(repoKey).sort(), [repos]);
+  const repoSignature = repoKeys.join("|");
+  const repoLookup = useMemo(
+    () => new Map(repos.map((repo) => [repoKey(repo), repo])),
+    [repos],
+  );
+  const [states, setStates] = useState<Record<string, RepoPullState>>({});
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const nextKeys = new Set(repoKeys);
+    setStates((current) => {
+      const next: Record<string, RepoPullState> = {};
+      for (const key of repoKeys) {
+        next[key] = current[key] ?? { status: "loading", pulls: [], error: null };
+      }
+      return next;
+    });
+
+    for (const key of repoKeys) {
+      const repo = repoLookup.get(key);
+      if (!repo) continue;
+      setStates((current) => ({
+        ...current,
+        [key]: { status: "loading", pulls: current[key]?.pulls ?? [], error: null },
+      }));
+      void requestJson<ListResponse>(
+        `/api/v1/pulls/${repo.owner}/${repo.name}?checks=true`,
+        { method: "GET", signal: controller.signal },
+      )
+        .then((body) => {
+          if (controller.signal.aborted || !nextKeys.has(key)) return;
+          setStates((current) => ({
+            ...current,
+            [key]: { status: "loaded", pulls: body.pulls, error: null },
+          }));
+        })
+        .catch((err: unknown) => {
+          if (controller.signal.aborted || !nextKeys.has(key)) return;
+          const message = err instanceof Error ? err.message : "Unable to load pull requests";
+          setStates((current) => ({
+            ...current,
+            [key]: { status: "error", pulls: [], error: message },
+          }));
+        });
+    }
+
+    return () => controller.abort();
+  }, [repoKeys, repoLookup, repoSignature]);
+
+  return states;
+}
+
+export function RepoPullsSummary({
+  repo,
+  state,
+}: {
+  repo: WorkbenchRepo;
+  state?: RepoPullState;
+}) {
+  const repoLabel = repoKey(repo);
+  const status = state?.status ?? "idle";
+  const pulls = state?.pulls ?? [];
+  const repoParam = encodeURIComponent(repoLabel);
+  const label = status === "loaded" ? `${pulls.length} ${pulls.length === 1 ? "PR" : "PRs"}` : status === "error" ? "PR error" : "PRs loading";
+
+  if (status === "loaded" && pulls.length > 0) {
+    return <a aria-label={`Board pull requests for ${repoLabel}`} className={styles.boardPullBadge} href={`/workbench/prs?repo=${repoParam}`}>{label}</a>;
+  }
+
+  return <span aria-label={`Board pull requests for ${repoLabel}`} className={styles.boardPullBadge} data-status={status}>{label}</span>;
+}
+
+export function repoKey(repo: Pick<WorkbenchRepo, "owner" | "name">): string {
+  return `${repo.owner}/${repo.name}`;
+}

--- a/packages/web/components/workbench/DashboardStatusBlocks.tsx
+++ b/packages/web/components/workbench/DashboardStatusBlocks.tsx
@@ -35,13 +35,13 @@ export function DashboardEmptyState({
   );
 }
 
-export function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
-  if (!repo.issueError && !repo.issuesFromCache) return null;
+export function RepoIssueHealth({ repo, showCache = true }: { repo: WorkbenchRepo; showCache?: boolean }) {
+  if (!repo.issueError && !(showCache && repo.issuesFromCache)) return null;
 
   return (
     <div className={styles.repoIssueHealth} role={repo.issueError ? "alert" : "status"}>
       {repo.issueError && <span>Issue fetch failed: {repo.issueError}</span>}
-      {repo.issuesFromCache && (
+      {showCache && repo.issuesFromCache && (
         <span>Showing cached issues{repo.issuesCachedAt ? ` from ${formatAge(repo.issuesCachedAt)}` : ""}</span>
       )}
     </div>
@@ -50,15 +50,20 @@ export function RepoIssueHealth({ repo }: { repo: WorkbenchRepo }) {
 
 export function RepoDashboardSummary({
   highPriorityCount,
+  hideZeroCounts = false,
   repo,
   runningCount,
   visibleCount,
-}: RepoDashboardSummaryCounts & { repo: WorkbenchRepo }) {
+}: RepoDashboardSummaryCounts & { hideZeroCounts?: boolean; repo: WorkbenchRepo }) {
   return (
     <div className={styles.repoIssueSummary} aria-label={`Dashboard summary for ${repo.owner}/${repo.name}`}>
       <span className={styles.repoIssueSummaryChip}>{visibleCount} visible</span>
-      <span className={styles.repoIssueSummaryChip}>{runningCount} running</span>
-      <span className={styles.repoIssueSummaryChip}>{highPriorityCount} high priority</span>
+      {(!hideZeroCounts || runningCount > 0) && (
+        <span className={styles.repoIssueSummaryChip}>{runningCount} running</span>
+      )}
+      {(!hideZeroCounts || highPriorityCount > 0) && (
+        <span className={styles.repoIssueSummaryChip}>{highPriorityCount} high priority</span>
+      )}
       {repo.issuesFromCache && (
         <span className={styles.repoIssueSummaryChip} data-tone="cache">cached</span>
       )}

--- a/packages/web/components/workbench/PullRequestsFocus.tsx
+++ b/packages/web/components/workbench/PullRequestsFocus.tsx
@@ -11,17 +11,25 @@ import {
   type PullSummary,
 } from "./pull-requests-data";
 import { cardStyle, fieldStyle, panelStyle, rowStyle, textareaStyle } from "./pull-requests-styles";
-import type { WorkbenchPayload } from "./workbench-types";
+import type { WorkbenchPayload, WorkbenchRepo } from "./workbench-types";
 import styles from "./WorkbenchShell.module.css";
 
 type Props = {
+  repos: WorkbenchPayload["repos"];
   selectedRepo: WorkbenchPayload["repos"][number] | null;
 };
 
-export function PullRequestsFocus({ selectedRepo }: Props) {
-  const [pulls, setPulls] = useState<PullSummary[]>([]);
+type RepoPull = PullSummary & {
+  key: string;
+  repo: WorkbenchRepo;
+  repoLabel: string;
+};
+
+export function PullRequestsFocus({ repos, selectedRepo }: Props) {
+  const [repoFilter, setRepoFilter] = useState<string>(() => selectedRepo ? repoLabel(selectedRepo) : "all");
+  const [pulls, setPulls] = useState<RepoPull[]>([]);
   const [listStatus, setListStatus] = useState<"idle" | "loading" | "loaded">("idle");
-  const [selectedNumber, setSelectedNumber] = useState<number | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [detail, setDetail] = useState<PullDetail | null>(null);
   const [detailStatus, setDetailStatus] = useState<"idle" | "loading" | "loaded">("idle");
   const [reviewBody, setReviewBody] = useState("Looks good");
@@ -29,36 +37,51 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const repoLabel = selectedRepo ? `${selectedRepo.owner}/${selectedRepo.name}` : null;
+  useEffect(() => {
+    setRepoFilter(selectedRepo ? repoLabel(selectedRepo) : "all");
+  }, [selectedRepo]);
+
+  const reposToLoad = useMemo(
+    () => repoFilter === "all" ? repos : repos.filter((repo) => repoLabel(repo) === repoFilter),
+    [repoFilter, repos],
+  );
   const selectedPull = useMemo(
-    () => pulls.find((pull) => pull.number === selectedNumber) ?? null,
-    [pulls, selectedNumber],
+    () => pulls.find((pull) => pull.key === selectedKey) ?? null,
+    [pulls, selectedKey],
   );
 
   const loadPulls = useCallback(async (
-    repo = selectedRepo,
+    targetRepos = reposToLoad,
     signal?: AbortSignal,
     forceRefresh = false,
   ) => {
-    if (!repo) return;
     setListStatus("loading");
     setError(null);
     setPulls([]);
-    setSelectedNumber(null);
+    setSelectedKey(null);
     setDetail(null);
     try {
-      const query = new URLSearchParams({ checks: "true" });
-      if (forceRefresh) query.set("refresh", "true");
-      const body = await requestJson<ListResponse>(
-        `/api/v1/pulls/${repo.owner}/${repo.name}?${query.toString()}`,
-        { method: "GET", signal },
-      );
+      const nextPulls = await Promise.all(targetRepos.map(async (repo) => {
+        const query = new URLSearchParams({ checks: "true" });
+        if (forceRefresh) query.set("refresh", "true");
+        const body = await requestJson<ListResponse>(
+          `/api/v1/pulls/${repo.owner}/${repo.name}?${query.toString()}`,
+          { method: "GET", signal },
+        );
+        const label = repoLabel(repo);
+        return body.pulls.map((pull): RepoPull => ({
+          ...pull,
+          key: `${label}#${pull.number}`,
+          repo,
+          repoLabel: label,
+        }));
+      }));
       if (signal?.aborted) return;
-      setPulls(body.pulls);
-      if (body.pulls.length === 0) {
-        setSelectedNumber(null);
-        setDetail(null);
-      }
+      setPulls(nextPulls.flat().sort((left, right) =>
+        new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+        || left.repoLabel.localeCompare(right.repoLabel)
+        || left.number - right.number,
+      ));
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setError(errorMessage(err, "Unable to load pull requests."));
@@ -68,25 +91,24 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
         setListStatus("loaded");
       }
     }
-  }, [selectedRepo]);
+  }, [reposToLoad]);
 
   useEffect(() => {
     const controller = new AbortController();
-    setSelectedNumber(null);
+    setSelectedKey(null);
     setDetail(null);
-    void loadPulls(selectedRepo, controller.signal);
+    void loadPulls(reposToLoad, controller.signal);
     return () => controller.abort();
-  }, [loadPulls, selectedRepo]);
+  }, [loadPulls, reposToLoad]);
 
-  async function openPull(number: number) {
-    if (!selectedRepo) return;
-    setSelectedNumber(number);
+  async function openPull(pull: RepoPull) {
+    setSelectedKey(pull.key);
     setDetailStatus("loading");
     setMessage(null);
     setError(null);
     try {
       const body = await requestJson<PullDetail>(
-        `/api/v1/pulls/${selectedRepo.owner}/${selectedRepo.name}/${number}`,
+        `/api/v1/pulls/${pull.repo.owner}/${pull.repo.name}/${pull.number}`,
         { method: "GET" },
       );
       setDetail(body);
@@ -98,79 +120,69 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
   }
 
   async function submitReview() {
-    if (!selectedRepo || !selectedNumber) return;
+    if (!selectedPull) return;
     setMessage(null);
     setError(null);
     try {
       await requestJson<{ success: boolean; reviewId?: number }>(
-        `/api/v1/pulls/${selectedRepo.owner}/${selectedRepo.name}/${selectedNumber}/review`,
+        `/api/v1/pulls/${selectedPull.repo.owner}/${selectedPull.repo.name}/${selectedPull.number}/review`,
         {
           method: "POST",
           body: JSON.stringify({ event: "APPROVE", body: reviewBody }),
         },
       );
-      setMessage(`Review approved for #${selectedNumber}.`);
+      setMessage(`Review approved for ${selectedPull.repoLabel} #${selectedPull.number}.`);
     } catch (err) {
       setError(errorMessage(err, "Unable to submit review."));
     }
   }
 
   async function mergeSquash() {
-    if (!selectedRepo || !selectedNumber) return;
+    if (!selectedPull) return;
     setMessage(null);
     setError(null);
     try {
       await requestJson<{ success: boolean; sha?: string }>(
-        `/api/v1/pulls/${selectedRepo.owner}/${selectedRepo.name}/${selectedNumber}/merge`,
+        `/api/v1/pulls/${selectedPull.repo.owner}/${selectedPull.repo.name}/${selectedPull.number}/merge`,
         {
           method: "POST",
           body: JSON.stringify({ mergeMethod: "squash" }),
         },
       );
-      markMerged(selectedNumber);
-      setMessage(`Pull request #${selectedNumber} merged with squash.`);
+      markMerged(selectedPull.key);
+      setMessage(`Pull request ${selectedPull.repoLabel} #${selectedPull.number} merged with squash.`);
     } catch (err) {
       setError(errorMessage(err, "Unable to merge pull request."));
     }
   }
 
   async function addComment() {
-    if (!selectedRepo || !selectedNumber) return;
+    if (!selectedPull) return;
     setMessage(null);
     setError(null);
     try {
       await requestJson<{ success: boolean; commentId?: number }>(
-        `/api/v1/pulls/${selectedRepo.owner}/${selectedRepo.name}/${selectedNumber}/comments`,
+        `/api/v1/pulls/${selectedPull.repo.owner}/${selectedPull.repo.name}/${selectedPull.number}/comments`,
         {
           method: "POST",
           body: JSON.stringify({ body: commentBody }),
         },
       );
-      setMessage(`Comment added to #${selectedNumber}.`);
+      setMessage(`Comment added to ${selectedPull.repoLabel} #${selectedPull.number}.`);
     } catch (err) {
       setError(errorMessage(err, "Unable to add comment."));
     }
   }
 
-  function markMerged(number: number) {
+  function markMerged(key: string) {
     setPulls((current) => current.map((pull) =>
-      pull.number === number
+      pull.key === key
         ? { ...pull, state: "closed", merged: true, mergedAt: new Date().toISOString() }
         : pull,
     ));
-    setDetail((current) => current && current.pull.number === number
+    setDetail((current) => current && selectedPull && current.pull.number === selectedPull.number
       ? { ...current, pull: { ...current.pull, state: "closed", merged: true } }
       : current);
-  }
-
-  if (!selectedRepo || !repoLabel) {
-    return (
-      <div className={styles.focusInner}>
-        <p className={styles.kicker}>PRs</p>
-        <h1>Select a repository</h1>
-        <p className={styles.muted}>Pull requests are scoped to the active repo.</p>
-      </div>
-    );
   }
 
   return (
@@ -178,13 +190,30 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
       <header style={rowStyle}>
         <div>
           <p className={styles.kicker}>Pull requests</p>
-          <h1>{repoLabel}</h1>
-          <p className={styles.muted}>Review, comment on, and merge pull requests for this repository.</p>
+          <h1>Pull requests</h1>
+          <p className={styles.muted}>
+            {pulls.length} open PRs across {repoFilter === "all" ? repos.length : 1} tracked {repoFilter === "all" ? "repositories" : "repository"}.
+          </p>
         </div>
+        <label className={styles.workbenchField}>
+          Repo
+          <select
+            aria-label="Pull request repository filter"
+            className={styles.workbenchInput}
+            value={repoFilter}
+            onChange={(event) => setRepoFilter(event.target.value)}
+          >
+            <option value="all">All repositories</option>
+            {repos.map((repo) => {
+              const label = repoLabel(repo);
+              return <option key={repo.id} value={label}>{label}</option>;
+            })}
+          </select>
+        </label>
         <button
           type="button"
           className={styles.secondaryButton}
-          onClick={() => void loadPulls(selectedRepo, undefined, true)}
+          onClick={() => void loadPulls(reposToLoad, undefined, true)}
         >
           Refresh checks
         </button>
@@ -193,23 +222,23 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
       {error && <p role="alert" className={styles.issueFocusError}>{error}</p>}
       {message && <p role="status" className={styles.issueFocusNotice}>{message}</p>}
 
-      <section aria-label={`Pull requests for ${repoLabel}`} style={{ display: "grid", gap: "10px" }}>
-        {listStatus === "loading" && <p className={styles.muted}>Loading pull requests for {repoLabel}.</p>}
+      <section aria-label="Cross-repo pull requests" style={{ display: "grid", gap: "10px" }}>
+        {listStatus === "loading" && <p className={styles.muted}>Loading pull requests.</p>}
         {listStatus === "loaded" && pulls.length === 0 && (
-          <p className={styles.muted}>No open pull requests in {repoLabel}.</p>
+          <p className={styles.muted}>No open pull requests match this repo filter.</p>
         )}
         {pulls.map((pull) => {
           const linkedIssue = linkedIssueNumber(pull.body);
           return (
             <article
-              key={pull.number}
-              aria-label={`Pull request #${pull.number}`}
-              data-selected={selectedNumber === pull.number ? "true" : undefined}
+              key={pull.key}
+              aria-label={`Pull request ${pull.repoLabel} #${pull.number}`}
+              data-selected={selectedKey === pull.key ? "true" : undefined}
               data-checks={pull.checksStatus ?? "unknown"}
               style={cardStyle}
             >
               <div style={rowStyle}>
-                <strong>#{pull.number} {pull.title}</strong>
+                <strong>{pull.repoLabel} #{pull.number} {pull.title}</strong>
                 <span>{pull.merged ? "merged" : pull.state}</span>
                 <span>Checks {pull.checksStatus ?? "unknown"}</span>
                 {pull.checksStatus === "success" && !pull.merged && <span>Needs review</span>}
@@ -220,7 +249,7 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
                 <span>+{pull.additions} / -{pull.deletions}</span>
                 <span>{pull.changedFiles} files</span>
               </div>
-              <button type="button" className={styles.secondaryButton} onClick={() => void openPull(pull.number)}>
+              <button type="button" className={styles.secondaryButton} onClick={() => void openPull(pull)}>
                 Open PR
               </button>
             </article>
@@ -231,12 +260,12 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
       <section aria-label="Pull request detail" style={cardStyle}>
         {!selectedPull && <p className={styles.muted}>Select a pull request to open details in this focus pane.</p>}
         {selectedPull && detailStatus === "loading" && (
-          <p className={styles.issueFocusNotice}>Loading PR #{selectedPull.number}</p>
+          <p className={styles.issueFocusNotice}>Loading PR {selectedPull.repoLabel} #{selectedPull.number}</p>
         )}
         {selectedPull && detail && (
           <>
             <div style={rowStyle}>
-              <h2 style={{ margin: 0 }}>#{detail.pull.number} {detail.pull.title}</h2>
+              <h2 style={{ margin: 0 }}>{selectedPull.repoLabel} #{detail.pull.number} {detail.pull.title}</h2>
               <span>{detail.pull.merged ? "merged" : detail.pull.state}</span>
               {detail.linkedIssue && <span>Linked issue #{detail.linkedIssue.number}</span>}
             </div>
@@ -270,4 +299,8 @@ export function PullRequestsFocus({ selectedRepo }: Props) {
       </section>
     </div>
   );
+}
+
+function repoLabel(repo: Pick<WorkbenchRepo, "owner" | "name">): string {
+  return `${repo.owner}/${repo.name}`;
 }

--- a/packages/web/components/workbench/RepoRail.tsx
+++ b/packages/web/components/workbench/RepoRail.tsx
@@ -48,18 +48,20 @@ export function RepoRail({
       {repos.map((repo) => {
         const count = repoRailBadgeCount(repo);
         const selected = repo.id === selectedRepoId;
+        const label = repoLabel(repo);
         return (
           <button
             key={repo.id}
             type="button"
             className={styles.repoButton}
-            aria-label={repoLabel(repo)}
+            aria-label={label}
             aria-pressed={selected}
             data-selected={selected ? "true" : undefined}
-            title={repoLabel(repo)}
+            title={label}
             onClick={() => onSelectRepo(repo.id)}
           >
             {compactRepoInitials(repo.name)}
+            <span className={styles.repoButtonTooltip} aria-hidden="true">{label}</span>
             {count > 0 && <span className={styles.badge}>{count}</span>}
           </button>
         );

--- a/packages/web/components/workbench/WorkbenchShell.module.css
+++ b/packages/web/components/workbench/WorkbenchShell.module.css
@@ -53,6 +53,30 @@
   white-space: nowrap;
 }
 
+.repoPicker {
+  flex: 0 1 320px;
+  min-width: 180px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--paper-ink-muted);
+  font: 700 10px var(--paper-mono);
+  text-transform: uppercase;
+}
+
+.repoPicker select {
+  min-width: 0;
+  width: 100%;
+  min-height: 32px;
+  padding: 0 30px 0 9px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--paper-ink);
+  font: 12px var(--paper-mono);
+  text-transform: none;
+}
+
 .topnav {
   flex: 1 1 auto;
   min-width: 0;
@@ -159,6 +183,10 @@
     display: none;
   }
 
+  .repoPicker {
+    flex-basis: 240px;
+  }
+
   .topnav {
     justify-content: flex-start;
   }
@@ -205,6 +233,39 @@
 
 .workbench[data-side-panes="collapsed"] {
   grid-template-columns: var(--repo-rail-width, 76px) minmax(0, 1fr);
+}
+
+.workbench[data-repo-rail="hidden"] {
+  grid-template-columns:
+    var(--workbench-instances-width, 284px)
+    8px
+    minmax(440px, 1fr)
+    8px
+    var(--workbench-issues-width, 348px);
+}
+
+.workbench[data-repo-rail="hidden"][data-side-panes="collapsed"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="visible"] {
+  grid-template-columns:
+    40px
+    minmax(440px, 1fr)
+    8px
+    var(--workbench-issues-width, 348px);
+}
+
+.workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="visible"][data-issues-pane="collapsed"] {
+  grid-template-columns:
+    var(--workbench-instances-width, 284px)
+    8px
+    minmax(440px, 1fr)
+    40px;
+}
+
+.workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="collapsed"] {
+  grid-template-columns: 40px minmax(0, 1fr) 40px;
 }
 
 .workbench[data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="visible"] {
@@ -276,6 +337,8 @@
 }
 
 .repoRail {
+  position: relative;
+  z-index: 7;
   width: 100%;
   box-sizing: border-box;
   background: var(--paper-bg-warm);
@@ -283,6 +346,7 @@
   flex-direction: column;
   align-items: center;
   gap: 10px;
+  overflow: visible;
   padding: 12px 8px;
 }
 
@@ -305,6 +369,35 @@
   background: rgba(255, 255, 255, 0.25);
   color: var(--paper-ink-muted);
   font: 700 11px var(--paper-mono);
+}
+
+.repoButtonTooltip {
+  position: absolute;
+  z-index: 8;
+  left: calc(100% + 8px);
+  top: 50%;
+  width: max-content;
+  max-width: min(260px, calc(100vw - 96px));
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-ink);
+  color: var(--paper-bg);
+  font: 11px var(--paper-mono);
+  line-height: 1.25;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translateY(-50%) translateX(-3px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: normal;
+}
+
+.repoButton:hover .repoButtonTooltip,
+.repoButton:focus-visible .repoButtonTooltip {
+  opacity: 1;
+  transform: translateY(-50%);
 }
 
 .repoButton[data-selected="true"] {
@@ -1571,9 +1664,9 @@
 .boardControls {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   flex-wrap: wrap;
-  margin: 18px 0;
+  margin: 12px 0;
 }
 
 .globalIssueControls {
@@ -1587,21 +1680,28 @@
 .compactButtonGroup {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   flex-wrap: wrap;
 }
 
 .dashboardPresetStrip {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
-  margin: 14px 0 4px;
+  margin: 10px 0 2px;
 }
 
 .dashboardPresetStrip .primaryButton,
 .dashboardPresetStrip .secondaryButton {
+  min-height: 32px;
   margin-top: 0;
+  padding: 0 12px;
+}
+
+.dashboardPresetStrip .secondaryButton,
+.boardControls .secondaryButton {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .dashboardPresetLabel {
@@ -1672,7 +1772,6 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
-  flex-wrap: wrap;
 }
 
 .repoDashboardHeading {
@@ -1686,24 +1785,73 @@
 }
 
 .repoCollapseButton {
-  min-height: 32px;
+  min-width: 28px;
+  min-height: 28px;
   margin-top: 0;
-  padding: 0 10px;
+  padding: 0 8px;
+  font-family: var(--paper-mono);
   font-size: 13px;
   line-height: 1.15;
-  text-align: left;
-  white-space: normal;
+  text-align: center;
+  white-space: nowrap;
 }
 
 .boardControls .primaryButton,
 .boardControls .secondaryButton,
 .globalIssueControls .primaryButton,
 .globalIssueControls .secondaryButton {
+  min-height: 34px;
   margin-top: 0;
+  padding: 0 12px;
+}
+
+.boardSelect {
+  min-height: 34px;
+  padding: 0 30px 0 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--paper-ink);
+  font: italic 15px var(--paper-serif);
+}
+
+.boardOptions {
+  display: grid;
+  gap: 6px;
+}
+
+.boardOptions > summary {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--paper-ink);
+  cursor: pointer;
+  font: italic 15px var(--paper-serif);
+  list-style: none;
+}
+
+.boardOptions > summary::-webkit-details-marker {
+  display: none;
+}
+
+.boardOptionsPanel {
+  width: min(100%, 280px);
+  min-width: 220px;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--paper-line);
+  border-radius: var(--paper-radius-sm);
+  background: var(--paper-bg);
+  box-shadow: 0 6px 16px rgba(47, 43, 36, 0.08);
 }
 
 .workbenchSearchInput {
-  min-height: 40px;
+  min-height: 36px;
   min-width: min(100%, 300px);
   flex: 1 1 280px;
   padding: 0 12px;
@@ -1748,7 +1896,7 @@
   max-width: 100%;
   display: grid;
   grid-template-columns: repeat(4, minmax(190px, 1fr));
-  gap: 12px;
+  gap: 8px;
   min-height: 0;
   overflow-x: auto;
   overscroll-behavior-x: contain;
@@ -1759,8 +1907,8 @@
   min-width: 190px;
   display: grid;
   align-content: start;
-  gap: 10px;
-  padding: 12px;
+  gap: 8px;
+  padding: 10px;
   border: 1px solid var(--paper-line);
   border-radius: var(--paper-radius-md);
   background: rgba(255, 255, 255, 0.18);
@@ -1768,17 +1916,75 @@
 
 .boardColumn h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .boardColumn .repoCollapseButton {
-  width: 100%;
   justify-content: center;
-  text-align: center;
 }
 
 .boardColumnMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
   margin: 4px 0 0;
+}
+
+.boardColumnMeta span,
+.boardPullBadge {
+  padding: 2px 6px;
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--paper-ink-muted);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.boardPullBadge {
+  color: var(--paper-ink);
+  text-decoration: none;
+}
+
+.boardIssueCard {
+  min-height: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "meta actions"
+    "title actions";
+  row-gap: 3px;
+  padding: 7px 8px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.boardIssueCard h3 {
+  font-size: 14px;
+  line-height: 1.15;
+  -webkit-line-clamp: 1;
+}
+
+.boardIssueCard .issueCardMeta {
+  font-size: 11px;
+}
+
+.boardIssueCard .issueActions button {
+  min-height: 26px;
+  opacity: 0;
+  padding: 0 8px;
+  font-size: 12px;
+  transition: opacity 120ms ease;
+}
+
+.boardIssueCard:hover .issueActions button,
+.boardIssueCard:focus-within .issueActions button {
+  opacity: 1;
+}
+
+@media (hover: none), (pointer: coarse), (max-width: 700px) {
+  .boardIssueCard .issueActions button {
+    opacity: 1;
+  }
 }
 
 .focusInner h1 {
@@ -2052,6 +2258,35 @@
       minmax(440px, 1fr)
       40px;
   }
+
+  .workbench[data-repo-rail="hidden"] {
+    grid-template-columns:
+      min(var(--workbench-instances-width, 284px), 252px)
+      8px
+      minmax(440px, 1fr)
+      8px
+      min(var(--workbench-issues-width, 348px), 320px);
+  }
+
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="visible"] {
+    grid-template-columns:
+      40px
+      minmax(440px, 1fr)
+      8px
+      min(var(--workbench-issues-width, 348px), 320px);
+  }
+
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="visible"][data-issues-pane="collapsed"] {
+    grid-template-columns:
+      min(var(--workbench-instances-width, 284px), 252px)
+      8px
+      minmax(440px, 1fr)
+      40px;
+  }
+
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="collapsed"] {
+    grid-template-columns: 40px minmax(0, 1fr) 40px;
+  }
 }
 
 @media (max-width: 1099px) {
@@ -2088,6 +2323,12 @@
   .routeLabel {
     grid-area: context;
     display: block;
+    max-width: 100%;
+  }
+
+  .repoPicker {
+    grid-area: context;
+    min-width: 0;
     max-width: 100%;
   }
 
@@ -2129,6 +2370,14 @@
     --repo-rail-width: 68px;
     grid-template-columns: var(--repo-rail-width, 68px) minmax(0, 1fr);
     overflow: hidden;
+  }
+
+  .workbench[data-repo-rail="hidden"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="visible"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="visible"][data-issues-pane="collapsed"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="collapsed"] {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .instancePane,
@@ -2254,6 +2503,14 @@
   .workbench[data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="collapsed"] {
     --repo-rail-width: 60px;
     grid-template-columns: 60px minmax(0, 1fr);
+  }
+
+  .workbench[data-repo-rail="hidden"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="visible"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="visible"][data-issues-pane="collapsed"],
+  .workbench[data-repo-rail="hidden"][data-side-panes="visible"][data-instances-pane="collapsed"][data-issues-pane="collapsed"] {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .repoRail {

--- a/packages/web/components/workbench/WorkbenchShell.tsx
+++ b/packages/web/components/workbench/WorkbenchShell.tsx
@@ -18,7 +18,6 @@ import { IssueQueuePane } from "./IssueQueuePane";
 import { PullRequestsFocus } from "./PullRequestsFocus";
 import { QuickCreateFocus } from "./QuickCreateFocus";
 import { RepoOverviewFocus } from "./RepoOverviewFocus";
-import { RepoRail } from "./RepoRail";
 import { RepoSetupFocus } from "./RepoSetupFocus";
 import { SettingsFocus } from "./SettingsFocus";
 import { TerminalFocus } from "./TerminalFocus";
@@ -249,6 +248,7 @@ export function WorkbenchShell({
   });
   const reassignTargets = payload?.repos.filter((repo) => repo.id !== selectedRepo?.id) ?? [];
   const hideSidePanes = !sidePaneWidthsApply(selection.mode);
+  const repoPickerVisible = repoPickerApplies(selection.mode) && loadState.status === "loaded" && loadState.data.repos.length > 0;
   const compactSidePanesHidden = compactLayout || hideSidePanes;
   const instancesPaneCollapsed = compactSidePanesHidden || drawerCollapse.instances;
   const issuesPaneCollapsed = compactSidePanesHidden || drawerCollapse.issues;
@@ -280,17 +280,17 @@ export function WorkbenchShell({
     setRepoSetupRequested(pathParams.get("repoSetup") === "1");
   }
 
-  function modePathWithRepo(path: string): string {
-    if (!selectedRepo) return path;
+  function modePathForMode(mode: WorkbenchMode, path: string): string {
+    if (!selectedRepo || !repoPickerApplies(mode)) return path;
     const separator = path.includes("?") ? "&" : "?";
-    return `${path}${separator}repo=${encodeURIComponent(`${selectedRepo.owner}/${selectedRepo.name}`)}`;
+    return `${path}${separator}repo=${encodeURIComponent(repoLabel(selectedRepo))}`;
   }
 
   function selectRepo(repoId: number) {
     rememberCompactOverviewScroll();
     setUrlRecoveryNotice(null);
     const repo = payload?.repos.find((item) => item.id === repoId) ?? null;
-    const nextMode = repoScopedMode(selection.mode) ? selection.mode : "workbench";
+    const nextMode = repoPickerApplies(selection.mode) ? selection.mode : "workbench";
     dispatch({
       type: "applyUrlSelection",
       mode: nextMode,
@@ -721,9 +721,28 @@ export function WorkbenchShell({
         <Link href="/workbench" className={styles.brand} aria-label="issuectl workbench">
           issuectl<span className={styles.brandDot} />
         </Link>
-        <span className={styles.routeLabel} aria-label="Workbench context" title={contextLabel}>
-          {contextLabel}
-        </span>
+        {!repoPickerVisible && (
+          <span className={styles.routeLabel} aria-label="Workbench context" title={contextLabel}>
+            {contextLabel}
+          </span>
+        )}
+        {repoPickerVisible && payload && (
+          <label className={styles.repoPicker}>
+            <span>Repo</span>
+            <select
+              aria-label="Workbench repository"
+              value={selection.selectedRepoId ?? ""}
+              onChange={(event) => {
+                const repoId = Number(event.target.value);
+                if (Number.isInteger(repoId)) selectRepo(repoId);
+              }}
+            >
+              {payload.repos.map((repo) => (
+                <option key={repo.id} value={repo.id}>{repo.owner}/{repo.name}</option>
+              ))}
+            </select>
+          </label>
+        )}
         {!compactSidePanesHidden && (
           <div className={styles.toolbarTools} aria-label="Workbench layout controls">
             <button
@@ -770,7 +789,7 @@ export function WorkbenchShell({
               className={styles.navButton}
               data-active={selection.mode === item.mode ? "true" : undefined}
               aria-current={selection.mode === item.mode ? "page" : undefined}
-              onClick={() => selectMode(item.mode, modePathWithRepo(item.path))}
+              onClick={() => selectMode(item.mode, modePathForMode(item.mode, item.path))}
             >
               {item.label}
             </button>
@@ -781,6 +800,7 @@ export function WorkbenchShell({
       <main
         className={styles.workbench}
         data-mode={selection.mode}
+        data-repo-rail="hidden"
         data-side-panes={compactSidePanesHidden ? "collapsed" : "visible"}
         data-instances-pane={instancesPaneCollapsed ? "collapsed" : "visible"}
         data-issues-pane={issuesPaneCollapsed ? "collapsed" : "visible"}
@@ -788,17 +808,6 @@ export function WorkbenchShell({
         style={workbenchStyle}
         aria-label="Workbench"
       >
-        <aside className={`${styles.pane} ${styles.repoRail}`} aria-label="Repositories">
-          <RepoRail
-            repos={payload?.repos ?? null}
-            selectedRepoId={selection.selectedRepoId}
-            status={loadState.status}
-            onSelectRepo={selectRepo}
-            onAddRepository={openRepoSetup}
-            onOpenSettings={() => selectMode("settings", modePathWithRepo("/workbench/settings"))}
-          />
-        </aside>
-
         {!compactSidePanesHidden && instancesPaneCollapsed && (
           <button
             type="button"
@@ -1117,7 +1126,7 @@ function FocusContent({
   }
 
   if (mode === "pullRequests") {
-    return <PullRequestsFocus selectedRepo={selectedRepo} />;
+    return <PullRequestsFocus repos={loadState.data.repos} selectedRepo={selectedRepo} />;
   }
 
   if (mode === "workbench" && selectedIssue) {
@@ -1285,19 +1294,32 @@ function selectionFromUrl(payload: WorkbenchPayload, pathname: string, search: s
   const params = new URLSearchParams(search);
   const requestedRepoParam = params.get("repo");
   const requestedRepo = repoFromUrlParam(payload, requestedRepoParam) ?? payload.repos[0] ?? null;
+  const deploymentId = numberParam(params.get("deployment"));
+  const issueNumber = numberParam(params.get("issue"));
 
-  if (mode !== "workbench") {
+  if (mode === "workbench" && !requestedRepoParam && deploymentId === null && issueNumber === null) {
     return {
-      mode,
+      mode: "board",
       repoId: requestedRepo?.id ?? null,
       issueNumber: null,
       deploymentId: null,
       recoveryNotice: null,
-      normalizedUrl: null,
+      normalizedUrl: "/workbench/board",
     };
   }
 
-  const deploymentId = numberParam(params.get("deployment"));
+  if (mode !== "workbench") {
+    const repoParamApplies = mode === "pullRequests" || repoPickerApplies(mode);
+    return {
+      mode,
+      repoId: repoParamApplies && requestedRepoParam ? requestedRepo?.id ?? null : null,
+      issueNumber: null,
+      deploymentId: null,
+      recoveryNotice: null,
+      normalizedUrl: repoParamApplies ? null : urlWithoutRepoParam(pathname, search),
+    };
+  }
+
   if (deploymentId !== null) {
     const deployment = payload.deployments.find((item) => item.id === deploymentId);
     if (deployment) {
@@ -1321,7 +1343,6 @@ function selectionFromUrl(payload: WorkbenchPayload, pathname: string, search: s
     };
   }
 
-  const issueNumber = numberParam(params.get("issue"));
   if (requestedRepo && issueNumber !== null && requestedRepo.issues.some((issue) => issue.number === issueNumber)) {
     return {
       mode,
@@ -1383,6 +1404,14 @@ function repoFromUrlParam(payload: WorkbenchPayload, value: string | null): Work
   return payload.repos.find((repo) => repo.owner === owner && repo.name === name) ?? null;
 }
 
+function urlWithoutRepoParam(pathname: string, search: string): string | null {
+  const params = new URLSearchParams(search);
+  if (!params.has("repo")) return null;
+  params.delete("repo");
+  const nextSearch = params.toString();
+  return nextSearch ? `${pathname}?${nextSearch}` : pathname;
+}
+
 function numberParam(value: string | null): number | null {
   if (!value) return null;
   const parsed = Number(value);
@@ -1390,7 +1419,7 @@ function numberParam(value: string | null): number | null {
 }
 
 function workbenchRepoUrl(repo: Pick<WorkbenchRepo, "owner" | "name">): string {
-  return `/workbench?repo=${encodeURIComponent(`${repo.owner}/${repo.name}`)}`;
+  return `/workbench?repo=${encodeURIComponent(repoLabel(repo))}`;
 }
 
 function workbenchRepoSetupUrl(repo: Pick<WorkbenchRepo, "owner" | "name">): string {
@@ -1410,7 +1439,7 @@ function workbenchRepoModeUrl(
   mode: WorkbenchMode,
   repoSetupRequested: boolean,
 ): string {
-  const repoParam = `repo=${encodeURIComponent(`${repo.owner}/${repo.name}`)}`;
+  const repoParam = `repo=${encodeURIComponent(repoLabel(repo))}`;
   if (mode === "pullRequests") {
     return `/workbench/prs?${repoParam}`;
   }
@@ -1425,8 +1454,12 @@ function workbenchRepoModeUrl(
   return workbenchRepoUrl(repo);
 }
 
-function repoScopedMode(mode: WorkbenchMode): boolean {
-  return mode === "pullRequests" || mode === "quickCreate" || mode === "settings";
+function repoPickerApplies(mode: WorkbenchMode): boolean {
+  return mode === "workbench" || mode === "quickCreate" || mode === "settings";
+}
+
+function repoLabel(repo: Pick<WorkbenchRepo, "owner" | "name">): string {
+  return `${repo.owner}/${repo.name}`;
 }
 
 function modeFromPath(pathname: string): WorkbenchMode {

--- a/packages/web/components/workbench/dashboard-repo-collapse.tsx
+++ b/packages/web/components/workbench/dashboard-repo-collapse.tsx
@@ -73,13 +73,15 @@ export function DashboardRepoGroupingControls({
   repos: RepoIdentity[];
 }) {
   const disabled = repos.length === 0;
+  const collapsedCount = repos.filter((repo) => collapse.isCollapsed(repo)).length;
+  const expandedCount = repos.length - collapsedCount;
 
   return (
     <div className={styles.compactButtonGroup} role="group" aria-label={ariaLabel}>
-      <button type="button" className={styles.secondaryButton} onClick={() => collapse.collapseAll(repos)} disabled={disabled}>
+      <button type="button" className={styles.secondaryButton} onClick={() => collapse.collapseAll(repos)} disabled={disabled || expandedCount === 0}>
         Collapse all repos
       </button>
-      <button type="button" className={styles.secondaryButton} onClick={() => collapse.expandAll(repos)} disabled={disabled}>
+      <button type="button" className={styles.secondaryButton} onClick={() => collapse.expandAll(repos)} disabled={disabled || collapsedCount === 0}>
         Expand all repos
       </button>
     </div>
@@ -109,9 +111,10 @@ export function DashboardRepoHeader({
         type="button"
         className={`${styles.secondaryButton} ${styles.repoCollapseButton}`}
         aria-expanded={!collapsed}
+        aria-label={`${collapsed ? "Expand" : "Collapse"} ${label}`}
         onClick={onToggle}
       >
-        {collapsed ? "Expand" : "Collapse"} {label}
+        {collapsed ? ">" : "v"}
       </button>
     </header>
   );

--- a/packages/web/components/workbench/dashboard-url-state-hooks.ts
+++ b/packages/web/components/workbench/dashboard-url-state-hooks.ts
@@ -74,14 +74,12 @@ function useDashboardUrlState<TState extends GlobalIssueUrlState | BoardUrlState
   }, [defaultPresetId, parse, presetState]);
 
   const updateState = (patch: Partial<TState>) => {
-    setState((current) => {
-      const next = { ...current, ...patch };
-      if (typeof window !== "undefined") {
-        const nextSearch = dashboardUrlSearch(surface, window.location.search, next);
-        window.history.replaceState(null, "", `${window.location.pathname}${nextSearch}${window.location.hash}`);
-      }
-      return next;
-    });
+    const next = { ...state, ...patch };
+    if (typeof window !== "undefined") {
+      const nextSearch = dashboardUrlSearch(surface, window.location.search, next);
+      window.history.replaceState(null, "", `${window.location.pathname}${nextSearch}${window.location.hash}`);
+    }
+    setState(next);
   };
 
   const setDefaultPresetId = (presetId: DashboardPresetId) => {

--- a/packages/web/e2e/action-sheets.spec.ts
+++ b/packages/web/e2e/action-sheets.spec.ts
@@ -120,23 +120,27 @@ function createTestDb(dbPath: string): void {
   }
 }
 
+function issueFixture(issueNumber: number, title: string) {
+  return {
+    number: issueNumber,
+    title,
+    body: "Created by e2e test",
+    state: "open",
+    labels: [],
+    user: { login: "test-bot", avatarUrl: "" },
+    commentCount: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    closedAt: null,
+    htmlUrl: `https://github.com/${TEST_OWNER}/${TEST_REPO}/issues/${issueNumber}`,
+  };
+}
+
 /** Seed the issue-header cache so the detail page renders without a GitHub fetch. */
 function seedIssueCache(dbPath: string, issueNumber: number, title: string): void {
   const db = new Database(dbPath);
   try {
-    const issue = {
-      number: issueNumber,
-      title,
-      body: "Created by e2e test",
-      state: "open",
-      labels: [],
-      user: { login: "test-bot", avatarUrl: "" },
-      commentCount: 0,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      closedAt: null,
-      htmlUrl: `https://github.com/${TEST_OWNER}/${TEST_REPO}/issues/${issueNumber}`,
-    };
+    const issue = issueFixture(issueNumber, title);
     db.prepare(
       "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
     ).run(
@@ -152,6 +156,27 @@ function seedIssueCache(dbPath: string, issueNumber: number, title: string): voi
       `issue-content:${TEST_OWNER}/${TEST_REPO}#${issueNumber}`,
       JSON.stringify({ comments: [], linkedPRs: [] }),
     );
+  } finally {
+    db.close();
+  }
+}
+
+function seedIssuesListCache(dbPath: string, issues: Array<ReturnType<typeof issueFixture>>): void {
+  const db = new Database(dbPath);
+  try {
+    db.prepare(
+      "INSERT OR REPLACE INTO cache (key, data, fetched_at) VALUES (?, ?, datetime('now'))",
+    ).run(`issues:${TEST_OWNER}/${TEST_REPO}`, JSON.stringify(issues));
+  } finally {
+    db.close();
+  }
+}
+
+function hasIssuesListCache(dbPath: string): boolean {
+  const db = new Database(dbPath);
+  try {
+    const row = db.prepare("SELECT 1 FROM cache WHERE key = ?").get(`issues:${TEST_OWNER}/${TEST_REPO}`);
+    return Boolean(row);
   } finally {
     db.close();
   }
@@ -483,10 +508,15 @@ test.describe("draft assign — cache invalidation", () => {
     // Extract the issue number from the URL for cleanup
     const issueMatch = page.url().match(/\/issues\/[^/]+\/[^/]+\/(\d+)/);
     const newIssueNumber = issueMatch ? Number(issueMatch[1]) : null;
+    expect(newIssueNumber).not.toBeNull();
+
+    // The assignment action must clear the stale empty issues cache for this repo.
+    expect(hasIssuesListCache(dbPath)).toBe(false);
+    seedIssuesListCache(dbPath, [
+      issueFixture(newIssueNumber!, ASSIGN_DRAFT_TITLE),
+    ]);
 
     // Navigate home and verify the issue appears in the "open" section.
-    // Wait for networkidle so the Suspense streaming completes — the
-    // dashboard fetches from GitHub via an async Server Component.
     await page.goto(BASE_URL);
     await page.waitForLoadState("networkidle");
     await expect(page.getByText(ASSIGN_DRAFT_TITLE)).toBeVisible({

--- a/packages/web/e2e/pull-to-refresh.spec.ts
+++ b/packages/web/e2e/pull-to-refresh.spec.ts
@@ -263,8 +263,6 @@ test.describe("Pull-to-refresh (#133)", () => {
 
     // Basic check: the dashboard still has its core elements after load
     await expect(page.locator("h1")).toContainText("issuectl");
-    await expect(
-      page.locator('button[aria-label="Open navigation"]'),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open navigation" }).first()).toBeVisible();
   });
 });

--- a/packages/web/e2e/terminal-persistence.spec.ts
+++ b/packages/web/e2e/terminal-persistence.spec.ts
@@ -133,12 +133,27 @@ async function resetTestState(): Promise<void> {
 
   const db = new Database(dbPath);
   try {
-    const result = db.prepare(
-      "UPDATE deployments SET ended_at = NULL, ttyd_port = ?, ttyd_pid = ? WHERE id = 1",
-    ).run(TTYD_PORT, ttydProc.pid);
-    if (result.changes === 0) {
-      throw new Error("resetTestState: deployment id=1 missing from DB — cannot reset");
-    }
+    const repo = db
+      .prepare("SELECT id FROM repos WHERE owner = ? AND name = ?")
+      .get(TEST_OWNER, TEST_REPO) as { id: number };
+    db.prepare(
+      `INSERT INTO deployments
+       (id, repo_id, issue_number, target_type, target_number, branch_name, workspace_mode, workspace_path, state, terminal_backend, ttyd_port, ttyd_pid, ended_at)
+       VALUES (?, ?, ?, 'issue', ?, ?, ?, ?, 'active', 'ttyd', ?, ?, NULL)
+       ON CONFLICT(id) DO UPDATE SET
+         repo_id = excluded.repo_id,
+         issue_number = excluded.issue_number,
+         target_type = excluded.target_type,
+         target_number = excluded.target_number,
+         branch_name = excluded.branch_name,
+         workspace_mode = excluded.workspace_mode,
+         workspace_path = excluded.workspace_path,
+         state = excluded.state,
+         terminal_backend = excluded.terminal_backend,
+         ttyd_port = excluded.ttyd_port,
+         ttyd_pid = excluded.ttyd_pid,
+         ended_at = NULL`,
+    ).run(1, repo.id, TEST_ISSUE, TEST_ISSUE, `issue-${TEST_ISSUE}-test`, "worktree", "/tmp/test-workspace", TTYD_PORT, ttydProc.pid);
   } finally {
     db.close();
   }
@@ -194,12 +209,15 @@ function createTestDb(dbPath: string, ttydPid: number): void {
       .prepare("SELECT id FROM repos WHERE owner = ? AND name = ?")
       .get(TEST_OWNER, TEST_REPO) as { id: number };
 
-    // Active deployment with real ttyd PID and port
-    db.prepare(
-      `INSERT OR IGNORE INTO deployments
-       (id, repo_id, issue_number, branch_name, workspace_mode, workspace_path, state, ttyd_port, ttyd_pid)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(1, repo.id, TEST_ISSUE, `issue-${TEST_ISSUE}-test`, "worktree", "/tmp/test-workspace", "active", TTYD_PORT, ttydPid);
+    // Active deployment with real ttyd PID and port.
+    const deploymentResult = db.prepare(
+      `INSERT INTO deployments
+       (id, repo_id, issue_number, target_type, target_number, branch_name, workspace_mode, workspace_path, state, terminal_backend, ttyd_port, ttyd_pid)
+       VALUES (?, ?, ?, 'issue', ?, ?, ?, ?, ?, 'ttyd', ?, ?)`,
+    ).run(1, repo.id, TEST_ISSUE, TEST_ISSUE, `issue-${TEST_ISSUE}-test`, "worktree", "/tmp/test-workspace", "active", TTYD_PORT, ttydPid);
+    if (deploymentResult.changes !== 1) {
+      throw new Error("createTestDb: failed to seed active deployment");
+    }
 
     // Pre-seed all cache entries so page renders without GitHub API calls.
     const insertCache = db.prepare(

--- a/packages/web/e2e/workbench.spec.ts
+++ b/packages/web/e2e/workbench.spec.ts
@@ -369,12 +369,10 @@ test("renders the production shell without prototype controls", async ({ page })
   await expect(page.getByText("Repo selected")).toHaveCount(0);
   await expect(page.getByText("Repo setup")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "New shell", exact: true })).toHaveCount(0);
-  await expect(page.getByLabel("Repositories")).toBeVisible();
+  await expect(page.getByLabel("Repositories")).toHaveCount(0);
+  await expect(page.getByLabel("Workbench repository")).toHaveValue("1");
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "mean-weasel/issuectl" })).toContainText("IC");
-  await expect(page.getByRole("button", { name: "mean-weasel/bugdrop" })).toContainText("BD");
-  await expect(page.getByRole("button", { name: "mean-weasel/api" })).toContainText("API");
-  await expect(page.getByRole("button", { name: "mean-weasel/web" })).toContainText("WEB");
+  await expect(page.getByLabel("Workbench repository")).toContainText("mean-weasel/bugdrop");
 });
 
 test("bootstraps the API token for first-load workbench issue detail requests", async ({ browser }) => {
@@ -402,7 +400,11 @@ test("bootstraps the API token for first-load workbench issue detail requests", 
 
   try {
     await gotoWorkbenchWithRetry(page);
-    await page.getByLabel("Issue #512").click();
+    await page
+      .getByRole("complementary", { name: "Repo issues" })
+      .getByLabel("Issue #512")
+      .getByRole("button", { name: "Open #512: Desktop instance manager workbench" })
+      .click();
 
     await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
     await expect(page.getByText("Issue detail failed to load")).toHaveCount(0);
@@ -497,28 +499,27 @@ test("direct-load workbench settings bootstraps the API token before client acti
   }
 });
 
-test("keeps rail width stable across loading and loaded states", async ({ page }) => {
+test("keeps repo picker stable across loading and loaded states", async ({ page }) => {
   await gotoWorkbenchWithRetry(page);
-  const rail = page.getByLabel("Repositories");
-  await expect(rail).toBeVisible();
-  const before = await rail.boundingBox();
+  const picker = page.getByLabel("Workbench repository");
+  await expect(picker).toBeVisible();
+  const before = await picker.boundingBox();
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
-  const after = await rail.boundingBox();
+  const after = await picker.boundingBox();
 
-  expect(before?.width).toBeGreaterThanOrEqual(68);
-  expect(before?.width).toBeLessThanOrEqual(76);
+  expect(before?.width).toBeGreaterThanOrEqual(160);
   expect(after?.width).toBe(before?.width);
 });
 
-test("sets the compact rail width at 1100px", async ({ page }) => {
+test("keeps the repo picker reachable at 1100px", async ({ page }) => {
   await page.setViewportSize({ width: 1100, height: 850 });
 
   await gotoWorkbenchWithRetry(page);
-  const rail = page.getByLabel("Repositories");
-  await expect(rail).toBeVisible();
-  const box = await rail.boundingBox();
+  const picker = page.getByLabel("Workbench repository");
+  await expect(picker).toBeVisible();
+  const box = await picker.boundingBox();
 
-  expect(box?.width).toBe(68);
+  expect(box?.width).toBeGreaterThanOrEqual(160);
 });
 
 test("resizes workbench columns, persists widths, and resets them", async ({ page }) => {
@@ -626,7 +627,8 @@ test("passes the responsive QA layout matrix", async ({ page }) => {
 
   for (const viewport of matrix) {
     await page.setViewportSize(viewport);
-    await page.goto(`${baseUrl}/workbench`);
+    await page.goto("about:blank");
+    await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`, { waitUntil: "commit" });
     await expectNavOneRowAndClickable(page);
     await assertVisibleWorkbenchLayout(page);
 
@@ -643,18 +645,20 @@ test("passes the responsive QA layout matrix", async ({ page }) => {
       JSON.stringify({ instances: 360, issues: 420 }),
     );
   });
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await assertVisibleWorkbenchLayout(page);
   await expectNoHorizontalPageScroll(page);
   await page.evaluate(() => window.localStorage.removeItem("issuectl.workbench.columnWidths"));
 
   await page.setViewportSize({ width: 1440, height: 1000 });
-  await page.goto(`${baseUrl}/workbench/board`);
+  await page.goto("about:blank");
+  await page.goto(`${baseUrl}/workbench/board?repo=mean-weasel%2Fissuectl`, { waitUntil: "commit" });
   await expectBoardColumnWidths(page, 240);
   await expectNoHorizontalPageScroll(page);
 
   await page.setViewportSize({ width: 1100, height: 850 });
-  await page.goto(`${baseUrl}/workbench/board`);
+  await page.goto("about:blank");
+  await page.goto(`${baseUrl}/workbench/board?repo=mean-weasel%2Fissuectl`, { waitUntil: "commit" });
   await expectBoardColumnWidths(page, 220);
   await expectNoHorizontalPageScroll(page);
 });
@@ -667,7 +671,8 @@ test("keeps compact workbench layouts usable on tablet and mobile", async ({ pag
     { width: 320, height: 568 },
   ]) {
     await page.setViewportSize(viewport);
-    await page.goto(`${baseUrl}/workbench`);
+    await page.goto("about:blank");
+    await page.goto(`${baseUrl}/workbench/board?repo=mean-weasel%2Fissuectl`, { waitUntil: "commit" });
 
     const nav = page.getByRole("navigation", { name: "Workbench navigation" });
 
@@ -731,13 +736,13 @@ test("keeps compact mode matrix primary actions reachable", async ({ page }) => 
         page.getByLabel("mean-weasel/issuectl issue #512").getByRole("button", { name: "Prepare launch" }),
       verify: async () => {
         await expect(page.getByRole("heading", { name: "Issues" })).toBeVisible();
-        await expect(page.getByLabel("Global issues")).toBeVisible();
+        await expect(page.getByLabel("Global issues", { exact: true })).toBeVisible();
       },
     },
     {
       path: "/workbench/board",
       current: "Board",
-      primary: async () => page.getByLabel("Board controls").getByRole("button", { name: "Show running only" }),
+      primary: async () => page.getByLabel("Board view"),
       verify: async () => {
         await expect(page.getByRole("heading", { name: "Cross-repo board" })).toBeVisible();
         await expect(page.getByLabel("Cross-repo board")).toBeVisible();
@@ -749,8 +754,8 @@ test("keeps compact mode matrix primary actions reachable", async ({ page }) => 
       current: "PRs",
       primary: async () => page.getByRole("button", { name: "Refresh checks" }),
       verify: async () => {
-        await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
-        await expect(page.getByLabel("Pull requests for mean-weasel/issuectl")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Pull requests" })).toBeVisible();
+        await expect(page.getByLabel("Cross-repo pull requests")).toBeVisible();
       },
     },
     {
@@ -780,7 +785,8 @@ test("keeps compact mode matrix primary actions reachable", async ({ page }) => 
   ]) {
     await page.setViewportSize(viewport);
     for (const item of matrix) {
-      await page.goto(`${baseUrl}${item.path}?repo=mean-weasel%2Fissuectl`);
+      await page.goto("about:blank", { waitUntil: "commit" });
+      await page.goto(`${baseUrl}${item.path}?repo=mean-weasel%2Fissuectl`, { waitUntil: "commit" });
       await expect(page.getByRole("link", { name: "issuectl workbench" })).toBeVisible();
       await expect(
         page
@@ -914,6 +920,14 @@ test("keeps compact state-changing workbench workflows inside the viewport", asy
       });
       return;
     }
+    if (url.pathname.split("/").length === 6 && request.method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ pulls: [], fromCache: false, cachedAt: null }),
+      });
+      return;
+    }
 
     await route.fallback();
   });
@@ -1016,27 +1030,31 @@ test("keeps compact state-changing workbench workflows inside the viewport", asy
   });
 
   await page.goto(`${baseUrl}/workbench/board?repo=mean-weasel%2Fissuectl`);
-  await page.getByRole("button", { name: "Show running only" }).click();
+  await page.getByLabel("Board view").selectOption("active");
+  await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
   await expect(page.locator('article[aria-label^="Board issue"]')).toHaveCount(4);
   await expectCompactWorkbenchViewport(page);
-  await page.getByRole("button", { name: "Sort by priority" }).click();
+  await page.getByText("Board options").click();
+  await page.getByLabel("Sort board issues").selectOption("priority");
+  await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1&sort=priority$/);
   await expect(page.getByLabel("Board column mean-weasel/issuectl").locator('article[aria-label^="Board issue"]').first())
     .toHaveAttribute("aria-label", "Board issue mean-weasel/issuectl #447");
   await expectCompactWorkbenchViewport(page);
 
+  await page.goto("about:blank");
   await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
-  await page.getByLabel("Pull request #501").getByRole("button", { name: "Open PR" }).click();
+  await page.getByLabel("Pull request mean-weasel/issuectl #501").getByRole("button", { name: "Open PR" }).click();
   await expect(page.getByLabel("Pull request detail")).toContainText("Linked issue #512");
   await expectCompactWorkbenchViewport(page);
   const pullDetail = page.getByLabel("Pull request detail");
   await pullDetail.getByRole("button", { name: "Review", exact: true }).click();
-  await expect(page.getByRole("status")).toContainText("Review approved for #501");
+  await expect(page.getByRole("status")).toContainText("Review approved for mean-weasel/issuectl #501");
   await expectCompactWorkbenchViewport(page);
   await pullDetail.getByRole("button", { name: "Merge squash", exact: true }).click();
   await expect(page.getByRole("status")).toContainText("merged with squash");
   await expectCompactWorkbenchViewport(page);
   await pullDetail.getByRole("button", { name: "Comment", exact: true }).click();
-  await expect(page.getByRole("status")).toContainText("Comment added to #501");
+  await expect(page.getByRole("status")).toContainText("Comment added to mean-weasel/issuectl #501");
   await expectCompactWorkbenchViewport(page);
 
   await page.goto(`${baseUrl}/workbench/settings?repo=mean-weasel%2Fissuectl`);
@@ -1045,6 +1063,7 @@ test("keeps compact state-changing workbench workflows inside the viewport", asy
   await expect(page.getByText("Settings saved")).toBeVisible();
   await expectCompactWorkbenchViewport(page);
 
+  await page.goto("about:blank", { waitUntil: "commit" });
   await page.goto(`${baseUrl}/workbench/quick-create?repo=mean-weasel%2Fissuectl`);
   await page.getByLabel("Parse text").fill("Fix compact workflow state changes");
   await page.getByRole("button", { name: "Parse", exact: true }).click();
@@ -1129,7 +1148,7 @@ test("keeps compact issue entry reachable from the workbench overview", async ({
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
   await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
   const compactIssues = page.getByLabel("Compact repo issues");
@@ -1157,7 +1176,7 @@ test("keeps compact session entry reachable from the workbench overview", async 
   });
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
   await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
   const compactSessions = page.getByLabel("Compact active sessions");
@@ -1195,7 +1214,7 @@ test("keeps compact keyboard focus visible after issue and terminal shortcut act
   });
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await expectFocusedWorkbenchPaneVisible(page);
 
   const issueShortcut = page.getByLabel("Compact repo issues")
@@ -1242,7 +1261,7 @@ test("restores compact overview scroll after opening an issue detail", async ({ 
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
   const focus = page.getByLabel("Workbench focus");
   await expect(focus).toBeFocused();
@@ -1323,17 +1342,17 @@ test("keeps compact failure empty and stale workbench states inside the viewport
   seedWorkbenchRepos(dbPath, []);
   await page.goto(`${baseUrl}/workbench`);
   await expect(page.getByRole("heading", { name: "No tracked repositories" })).toBeVisible();
-  await expect(page.getByLabel("Workbench focus").getByRole("button", { name: "Add repository" })).toBeVisible();
+  await expect(page.getByLabel("Workbench focus").getByRole("link", { name: "Add repository" })).toBeVisible();
   await expectCompactWorkbenchViewport(page);
 
   seedWorkbenchRepos(dbPath);
-  await page.goto(`${baseUrl}/workbench`);
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fweb`);
   await expect(page.getByRole("heading", { name: "mean-weasel/web" })).toBeVisible();
   await expect(page.getByText("Set up local path")).toBeVisible();
   await expect(page.getByRole("button", { name: "Open repo setup" })).toBeVisible();
   await expectCompactWorkbenchViewport(page);
 
+  await page.goto("about:blank", { waitUntil: "commit" });
   await page.route("**/api/v1/pulls/mean-weasel/issuectl**", async (route) => {
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
     await route.fulfill({
@@ -1343,7 +1362,8 @@ test("keeps compact failure empty and stale workbench states inside the viewport
     });
   });
   await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
-  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Pull requests" })).toBeVisible();
+  await expect(page.getByLabel("Pull request repository filter")).toHaveValue("mean-weasel/issuectl");
   await expect(page.locator('[role="alert"]').filter({ hasText: "GitHub checks are temporarily unavailable" })).toBeVisible();
   await expect(page.getByText("Select a pull request to open details in this focus pane.")).toBeVisible();
   await expectCompactWorkbenchViewport(page);
@@ -1446,7 +1466,8 @@ test("keeps compact empty and service failure states stable in WebKit", async ({
       });
     });
     await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
-    await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Pull requests" })).toBeVisible();
+    await expect(page.getByLabel("Pull request repository filter")).toHaveValue("mean-weasel/issuectl");
     await expect(page.locator('[role="alert"]').filter({ hasText: "GitHub checks are temporarily unavailable" })).toBeVisible();
     await expect(page.getByText("Select a pull request to open details in this focus pane.")).toBeVisible();
     await expectCompactWorkbenchViewport(page);
@@ -1632,18 +1653,18 @@ test("keeps compact workbench context visible while switching focus", async ({ p
   });
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
-  await page.goto(`${baseUrl}/workbench`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl");
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
 
   await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #512");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
 
+  await page.goto("about:blank", { waitUntil: "commit" });
   await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&deployment=101`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #447 terminal");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
 
-  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
+  await selectWorkbenchRepo(page, "mean-weasel/bugdrop");
   await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fbugdrop$/);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/bugdrop");
   await expectNoHorizontalPageScroll(page);
   await expectWorkbenchFitsViewport(page);
 });
@@ -1660,10 +1681,10 @@ test("preserves compact repo-scoped mode while switching repos from deep links",
   });
 
   await page.goto(`${baseUrl}/workbench/prs?repo=mean-weasel%2Fissuectl`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl PRs");
-  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
-  await expect(page).toHaveURL(/\/workbench\/prs\?repo=mean-weasel%2Fbugdrop$/);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/bugdrop PRs");
+  await expect(page.getByRole("heading", { name: "Pull requests" })).toBeVisible();
+  await expect(page.getByLabel("Pull request repository filter")).toHaveValue("mean-weasel/issuectl");
+  await page.getByLabel("Pull request repository filter").selectOption("mean-weasel/bugdrop");
+  await expect(page.getByLabel("Pull request repository filter")).toHaveValue("mean-weasel/bugdrop");
   await expect(
     page
       .getByRole("navigation", { name: "Workbench navigation" })
@@ -1671,10 +1692,9 @@ test("preserves compact repo-scoped mode while switching repos from deep links",
   ).toHaveAttribute("aria-current", "page");
 
   await page.goto(`${baseUrl}/workbench/settings?repoSetup=1&repo=mean-weasel%2Fissuectl`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl settings");
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
+  await selectWorkbenchRepo(page, "mean-weasel/web");
   await expect(page).toHaveURL(/\/workbench\/settings\?repoSetup=1&repo=mean-weasel%2Fweb$/);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/web settings");
   await expectNoHorizontalPageScroll(page);
   await expectWorkbenchFitsViewport(page);
 });
@@ -1782,7 +1802,7 @@ test("keeps compact issue mutations and session navigation coherent end to end",
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
   await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl&issue=512`);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #512");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
   await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
 
@@ -1800,7 +1820,7 @@ test("keeps compact issue mutations and session navigation coherent end to end",
 
   await page.getByLabel("Issue detail metadata").getByRole("button", { name: "Jump to session" }).click();
   await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl&deployment=101$/);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #447 terminal");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
   await expect(page.frameLocator('iframe[title="Terminal for issue 447"]').getByText("terminal ready")).toBeVisible();
 
@@ -2026,7 +2046,7 @@ test("preserves compact issue and terminal context across keyboard navigation hi
   await expect(jumpToSession).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/\/workbench\?repo=mean-weasel%2Fissuectl&deployment=101$/);
-  await expect(page.getByLabel("Workbench context")).toContainText("mean-weasel/issuectl #447 terminal");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/issuectl");
   await expectFocusedWorkbenchPaneVisible(page);
   await expect.poll(() => focusPane.evaluate((element) => Math.round(element.scrollTop))).toBe(0);
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
@@ -2196,7 +2216,7 @@ test("captures workbench QA screenshots", async ({ browser }) => {
   });
 
   try {
-    await page.goto(`${baseUrl}/workbench`);
+    await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
     await expectNoWorkbenchSplash(page);
     await page.getByLabel("Session #447").getByRole("button").first().click();
     await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
@@ -2204,12 +2224,17 @@ test("captures workbench QA screenshots", async ({ browser }) => {
     await page.screenshot({ path: join(artifactDir, "workbench-terminal-1440.png"), fullPage: true });
 
     await page.getByRole("button", { name: "Workbench" }).click();
-    await page.getByLabel("Issue #512").click();
+    await page
+      .getByRole("complementary", { name: "Repo issues" })
+      .getByLabel("Issue #512")
+      .getByRole("button", { name: "Open #512: Desktop instance manager workbench" })
+      .click();
     await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
     await expect(page.getByLabel("Issue labels")).toContainText("high");
     await expectNoWorkbenchSplash(page);
     await page.screenshot({ path: join(artifactDir, "workbench-issue-1440.png"), fullPage: true });
 
+    await page.goto("about:blank", { waitUntil: "commit" });
     await page.goto(`${baseUrl}/workbench/settings?repoSetup=1`);
     await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
     await expect(page.getByLabel("Repository picker")).toBeVisible();
@@ -2217,15 +2242,17 @@ test("captures workbench QA screenshots", async ({ browser }) => {
     await page.screenshot({ path: join(artifactDir, "workbench-settings-1440.png"), fullPage: true });
 
     await page.setViewportSize({ width: 1440, height: 1400 });
+    await page.goto("about:blank", { waitUntil: "commit" });
     await page.goto(`${baseUrl}/workbench/board`);
-    await expect(page.getByRole("heading", { name: "Board" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Cross-repo board" })).toBeVisible();
     await expect(page.getByLabel("Cross-repo board")).toBeVisible();
     await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
     await expectNoWorkbenchSplash(page);
     await page.screenshot({ path: join(artifactDir, "workbench-board-1440.png"), fullPage: true });
 
     await page.setViewportSize({ width: 1100, height: 850 });
-    await page.goto(`${baseUrl}/workbench`);
+    await page.goto("about:blank", { waitUntil: "commit" });
+    await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
     await page.getByLabel("Session #447").getByRole("button").first().click();
     await expect(page.locator('iframe[title="Terminal for issue 447"]')).toBeVisible();
     await expect(page.frameLocator('iframe[title="Terminal for issue 447"]').getByText("terminal ready")).toBeVisible();
@@ -2237,6 +2264,8 @@ test("captures workbench QA screenshots", async ({ browser }) => {
 });
 
 test("collapses workbench drawers and flattens active sessions", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Drawer collapse controls are desktop-only; compact coverage uses the overview cards.");
+
   await gotoWorkbenchWithRetry(page);
 
   const workbench = page.getByRole("main", { name: "Workbench" });
@@ -2264,6 +2293,8 @@ test("collapses workbench drawers and flattens active sessions", async ({ page }
 });
 
 test("keeps drawer restore controls out of issue and terminal headers", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Drawer restore controls are desktop-only in the compact workbench.");
+
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -2306,6 +2337,8 @@ test("refreshes server-loaded workbench content", async ({ page }) => {
 });
 
 test("supports top nav modes and collapses side panes for global modes", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Side-pane collapse assertions are desktop-only; compact navigation has separate coverage.");
+
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -2333,28 +2366,26 @@ test("supports top nav modes and collapses side panes for global modes", async (
   await clickNavAndExpect(page, "Workbench", "/workbench", false);
 });
 
-test("preserves selected repo across global mode reloads", async ({ page }) => {
+test("preserves repo picker across repo-scoped reloads and resets aggregate PR reloads", async ({ page }) => {
   await gotoWorkbenchWithRetry(page);
-  const bugdropRepo = page.getByRole("button", { name: "mean-weasel/bugdrop" });
-  await expect(bugdropRepo).toBeVisible();
-  await expect(async () => {
-    await bugdropRepo.click();
-    await expect(page).toHaveURL(/repo=mean-weasel%2Fbugdrop/, { timeout: 1_000 });
-  }).toPass();
+  await selectWorkbenchRepo(page, "mean-weasel/bugdrop");
   const nav = page.getByRole("navigation", { name: "Workbench navigation" });
 
   await nav.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(page).toHaveURL(/\/workbench\/settings\?repo=mean-weasel%2Fbugdrop$/);
   await page.reload({ waitUntil: "domcontentloaded" });
-  await expect(page.getByRole("button", { name: "mean-weasel/bugdrop" })).toHaveAttribute("data-selected", "true");
+  await expectWorkbenchRepoPicker(page, "mean-weasel/bugdrop");
 
   await nav.getByRole("button", { name: "PRs", exact: true }).click();
-  await expect(page).toHaveURL(/\/workbench\/prs\?repo=mean-weasel%2Fbugdrop$/);
+  await expect(page).toHaveURL(/\/workbench\/prs$/);
+  await expect(page.getByLabel("Pull request repository filter")).toHaveValue("mean-weasel/bugdrop");
   await page.reload({ waitUntil: "domcontentloaded" });
-  await expect(page.getByRole("button", { name: "mean-weasel/bugdrop" })).toHaveAttribute("data-selected", "true");
+  await expect(page.getByLabel("Pull request repository filter")).toHaveValue("all");
 });
 
 test("restores URL focus for repo issue and deployment across reload and back forward", async ({ page }) => {
+  test.skip(isCompactViewport(page), "URL focus through side-pane terminal/detail views is desktop-only.");
+
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
     if (route.request().method() !== "GET") {
       await route.fallback();
@@ -2405,6 +2436,8 @@ test("restores URL focus for repo issue and deployment across reload and back fo
 });
 
 test("quick create parses, creates accepted issues, and uses draft endpoints", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Full quick-create side-pane contract is desktop-only; compact draft navigation is covered separately.");
+
   const draftId = "11111111-1111-4111-8111-111111111111";
   const seen = {
     parse: false,
@@ -2644,6 +2677,15 @@ test("pull requests mode loads repo PRs and calls detail review merge comment en
       return;
     }
 
+    if (url.pathname.startsWith("/api/v1/pulls/") && request.method() === "GET" && url.pathname.split("/").length === 6) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ pulls: [], fromCache: false, cachedAt: null }),
+      });
+      return;
+    }
+
     if (url.pathname === "/api/v1/pulls/mean-weasel/issuectl/501" && request.method() === "GET") {
       seen.detail = true;
       await route.fulfill({
@@ -2693,39 +2735,35 @@ test("pull requests mode loads repo PRs and calls detail review merge comment en
     await route.fallback();
   });
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await page
     .getByRole("navigation", { name: "Workbench navigation" })
     .getByRole("button", { name: "PRs", exact: true })
     .click();
 
-  await expect(page).toHaveURL(new RegExp("/workbench/prs\\?repo=mean-weasel%2Fissuectl$"));
-  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
-  await expect(page.getByLabel("Pull requests for mean-weasel/issuectl")).toContainText("Checks success");
-  await expect(page.getByLabel("Pull request #501")).toContainText("Linked issue #512");
-  await expect(page.getByLabel("Pull request #501")).toContainText("Needs review");
-  await expect(page.getByLabel("Pull request #502")).toContainText("Checks pending");
+  await expect(page).toHaveURL(new RegExp("/workbench/prs$"));
+  await expect(page.getByRole("heading", { name: "Pull requests" })).toBeVisible();
+  await expect(page.getByLabel("Cross-repo pull requests")).toContainText("mean-weasel/issuectl #501");
+  await expect(page.getByLabel("Pull request mean-weasel/issuectl #501")).toContainText("Linked issue #512");
+  await expect(page.getByLabel("Pull request mean-weasel/issuectl #501")).toContainText("Needs review");
+  await expect(page.getByLabel("Pull request mean-weasel/issuectl #502")).toContainText("Checks pending");
 
-  await page.getByLabel("Pull request #501").getByRole("button", { name: "Open PR" }).click();
-  await expect(page.getByRole("heading", { name: "#501 Add workbench PR review surface" })).toBeVisible();
+  await page.getByLabel("Pull request mean-weasel/issuectl #501").getByRole("button", { name: "Open PR" }).click();
+  await expect(page.getByRole("heading", { name: "mean-weasel/issuectl #501 Add workbench PR review surface" })).toBeVisible();
   await expect(page.getByLabel("Pull request detail")).toContainText("Linked issue #512");
   await expect(page.getByLabel("Pull request detail")).toContainText("Checks: success");
 
   const pullDetail = page.getByLabel("Pull request detail");
   await pullDetail.getByRole("button", { name: "Review", exact: true }).click();
-  await expect(page.getByRole("status")).toContainText("Review approved for #501");
+  await expect(page.getByRole("status")).toContainText("Review approved for mean-weasel/issuectl #501");
   await pullDetail.getByRole("button", { name: "Merge squash", exact: true }).click();
   await expect(page.getByRole("status")).toContainText("merged with squash");
-  await expect(page.getByLabel("Pull request #501")).toContainText("merged");
+  await expect(page.getByLabel("Pull request mean-weasel/issuectl #501")).toContainText("merged");
   await pullDetail.getByRole("button", { name: "Comment", exact: true }).click();
-  await expect(page.getByRole("status")).toContainText("Comment added to #501");
+  await expect(page.getByRole("status")).toContainText("Comment added to mean-weasel/issuectl #501");
 
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
-  await page
-    .getByRole("navigation", { name: "Workbench navigation" })
-    .getByRole("button", { name: "PRs", exact: true })
-    .click();
-  await expect(page.getByText("No open pull requests in mean-weasel/web.")).toBeVisible();
+  await page.getByLabel("Pull request repository filter").selectOption("mean-weasel/web");
+  await expect(page.getByText("No open pull requests match this repo filter.")).toBeVisible();
 
   expect(seen).toEqual({
     list: true,
@@ -2782,11 +2820,38 @@ test("shows global issues by repo and opens the selected repo issue", async ({ p
   await page.getByLabel("mean-weasel/issuectl issue #512").getByRole("button", { name: "Prepare launch" }).click();
 
   await expect(page).toHaveURL(new RegExp("/workbench\\?repo=mean-weasel%2Fissuectl&issue=512$"));
-  await expect(page.getByRole("button", { name: "mean-weasel/issuectl" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Workbench repository")).toHaveValue("1");
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
 });
 
 test("shows cross-repo board columns and reversible running filter", async ({ page }) => {
+  await page.route("**/api/v1/pulls/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    expect(request.headers().authorization).toBe(`Bearer ${apiToken}`);
+    expect(request.method()).toBe("GET");
+
+    const pulls = url.pathname === "/api/v1/pulls/mean-weasel/issuectl"
+      ? [
+          pullFixture(501, {
+            title: "Add workbench PR review surface",
+            body: "Fixes #512",
+            checksStatus: "success",
+          }),
+          pullFixture(502, {
+            title: "Polish session preview copy",
+            checksStatus: "pending",
+          }),
+        ]
+      : url.pathname === "/api/v1/pulls/mean-weasel/bugdrop"
+        ? [pullFixture(601, { title: "Wire bugdrop dashboard review", checksStatus: "failure" })]
+        : [];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ pulls, fromCache: false, cachedAt: null }),
+    });
+  });
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
     if (route.request().method() !== "GET") {
       await route.fallback();
@@ -2806,56 +2871,82 @@ test("shows cross-repo board columns and reversible running filter", async ({ pa
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   await clickNavAndExpect(page, "Board", "/workbench/board", true);
 
-  await expect(page.getByLabel("Repositories")).toBeVisible();
+  await expect(page.getByLabel("Repositories")).toHaveCount(0);
   const board = page.getByLabel("Cross-repo board");
+  const boardColumns = board.locator('section[aria-label^="Board column "]');
   await expect(board).toBeVisible();
-  await expect(board.getByRole("region")).toHaveCount(4);
+  await expect(boardColumns).toHaveCount(4);
   await expect(page.getByLabel("Board column mean-weasel/issuectl")).toBeVisible();
   await expect(page.getByLabel("Board column mean-weasel/bugdrop")).toBeVisible();
   await expect(page.getByLabel("Board column mean-weasel/api")).toBeVisible();
   await expect(page.getByLabel("Board column mean-weasel/web")).toBeVisible();
   await expect(page.locator('article[aria-label^="Board issue"]')).toHaveCount(7);
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toContainText("2 PRs");
+  await expect(page.getByLabel("Board pull requests for mean-weasel/bugdrop")).toContainText("1 PR");
+  await expect(page.locator('[aria-label^="Board pull request "]')).toHaveCount(0);
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toHaveAttribute("href", /\/workbench\/prs\?repo=mean-weasel%2Fissuectl$/);
 
-  await page.getByRole("button", { name: "Show running only" }).click();
+  await page.getByLabel("Board view").selectOption("active");
+  await expect(page).toHaveURL(/\/workbench\/board\?(?:repo=mean-weasel%2Fissuectl&)?view=running&running=1$/);
   await expect(page.locator('article[aria-label^="Board issue"]')).toHaveCount(4);
-  await expect(page.getByText("No matching issues.")).toHaveCount(2);
-  await expect(board.getByRole("region")).toHaveCount(4);
+  await expect(page.getByText("No matching issues.")).toHaveCount(0);
+  await expect(boardColumns).toHaveCount(2);
   await expect(
     page.getByLabel("Board issue mean-weasel/issuectl #447").getByRole("button", { name: "Jump to session" }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "Show running only" }).click();
+  await page.getByLabel("Board view").selectOption("all");
+  await expect(page).toHaveURL(/\/workbench\/board(?:\?repo=mean-weasel%2Fissuectl)?$/);
   await expect(page.locator('article[aria-label^="Board issue"]')).toHaveCount(7);
   await page.getByLabel("Search board issues").fill("bugdrop #440");
   await expect(page.locator('article[aria-label^="Board issue"]')).toHaveCount(1);
   await expect(page.getByLabel("Board issue mean-weasel/bugdrop #440")).toBeVisible();
   await page.getByLabel("Search board issues").fill("");
 
-  await page.getByRole("button", { name: "Sort by priority" }).click();
+  await page.getByText("Board options").click();
+  await page.getByLabel("Sort board issues").selectOption("priority");
+  await expect(page).toHaveURL(/\/workbench\/board\?(?:repo=mean-weasel%2Fissuectl&)?sort=priority$/);
   const issuectlCards = page.getByLabel("Board column mean-weasel/issuectl")
     .locator('article[aria-label^="Board issue"]');
   await expect(issuectlCards.first()).toHaveAttribute("aria-label", "Board issue mean-weasel/issuectl #512");
-  await expect(issuectlCards.first().locator("[data-card-chip]")).toHaveCount(2);
+  await expect(issuectlCards.first().locator("[data-card-chip]")).toHaveCount(1);
 
   await page.getByLabel("Board issue mean-weasel/issuectl #512")
     .getByRole("button", { name: "Prepare launch" })
     .click();
   await expect(page).toHaveURL(new RegExp("/workbench\\?repo=mean-weasel%2Fissuectl&issue=512$"));
-  await expect(page.getByRole("button", { name: "mean-weasel/issuectl" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Workbench repository")).toHaveValue("1");
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
 });
 
 test("supports repo grouping collapse controls across dashboard surfaces", async ({ page }) => {
+  await page.route("**/api/v1/pulls/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pulls = url.pathname === "/api/v1/pulls/mean-weasel/issuectl"
+      ? [pullFixture(501, { title: "Add workbench PR review surface", checksStatus: "success" })]
+      : [];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ pulls, fromCache: false, cachedAt: null }),
+    });
+  });
   await page.goto(`${baseUrl}/workbench/issues`);
   await page.evaluate(() => window.localStorage.clear());
   await page.goto(`${baseUrl}/workbench/issues`);
 
+  const globalCollapseAll = page.getByRole("button", { name: "Collapse all repos" });
+  const globalExpandAll = page.getByRole("button", { name: "Expand all repos" });
+  await expect(globalCollapseAll).toBeEnabled();
+  await expect(globalExpandAll).toBeDisabled();
   await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
   await page.getByRole("button", { name: "Collapse mean-weasel/issuectl" }).click();
+  await expect(globalCollapseAll).toBeEnabled();
+  await expect(globalExpandAll).toBeEnabled();
   await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
   await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toHaveCount(0);
@@ -2867,30 +2958,53 @@ test("supports repo grouping collapse controls across dashboard surfaces", async
   await page.getByRole("button", { name: "Expand mean-weasel/issuectl" }).click();
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
 
-  await page.getByRole("button", { name: "Collapse all repos" }).click();
+  await globalCollapseAll.click();
+  await expect(globalCollapseAll).toBeDisabled();
+  await expect(globalExpandAll).toBeEnabled();
   await expect(page.getByLabel("Dashboard summary for mean-weasel/bugdrop")).toContainText("1 visible");
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toHaveCount(0);
   await expect(page.getByLabel("mean-weasel/bugdrop issue #440")).toHaveCount(0);
-  await page.getByRole("button", { name: "Expand all repos" }).click();
+  await globalExpandAll.click();
+  await expect(globalCollapseAll).toBeEnabled();
+  await expect(globalExpandAll).toBeDisabled();
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
   await expect(page.getByLabel("mean-weasel/bugdrop issue #440")).toBeVisible();
 
-  await page.goto(`${baseUrl}/workbench/board`);
+  await page.goto("about:blank");
+  await page.goto(`${baseUrl}/workbench/board`, { waitUntil: "commit" });
+  await page.getByText("Board options").click();
+  const boardCollapseAll = page.getByRole("button", { name: "Collapse all repos" });
+  const boardExpandAll = page.getByRole("button", { name: "Expand all repos" });
+  await expect(boardCollapseAll).toBeEnabled();
+  await expect(boardExpandAll).toBeDisabled();
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toBeVisible();
   await page.getByRole("button", { name: "Collapse mean-weasel/issuectl" }).click();
+  await expect(boardCollapseAll).toBeEnabled();
+  await expect(boardExpandAll).toBeEnabled();
   await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
-  await expect(page.getByLabel("Dashboard summary for mean-weasel/issuectl")).toContainText("4 visible");
+  await expect(page.getByLabel("Board summary for mean-weasel/issuectl")).toContainText("4 issues");
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toBeVisible();
 
-  await page.goto(`${baseUrl}/workbench/board`);
+  await page.goto("about:blank");
+  await page.goto(`${baseUrl}/workbench/board`, { waitUntil: "commit" });
   await expect(page.getByRole("button", { name: "Expand mean-weasel/issuectl" })).toHaveAttribute("aria-expanded", "false");
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toBeVisible();
   await page.goto(`${baseUrl}/workbench/issues`);
   await expect(page.getByLabel("mean-weasel/issuectl issue #512")).toBeVisible();
-  await page.goto(`${baseUrl}/workbench/board`);
+  await page.goto("about:blank");
+  await page.goto(`${baseUrl}/workbench/board`, { waitUntil: "commit" });
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toHaveCount(0);
-  await page.getByRole("button", { name: "Expand all repos" }).click();
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toBeVisible();
+  await page.getByText("Board options").click();
+  await expect(boardExpandAll).toBeEnabled();
+  await boardExpandAll.click();
+  await expect(boardCollapseAll).toBeEnabled();
+  await expect(boardExpandAll).toBeDisabled();
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
+  await expect(page.getByLabel("Board pull requests for mean-weasel/issuectl")).toBeVisible();
 });
 
 test("surfaces duplicate repo names plus issue cache and error state in global dashboards", async ({ page }) => {
@@ -2990,34 +3104,33 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await expect(globalIssuectlSummary).toContainText("3 running");
 
   await page.goto(`${baseUrl}/workbench/board?view=running&running=1&q=bugdrop`);
+  await page.getByText("Board options").click();
   await page.getByRole("button", { name: "Refresh" }).click();
-  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Board view")).toHaveValue("custom");
   await expect(page.getByLabel("Search board issues")).toHaveValue("bugdrop");
   await expect(page.getByLabel("Board issue mean-weasel/bugdrop #440")).toBeVisible();
-  await expect(page.getByLabel("Dashboard summary for mean-weasel/bugdrop")).toContainText("1 visible");
-  const boardPresets = page.getByRole("group", { name: "Board triage presets" });
-  await boardPresets.getByRole("button", { name: "Active work" }).click();
+  await expect(page.getByLabel("Board summary for mean-weasel/bugdrop")).toContainText("1 running");
+  await page.getByLabel("Board view").selectOption("active");
   await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
   await expect(page.getByLabel("Search board issues")).toHaveValue("");
-  await expect(boardPresets.getByRole("button", { name: "Active work" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Board view")).toHaveValue("active");
   await expect(page.getByLabel("Cross-repo board").locator("section").first())
     .toHaveAttribute("aria-label", "Board column mean-weasel/issuectl");
-  await boardPresets.getByRole("button", { name: "Set default" }).click();
-  await expect(boardPresets).toContainText("Default: Active work");
-  await page.getByRole("button", { name: "Show running only" }).click();
-  const boardViews = page.getByRole("group", { name: "Board operational views" });
-  await boardViews.getByRole("button", { name: "All 8" }).click();
+  await page.getByRole("button", { name: "Set default view" }).click();
+  await expect(page.getByRole("button", { name: "Clear default: Active work" })).toBeVisible();
+  const boardViews = page.getByLabel("Board view");
+  await boardViews.selectOption("all");
   await expect(page.getByLabel("Board column paper-owl/web")).toBeVisible();
   await expect(page.getByText("Issue fetch failed: GitHub unavailable for paper-owl/api")).toBeVisible();
-  await boardViews.getByRole("button", { name: "Attention 4" }).click();
-  await expect(page).toHaveURL(/\/workbench\/board\?view=attention$/);
+  await boardViews.selectOption("attention");
+  await expect(page).toHaveURL(/\/workbench\/board\?view=attention&sort=priority$/);
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #512")).toBeVisible();
-  await boardViews.getByRole("button", { name: "Cached 1" }).click();
+  await boardViews.selectOption("cached");
   await expect(page.getByLabel("Board issue paper-owl/web #701")).toBeVisible();
   await expect(page.getByLabel("Board issue mean-weasel/issuectl #447")).toHaveCount(0);
-  await boardViews.getByRole("button", { name: "Errors 2" }).click();
+  await boardViews.selectOption("errors");
   await expect(page.getByLabel("Board column paper-owl/api")).toBeVisible();
-  await boardViews.getByRole("button", { name: "All 8" }).click();
+  await boardViews.selectOption("all");
   await page.getByLabel("Search board issues").fill("paper-owl web #701");
   await expect(page.getByLabel("Board issue paper-owl/web #701")).toBeVisible();
   await expect(page.getByLabel("Board issue mean-weasel/web #440")).toHaveCount(0);
@@ -3026,10 +3139,10 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
   await page.getByRole("button", { name: "Clear dashboard filters" }).click();
   await expect(page).toHaveURL(/\/workbench\/board$/);
   await expect(page.getByLabel("Search board issues")).toHaveValue("");
-  await expect(boardViews.getByRole("button", { name: "All 8" })).toHaveAttribute("aria-pressed", "true");
-  await expect(boardPresets).not.toContainText("Default: Active work");
-  const boardIssuectlSummary = page.getByLabel("Dashboard summary for mean-weasel/issuectl");
-  await expect(boardIssuectlSummary).toContainText("4 visible");
+  await expect(boardViews).toHaveValue("all");
+  await expect(page.getByRole("button", { name: "Clear default: Active work" })).toHaveCount(0);
+  const boardIssuectlSummary = page.getByLabel("Board summary for mean-weasel/issuectl");
+  await expect(boardIssuectlSummary).toContainText("4 issues");
   await expect(boardIssuectlSummary).toContainText("3 running");
 
   await page.goto(`${baseUrl}/workbench/issues`);
@@ -3046,11 +3159,9 @@ test("surfaces duplicate repo names plus issue cache and error state in global d
 
   await page.goto(`${baseUrl}/workbench/board`);
   await expect(page).toHaveURL(/\/workbench\/board$/);
-  const savedBoardPresets = page.getByRole("group", { name: "Board triage presets" });
-  await expect(savedBoardPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "false");
-  await expect(savedBoardPresets).not.toContainText("Default: Active work");
-  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByLabel("Board view")).toHaveValue("all");
+  await page.getByText("Board options").click();
+  await expect(page.getByRole("button", { name: "Clear default: Active work" })).toHaveCount(0);
 });
 
 test("clears saved dashboard defaults from preset strips", async ({ page }) => {
@@ -3074,22 +3185,21 @@ test("clears saved dashboard defaults from preset strips", async ({ page }) => {
     .toHaveAttribute("aria-pressed", "false");
 
   await page.goto(`${baseUrl}/workbench/board`);
-  const boardPresets = page.getByRole("group", { name: "Board triage presets" });
-  await boardPresets.getByRole("button", { name: "Active work" }).click();
-  await boardPresets.getByRole("button", { name: "Set default" }).click();
-  await expect(boardPresets).toContainText("Default: Active work");
+  await page.getByLabel("Board view").selectOption("active");
+  await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
+  await page.getByText("Board options").click();
+  await page.getByRole("button", { name: "Set default view" }).click();
+  await expect(page.getByRole("button", { name: "Clear default: Active work" })).toBeVisible();
+  await expect(page).toHaveURL(/\/workbench\/board\?view=running&running=1$/);
+  await page.goto("about:blank", { waitUntil: "commit" });
   await page.goto(`${baseUrl}/workbench/board`);
-  await expect(boardPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "true");
-  await boardPresets.getByRole("button", { name: "Clear default" }).click();
-  await expect(boardPresets).not.toContainText("Default: Active work");
-  await expect(boardPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "false");
-  await expect(page.getByRole("button", { name: "Show running only" })).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByLabel("Board view")).toHaveValue("active");
+  await page.getByText("Board options").click();
+  await page.getByRole("button", { name: "Clear default: Active work" }).click();
+  await expect(page.getByRole("button", { name: "Clear default: Active work" })).toHaveCount(0);
+  await expect(page.getByLabel("Board view")).toHaveValue("all");
   await page.goto(`${baseUrl}/workbench/board`);
-  await expect(boardPresets.getByRole("button", { name: "Active work" }))
-    .toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByLabel("Board view")).toHaveValue("all");
 });
 
 test("deep links workbench subpaths without a 404", async ({ page }) => {
@@ -3265,11 +3375,11 @@ test("opens repo setup and calls add patch delete repo endpoints", async ({ page
       return;
     }
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
-    expect(await route.request().postDataJSON()).toEqual({ owner: "mean-weasel", name: "web" });
+    expect(await route.request().postDataJSON()).toEqual({ owner: "mean-weasel", name: "new-tool" });
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ success: true, repo: { ...repo(4, "web", 0), localPath: null } }),
+      body: JSON.stringify({ success: true, repo: { ...repo(5, "new-tool", 0), localPath: null } }),
     });
   });
   page.on("dialog", async (dialog) => {
@@ -3279,8 +3389,7 @@ test("opens repo setup and calls add patch delete repo endpoints", async ({ page
     await dialog.accept();
   });
 
-  await page.goto(`${baseUrl}/workbench`);
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fweb`);
   await page.getByRole("button", { name: "Open repo setup" }).click();
   await expect(page).toHaveURL(new RegExp("/workbench/settings\\?repoSetup=1&repo=mean-weasel%2Fweb$"));
   await expect(page.getByRole("heading", { name: "mean-weasel/web" })).toBeVisible();
@@ -3303,45 +3412,49 @@ test("opens repo setup and calls add patch delete repo endpoints", async ({ page
   await page.getByRole("button", { name: "Refresh GitHub repos" }).click();
   await page.getByRole("button", { name: "Remove repository" }).click();
   await expect(page.getByText("mean-weasel/web removed")).toBeVisible();
-  await expect(page.getByRole("button", { name: "mean-weasel/web" })).toHaveCount(0);
+  await expect(page.getByLabel("Workbench repository")).not.toContainText("mean-weasel/web");
   await page.getByRole("navigation", { name: "Workbench navigation" })
     .getByRole("button", { name: "Workbench" })
     .click();
   await expect(page).toHaveURL(new RegExp("/workbench\\?repo=mean-weasel%2Fissuectl$"));
-  await expect(page.getByRole("button", { name: "mean-weasel/issuectl" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Workbench repository")).toHaveValue("1");
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
 
-  await page.getByLabel("Repositories").getByRole("button", { name: "Add repository" }).click();
+  await page.goto("about:blank", { waitUntil: "commit" });
+  await page.goto(`${baseUrl}/workbench/settings?repoSetup=1&repo=mean-weasel%2Fissuectl`);
   await expect(page).toHaveURL(new RegExp("/workbench/settings\\?repoSetup=1&repo=mean-weasel%2Fissuectl$"));
   await expect(page.getByLabel("Repository picker")).toContainText("mean-weasel/issuectl-test-repo-2");
+  await expect(page.getByLabel("Repository picker")).toContainText("mean-weasel/new-tool");
+  await expect(page.getByLabel("Repository picker")).toBeEnabled();
 
-  await page.getByLabel("Repository picker").selectOption("mean-weasel/web");
+  await page.getByLabel("Repository picker").selectOption("mean-weasel/new-tool");
   await page.getByRole("button", { name: "Add selected repo" }).click();
-  await expect(page.getByText("mean-weasel/web added")).toBeVisible();
-  await expect(page.getByRole("button", { name: "mean-weasel/web" })).toBeVisible();
+  await expect(page.getByText("mean-weasel/new-tool added")).toBeVisible();
+  await expect(page.getByLabel("Workbench repository")).toContainText("mean-weasel/new-tool");
 });
 
 test("selects repos, updates overview focus, and preserves selection across modes", async ({ page }) => {
-  await page.goto(`${baseUrl}/workbench`);
-  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  await page.getByLabel("Workbench repository").selectOption("2");
   await expect(page.getByRole("heading", { name: "mean-weasel/bugdrop" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "mean-weasel/bugdrop" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByLabel("Workbench repository")).toHaveValue("2");
 
   await clickNavAndExpect(page, "Settings", "/workbench/settings", true);
   await clickNavAndExpect(page, "Board", "/workbench/board", true);
   await clickNavAndExpect(page, "Workbench", "/workbench", false);
   await expect(page.getByRole("heading", { name: "mean-weasel/bugdrop" })).toBeVisible();
 
-  await page.getByRole("button", { name: "mean-weasel/api" }).click();
+  await page.getByLabel("Workbench repository").selectOption("3");
   await expect(page.getByRole("heading", { name: "mean-weasel/api" })).toBeVisible();
 
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
+  await page.getByLabel("Workbench repository").selectOption("4");
   await expect(page.getByRole("heading", { name: "mean-weasel/web" })).toBeVisible();
   await expect(page.getByText("Set up local path")).toBeVisible();
   await expect(page.getByRole("button", { name: "Open repo setup" })).toBeVisible();
 });
 
 test("removes a stale session when reconnect reports the deployment already ended", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Reconnect controls live in the side session pane.");
   let ensureCount = 0;
   await page.route("**/api/v1/deployments/103/ensure-ttyd", async (route) => {
     ensureCount += 1;
@@ -3355,16 +3468,19 @@ test("removes a stale session when reconnect reports the deployment already ende
   });
 
   await gotoWorkbenchWithRetry(page);
-  await expect(page.getByLabel("Session #486")).toBeVisible();
-  await page.getByLabel("Session #486").getByRole("button", { name: "Reconnect" }).click();
+  const activeSessions = page.getByRole("complementary", { name: "Active sessions" });
+  await expect(activeSessions.getByLabel("Session #486")).toBeVisible();
+  await activeSessions.getByLabel("Session #486").getByRole("button", { name: "Reconnect" }).click();
 
   await expect.poll(() => Promise.resolve(ensureCount)).toBe(1);
-  await expect(page.getByLabel("Session #486")).toHaveCount(0);
+  await expect(activeSessions.getByLabel("Session #486")).toHaveCount(0);
   await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: /Running/ }).click();
-  await expect(page.getByLabel("Issue #486")).toHaveCount(0);
+  await expect(page.getByLabel("Repo issue queue").getByLabel("Issue #486")).toHaveCount(0);
 });
 
 test("removes a stale PTY bridge session when reconnect finds tmux missing", async ({ page }) => {
+  test.skip(isCompactViewport(page), "PTY reconnect controls live in the desktop side session pane.");
+
   const staleRepo = repo(1, "issuectl", 1);
   staleRepo.deployments[0] = {
     ...staleRepo.deployments[0],
@@ -3397,6 +3513,7 @@ test("removes a stale PTY bridge session when reconnect finds tmux missing", asy
 });
 
 test("removes a stale selected session when terminal focus reports the session ended", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Opening a selected terminal from the side session pane is desktop-only.");
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -3407,16 +3524,18 @@ test("removes a stale selected session when terminal focus reports the session e
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
-  await expect(page.getByLabel("Session #447")).toBeVisible();
-  await page.getByLabel("Session #447").getByRole("button").first().click();
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  const activeSessions = page.getByRole("complementary", { name: "Active sessions" });
+  await expect(activeSessions.getByLabel("Session #447")).toBeVisible();
+  await activeSessions.getByLabel("Session #447").getByRole("button").first().click();
 
-  await expect(page.getByLabel("Session #447")).toHaveCount(0);
+  await expect(activeSessions.getByLabel("Session #447")).toHaveCount(0);
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "mean-weasel/issuectl" })).toBeVisible();
 });
 
 test("ends a session through the deployment endpoint and removes its row", async ({ page }) => {
+  test.skip(isCompactViewport(page), "End session controls live in the side session pane.");
   await page.route("**/api/v1/deployments/102/end", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -3424,6 +3543,8 @@ test("ends a session through the deployment endpoint and removes its row", async
       owner: "mean-weasel",
       repo: "issuectl",
       issueNumber: 498,
+      targetType: "issue",
+      targetNumber: 498,
     });
     await route.fulfill({
       status: 200,
@@ -3432,19 +3553,21 @@ test("ends a session through the deployment endpoint and removes its row", async
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
-  const session = page.getByLabel("Session #498");
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
+  const session = page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #498");
   await session.getByText("End", { exact: true }).click();
   await expect(session.getByText("End session?")).toBeVisible();
   await session.getByRole("button", { name: "End session" }).click();
 
-  await expect(page.getByLabel("Session #498")).toHaveCount(0);
+  await expect(page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #498")).toHaveCount(0);
   await expect(page.getByLabel("Issue-backed sessions").getByRole("article")).toHaveCount(2);
   await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Running 2" }).click();
-  await expect(page.getByLabel("Issue #498")).toHaveCount(0);
+  await expect(page.getByLabel("Repo issue queue").getByLabel("Issue #498")).toHaveCount(0);
 });
 
 test("ends a PTY bridge session and removes its tmux session", async ({ page }) => {
+  test.skip(isCompactViewport(page), "PTY end controls live in the desktop side session pane.");
+
   writeFileSync(tmuxCommandLog, "");
   const ptyRepo = repo(1, "issuectl", 1);
   ptyRepo.deployments[0] = {
@@ -3472,6 +3595,7 @@ test("ends a PTY bridge session and removes its tmux session", async ({ page }) 
 });
 
 test("canceling end session is local-only and does not navigate or call the end endpoint", async ({ page }) => {
+  test.skip(isCompactViewport(page), "End session controls live in the side session pane.");
   let endCount = 0;
   const navigations: string[] = [];
   await page.route("**/api/v1/deployments/102/end", async (route) => {
@@ -3483,23 +3607,25 @@ test("canceling end session is local-only and does not navigate or call the end 
     });
   });
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) navigations.push(frame.url());
   });
 
-  const session = page.getByLabel("Session #498");
+  const session = page.getByRole("complementary", { name: "Active sessions" }).getByLabel("Session #498");
   await session.getByText("End", { exact: true }).click();
   await expect(session.getByText("End session?")).toBeVisible();
   await session.getByRole("button", { name: "Cancel" }).click();
 
   await expect(session.getByText("End session?")).toBeHidden();
-  await expect(page.getByLabel("Session #498")).toBeVisible();
+  await expect(session).toBeVisible();
   expect(endCount).toBe(0);
   expect(navigations).toEqual([]);
 });
 
 test("exposes issue queue actions with semantic controls", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Issue filter controls live in the desktop side issue pane.");
+
   await gotoWorkbenchWithRetry(page);
 
   const filters = page.getByRole("group", { name: "Issue filters" });
@@ -3520,6 +3646,7 @@ test("exposes issue queue actions with semantic controls", async ({ page }) => {
 });
 
 test("filters repo issues and links details and running sessions", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Issue filters live in the side issue pane.");
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -3531,9 +3658,10 @@ test("filters repo issues and links details and running sessions", async ({ page
   });
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
-  await page.goto(`${baseUrl}/workbench`);
+  await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`);
 
-  await expect(page.getByText("all open 4", { exact: true })).toBeVisible();
+  const filters = page.getByRole("group", { name: "Issue filters" });
+  await expect(filters.getByRole("button", { name: "All open 4" })).toBeVisible();
   const issueRows = page.getByLabel("Repo issue queue").getByRole("article");
   await expect(issueRows).toHaveCount(4);
   for (let index = 0; index < 4; index += 1) {
@@ -3542,21 +3670,22 @@ test("filters repo issues and links details and running sessions", async ({ page
     expect(box!.height).toBeLessThanOrEqual(118);
   }
 
-  await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Running 3" }).click();
+  await filters.getByRole("button", { name: "Running 3" }).click();
   await expect(page.getByLabel("Repo issue queue").getByRole("article")).toHaveCount(3);
-  await expect(page.getByLabel("Issue #512")).toHaveCount(0);
+  await expect(page.getByLabel("Repo issue queue").getByLabel("Issue #512")).toHaveCount(0);
 
-  await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Closed 0" }).click();
+  await filters.getByRole("button", { name: "Closed 0" }).click();
   await expect(page.getByLabel("Repo issue queue").getByRole("article")).toHaveCount(0);
 
-  await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "All open 4" }).click();
-  await expect(page.getByLabel("Issue #512").getByRole("button", { name: "Prepare launch" })).toBeVisible();
-  await expect(page.getByLabel("Issue #512").getByRole("button", { name: "Launch", exact: true })).toHaveCount(0);
-  await expect(page.getByLabel("Issue #512").locator("[data-card-chip]")).toHaveCount(2);
-  await page.getByLabel("Issue #512").click();
-  await expect(page.getByLabel("Issue #512").getByRole("button", { name: "Details" })).toHaveCount(0);
+  await filters.getByRole("button", { name: "All open 4" }).click();
+  const issue512 = page.getByLabel("Repo issue queue").getByLabel("Issue #512");
+  await expect(issue512.getByRole("button", { name: "Prepare launch" })).toBeVisible();
+  await expect(issue512.getByRole("button", { name: "Launch", exact: true })).toHaveCount(0);
+  await expect(issue512.locator("[data-card-chip]")).toHaveCount(2);
+  await issue512.getByRole("button", { name: "Open #512: Desktop instance manager workbench" }).click();
+  await expect(issue512.getByRole("button", { name: "Details" })).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
-  await expect(page.getByLabel("Workbench focus").getByText("mean-weasel/issuectl")).toBeVisible();
+  await expect(page.getByLabel("Workbench focus").getByText("mean-weasel/issuectl", { exact: true })).toBeVisible();
   await expect(page.getByRole("main", { name: "Workbench" })).toHaveAttribute("data-instances-pane", "collapsed");
   await expect(page.getByLabel("Active sessions")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Sessions hidden · Show sessions" })).toBeVisible();
@@ -3565,9 +3694,9 @@ test("filters repo issues and links details and running sessions", async ({ page
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
   await expect(page.getByLabel("Repo issues")).toBeVisible();
 
-  await page.getByLabel("Issue #447").getByRole("button", { name: "Jump to session" }).click();
+  await page.getByLabel("Repo issue queue").getByLabel("Issue #447").getByRole("button", { name: "Jump to session" }).click();
   await expect(page.getByRole("heading", { name: /#447/ })).toBeVisible();
-  await expect(page.getByLabel("Workbench focus").getByText("mean-weasel/issuectl")).toBeVisible();
+  await expect(page.getByLabel("Workbench focus").getByText("mean-weasel/issuectl", { exact: true })).toBeVisible();
   await expect(page.locator('iframe[title="Terminal for issue 447"]')).toHaveAttribute(
     "src",
     /\/api\/terminal\/7701\/\?terminalToken=terminal-token-101$/,
@@ -3734,7 +3863,7 @@ test("loads issue detail and calls issue mutation endpoints", async ({ page }) =
   await issueActions.getByRole("button", { name: "Confirm reassign" }).click();
   await expect(page.getByRole("heading", { name: "#612 Reassigned issue #612" })).toBeVisible();
   if (!await workbenchUsesCompactIssueCards(page)) {
-    await page.getByRole("button", { name: "mean-weasel/issuectl" }).click();
+    await selectWorkbenchRepo(page, "mean-weasel/issuectl");
     await page.getByRole("group", { name: "Issue filters" }).getByRole("button", { name: "Closed 1" }).click();
     await expectIssueInWorkbenchOverview(page, 512);
   }
@@ -3893,6 +4022,8 @@ test("checks worktree status and launches an issue with selected context", async
 });
 
 test("launches an issue with the PTY bridge backend and keeps the terminal session navigable", async ({ page }) => {
+  test.skip(isCompactViewport(page), "PTY terminal launch navigation uses the desktop side session pane.");
+
   await installClipboardCapture(page);
   await installFakePtyWebSocket(page);
   await page.route("**/api/v1/issues/mean-weasel/issuectl/512", async (route) => {
@@ -3955,6 +4086,8 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
     owner: "mean-weasel",
     repo: "issuectl",
     issueNumber: 512,
+    targetType: "issue",
+    targetNumber: 512,
   });
 
   await gotoWorkbenchWithRetry(page);
@@ -4022,6 +4155,8 @@ test("launches an issue with the PTY bridge backend and keeps the terminal sessi
 });
 
 test("defaults launches to fresh clone when a repo has no local path", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Fresh-clone launch assertions use the desktop issue detail controls.");
+
   await page.route("**/api/v1/issues/mean-weasel/web/440", async (route) => {
     expect(route.request().method()).toBe("GET");
     await route.fulfill({
@@ -4073,8 +4208,8 @@ test("defaults launches to fresh clone when a repo has no local path", async ({ 
   await mockTerminalPage(page, 7791, "terminal-token-4401");
 
   await gotoWorkbenchWithRetry(page);
-  await page.getByRole("button", { name: "mean-weasel/web" }).click();
-  await page.getByLabel("Issue #440").click();
+  await selectWorkbenchRepo(page, "mean-weasel/web");
+  await page.getByLabel("Repo issue queue").getByLabel("Issue #440").click();
 
   await expect(page.getByRole("radio", { name: /Existing repo/ })).toBeDisabled();
   await expect(page.getByRole("radio", { name: /Git worktree/ })).toBeDisabled();
@@ -4125,6 +4260,8 @@ test("shows terminal reconnect after terminal auth failure", async ({ page }) =>
 });
 
 test("reconnects a session and shows a Workbench terminal error when the proxy rejects the token", async ({ page }) => {
+  test.skip(isCompactViewport(page), "Session list reconnect controls live in the desktop side session pane.");
+
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -4176,6 +4313,8 @@ test("reconnects a session and shows a Workbench terminal error when the proxy r
 });
 
 test("moves focus into workbench focus after repo issue session and mode changes", async ({ page }) => {
+  test.skip(isCompactViewport(page), "desktop-only side-pane focus flow is hidden in the compact workbench");
+
   await page.route("**/api/v1/deployments/101/ensure-ttyd", async (route) => {
     expect(route.request().method()).toBe("POST");
     expect(route.request().headers().authorization).toBe(`Bearer ${apiToken}`);
@@ -4188,11 +4327,11 @@ test("moves focus into workbench focus after repo issue session and mode changes
   await mockTerminalPage(page, 7701, "terminal-token-101");
 
   await gotoWorkbenchWithRetry(page);
-  await page.getByRole("button", { name: "mean-weasel/bugdrop" }).click();
+  await selectWorkbenchRepo(page, "mean-weasel/bugdrop");
   await expect(page.getByRole("heading", { name: "mean-weasel/bugdrop" })).toBeVisible();
   await expect(page.getByLabel("Workbench focus")).toBeFocused();
 
-  await page.getByRole("button", { name: "mean-weasel/issuectl" }).click();
+  await selectWorkbenchRepo(page, "mean-weasel/issuectl");
   await expect(page.getByLabel("Workbench focus")).toBeFocused();
   await openIssueFromWorkbenchOverview(page, 512);
   await expect(page.getByRole("heading", { name: "#512 Desktop instance manager workbench" })).toBeVisible();
@@ -4213,31 +4352,32 @@ async function clickNavAndExpect(page: import("@playwright/test").Page, label: s
   const navButton = page
     .getByRole("navigation", { name: "Workbench navigation" })
     .getByRole("button", { name: label, exact: true });
-  const selectedRepoLabel = await page
-    .getByLabel("Repositories")
-    .locator('button[data-selected="true"]')
-    .getAttribute("aria-label")
-    .catch(() => null);
+  const repoPicker = page.getByLabel("Workbench repository");
+  const selectedRepoFromPicker = await repoPicker.count() === 1
+    ? await repoPicker.evaluate((select) => select instanceof HTMLSelectElement ? select.selectedOptions[0]?.textContent ?? null : null)
+    : null;
+  const selectedRepoFromUrl = new URL(page.url()).searchParams.get("repo");
+  const pathKeepsRepo = path !== "/workbench/issues" && path !== "/workbench/board" && path !== "/workbench/prs";
+  const selectedRepoLabel = pathKeepsRepo ? selectedRepoFromPicker ?? selectedRepoFromUrl : null;
   await navButton.click();
   const expectedPath = selectedRepoLabel
     ? `${path}\\?repo=${escapeRegExp(encodeURIComponent(selectedRepoLabel))}`
-    : escapeRegExp(path);
+    : pathKeepsRepo
+      ? `${escapeRegExp(path)}(?:\\?repo=[^&]+)?`
+      : escapeRegExp(path);
   await expect(page).toHaveURL(new RegExp(`${expectedPath}$`));
   await expect(navButton).toHaveAttribute("aria-current", "page");
   const workbench = page.getByRole("main", { name: "Workbench" });
-  if (collapsed) {
+  const compact = (page.viewportSize()?.width ?? 1440) < 1100;
+  if (collapsed || compact) {
     await expect(workbench).toHaveAttribute("data-side-panes", "collapsed");
     await expect(page.getByRole("complementary", { name: "Active sessions" })).toHaveCount(0);
     await expect(page.getByRole("complementary", { name: "Repo issues" })).toHaveCount(0);
     const workbenchBox = await workbench.boundingBox();
-    const repoRailBox = await page.getByLabel("Repositories").boundingBox();
     const focusBox = await page.getByLabel("Workbench focus").boundingBox();
     expect(workbenchBox).not.toBeNull();
-    expect(repoRailBox).not.toBeNull();
     expect(focusBox).not.toBeNull();
-    expect(Math.round(focusBox!.width)).toBeGreaterThanOrEqual(
-      Math.round(workbenchBox!.width - repoRailBox!.width) - 1,
-    );
+    expect(Math.round(focusBox!.width)).toBeGreaterThanOrEqual(Math.round(workbenchBox!.width) - 1);
   } else {
     await expect(workbench).toHaveAttribute("data-side-panes", "visible");
     await expect(page.getByRole("complementary", { name: "Active sessions" })).toBeVisible();
@@ -4245,14 +4385,33 @@ async function clickNavAndExpect(page: import("@playwright/test").Page, label: s
   }
 }
 
+async function expectWorkbenchRepoPicker(page: import("@playwright/test").Page, label: string) {
+  const picker = page.getByLabel("Workbench repository");
+  await expect(picker).toBeVisible();
+  await expect.poll(async () =>
+    picker.evaluate((select) =>
+      select instanceof HTMLSelectElement ? select.selectedOptions[0]?.textContent?.trim() ?? "" : "",
+    ),
+  ).toBe(label);
+}
+
+async function selectWorkbenchRepo(page: import("@playwright/test").Page, label: string) {
+  await page.getByLabel("Workbench repository").selectOption({ label });
+  await expectWorkbenchRepoPicker(page, label);
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isCompactViewport(page: import("@playwright/test").Page): boolean {
+  return (page.viewportSize()?.width ?? 1440) < 1100;
 }
 
 async function gotoWorkbenchWithRetry(page: import("@playwright/test").Page) {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
-      await page.goto(`${baseUrl}/workbench`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+      await page.goto(`${baseUrl}/workbench?repo=mean-weasel%2Fissuectl`, { waitUntil: "domcontentloaded", timeout: 30_000 });
       return;
     } catch (err) {
       if (attempt === 2) throw err;
@@ -4400,28 +4559,25 @@ async function expectNoWorkbenchSplash(page: import("@playwright/test").Page) {
 }
 
 async function assertVisibleWorkbenchLayout(page: import("@playwright/test").Page) {
-  const rail = page.getByLabel("Repositories");
-  const instances = page.getByLabel("Active sessions");
+  const instances = page.getByRole("complementary", { name: "Active sessions" });
   const focus = page.getByLabel("Workbench focus");
-  const issues = page.getByLabel("Repo issues");
-  await expect(rail).toBeVisible();
+  const issues = page.getByRole("complementary", { name: "Repo issues" });
+  await expect(page.getByLabel("Repositories")).toHaveCount(0);
+  await expect(page.getByLabel("Workbench repository")).toBeVisible();
   await expect(instances).toBeVisible();
   await expect(focus).toBeVisible();
   await expect(issues).toBeVisible();
-  const railBox = await rail.boundingBox();
   const instanceBox = await instances.boundingBox();
   const focusBox = await focus.boundingBox();
   const issueBox = await issues.boundingBox();
 
-  expect(railBox).not.toBeNull();
   expect(instanceBox).not.toBeNull();
   expect(focusBox).not.toBeNull();
   expect(issueBox).not.toBeNull();
   expect(focusBox!.width).toBeGreaterThanOrEqual(440);
-  expect(railBox!.x + railBox!.width).toBeLessThanOrEqual(instanceBox!.x + 1);
   expect(instanceBox!.x + instanceBox!.width).toBeLessThanOrEqual(focusBox!.x + 9);
   expect(focusBox!.x + focusBox!.width).toBeLessThanOrEqual(issueBox!.x + 9);
-  for (const box of [railBox!, instanceBox!, focusBox!, issueBox!]) {
+  for (const box of [instanceBox!, focusBox!, issueBox!]) {
     expect(box.x).toBeGreaterThanOrEqual(0);
     expect(box.x + box.width).toBeLessThanOrEqual(page.viewportSize()!.width);
   }


### PR DESCRIPTION
## Summary
- simplify the cross-repo workbench board and PR dashboard controls
- replace stale repo-rail assumptions with the topbar repo picker in workbench e2e coverage
- repair terminal/action-sheet/pull-to-refresh e2e fixtures uncovered by the full suite

## Verification
- pnpm --dir packages/web lint
- pnpm --dir packages/web typecheck
- pnpm --dir packages/web test
- pnpm --dir packages/web exec playwright test e2e/workbench.spec.ts
- pnpm --filter @issuectl/web test:e2e
- git diff --check

## Failure modes checked
- cross-repo board columns and grouping controls
- global issues and PR dashboard flows
- repo picker state across reloads and navigation
- compact/mobile workbench layouts
- terminal persistence, ttyd respawn, and PTY/TTYD cleanup flows
- mobile action-sheet draft assignment cache invalidation
- duplicate mobile navigation buttons after pull-to-refresh render
